### PR TITLE
Fix DOM traversal when conditionals are between sibling elements

### DIFF
--- a/packages/jsx/src/utils/element-paths.ts
+++ b/packages/jsx/src/utils/element-paths.ts
@@ -80,8 +80,8 @@ function calculateFragmentPaths(fragment: IRFragment, paths: ElementPath[]): voi
       siblingIndex++
     } else if (child.type === 'conditional') {
       // Conditional at fragment level
+      // Don't increment siblingIndex - conditionals render as comments, not elements
       processConditional(child, siblingIndex === 0 ? '' : buildSiblingPath(siblingIndex), paths)
-      siblingIndex++
     }
     // Skip text and expression nodes (they don't affect element position)
   }
@@ -114,9 +114,9 @@ function processChildren(children: IRNode[], basePath: string, paths: ElementPat
       processChildren(child.children, childPath ?? buildChildPath(basePath, elementIndex), paths)
       elementIndex++
     } else if (child.type === 'conditional') {
+      // Don't increment elementIndex - conditionals render as comments, not elements
       const childPath = hasComponentBefore ? null : buildChildPath(basePath, elementIndex)
       processConditional(child, childPath, paths, hasComponentBefore)
-      elementIndex++
     } else if (child.type === 'fragment') {
       // Nested fragment: process its children as if they were direct children
       for (const fragChild of child.children) {


### PR DESCRIPTION
## Summary

- Fixed incorrect DOM traversal path calculation when conditional renders exist between sibling elements
- Conditionals (`{condition && <element>}`) render as HTML comments, not DOM elements, so they should not affect sibling indices
- Removed `siblingIndex++` and `elementIndex++` increments for conditionals in `element-paths.ts`

Closes #82

## Test plan

- [x] Unit tests added for conditionals between siblings (fragment and children cases)
- [x] All 422 JSX package unit tests pass
- [x] All 48 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)