### PR TITLE
Add Tooltip component

### DIFF
--- a/ui/components/Tooltip.tsx
+++ b/ui/components/Tooltip.tsx
@@ -1,0 +1,165 @@
+"use client"
+/**
+ * Tooltip Component
+ *
+ * A popup that displays contextual information on hover or focus.
+ *
+ * Features:
+ * - Open/close state management via props
+ * - Shows on hover (mouseenter/mouseleave)
+ * - Shows on focus (for keyboard accessibility)
+ * - Configurable placement (top, right, bottom, left)
+ * - Accessibility (role="tooltip", aria-describedby)
+ *
+ * Design Decision: Props-based state management
+ * Similar to Dialog/Accordion, this component uses props for state.
+ * The parent component manages the open state with a signal.
+ *
+ * Note: Uses CSS-based visibility (hidden class) due to BarefootJS compiler
+ * constraints. The compiler processes JSX structure but does not preserve
+ * custom createEffect logic.
+ */
+
+import type { Child } from '../types'
+
+// --- TooltipTrigger ---
+
+export interface TooltipTriggerProps {
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  onFocus?: () => void
+  onBlur?: () => void
+  ariaDescribedby?: string
+  children?: Child
+}
+
+export function TooltipTrigger({
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
+  ariaDescribedby,
+  children,
+}: TooltipTriggerProps) {
+  return (
+    <span
+      class="inline-block"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      aria-describedby={ariaDescribedby}
+      data-tooltip-trigger
+    >
+      {children}
+    </span>
+  )
+}
+
+// --- TooltipContent ---
+
+export interface TooltipContentProps {
+  open?: boolean
+  id?: string
+  children?: Child
+}
+
+// Tooltip positioned at top (default)
+export function TooltipContent({
+  open = false,
+  id,
+  children,
+}: TooltipContentProps) {
+  return (
+    <div
+      class={`absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 ${open ? '' : 'hidden'}`}
+      role="tooltip"
+      id={id}
+      data-tooltip-content
+      data-tooltip-open={open ? 'true' : 'false'}
+    >
+      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
+        {children}
+      </div>
+      <span
+        class="absolute w-0 h-0 border-4 top-full left-1/2 -translate-x-1/2 border-t-zinc-900 border-l-transparent border-r-transparent border-b-transparent"
+        aria-hidden="true"
+      />
+    </div>
+  )
+}
+
+// Tooltip positioned at right
+export function TooltipContentRight({
+  open = false,
+  id,
+  children,
+}: TooltipContentProps) {
+  return (
+    <div
+      class={`absolute z-50 left-full top-1/2 -translate-y-1/2 ml-2 ${open ? '' : 'hidden'}`}
+      role="tooltip"
+      id={id}
+      data-tooltip-content
+      data-tooltip-open={open ? 'true' : 'false'}
+    >
+      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
+        {children}
+      </div>
+      <span
+        class="absolute w-0 h-0 border-4 right-full top-1/2 -translate-y-1/2 border-r-zinc-900 border-t-transparent border-b-transparent border-l-transparent"
+        aria-hidden="true"
+      />
+    </div>
+  )
+}
+
+// Tooltip positioned at bottom
+export function TooltipContentBottom({
+  open = false,
+  id,
+  children,
+}: TooltipContentProps) {
+  return (
+    <div
+      class={`absolute z-50 top-full left-1/2 -translate-x-1/2 mt-2 ${open ? '' : 'hidden'}`}
+      role="tooltip"
+      id={id}
+      data-tooltip-content
+      data-tooltip-open={open ? 'true' : 'false'}
+    >
+      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
+        {children}
+      </div>
+      <span
+        class="absolute w-0 h-0 border-4 bottom-full left-1/2 -translate-x-1/2 border-b-zinc-900 border-l-transparent border-r-transparent border-t-transparent"
+        aria-hidden="true"
+      />
+    </div>
+  )
+}
+
+// Tooltip positioned at left
+export function TooltipContentLeft({
+  open = false,
+  id,
+  children,
+}: TooltipContentProps) {
+  return (
+    <div
+      class={`absolute z-50 right-full top-1/2 -translate-y-1/2 mr-2 ${open ? '' : 'hidden'}`}
+      role="tooltip"
+      id={id}
+      data-tooltip-content
+      data-tooltip-open={open ? 'true' : 'false'}
+    >
+      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
+        {children}
+      </div>
+      <span
+        class="absolute w-0 h-0 border-4 left-full top-1/2 -translate-y-1/2 border-l-zinc-900 border-t-transparent border-b-transparent border-r-transparent"
+        aria-hidden="true"
+      />
+    </div>
+  )
+}

