### PR TITLE
fix: handle boolean attributes (checked, disabled) correctly

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -649,8 +649,8 @@ export class HonoAdapter implements TemplateAdapter {
       } else if (attr.dynamic) {
         // Dynamic attribute
         if (isBooleanAttr(attrName)) {
-          // Boolean attrs: render attr name only when truthy, omit when falsy
-          parts.push(`{${attr.value} && '${attrName}'}`)
+          // Boolean attrs: pass undefined when falsy so Hono omits the attribute
+          parts.push(`${attrName}={${attr.value} || undefined}`)
         } else {
           parts.push(`${attrName}={${attr.value}}`)
         }

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -18,6 +18,7 @@ import {
   type ParamInfo,
   type AdapterOutput,
   type TemplateAdapter,
+  isBooleanAttr,
 } from '@barefootjs/jsx'
 
 export interface HonoAdapterOptions {
@@ -647,7 +648,12 @@ export class HonoAdapter implements TemplateAdapter {
         parts.push(`${attrName}={${output}}`)
       } else if (attr.dynamic) {
         // Dynamic attribute
-        parts.push(`${attrName}={${attr.value}}`)
+        if (isBooleanAttr(attrName)) {
+          // Boolean attrs: render attr name only when truthy, omit when falsy
+          parts.push(`{${attr.value} && '${attrName}'}`)
+        } else {
+          parts.push(`${attrName}={${attr.value}}`)
+        }
       } else {
         // Static attribute
         parts.push(`${attrName}="${attr.value}"`)

--- a/packages/jsx/src/html-constants.ts
+++ b/packages/jsx/src/html-constants.ts
@@ -1,0 +1,29 @@
+/**
+ * HTML boolean attributes that should be rendered without values.
+ *
+ * When true: render as attribute name only (e.g., `checked`)
+ * When false/null/undefined: omit from output entirely
+ */
+export const BOOLEAN_ATTRS = new Set([
+  'checked',
+  'disabled',
+  'readonly',
+  'selected',
+  'required',
+  'hidden',
+  'autofocus',
+  'autoplay',
+  'controls',
+  'loop',
+  'muted',
+  'open',
+  'multiple',
+  'novalidate',
+])
+
+/**
+ * Check if an attribute name is a boolean attribute.
+ */
+export function isBooleanAttr(name: string): boolean {
+  return BOOLEAN_ATTRS.has(name.toLowerCase())
+}

--- a/packages/jsx/src/html-types.ts
+++ b/packages/jsx/src/html-types.ts
@@ -83,10 +83,10 @@ export interface HTMLBaseAttributes extends BaseEventAttributes {
   style?: string | Record<string, string | number>
   title?: string
   tabindex?: number
-  hidden?: boolean
-  draggable?: boolean
-  contenteditable?: boolean | 'inherit' | 'plaintext-only'
-  spellcheck?: boolean
+  hidden?: boolean | null
+  draggable?: boolean | null
+  contenteditable?: boolean | 'inherit' | 'plaintext-only' | null
+  spellcheck?: boolean | null
   accesskey?: string
   dir?: 'ltr' | 'rtl' | 'auto'
   lang?: string
@@ -157,13 +157,13 @@ export type HTMLAttributeAnchorTarget =
 // ============================================================================
 
 export interface ButtonHTMLAttributes extends HTMLBaseAttributes {
-  autofocus?: boolean
-  disabled?: boolean
+  autofocus?: boolean | null
+  disabled?: boolean | null
   form?: string
   formaction?: string
   formenctype?: HTMLAttributeFormEnctype
   formmethod?: HTMLAttributeFormMethod
-  formnovalidate?: boolean
+  formnovalidate?: boolean | null
   formtarget?: HTMLAttributeAnchorTarget
   name?: string
   type?: 'submit' | 'reset' | 'button'
@@ -189,15 +189,15 @@ export interface InputHTMLAttributes extends HTMLBaseAttributes {
   accept?: string
   alt?: string
   autocomplete?: string
-  autofocus?: boolean
+  autofocus?: boolean | null
   capture?: boolean | 'user' | 'environment'
-  checked?: boolean
-  disabled?: boolean
+  checked?: boolean | null
+  disabled?: boolean | null
   form?: string
   formaction?: string
   formenctype?: HTMLAttributeFormEnctype
   formmethod?: HTMLAttributeFormMethod
-  formnovalidate?: boolean
+  formnovalidate?: boolean | null
   formtarget?: HTMLAttributeAnchorTarget
   height?: number | string
   list?: string
@@ -205,12 +205,12 @@ export interface InputHTMLAttributes extends HTMLBaseAttributes {
   maxlength?: number
   min?: number | string
   minlength?: number
-  multiple?: boolean
+  multiple?: boolean | null
   name?: string
   pattern?: string
   placeholder?: string
-  readonly?: boolean
-  required?: boolean
+  readonly?: boolean | null
+  required?: boolean | null
   size?: number
   src?: string
   step?: number | string
@@ -234,16 +234,16 @@ export interface InputHTMLAttributes extends HTMLBaseAttributes {
 
 export interface TextareaHTMLAttributes extends HTMLBaseAttributes {
   autocomplete?: string
-  autofocus?: boolean
+  autofocus?: boolean | null
   cols?: number
-  disabled?: boolean
+  disabled?: boolean | null
   form?: string
   maxlength?: number
   minlength?: number
   name?: string
   placeholder?: string
-  readonly?: boolean
-  required?: boolean
+  readonly?: boolean | null
+  required?: boolean | null
   rows?: number
   value?: string
   wrap?: 'hard' | 'soft' | 'off'
@@ -264,12 +264,12 @@ export interface TextareaHTMLAttributes extends HTMLBaseAttributes {
 
 export interface SelectHTMLAttributes extends HTMLBaseAttributes {
   autocomplete?: string
-  autofocus?: boolean
-  disabled?: boolean
+  autofocus?: boolean | null
+  disabled?: boolean | null
   form?: string
-  multiple?: boolean
+  multiple?: boolean | null
   name?: string
-  required?: boolean
+  required?: boolean | null
   size?: number
   value?: string | ReadonlyArray<string>
 
@@ -344,8 +344,8 @@ export interface LabelHTMLAttributes extends HTMLBaseAttributes {
 // ============================================================================
 
 export interface OptionHTMLAttributes extends HTMLBaseAttributes {
-  disabled?: boolean
+  disabled?: boolean | null
   label?: string
-  selected?: boolean
+  selected?: boolean | null
   value?: string | ReadonlyArray<string> | number
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -46,6 +46,9 @@ export { generateClientJs } from './ir-to-client-js'
 // Errors
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors'
 
+// HTML constants
+export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'
+
 // HTML element attribute types
 export type {
   // Event types

--- a/packages/jsx/src/ir-to-client-js.ts
+++ b/packages/jsx/src/ir-to-client-js.ts
@@ -18,6 +18,7 @@ import type {
   ConstantInfo,
   ParamInfo,
 } from './types'
+import { isBooleanAttr } from './html-constants'
 
 /**
  * Convert an attribute value to a string expression.
@@ -1350,6 +1351,10 @@ function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext): string {
         if (attr.attrName === 'value') {
           lines.push(`      const __val = String(${attr.expression})`)
           lines.push(`      if (_${slotId}.value !== __val) _${slotId}.value = __val`)
+        } else if (isBooleanAttr(attr.attrName)) {
+          // Boolean attributes: set property directly (checked, disabled, etc.)
+          // true → sets property to true, false → sets to false (removes attribute effect)
+          lines.push(`      _${slotId}.${attr.attrName} = !!(${attr.expression})`)
         } else {
           lines.push(`      _${slotId}.setAttribute('${attr.attrName}', String(${attr.expression}))`)
         }


### PR DESCRIPTION
## Summary
- Boolean attributes like `checked={false}` were incorrectly rendered as `checked="false"`, which HTML interprets as checked
- Now correctly handles: `true` → attribute name only, `false/null/undefined` → no output
- Extended TypeScript types to allow `null` for boolean attributes (React convention)

## Test plan
- [x] Unit tests added for `isBooleanAttr()` and dynamic boolean attribute compilation
- [x] All 115 existing tests pass
- [x] Build verified for jsx, hono, go-template packages

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)