### PR TITLE
Add Select component with reactive value binding

### DIFF
--- a/examples/hono/components/Select.tsx
+++ b/examples/hono/components/Select.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+/**
+ * Select Component
+ *
+ * Demonstrates reactive select dropdown with value binding.
+ * Changes to the select update the displayed value in real-time.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+
+type Props = {
+  initialValue?: string
+}
+
+function Select({ initialValue = 'option-a' }: Props) {
+  const [selected, setSelected] = createSignal(initialValue)
+
+  return (
+    <>
+      <div class="select-container">
+        <label>Choose an option:</label>
+        <select
+          class="select"
+          value={selected()}
+          onChange={(e) => setSelected(e.target.value)}
+        >
+          <option value="option-a">Option A</option>
+          <option value="option-b">Option B</option>
+          <option value="option-c">Option C</option>
+        </select>
+      </div>
+      <p class="selected-value">Selected: {selected()}</p>
+    </>
+  )
+}
+
+export default Select

--- a/examples/hono/e2e/select.spec.ts
+++ b/examples/hono/e2e/select.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Select', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/select')
+  })
+
+  test('displays initial value', async ({ page }) => {
+    const select = page.locator('.select')
+    await expect(select).toHaveValue('option-a')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-a')
+  })
+
+  test('changes value on selection', async ({ page }) => {
+    const select = page.locator('.select')
+
+    await select.selectOption('option-b')
+    await expect(select).toHaveValue('option-b')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-b')
+  })
+
+  test('syncs display with selection', async ({ page }) => {
+    const select = page.locator('.select')
+
+    await select.selectOption('option-c')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-c')
+
+    await select.selectOption('option-a')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-a')
+  })
+
+  test('cycles through all options', async ({ page }) => {
+    const select = page.locator('.select')
+
+    // Option A (initial)
+    await expect(select).toHaveValue('option-a')
+
+    // Option B
+    await select.selectOption('option-b')
+    await expect(select).toHaveValue('option-b')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-b')
+
+    // Option C
+    await select.selectOption('option-c')
+    await expect(select).toHaveValue('option-c')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-c')
+
+    // Back to Option A
+    await select.selectOption('option-a')
+    await expect(select).toHaveValue('option-a')
+    await expect(page.locator('.selected-value')).toContainText('Selected: option-a')
+  })
+})

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -15,6 +15,7 @@ import TodoApp from '@/components/TodoApp'
 import Dashboard from '@/components/Dashboard'
 import Game from '@/components/Game'
 import FizzBuzzCounter from '@/components/FizzBuzzCounter'
+import Select from '@/components/Select'
 import { AsyncUserList } from './components/AsyncUserList'
 import { AsyncCounterWrapper } from './components/AsyncCounterWrapper'
 
@@ -46,6 +47,7 @@ app.get('/', (c) => {
           <li><a href="/counter">Counter</a></li>
           <li><a href="/fizzbuzz">Conditional Counter</a></li>
           <li><a href="/toggle">Toggle</a></li>
+          <li><a href="/select">Select</a></li>
           <li><a href="/todos">Todo (SSR + API)</a></li>
           <li><a href="/dashboard">Dashboard (All widgets)</a></li>
           <li><a href="/dashboard/counter-only">Dashboard (Counter only)</a></li>
@@ -89,6 +91,16 @@ app.get('/toggle', (c) => {
     <div>
       <h1>Toggle Example</h1>
       <Toggle />
+      <p><a href="/">← Back</a></p>
+    </div>
+  )
+})
+
+app.get('/select', (c) => {
+  return c.render(
+    <div>
+      <h1>Select Example</h1>
+      <Select initialValue="option-a" />
       <p><a href="/">← Back</a></p>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add Select component demonstrating `<select>` dropdown with reactive value binding
- Uses `createSignal` for state management and `onChange` for selection updates
- Display syncs with selected value in real-time

## Test plan
- [x] Unit tests pass (410 tests)
- [x] E2E tests for Select component (4 tests)
- [x] All existing E2E tests pass (52 tests total)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)