### PR TITLE
feat: improve mobile UI for button documentation page

### DIFF
--- a/docs/ui/components/mobile-menu.tsx
+++ b/docs/ui/components/mobile-menu.tsx
@@ -181,7 +181,7 @@ export function MobileMenu() {
       {/* Menu button - fixed at bottom left, visible on mobile only */}
       <button
         data-mobile-menu-toggle
-        class="sm:hidden fixed bottom-6 left-6 z-[10000] w-14 h-14 flex items-center justify-center bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors"
+        class="sm:hidden fixed bottom-6 left-4 z-[10000] w-11 h-11 flex items-center justify-center bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors"
         aria-label="Open menu"
       >
         <DotsVerticalIcon />

--- a/docs/ui/components/mobile-menu.tsx
+++ b/docs/ui/components/mobile-menu.tsx
@@ -3,25 +3,19 @@
 /**
  * Mobile Menu Component
  *
- * Hamburger menu for mobile devices.
- * Features:
- * - Hamburger button visible on mobile (hidden on xl:)
- * - Slide-in drawer with menu items
- * - Close on overlay click or close button
- * - Close on navigation
+ * Bottom sheet menu for mobile devices with drag-to-resize functionality.
  */
 
 import { createSignal, createEffect } from '@barefootjs/dom'
 import { XIcon, ChevronRightIcon } from '@ui/components/ui/icon'
 
-// Three vertical dots icon (custom, not in Icon component)
+const summaryClass = 'flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden'
+const menuLinkClass = 'block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline'
+const activeLinkClass = 'block py-2.5 px-4 text-base rounded-md no-underline bg-accent text-foreground font-medium'
+
 function DotsVerticalIcon() {
   return (
-    <svg
-      class="h-6 w-6"
-      fill="currentColor"
-      viewBox="0 0 24 24"
-    >
+    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
       <circle cx="12" cy="5" r="2" />
       <circle cx="12" cy="12" r="2" />
       <circle cx="12" cy="19" r="2" />
@@ -31,9 +25,8 @@ function DotsVerticalIcon() {
 
 export function MobileMenu() {
   const [open, setOpen] = createSignal(false)
-  const [expanded, setExpanded] = createSignal(false) // false = 50%, true = 85%
+  const [expanded, setExpanded] = createSignal(false)
 
-  // Event delegation for menu interactions and drag handling
   createEffect(() => {
     const toggleBtn = document.querySelector('[data-mobile-menu-toggle]')
     const closeBtn = document.querySelector('[data-mobile-menu-close]')
@@ -43,142 +36,125 @@ export function MobileMenu() {
 
     if (!toggleBtn || !overlay || !drawer) return
 
-    // Open current category based on URL and highlight active item
     const currentPath = window.location.pathname
-    const activeClass = 'bg-accent text-foreground font-medium'
 
-    // Find and highlight active menu item
     const allLinks = drawer.querySelectorAll('nav a[href]') as NodeListOf<HTMLAnchorElement>
     allLinks.forEach(link => {
       if (link.getAttribute('href') === currentPath) {
-        link.className = `block py-2.5 px-4 text-base rounded-md no-underline ${activeClass}`
+        link.className = activeLinkClass
       }
     })
 
-    // Open the category containing the current page
-    if (currentPath === '/') {
-      const details = drawer.querySelector('[data-category="get-started"]') as HTMLDetailsElement
+    const openCategory = (category: string): void => {
+      const details = drawer.querySelector(`[data-category="${category}"]`) as HTMLDetailsElement
       if (details) details.open = true
-    } else {
-      const categoryMap: Record<string, string> = {
-        '/docs/components': 'components',
-        '/docs/forms': 'forms',
-        '/blocks': 'blocks',
-        '/charts': 'charts',
-      }
-      for (const [prefix, category] of Object.entries(categoryMap)) {
-        if (currentPath.startsWith(prefix)) {
-          const details = drawer.querySelector(`[data-category="${category}"]`) as HTMLDetailsElement
-          if (details) details.open = true
-        }
-      }
     }
 
-    const openMenu = () => {
+    if (currentPath === '/') {
+      openCategory('get-started')
+    } else if (currentPath.startsWith('/docs/components')) {
+      openCategory('components')
+    } else if (currentPath.startsWith('/docs/forms')) {
+      openCategory('forms')
+    } else if (currentPath.startsWith('/blocks')) {
+      openCategory('blocks')
+    } else if (currentPath.startsWith('/charts')) {
+      openCategory('charts')
+    }
+
+    const openMenu = (): void => {
       setOpen(true)
-      setExpanded(false) // Start at 50%
+      setExpanded(false)
       document.body.style.overflow = 'hidden'
     }
 
-    const closeMenu = () => {
+    const closeMenu = (): void => {
       setOpen(false)
       setExpanded(false)
       document.body.style.overflow = ''
     }
 
-    // Drag handling (supports both touch and mouse events)
     let startY = 0
     let startHeight = 0
     let isDragging = false
 
-    const handleDragStart = (clientY: number) => {
+    const handleDragStart = (clientY: number): void => {
       isDragging = true
       startY = clientY
       startHeight = drawer.offsetHeight
       drawer.style.transition = 'none'
     }
 
-    const handleDragMove = (clientY: number) => {
+    const handleDragMove = (clientY: number): void => {
       if (!isDragging) return
       const deltaY = startY - clientY
-      const newHeight = Math.min(Math.max(startHeight + deltaY, window.innerHeight * 0.3), window.innerHeight * 0.85)
+      const minHeight = window.innerHeight * 0.3
+      const maxHeight = window.innerHeight * 0.85
+      const newHeight = Math.min(Math.max(startHeight + deltaY, minHeight), maxHeight)
       drawer.style.height = `${newHeight}px`
     }
 
-    const handleDragEnd = () => {
+    const handleDragEnd = (): void => {
       if (!isDragging) return
       isDragging = false
       drawer.style.transition = ''
-      const currentHeight = drawer.offsetHeight
-      const threshold = window.innerHeight * 0.65
+      drawer.style.height = ''
 
-      if (currentHeight > threshold) {
+      const currentHeight = drawer.offsetHeight
+      if (currentHeight > window.innerHeight * 0.65) {
         setExpanded(true)
-        drawer.style.height = ''
       } else if (currentHeight < window.innerHeight * 0.35) {
         closeMenu()
-        drawer.style.height = ''
       } else {
         setExpanded(false)
-        drawer.style.height = ''
       }
     }
 
-    // Touch events
-    const handleTouchStart = (e: TouchEvent) => handleDragStart(e.touches[0].clientY)
-    const handleTouchMove = (e: TouchEvent) => handleDragMove(e.touches[0].clientY)
-    const handleTouchEnd = () => handleDragEnd()
-
-    // Mouse events (for PC)
-    const handleMouseDown = (e: MouseEvent) => {
+    const handleTouchStart = (e: TouchEvent): void => handleDragStart(e.touches[0].clientY)
+    const handleTouchMove = (e: TouchEvent): void => handleDragMove(e.touches[0].clientY)
+    const handleMouseDown = (e: MouseEvent): void => {
       e.preventDefault()
       handleDragStart(e.clientY)
     }
-    const handleMouseMove = (e: MouseEvent) => handleDragMove(e.clientY)
-    const handleMouseUp = () => handleDragEnd()
+    const handleMouseMove = (e: MouseEvent): void => handleDragMove(e.clientY)
 
-    const handleToggleClick = () => openMenu()
-    const handleCloseClick = () => closeMenu()
-    const handleOverlayClick = (e: Event) => {
+    const handleOverlayClick = (e: Event): void => {
       if (e.target === overlay) closeMenu()
     }
-    const handleNavClick = (e: Event) => {
+    const handleNavClick = (e: Event): void => {
       const target = e.target as HTMLElement
       if (target.tagName === 'A') closeMenu()
     }
 
-    toggleBtn.addEventListener('click', handleToggleClick)
-    closeBtn?.addEventListener('click', handleCloseClick)
+    toggleBtn.addEventListener('click', openMenu)
+    closeBtn?.addEventListener('click', closeMenu)
     overlay.addEventListener('click', handleOverlayClick)
     drawer.addEventListener('click', handleNavClick)
-    // Touch events
     dragHandle?.addEventListener('touchstart', handleTouchStart)
-    document.addEventListener('touchmove', handleTouchMove)
-    document.addEventListener('touchend', handleTouchEnd)
-    // Mouse events (for PC)
     dragHandle?.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('touchmove', handleTouchMove)
+    document.addEventListener('touchend', handleDragEnd)
     document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
+    document.addEventListener('mouseup', handleDragEnd)
 
     return () => {
-      toggleBtn.removeEventListener('click', handleToggleClick)
-      closeBtn?.removeEventListener('click', handleCloseClick)
+      toggleBtn.removeEventListener('click', openMenu)
+      closeBtn?.removeEventListener('click', closeMenu)
       overlay.removeEventListener('click', handleOverlayClick)
       drawer.removeEventListener('click', handleNavClick)
-      // Touch events
       dragHandle?.removeEventListener('touchstart', handleTouchStart)
-      document.removeEventListener('touchmove', handleTouchMove)
-      document.removeEventListener('touchend', handleTouchEnd)
-      // Mouse events
       dragHandle?.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('touchmove', handleTouchMove)
+      document.removeEventListener('touchend', handleDragEnd)
       document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
+      document.removeEventListener('mouseup', handleDragEnd)
     }
   })
 
+  const chevronClass = 'transition-transform duration-200 group-open:rotate-90'
+
   return (
     <>
-      {/* Menu button - fixed at bottom left, visible on mobile only */}
       <button
         data-mobile-menu-toggle
         class="sm:hidden fixed bottom-6 left-4 z-[10000] w-11 h-11 flex items-center justify-center bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors"
@@ -187,20 +163,17 @@ export function MobileMenu() {
         <DotsVerticalIcon />
       </button>
 
-      {/* Overlay */}
       <div
         data-mobile-menu-overlay
         data-state={open() ? 'open' : 'closed'}
         class="fixed inset-0 z-[10001] bg-black/50 sm:hidden transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=closed]:pointer-events-none"
       >
-        {/* Bottom Sheet */}
         <div
           data-mobile-menu-drawer
           class="fixed bottom-0 left-0 right-0 z-[10002] bg-background rounded-t-2xl shadow-lg transform transition-all duration-300 ease-out data-[state=closed]:translate-y-full data-[expanded=false]:h-[50vh] data-[expanded=true]:h-[85vh]"
           data-state={open() ? 'open' : 'closed'}
           data-expanded={expanded() ? 'true' : 'false'}
         >
-          {/* Drag Handle + Close Button */}
           <div class="flex items-center justify-between px-4 pt-3 pb-2">
             <div data-drag-handle class="flex-1 flex justify-center cursor-grab active:cursor-grabbing touch-none">
               <div class="w-12 h-1.5 bg-muted-foreground/30 rounded-full"></div>
@@ -214,80 +187,68 @@ export function MobileMenu() {
             </button>
           </div>
 
-          {/* Navigation */}
           <nav class="p-4 overflow-y-auto h-[calc(100%-48px)]">
             <div class="space-y-1">
-              {/* Get Started */}
               <details data-category="get-started" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class={summaryClass}>
                   <span>Get Started</span>
-                  <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
+                  <ChevronRightIcon size="sm" class={chevronClass} />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">
-                    Introduction
-                  </a>
+                  <a href="/" class={menuLinkClass}>Introduction</a>
                 </div>
               </details>
 
-              {/* Components */}
               <details data-category="components" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class={summaryClass}>
                   <span>Components</span>
-                  <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
+                  <ChevronRightIcon size="sm" class={chevronClass} />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/components/accordion" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Accordion</a>
-                  <a href="/docs/components/badge" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Badge</a>
-                  <a href="/docs/components/button" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Button</a>
-                  <a href="/docs/components/card" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Card</a>
-                  <a href="/docs/components/checkbox" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Checkbox</a>
-                  <a href="/docs/components/counter" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Counter</a>
-                  <a href="/docs/components/dialog" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dialog</a>
-                  <a href="/docs/components/dropdown" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dropdown</a>
-                  <a href="/docs/components/input" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Input</a>
-                  <a href="/docs/components/select" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Select</a>
-                  <a href="/docs/components/switch" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Switch</a>
-                  <a href="/docs/components/tabs" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tabs</a>
-                  <a href="/docs/components/toast" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Toast</a>
-                  <a href="/docs/components/tooltip" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tooltip</a>
+                  <a href="/docs/components/accordion" class={menuLinkClass}>Accordion</a>
+                  <a href="/docs/components/badge" class={menuLinkClass}>Badge</a>
+                  <a href="/docs/components/button" class={menuLinkClass}>Button</a>
+                  <a href="/docs/components/card" class={menuLinkClass}>Card</a>
+                  <a href="/docs/components/checkbox" class={menuLinkClass}>Checkbox</a>
+                  <a href="/docs/components/counter" class={menuLinkClass}>Counter</a>
+                  <a href="/docs/components/dialog" class={menuLinkClass}>Dialog</a>
+                  <a href="/docs/components/dropdown" class={menuLinkClass}>Dropdown</a>
+                  <a href="/docs/components/input" class={menuLinkClass}>Input</a>
+                  <a href="/docs/components/select" class={menuLinkClass}>Select</a>
+                  <a href="/docs/components/switch" class={menuLinkClass}>Switch</a>
+                  <a href="/docs/components/tabs" class={menuLinkClass}>Tabs</a>
+                  <a href="/docs/components/toast" class={menuLinkClass}>Toast</a>
+                  <a href="/docs/components/tooltip" class={menuLinkClass}>Tooltip</a>
                 </div>
               </details>
 
-              {/* Forms */}
               <details data-category="forms" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class={summaryClass}>
                   <span>Forms</span>
-                  <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
+                  <ChevronRightIcon size="sm" class={chevronClass} />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/forms/controlled-input" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Controlled Input</a>
-                  <a href="/docs/forms/field-arrays" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Field Arrays</a>
-                  <a href="/docs/forms/submit" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Submit</a>
-                  <a href="/docs/forms/validation" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Validation</a>
+                  <a href="/docs/forms/controlled-input" class={menuLinkClass}>Controlled Input</a>
+                  <a href="/docs/forms/field-arrays" class={menuLinkClass}>Field Arrays</a>
+                  <a href="/docs/forms/submit" class={menuLinkClass}>Submit</a>
+                  <a href="/docs/forms/validation" class={menuLinkClass}>Validation</a>
                 </div>
               </details>
 
-              {/* Blocks */}
               <details data-category="blocks" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class={summaryClass}>
                   <span>Blocks</span>
-                  <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
+                  <ChevronRightIcon size="sm" class={chevronClass} />
                 </summary>
-                <div class="pl-2 py-1 space-y-0.5">
-                  {/* Empty for now */}
-                </div>
+                <div class="pl-2 py-1 space-y-0.5"></div>
               </details>
 
-              {/* Charts */}
               <details data-category="charts" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class={summaryClass}>
                   <span>Charts</span>
-                  <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
+                  <ChevronRightIcon size="sm" class={chevronClass} />
                 </summary>
-                <div class="pl-2 py-1 space-y-0.5">
-                  {/* Empty for now */}
-                </div>
+                <div class="pl-2 py-1 space-y-0.5"></div>
               </details>
             </div>
           </nav>

--- a/docs/ui/components/mobile-menu.tsx
+++ b/docs/ui/components/mobile-menu.tsx
@@ -51,7 +51,7 @@ export function MobileMenu() {
     const allLinks = drawer.querySelectorAll('nav a[href]') as NodeListOf<HTMLAnchorElement>
     allLinks.forEach(link => {
       if (link.getAttribute('href') === currentPath) {
-        link.className = `block py-1.5 px-3 text-sm rounded-md no-underline ${activeClass}`
+        link.className = `block py-2.5 px-4 text-base rounded-md no-underline ${activeClass}`
       }
     })
 
@@ -178,10 +178,10 @@ export function MobileMenu() {
 
   return (
     <>
-      {/* Menu button - fixed at bottom right, visible on mobile only */}
+      {/* Menu button - fixed at bottom left, visible on mobile only */}
       <button
         data-mobile-menu-toggle
-        class="sm:hidden fixed bottom-6 right-6 z-[10000] w-14 h-14 flex items-center justify-center bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors"
+        class="sm:hidden fixed bottom-6 left-6 z-[10000] w-14 h-14 flex items-center justify-center bg-primary text-primary-foreground rounded-full shadow-lg hover:bg-primary/90 transition-colors"
         aria-label="Open menu"
       >
         <DotsVerticalIcon />
@@ -219,12 +219,12 @@ export function MobileMenu() {
             <div class="space-y-1">
               {/* Get Started */}
               <details data-category="get-started" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2 px-3 text-sm font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
                   <span>Get Started</span>
                   <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">
+                  <a href="/" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">
                     Introduction
                   </a>
                 </div>
@@ -232,45 +232,45 @@ export function MobileMenu() {
 
               {/* Components */}
               <details data-category="components" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2 px-3 text-sm font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
                   <span>Components</span>
                   <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/components/accordion" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Accordion</a>
-                  <a href="/docs/components/badge" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Badge</a>
-                  <a href="/docs/components/button" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Button</a>
-                  <a href="/docs/components/card" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Card</a>
-                  <a href="/docs/components/checkbox" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Checkbox</a>
-                  <a href="/docs/components/counter" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Counter</a>
-                  <a href="/docs/components/dialog" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dialog</a>
-                  <a href="/docs/components/dropdown" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dropdown</a>
-                  <a href="/docs/components/input" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Input</a>
-                  <a href="/docs/components/select" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Select</a>
-                  <a href="/docs/components/switch" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Switch</a>
-                  <a href="/docs/components/tabs" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tabs</a>
-                  <a href="/docs/components/toast" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Toast</a>
-                  <a href="/docs/components/tooltip" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tooltip</a>
+                  <a href="/docs/components/accordion" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Accordion</a>
+                  <a href="/docs/components/badge" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Badge</a>
+                  <a href="/docs/components/button" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Button</a>
+                  <a href="/docs/components/card" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Card</a>
+                  <a href="/docs/components/checkbox" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Checkbox</a>
+                  <a href="/docs/components/counter" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Counter</a>
+                  <a href="/docs/components/dialog" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dialog</a>
+                  <a href="/docs/components/dropdown" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Dropdown</a>
+                  <a href="/docs/components/input" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Input</a>
+                  <a href="/docs/components/select" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Select</a>
+                  <a href="/docs/components/switch" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Switch</a>
+                  <a href="/docs/components/tabs" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tabs</a>
+                  <a href="/docs/components/toast" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Toast</a>
+                  <a href="/docs/components/tooltip" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Tooltip</a>
                 </div>
               </details>
 
               {/* Forms */}
               <details data-category="forms" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2 px-3 text-sm font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
                   <span>Forms</span>
                   <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
                 </summary>
                 <div class="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/forms/controlled-input" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Controlled Input</a>
-                  <a href="/docs/forms/field-arrays" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Field Arrays</a>
-                  <a href="/docs/forms/submit" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Submit</a>
-                  <a href="/docs/forms/validation" class="block py-1.5 px-3 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Validation</a>
+                  <a href="/docs/forms/controlled-input" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Controlled Input</a>
+                  <a href="/docs/forms/field-arrays" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Field Arrays</a>
+                  <a href="/docs/forms/submit" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Submit</a>
+                  <a href="/docs/forms/validation" class="block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline">Validation</a>
                 </div>
               </details>
 
               {/* Blocks */}
               <details data-category="blocks" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2 px-3 text-sm font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
                   <span>Blocks</span>
                   <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
                 </summary>
@@ -281,7 +281,7 @@ export function MobileMenu() {
 
               {/* Charts */}
               <details data-category="charts" class="mb-2 group">
-                <summary class="flex w-full items-center justify-between py-2 px-3 text-sm font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+                <summary class="flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
                   <span>Charts</span>
                   <ChevronRightIcon size="sm" class="transition-transform duration-200 group-open:rotate-90" />
                 </summary>

--- a/docs/ui/components/mobile-page-nav.tsx
+++ b/docs/ui/components/mobile-page-nav.tsx
@@ -1,8 +1,8 @@
 /**
  * Mobile Page Navigation Component
  *
- * Fixed bottom-right navigation for mobile devices.
- * Shows prev/next page links like: < Badge | Card >
+ * Fixed bottom navigation for mobile devices.
+ * Shows prev/next as separate buttons.
  */
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@ui/components/ui/icon'
@@ -24,25 +24,24 @@ export function MobilePageNav({ currentPath }: MobilePageNavProps) {
   if (!prev && !next) return null
 
   return (
-    <div class="fixed bottom-6 right-6 z-[10000] sm:hidden flex items-center gap-1 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border px-2 py-1.5">
+    <div class="fixed bottom-6 left-18 right-4 z-[10000] sm:hidden flex items-center justify-end gap-2">
       {prev && (
         <a
           href={prev.href}
-          class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
+          class="flex items-center gap-1 px-3 py-2 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
           aria-label={`Previous: ${prev.title}`}
         >
           <ChevronLeftIcon size="sm" />
-          <span class="text-sm max-w-16 truncate">{prev.title}</span>
+          <span class="text-sm truncate">{prev.title}</span>
         </a>
       )}
-      {prev && next && <span class="text-muted-foreground/50">|</span>}
       {next && (
         <a
           href={next.href}
-          class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
+          class="flex items-center gap-1 px-3 py-2 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
           aria-label={`Next: ${next.title}`}
         >
-          <span class="text-sm max-w-16 truncate">{next.title}</span>
+          <span class="text-sm truncate">{next.title}</span>
           <ChevronRightIcon size="sm" />
         </a>
       )}

--- a/docs/ui/components/mobile-page-nav.tsx
+++ b/docs/ui/components/mobile-page-nav.tsx
@@ -28,21 +28,21 @@ export function MobilePageNav({ currentPath }: MobilePageNavProps) {
       {prev && (
         <a
           href={prev.href}
-          class="flex items-center gap-1 px-3 py-2 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
+          class="flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
           aria-label={`Previous: ${prev.title}`}
         >
-          <ChevronLeftIcon size="sm" />
-          <span class="text-sm truncate">{prev.title}</span>
+          <ChevronLeftIcon size="sm" class="shrink-0" />
+          <span class="flex-1 text-center text-xs truncate">{prev.title}</span>
         </a>
       )}
       {next && (
         <a
           href={next.href}
-          class="flex items-center gap-1 px-3 py-2 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
+          class="flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
           aria-label={`Next: ${next.title}`}
         >
-          <span class="text-sm truncate">{next.title}</span>
-          <ChevronRightIcon size="sm" />
+          <span class="flex-1 text-center text-xs truncate">{next.title}</span>
+          <ChevronRightIcon size="sm" class="shrink-0" />
         </a>
       )}
     </div>

--- a/docs/ui/components/mobile-page-nav.tsx
+++ b/docs/ui/components/mobile-page-nav.tsx
@@ -1,0 +1,55 @@
+/**
+ * Mobile Page Navigation Component
+ *
+ * Fixed bottom-right navigation for mobile devices.
+ * Shows prev/next page links like: < Badge | Card >
+ */
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@ui/components/ui/icon'
+import { getNavLinks } from './shared/PageNavigation'
+
+interface MobilePageNavProps {
+  currentPath: string
+}
+
+export function MobilePageNav({ currentPath }: MobilePageNavProps) {
+  // Extract slug from path like /docs/components/button -> button
+  const match = currentPath.match(/\/docs\/components\/([^/]+)/)
+  if (!match) return null
+
+  const slug = match[1]
+  const { prev, next } = getNavLinks(slug)
+
+  // Don't render if no prev and no next
+  if (!prev && !next) return null
+
+  return (
+    <div class="fixed bottom-6 right-6 z-[10000] sm:hidden flex items-center gap-1 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border px-2 py-1.5">
+      {prev ? (
+        <a
+          href={prev.href}
+          class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
+          aria-label={`Previous: ${prev.title}`}
+        >
+          <ChevronLeftIcon size="sm" />
+          <span class="text-sm max-w-16 truncate">{prev.title}</span>
+        </a>
+      ) : (
+        <div class="w-16" />
+      )}
+      <span class="text-muted-foreground/50">|</span>
+      {next ? (
+        <a
+          href={next.href}
+          class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
+          aria-label={`Next: ${next.title}`}
+        >
+          <span class="text-sm max-w-16 truncate">{next.title}</span>
+          <ChevronRightIcon size="sm" />
+        </a>
+      ) : (
+        <div class="w-16" />
+      )}
+    </div>
+  )
+}

--- a/docs/ui/components/mobile-page-nav.tsx
+++ b/docs/ui/components/mobile-page-nav.tsx
@@ -1,8 +1,7 @@
 /**
  * Mobile Page Navigation Component
  *
- * Fixed bottom navigation for mobile devices.
- * Shows prev/next as separate buttons.
+ * Fixed bottom navigation for mobile devices with prev/next buttons.
  */
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@ui/components/ui/icon'
@@ -12,35 +11,27 @@ interface MobilePageNavProps {
   currentPath: string
 }
 
+const navLinkClass = 'flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline'
+
 export function MobilePageNav({ currentPath }: MobilePageNavProps) {
-  // Extract slug from path like /docs/components/button -> button
   const match = currentPath.match(/\/docs\/components\/([^/]+)/)
   if (!match) return null
 
   const slug = match[1]
   const { prev, next } = getNavLinks(slug)
 
-  // Don't render if no prev and no next
   if (!prev && !next) return null
 
   return (
     <div class="fixed bottom-6 left-18 right-4 z-[10000] sm:hidden flex items-center justify-end gap-2">
       {prev && (
-        <a
-          href={prev.href}
-          class="flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
-          aria-label={`Previous: ${prev.title}`}
-        >
+        <a href={prev.href} class={navLinkClass} aria-label={`Previous: ${prev.title}`}>
           <ChevronLeftIcon size="sm" class="shrink-0" />
           <span class="flex-1 text-center text-xs truncate">{prev.title}</span>
         </a>
       )}
       {next && (
-        <a
-          href={next.href}
-          class="flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline"
-          aria-label={`Next: ${next.title}`}
-        >
+        <a href={next.href} class={navLinkClass} aria-label={`Next: ${next.title}`}>
           <span class="flex-1 text-center text-xs truncate">{next.title}</span>
           <ChevronRightIcon size="sm" class="shrink-0" />
         </a>

--- a/docs/ui/components/mobile-page-nav.tsx
+++ b/docs/ui/components/mobile-page-nav.tsx
@@ -25,7 +25,7 @@ export function MobilePageNav({ currentPath }: MobilePageNavProps) {
 
   return (
     <div class="fixed bottom-6 right-6 z-[10000] sm:hidden flex items-center gap-1 bg-background/95 backdrop-blur rounded-full shadow-lg border border-border px-2 py-1.5">
-      {prev ? (
+      {prev && (
         <a
           href={prev.href}
           class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
@@ -34,11 +34,9 @@ export function MobilePageNav({ currentPath }: MobilePageNavProps) {
           <ChevronLeftIcon size="sm" />
           <span class="text-sm max-w-16 truncate">{prev.title}</span>
         </a>
-      ) : (
-        <div class="w-16" />
       )}
-      <span class="text-muted-foreground/50">|</span>
-      {next ? (
+      {prev && next && <span class="text-muted-foreground/50">|</span>}
+      {next && (
         <a
           href={next.href}
           class="flex items-center gap-1 px-2 py-1 text-muted-foreground hover:text-foreground transition-colors no-underline"
@@ -47,8 +45,6 @@ export function MobilePageNav({ currentPath }: MobilePageNavProps) {
           <span class="text-sm max-w-16 truncate">{next.title}</span>
           <ChevronRightIcon size="sm" />
         </a>
-      ) : (
-        <div class="w-16" />
       )}
     </div>
   )

--- a/docs/ui/components/shared/PageNavigation.tsx
+++ b/docs/ui/components/shared/PageNavigation.tsx
@@ -21,7 +21,7 @@ export function PageNavigation({ prev, next }: PageNavigationProps) {
   if (!prev && !next) return null
 
   return (
-    <nav class="flex items-center justify-between pt-8 mt-12 border-0 border-t border-solid border-border" aria-label="Page navigation">
+    <nav class="hidden sm:flex items-center justify-between pt-8 mt-12 border-0 border-t border-solid border-border" aria-label="Page navigation">
       {prev ? (
         <a
           href={prev.href}

--- a/docs/ui/components/shared/docs.tsx
+++ b/docs/ui/components/shared/docs.tsx
@@ -238,7 +238,17 @@ function toKebabCase(str: string): string {
 }
 
 // Example component with preview and code in a unified container
-export function Example({ title, code, children }: { title?: string; code: string; children: any }) {
+export function Example({
+  title,
+  code,
+  children,
+  showLineNumbers: showLineNumbersProp,
+}: {
+  title?: string
+  code: string
+  children: any
+  showLineNumbers?: boolean
+}) {
   // Highlight code and split into lines for line number display
   const highlightedCode = highlight(code, 'tsx')
   const lines = highlightedCode.split('\n')
@@ -246,6 +256,9 @@ export function Example({ title, code, children }: { title?: string; code: strin
   if (lines[lines.length - 1] === '') {
     lines.pop()
   }
+
+  // Auto-hide line numbers for 3 or fewer lines, unless explicitly set
+  const showLineNumbers = showLineNumbersProp ?? lines.length > 3
 
   const id = title ? toKebabCase(title) : undefined
 
@@ -273,18 +286,22 @@ export function Example({ title, code, children }: { title?: string; code: strin
             {children}
           </div>
         </div>
-        {/* Code section with line numbers */}
+        {/* Code section with conditional line numbers */}
         <div class="relative group">
           <pre class="m-0 p-4 pr-12 bg-muted overflow-x-auto text-sm font-mono">
             <code class="block">
-              {lines.map((line, i) => (
-                <span key={i} class="table-row">
-                  <span class="table-cell pr-4 text-right select-none text-muted-foreground/50 w-8">
-                    {i + 1}
+              {showLineNumbers ? (
+                lines.map((line, i) => (
+                  <span key={i} class="table-row">
+                    <span class="table-cell pr-4 text-right select-none text-muted-foreground/50 w-8">
+                      {i + 1}
+                    </span>
+                    <span class="table-cell" dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }} />
                   </span>
-                  <span class="table-cell" dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }} />
-                </span>
-              ))}
+                ))
+              ) : (
+                <span dangerouslySetInnerHTML={{ __html: highlightedCode }} />
+              )}
             </code>
           </pre>
           <CopyButton code={code} />

--- a/docs/ui/components/shared/docs.tsx
+++ b/docs/ui/components/shared/docs.tsx
@@ -201,25 +201,25 @@ export interface PropDefinition {
 function PropRow({ name, type, defaultValue, description }: PropDefinition) {
   return (
     <tr class="border-b border-border last:border-b-0">
-      <td class="py-3 px-4 font-mono text-sm text-foreground">{name}</td>
-      <td class="py-3 px-4 font-mono text-sm text-muted-foreground">{type}</td>
-      <td class="py-3 px-4 font-mono text-sm text-muted-foreground">{defaultValue || '-'}</td>
-      <td class="py-3 px-4 text-sm text-muted-foreground">{description}</td>
+      <td class="py-3 px-4 font-mono text-sm text-foreground whitespace-nowrap">{name}</td>
+      <td class="py-3 px-4 font-mono text-sm text-muted-foreground whitespace-nowrap">{type}</td>
+      <td class="py-3 px-4 font-mono text-sm text-muted-foreground whitespace-nowrap">{defaultValue || '-'}</td>
+      <td class="py-3 px-4 text-sm text-muted-foreground whitespace-nowrap">{description}</td>
     </tr>
   )
 }
 
-// Props table component
+// Props table component with horizontal scroll for mobile
 export function PropsTable({ props }: { props: PropDefinition[] }) {
   return (
-    <div class="border border-border rounded-lg overflow-hidden">
-      <table class="w-full text-left">
+    <div class="border border-border rounded-lg overflow-x-auto">
+      <table class="w-full text-left min-w-[600px]">
         <thead class="bg-muted">
           <tr class="border-b border-border">
-            <th class="py-3 px-4 text-sm font-medium text-foreground">Prop</th>
-            <th class="py-3 px-4 text-sm font-medium text-foreground">Type</th>
-            <th class="py-3 px-4 text-sm font-medium text-foreground">Default</th>
-            <th class="py-3 px-4 text-sm font-medium text-foreground">Description</th>
+            <th class="py-3 px-4 text-sm font-medium text-foreground whitespace-nowrap">Prop</th>
+            <th class="py-3 px-4 text-sm font-medium text-foreground whitespace-nowrap">Type</th>
+            <th class="py-3 px-4 text-sm font-medium text-foreground whitespace-nowrap">Default</th>
+            <th class="py-3 px-4 text-sm font-medium text-foreground whitespace-nowrap">Description</th>
           </tr>
         </thead>
         <tbody>

--- a/docs/ui/components/shared/docs.tsx
+++ b/docs/ui/components/shared/docs.tsx
@@ -257,8 +257,8 @@ export function Example({
     lines.pop()
   }
 
-  // Auto-hide line numbers for 3 or fewer lines, unless explicitly set
-  const showLineNumbers = showLineNumbersProp ?? lines.length > 3
+  // Default to showing line numbers, can be explicitly disabled
+  const showLineNumbers = showLineNumbersProp ?? true
 
   const id = title ? toKebabCase(title) : undefined
 

--- a/docs/ui/pages/button.tsx
+++ b/docs/ui/pages/button.tsx
@@ -39,13 +39,13 @@ const sizeCode = `<Button size="sm">Small</Button>
 <Button size="lg">Large</Button>`
 
 const iconSizeCode = `<Button size="icon-sm">
-  <PlusIcon size="sm" />
+  <PlusIcon />
 </Button>
 <Button size="icon">
-  <PlusIcon size="sm" />
+  <PlusIcon />
 </Button>
 <Button size="icon-lg">
-  <PlusIcon size="sm" />
+  <PlusIcon />
 </Button>`
 
 const counterCode = `import { createSignal } from '@barefootjs/dom'
@@ -103,7 +103,7 @@ function ButtonExample() {
     <div class="flex flex-wrap items-center gap-2 md:flex-row">
       <Button variant="outline">Button</Button>
       <Button variant="outline" size="icon" aria-label="Submit">
-          <PlusIcon size="sm" />
+          <PlusIcon />
       </Button>
     </div>
   )
@@ -112,7 +112,7 @@ function ButtonExample() {
           <div class="flex flex-wrap items-center gap-2 md:flex-row">
             <Button variant="outline">Button</Button>
             <Button variant="outline" size="icon" aria-label="Submit">
-                <PlusIcon size="sm" />
+                <PlusIcon />
             </Button>
           </div>
         </Example>
@@ -155,13 +155,13 @@ function ButtonExample() {
 
             <Example title="Icon Sizes" code={iconSizeCode}>
               <Button size="icon-sm">
-                <PlusIcon size="sm" />
+                <PlusIcon />
               </Button>
               <Button size="icon">
-                <PlusIcon size="sm" />
+                <PlusIcon />
               </Button>
               <Button size="icon-lg">
-                <PlusIcon size="sm" />
+                <PlusIcon />
               </Button>
             </Example>
 

--- a/docs/ui/pages/button.tsx
+++ b/docs/ui/pages/button.tsx
@@ -38,17 +38,19 @@ const sizeCode = `<Button size="sm">Small</Button>
 <Button size="default">Default</Button>
 <Button size="lg">Large</Button>`
 
-const iconSizeCode = `<Button size="icon-sm">
+const iconSizeCode = `<Button size="icon-sm" aria-label="Add">
   <PlusIcon />
 </Button>
-<Button size="icon">
+<Button size="icon" aria-label="Add">
   <PlusIcon />
 </Button>
-<Button size="icon-lg">
+<Button size="icon-lg" aria-label="Add">
   <PlusIcon />
 </Button>`
 
-const counterCode = `import { createSignal } from '@barefootjs/dom'
+const counterCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
 import { Button } from '@/components/ui/button'
 
 function Counter() {
@@ -154,13 +156,13 @@ function ButtonExample() {
             </Example>
 
             <Example title="Icon Sizes" code={iconSizeCode}>
-              <Button size="icon-sm">
+              <Button size="icon-sm" aria-label="Add">
                 <PlusIcon />
               </Button>
-              <Button size="icon">
+              <Button size="icon" aria-label="Add">
                 <PlusIcon />
               </Button>
-              <Button size="icon-lg">
+              <Button size="icon-lg" aria-label="Add">
                 <PlusIcon />
               </Button>
             </Example>

--- a/docs/ui/pages/button.tsx
+++ b/docs/ui/pages/button.tsx
@@ -123,31 +123,31 @@ function ButtonExample() {
 
         <Section id="examples" title="Examples">
           <div class="space-y-8">
-            <Example title="Default" code={`<Button variant="default">Default</Button>`}>
+            <Example title="Default" code={`<Button variant="default">Default</Button>`} showLineNumbers={false}>
               <Button variant="default">Default</Button>
             </Example>
 
-            <Example title="Secondary" code={`<Button variant="secondary">Secondary</Button>`}>
+            <Example title="Secondary" code={`<Button variant="secondary">Secondary</Button>`} showLineNumbers={false}>
               <Button variant="secondary">Secondary</Button>
             </Example>
 
-            <Example title="Destructive" code={`<Button variant="destructive">Destructive</Button>`}>
+            <Example title="Destructive" code={`<Button variant="destructive">Destructive</Button>`} showLineNumbers={false}>
               <Button variant="destructive">Destructive</Button>
             </Example>
 
-            <Example title="Outline" code={`<Button variant="outline">Outline</Button>`}>
+            <Example title="Outline" code={`<Button variant="outline">Outline</Button>`} showLineNumbers={false}>
               <Button variant="outline">Outline</Button>
             </Example>
 
-            <Example title="Ghost" code={`<Button variant="ghost">Ghost</Button>`}>
+            <Example title="Ghost" code={`<Button variant="ghost">Ghost</Button>`} showLineNumbers={false}>
               <Button variant="ghost">Ghost</Button>
             </Example>
 
-            <Example title="Link" code={`<Button variant="link">Link</Button>`}>
+            <Example title="Link" code={`<Button variant="link">Link</Button>`} showLineNumbers={false}>
               <Button variant="link">Link</Button>
             </Example>
 
-            <Example title="Sizes" code={sizeCode}>
+            <Example title="Sizes" code={sizeCode} showLineNumbers={false}>
               <Button size="sm">Small</Button>
               <Button size="default">Default</Button>
               <Button size="lg">Large</Button>

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -25,6 +25,7 @@ import { SidebarPreview } from '@/components/sidebar-preview'
 import { Header } from '@/components/header'
 import { MobileHeader } from '@/components/mobile-header'
 import { MobileMenu } from '@/components/mobile-menu'
+import { MobilePageNav } from '@/components/mobile-page-nav'
 import { CommandPalette } from '@/components/command-palette'
 
 // Import manifest for dependency-aware preloading
@@ -106,6 +107,7 @@ export const renderer = jsxRenderer(
             <Header currentPath={currentPath} />
             <MobileHeader />
             <MobileMenu />
+            <MobilePageNav currentPath={currentPath} />
             <CommandPalette />
             <SidebarMenu currentPath={currentPath} />
             <SidebarPreview />

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -93,7 +93,12 @@ export const renderer = jsxRenderer(
             <link rel="stylesheet" href="/static/uno.css" />
             <style>{`
               body {
-                padding: 5rem 1.5rem 3rem;
+                padding: 5rem 0.5rem 3rem;
+              }
+              @media (min-width: 640px) {
+                body {
+                  padding: 5rem 1.5rem 3rem;
+                }
               }
             `}</style>
           </head>
@@ -105,7 +110,7 @@ export const renderer = jsxRenderer(
             <SidebarMenu currentPath={currentPath} />
             <SidebarPreview />
             <div class="sm:pl-56">
-              <main class="max-w-[1000px] mx-auto px-4">
+              <main class="max-w-[1000px] mx-auto px-2 sm:px-4">
                 {children}
               </main>
             </div>

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -93,7 +93,7 @@ export const renderer = jsxRenderer(
             <link rel="stylesheet" href="/static/uno.css" />
             <style>{`
               body {
-                padding: 5rem 0.5rem 3rem;
+                padding: 5rem 0 3rem;
               }
               @media (min-width: 640px) {
                 body {
@@ -110,7 +110,7 @@ export const renderer = jsxRenderer(
             <SidebarMenu currentPath={currentPath} />
             <SidebarPreview />
             <div class="sm:pl-56">
-              <main class="max-w-[1000px] mx-auto px-2 sm:px-4">
+              <main class="max-w-[1000px] mx-auto px-0 sm:px-4">
                 {children}
               </main>
             </div>

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -93,7 +93,7 @@ export const renderer = jsxRenderer(
             <link rel="stylesheet" href="/static/uno.css" />
             <style>{`
               body {
-                padding: 5rem 0 3rem;
+                padding: 5rem 0.3rem 3rem;
               }
               @media (min-width: 640px) {
                 body {

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -32,7 +32,7 @@ type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghos
 type ButtonSize = 'default' | 'sm' | 'lg' | 'icon' | 'icon-sm' | 'icon-lg'
 
 // Base classes shared by all buttons
-const baseClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+const baseClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-action-manipulation'
 
 // Variant-specific classes
 const variantClasses: Record<ButtonVariant, string> = {

--- a/ui/components/ui/icon.tsx
+++ b/ui/components/ui/icon.tsx
@@ -50,172 +50,172 @@ export type IconName = keyof typeof strokePaths | 'github' | 'search'
 // Icons that need butt linecap for proper visual centering
 const buttLinecapIcons = ['plus', 'minus'] as const
 
-export function CheckIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function CheckIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['check']} />
     </svg>
   )
 }
 
-export function ChevronDownIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ChevronDownIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['chevron-down']} />
     </svg>
   )
 }
 
-export function ChevronUpIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ChevronUpIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['chevron-up']} />
     </svg>
   )
 }
 
-export function ChevronLeftIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ChevronLeftIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['chevron-left']} />
     </svg>
   )
 }
 
-export function ChevronRightIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ChevronRightIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['chevron-right']} />
     </svg>
   )
 }
 
-export function XIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function XIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['x']} />
     </svg>
   )
 }
 
-export function PlusIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function PlusIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['plus']} />
     </svg>
   )
 }
 
-export function MinusIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function MinusIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['minus']} />
     </svg>
   )
 }
 
-export function SunIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function SunIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['sun']} />
     </svg>
   )
 }
 
-export function MoonIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function MoonIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['moon']} />
     </svg>
   )
 }
 
-export function MonitorIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function MonitorIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['monitor']} />
     </svg>
   )
 }
 
-export function CopyIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function CopyIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['copy']} />
     </svg>
   )
 }
 
-export function ClipboardIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ClipboardIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['clipboard']} />
     </svg>
   )
 }
 
-export function ClipboardCheckIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ClipboardCheckIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['clipboard-check']} />
     </svg>
   )
 }
 
-export function MenuIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function MenuIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['menu']} />
     </svg>
   )
 }
 
-export function ArrowLeftIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ArrowLeftIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['arrow-left']} />
     </svg>
   )
 }
 
-export function ArrowRightIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function ArrowRightIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['arrow-right']} />
     </svg>
   )
 }
 
-export function GitHubIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function GitHubIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="currentColor" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="currentColor" class={`shrink-0 ${className}`} aria-hidden="true">
       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
     </svg>
   )
 }
 
-export function SearchIcon({ size = 'md', class: className = '' }: IconProps) {
-  const s = sizeMap[size]
+export function SearchIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${className}`} aria-hidden="true">
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.35-4.35" />
     </svg>


### PR DESCRIPTION
## Summary

### Phase 1
- Adjust mobile content horizontal padding (body: 0.3rem)
- Add showLineNumbers prop for code examples (default: true)
- Make Icon size prop optional for parent container (Button) control
- Add touch-action-manipulation to Button to prevent double-tap zoom

### Phase 2
- Add "use client" directive to Counter example
- Make API Reference table horizontally scrollable
- Add aria-label to Icon examples
- Mobile menu improvements:
  - Move FAB button to bottom-left & reduce size (w-11 h-11)
  - Increase menu font size (text-base)
  - Expand tap target area (py-2.5 px-4)

### Mobile Page Navigation
- Add fixed page navigation at bottom-right
- Display prev/next as separate buttons
- Fixed button width (w-28) to prevent position shift on navigation
- Icons fixed at edges, text centered
- Remove shadow, use subtle rounded corners (rounded-md)

### Code Refactoring
- Extract repeated CSS classes to constants
- Simplify category opening logic with helper function
- Remove redundant wrapper functions for event handlers

## Test plan
- [ ] Verify button page on mobile viewport (375px width)
- [ ] Confirm FAB button displays at bottom-left
- [ ] Confirm page nav (prev/next) displays at bottom-right with fixed width
- [ ] Verify menu fonts are larger and tap-friendly
- [ ] Confirm API Reference table is horizontally scrollable
- [ ] Verify Counter example code includes "use client"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)