--- a/ui/components/TooltipDemo.tsx
+++ b/ui/components/TooltipDemo.tsx
@@ -1,0 +1,177 @@
+"use client"
+/**
+ * TooltipDemo Components
+ *
+ * Interactive demos for Tooltip component.
+ * Used in tooltip documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  TooltipTrigger,
+  TooltipContent,
+  TooltipContentRight,
+  TooltipContentBottom,
+  TooltipContentLeft,
+} from './Tooltip'
+
+/**
+ * Basic tooltip demo
+ */
+export function TooltipBasicDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="tooltip-basic"
+      >
+        <span class="underline decoration-dotted cursor-help">
+          Hover me
+        </span>
+      </TooltipTrigger>
+      <TooltipContent open={open()} id="tooltip-basic">
+        This is a tooltip
+      </TooltipContent>
+    </div>
+  )
+}
+
+/**
+ * Tooltip with button (focus support)
+ */
+export function TooltipButtonDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        ariaDescribedby="tooltip-button"
+      >
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 bg-zinc-900 text-zinc-50 hover:bg-zinc-900/90 h-10 px-4 py-2"
+        >
+          Hover or Focus
+        </button>
+      </TooltipTrigger>
+      <TooltipContent open={open()} id="tooltip-button">
+        Keyboard accessible tooltip
+      </TooltipContent>
+    </div>
+  )
+}
+
+/**
+ * Tooltip placement demo - Top
+ */
+export function TooltipTopDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="tooltip-top"
+      >
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium border border-zinc-200 bg-white hover:bg-zinc-100 h-10 px-4 py-2"
+        >
+          Top
+        </button>
+      </TooltipTrigger>
+      <TooltipContent open={open()} id="tooltip-top">
+        Top placement
+      </TooltipContent>
+    </div>
+  )
+}
+
+/**
+ * Tooltip placement demo - Right
+ */
+export function TooltipRightDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="tooltip-right"
+      >
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium border border-zinc-200 bg-white hover:bg-zinc-100 h-10 px-4 py-2"
+        >
+          Right
+        </button>
+      </TooltipTrigger>
+      <TooltipContentRight open={open()} id="tooltip-right">
+        Right placement
+      </TooltipContentRight>
+    </div>
+  )
+}
+
+/**
+ * Tooltip placement demo - Bottom
+ */
+export function TooltipBottomDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="tooltip-bottom"
+      >
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium border border-zinc-200 bg-white hover:bg-zinc-100 h-10 px-4 py-2"
+        >
+          Bottom
+        </button>
+      </TooltipTrigger>
+      <TooltipContentBottom open={open()} id="tooltip-bottom">
+        Bottom placement
+      </TooltipContentBottom>
+    </div>
+  )
+}
+
+/**
+ * Tooltip placement demo - Left
+ */
+export function TooltipLeftDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="tooltip-left"
+      >
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium border border-zinc-200 bg-white hover:bg-zinc-100 h-10 px-4 py-2"
+        >
+          Left
+        </button>
+      </TooltipTrigger>
+      <TooltipContentLeft open={open()} id="tooltip-left">
+        Left placement
+      </TooltipContentLeft>
+    </div>
+  )
+}

