### PR TITLE
Fix conditional branching for components and if/return patterns

### DIFF
--- a/spec/spec.tsv
+++ b/spec/spec.tsv
@@ -73,7 +73,12 @@ CTRL-013	Control Flow	items().map((item, i) => <li key={i}>)	key uses __index	ma
 CTRL-014	Control Flow	<li key={item.a + item.b}>	Complex key expression preserved	markedJsx	✅ Implemented	Computed key
 CTRL-015	Control Flow	items().map(i => i.subs.map(s => <X/>))	Nested innerHTML	clientJs	✅ Implemented	Nested map
 CTRL-016	Control Flow	items().map(i => i.done ? <A/> : <B/>)	Ternary in template string	clientJs	✅ Implemented	Conditional in map
+CTRL-017	Control Flow	{show() ? <ComponentA /> : <ComponentB />}	markedJsx: data-bf-cond markers on both	both	✅ Implemented	Component ternary (#171)
+CTRL-018	Control Flow	{show() ? <Child /> : null}	markedJsx: data-bf-cond on component	both	✅ Implemented	Component with null (#171)
+CTRL-019	Control Flow	{show() && <Child />}	markedJsx: data-bf-cond on component	both	✅ Implemented	Logical AND with component (#171)
 CTRL-020	Control Flow	{a ? (b ? <X/> : <Y/>) : <Z/>}	Properly escaped template literal	clientJs	✅ Implemented	Nested ternary JSX escaping
+CTRL-021	Control Flow	if (sig()) return <A/>; return <B/>	Converted to IRConditional	both	✅ Implemented	If early return (#171)
+CTRL-022	Control Flow	if (sig()) return <A/>; else return <B/>	Converted to IRConditional	both	✅ Implemented	If-else returns (#171)
 COMP-001	Components	<Child />	<Child /> (direct render)	preserve	✅ Implemented	Static component
 COMP-002	Components	<Child name='A' />	Props passed to Child	preserve	✅ Implemented	Static props
 COMP-003	Components	<Child value={count()} />	Props wrapped: { value: () => count() }	clientJs	✅ Implemented	Dynamic props wrapped


### PR DESCRIPTION
## Summary

This PR fixes two issues with how the BarefootJS compiler handles conditional branching in components:

### Issue 1: Components in JSX ternary expressions
- **Problem**: The `hasJsxBranch` check in `conditionalToIR()` only recognized `'element'` and `'fragment'` types, ignoring `'component'` type nodes
- **Result**: Components in ternary expressions didn't get slot IDs, causing them to be evaluated at SSR time instead of client-side
- **Fix**: Added `'component'` type to the `hasJsxBranch` check

### Issue 2: If statements with early returns
- **Problem**: The `findReturnInBody()` function used a simple depth-first traversal that captured only the first JSX return found
- **Result**: If/else patterns with different return JSX only rendered the fallthrough return
- **Fix**: Added `processIfStatementReturns()` and helper functions to detect if/return patterns and convert them to `IRConditional` nodes

## Changes

- `packages/jsx/src/transformers/jsx-to-ir.ts`: Core fix for both issues
- `packages/jsx/__tests__/spec/control-flow.test.ts`: New tests for CTRL-017 through CTRL-021
- `spec/spec.tsv`: New spec entries for the added functionality

## Test plan

- [x] All 707 existing tests pass
- [x] New tests verify component ternary generates `cond()` call
- [x] New tests verify if/return patterns are converted to conditional IR
- [x] New tests verify correct initial branch is shown in HTML

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)