### PR TITLE
Fix whitespace preservation between JSX elements

### DIFF
--- a/packages/jsx/src/transformers/jsx-to-ir.ts
+++ b/packages/jsx/src/transformers/jsx-to-ir.ts
@@ -49,7 +49,8 @@ export function jsxToIR(node: ts.Node, ctx: JsxToIRContext): IRNode | null {
     // 3. Leading/trailing newlines with their indentation are trimmed
     // 4. Internal newlines are converted to single space
     // 5. Adjacent whitespace is preserved (e.g., "text: " keeps trailing space)
-    const rawText = node.getText(ctx.sourceFile)
+    // Note: node.text preserves leading/trailing whitespace, unlike getText()
+    const rawText = node.text
 
     // If text is only whitespace
     if (/^\s*$/.test(rawText)) {


### PR DESCRIPTION
## Summary

- Fixed issue where whitespace between inline JSX elements was being removed during compilation
- The root cause was using TypeScript's `node.getText()` which doesn't include leading/trailing whitespace for JsxText nodes
- Changed to use `node.text` property which preserves the original whitespace

## Example

Before fix:
```jsx
<span>{count()}</span> remaining
// Generated: <span>100</span>remaining (missing space!)
```

After fix:
```jsx
<span>{count()}</span> remaining
// Generated: <span>100</span> remaining (space preserved)
```

## Changes

- `jsx-to-ir.ts`: Use `node.text` instead of `node.getText()` for JsxText nodes
- `template-generator.ts`: Use `node.text` with `normalizeJsxText()` helper function
- `edge-cases.test.ts`: Added test cases for whitespace preservation

## Test plan

- [x] All 419 unit tests pass
- [x] All 48 E2E tests pass
- [x] New test cases specifically verify whitespace preservation:
  - Whitespace after closing element (`</span> remaining`)
  - Whitespace in list templates (`</span> items left`)
  - Whitespace before elements (`Item: <span>`)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)