### PR TITLE
perf: Module dependency chain preloading via manifest

### DIFF
--- a/docs/ui/build.ts
+++ b/docs/ui/build.ts
@@ -101,7 +101,7 @@ await Bun.write(
 console.log(`Generated: dist/${barefootFileName}`)
 
 // Manifest
-const manifest: Record<string, { clientJs?: string; markedJsx: string; props: PropWithType[] }> = {
+const manifest: Record<string, { clientJs?: string; markedJsx: string; props: PropWithType[]; dependencies?: string[] }> = {
   '__barefoot__': { markedJsx: '', clientJs: `components/${barefootFileName}`, props: [] }
 }
 
@@ -154,10 +154,12 @@ for (const entryPath of componentFiles) {
 
     // Manifest entries for each component in file
     for (const compName of file.componentNames) {
+      const deps = file.componentDependencies[compName]
       manifest[compName] = {
         markedJsx: markedJsxPath,
         clientJs: clientJsPath,
         props: file.componentProps[compName] || [],
+        dependencies: deps && deps.length > 0 ? deps : undefined,
       }
     }
   }

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -19,12 +19,17 @@ declare module 'hono' {
   }
 }
 import { BfScripts } from '../../packages/hono/src/scripts'
-import { BfPreload } from '../../packages/hono/src/preload'
+import { BfPreload, type Manifest } from '../../packages/hono/src/preload'
 import { SidebarMenu } from '@/components/sidebar-menu'
 import { SidebarPreview } from '@/components/sidebar-preview'
 import { Header } from '@/components/header'
 import { MobileHeader } from '@/components/mobile-header'
 import { CommandPalette } from '@/components/command-palette'
+
+// Import manifest for dependency-aware preloading
+// This enables BfPreload to automatically preload the full dependency chain
+// Example: If Button depends on Slot, preloading Button will also preload Slot
+import manifest from './dist/components/manifest.json'
 
 /**
  * Predictable instance ID generator for E2E testing.
@@ -69,7 +74,10 @@ export const renderer = jsxRenderer(
       <WithPredictableIds>
         <html lang="en">
           <head>
-            <BfPreload />
+            <BfPreload
+              manifest={manifest as Manifest}
+              components={['Button', 'CopyButton', 'Toggle', 'ThemeToggle']}
+            />
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <title>{pageTitle}</title>

--- a/examples/hono/build.ts
+++ b/examples/hono/build.ts
@@ -45,7 +45,7 @@ await Bun.write(
 console.log(`Generated: dist/components/${barefootFileName}`)
 
 // Manifest
-const manifest: Record<string, { clientJs?: string; markedJsx: string; props: PropWithType[] }> = {
+const manifest: Record<string, { clientJs?: string; markedJsx: string; props: PropWithType[]; dependencies?: string[] }> = {
   '__barefoot__': { markedJsx: '', clientJs: `components/${barefootFileName}`, props: [] }
 }
 
@@ -81,10 +81,12 @@ for (const entryPath of componentFiles) {
 
     // Manifest entries for each component in file
     for (const compName of file.componentNames) {
+      const deps = file.componentDependencies[compName]
       manifest[compName] = {
         markedJsx: markedJsxPath,
         clientJs: clientJsPath,
         props: file.componentProps[compName],
+        dependencies: deps && deps.length > 0 ? deps : undefined,
       }
     }
   }

--- a/packages/hono/src/preload.tsx
+++ b/packages/hono/src/preload.tsx
@@ -8,12 +8,15 @@
  * Usage:
  * ```tsx
  * import { BfPreload } from '@barefootjs/hono/preload'
+ * import manifest from './dist/components/manifest.json'
  *
  * <html>
  *   <head>
  *     <BfPreload />
  *     {/* or with additional scripts *\/}
  *     <BfPreload scripts={['/static/components/button.js']} />
+ *     {/* or with manifest-based dependency preloading *\/}
+ *     <BfPreload manifest={manifest} components={['Button', 'TodoApp']} />
  *   </head>
  *   <body>
  *     {children}
@@ -26,6 +29,21 @@
 /** @jsxImportSource hono/jsx */
 
 import { Fragment } from 'hono/jsx'
+
+/**
+ * Manifest entry type for dependency tracking.
+ */
+export interface ManifestEntry {
+  markedJsx: string
+  clientJs?: string
+  props?: Array<{ name: string; type: string; optional: boolean }>
+  dependencies?: string[]
+}
+
+/**
+ * Manifest type mapping component names to their metadata.
+ */
+export type Manifest = Record<string, ManifestEntry>
 
 export interface BfPreloadProps {
   /**
@@ -45,6 +63,56 @@ export interface BfPreloadProps {
    * @default true
    */
   includeRuntime?: boolean
+
+  /**
+   * Component manifest with dependency information.
+   * Used for automatic dependency chain preloading.
+   */
+  manifest?: Manifest
+
+  /**
+   * Component names to preload with their dependencies.
+   * Requires manifest to be provided.
+   */
+  components?: string[]
+}
+
+/**
+ * Resolves the full dependency chain for given components.
+ * Uses a visited set to prevent infinite loops from circular dependencies.
+ *
+ * @param components - Component names to resolve
+ * @param manifest - Component manifest with dependency information
+ * @param visited - Set of already visited component names (for cycle detection)
+ * @returns Array of clientJs paths for all dependencies
+ */
+function resolveDependencyChain(
+  components: string[],
+  manifest: Manifest,
+  visited = new Set<string>()
+): string[] {
+  const result: string[] = []
+
+  for (const compName of components) {
+    if (visited.has(compName)) continue
+    visited.add(compName)
+
+    const entry = manifest[compName]
+    if (!entry) continue
+
+    // Add this component's clientJs
+    if (entry.clientJs) {
+      result.push(entry.clientJs)
+    }
+
+    // Recursively add dependencies
+    if (entry.dependencies && entry.dependencies.length > 0) {
+      const childScripts = resolveDependencyChain(entry.dependencies, manifest, visited)
+      result.push(...childScripts)
+    }
+  }
+
+  return result
 }
 
 /**
@@ -53,11 +121,16 @@ export interface BfPreloadProps {
  *
  * By default, preloads the barefoot.js runtime which is required
  * by all BarefootJS components.
+ *
+ * When manifest and components props are provided, automatically
+ * preloads the full dependency chain for those components.
  */
 export function BfPreload({
   staticPath = '/static',
   scripts = [],
   includeRuntime = true,
+  manifest,
+  components = [],
 }: BfPreloadProps = {}) {
   const urls: string[] = []
 
@@ -66,12 +139,23 @@ export function BfPreload({
     urls.push(`${staticPath}/barefoot.js`)
   }
 
+  // Auto-preload component dependencies from manifest
+  if (manifest && components.length > 0) {
+    const dependencyScripts = resolveDependencyChain(components, manifest)
+    for (const script of dependencyScripts) {
+      urls.push(`${staticPath}/${script}`)
+    }
+  }
+
   // Add additional scripts
   urls.push(...scripts)
 
+  // Deduplicate URLs while preserving order
+  const uniqueUrls = [...new Set(urls)]
+
   return (
     <Fragment>
-      {urls.map((url) => (
+      {uniqueUrls.map((url) => (
         <link rel="modulepreload" href={url} />
       ))}
     </Fragment>

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -301,6 +301,8 @@ export type FileOutput = {
   componentProps: Record<string, PropWithType[]>
   /** Whether file has "use client" directive */
   hasUseClientDirective: boolean
+  /** Component dependencies (keyed by component name) - child components that need client-side initialization */
+  componentDependencies: Record<string, string[]>
 }
 
 export type CompileJSXResult = {


### PR DESCRIPTION
## Summary

- Add `componentDependencies` to `FileOutput` type for tracking component dependencies
- Extend `BfPreload` with `manifest` and `components` props for automatic dependency preloading
- Extract dependencies from both `childInits` and `conditionalElements` (whenTrue/whenFalse branches)
- Implement `resolveDependencyChain` function with circular dependency protection
- Update build scripts to include dependencies in `manifest.json`

## Test plan

- [x] Unit tests pass (801 tests)
- [x] Build succeeds for packages/jsx, packages/hono, docs/ui, examples/hono
- [x] Manifest includes `dependencies` field (verified: Button → Slot, Icon, etc.)
- [ ] E2E tests verify modulepreload tags include dependency chain
- [ ] Lighthouse shows reduced critical path latency

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)