### PR TITLE
feat: add onMount hook for one-time mount code

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -4,6 +4,7 @@ export {
   createMemo,
   onCleanup,
   onMount,
+  untrack,
   type Signal,
   type Memo,
   type CleanupFn,

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -3,6 +3,7 @@ export {
   createEffect,
   createMemo,
   onCleanup,
+  onMount,
   type Signal,
   type Memo,
   type CleanupFn,

--- a/packages/jsx/src/ir-to-client-js.ts
+++ b/packages/jsx/src/ir-to-client-js.ts
@@ -1127,7 +1127,7 @@ function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext): string {
   const name = ctx.componentName
 
   // Imports
-  lines.push(`import { createSignal, createMemo, createEffect, findScope, find, hydrate, cond, insert, reconcileList, createComponent, registerComponent, registerTemplate, initChild } from '@barefootjs/dom'`)
+  lines.push(`import { createSignal, createMemo, createEffect, onCleanup, onMount, findScope, find, hydrate, cond, insert, reconcileList, createComponent, registerComponent, registerTemplate, initChild } from '@barefootjs/dom'`)
   lines.push('')
 
   // Init function


### PR DESCRIPTION
## Summary
- Add `onMount` hook as a thin wrapper around `createEffect` for one-time mount code
- Add `isTracking` flag to separate signal tracking from cleanup registration
- Export `onMount` from `@barefootjs/dom`
- Add `onCleanup` and `onMount` to compiler-generated imports

## Test plan
- [x] `onMount` runs once on mount
- [x] `onMount` does not re-run when signals change inside it
- [x] `onCleanup` can be registered inside `onMount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)