### PR TITLE
Add createPortal() - Client-side Portal utility

### DIFF
--- a/packages/dom/__tests__/portal.test.ts
+++ b/packages/dom/__tests__/portal.test.ts
@@ -205,4 +205,50 @@ describe('createPortal', () => {
       expect(container.children[0].textContent).toBe('Updated content')
     })
   })
+
+  describe('with Renderable (JSX.Element)', () => {
+    test('mounts object with toString() method', () => {
+      // Simulates Hono's HtmlEscapedString / JSX.Element
+      const jsxElement = {
+        toString() {
+          return '<div class="modal">From JSX</div>'
+        }
+      }
+
+      const portal = createPortal(jsxElement, container)
+
+      expect(container.children.length).toBe(1)
+      expect(portal.element.className).toBe('modal')
+      expect(portal.element.textContent).toBe('From JSX')
+    })
+
+    test('mounts complex JSX-like structure', () => {
+      const jsxElement = {
+        toString() {
+          return `
+            <div class="dialog" role="dialog">
+              <h2>Dialog Title</h2>
+              <p>Dialog content</p>
+            </div>
+          `
+        }
+      }
+
+      const portal = createPortal(jsxElement, container)
+
+      expect(portal.element.className).toBe('dialog')
+      expect(portal.element.getAttribute('role')).toBe('dialog')
+      expect(portal.element.querySelector('h2')?.textContent).toBe('Dialog Title')
+    })
+
+    test('throws error for Renderable returning empty HTML', () => {
+      const emptyJsx = {
+        toString() {
+          return ''
+        }
+      }
+
+      expect(() => createPortal(emptyJsx, container)).toThrow('createPortal: Invalid HTML provided')
+    })
+  })
 })

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -10,4 +10,9 @@ export {
   type EffectFn,
 } from './reactive'
 
-export { createPortal, type Portal } from './portal'
+export {
+  createPortal,
+  type Portal,
+  type Renderable,
+  type PortalChildren,
+} from './portal'


### PR DESCRIPTION
## Summary

- Implement `createPortal()` function in `@barefootjs/dom` package
- Client-side only utility to mount elements at arbitrary DOM positions (typically `document.body`)
- API inspired by React's `createPortal(children, domNode)`
- Prerequisite for Modal/Dialog (#32)

## API

```typescript
import { createPortal } from '@barefootjs/dom'

// With HTML string
const portal = createPortal(`
  <div class="modal-overlay">
    <div class="modal" role="dialog" aria-modal="true">
      ...
    </div>
  </div>
`, document.body)

// With HTMLElement
const modalEl = document.createElement('div')
const portal = createPortal(modalEl, document.body)

// With JSX.Element (Hono)
const portal = createPortal(<Modal />, document.body)

// Access mounted element
console.log(portal.element)

// Later: unmount
portal.unmount()
```

## Types

```typescript
type Renderable = { toString(): string }
type PortalChildren = HTMLElement | string | Renderable

type Portal = {
  element: HTMLElement
  unmount: () => void
}

function createPortal(
  children: PortalChildren,
  container?: HTMLElement  // defaults to document.body
): Portal
```

## Test plan

- [x] Basic mount/unmount functionality
- [x] Default container (document.body)
- [x] Custom container
- [x] HTMLElement input
- [x] Renderable (JSX.Element) input via toString()
- [x] Error handling for invalid HTML
- [x] Multiple independent portals
- [x] Complex nested HTML
- [x] Attribute preservation
- [x] Element reference access and modification

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)