### PR TITLE
Fix compiler element path and SSR/client state mismatch

### DIFF
--- a/packages/jsx/__tests__/utils/element-paths.test.ts
+++ b/packages/jsx/__tests__/utils/element-paths.test.ts
@@ -393,9 +393,9 @@ describe('generatePathExpression', () => {
 })
 
 describe('conditionals between siblings', () => {
-  it('does not count conditionals as elements in fragment', () => {
-    // Issue #82: Conditionals render as comments, not elements
-    // They should not affect sibling indices
+  it('elements after conditionals get null paths in fragment (Issue #115)', () => {
+    // Issue #115: Elements after conditionals need querySelector fallback
+    // because conditionals render as comments, making path-based navigation unreliable
     const ir: IRFragment = {
       type: 'fragment',
       children: [
@@ -449,12 +449,12 @@ describe('conditionals between siblings', () => {
     expect(paths).toEqual([
       { id: '0', path: '' },  // First element is scope
       { id: 'cond-0', path: null },  // Element inside conditional gets null path
-      { id: '1', path: 'nextElementSibling' },  // NOT 'nextElementSibling.nextElementSibling'
+      { id: '1', path: null },  // Element after conditional gets null path (querySelector fallback)
     ])
   })
 
-  it('does not count conditionals as elements in children', () => {
-    // Issue #82: Conditionals between child elements should not affect indices
+  it('elements after conditionals get null paths in children (Issue #115)', () => {
+    // Issue #115: Elements after conditionals need querySelector fallback
     const ir: IRElement = {
       type: 'element',
       tagName: 'div',
@@ -515,14 +515,14 @@ describe('conditionals between siblings', () => {
 
     const paths = calculateElementPaths(ir)
     expect(paths).toEqual([
-      { id: '0', path: 'firstElementChild' },
+      { id: '0', path: 'firstElementChild' },  // Before conditional - valid path
       { id: 'cond-0', path: null },  // Element inside conditional
-      { id: '1', path: 'firstElementChild.nextElementSibling' },  // NOT .nextElementSibling.nextElementSibling
+      { id: '1', path: null },  // After conditional - null path (querySelector fallback)
     ])
   })
 
-  it('handles multiple conditionals between elements', () => {
-    // Issue #82: Multiple conditionals should not affect sibling indices
+  it('elements before conditionals keep valid paths', () => {
+    // Elements before conditionals should still have valid paths
     const ir: IRElement = {
       type: 'element',
       tagName: 'div',
@@ -589,10 +589,9 @@ describe('conditionals between siblings', () => {
 
     const paths = calculateElementPaths(ir)
     expect(paths).toEqual([
-      { id: '0', path: 'firstElementChild' },
-      { id: '1', path: 'firstElementChild.nextElementSibling' },
-      // Two conditionals don't add to the index
-      { id: '2', path: 'firstElementChild.nextElementSibling.nextElementSibling' },
+      { id: '0', path: 'firstElementChild' },  // Before conditionals
+      { id: '1', path: 'firstElementChild.nextElementSibling' },  // Before conditionals
+      { id: '2', path: null },  // After conditionals - null path
     ])
   })
 })

--- a/packages/jsx/src/compiler/marked-jsx-generator.ts
+++ b/packages/jsx/src/compiler/marked-jsx-generator.ts
@@ -38,7 +38,7 @@ export function generateFileMarkedJsx(
         c.name,
         c.result.signals,
         needsDataBfIds,
-        { outputEventAttrs: true, memos: c.result.memos }
+        { outputEventAttrs: true, memos: c.result.memos, props: c.result.props }
       )
       const childComponents = collectAllChildComponentNames(c.result.ir!)
 

--- a/packages/jsx/src/compiler/template-generator.ts
+++ b/packages/jsx/src/compiler/template-generator.ts
@@ -15,6 +15,16 @@ import { isArrowFunction, extractArrowParams, extractArrowBody } from '../extrac
  * Boolean HTML attributes that should only be present when truthy.
  * When value is false, the attribute should be omitted entirely.
  */
+/**
+ * Escapes backticks for nesting inside another template literal.
+ * When embedding a template literal result inside another template literal,
+ * only backticks need to be escaped. ${...} expressions should remain
+ * uneescaped so they are evaluated within the nested template.
+ */
+function escapeForNestedTemplate(str: string): string {
+  return str.replace(/`/g, '\\`')
+}
+
 const BOOLEAN_HTML_ATTRS = new Set([
   'disabled',
   'readonly',
@@ -197,7 +207,10 @@ export function jsxToTemplateString(
           const condition = substituteProps(cond.condition)
           const whenTrue = processIRNode(cond.whenTrue, false)
           const whenFalse = cond.whenFalse ? processIRNode(cond.whenFalse, false) : ''
-          return `\${${condition} ? \`${whenTrue}\` : \`${whenFalse}\`}`
+          // Escape inner template literal characters to prevent syntax errors in nested templates
+          const escapedTrue = escapeForNestedTemplate(whenTrue)
+          const escapedFalse = escapeForNestedTemplate(whenFalse)
+          return `\${${condition} ? \`${escapedTrue}\` : \`${escapedFalse}\`}`
         }
 
         case 'fragment': {

--- a/packages/jsx/src/transformers/ir-to-client-js.ts
+++ b/packages/jsx/src/transformers/ir-to-client-js.ts
@@ -222,7 +222,10 @@ function irToHtmlTemplate(node: IRNode, condId: string, ctx: CollectContext): st
       // Nested conditional - use ternary in template literal
       const whenTrueHtml = irNodeToHtmlDynamic(node.whenTrue, ctx)
       const whenFalseHtml = irNodeToHtmlDynamic(node.whenFalse, ctx)
-      return `<span data-bf-cond="${condId}">\${${node.condition} ? \`${whenTrueHtml}\` : \`${whenFalseHtml}\`}</span>`
+      // Escape inner template literal characters to prevent syntax errors in nested templates
+      const escapedTrue = escapeForNestedTemplate(whenTrueHtml)
+      const escapedFalse = escapeForNestedTemplate(whenFalseHtml)
+      return `<span data-bf-cond="${condId}">\${${node.condition} ? \`${escapedTrue}\` : \`${escapedFalse}\`}</span>`
     }
   }
 }
@@ -330,9 +333,22 @@ function irNodeToHtmlDynamic(node: IRNode, ctx: CollectContext): string {
       // Nested conditional - use ternary in template literal
       const whenTrueHtml = irNodeToHtmlDynamic(node.whenTrue, ctx)
       const whenFalseHtml = irNodeToHtmlDynamic(node.whenFalse, ctx)
-      return `\${${node.condition} ? \`${whenTrueHtml}\` : \`${whenFalseHtml}\`}`
+      // Escape inner template literal characters to prevent syntax errors in nested templates
+      const escapedTrue = escapeForNestedTemplate(whenTrueHtml)
+      const escapedFalse = escapeForNestedTemplate(whenFalseHtml)
+      return `\${${node.condition} ? \`${escapedTrue}\` : \`${escapedFalse}\`}`
     }
   }
+}
+
+/**
+ * Escapes backticks for nesting inside another template literal.
+ * When embedding a template literal result inside another template literal,
+ * only backticks need to be escaped. ${...} expressions should remain
+ * uneescaped so they are evaluated within the nested template.
+ */
+function escapeForNestedTemplate(str: string): string {
+  return str.replace(/`/g, '\\`')
 }
 
 /**

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -64,6 +64,8 @@ export interface MarkedJsxContext extends BaseTransformContext {
   eventIdCounter: { value: number } | null
   /** Whether we're inside a list context (for passing __listIndex to child components) */
   inListContext: boolean
+  /** Props with default values for SSR/client consistency */
+  propsWithDefaults: Map<string, string>
 }
 
 /**

--- a/spec/spec.tsv
+++ b/spec/spec.tsv
@@ -51,6 +51,7 @@ EXPR-031	Expressions	function fmt(x) {...}; <p>{fmt(v)}</p>	clientJs: function f
 EXPR-032	Expressions	function C() { const x = 1; return <p>{x}</p> }	clientJs: const x = 1	clientJs	✅ Implemented	Local var included
 EXPR-033	Expressions	function C() { const fn = () => {}; ... }	clientJs: const fn = () => {}	clientJs	✅ Implemented	Local fn included
 EXPR-034	Expressions	const X = 5; <Child value={X} />	clientJs: const X = 5	clientJs	✅ Implemented	Const in child props
+EXPR-040	Expressions	const [x] = createSignal(propWithDefault)	markedJsx: (propWithDefault ?? 'default')	markedJsx	✅ Implemented	Prop default fallback for SSR
 CTRL-001	Control Flow	{true ? 'A' : 'B'}	'A' (evaluated at compile time)	markedJsx	✅ Implemented	Static ternary
 CTRL-002	Control Flow	<p>{show() ? 'Yes' : 'No'}</p>	clientJs: _0.textContent = show() ? 'Yes' : 'No'	both	✅ Implemented	Dynamic text ternary
 CTRL-003	Control Flow	{show() ? <A/> : <B/>}	markedJsx: <A data-bf-cond='0'/> + <B data-bf-cond='0'/>	both	✅ Implemented	Element ternary
@@ -67,6 +68,7 @@ CTRL-013	Control Flow	items().map((item, i) => <li key={i}>)	key uses __index	ma
 CTRL-014	Control Flow	<li key={item.a + item.b}>	Complex key expression preserved	markedJsx	✅ Implemented	Computed key
 CTRL-015	Control Flow	items().map(i => i.subs.map(s => <X/>))	Nested innerHTML	clientJs	✅ Implemented	Nested map
 CTRL-016	Control Flow	items().map(i => i.done ? <A/> : <B/>)	Ternary in template string	clientJs	✅ Implemented	Conditional in map
+CTRL-020	Control Flow	{a ? (b ? <X/> : <Y/>) : <Z/>}	Properly escaped template literal	clientJs	✅ Implemented	Nested ternary JSX escaping
 COMP-001	Components	<Child />	<Child /> (direct render)	preserve	✅ Implemented	Static component
 COMP-002	Components	<Child name='A' />	Props passed to Child	preserve	✅ Implemented	Static props
 COMP-003	Components	<Child value={count()} />	Props wrapped: { value: () => count() }	clientJs	✅ Implemented	Dynamic props wrapped
@@ -148,6 +150,8 @@ PATH-003	Element Paths	<div>text<span data-bf='0'>	Text nodes skipped in path	cl
 PATH-004	Element Paths	<><p data-bf='0'/><span data-bf='1'/></>	Path per fragment child	clientJs	✅ Implemented	Fragment paths
 PATH-005	Element Paths	<div><Child/><span data-bf='0'/>	null (uses querySelector)	clientJs	✅ Implemented	After component
 PATH-006	Element Paths	<div>{show() && <X/>}<span data-bf='0'>	Conditional skipped	clientJs	✅ Implemented	Conditional in path
+PATH-007	Element Paths	{cond ? <X/> : null}<span data-bf='0'>{text()}</span>	path: null (querySelector fallback)	clientJs	✅ Implemented	Elements after conditionals use querySelector
+PATH-008	Element Paths	{c1 && <X/>}{c2 && <Y/>}<span data-bf='0'>	path: null (querySelector fallback)	clientJs	✅ Implemented	Multiple conditionals before element
 OOS-001	Out of Scope	useEffect(() => {...})	Not supported	n/a	❌ OOS	Use createEffect
 OOS-002	Out of Scope	useState(0)	Not supported	n/a	❌ OOS	Use createSignal
 OOS-003	Out of Scope	<Context.Provider value={...}>	Not supported	n/a	❌ OOS	Pass props


### PR DESCRIPTION
## Summary

Fixes #115 - Addresses three compiler issues related to element path calculation and SSR/client state synchronization.

### Changes

1. **Element path calculation after conditionals** (Issue 1)
   - Elements after conditional nodes now receive `null` paths
   - This triggers `querySelector('[data-bf="id"]')` fallback for reliable DOM access
   - Conditionals render as comment nodes at runtime, making path-based navigation unreliable

2. **SSR/client state mismatch for signals with prop defaults** (Issue 2)
   - Signal initial values that reference props with defaults now use nullish coalescing: `(propName ?? defaultValue)`
   - Ensures SSR and client evaluate the same value when props aren't passed
   - Example: `createSignal(defaultTheme)` where `defaultTheme = 'system'` now correctly uses `'system'` in both SSR and client

3. **Nested ternary template escaping** (Issue 3)
   - Fixed template literal escaping in nested ternary expressions
   - Only backticks are escaped, `${...}` expressions remain unescaped for proper evaluation
   - Prevents syntax errors in generated client JS

### Files Changed

- `packages/jsx/src/utils/element-paths.ts` - Added conditional tracking
- `packages/jsx/src/transformers/ir-to-marked-jsx.ts` - Added prop default fallback
- `packages/jsx/src/transformers/ir-to-client-js.ts` - Fixed nested template escaping
- `packages/jsx/src/compiler/template-generator.ts` - Fixed nested template escaping
- `packages/jsx/src/types.ts` - Extended MarkedJsxContext with propsWithDefaults
- `packages/jsx/src/compiler/marked-jsx-generator.ts` - Pass props to irToMarkedJsx
- `spec/spec.tsv` - Added new specification entries

## Test plan

- [x] Unit tests pass (596 tests)
- [x] E2E tests pass (62 tests)
- [x] Updated element-paths.test.ts for new behavior
- [x] Added spec entries PATH-007, PATH-008, EXPR-040, CTRL-020

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)