### PR TITLE
Fix client-side hydration for interactive components

### DIFF
--- a/packages/hono/src/server-adapter.ts
+++ b/packages/hono/src/server-adapter.ts
@@ -177,6 +177,7 @@ ${contextHelper}
 
   return (
     <>
+      ${jsxWithDataKey}
       ${scriptTags}
       {__isRoot && __hasHydrateProps && (
         <script
@@ -185,7 +186,6 @@ ${contextHelper}
           dangerouslySetInnerHTML={{ __html: JSON.stringify(__hydrateProps) }}
         />
       )}
-      ${jsxWithDataKey}
     </>
   )
 }
@@ -199,8 +199,8 @@ ${contextHelper}
 
   return (
     <>
-      ${scriptTags}
       ${jsxWithDataKey}
+      ${scriptTags}
     </>
   )
 }
@@ -322,6 +322,7 @@ ${contextHelper}
 
   return (
     <>
+      ${jsxWithDataKey}
       ${scriptTags}
       {__isRoot && __hasHydrateProps && (
         <script
@@ -330,7 +331,6 @@ ${contextHelper}
           dangerouslySetInnerHTML={{ __html: JSON.stringify(__hydrateProps) }}
         />
       )}
-      ${jsxWithDataKey}
     </>
   )
 }`
@@ -340,8 +340,8 @@ ${contextHelper}
 
   return (
     <>
-      ${scriptTags}
       ${jsxWithDataKey}
+      ${scriptTags}
     </>
   )
 }`

--- a/packages/jsx/__tests__/adapters/hono-integration.test.ts
+++ b/packages/jsx/__tests__/adapters/hono-integration.test.ts
@@ -78,8 +78,10 @@ describe('Hono Adapter Integration', () => {
 
       expect(component.serverJsx).toContain('{0}')       // count()
       expect(component.serverJsx).toContain('{0 * 2}')   // count() * 2
-      expect(component.clientJs).toContain('String(count())')
-      expect(component.clientJs).toContain('String(count() * 2)')
+      // Expression is evaluated before element check to ensure signal dependencies are tracked
+      expect(component.clientJs).toContain('const __textValue = count()')
+      expect(component.clientJs).toContain('const __textValue = "doubled: " + String(count() * 2)')
+      expect(component.clientJs).toContain('String(__textValue)')
     })
   })
 

--- a/packages/jsx/__tests__/compiler/attributes.test.ts
+++ b/packages/jsx/__tests__/compiler/attributes.test.ts
@@ -47,8 +47,8 @@ describe('HTML Attributes - Dynamic class', () => {
     const result = await compile(source)
     const component = result.components[0]
 
-    // className is updated in client JS (with existence check)
-    expect(component.clientJs).toContain("_0.className = isActive() ? 'active' : ''")
+    // class is updated via setAttribute in client JS (for SVG compatibility)
+    expect(component.clientJs).toContain("_0.setAttribute('class', isActive() ? 'active' : '')")
   })
 })
 

--- a/packages/jsx/__tests__/compiler/dynamic-content.test.ts
+++ b/packages/jsx/__tests__/compiler/dynamic-content.test.ts
@@ -43,7 +43,9 @@ describe('Dynamic Content', () => {
     const component = result.components[0]
 
     // Updated with createEffect, existence check, and String() wrapper
-    expect(component.clientJs).toContain('_0.textContent = String(count())')
+    // Expression is evaluated before element check to ensure signal dependencies are tracked
+    expect(component.clientJs).toContain('const __textValue = count()')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
     expect(component.clientJs).toContain('if (_0)')
   })
 
