### PR TITLE
docs: improve Button documentation page layout

### DIFF
--- a/docs/ui/pages/button.tsx
+++ b/docs/ui/pages/button.tsx
@@ -95,8 +95,7 @@ export function ButtonPage() {
           {...getNavLinks('button')}
         />
 
-        <Example title="" code={`
-import { Button } from "@/components/ui/button"
+        <Example title="" code={`import { Button } from "@/components/ui/button"
 import { PlusIcon } from "@/components/ui/icon"
 
 function ButtonExample() {


### PR DESCRIPTION
## Summary
- Split Variants into individual Examples (Default → Secondary → Destructive → Outline → Ghost → Link)
- Add missing icon sizes (`icon-sm`, `icon-lg`) to Sizes section
- Update Table of Contents to reflect the new structure
- Remove unused `variantCode` variable

## Test plan
- [x] Verify Button documentation page renders correctly
- [ ] Check that each variant Example links correctly from TOC
- [x] Confirm all 6 size options are displayed in Sizes section

🤖 Generated with [Claude Code](https://claude.com/claude-code)