### PR TITLE
Add Form Submit handling pattern documentation

### DIFF
--- a/ui/components/SubmitDemo.tsx
+++ b/ui/components/SubmitDemo.tsx
@@ -1,0 +1,269 @@
+"use client"
+/**
+ * SubmitDemo Components
+ *
+ * Interactive demos for form submit handling patterns.
+ * Demonstrates async state management with loading, success, and error states.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Input } from './Input'
+import { Button } from './Button'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+} from './Toast'
+
+/**
+ * Basic submit demo - shows loading state and success feedback
+ */
+export function BasicSubmitDemo() {
+  const [email, setEmail] = createSignal('')
+  const [touched, setTouched] = createSignal(false)
+  const [loading, setLoading] = createSignal(false)
+  const [success, setSuccess] = createSignal(false)
+
+  const error = createMemo(() => {
+    if (!touched()) return ''
+    if (email().trim() === '') return 'Email is required'
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email())) return 'Invalid email format'
+    return ''
+  })
+
+  const isValid = createMemo(() => error() === '' && email().trim() !== '')
+
+  const handleSubmit = async () => {
+    if (!isValid() || loading()) return
+
+    setLoading(true)
+
+    // Simulate API call
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    setLoading(false)
+    setSuccess(true)
+    setEmail('')
+    setTouched(false)
+
+    // Auto-hide success toast
+    setTimeout(() => setSuccess(false), 3000)
+  }
+
+  return (
+    <div class="space-y-4">
+      <div class="space-y-2">
+        <label class="text-sm text-zinc-400">Email *</label>
+        <Input
+          inputType="email"
+          inputValue={email()}
+          onInput={(e) => setEmail(e.target.value)}
+          onBlur={() => setTouched(true)}
+          inputPlaceholder="Enter your email"
+          inputDisabled={loading()}
+        />
+        <p class="error-message text-sm text-red-400 min-h-5">{error()}</p>
+      </div>
+
+      <Button
+        onClick={handleSubmit}
+        disabled={!isValid() || loading()}
+      >
+        <span class="button-text">{loading() ? 'Submitting...' : 'Subscribe'}</span>
+      </Button>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={success()}>
+          <div class="flex-1">
+            <ToastTitle>Success</ToastTitle>
+            <ToastDescription>You have been subscribed successfully!</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setSuccess(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}
+
+/**
+ * Network error demo - shows error handling and retry functionality
+ */
+export function NetworkErrorDemo() {
+  const [message, setMessage] = createSignal('')
+  const [touched, setTouched] = createSignal(false)
+  const [loading, setLoading] = createSignal(false)
+  const [errorMsg, setErrorMsg] = createSignal('')
+  const [success, setSuccess] = createSignal(false)
+  const [attemptCount, setAttemptCount] = createSignal(0)
+
+  const validationError = createMemo(() => {
+    if (!touched()) return ''
+    if (message().trim() === '') return 'Message is required'
+    return ''
+  })
+
+  const isValid = createMemo(() => validationError() === '' && message().trim() !== '')
+
+  const handleSubmit = async () => {
+    if (!isValid() || loading()) return
+
+    setLoading(true)
+    setErrorMsg('')
+    setAttemptCount(attemptCount() + 1)
+
+    // Simulate API call that fails on first attempt
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    setLoading(false)
+
+    // Fail on first attempt, succeed on retry
+    if (attemptCount() === 1) {
+      setErrorMsg('Network error. Please try again.')
+    } else {
+      setSuccess(true)
+      setMessage('')
+      setTouched(false)
+      setAttemptCount(0)
+      setTimeout(() => setSuccess(false), 3000)
+    }
+  }
+
+  const handleRetry = () => {
+    setErrorMsg('')
+    handleSubmit()
+  }
+
+  return (
+    <div class="space-y-4">
+      <div class="space-y-2">
+        <label class="text-sm text-zinc-400">Message *</label>
+        <Input
+          inputValue={message()}
+          onInput={(e) => setMessage(e.target.value)}
+          onBlur={() => setTouched(true)}
+          inputPlaceholder="Enter your message"
+          inputDisabled={loading()}
+        />
+        <p class="validation-error text-sm text-red-400 min-h-5">{validationError()}</p>
+      </div>
+
+      <Button
+        onClick={handleSubmit}
+        disabled={!isValid() || loading()}
+      >
+        <span class="button-text">{loading() ? 'Sending...' : 'Send Message'}</span>
+      </Button>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={success()}>
+          <div class="flex-1">
+            <ToastTitle>Success</ToastTitle>
+            <ToastDescription>Message sent successfully!</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setSuccess(false)} />
+        </Toast>
+        <Toast variant="error" open={errorMsg() !== ''}>
+          <div class="flex-1">
+            <ToastTitle>Error</ToastTitle>
+            <ToastDescription class="error-description">{errorMsg()}</ToastDescription>
+          </div>
+          <div class="flex gap-2">
+            <ToastAction altText="Retry sending" onClick={handleRetry}>
+              Retry
+            </ToastAction>
+            <ToastClose onClick={() => setErrorMsg('')} />
+          </div>
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}
+
+/**
+ * Server validation error demo - shows server-side validation errors
+ */
+export function ServerValidationDemo() {
+  const [email, setEmail] = createSignal('')
+  const [touched, setTouched] = createSignal(false)
+  const [loading, setLoading] = createSignal(false)
+  const [serverError, setServerError] = createSignal('')
+  const [success, setSuccess] = createSignal(false)
+
+  const clientError = createMemo(() => {
+    if (!touched()) return ''
+    if (email().trim() === '') return 'Email is required'
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email())) return 'Invalid email format'
+    return ''
+  })
+
+  const isValid = createMemo(() => clientError() === '' && email().trim() !== '')
+
+  const handleSubmit = async () => {
+    if (!isValid() || loading()) return
+
+    setLoading(true)
+    setServerError('')
+
+    // Simulate API call
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    setLoading(false)
+
+    // Simulate server validation error for specific email
+    if (email().toLowerCase() === 'taken@example.com') {
+      setServerError('This email is already registered')
+    } else {
+      setSuccess(true)
+      setEmail('')
+      setTouched(false)
+      setTimeout(() => setSuccess(false), 3000)
+    }
+  }
+
+  return (
+    <div class="space-y-4">
+      <div class="space-y-2">
+        <label class="text-sm text-zinc-400">Email *</label>
+        <Input
+          inputType="email"
+          inputValue={email()}
+          onInput={(e) => {
+            setEmail(e.target.value)
+            setServerError('')
+          }}
+          onBlur={() => setTouched(true)}
+          inputPlaceholder="Enter your email"
+          inputDisabled={loading()}
+        />
+        <p class="client-error text-sm text-red-400 min-h-5">{clientError()}</p>
+        {serverError() !== '' ? (
+          <p class="server-error text-sm text-red-400">{serverError()}</p>
+        ) : null}
+      </div>
+
+      <p class="text-xs text-zinc-500">
+        Try "taken@example.com" to see server validation error
+      </p>
+
+      <Button
+        onClick={handleSubmit}
+        disabled={!isValid() || loading()}
+      >
+        <span class="button-text">{loading() ? 'Registering...' : 'Register'}</span>
+      </Button>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={success()}>
+          <div class="flex-1">
+            <ToastTitle>Success</ToastTitle>
+            <ToastDescription>Registration successful!</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setSuccess(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/ui/e2e/submit.spec.ts
+++ b/ui/e2e/submit.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Form Submit Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/forms/submit')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Form Submit')
+    await expect(page.locator('p.text-zinc-400.text-lg')).toContainText('async submit handling')
+  })
+
+  test('displays pattern overview section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Pattern Overview")')).toBeVisible()
+  })
+
+  test('displays examples section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
+  })
+
+  test('displays key points section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Key Points")')).toBeVisible()
+  })
+
+  test.describe('Basic Submit Demo', () => {
+    test('displays basic submit demo', async ({ page }) => {
+      await expect(page.locator('[data-bf-scope="BasicSubmitDemo"]')).toBeVisible()
+    })
+
+    test('shows no error initially', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const error = demo.locator('.error-message')
+      await expect(error).toHaveText('')
+    })
+
+    test('shows validation error on blur when empty', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+      const error = demo.locator('.error-message')
+
+      await input.focus()
+      await input.blur()
+      await expect(error).toHaveText('Email is required')
+    })
+
+    test('shows format error for invalid email', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+      const error = demo.locator('.error-message')
+
+      await input.fill('invalid-email')
+      await input.blur()
+      await expect(error).toHaveText('Invalid email format')
+    })
+
+    test('button is disabled when form is invalid', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await expect(button).toBeDisabled()
+    })
+
+    test('button is enabled when form is valid', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('test@example.com')
+      await expect(button).not.toBeDisabled()
+    })
+
+    test('shows loading state during submission', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('test@example.com')
+      await button.click()
+
+      // Button should be disabled during loading
+      await expect(button).toBeDisabled()
+      // Input should be disabled during loading
+      await expect(input).toBeDisabled()
+    })
+
+    test('shows success toast after submission', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('test@example.com')
+      await button.click()
+
+      // Wait for submission to complete
+      const toast = demo.locator('[data-toast-variant="success"]')
+      await expect(toast).toBeVisible({ timeout: 5000 })
+      await expect(toast.locator('[data-toast-title]')).toContainText('Success')
+    })
+
+    test('form resets after successful submission', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="BasicSubmitDemo"]')
+      const input = demo.locator('input')
+
+      await input.fill('test@example.com')
+
+      // Wait for success toast to appear (indicates submission completed)
+      const toast = demo.locator('[data-toast-variant="success"]')
+      const button = demo.locator('[data-bf-scope="Button"]')
+      await button.click()
+
+      await expect(toast).toBeVisible({ timeout: 5000 })
+      // Input should be cleared after successful submission
+      await expect(input).toHaveValue('')
+    })
+  })
+
+  test.describe('Network Error Demo', () => {
+    test('displays network error demo', async ({ page }) => {
+      await expect(page.locator('[data-bf-scope="NetworkErrorDemo"]')).toBeVisible()
+    })
+
+    test('shows loading state during submission', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="NetworkErrorDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('Test message')
+      await button.click()
+
+      // Button should be disabled during loading
+      await expect(button).toBeDisabled()
+    })
+
+    test('completes submission and returns to idle state', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="NetworkErrorDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('Test message')
+      await button.click()
+
+      // Wait for submission to complete (button becomes enabled again)
+      await expect(button).not.toBeDisabled({ timeout: 5000 })
+    })
+  })
+
+  test.describe('Server Validation Demo', () => {
+    test('displays server validation demo', async ({ page }) => {
+      await expect(page.locator('[data-bf-scope="ServerValidationDemo"]')).toBeVisible()
+    })
+
+    test('shows client-side validation error', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="ServerValidationDemo"]')
+      const input = demo.locator('input')
+      const error = demo.locator('.client-error')
+
+      await input.fill('invalid-email')
+      await input.blur()
+      await expect(error).toHaveText('Invalid email format')
+    })
+
+    test('shows server validation error for taken email', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="ServerValidationDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('taken@example.com')
+      await button.click()
+
+      // Wait for server error
+      const serverError = demo.locator('.server-error')
+      await expect(serverError).toBeVisible({ timeout: 5000 })
+      await expect(serverError).toContainText('already registered')
+    })
+
+    test('clears server error when input changes', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="ServerValidationDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('taken@example.com')
+      await button.click()
+
+      // Wait for server error
+      const serverError = demo.locator('.server-error')
+      await expect(serverError).toBeVisible({ timeout: 5000 })
+
+      // Modify input
+      await input.fill('new@example.com')
+      await expect(serverError).not.toBeVisible()
+    })
+
+    test('shows success for valid email', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope="ServerValidationDemo"]')
+      const input = demo.locator('input')
+      const button = demo.locator('[data-bf-scope="Button"]')
+
+      await input.fill('valid@example.com')
+      await button.click()
+
+      // Wait for success toast
+      const successToast = demo.locator('[data-toast-variant="success"]')
+      await expect(successToast).toBeVisible({ timeout: 5000 })
+    })
+  })
+})
+
+test.describe('Home Page - Form Submit Link', () => {
+  test('displays Form Patterns section', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
+  })
+
+  test('displays Form Submit link', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('a[href="/forms/submit"]')).toBeVisible()
+    await expect(page.locator('a[href="/forms/submit"] h2')).toContainText('Form Submit')
+  })
+
+  test('navigates to Form Submit page on click', async ({ page }) => {
+    await page.goto('/')
+    await page.click('a[href="/forms/submit"]')
+    await expect(page).toHaveURL('/forms/submit')
+    await expect(page.locator('h1')).toContainText('Form Submit')
+  })
+})

