### PR TITLE
Add Badge component (Issue #20)

### DIFF
--- a/ui/build.ts
+++ b/ui/build.ts
@@ -20,9 +20,11 @@ const DOM_PKG_DIR = resolve(ROOT_DIR, '../packages/dom')
 
 // Entry files to compile
 const ENTRIES: string[] = [
+  'components/Badge.tsx',
   'components/Button.tsx',
   'components/Checkbox.tsx',
   'components/Input.tsx',
+  'pages/badge.tsx',
   'pages/button.tsx',
   'pages/checkbox.tsx',
   'pages/input.tsx',

--- a/ui/components/Badge.tsx
+++ b/ui/components/Badge.tsx
@@ -1,0 +1,31 @@
+/**
+ * Badge Component
+ *
+ * A small status indicator component inspired by shadcn/ui.
+ * Supports multiple variants for different semantic meanings.
+ */
+
+export type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline'
+
+export interface BadgeProps {
+  variant?: BadgeVariant
+  children?: any
+}
+
+export function Badge({
+  variant = 'default',
+  children
+}: BadgeProps) {
+  return (
+    <span
+      class={`inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 ${
+        variant === 'secondary' ? 'bg-zinc-100 text-zinc-900 hover:bg-zinc-100/80' :
+        variant === 'destructive' ? 'bg-red-500 text-zinc-50 hover:bg-red-500/80' :
+        variant === 'outline' ? 'border border-zinc-200 text-zinc-950' :
+        'bg-zinc-900 text-zinc-50 hover:bg-zinc-900/80'
+      }`}
+    >
+      {children}
+    </span>
+  )
+}

--- a/ui/e2e/badge.spec.ts
+++ b/ui/e2e/badge.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Badge Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/badge')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Badge')
+    await expect(page.locator('text=Displays a badge or a component')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('text=bunx barefoot add badge')).toBeVisible()
+  })
+
+  test('displays usage section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Usage")')).toBeVisible()
+  })
+
+  test.describe('Badge Variants', () => {
+    test('displays all variant badges', async ({ page }) => {
+      await expect(page.locator('span:has-text("Default")').first()).toBeVisible()
+      await expect(page.locator('span:has-text("Secondary")')).toBeVisible()
+      await expect(page.locator('span:has-text("Destructive")')).toBeVisible()
+      await expect(page.locator('span:has-text("Outline")')).toBeVisible()
+    })
+
+    test('default badge has correct styling', async ({ page }) => {
+      const defaultBadge = page.locator('span:has-text("Default")').first()
+      await expect(defaultBadge).toHaveClass(/bg-zinc-900/)
+    })
+
+    test('secondary badge has correct styling', async ({ page }) => {
+      const secondaryBadge = page.locator('span:has-text("Secondary")')
+      await expect(secondaryBadge).toHaveClass(/bg-zinc-100/)
+    })
+
+    test('destructive badge has correct styling', async ({ page }) => {
+      const destructiveBadge = page.locator('span:has-text("Destructive")')
+      await expect(destructiveBadge).toHaveClass(/bg-red-500/)
+    })
+
+    test('outline badge has correct styling', async ({ page }) => {
+      const outlineBadge = page.locator('span:has-text("Outline")')
+      await expect(outlineBadge).toHaveClass(/border/)
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^children$/ })).toBeVisible()
+    })
+  })
+})

--- a/ui/pages/badge.tsx
+++ b/ui/pages/badge.tsx
@@ -1,0 +1,85 @@
+/**
+ * Badge Documentation Page
+ */
+
+import { Badge } from '../components/Badge'
+import {
+  PageHeader,
+  Section,
+  Example,
+  CodeBlock,
+  PropsTable,
+  type PropDefinition,
+} from '../_shared/docs'
+
+// Code examples
+const installCode = `bunx barefoot add badge`
+
+const usageCode = `import { Badge } from '@/components/badge'
+
+export default function Page() {
+  return <Badge>Badge</Badge>
+}`
+
+const variantCode = `<Badge variant="default">Default</Badge>
+<Badge variant="secondary">Secondary</Badge>
+<Badge variant="destructive">Destructive</Badge>
+<Badge variant="outline">Outline</Badge>`
+
+// Props definition
+const badgeProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: "'default' | 'secondary' | 'destructive' | 'outline'",
+    defaultValue: "'default'",
+    description: 'The visual style of the badge.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The content of the badge.',
+  },
+]
+
+export function BadgePage() {
+  return (
+    <div class="space-y-12">
+      <PageHeader
+        title="Badge"
+        description="Displays a badge or a component that looks like a badge."
+      />
+
+      {/* Preview */}
+      <Example title="" code={`<Badge>Badge</Badge>`}>
+        <Badge>Badge</Badge>
+      </Example>
+
+      {/* Installation */}
+      <Section title="Installation">
+        <CodeBlock code={installCode} lang="bash" />
+      </Section>
+
+      {/* Usage */}
+      <Section title="Usage">
+        <CodeBlock code={usageCode} />
+      </Section>
+
+      {/* Examples */}
+      <Section title="Examples">
+        <div class="space-y-8">
+          <Example title="Variants" code={variantCode}>
+            <Badge variant="default">Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+            <Badge variant="outline">Outline</Badge>
+          </Example>
+        </div>
+      </Section>
+
+      {/* API Reference */}
+      <Section title="API Reference">
+        <PropsTable props={badgeProps} />
+      </Section>
+    </div>
+  )
+}

--- a/ui/server.tsx
+++ b/ui/server.tsx
@@ -7,6 +7,7 @@
 import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { renderer } from './renderer'
+import { BadgePage } from './dist/pages/badge'
 import { ButtonPage } from './dist/pages/button'
 import { CheckboxPage } from './dist/pages/checkbox'
 import { InputPage } from './dist/pages/input'
@@ -32,6 +33,15 @@ app.get('/', (c) => {
       </div>
 
       <div class="grid gap-4">
+        <a
+          href="/components/badge"
+          class="block p-4 border border-zinc-800 rounded-lg hover:border-zinc-600 hover:bg-zinc-900 transition-colors"
+        >
+          <h2 class="font-semibold text-zinc-100">Badge</h2>
+          <p class="text-sm text-zinc-400 mt-1">
+            Displays a badge or a component that looks like a badge.
+          </p>
+        </a>
         <a
           href="/components/button"
           class="block p-4 border border-zinc-800 rounded-lg hover:border-zinc-600 hover:bg-zinc-900 transition-colors"
@@ -62,6 +72,11 @@ app.get('/', (c) => {
       </div>
     </div>
   )
+})
+
+// Badge documentation
+app.get('/components/badge', (c) => {
+  return c.render(<BadgePage />)
 })
 
 // Button documentation


### PR DESCRIPTION
## Summary

- Add Badge component with 4 variants (default, secondary, destructive, outline)
- Add documentation page with installation, usage examples, and API reference
- Add E2E tests covering all variants and props table display
- Add Badge link to home page and routing in server.tsx

This implements the Badge component for Issue #20 (Phase 1: Simple Components), validating:
- **Static props**: variant property correctly applies styling
- **children composition**: child elements render correctly

Closes part of #20

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run test:e2e` passes (62 tests including 11 Badge tests)
- [ ] Manual verification: visit `/components/badge` to see documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)