### PR TITLE
Refactor: Extract common patterns in extractors

### DIFF
--- a/packages/jsx/src/extractors/__tests__/common.test.ts
+++ b/packages/jsx/src/extractors/__tests__/common.test.ts
@@ -1,0 +1,232 @@
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import { createSourceFile } from '../../utils/helpers'
+import {
+  isComponentFunction,
+  findComponentFunction,
+  forEachComponentFunction,
+  forEachVariableDeclaration
+} from '../common'
+
+describe('isComponentFunction', () => {
+  test('returns true for PascalCase function declarations', () => {
+    const source = `function Counter() { return <div /> }`
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    let found = false
+    ts.forEachChild(sourceFile, (node) => {
+      if (isComponentFunction(node)) {
+        found = true
+        expect(node.name.text).toBe('Counter')
+      }
+    })
+    expect(found).toBe(true)
+  })
+
+  test('returns false for camelCase function declarations', () => {
+    const source = `function myHelper() { return 1 }`
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    let found = false
+    ts.forEachChild(sourceFile, (node) => {
+      if (isComponentFunction(node)) {
+        found = true
+      }
+    })
+    expect(found).toBe(false)
+  })
+
+  test('returns false for anonymous functions', () => {
+    const source = `const fn = function() { return 1 }`
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    let found = false
+    ts.forEachChild(sourceFile, (node) => {
+      if (isComponentFunction(node)) {
+        found = true
+      }
+    })
+    expect(found).toBe(false)
+  })
+})
+
+describe('findComponentFunction', () => {
+  test('finds first component when no target specified', () => {
+    const source = `
+      function Helper() { return <span /> }
+      function Counter() { return <div /> }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile)
+    expect(component).toBeDefined()
+    expect(component?.name.text).toBe('Helper')
+  })
+
+  test('finds specific component by name', () => {
+    const source = `
+      function Helper() { return <span /> }
+      function Counter() { return <div /> }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile, 'Counter')
+    expect(component).toBeDefined()
+    expect(component?.name.text).toBe('Counter')
+  })
+
+  test('returns undefined when target not found', () => {
+    const source = `
+      function Helper() { return <span /> }
+      function Counter() { return <div /> }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile, 'NonExistent')
+    expect(component).toBeUndefined()
+  })
+
+  test('finds nested component functions', () => {
+    const source = `
+      export default function Wrapper() {
+        function Inner() { return <span /> }
+        return <Inner />
+      }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    // Without target, finds Wrapper first
+    const wrapper = findComponentFunction(sourceFile)
+    expect(wrapper?.name.text).toBe('Wrapper')
+
+    // With target, can find Inner
+    const inner = findComponentFunction(sourceFile, 'Inner')
+    expect(inner?.name.text).toBe('Inner')
+  })
+})
+
+describe('forEachComponentFunction', () => {
+  test('iterates all component functions', () => {
+    const source = `
+      function First() { return <div /> }
+      function Second() { return <span /> }
+      function Third() { return <p /> }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const names: string[] = []
+    forEachComponentFunction(sourceFile, (component, name) => {
+      names.push(name)
+    })
+
+    expect(names).toEqual(['First', 'Second', 'Third'])
+  })
+
+  test('excludes specified component', () => {
+    const source = `
+      function Main() { return <div /> }
+      function Helper() { return <span /> }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const names: string[] = []
+    forEachComponentFunction(
+      sourceFile,
+      (component, name) => { names.push(name) },
+      { excludeName: 'Main' }
+    )
+
+    expect(names).toEqual(['Helper'])
+  })
+
+  test('applies predicate filter', () => {
+    const source = `
+      function HasBody() { return <div /> }
+      function NoBody(): JSX.Element;
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const names: string[] = []
+    forEachComponentFunction(
+      sourceFile,
+      (component, name) => { names.push(name) },
+      { predicate: (node) => node.body !== undefined }
+    )
+
+    expect(names).toEqual(['HasBody'])
+  })
+})
+
+describe('forEachVariableDeclaration', () => {
+  test('iterates variable declarations in block', () => {
+    const source = `
+      function Component() {
+        const a = 1
+        const b = 2
+        let c = 3
+        return <div />
+      }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile)
+    expect(component?.body).toBeDefined()
+
+    const names: string[] = []
+    forEachVariableDeclaration(component!.body!, (decl) => {
+      if (ts.isIdentifier(decl.name)) {
+        names.push(decl.name.text)
+      }
+    })
+
+    expect(names).toEqual(['a', 'b', 'c'])
+  })
+
+  test('handles destructuring declarations', () => {
+    const source = `
+      function Component() {
+        const [count, setCount] = createSignal(0)
+        const { a, b } = props
+        return <div />
+      }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile)
+    expect(component?.body).toBeDefined()
+
+    let arrayBindingCount = 0
+    let objectBindingCount = 0
+    forEachVariableDeclaration(component!.body!, (decl) => {
+      if (ts.isArrayBindingPattern(decl.name)) {
+        arrayBindingCount++
+      }
+      if (ts.isObjectBindingPattern(decl.name)) {
+        objectBindingCount++
+      }
+    })
+
+    expect(arrayBindingCount).toBe(1)
+    expect(objectBindingCount).toBe(1)
+  })
+
+  test('provides statement context', () => {
+    const source = `
+      function Component() {
+        const handler = () => {}
+        return <div />
+      }
+    `
+    const sourceFile = createSourceFile(source, 'test.tsx')
+
+    const component = findComponentFunction(sourceFile)
+    expect(component?.body).toBeDefined()
+
+    let statementText = ''
+    forEachVariableDeclaration(component!.body!, (decl, statement) => {
+      statementText = statement.getText(sourceFile)
+    })
+
+    expect(statementText).toBe('const handler = () => {}')
+  })
+})

--- a/packages/jsx/src/extractors/common.ts
+++ b/packages/jsx/src/extractors/common.ts
@@ -1,0 +1,131 @@
+/**
+ * BarefootJS JSX Compiler - Common Extractor Utilities
+ *
+ * Shared utilities for component function detection and traversal patterns.
+ */
+
+import ts from 'typescript'
+import { isPascalCase } from '../utils/helpers'
+
+/**
+ * Checks if a node is a PascalCase function declaration (a component function).
+ *
+ * @param node - AST node to check
+ * @returns true if the node is a named function with PascalCase name
+ */
+export function isComponentFunction(node: ts.Node): node is ts.FunctionDeclaration & { name: ts.Identifier } {
+  return (
+    ts.isFunctionDeclaration(node) &&
+    node.name !== undefined &&
+    isPascalCase(node.name.text)
+  )
+}
+
+/**
+ * Finds the first component function in a source file.
+ *
+ * If targetName is provided, finds the component with that specific name.
+ * Otherwise, finds the first PascalCase function declaration.
+ *
+ * @param sourceFile - Source file to search
+ * @param targetName - Optional: specific component name to find
+ * @returns The found function declaration, or undefined if not found
+ */
+export function findComponentFunction(
+  sourceFile: ts.SourceFile,
+  targetName?: string
+): (ts.FunctionDeclaration & { name: ts.Identifier }) | undefined {
+  let found: (ts.FunctionDeclaration & { name: ts.Identifier }) | undefined
+
+  function visit(node: ts.Node) {
+    if (found) return
+
+    if (isComponentFunction(node)) {
+      if (targetName) {
+        if (node.name.text === targetName) {
+          found = node
+        }
+      } else {
+        found = node
+      }
+    }
+
+    if (!found) {
+      ts.forEachChild(node, visit)
+    }
+  }
+
+  visit(sourceFile)
+  return found
+}
+
+/**
+ * Options for forEachComponentFunction.
+ */
+export type ForEachComponentOptions = {
+  /**
+   * Skip components matching this name.
+   * Useful for excluding the main component when finding local components.
+   */
+  excludeName?: string
+
+  /**
+   * Additional predicate to filter components.
+   * Only components that pass this predicate will be processed.
+   */
+  predicate?: (node: ts.FunctionDeclaration & { name: ts.Identifier }) => boolean
+}
+
+/**
+ * Iterates over all component functions in a source file.
+ *
+ * Useful for extractors that need to process all components (like local-components.ts).
+ *
+ * @param sourceFile - Source file to search
+ * @param callback - Called for each component found
+ * @param options - Optional filtering options
+ */
+export function forEachComponentFunction(
+  sourceFile: ts.SourceFile,
+  callback: (component: ts.FunctionDeclaration & { name: ts.Identifier }, name: string) => void,
+  options?: ForEachComponentOptions
+): void {
+  ts.forEachChild(sourceFile, (node) => {
+    if (isComponentFunction(node)) {
+      const name = node.name.text
+
+      // Skip excluded name
+      if (options?.excludeName && name === options.excludeName) {
+        return
+      }
+
+      // Apply additional predicate
+      if (options?.predicate && !options.predicate(node)) {
+        return
+      }
+
+      callback(node, name)
+    }
+  })
+}
+
+/**
+ * Iterates over all variable declarations in a function body.
+ *
+ * This is the common pattern for extracting signals, memos, and local functions.
+ *
+ * @param body - Function body block
+ * @param callback - Called for each variable declaration found
+ */
+export function forEachVariableDeclaration(
+  body: ts.Block,
+  callback: (decl: ts.VariableDeclaration, statement: ts.VariableStatement) => void
+): void {
+  for (const statement of body.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        callback(decl, statement)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Create `extractors/common.ts` with shared utilities for component function detection and traversal patterns
- Refactor all extractor files (`signals.ts`, `memos.ts`, `local-functions.ts`, `props.ts`, `local-components.ts`) to use the shared utilities
- Add comprehensive tests for the new common utilities

### New Utilities in `common.ts`

| Utility | Description |
|---------|-------------|
| `isComponentFunction()` | Type guard to check if a node is a PascalCase function declaration |
| `findComponentFunction()` | Find first or specific component by name |
| `forEachComponentFunction()` | Iterate all components with exclude/predicate filtering |
| `forEachVariableDeclaration()` | Iterate variable declarations in a function body block |

### Impact

- Reduced code duplication (~50 lines removed)
- Consistent component detection logic across all extractors
- Easier maintenance and testing of core traversal patterns

## Test plan

- [x] Run unit tests: `bun test packages/jsx` (236 passed)
- [x] Run E2E tests: `bun run test:e2e` (48 passed)
- [x] Rebuild packages and examples

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)