### PR TITLE
fix: add data-bf-scope to conditional component root elements

### DIFF
--- a/packages/jsx/__tests__/transformers/ir-to-marked-jsx.test.ts
+++ b/packages/jsx/__tests__/transformers/ir-to-marked-jsx.test.ts
@@ -155,8 +155,8 @@ describe('irToMarkedJsx', () => {
       { getter: 'isOn', setter: 'setIsOn', initialValue: 'false' },
     ]
     const result = irToMarkedJsx(node, 'Test', isOnSignal)
-    // Element branches are valid JSX as-is
-    expect(result).toBe('{false ? <span className="on">ON</span> : <span className="off">OFF</span>}')
+    // Element branches at root get data-bf-scope for hydration
+    expect(result).toBe('{false ? <span {...(__listIndex === undefined ? { "data-bf-scope": __bfScope || __instanceId } : {})} className="on">ON</span> : <span {...(__listIndex === undefined ? { "data-bf-scope": __bfScope || __instanceId } : {})} className="off">OFF</span>}')
   })
 
   it('handles self-closing tags', () => {

--- a/packages/jsx/src/transformers/ir-to-marked-jsx.ts
+++ b/packages/jsx/src/transformers/ir-to-marked-jsx.ts
@@ -205,8 +205,9 @@ function irToMarkedJsxInternal(node: IRNode, ctx: MarkedJsxContext, isRoot: bool
       }
 
       // Static conditional - use standard processing
-      const whenTrue = nodeToJsxExpressionValueInternal(node.whenTrue, ctx)
-      const whenFalse = nodeToJsxExpressionValueInternal(node.whenFalse, ctx)
+      // Pass isRoot to branches so elements get data-bf-scope when at component root
+      const whenTrue = nodeToJsxExpressionValueInternal(node.whenTrue, ctx, isRoot)
+      const whenFalse = nodeToJsxExpressionValueInternal(node.whenFalse, ctx, isRoot)
       return `{${condition} ? ${whenTrue} : ${whenFalse}}`
 
     case 'element':
@@ -242,9 +243,10 @@ function fragmentToMarkedJsxInternal(node: IRFragment, ctx: MarkedJsxContext, is
  *
  * @param node - IR node to convert
  * @param ctx - Marked JSX context
+ * @param isRoot - Whether this is the root element (for data-bf-scope injection)
  * @returns String suitable for use inside JSX expression (e.g., ternary)
  */
-function nodeToJsxExpressionValueInternal(node: IRNode, ctx: MarkedJsxContext): string {
+function nodeToJsxExpressionValueInternal(node: IRNode, ctx: MarkedJsxContext, isRoot: boolean = false): string {
   switch (node.type) {
     case 'text':
       // Text inside expression context needs to be a quoted string
@@ -258,7 +260,8 @@ function nodeToJsxExpressionValueInternal(node: IRNode, ctx: MarkedJsxContext): 
 
     case 'element':
       // Element is valid JSX, use as-is
-      return elementToMarkedJsxInternal(node, ctx, false)
+      // Pass isRoot so root element gets data-bf-scope
+      return elementToMarkedJsxInternal(node, ctx, isRoot)
 
     case 'conditional':
       // Nested conditional - recursively process


### PR DESCRIPTION
## Summary

- Fix hydration failure for components with conditional return statements (e.g., Button's `asChild` prop)
- Propagate `isRoot` flag through `nodeToJsxExpressionValueInternal` to add `data-bf-scope` to conditional branch elements
- Update related unit test expectation

## Problem

When a component returns a conditional expression (e.g., `if (asChild) return <Slot>; return <button>`), the compiled output's root element in each branch was missing the `data-bf-scope` attribute. This caused:

1. `findScope('Button', ...)` to fail during hydration
2. Event handlers (like `onClick`) not being attached to DOM elements
3. Interactive components (like ButtonDemo's click counter) not working

## Solution

Modified `ir-to-marked-jsx.ts` to propagate the `isRoot` flag when processing conditional branches. Now elements at the component root get the proper `data-bf-scope` attribute regardless of whether they're inside a conditional.

## Test plan

- [x] Unit tests pass (`bun test packages/jsx`)
- [x] Verified `data-bf-scope="Button_xxx"` appears in generated HTML
- [x] ButtonDemo interactive counter should now work on `/docs/components/button#interactive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)