### PR TITLE
Refactor TooltipContent to use dynamic placement prop

### DIFF
--- a/ui/components/Tooltip.tsx
+++ b/ui/components/Tooltip.tsx
@@ -58,96 +58,43 @@ export function TooltipTrigger({
 
 // --- TooltipContent ---
 
+export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left'
+
 export interface TooltipContentProps {
+  placement?: TooltipPlacement
   open?: boolean
   id?: string
   children?: Child
 }
 
-// Tooltip positioned at top (default)
 export function TooltipContent({
+  placement = 'top',
   open = false,
   id,
   children,
 }: TooltipContentProps) {
-  return (
-    <div
-      class={`absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 ${open ? '' : 'hidden'}`}
-      role="tooltip"
-      id={id}
-      data-tooltip-content
-      data-tooltip-open={open ? 'true' : 'false'}
-    >
-      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
-        {children}
-      </div>
-      <span
-        class="absolute w-0 h-0 border-4 top-full left-1/2 -translate-x-1/2 border-t-zinc-900 border-l-transparent border-r-transparent border-b-transparent"
-        aria-hidden="true"
-      />
-    </div>
-  )
-}
+  // Placement CSS classes for tooltip container position
+  const placementClasses: Record<TooltipPlacement, string> = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+  }
 
-// Tooltip positioned at right
-export function TooltipContentRight({
-  open = false,
-  id,
-  children,
-}: TooltipContentProps) {
-  return (
-    <div
-      class={`absolute z-50 left-full top-1/2 -translate-y-1/2 ml-2 ${open ? '' : 'hidden'}`}
-      role="tooltip"
-      id={id}
-      data-tooltip-content
-      data-tooltip-open={open ? 'true' : 'false'}
-    >
-      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
-        {children}
-      </div>
-      <span
-        class="absolute w-0 h-0 border-4 right-full top-1/2 -translate-y-1/2 border-r-zinc-900 border-t-transparent border-b-transparent border-l-transparent"
-        aria-hidden="true"
-      />
-    </div>
-  )
-}
+  // Arrow CSS classes based on placement
+  const arrowClasses: Record<TooltipPlacement, string> = {
+    top: 'top-full left-1/2 -translate-x-1/2 border-t-zinc-900 border-l-transparent border-r-transparent border-b-transparent',
+    right: 'right-full top-1/2 -translate-y-1/2 border-r-zinc-900 border-t-transparent border-b-transparent border-l-transparent',
+    bottom: 'bottom-full left-1/2 -translate-x-1/2 border-b-zinc-900 border-l-transparent border-r-transparent border-t-transparent',
+    left: 'left-full top-1/2 -translate-y-1/2 border-l-zinc-900 border-t-transparent border-b-transparent border-r-transparent',
+  }
 
-// Tooltip positioned at bottom
-export function TooltipContentBottom({
-  open = false,
-  id,
-  children,
-}: TooltipContentProps) {
-  return (
-    <div
-      class={`absolute z-50 top-full left-1/2 -translate-x-1/2 mt-2 ${open ? '' : 'hidden'}`}
-      role="tooltip"
-      id={id}
-      data-tooltip-content
-      data-tooltip-open={open ? 'true' : 'false'}
-    >
-      <div class="bg-zinc-900 text-zinc-50 text-sm px-3 py-1.5 rounded-md shadow-md whitespace-nowrap">
-        {children}
-      </div>
-      <span
-        class="absolute w-0 h-0 border-4 bottom-full left-1/2 -translate-x-1/2 border-b-zinc-900 border-l-transparent border-r-transparent border-t-transparent"
-        aria-hidden="true"
-      />
-    </div>
-  )
-}
+  const placementClass = placementClasses[placement]
+  const arrowClass = arrowClasses[placement]
 
-// Tooltip positioned at left
-export function TooltipContentLeft({
-  open = false,
-  id,
-  children,
-}: TooltipContentProps) {
   return (
     <div
-      class={`absolute z-50 right-full top-1/2 -translate-y-1/2 mr-2 ${open ? '' : 'hidden'}`}
+      class={`absolute z-50 ${placementClass} ${open ? '' : 'hidden'}`}
       role="tooltip"
       id={id}
       data-tooltip-content
@@ -157,7 +104,7 @@ export function TooltipContentLeft({
         {children}
       </div>
       <span
-        class="absolute w-0 h-0 border-4 left-full top-1/2 -translate-y-1/2 border-l-zinc-900 border-t-transparent border-b-transparent border-r-transparent"
+        class={`absolute w-0 h-0 border-4 ${arrowClass}`}
         aria-hidden="true"
       />
     </div>

--- a/ui/components/TooltipDemo.tsx
+++ b/ui/components/TooltipDemo.tsx
@@ -7,13 +7,7 @@
  */
 
 import { createSignal } from '@barefootjs/dom'
-import {
-  TooltipTrigger,
-  TooltipContent,
-  TooltipContentRight,
-  TooltipContentBottom,
-  TooltipContentLeft,
-} from './Tooltip'
+import { TooltipTrigger, TooltipContent } from './Tooltip'
 
 /**
  * Basic tooltip demo
@@ -115,9 +109,9 @@ export function TooltipRightDemo() {
           Right
         </button>
       </TooltipTrigger>
-      <TooltipContentRight open={open()} id="tooltip-right">
+      <TooltipContent placement="right" open={open()} id="tooltip-right">
         Right placement
-      </TooltipContentRight>
+      </TooltipContent>
     </div>
   )
 }
@@ -142,9 +136,9 @@ export function TooltipBottomDemo() {
           Bottom
         </button>
       </TooltipTrigger>
-      <TooltipContentBottom open={open()} id="tooltip-bottom">
+      <TooltipContent placement="bottom" open={open()} id="tooltip-bottom">
         Bottom placement
-      </TooltipContentBottom>
+      </TooltipContent>
     </div>
   )
 }
@@ -169,9 +163,9 @@ export function TooltipLeftDemo() {
           Left
         </button>
       </TooltipTrigger>
-      <TooltipContentLeft open={open()} id="tooltip-left">
+      <TooltipContent placement="left" open={open()} id="tooltip-left">
         Left placement
-      </TooltipContentLeft>
+      </TooltipContent>
     </div>
   )
 }

--- a/ui/pages/tooltip.tsx
+++ b/ui/pages/tooltip.tsx
@@ -80,24 +80,19 @@ const buttonCode = `const [open, setOpen] = createSignal(false)
   </TooltipContent>
 </div>`
 
-const placementCode = `import {
-  TooltipContent,        // Top (default)
-  TooltipContentRight,   // Right
-  TooltipContentBottom,  // Bottom
-  TooltipContentLeft,    // Left
-} from '@/components/tooltip'
+const placementCode = `import { TooltipContent } from '@/components/tooltip'
 
 // Top placement (default)
 <TooltipContent open={open()}>...</TooltipContent>
 
 // Right placement
-<TooltipContentRight open={open()}>...</TooltipContentRight>
+<TooltipContent placement="right" open={open()}>...</TooltipContent>
 
 // Bottom placement
-<TooltipContentBottom open={open()}>...</TooltipContentBottom>
+<TooltipContent placement="bottom" open={open()}>...</TooltipContent>
 
 // Left placement
-<TooltipContentLeft open={open()}>...</TooltipContentLeft>`
+<TooltipContent placement="left" open={open()}>...</TooltipContent>`
 
 // Props definitions
 const tooltipTriggerProps: PropDefinition[] = [
@@ -129,6 +124,12 @@ const tooltipTriggerProps: PropDefinition[] = [
 ]
 
 const tooltipContentProps: PropDefinition[] = [
+  {
+    name: 'placement',
+    type: "'top' | 'right' | 'bottom' | 'left'",
+    defaultValue: "'top'",
+    description: 'Position of the tooltip relative to the trigger.',
+  },
   {
     name: 'open',
     type: 'boolean',
@@ -208,9 +209,9 @@ export function TooltipPage() {
             <PropsTable props={tooltipTriggerProps} />
           </div>
           <div>
-            <h3 class="text-lg font-medium text-zinc-100 mb-4">TooltipContent / TooltipContentRight / TooltipContentBottom / TooltipContentLeft</h3>
+            <h3 class="text-lg font-medium text-zinc-100 mb-4">TooltipContent</h3>
             <p class="text-zinc-400 text-sm mb-4">
-              Use TooltipContent for top placement (default), or use the directional variants for other placements.
+              The tooltip popup. Use the placement prop to control positioning.
             </p>
             <PropsTable props={tooltipContentProps} />
           </div>


### PR DESCRIPTION
## Summary

- Replace 4 separate components with a single `TooltipContent` component
- Add `placement` prop (`'top' | 'right' | 'bottom' | 'left'`, default: `'top'`)
- Simplify API from 4 components to 1
- Reduce code duplication (99 lines removed, 41 added)

### Before
```tsx
import { 
  TooltipContent, 
  TooltipContentRight, 
  TooltipContentBottom, 
  TooltipContentLeft 
} from './Tooltip'

<TooltipContent open={open()}>Top</TooltipContent>
<TooltipContentRight open={open()}>Right</TooltipContentRight>
```

### After
```tsx
import { TooltipContent } from './Tooltip'

<TooltipContent open={open()}>Top</TooltipContent>
<TooltipContent placement="right" open={open()}>Right</TooltipContent>
```

## Test plan

- [x] All 18 tooltip E2E tests pass
- [x] Manual verification of all placement options

## Notes

- Dialog component does not need refactoring (no placement variants exist)
- Uses inline lookup objects instead of external helper functions due to BarefootJS compiler limitations

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)