### PR TITLE
Refactor: Extract duplicated utility functions

### DIFF
--- a/packages/jsx/src/compiler/client-js-helpers.ts
+++ b/packages/jsx/src/compiler/client-js-helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Client JS generation helpers
+ *
+ * Provides utility functions for generating client-side JavaScript code.
+ */
+
+/**
+ * Component data with hasClientJs flag
+ */
+interface ComponentDataWithClientJs {
+  name: string
+  hasClientJs: boolean
+}
+
+/**
+ * Filter child component names that have client JS
+ *
+ * @param childNames - Array of child component names to filter
+ * @param componentData - Array of component data with hasClientJs flag
+ * @param excludeNames - Optional array of names to exclude (e.g., same-file components)
+ * @returns Array of child names that have client JS
+ */
+export function filterChildrenWithClientJs(
+  childNames: string[],
+  componentData: ComponentDataWithClientJs[],
+  excludeNames?: string[]
+): string[] {
+  return childNames.filter(childName => {
+    // Skip if child is in the exclude list
+    if (excludeNames?.includes(childName)) return false
+    const childData = componentData.find(d => d.name === childName)
+    if (!childData) return false
+    return childData.hasClientJs
+  })
+}
+
+/**
+ * Concatenate declaration strings (constants, signals, memos)
+ * Filters out empty/falsy strings and joins with newlines
+ *
+ * @param declarations - Array of declaration strings
+ * @returns Concatenated declarations string
+ */
+export function joinDeclarations(...declarations: (string | undefined | null | false)[]): string {
+  return declarations.filter(Boolean).join('\n')
+}


### PR DESCRIPTION
## Summary

- Add `filterChildrenWithClientJs` helper to filter child components that have client JS
- Add `joinDeclarations` helper to concatenate declaration strings (constants, signals, memos)
- Replace duplicated filtering logic in `jsx-compiler.ts` with the new helper functions

This is a pure refactoring with no behavioral changes. The extracted functions provide a single source of truth for:
1. Filtering child components by their `hasClientJs` flag
2. Concatenating declaration strings with proper filtering

## Changes

- **New file**: `packages/jsx/src/compiler/client-js-helpers.ts`
- **Modified**: `packages/jsx/src/jsx-compiler.ts`

## Test plan

- [ ] Unit tests pass (`bun test packages/jsx`)
- [ ] Package builds successfully (`cd packages/jsx && bun run build`)
- [ ] E2E tests pass (`cd examples/hono && bun run test:e2e`)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)