@@ -58,7 +60,8 @@ describe('Dynamic Content', () => {
     const result = await compile(source)
     const component = result.components[0]
 
-    expect(component.clientJs).toContain('_0.textContent = String(count() * 2)')
+    expect(component.clientJs).toContain('const __textValue = count() * 2')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
   })
 
   it('conditional expression (ternary operator)', async () => {
@@ -72,7 +75,8 @@ describe('Dynamic Content', () => {
     const result = await compile(source)
     const component = result.components[0]
 
-    expect(component.clientJs).toContain("_0.textContent = String(on() ? 'ON' : 'OFF')")
+    expect(component.clientJs).toContain("const __textValue = on() ? 'ON' : 'OFF'")
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
   })
 
   it('text + dynamic content', async () => {
@@ -88,7 +92,9 @@ describe('Dynamic Content', () => {
 
     // String() wrapper is added for safe concatenation with text (now double-wrapped)
     // Note: whitespace after "Count:" is preserved
-    expect(component.clientJs).toContain('_0.textContent = String("Count: " + String(count()))')
+    // Expression is evaluated before element check to ensure signal dependencies are tracked
+    expect(component.clientJs).toContain('const __textValue = "Count: " + String(count())')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
   })
 
 })

--- a/packages/jsx/__tests__/compiler/edge-cases.test.ts
+++ b/packages/jsx/__tests__/compiler/edge-cases.test.ts
@@ -36,8 +36,10 @@ describe('Deeply Nested JSX', () => {
     const component = result.components[0]
 
     // createEffect should be generated for the dynamic content with String() wrapper
+    // Expression is evaluated before element check to ensure signal dependencies are tracked
     expect(component.clientJs).toContain('createEffect')
-    expect(component.clientJs).toContain('_0.textContent = String(count())')
+    expect(component.clientJs).toContain('const __textValue = count()')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
   })
 
   it('handles nested elements with multiple dynamic values', async () => {
@@ -64,9 +66,13 @@ describe('Deeply Nested JSX', () => {
     const component = result.components[0]
 
     // Three createEffect calls (sequential slot IDs) with String() wrapper
-    expect(component.clientJs).toContain('_0.textContent = String(a())')
-    expect(component.clientJs).toContain('_1.textContent = String(b())')
-    expect(component.clientJs).toContain('_2.textContent = String(c())')
+    // Expression is evaluated before element check to ensure signal dependencies are tracked
+    expect(component.clientJs).toContain('const __textValue = a()')
+    expect(component.clientJs).toContain('const __textValue = b()')
+    expect(component.clientJs).toContain('const __textValue = c()')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
+    expect(component.clientJs).toContain('_1.textContent = String(__textValue)')
+    expect(component.clientJs).toContain('_2.textContent = String(__textValue)')
   })
 
   it('handles nested elements with events at different levels', async () => {

--- a/packages/jsx/__tests__/compiler/fragment.test.ts
+++ b/packages/jsx/__tests__/compiler/fragment.test.ts
@@ -54,8 +54,10 @@ describe('Fragment Support', () => {
     const component = result.components[0]
 
     // Dynamic content should be properly handled
+    // Expression is evaluated before element check to ensure signal dependencies are tracked
     expect(component.clientJs).toContain('createSignal(0)')
-    expect(component.clientJs).toContain('_0.textContent = String(count())')
+    expect(component.clientJs).toContain('const __textValue = count()')
+    expect(component.clientJs).toContain('_0.textContent = String(__textValue)')
     expect(component.clientJs).toContain('_1.onclick')
   })
 

--- a/packages/jsx/src/transformers/ir-to-server-jsx.ts
+++ b/packages/jsx/src/transformers/ir-to-server-jsx.ts
@@ -133,9 +133,10 @@ function irToServerJsxInternal(node: IRNode, ctx: ServerJsxContext, isRoot: bool
         componentOutput = `<${node.name}${propsStr ? ' ' + propsStr : ''} />`
       }
 
-      // Wrap in scope span if needed
+      // Wrap in scope div if needed
+      // Use div instead of span because components often contain block elements
       if (needsScopeWrapper) {
-        return `<span data-bf-scope="${ctx.componentName}">${componentOutput}</span>`
+        return `<div data-bf-scope="${ctx.componentName}">${componentOutput}</div>`
       }
       return componentOutput
     }

--- a/packages/jsx/src/transformers/jsx-to-ir.ts
+++ b/packages/jsx/src/transformers/jsx-to-ir.ts
@@ -270,7 +270,11 @@ function componentToIR(
       ? `{ ${allPropsForInit.map(p => {
           // Wrap dynamic props in getter functions for reactivity
           // Skip 'children' - it's already wrapped as a function when reactive
-          if (p.isDynamic && p.name !== 'children') {
+          // Skip event handlers (on*) - they should be passed as-is, not wrapped
+          // Skip arrow functions - they're already functions and shouldn't be double-wrapped
+          const isEventHandler = p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()
+          const isArrowFunction = /^\s*\(?\s*[\w,\s]*\)?\s*=>/.test(p.value)
+          if (p.isDynamic && p.name !== 'children' && !isEventHandler && !isArrowFunction) {
             return `${p.name}: () => ${p.value}`
           }
           return `${p.name}: ${p.value}`

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -56,6 +56,8 @@ export type ConditionalElement = {
   condition: string           // show()
   whenTrueTemplate: string    // '<span data-bf-cond="0">Content</span>' or '<!--bf-cond-start:0-->...<!--bf-cond-end:0-->'
   whenFalseTemplate: string   // '<!--bf-cond-start:0--><!--bf-cond-end:0-->' (for null)
+  /** Interactive elements inside this conditional that need event re-attachment after DOM updates */
+  interactiveElements: InteractiveElement[]
 }
 
 export type SignalDeclaration = {


### PR DESCRIPTION
## Summary
- Fix #31: Client-side hydration was not working for interactive components
- Counter, Toggle, Accordion, Tabs, and other components now properly respond to click events after server-side rendering

## Key Fixes

### 1. SVG className compatibility
Use `setAttribute('class', ...)` instead of `.className` for SVG elements. SVG className is a read-only `SVGAnimatedString` object, causing JavaScript errors when trying to assign directly.

### 2. Scoped element finder
Add `__findInScope` helper function to exclude elements inside nested `data-bf-scope` components. This prevents parent components from accidentally selecting child component elements.

### 3. DOM order fix
Move JSX content before script tags in server adapter. This ensures DOM elements exist when hydration scripts execute.

### 4. Scope wrapper fix
Change wrapper element from `<span>` to `<div>`. Components often contain block elements, and block elements inside inline elements cause layout issues (height: 0).

### 5. Event handler wrapping fix
Prevent double-wrapping of arrow functions and event handlers. Previously, `onClick: () => toggle()` was being wrapped to `onClick: () => () => toggle()`.

### 6. Signal tracking improvement
Evaluate expressions before element existence check. This ensures signal dependencies are always tracked, even when elements are conditionally hidden.

### 7. Conditional DOM event re-attachment
Re-attach event handlers after conditional DOM replacement. When conditionals change, new DOM elements need their handlers attached.

## Test plan
- [x] Unit tests pass (223/223)
- [x] UI E2E tests pass (149/149) - Accordion, Card, Tabs, etc.
- [x] examples/hono Counter E2E tests pass
- [x] examples/hono Toggle E2E tests pass

## Related
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)