### PR TITLE
Remove backward compatibility code for cleaner architecture

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -10,6 +10,3 @@ export type { MarkedJsxAdapter } from './types'
 // BfScripts is exported from a separate entry point to avoid JSX runtime issues in tests
 // Usage: import { BfScripts } from '@barefoot/hono/scripts'
 export type { CollectedScript, CollectedPropsScript } from './scripts'
-
-// Legacy alias for backwards compatibility
-export { honoMarkedJsxAdapter as honoServerAdapter } from './server-adapter'

--- a/packages/jsx/__tests__/adapters/hono-integration.test.ts
+++ b/packages/jsx/__tests__/adapters/hono-integration.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'bun:test'
 import { compileJSX, type CompileJSXResult } from '../../src'
-import { honoServerAdapter } from '@barefootjs/hono'
+import { honoMarkedJsxAdapter } from '@barefootjs/hono'
 
 async function compile(source: string): Promise<CompileJSXResult> {
   const files: Record<string, string> = {
@@ -16,7 +16,7 @@ async function compile(source: string): Promise<CompileJSXResult> {
   return compileJSX('/test/Component.tsx', async (path) => {
     if (files[path]) return files[path]
     throw new Error(`File not found: ${path}`)
-  }, { markedJsxAdapter: honoServerAdapter })
+  }, { markedJsxAdapter: honoMarkedJsxAdapter })
 }
 
 async function compileWithFiles(
@@ -26,7 +26,7 @@ async function compileWithFiles(
   return compileJSX(entryPath, async (path) => {
     if (files[path]) return files[path]
     throw new Error(`File not found: ${path}`)
-  }, { markedJsxAdapter: honoServerAdapter })
+  }, { markedJsxAdapter: honoMarkedJsxAdapter })
 }
 
 describe('Hono Adapter Integration', () => {

--- a/packages/jsx/src/adapters/testing.ts
+++ b/packages/jsx/src/adapters/testing.ts
@@ -90,9 +90,6 @@ export const testJsxAdapter: MarkedJsxAdapter = {
   },
 }
 
-// Legacy alias for backwards compatibility
-export const testMarkedJsxAdapter = testJsxAdapter
-
 /**
  * Test adapter that generates static HTML with initial values evaluated.
  *

--- a/packages/jsx/src/transformers/jsx-to-ir.ts
+++ b/packages/jsx/src/transformers/jsx-to-ir.ts
@@ -23,9 +23,6 @@ import type {
 import { isPascalCase } from '../utils/helpers'
 import { jsxToTemplateString } from '../compiler/template-generator'
 
-// Re-export types for backwards compatibility
-export type { JsxToIRContext, CompilerWarning }
-
 /**
  * Converts JSX AST node to IR
  */
@@ -758,16 +755,6 @@ function irNodeContainsReactiveCall(node: IRNode, signals: SignalDeclaration[], 
              irNodeContainsReactiveCall(node.whenTrue, signals, memos, valueProps) ||
              irNodeContainsReactiveCall(node.whenFalse, signals, memos, valueProps)
   }
-}
-
-/**
- * Checks if expression contains signal calls (legacy - for backwards compatibility)
- */
-function containsSignalCall(expr: string, signals: SignalDeclaration[]): boolean {
-  return signals.some(s => {
-    const regex = new RegExp(`\\b${s.getter}\\s*\\(`)
-    return regex.test(expr)
-  })
 }
 
 /**

--- a/packages/jsx/src/utils/id-generator.ts
+++ b/packages/jsx/src/utils/id-generator.ts
@@ -29,23 +29,4 @@ export class IdGenerator {
   getCurrentCount(): number {
     return this.slotCounter
   }
-
-  // Legacy methods for backwards compatibility during migration
-  // TODO: Remove after full migration to slot registry pattern
-
-  generateButtonId(): string {
-    return this.generateSlotId()
-  }
-
-  generateDynamicId(): string {
-    return this.generateSlotId()
-  }
-
-  generateListId(): string {
-    return this.generateSlotId()
-  }
-
-  generateAttrId(): string {
-    return this.generateSlotId()
-  }
 }


### PR DESCRIPTION
## Summary

This PR removes legacy backward compatibility code that adds unnecessary complexity to the codebase. Since we're in a phase where we prioritize simple and correct design over backward compatibility, these cleanups help maintain a cleaner architecture.

### Changes

- **Phase 1: Legacy Aliases**
  - Remove `testMarkedJsxAdapter` alias (use `testJsxAdapter` directly)
  - Remove `honoServerAdapter` alias (use `honoMarkedJsxAdapter` directly)
  - Update test file to use new name

- **Phase 2: Legacy ID Generation Methods**
  - Remove `generateButtonId`, `generateDynamicId`, `generateListId`, `generateAttrId` methods
  - These were already unused wrapper functions that just called `generateSlotId()`

- **Phase 3: Type Re-exports**
  - Remove re-exports from `jsx-to-ir.ts` and `ir-to-marked-jsx.ts`
  - Types are already exported from `types.ts`

- **Phase 5: Legacy Wrapper Functions**
  - Remove unused `elementToMarkedJsx` wrapper function
  - Remove unused `nodeToJsxExpressionValue` wrapper function
  - Inline `replaceSignalCallsWithProps` to use `replaceSignalAndMemoCalls` directly
  - Remove unused `containsSignalCall` function

### Skipped Items

The following items from Issue #88 were **not removed** after investigation:

- **Phase 4: `generateMarkedJsxComponent`** - While marked as `@deprecated`, this method is actively used in the server adapter implementation and multiple test files. Removing it would require a larger migration to `generateMarkedJsxFile`.

- **Phase 6: Fallback code** - The "fallback to template string" is a legitimate conditional branch, not dead code. The `irNodeToHtml` function is actively used and the comment refers to its approach, not its necessity.

## Test plan

- [x] All unit tests pass (`bun test packages/jsx` - 423 tests)
- [x] Packages rebuild successfully
- [x] All E2E tests pass (48 tests)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)