### PR TITLE
Fix compiler bug: ternary JSX in component children generates placeholders

### DIFF
--- a/spec/spec.tsv
+++ b/spec/spec.tsv
@@ -89,6 +89,10 @@ COMP-015	Components	<Child name='A' />	name: 'A' (not wrapped)	preserve	✅ Impl
 COMP-020	Components	<Card>{count()}</Card>	children: () => count()	clientJs	✅ Implemented	Reactive children
 COMP-021	Components	<Card><p>Static</p></Card>	children: <p>Static</p>	preserve	✅ Implemented	Static children
 COMP-022	Components	{children} in component	typeof children === 'function' ? children() : children	clientJs	✅ Implemented	Lazy children
+COMP-023	Components	<Card>{show() ? <A/> : <B/>}</Card>	No children prop (SSR DOM preserved)	preserve	✅ Implemented	Complex children preserved via SSR
+COMP-024	Components	<Card><p/>{show() && <X/>}</Card>	No children prop (SSR DOM preserved)	preserve	✅ Implemented	Mixed JSX children preserved
+COMP-025	Components	<Label>{count()}</Label>	children: () => count()	clientJs	✅ Implemented	Pure text reactive children
+COMP-026	Components	<Card>{text()}{show() ? <A/> : <B/>}</Card>	No children prop (text not reactive)	preserve	⚠️ Limitation	Mixed text+JSX children - text part not reactive
 COMP-030	Components	Component with signals/events	clientJs: function initComponentName(i, scope) {...}	clientJs	✅ Implemented	Init fn generated
 COMP-031	Components	Static component (no signals/events)	No clientJs generated	preserve	✅ Implemented	No init wrapper
 COMP-032	Components	<Parent><Child with signals/></Parent>	Parent clientJs: initChild(i, scope)	clientJs	✅ Implemented	Parent calls child init


### PR DESCRIPTION
## Summary

- Fix the compiler bug where ternary JSX in component children generates `[component]`, `[element]`, `[conditional]` placeholder strings
- Add `childrenContainComplexNodes()` helper function to detect complex IR nodes
- Skip children prop generation for complex JSX children (already server-rendered)
- Add safety check in `generateChildrenExpression()` to throw error if complex nodes slip through
- Add test cases COMP-023, COMP-024, COMP-025 to spec

## Root Cause

The `generateChildrenExpression()` function in `packages/jsx/src/transformers/jsx-to-ir.ts` was generating placeholder strings like `"[component]"` for complex IR nodes (element, fragment, component, conditional). These placeholders were then used in the client-side init function's children prop, which tried to set `textContent` on DOM elements, destroying the server-rendered HTML.

## Solution

Complex JSX children (elements, fragments, components, conditionals) are already server-rendered. The fix skips generating a `children` prop when children contain these complex nodes, preserving the SSR DOM.

## Limitation

Mixed text + JSX children: When children contain both text expressions AND JSX elements, the entire children prop is skipped. The text part will not be reactive. This is documented in spec.tsv as COMP-026.

**Workaround**: Wrap reactive text in its own element:
```tsx
<Card>
  <span>{prefix()}</span>  {/* This will update */}
  {show() ? <A/> : <B/>}   {/* This uses conditional system */}
</Card>
```

## Test plan

- [x] Run unit tests: `bun test packages/jsx` - 677 tests passed
- [x] Build packages: `packages/jsx`, `packages/hono`, `examples/hono` - all succeeded
- [x] Run E2E tests: `bun run test:e2e` - 62 tests passed

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)