--- a/ui/pages/forms/submit.tsx
+++ b/ui/pages/forms/submit.tsx
@@ -1,0 +1,234 @@
+/**
+ * Form Submit Documentation Page
+ *
+ * Demonstrates async submit handling with loading, success, and error states.
+ */
+
+import { Input } from '@/components/Input'
+import {
+  BasicSubmitDemo,
+  NetworkErrorDemo,
+  ServerValidationDemo,
+} from '@/components/SubmitDemo'
+import {
+  PageHeader,
+  Section,
+  Example,
+} from '../../_shared/docs'
+
+// Code examples
+const basicSubmitCode = `import { createSignal, createMemo } from '@barefootjs/dom'
+import { Input } from '@/components/Input'
+import { Button } from '@/components/Button'
+import { Toast, ToastProvider, ToastTitle, ToastDescription } from '@/components/Toast'
+
+const [email, setEmail] = createSignal('')
+const [loading, setLoading] = createSignal(false)
+const [success, setSuccess] = createSignal(false)
+
+const isValid = createMemo(() => /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(email()))
+
+const handleSubmit = async () => {
+  if (!isValid() || loading()) return
+
+  setLoading(true)
+
+  try {
+    await fetch('/api/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ email: email() })
+    })
+    setSuccess(true)
+    setTimeout(() => setSuccess(false), 3000)
+  } finally {
+    setLoading(false)
+  }
+}
+
+<Input
+  inputValue={email()}
+  onInput={(e) => setEmail(e.target.value)}
+  inputDisabled={loading()}
+/>
+<Button onClick={handleSubmit} disabled={!isValid() || loading()}>
+  {loading() ? 'Submitting...' : 'Subscribe'}
+</Button>
+<ToastProvider>
+  <Toast variant="success" open={success()}>
+    <ToastTitle>Success</ToastTitle>
+    <ToastDescription>Subscribed!</ToastDescription>
+  </Toast>
+</ToastProvider>`
+
+const errorHandlingCode = `import { createSignal, createMemo } from '@barefootjs/dom'
+
+const [loading, setLoading] = createSignal(false)
+const [errorMsg, setErrorMsg] = createSignal('')
+const [success, setSuccess] = createSignal(false)
+
+const handleSubmit = async () => {
+  setLoading(true)
+  setErrorMsg('')
+
+  try {
+    const res = await fetch('/api/submit', { method: 'POST', ... })
+    if (!res.ok) throw new Error('Request failed')
+    setSuccess(true)
+  } catch (err) {
+    setErrorMsg(err.message || 'Network error. Please try again.')
+  } finally {
+    setLoading(false)
+  }
+}
+
+const handleRetry = () => {
+  setErrorMsg('')
+  handleSubmit()
+}
+
+<Toast variant="error" open={errorMsg() !== ''}>
+  <ToastTitle>Error</ToastTitle>
+  <ToastDescription>{errorMsg()}</ToastDescription>
+  <ToastAction onClick={handleRetry}>Retry</ToastAction>
+</Toast>`
+
+const serverValidationCode = `import { createSignal, createMemo } from '@barefootjs/dom'
+
+const [email, setEmail] = createSignal('')
+const [serverError, setServerError] = createSignal('')
+
+// Client-side validation
+const clientError = createMemo(() => {
+  if (!/^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(email())) return 'Invalid email'
+  return ''
+})
+
+const handleSubmit = async () => {
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ email: email() })
+  })
+
+  if (!res.ok) {
+    const data = await res.json()
+    // Display server validation error
+    setServerError(data.error) // e.g., "Email already registered"
+    return
+  }
+
+  // Success handling...
+}
+
+// Clear server error when user modifies input
+<Input
+  onInput={(e) => {
+    setEmail(e.target.value)
+    setServerError('')
+  }}
+/>
+{serverError() && <p class="text-red-400">{serverError()}</p>}`
+
+export function SubmitPage() {
+  return (
+    <div class="space-y-12">
+      <PageHeader
+        title="Form Submit"
+        description="Demonstrates async submit handling with loading, success, and error states."
+      />
+
+      {/* Preview - Static example */}
+      <Example title="" code={basicSubmitCode}>
+        <div class="max-w-sm">
+          <Input inputPlaceholder="Enter your email" />
+          <p class="text-sm text-zinc-400 mt-2">
+            See interactive examples below.
+          </p>
+        </div>
+      </Example>
+
+      {/* Pattern Overview */}
+      <Section title="Pattern Overview">
+        <div class="prose prose-invert max-w-none">
+          <p class="text-zinc-400">
+            Form submission in BarefootJS uses signals to manage async state transitions:
+            <code class="text-zinc-200">idle → loading → success/error</code>.
+            This pattern provides reactive feedback without external state machines.
+          </p>
+          <p class="text-zinc-400 mt-2">
+            Key concepts:
+          </p>
+          <ul class="list-disc list-inside text-zinc-400 space-y-1 mt-2">
+            <li><strong>Loading signal</strong>: Tracks submission in progress</li>
+            <li><strong>Error signal</strong>: Stores error message from failed requests</li>
+            <li><strong>Success signal</strong>: Triggers success feedback (toast, message)</li>
+            <li><strong>Disabled state</strong>: Prevents double submission and shows loading</li>
+          </ul>
+        </div>
+      </Section>
+
+      {/* Examples */}
+      <Section title="Examples">
+        <div class="space-y-8">
+          <Example title="Basic Submit with Loading" code={basicSubmitCode}>
+            <div class="max-w-sm">
+              <BasicSubmitDemo />
+            </div>
+          </Example>
+
+          <Example title="Network Error and Retry" code={errorHandlingCode}>
+            <div class="max-w-sm">
+              <NetworkErrorDemo />
+            </div>
+          </Example>
+
+          <Example title="Server Validation Error" code={serverValidationCode}>
+            <div class="max-w-sm">
+              <ServerValidationDemo />
+            </div>
+          </Example>
+        </div>
+      </Section>
+
+      {/* Key Points */}
+      <Section title="Key Points">
+        <div class="space-y-4">
+          <div class="p-4 bg-zinc-800 rounded-lg">
+            <h3 class="font-semibold text-zinc-100 mb-2">Async State Management</h3>
+            <ul class="list-disc list-inside text-sm text-zinc-400 space-y-1">
+              <li>Use <code class="text-zinc-200">loading</code> signal to track submission state</li>
+              <li>Disable form inputs and button during submission</li>
+              <li>Show loading text in button: <code class="text-zinc-200">{'loading() ? "Submitting..." : "Submit"'}</code></li>
+              <li>Signals are sufficient for typical forms - no state machine needed</li>
+            </ul>
+          </div>
+          <div class="p-4 bg-zinc-800 rounded-lg">
+            <h3 class="font-semibold text-zinc-100 mb-2">Error Handling</h3>
+            <ul class="list-disc list-inside text-sm text-zinc-400 space-y-1">
+              <li>Store error message in signal: <code class="text-zinc-200">setErrorMsg(err.message)</code></li>
+              <li>Display errors via Toast (error variant) or inline message</li>
+              <li>Provide retry action for network errors</li>
+              <li>Clear error when user modifies input or retries</li>
+            </ul>
+          </div>
+          <div class="p-4 bg-zinc-800 rounded-lg">
+            <h3 class="font-semibold text-zinc-100 mb-2">Success Feedback</h3>
+            <ul class="list-disc list-inside text-sm text-zinc-400 space-y-1">
+              <li>Use Toast (success variant) for non-blocking feedback</li>
+              <li>Auto-dismiss success toast: <code class="text-zinc-200">setTimeout(() =&gt; setSuccess(false), 3000)</code></li>
+              <li>Reset form after successful submission if appropriate</li>
+            </ul>
+          </div>
+          <div class="p-4 bg-zinc-800 rounded-lg">
+            <h3 class="font-semibold text-zinc-100 mb-2">Server Validation</h3>
+            <ul class="list-disc list-inside text-sm text-zinc-400 space-y-1">
+              <li>Separate client-side and server-side validation signals</li>
+              <li>Display server errors inline near the relevant field</li>
+              <li>Clear server error when user modifies the field</li>
+              <li>Example: "Email already registered" from server response</li>
+            </ul>
+          </div>
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/ui/server.tsx
+++ b/ui/server.tsx
@@ -25,6 +25,7 @@ import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
 import { ControlledInputPage } from './pages/forms/controlled-input'
 import { ValidationPage } from './pages/forms/validation'
+import { SubmitPage } from './pages/forms/submit'
 
 const app = new Hono()
 
@@ -201,6 +202,15 @@ app.get('/', (c) => {
             Error state management and multi-field validation patterns.
           </p>
         </a>
+        <a
+          href="/forms/submit"
+          class="block p-4 border border-zinc-800 rounded-lg hover:border-zinc-600 hover:bg-zinc-900 transition-colors"
+        >
+          <h2 class="font-semibold text-zinc-100">Form Submit</h2>
+          <p class="text-sm text-zinc-400 mt-1">
+            Async submit handling with loading, success, and error states.
+          </p>
+        </a>
       </div>
     </div>
   )
@@ -284,6 +294,11 @@ app.get('/forms/controlled-input', (c) => {
 // Form Validation pattern documentation
 app.get('/forms/validation', (c) => {
   return c.render(<ValidationPage />)
+})
+
+// Form Submit pattern documentation
+app.get('/forms/submit', (c) => {
+  return c.render(<SubmitPage />)
 })
 
 export default { port: 3002, fetch: app.fetch }


### PR DESCRIPTION
## Summary

- Add `ui/pages/forms/submit.tsx` page documenting async submit handling patterns
- Create `SubmitDemo` components demonstrating:
  - Basic form submission with loading state and success toast
  - Network error handling with retry functionality  
  - Server-side validation error display
- Add comprehensive E2E tests for all submit patterns

### Compiler Fixes

Fixed two compiler bugs discovered during implementation:

1. **Comparison expressions in JSX props** - Expressions like `open={errorMsg() !== ''}` were being misidentified as string literals because they start with a quote, resulting in invalid JSX: `open='' !== ''`

2. **Nested memo references** - When a memo references another memo (e.g., `isValid()` calling `error()`), the inner memo wasn't being expanded, leaving undefined function calls on the server side

Both fixes include regression tests.

## Test plan

- [x] E2E tests pass (`bun run test:e2e` in `ui/`)
- [x] Unit tests pass for compiler changes (`bun test packages/jsx/`)
- [x] Page renders correctly at `/forms/submit`
- [x] Home page shows link to Form Submit pattern

## Validation Points (from Issue)

- **How to manage async state?** → Signals are sufficient (`loading`, `error`, `success`)
- **Is signal sufficient or do we need a state machine?** → Signals work for typical forms
- **Toast integration for feedback?** → Works with existing Toast component

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)