### PR TITLE
Make JSX-containing helper functions SSR-only

### DIFF
--- a/packages/jsx/src/compiler/client-js-generator.ts
+++ b/packages/jsx/src/compiler/client-js-generator.ts
@@ -63,6 +63,7 @@ export function generateFileClientJs(
   }
 
   // Collect and deduplicate module-level helper functions across all components in this file
+  // Note: JSX-containing functions have empty code and are SSR-only (not included here)
   const allModuleFunctions: Set<string> = new Set()
   for (const comp of fileComponents) {
     if (!comp.hasClientJs) continue
@@ -73,13 +74,6 @@ export function generateFileClientJs(
         allModuleFunctions.add(fn.trim())
       }
     }
-  }
-  // Check if any module functions contain jsx() calls (from JSX transformation)
-  const needsJsxImport = Array.from(allModuleFunctions).some(fn =>
-    fn.includes('jsx(') || fn.includes('jsxs(') || fn.includes('Fragment')
-  )
-  if (needsJsxImport) {
-    allImports.add(`import { jsx, jsxs, Fragment } from 'hono/jsx/dom'`)
   }
 
   const moduleFunctionsCode = allModuleFunctions.size > 0

--- a/packages/jsx/src/extractors/module-functions.ts
+++ b/packages/jsx/src/extractors/module-functions.ts
@@ -3,6 +3,9 @@
  *
  * Extracts helper functions defined at the module level (not inside components).
  * These functions are included in the client JS so they can be called by event handlers.
+ *
+ * Note: JSX-containing helper functions are SSR-only and not included in Client JS.
+ * This is by design - BarefootJS updates DOM directly without re-rendering JSX on the client.
  */
 
 import ts from 'typescript'
@@ -12,7 +15,6 @@ import {
   stripTypeAnnotations,
   containsJsxInCode,
   stripTypeAnnotationsPreserveJsx,
-  transpileWithJsx
 } from '../utils/helpers'
 import { isComponentFunction } from './common'
 
@@ -21,6 +23,10 @@ import { isComponentFunction } from './common'
  * These are functions defined at the top level of the file, not inside any component.
  * e.g., function validateEmail(email: string): string { ... }
  *       const createField = (id: number) => { ... }
+ *
+ * JSX-containing functions are SSR-only:
+ * - tsxCode is set for Marked JSX (SSR) output
+ * - code is empty (not included in Client JS)
  *
  * @param source - Source code
  * @param filePath - File path
@@ -44,12 +50,11 @@ export function extractModuleFunctions(
         const hasJsx = containsJsxInCode(tsCode)
 
         if (hasJsx) {
-          // JSX-containing function: different code for SSR vs Client
-          const tsxCode = stripTypeAnnotationsPreserveJsx(tsCode)  // For Marked JSX
-          const code = transpileWithJsx(tsCode)                     // For Client JS
-          moduleFunctions.push({ name, code, containsJsx: true, tsxCode })
+          // JSX-containing function: SSR-only (not included in Client JS)
+          const tsxCode = stripTypeAnnotationsPreserveJsx(tsCode)
+          moduleFunctions.push({ name, code: '', containsJsx: true, tsxCode })
         } else {
-          // No JSX: same code for both
+          // No JSX: included in both SSR and Client JS
           const code = stripTypeAnnotations(tsCode)
           moduleFunctions.push({ name, code, containsJsx: false })
         }
@@ -68,12 +73,11 @@ export function extractModuleFunctions(
             const hasJsx = containsJsxInCode(tsCode)
 
             if (hasJsx) {
-              // JSX-containing function: different code for SSR vs Client
-              const tsxCode = stripTypeAnnotationsPreserveJsx(tsCode)  // For Marked JSX
-              const code = transpileWithJsx(tsCode)                     // For Client JS
-              moduleFunctions.push({ name, code, containsJsx: true, tsxCode })
+              // JSX-containing function: SSR-only (not included in Client JS)
+              const tsxCode = stripTypeAnnotationsPreserveJsx(tsCode)
+              moduleFunctions.push({ name, code: '', containsJsx: true, tsxCode })
             } else {
-              // No JSX: same code for both
+              // No JSX: included in both SSR and Client JS
               const code = stripTypeAnnotations(tsCode)
               moduleFunctions.push({ name, code, containsJsx: false })
             }


### PR DESCRIPTION
## Summary

Follow-up to #177. Makes JSX-containing helper functions SSR-only to avoid dependency on `hono/jsx/dom`.

## Changes

- JSX-containing module-level helper functions are now **SSR-only**
  - Marked JSX (SSR): JSX syntax is preserved
  - Client JS: Functions with JSX are **NOT included**
- Removed `hono/jsx/dom` import logic from client-js-generator

## Rationale

BarefootJS updates DOM directly without re-rendering JSX on the client. JSX helpers are only needed at SSR time to generate the initial HTML.

This keeps the client bundle minimal and avoids runtime dependencies.

## Test plan

- [x] Updated tests to reflect new SSR-only behavior
- [x] All 329 compiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)