### PR TITLE
Include module functions in SSR output for use client components

### DIFF
--- a/packages/hono/src/server-adapter.ts
+++ b/packages/hono/src/server-adapter.ts
@@ -49,7 +49,7 @@ export const honoMarkedJsxAdapter: MarkedJsxAdapter = {
   /**
    * Generate Marked JSX file code (multiple components in one file)
    */
-  generateMarkedJsxFile: ({ sourcePath, components, moduleConstants, originalImports, externalImports = [] }) => {
+  generateMarkedJsxFile: ({ sourcePath, components, moduleConstants, moduleFunctions, originalImports, externalImports = [] }) => {
     // Calculate relative path to manifest.json based on source path depth
     const sourceDir = sourcePath.includes('/') ? sourcePath.substring(0, sourcePath.lastIndexOf('/')) : ''
     const dirDepth = sourceDir ? sourceDir.split('/').length : 0
@@ -94,6 +94,11 @@ export const honoMarkedJsxAdapter: MarkedJsxAdapter = {
     // Module-level constants (shared)
     const constantDefs = moduleConstants.length > 0
       ? '\n' + moduleConstants.map(c => c.code).join('\n') + '\n'
+      : ''
+
+    // Module-level helper functions (shared)
+    const functionDefs = moduleFunctions && moduleFunctions.length > 0
+      ? '\n' + moduleFunctions.map(fn => fn.code).join('\n\n') + '\n'
       : ''
 
     // Generate each component function
@@ -286,7 +291,7 @@ ${contextHelper}${localVarDefs}
     }).join('\n\n')
 
     return `${allImports}
-${typeDefs}${constantDefs}${rawHtmlHelper}
+${typeDefs}${constantDefs}${functionDefs}${rawHtmlHelper}
 ${componentFunctions}
 `
   }

--- a/packages/jsx/src/adapters/testing.ts
+++ b/packages/jsx/src/adapters/testing.ts
@@ -33,7 +33,7 @@ export const testJsxAdapter: MarkedJsxAdapter = {
     helperCode: "const __rawHtml = (s: string) => ({ dangerouslySetInnerHTML: { __html: s } })",
   },
 
-  generateMarkedJsxFile: ({ components }) => {
+  generateMarkedJsxFile: ({ components, moduleFunctions }) => {
     // For test adapter, only output the first component's JSX
     // This matches the behavior expected by existing tests
     const comp = components[0]
@@ -53,12 +53,17 @@ export const testJsxAdapter: MarkedJsxAdapter = {
     const needsRawHtml = comp.jsx.includes('__rawHtml(')
     const rawHtmlHelper = needsRawHtml ? 'const __rawHtml = (s: string) => ({ dangerouslySetInnerHTML: { __html: s } })\n\n' : ''
 
+    // Module-level helper functions
+    const functionDefs = moduleFunctions && moduleFunctions.length > 0
+      ? moduleFunctions.map(fn => fn.code).join('\n\n') + '\n\n'
+      : ''
+
     // Local variable declarations (computed from props)
     const localVarDefs = comp.localVariables && comp.localVariables.length > 0
       ? '\n  ' + comp.localVariables.map(v => v.code).join('\n  ') + '\n'
       : ''
 
-    return `${rawHtmlHelper}export function ${comp.name}(${propsParam}) {${localVarDefs}
+    return `${rawHtmlHelper}${functionDefs}export function ${comp.name}(${propsParam}) {${localVarDefs}
   return (
     ${comp.jsx}
   )
@@ -83,7 +88,7 @@ export const testJsxAdapter: MarkedJsxAdapter = {
  * ```
  */
 export const testHtmlAdapter: MarkedJsxAdapter = {
-  generateMarkedJsxFile: ({ components }) => {
+  generateMarkedJsxFile: ({ components, moduleFunctions: _moduleFunctions }) => {
     // For test adapter, only output the first component's HTML
     // This matches the behavior expected by existing tests
     const comp = components[0]

--- a/packages/jsx/src/compiler/marked-jsx-generator.ts
+++ b/packages/jsx/src/compiler/marked-jsx-generator.ts
@@ -64,6 +64,12 @@ export function generateFileMarkedJsx(
     arr.findIndex(x => x.name === c.name) === i
   )
 
+  // Collect all module functions (deduplicated)
+  const allModuleFunctions = fileComponents.flatMap(c => c.result.moduleFunctions)
+  const uniqueModuleFunctions = allModuleFunctions.filter((fn, i, arr) =>
+    arr.findIndex(x => x.name === fn.name) === i
+  )
+
   // Collect all imports (deduplicated)
   const allOriginalImports = fileComponents.flatMap(c => c.result.imports)
   const uniqueImports = allOriginalImports.filter((imp, i, arr) =>
@@ -80,6 +86,7 @@ export function generateFileMarkedJsx(
     sourcePath,
     components: markedJsxComponents,
     moduleConstants: uniqueModuleConstants,
+    moduleFunctions: uniqueModuleFunctions,
     originalImports: uniqueImports,
     externalImports: uniqueExternalImports,
   })

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -327,6 +327,8 @@ export type MarkedJsxAdapter = {
     components: MarkedJsxComponentData[]
     /** Module-level constants shared by all components */
     moduleConstants: ModuleConstant[]
+    /** Module-level helper functions shared by all components */
+    moduleFunctions: LocalFunction[]
     /** Original import statements for child components */
     originalImports: ComponentImport[]
     /** External package imports (npm packages like 'class-variance-authority') */


### PR DESCRIPTION
## Summary

- Fixed compiler to include module-level helper functions in SSR (Marked JSX) output
- Previously, helper functions were only included in client JS, causing `ReferenceError` during server rendering

## Changes

- Added `moduleFunctions` parameter to `MarkedJsxAdapter` interface
- Updated `marked-jsx-generator.ts` to collect and pass module functions to the adapter
- Updated Hono server adapter to output module function declarations
- Updated test adapters to support `moduleFunctions`
- Added test cases for SSR module function inclusion

## Test plan

- [x] Unit tests pass (`bun test packages/jsx/__tests__/compiler/module-functions.test.ts`)
- [x] All existing compiler tests pass
- [x] Package builds successfully

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)