### PR TITLE
fix: include top-level imperative code in client JS

### DIFF
--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -12,6 +12,7 @@ import type {
   ImportInfo,
   FunctionInfo,
   ConstantInfo,
+  ImperativeStatement,
   TypeDefinition,
   TypeInfo,
   CompilerError,
@@ -36,6 +37,7 @@ export interface AnalyzerContext {
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
   typeDefinitions: TypeDefinition[]
+  imperativeStatements: ImperativeStatement[]
 
   // Props
   propsType: TypeInfo | null
@@ -71,6 +73,7 @@ export function createAnalyzerContext(
     localFunctions: [],
     localConstants: [],
     typeDefinitions: [],
+    imperativeStatements: [],
 
     propsType: null,
     propsParams: [],

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -266,6 +266,7 @@ function buildMetadata(
     imports: ctx.imports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
+    imperativeStatements: ctx.imperativeStatements,
   }
 }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -279,6 +279,12 @@ export interface ConstantInfo {
   loc: SourceLocation
 }
 
+export interface ImperativeStatement {
+  code: string
+  kind: 'if' | 'for' | 'while' | 'expression' | 'switch' | 'try' | 'other'
+  loc: SourceLocation
+}
+
 export interface TypeDefinition {
   kind: 'interface' | 'type'
   name: string
@@ -299,6 +305,7 @@ export interface IRMetadata {
   imports: ImportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
+  imperativeStatements: ImperativeStatement[]
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Fix issue where top-level imperative statements (if, for, while, etc.) were not included in generated client JS
- Add `ImperativeStatement` type and collection logic to analyzer
- Output imperative statements after effects in `generateInitFunction()`

Fixes #218

## Changes

| File | Description |
|------|-------------|
| `types.ts` | Add `ImperativeStatement` interface, extend `IRMetadata` |
| `analyzer-context.ts` | Add `imperativeStatements` to context |
| `analyzer.ts` | Add `collectImperativeStatement()`, extend `visitComponentBody()` |
| `compiler.ts` | Include `imperativeStatements` in `buildMetadata()` |
| `ir-to-client-js.ts` | Output imperative statements in `generateInitFunction()` |
| `compiler.test.ts` | Add 8 test cases including Issue #218 reproduction |

## Test plan

- [x] Unit tests for if, for, while, switch, try-catch extraction
- [x] Integration test for Issue #218 reproduction code
- [x] Regression test for nested functions (should not extract)
- [x] All existing tests pass

```bash
bun test packages/jsx/src/__tests__/compiler.test.ts
# 28 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)