### PR TITLE
Fix __findInScope not generated for elements inside component children

### DIFF
--- a/packages/jsx/src/jsx-compiler.ts
+++ b/packages/jsx/src/jsx-compiler.ts
@@ -464,9 +464,6 @@ function generateElementQueries(
     lines.push(`__scope.setAttribute('data-bf-init', 'true')`)
   }
 
-  // Check if we need a scoped element finder (for elements with null paths)
-  const needsScopedFinder = [...ctx.elementPaths.values()].some(p => p === null || p === undefined)
-
   // Collect all element IDs that need to be queried, sorted by path length
   // This ensures shorter paths are declared first for optimal chaining
   const allElementIds = new Set<string>()
@@ -476,6 +473,13 @@ function generateElementQueries(
   for (const el of interactiveElements) allElementIds.add(el.id)
   for (const el of refElements) allElementIds.add(el.id)
   // Note: conditional elements are found by data-bf-cond attribute, not by ID/path
+
+  // Check if we need a scoped element finder
+  // True if any element we need to query has a null/undefined path or is not in elementPaths
+  const needsScopedFinder = [...allElementIds].some(id => {
+    const path = ctx.elementPaths.get(id)
+    return path === null || path === undefined
+  })
 
   // Add scoped element finder helper if needed (for elements with null paths)
   // This finder excludes elements that are inside nested data-bf-scope components


### PR DESCRIPTION
## Summary

- Fix `needsScopedFinder` check to detect elements that are in `dynamicAttributes` but not in `elementPaths`
- Add regression test for Issue #160

## Problem

After PR #159, the compiler fails to generate the `__findInScope` helper function for elements inside component children, causing `ReferenceError: __findInScope is not defined` at runtime.

### Root Cause

There's a mismatch between `calculateElementPaths` and `collectClientJsInfo`:

1. `collectClientJsInfo` recursively processes children of component nodes, adding elements to `dynamicAttributes`
2. `calculateElementPaths` does NOT recursively process component children, so these elements are not added to `elementPaths`

The `needsScopedFinder` check was using `elementPaths.values()` to detect elements needing `__findInScope`. But since the elements weren't in `elementPaths`, the check returned `false` even though `getElementAccessCode` would use `__findInScope` for them.

### Fix

Move the `needsScopedFinder` check after `allElementIds` is built, and check if any element ID we need to query has a null/undefined path or is not in `elementPaths` at all.

## Test plan

- [x] Added regression test in `components.test.ts`
- [x] All compiler tests pass (`bun test packages/jsx/__tests__/compiler`)
- [x] UI builds successfully with `__findInScope` generated in `package-manager-tabs-*.js`

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)