### PR TITLE
Refactor: Consolidate context types in types.ts

### DIFF
--- a/packages/jsx/src/jsx-compiler.ts
+++ b/packages/jsx/src/jsx-compiler.ts
@@ -28,6 +28,8 @@ import type {
   IRNode,
   FileOutput,
   ServerComponentData,
+  JsxToIRContext,
+  ClientJsGeneratorContext,
 } from './types'
 import {
   extractImports,
@@ -52,7 +54,6 @@ import {
   collectClientJsInfo,
   collectAllChildComponentNames,
   findAndConvertJsxReturn,
-  type JsxToIRContext,
 } from './transformers'
 import {
   generateContentHash,
@@ -866,17 +867,6 @@ function generateAttributeUpdateWithVar(da: DynamicAttribute, varName: string): 
   return `{ const __val = ${expression}; if (__val !== undefined) ${varName}.setAttribute('${attrName}', __val) }`
 }
 
-/**
- * Context for client JS generation functions
- */
-type ClientJsGeneratorContext = {
-  componentName: string
-  elementPaths: Map<string, string | null>
-  declaredPaths: Map<string, string>
-  queriedIds: Set<string>
-  varName: (id: string) => string
-  getElementAccessCode: (id: string) => string
-}
 
 /**
  * Generate element queries: scope setup, path calculation, element declarations

--- a/packages/jsx/src/transformers/index.ts
+++ b/packages/jsx/src/transformers/index.ts
@@ -2,7 +2,7 @@
  * BarefootJS JSX Compiler - Transformers
  */
 
-export { irToServerJsx, type ServerJsxContext } from './ir-to-server-jsx'
+export { irToServerJsx } from './ir-to-server-jsx'
 export {
   collectClientJsInfo,
   collectAllChildComponentNames,
@@ -13,4 +13,12 @@ export {
   isBooleanAttribute,
   generateAttributeUpdate,
 } from './ir-to-client-js'
-export { jsxToIR, findAndConvertJsxReturn, type JsxToIRContext } from './jsx-to-ir'
+export { jsxToIR, findAndConvertJsxReturn } from './jsx-to-ir'
+
+// Re-export context types from types.ts for backwards compatibility
+export type {
+  JsxToIRContext,
+  ServerJsxContext,
+  CollectContext,
+  CompilerWarning,
+} from '../types'

--- a/packages/jsx/src/transformers/ir-to-client-js.ts
+++ b/packages/jsx/src/transformers/ir-to-client-js.ts
@@ -16,7 +16,11 @@ import type {
   DynamicAttribute,
   RefElement,
   ConditionalElement,
+  CollectContext,
 } from '../types'
+
+// Re-export type for backwards compatibility
+export type { CollectContext }
 
 // Import parsers using TypeScript API
 import {
@@ -205,13 +209,6 @@ function collectChildComponentNamesRecursive(node: IRNode, names: string[]): voi
   }
 }
 
-/**
- * Context for collecting conditional elements
- */
-export type CollectContext = {
-  signals: SignalDeclaration[]
-  memos: MemoDeclaration[]
-}
 
 /**
  * Converts IR node to HTML template string for client-side rendering

--- a/packages/jsx/src/transformers/ir-to-server-jsx.ts
+++ b/packages/jsx/src/transformers/ir-to-server-jsx.ts
@@ -5,22 +5,18 @@
  * Unlike ir-to-html which evaluates expressions, this preserves them as JSX.
  */
 
-import type { IRNode, IRElement, IRFragment, SignalDeclaration, MemoDeclaration } from '../types'
+import type {
+  IRNode,
+  IRElement,
+  IRFragment,
+  SignalDeclaration,
+  MemoDeclaration,
+  ServerJsxContext,
+} from '../types'
 import { isSvgRoot } from '../utils/svg-helpers'
 
-/**
- * Context for server JSX generation
- */
-export type ServerJsxContext = {
-  componentName: string
-  signals: SignalDeclaration[]
-  memos: MemoDeclaration[]
-  needsDataBfIds: Set<string>  // IDs that need data-bf attribute for querySelector fallback
-  /** Event ID counter for event attribute output (to match client-side event delegation) */
-  eventIdCounter: { value: number } | null
-  /** Whether we're inside a list context (for passing __listIndex to child components) */
-  inListContext: boolean
-}
+// Re-export type for backwards compatibility
+export type { ServerJsxContext }
 
 /**
  * Converts HTML to JSX format (internal helper)

--- a/packages/jsx/src/transformers/jsx-to-ir.ts
+++ b/packages/jsx/src/transformers/jsx-to-ir.ts
@@ -17,31 +17,14 @@ import type {
   SignalDeclaration,
   MemoDeclaration,
   CompileResult,
+  JsxToIRContext,
+  CompilerWarning,
 } from '../types'
 import { isPascalCase } from '../utils/helpers'
-import { IdGenerator } from '../utils/id-generator'
 import { jsxToTemplateString } from '../compiler/template-generator'
 
-export type CompilerWarning = {
-  type: 'reactive-children'
-  message: string
-  componentName: string
-  parentComponent: string
-}
-
-export type JsxToIRContext = {
-  sourceFile: ts.SourceFile
-  signals: SignalDeclaration[]
-  memos: MemoDeclaration[]
-  components: Map<string, CompileResult>
-  idGenerator: IdGenerator
-  /** Warnings collected during compilation */
-  warnings: CompilerWarning[]
-  /** Current component name being compiled */
-  currentComponentName: string
-  /** Value prop names (non-callback props) for reactivity detection */
-  valueProps: string[]
-}
+// Re-export types for backwards compatibility
+export type { JsxToIRContext, CompilerWarning }
 
 /**
  * Converts JSX AST node to IR


### PR DESCRIPTION
## Summary

- Add `BaseTransformContext` interface with shared `signals` and `memos` properties
- Move `JsxToIRContext` from jsx-to-ir.ts to types.ts
- Move `ServerJsxContext` from ir-to-server-jsx.ts to types.ts  
- Move `CollectContext` from ir-to-client-js.ts to types.ts
- Move `ClientJsGeneratorContext` from jsx-compiler.ts to types.ts
- Move `CompilerWarning` type to types.ts
- Add re-exports in original files for backwards compatibility

## Test plan

- [ ] Run `bun test packages/jsx` to verify unit tests pass
- [ ] Run `bun run build` in packages/jsx to verify build succeeds
- [ ] Verify type checking passes with `bunx tsc --noEmit`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)