### PR TITLE
Refactor: Remove unused generateClientJs function

### DIFF
--- a/packages/jsx/src/transformers/index.ts
+++ b/packages/jsx/src/transformers/index.ts
@@ -4,7 +4,6 @@
 
 export { irToServerJsx, type ServerJsxContext } from './ir-to-server-jsx'
 export {
-  generateClientJs,
   collectClientJsInfo,
   collectAllChildComponentNames,
   extractArrowBody,
@@ -13,6 +12,5 @@ export {
   parseConditionalHandler,
   isBooleanAttribute,
   generateAttributeUpdate,
-  type ClientJsContext,
 } from './ir-to-client-js'
 export { jsxToIR, findAndConvertJsxReturn, type JsxToIRContext } from './jsx-to-ir'


### PR DESCRIPTION
## Summary

- Remove unused `generateClientJs` function from `ir-to-client-js.ts`
- Remove associated `ClientJsContext` type
- Remove unused `LocalFunction` import

## Investigation

1. `generateClientJs` was exported from `transformers/index.ts` but never imported or used anywhere in the codebase
2. The function used an older `updateAll()` approach while `generateClientJsWithCreateEffect` (in `jsx-compiler.ts`) uses the modern `createEffect`-based reactive system
3. The old function was never removed after migration to the reactive system

## Test plan

- [x] Verified no imports of `generateClientJs` exist in the codebase
- [x] Verified no tests depend on `generateClientJs`
- [x] Code compiles without errors

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)