### PR TITLE
Strip TypeScript type assertions from createEffect blocks

### DIFF
--- a/packages/jsx/src/extractors/effects.ts
+++ b/packages/jsx/src/extractors/effects.ts
@@ -7,7 +7,7 @@
 
 import ts from 'typescript'
 import type { EffectDeclaration } from '../types'
-import { createSourceFile } from '../utils/helpers'
+import { createSourceFile, stripTypeAnnotations } from '../utils/helpers'
 import { isComponentFunction } from './common'
 
 /**
@@ -41,9 +41,11 @@ export function extractEffects(
           parent = parent.parent
         }
 
-        const code = ts.isExpressionStatement(parent)
+        const tsCode = ts.isExpressionStatement(parent)
           ? parent.getText(sourceFile)
           : node.getText(sourceFile)
+        // Strip TypeScript type annotations to produce valid JavaScript
+        const code = stripTypeAnnotations(tsCode)
 
         effects.push({ code })
       }


### PR DESCRIPTION
## Summary

- Apply `stripTypeAnnotations()` to extracted `createEffect` code
- Add unit tests verifying TypeScript syntax is properly stripped

## Problem

When user-written `createEffect` blocks contain TypeScript type assertions (`as Type`), they were preserved in compiled JavaScript output, causing runtime SyntaxError in the browser.

Example:
```tsx
createEffect(() => {
  const stored = localStorage.getItem('theme') as Theme | null  // TS syntax
})
```

Compiled (before fix):
```js
createEffect(() => {
  const stored = localStorage.getItem('theme') as Theme | null  // ❌ SyntaxError
})
```

## Solution

Apply `stripTypeAnnotations()` to the extracted effect code, matching the pattern already used in `local-functions.ts`, `local-variables.ts`, and `module-functions.ts` extractors.

## Test plan

- [x] Unit tests pass (`bun test packages/jsx/__tests__/extractors/effects.test.ts`)
- [x] E2E tests pass (`bun run test:e2e`)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)