--- a/ui/e2e/tooltip.spec.ts
+++ b/ui/e2e/tooltip.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Tooltip Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/tooltip')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Tooltip')
+    await expect(page.locator('text=A popup that displays contextual information')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('text=bunx barefoot add tooltip')).toBeVisible()
+  })
+
+  test('displays usage section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Usage")')).toBeVisible()
+  })
+
+  test('displays features section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Hover trigger")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Focus trigger")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Placement options")')).toBeVisible()
+  })
+
+  test.describe('Basic Tooltip', () => {
+    test('shows tooltip on hover', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope="TooltipBasicDemo"]').first()
+      const trigger = basicDemo.locator('[data-tooltip-trigger]')
+      const tooltip = basicDemo.locator('[role="tooltip"]')
+
+      // Initially hidden
+      await expect(tooltip).not.toBeVisible()
+
+      // Hover to show
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('This is a tooltip')
+    })
+
+    test('hides tooltip on mouse leave', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope="TooltipBasicDemo"]').first()
+      const trigger = basicDemo.locator('[data-tooltip-trigger]')
+      const tooltip = basicDemo.locator('[role="tooltip"]')
+
+      // Hover to show
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+
+      // Move mouse away to hide
+      await page.mouse.move(0, 0)
+      await expect(tooltip).not.toBeVisible()
+    })
+
+    test('has correct accessibility attributes', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope="TooltipBasicDemo"]').first()
+      const trigger = basicDemo.locator('[data-tooltip-trigger]')
+      const tooltip = basicDemo.locator('[role="tooltip"]')
+
+      // Check aria-describedby
+      await expect(trigger).toHaveAttribute('aria-describedby', 'tooltip-basic')
+
+      // Check tooltip has correct id
+      await expect(tooltip).toHaveAttribute('id', 'tooltip-basic')
+    })
+  })
+
+  test.describe('Button with Hover Support', () => {
+    test('shows tooltip on hover', async ({ page }) => {
+      const buttonDemo = page.locator('[data-bf-scope="TooltipButtonDemo"]').first()
+      const trigger = buttonDemo.locator('[data-tooltip-trigger]')
+      const tooltip = buttonDemo.locator('[role="tooltip"]')
+
+      // Initially hidden
+      await expect(tooltip).not.toBeVisible()
+
+      // Hover to show
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('Keyboard accessible tooltip')
+    })
+
+    test('hides tooltip on mouse leave', async ({ page }) => {
+      const buttonDemo = page.locator('[data-bf-scope="TooltipButtonDemo"]').first()
+      const trigger = buttonDemo.locator('[data-tooltip-trigger]')
+      const tooltip = buttonDemo.locator('[role="tooltip"]')
+
+      // Hover to show
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+
+      // Move mouse away to hide
+      await page.mouse.move(0, 0)
+      await expect(tooltip).not.toBeVisible()
+    })
+  })
+
+  test.describe('Placement Options', () => {
+    test('top placement shows tooltip above trigger', async ({ page }) => {
+      const topDemo = page.locator('[data-bf-scope="TooltipTopDemo"]').first()
+      const trigger = topDemo.locator('[data-tooltip-trigger]')
+      const tooltip = topDemo.locator('[role="tooltip"]')
+
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('Top placement')
+    })
+
+    test('right placement shows tooltip to the right', async ({ page }) => {
+      const rightDemo = page.locator('[data-bf-scope="TooltipRightDemo"]').first()
+      const trigger = rightDemo.locator('[data-tooltip-trigger]')
+      const tooltip = rightDemo.locator('[role="tooltip"]')
+
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('Right placement')
+    })
+
+    test('bottom placement shows tooltip below trigger', async ({ page }) => {
+      const bottomDemo = page.locator('[data-bf-scope="TooltipBottomDemo"]').first()
+      const trigger = bottomDemo.locator('[data-tooltip-trigger]')
+      const tooltip = bottomDemo.locator('[role="tooltip"]')
+
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('Bottom placement')
+    })
+
+    test('left placement shows tooltip to the left', async ({ page }) => {
+      const leftDemo = page.locator('[data-bf-scope="TooltipLeftDemo"]').first()
+      const trigger = leftDemo.locator('[data-tooltip-trigger]')
+      const tooltip = leftDemo.locator('[role="tooltip"]')
+
+      await trigger.hover()
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toContainText('Left placement')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays TooltipTrigger props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("TooltipTrigger")')).toBeVisible()
+    })
+
+    test('displays TooltipContent props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("TooltipContent")')).toBeVisible()
+    })
+  })
+})
+
+test.describe('Home Page - Tooltip Link', () => {
+  test('displays Tooltip component link', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('a[href="/components/tooltip"]')).toBeVisible()
+    await expect(page.locator('a[href="/components/tooltip"] h2')).toContainText('Tooltip')
+  })
+
+  test('navigates to Tooltip page on click', async ({ page }) => {
+    await page.goto('/')
+    await page.click('a[href="/components/tooltip"]')
+    await expect(page).toHaveURL('/components/tooltip')
+    await expect(page.locator('h1')).toContainText('Tooltip')
+  })
+})

