### PR TITLE
Use SolidJS-style props access pattern to fix reactive prop detection

### DIFF
--- a/packages/jsx/__tests__/compiler/issue-157-props-reactivity.test.ts
+++ b/packages/jsx/__tests__/compiler/issue-157-props-reactivity.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Issue #157: Props should not be forcibly made reactive
+ *
+ * This test verifies that:
+ * 1. Props are accessed via __props.propName pattern (SolidJS style)
+ * 2. Props alone don't trigger reactive wrapping (no createEffect just for prop access)
+ * 3. map() with static data works correctly without JSX syntax errors
+ *
+ * Note: Static text content {prop} is SSR-only and doesn't generate Client JS.
+ * Only dynamic attributes or expressions that need client updates generate Client JS.
+ *
+ * @see https://github.com/kfly8/barefootjs/issues/157
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { compileWithFiles } from './test-helpers'
+
+describe('Issue #157: Props are not forcibly made reactive', () => {
+  it('props in dynamic attributes are accessed via __props.propName pattern', async () => {
+    const files = {
+      '/test/Component.tsx': `
+        "use client"
+        function Component({ currentPath }: { currentPath: string }) {
+          return <div class={currentPath}>{currentPath}</div>
+        }
+        export default Component
+      `,
+    }
+    const result = await compileWithFiles('/test/Component.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('Component'))
+
+    // Should use __props.propName pattern for dynamic attributes
+    expect(comp!.clientJs).toContain('__props.currentPath')
+    // Should NOT use old getter pattern
+    expect(comp!.clientJs).not.toContain('__raw_currentPath')
+    expect(comp!.clientJs).not.toContain('currentPath()')
+  })
+
+  it('static prop in text content is SSR-only (no Client JS)', async () => {
+    const files = {
+      '/test/StaticText.tsx': `
+        "use client"
+        function StaticText({ message }: { message: string }) {
+          return <div>{message}</div>
+        }
+        export default StaticText
+      `,
+    }
+    const result = await compileWithFiles('/test/StaticText.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('StaticText'))
+
+    // Static text content with props is SSR-only - no createEffect needed
+    // The prop value is baked into the HTML at render time
+    expect(comp!.clientJs).not.toContain('createEffect')
+  })
+
+  it('static prop reference in map callback does not create reactive wrapper', async () => {
+    const files = {
+      '/test/SidebarMenu.tsx': `
+        "use client"
+        const menuData = [
+          { title: 'Home', items: [{ href: '/' }] },
+          { title: 'About', items: [{ href: '/about' }] }
+        ]
+
+        function SidebarMenu({ currentPath }: { currentPath: string }) {
+          return (
+            <div class={currentPath}>
+              {menuData.map(category => {
+                const shouldOpen = category.items.some(item => item.href === currentPath)
+                return <span key={category.title}>{shouldOpen ? 'open' : 'closed'}</span>
+              })}
+            </div>
+          )
+        }
+        export default SidebarMenu
+      `,
+    }
+    const result = await compileWithFiles('/test/SidebarMenu.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('SidebarMenu'))
+
+    // The prop should be accessed via __props pattern
+    expect(comp!.clientJs).toContain('__props.currentPath')
+
+    // The map is over static data (menuData), not a signal
+    // So it should NOT generate reconcileList
+    expect(comp!.clientJs).not.toContain('reconcileList')
+  })
+
+  it('signal-based map still creates reactive wrapper', async () => {
+    const files = {
+      '/test/TodoList.tsx': `
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+
+        function TodoList() {
+          const [todos, setTodos] = createSignal([
+            { id: 1, text: 'Task 1' },
+            { id: 2, text: 'Task 2' }
+          ])
+
+          return (
+            <ul>
+              {todos().map(todo => <li key={todo.id}>{todo.text}</li>)}
+            </ul>
+          )
+        }
+        export default TodoList
+      `,
+    }
+    const result = await compileWithFiles('/test/TodoList.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('TodoList'))
+
+    // Signal-based map should have reconcileList for dynamic updates
+    expect(comp!.clientJs).toContain('reconcileList')
+  })
+
+  it('prop used in ternary expression does not force reactivity', async () => {
+    const files = {
+      '/test/ConditionalDisplay.tsx': `
+        "use client"
+        function ConditionalDisplay({ isVisible }: { isVisible: boolean }) {
+          return <div class={isVisible ? 'show' : 'hide'}>Content</div>
+        }
+        export default ConditionalDisplay
+      `,
+    }
+    const result = await compileWithFiles('/test/ConditionalDisplay.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('ConditionalDisplay'))
+
+    // Should access prop via __props pattern
+    expect(comp!.clientJs).toContain('__props.isVisible')
+  })
+
+  it('callback props are destructured directly from __props', async () => {
+    const files = {
+      '/test/ButtonWithCallback.tsx': `
+        "use client"
+        function ButtonWithCallback({ onClick, label }: { onClick: () => void, label: string }) {
+          return <button onClick={onClick} class={label}>Click</button>
+        }
+        export default ButtonWithCallback
+      `,
+    }
+    const result = await compileWithFiles('/test/ButtonWithCallback.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('ButtonWithCallback'))
+
+    // Callback props (onClick) should be destructured from __props
+    expect(comp!.clientJs).toContain('const { onClick } = __props')
+    // Value props (label) should use __props.propName pattern
+    expect(comp!.clientJs).toContain('__props.label')
+  })
+
+  it('multiple props work correctly together', async () => {
+    const files = {
+      '/test/MultiPropComponent.tsx': `
+        "use client"
+        function MultiPropComponent({
+          title,
+          count,
+          isActive,
+          onToggle
+        }: {
+          title: string
+          count: number
+          isActive: boolean
+          onToggle: () => void
+        }) {
+          return (
+            <div class={isActive ? 'active' : 'inactive'} data-title={title} data-count={count}>
+              <h1>{title}</h1>
+              <span>{count}</span>
+              <button onClick={onToggle}>Toggle</button>
+            </div>
+          )
+        }
+        export default MultiPropComponent
+      `,
+    }
+    const result = await compileWithFiles('/test/MultiPropComponent.tsx', files)
+    const comp = result.files.find(f => f.componentNames.includes('MultiPropComponent'))
+
+    // Value props in attributes should use __props pattern
+    expect(comp!.clientJs).toContain('__props.isActive')
+
+    // Callback should be destructured
+    expect(comp!.clientJs).toContain('const { onToggle } = __props')
+  })
+})

--- a/packages/jsx/__tests__/transformers/jsx-to-ir.test.ts
+++ b/packages/jsx/__tests__/transformers/jsx-to-ir.test.ts
@@ -298,8 +298,9 @@ describe('jsxToIR', () => {
       expect((result.children[0] as IRExpression).isDynamic).toBe(true)
     })
 
-    // EXPR-025: Prop reference
-    it('EXPR-025: converts prop reference as dynamic', () => {
+    // EXPR-025: Prop reference is static (accessed via props.propName in SolidJS style)
+    // Props are now accessed via getter pattern, so standalone prop names are not reactive
+    it('EXPR-025: prop reference alone is not reactive (use props.propName pattern)', () => {
       const source = '<div>{value}</div>'
       const sourceFile = parseJsx(source)
       const ctx = createContext(sourceFile, { valueProps: ['value'] })
@@ -307,7 +308,8 @@ describe('jsxToIR', () => {
 
       const result = jsxToIR(jsx, ctx) as IRElement
       expect(result.children[0].type).toBe('expression')
-      expect((result.children[0] as IRExpression).isDynamic).toBe(true)
+      // Props accessed via props.propName pattern - standalone prop name is not reactive
+      expect((result.children[0] as IRExpression).isDynamic).toBe(false)
     })
 
     // EXPR-026: Children always dynamic

--- a/packages/jsx/src/extractors/expression.ts
+++ b/packages/jsx/src/extractors/expression.ts
@@ -640,3 +640,113 @@ export function substitutePropCallsAST(
 
   return result
 }
+
+/**
+ * Replace prop identifiers with object property access using AST transformation.
+ *
+ * e.g., `variant` → `__props.variant` (SolidJS-style props access)
+ *
+ * Handles:
+ * - Regular identifier: variant → __props.variant
+ * - Shorthand property: { variant } → { variant: __props.variant }
+ * - Skips: property access (.variant), declarations (const variant = ...), etc.
+ */
+export function replacePropsWithObjectAccess(
+  code: string,
+  propNames: string[],
+  propsObjectName: string = '__props'
+): string {
+  if (propNames.length === 0 || code.trim() === '') {
+    return code
+  }
+
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    code,
+    ts.ScriptTarget.Latest,
+    true
+  )
+
+  const replacements: Array<{ start: number; end: number; value: string }> = []
+  const propSet = new Set(propNames)
+
+  function shouldSkipIdentifier(node: ts.Identifier): boolean {
+    const parent = node.parent
+
+    // Property access right side: obj.variant
+    if (ts.isPropertyAccessExpression(parent) && parent.name === node) {
+      return true
+    }
+
+    // Property definition key: { variant: value }
+    if (ts.isPropertyAssignment(parent) && parent.name === node) {
+      return true
+    }
+
+    // Parameter definition: (variant) => ...
+    if (ts.isParameter(parent)) {
+      return true
+    }
+
+    // Variable declaration left side: const variant = ...
+    if (ts.isVariableDeclaration(parent) && parent.name === node) {
+      return true
+    }
+
+    // Binding element (destructuring): const { variant } = obj
+    if (ts.isBindingElement(parent)) {
+      return true
+    }
+
+    // Function declaration name: function variant() {}
+    if (ts.isFunctionDeclaration(parent) && parent.name === node) {
+      return true
+    }
+
+    // Method name: { variant() {} }
+    if (ts.isMethodDeclaration(parent) && parent.name === node) {
+      return true
+    }
+
+    return false
+  }
+
+  function visit(node: ts.Node) {
+    // Shorthand property: { variant } → { variant: __props.variant }
+    if (ts.isShorthandPropertyAssignment(node)) {
+      const name = node.name.text
+      if (propSet.has(name)) {
+        replacements.push({
+          start: node.getStart(),
+          end: node.getEnd(),
+          value: `${name}: ${propsObjectName}.${name}`
+        })
+        return // Don't visit children
+      }
+    }
+
+    // Regular identifier: variant → __props.variant
+    if (ts.isIdentifier(node) && propSet.has(node.text)) {
+      if (!shouldSkipIdentifier(node)) {
+        replacements.push({
+          start: node.getStart(),
+          end: node.getEnd(),
+          value: `${propsObjectName}.${node.text}`
+        })
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  // Replace from end to preserve positions
+  replacements.sort((a, b) => b.start - a.start)
+  let result = code
+  for (const r of replacements) {
+    result = result.slice(0, r.start) + r.value + result.slice(r.end)
+  }
+
+  return result
+}

--- a/packages/jsx/src/transformers/jsx-to-ir.ts
+++ b/packages/jsx/src/transformers/jsx-to-ir.ts
@@ -683,12 +683,12 @@ function generateSlotId(ctx: JsxToIRContext): string {
 }
 
 /**
- * Checks if expression contains signal, memo calls, or prop references
+ * Checks if expression contains signal or memo calls
  *
- * Props passed from parent components may be reactive (wrapped in getter functions),
- * so expressions containing prop references should be treated as potentially reactive.
+ * Props are now accessed via getter (props.propName), so they don't need
+ * to be tracked here. The reactivity is handled by the getter access pattern.
  */
-function containsReactiveCall(expr: string, signals: SignalDeclaration[], memos: MemoDeclaration[], valueProps: string[] = []): boolean {
+function containsReactiveCall(expr: string, signals: SignalDeclaration[], memos: MemoDeclaration[], _valueProps: string[] = []): boolean {
   const hasSignalCall = signals.some(s => {
     const regex = new RegExp(`\\b${s.getter}\\s*\\(`)
     return regex.test(expr)
@@ -699,16 +699,7 @@ function containsReactiveCall(expr: string, signals: SignalDeclaration[], memos:
     const regex = new RegExp(`\\b${m.getter}\\s*\\(`)
     return regex.test(expr)
   })
-  if (hasMemoCall) return true
-
-  // Check for prop references (value props may be reactive when passed from parent)
-  const hasPropReference = valueProps.some(propName => {
-    // Match standalone prop name (not followed by ( to avoid false positives with function calls)
-    // Also avoid matching as part of other identifiers
-    const regex = new RegExp(`\\b${propName}\\b(?!\\s*\\()`)
-    return regex.test(expr)
-  })
-  return hasPropReference
+  return hasMemoCall
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove prop reference check from `containsReactiveCall()` - props no longer trigger reactivity detection
- Change props access to `__props.propName` pattern instead of getter function wrapping
- Add `replacePropsWithObjectAccess()` function for proper prop access transformation

## Changes

### `packages/jsx/src/transformers/jsx-to-ir.ts`
- Removed prop reference check from `containsReactiveCall()` function
- Props are now accessed via getter pattern, so they don't need to be tracked as reactive sources

### `packages/jsx/src/compiler/client-js-generator.ts`
- Changed init function to receive props as `__props` object
- Callback props (on*) are destructured from `__props`
- Value props are accessed via `__props.propName`

### `packages/jsx/src/extractors/expression.ts`
- Added `replacePropsWithObjectAccess()` function
- Converts `propName` → `__props.propName` in generated code
- Handles shorthand properties: `{ prop }` → `{ prop: __props.prop }`

## Test plan

- [x] All unit tests pass (691 tests)
- [x] All E2E tests pass (62 tests)
- [x] Added Issue #157 specific regression tests

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)