### PR TITLE
fix: unify BfPreload default path to prevent duplicate barefoot.js loading

### DIFF
--- a/packages/hono/src/preload.tsx
+++ b/packages/hono/src/preload.tsx
@@ -30,7 +30,7 @@ import { Fragment } from 'hono/jsx'
 export interface BfPreloadProps {
   /**
    * Path to static files directory.
-   * @default '/static'
+   * @default '/static/components'
    */
   staticPath?: string
 
@@ -55,7 +55,7 @@ export interface BfPreloadProps {
  * by all BarefootJS components.
  */
 export function BfPreload({
-  staticPath = '/static',
+  staticPath = '/static/components',
   scripts = [],
   includeRuntime = true,
 }: BfPreloadProps = {}) {


### PR DESCRIPTION
## Summary

- Change BfPreload default `staticPath` from `/static` to `/static/components`
- This aligns BfPreload with BfScripts, preventing duplicate barefoot.js downloads

## Problem

Lighthouse diagnostics revealed that `barefoot.js` was being loaded from two different paths:

| Component | Output Path |
|-----------|-------------|
| BfPreload (modulepreload) | `/static/barefoot.js` |
| BfScripts (script tag) | `/static/components/barefoot.js` |

This caused the browser to download the same ~4KB runtime twice.

## Solution

Changed BfPreload's default `staticPath` from `/static` to `/static/components` to match the manifest entry used by BfScripts.

## Test plan

- [ ] Verify barefoot.js loads only once via browser Network tab
- [ ] Run Lighthouse to confirm no duplicate resource warning

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)