### PR TITLE
fix: convert className to class attribute in HTML output

### DIFF
--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -94,7 +94,7 @@ app.get('/async-counter', (c) => {
   return c.render(
     <div>
       <h1>Async Counter with Suspense + BarefootJS</h1>
-      <Suspense fallback={<p class="loading">Loading counter...</p>}>
+      <Suspense fallback={<p className="loading">Loading counter...</p>}>
         <AsyncCounterWrapper />
       </Suspense>
       <p><a href="/">← Back</a></p>

--- a/examples/shared/components/AddTodoForm.tsx
+++ b/examples/shared/components/AddTodoForm.tsx
@@ -22,16 +22,16 @@ function AddTodoForm({ onAdd }: Props) {
   }
 
   return (
-    <div class="add-form">
+    <div className="add-form">
       <input
         type="text"
-        class="new-todo-input"
+        className="new-todo-input"
         placeholder="Enter new todo..."
         value={newText()}
         onInput={(e) => setNewText(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && !e.isComposing && handleAdd()}
       />
-      <button class="add-btn" onClick={() => handleAdd()}>
+      <button className="add-btn" onClick={() => handleAdd()}>
         Add
       </button>
     </div>

--- a/examples/shared/components/Counter.tsx
+++ b/examples/shared/components/Counter.tsx
@@ -18,13 +18,13 @@ export function Counter({ initial = 0 }: CounterProps) {
   const doubled = createMemo(() => count() * 2)
 
   return (
-    <div class="counter-container">
-      <p class="counter-value">{count()}</p>
-      <p class="counter-doubled">doubled: {doubled()}</p>
-      <div class="counter-buttons">
-        <button class="btn btn-increment" onClick={() => setCount(n => n + 1)}>+1</button>
-        <button class="btn btn-decrement" onClick={() => setCount(n => n - 1)}>-1</button>
-        <button class="btn btn-reset" onClick={() => setCount(0)}>Reset</button>
+    <div className="counter-container">
+      <p className="counter-value">{count()}</p>
+      <p className="counter-doubled">doubled: {doubled()}</p>
+      <div className="counter-buttons">
+        <button className="btn btn-increment" onClick={() => setCount(n => n + 1)}>+1</button>
+        <button className="btn btn-decrement" onClick={() => setCount(n => n - 1)}>-1</button>
+        <button className="btn btn-reset" onClick={() => setCount(0)}>Reset</button>
       </div>
     </div>
   )

--- a/examples/shared/components/TodoApp.tsx
+++ b/examples/shared/components/TodoApp.tsx
@@ -94,13 +94,13 @@ function TodoApp({ initialTodos = [] }: Props) {
     <div>
       <h1>BarefootJS Todo (SSR + API)</h1>
 
-      <p class="status">
-        Done: <span class="count">{todos().filter(t => t.done).length}</span> / <span class="total">{todos().length}</span>
+      <p className="status">
+        Done: <span className="count">{todos().filter(t => t.done).length}</span> / <span className="total">{todos().length}</span>
       </p>
 
       <AddTodoForm onAdd={handleAdd} />
 
-      <ul class="todo-list">
+      <ul className="todo-list">
         {todos().map(todo => (
           <TodoItem
             key={todo.id}

--- a/examples/shared/components/TodoItem.tsx
+++ b/examples/shared/components/TodoItem.tsx
@@ -21,25 +21,25 @@ type Props = {
 
 function TodoItem({ todo, onToggle, onDelete, onStartEdit, onFinishEdit }: Props) {
   return (
-    <li class={todo.done ? 'todo-item done' : 'todo-item'}>
+    <li className={todo.done ? 'todo-item done' : 'todo-item'}>
       {todo.editing ? (
         <input
           type="text"
-          class="todo-input"
+          className="todo-input"
           value={todo.text}
           autofocus
           onBlur={(e) => onFinishEdit(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && !e.isComposing && onFinishEdit(e.target.value)}
         />
       ) : (
-        <span class="todo-text" onClick={() => onStartEdit()}>
+        <span className="todo-text" onClick={() => onStartEdit()}>
           {todo.text}
         </span>
       )}
-      <button class="toggle-btn" onClick={() => onToggle()}>
+      <button className="toggle-btn" onClick={() => onToggle()}>
         {todo.done ? 'Undo' : 'Done'}
       </button>
-      <button class="delete-btn" onClick={() => onDelete()}>
+      <button className="delete-btn" onClick={() => onDelete()}>
         Delete
       </button>
     </li>

--- a/examples/shared/components/Toggle.tsx
+++ b/examples/shared/components/Toggle.tsx
@@ -11,7 +11,7 @@ type ToggleItemProps = {
 function ToggleItem({ label, defaultOn = false }: ToggleItemProps) {
   const [on, setOn] = createSignal(defaultOn)
   return (
-    <div class="toggle-item" style="display: flex; align-items: center; gap: 12px; padding: 8px 0;">
+    <div className="toggle-item" style="display: flex; align-items: center; gap: 12px; padding: 8px 0;">
       <span style="min-width: 120px;">{label}</span>
       <button
         onClick={() => setOn(!on())}
@@ -30,7 +30,7 @@ type ToggleProps = {
 // Settings panel with multiple toggles
 function Toggle({ toggleItems }: ToggleProps) {
   return (
-    <div class="settings-panel" style="padding: 16px; border: 1px solid #ddd; border-radius: 8px;">
+    <div className="settings-panel" style="padding: 16px; border: 1px solid #ddd; border-radius: 8px;">
       <h3 style="margin-top: 0;">Settings</h3>
       {toggleItems.map((item) => (
         <ToggleItem label={item.label} defaultOn={item.defaultOn} />

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -62,6 +62,23 @@ describe('GoTemplateAdapter', () => {
       expect(result).toBe('<div class="container" id="main"></div>')
     })
 
+    test('converts className to class attribute', () => {
+      const element: IRElement = {
+        type: 'element',
+        tag: 'div',
+        attrs: [{ name: 'className', value: 'container', dynamic: false, isLiteral: true, loc }],
+        events: [],
+        ref: null,
+        children: [],
+        slotId: null,
+        needsScope: false,
+        loc,
+      }
+
+      const result = adapter.renderElement(element)
+      expect(result).toBe('<div class="container"></div>')
+    })
+
     test('renders element with dynamic attribute', () => {
       const element: IRElement = {
         type: 'element',

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -840,13 +840,16 @@ export class GoTemplateAdapter extends BaseAdapter {
         continue
       }
 
+      // Convert JSX className to HTML class attribute
+      const attrName = attr.name === 'className' ? 'class' : attr.name
+
       if (attr.value === null) {
         // Boolean attribute
-        parts.push(attr.name)
+        parts.push(attrName)
       } else if (typeof attr.value === 'object' && attr.value.type === 'template-literal') {
         // Template literal with structured ternaries
         const output = this.renderTemplateLiteral(attr.value)
-        parts.push(`${attr.name}="${output}"`)
+        parts.push(`${attrName}="${output}"`)
       } else if (attr.dynamic) {
         const value = attr.value as string
         // Check for ternary operator: cond ? 'a' : 'b'
@@ -854,13 +857,13 @@ export class GoTemplateAdapter extends BaseAdapter {
         if (ternaryMatch) {
           const [, condition, trueVal, falseVal] = ternaryMatch
           const goCond = this.convertConditionToGo(condition)
-          parts.push(`${attr.name}="{{if ${goCond}}}${trueVal}{{else}}${falseVal}{{end}}"`)
+          parts.push(`${attrName}="{{if ${goCond}}}${trueVal}{{else}}${falseVal}{{end}}"`)
         } else {
           const goValue = this.convertExpressionToGo(value)
-          parts.push(`${attr.name}="{{${goValue}}}"`)
+          parts.push(`${attrName}="{{${goValue}}}"`)
         }
       } else {
-        parts.push(`${attr.name}="${attr.value}"`)
+        parts.push(`${attrName}="${attr.value}"`)
       }
     }
 

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -632,7 +632,8 @@ export class HonoAdapter implements TemplateAdapter {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
-      const attrName = attr.name
+      // Convert JSX className to HTML class attribute
+      const attrName = attr.name === 'className' ? 'class' : attr.name
 
       if (attr.name === '...') {
         // Spread attribute


### PR DESCRIPTION
## Summary
- Fix className → class conversion in HonoAdapter and GoTemplateAdapter
- Standardize on className in JSX source code (React convention)
- Add test for className → class conversion

## Problem
JSX `className` prop was rendered as `classname` attribute instead of standard `class` HTML attribute, causing CSS selectors to fail.

## Solution
- Add `className` → `class` conversion in `renderAttributes()` methods of both adapters
- Migrate existing `class=` usage in examples/shared to `className=`

## Test plan
- [x] Unit test added for className → class conversion
- [x] Existing tests pass (44 pass)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)