### PR TITLE
fix: enable Shiki code highlighting on Cloudflare Workers

### DIFF
--- a/docs/ui/package.json
+++ b/docs/ui/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@barefootjs/dom": "workspace:*",
     "@barefootjs/hono": "workspace:*",
+    "@shikijs/langs": "^3.21.0",
+    "@shikijs/themes": "^3.21.0",
     "hono": "^4",
     "lucide-static": "^0.562.0",
     "shiki": "^3.20.0"

--- a/docs/ui/worker.ts
+++ b/docs/ui/worker.ts
@@ -3,12 +3,13 @@
  *
  * Production server for Cloudflare Workers.
  * Static files in ./dist are served automatically via [assets] in wrangler.toml.
- *
- * Note: Syntax highlighting may not be available in Workers environment.
- * Code blocks will display without highlighting as a fallback.
  */
 
+import { initHighlighter } from './components/shared/highlighter'
 import { createApp } from './routes'
+
+// Initialize syntax highlighter at startup
+await initHighlighter()
 
 const app = createApp()
 


### PR DESCRIPTION
## Summary

- Fix Shiki syntax highlighting not working on Cloudflare Workers (wrangler dev)
- Switch from WASM-based Oniguruma engine to JavaScript RegExp engine for Workers compatibility
- Initialize highlighter in worker.ts at startup

Closes #189

## Changes

- **docs/ui/components/shared/highlighter.ts**: Use `createHighlighterCore` with `createJavaScriptRegexEngine` instead of WASM-based Oniguruma
- **docs/ui/components/shared/highlight.ts**: Apply same changes for consistency
- **docs/ui/worker.ts**: Add `initHighlighter()` call at startup
- **docs/ui/package.json**: Add `@shikijs/themes` and `@shikijs/langs` for fine-grained bundle imports

## Root Cause

Cloudflare Workers does not support initializing WebAssembly from binary data. The previous implementation used Shiki's default WASM-based Oniguruma engine, which fails in the Workers environment.

## Solution

Use Shiki's JavaScript RegExp engine (`createJavaScriptRegexEngine`) which doesn't require WASM. This engine is supported by Shiki v3.9.1+ for all built-in languages.

## Test plan

- [x] Verify `bun run dev` works with syntax highlighting
- [x] Verify `bunx wrangler dev` works with syntax highlighting
- [x] Confirm Shiki styles (`--shiki-light`, `--shiki-dark`) present in HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)