--- a/ui/pages/tooltip.tsx
+++ b/ui/pages/tooltip.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tooltip Documentation Page
+ */
+
+import {
+  TooltipBasicDemo,
+  TooltipButtonDemo,
+  TooltipTopDemo,
+  TooltipRightDemo,
+  TooltipBottomDemo,
+  TooltipLeftDemo,
+} from '@/components/TooltipDemo'
+import {
+  PageHeader,
+  Section,
+  Example,
+  CodeBlock,
+  PropsTable,
+  type PropDefinition,
+} from '../_shared/docs'
+
+// Code examples
+const installCode = `bunx barefoot add tooltip`
+
+const usageCode = `import { createSignal } from '@barefootjs/dom'
+import { TooltipTrigger, TooltipContent } from '@/components/tooltip'
+
+export default function Page() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div class="relative inline-block">
+      <TooltipTrigger
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        ariaDescribedby="my-tooltip"
+      >
+        <span>Hover me</span>
+      </TooltipTrigger>
+      <TooltipContent open={open()} id="my-tooltip">
+        Tooltip content
+      </TooltipContent>
+    </div>
+  )
+}`
+
+const basicCode = `const [open, setOpen] = createSignal(false)
+
+<div class="relative inline-block">
+  <TooltipTrigger
+    onMouseEnter={() => setOpen(true)}
+    onMouseLeave={() => setOpen(false)}
+    ariaDescribedby="tooltip-basic"
+  >
+    <span class="underline decoration-dotted cursor-help">
+      Hover me
+    </span>
+  </TooltipTrigger>
+  <TooltipContent open={open()} id="tooltip-basic">
+    This is a tooltip
+  </TooltipContent>
+</div>`
+
+const buttonCode = `const [open, setOpen] = createSignal(false)
+
+<div class="relative inline-block">
+  <TooltipTrigger
+    onMouseEnter={() => setOpen(true)}
+    onMouseLeave={() => setOpen(false)}
+    onFocus={() => setOpen(true)}
+    onBlur={() => setOpen(false)}
+    ariaDescribedby="tooltip-button"
+  >
+    <button type="button" class="...">
+      Hover or Focus
+    </button>
+  </TooltipTrigger>
+  <TooltipContent open={open()} id="tooltip-button">
+    Keyboard accessible tooltip
+  </TooltipContent>
+</div>`
+
+const placementCode = `import {
+  TooltipContent,        // Top (default)
+  TooltipContentRight,   // Right
+  TooltipContentBottom,  // Bottom
+  TooltipContentLeft,    // Left
+} from '@/components/tooltip'
+
+// Top placement (default)
+<TooltipContent open={open()}>...</TooltipContent>
+
+// Right placement
+<TooltipContentRight open={open()}>...</TooltipContentRight>
+
+// Bottom placement
+<TooltipContentBottom open={open()}>...</TooltipContentBottom>
+
+// Left placement
+<TooltipContentLeft open={open()}>...</TooltipContentLeft>`
+
+// Props definitions
+const tooltipTriggerProps: PropDefinition[] = [
+  {
+    name: 'onMouseEnter',
+    type: '() => void',
+    description: 'Event handler called when mouse enters the trigger.',
+  },
+  {
+    name: 'onMouseLeave',
+    type: '() => void',
+    description: 'Event handler called when mouse leaves the trigger.',
+  },
+  {
+    name: 'onFocus',
+    type: '() => void',
+    description: 'Event handler called when the trigger receives focus.',
+  },
+  {
+    name: 'onBlur',
+    type: '() => void',
+    description: 'Event handler called when the trigger loses focus.',
+  },
+  {
+    name: 'ariaDescribedby',
+    type: 'string',
+    description: 'ID of the tooltip element for accessibility.',
+  },
+]
+
+const tooltipContentProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the tooltip is visible.',
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID for aria-describedby reference.',
+  },
+]
+
+export function TooltipPage() {
+  return (
+    <div class="space-y-12">
+      <PageHeader
+        title="Tooltip"
+        description="A popup that displays contextual information on hover or focus."
+      />
+
+      {/* Preview */}
+      <Example title="" code={`<TooltipContent open={open()}>...</TooltipContent>`}>
+        <div class="flex gap-4">
+          <TooltipBasicDemo />
+        </div>
+      </Example>
+
+      {/* Installation */}
+      <Section title="Installation">
+        <CodeBlock code={installCode} lang="bash" />
+      </Section>
+
+      {/* Usage */}
+      <Section title="Usage">
+        <CodeBlock code={usageCode} />
+      </Section>
+
+      {/* Features */}
+      <Section title="Features">
+        <ul class="list-disc list-inside space-y-2 text-zinc-400">
+          <li><strong class="text-zinc-200">Hover trigger</strong> - Shows tooltip on mouse enter, hides on mouse leave</li>
+          <li><strong class="text-zinc-200">Focus trigger</strong> - Shows tooltip on focus for keyboard accessibility</li>
+          <li><strong class="text-zinc-200">Placement options</strong> - Top, right, bottom, or left positioning</li>
+          <li><strong class="text-zinc-200">Arrow indicator</strong> - Visual arrow pointing to the trigger</li>
+          <li><strong class="text-zinc-200">Accessibility</strong> - role="tooltip", aria-describedby for screen readers</li>
+        </ul>
+      </Section>
+
+      {/* Examples */}
+      <Section title="Examples">
+        <div class="space-y-8">
+          <Example title="Basic Tooltip" code={basicCode}>
+            <TooltipBasicDemo />
+          </Example>
+
+          <Example title="Button with Focus Support" code={buttonCode}>
+            <TooltipButtonDemo />
+          </Example>
+
+          <Example title="Placement Options" code={placementCode}>
+            <div class="flex flex-wrap gap-4 py-4">
+              <TooltipTopDemo />
+              <TooltipRightDemo />
+              <TooltipBottomDemo />
+              <TooltipLeftDemo />
+            </div>
+          </Example>
+        </div>
+      </Section>
+
+      {/* API Reference */}
+      <Section title="API Reference">
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-medium text-zinc-100 mb-4">TooltipTrigger</h3>
+            <PropsTable props={tooltipTriggerProps} />
+          </div>
+          <div>
+            <h3 class="text-lg font-medium text-zinc-100 mb-4">TooltipContent / TooltipContentRight / TooltipContentBottom / TooltipContentLeft</h3>
+            <p class="text-zinc-400 text-sm mb-4">
+              Use TooltipContent for top placement (default), or use the directional variants for other placements.
+            </p>
+            <PropsTable props={tooltipContentProps} />
+          </div>
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/ui/server.tsx
+++ b/ui/server.tsx
@@ -19,6 +19,7 @@ import { CounterPage } from './pages/counter'
 import { AccordionPage } from './pages/accordion'
 import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
+import { TooltipPage } from './pages/tooltip'
 
 const app = new Hono()
 
@@ -131,6 +132,15 @@ app.get('/', (c) => {
             A modal dialog that displays content in a layer above the page.
           </p>
         </a>
+        <a
+          href="/components/tooltip"
+          class="block p-4 border border-zinc-800 rounded-lg hover:border-zinc-600 hover:bg-zinc-900 transition-colors"
+        >
+          <h2 class="font-semibold text-zinc-100">Tooltip</h2>
+          <p class="text-sm text-zinc-400 mt-1">
+            A popup that displays contextual information on hover or focus.
+          </p>
+        </a>
       </div>
     </div>
   )
@@ -184,6 +194,11 @@ app.get('/components/tabs', (c) => {
 // Dialog documentation
 app.get('/components/dialog', (c) => {
   return c.render(<DialogPage />)
+})
+
+// Tooltip documentation
+app.get('/components/tooltip', (c) => {
+  return c.render(<TooltipPage />)
 })
 
 export default { port: 3002, fetch: app.fetch }


### PR DESCRIPTION
## Summary
- Add Tooltip component with TooltipTrigger and TooltipContent
- Support 4 placement options (top/right/bottom/left) via separate components
- Include documentation page with examples and E2E tests

## Test plan
- [x] Unit build passes
- [x] E2E tests pass (18 tests)
- [x] Documentation page renders correctly
- [x] Hover triggers tooltip display
- [x] Placement variants position correctly

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)