### PR TITLE
fix: move slot.tsx to ui/components/ui/ to prevent duplicate barefoot.js loading

### DIFF
--- a/docs/ui/build.ts
+++ b/docs/ui/build.ts
@@ -4,7 +4,7 @@
  * Generates (file-based output):
  * - dist/components/{Component}.tsx (Marked JSX)
  * - dist/components/{Component}-{hash}.js (Client JS)
- * - dist/barefoot.js (Runtime)
+ * - dist/components/barefoot.js (Runtime)
  * - dist/uno.css (UnoCSS output)
  * - dist/manifest.json
  *
@@ -92,13 +92,6 @@ await Bun.write(
 )
 console.log(`Generated: dist/components/${barefootFileName}`)
 
-// Also copy to dist/ root for components outside rootDir (ui/base/)
-// Their relative imports resolve to dist/ level
-await Bun.write(
-  resolve(DIST_DIR, barefootFileName),
-  Bun.file(domDistFile)
-)
-console.log(`Generated: dist/${barefootFileName}`)
 
 // Manifest
 const manifest: Record<string, { clientJs?: string; markedJsx: string; props: PropWithType[]; dependencies?: string[] }> = {
@@ -205,12 +198,10 @@ if (await Bun.file(globalsSource).exists()) {
   console.log('Copied: dist/globals.css')
 }
 
-// Copy lib/ and base/ directories to dist/
+// Copy lib/ directory to dist/
 // These are runtime utilities needed by compiled components
 const LIB_DIR = resolve(ROOT_DIR, 'lib')
-const BASE_DIR = resolve(ROOT_DIR, '../../ui/base')
 const DIST_LIB_DIR = resolve(DIST_DIR, 'lib')
-const DIST_BASE_DIR = resolve(DIST_DIR, 'base')
 
 // Copy lib/*.tsx files
 await copyTsFiles(LIB_DIR, DIST_LIB_DIR, 'dist/lib/')
@@ -252,9 +243,6 @@ await copyServerComponents(UI_COMPONENTS_DIR, DIST_COMPONENTS_DIR)
 const SHARED_DIR = resolve(ROOT_DIR, 'components/shared')
 const DIST_SHARED_DIR = resolve(DIST_COMPONENTS_DIR, 'shared')
 await copyTsFiles(SHARED_DIR, DIST_SHARED_DIR, 'dist/components/shared/')
-
-// Copy base/*.tsx files
-await copyTsFiles(BASE_DIR, DIST_BASE_DIR, 'dist/base/')
 
 // Rewrite @ui/ imports in all dist/*.tsx files to @/
 // This is needed because compiled components may reference @ui/ paths
@@ -298,10 +286,6 @@ await Bun.write(resolve(DIST_STATIC_DIR, 'uno.css'), Bun.file(resolve(DIST_DIR, 
 console.log('Copied: dist/static/globals.css')
 console.log('Copied: dist/static/uno.css')
 
-// Copy barefoot.js to static/ root for base components
-await Bun.write(resolve(DIST_STATIC_DIR, 'barefoot.js'), Bun.file(resolve(DIST_DIR, 'barefoot.js')))
-console.log('Copied: dist/static/barefoot.js')
-
 // Copy components/ to static/components/ for client JS
 async function copyDir(src: string, dest: string) {
   await mkdir(dest, { recursive: true })
@@ -318,9 +302,5 @@ async function copyDir(src: string, dest: string) {
 }
 await copyDir(DIST_COMPONENTS_DIR, resolve(DIST_STATIC_DIR, 'components'))
 console.log('Copied: dist/static/components/')
-
-// Copy base/ to static/base/ for base component client JS (e.g., slot)
-await copyDir(DIST_BASE_DIR, resolve(DIST_STATIC_DIR, 'base'))
-console.log('Copied: dist/static/base/')
 
 console.log('\nBuild complete!')

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -25,7 +25,7 @@
  */
 
 import type { ButtonHTMLAttributes } from '@barefootjs/jsx'
-import { Slot } from '../../base/slot'
+import { Slot } from './slot'
 
 // Type definitions for button variants
 type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'

--- a/ui/components/ui/slot.tsx
+++ b/ui/components/ui/slot.tsx
@@ -12,7 +12,7 @@
  *   <Slot class="btn">{children}</Slot>
  */
 
-import type { Child } from '../types'
+import type { Child } from '../../types'
 
 export interface SlotProps {
   children?: Child


### PR DESCRIPTION
## Summary
- Move `ui/base/slot.tsx` to `ui/components/ui/slot.tsx` to unify directory structure
- Update `button.tsx` import path to use `./slot`
- Remove `base/` directory handling from `docs/ui/build.ts`
- Remove duplicate `barefoot.js` copy to dist root

## Problem
The docs/ui site was loading `barefoot.js` twice from different paths:
- `/static/barefoot.js` (for `ui/base/` components)
- `/static/components/barefoot.js` (for `ui/components/` components)

This happened because the compiler generates relative imports (`../barefoot.js`) that resolve differently based on the component's directory depth.

## Solution
Move `slot.tsx` to `ui/components/ui/` so all components share the same directory structure and resolve to the same `barefoot.js` path.

## Test plan
- [x] Build passes: `cd docs/ui && bun run build`
- [x] Verify barefoot.js is only in one location: `find docs/ui/dist -name "barefoot.js"` shows only `dist/components/barefoot.js` and `dist/static/components/barefoot.js`
- [x] Unit tests pass: `bun test packages/jsx`

Closes #191

🤖 Generated with [Claude Code](https://claude.ai/code)