### PR TITLE
fix: prevent function-scoped variables from leaking to component top-level

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -77,6 +77,32 @@ describe('Compiler', () => {
       expect(ctx.memos[0].name).toBe('doubled')
       expect(ctx.memos[0].computation).toBe('() => count() * 2')
     })
+
+    test('does not collect variables from nested function declarations', () => {
+      const source = `
+        'use client'
+
+        export function FilterList() {
+          const topLevelConst = 'visible'
+
+          function getInitialFilter() {
+            const hash = window.location.hash
+            return hash ? hash.slice(1) : 'all'
+          }
+
+          return <div>{topLevelConst}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'FilterList.tsx')
+
+      // Should collect top-level const
+      expect(ctx.localConstants.some((c) => c.name === 'topLevelConst')).toBe(
+        true
+      )
+      // Should NOT collect variables from nested function declaration
+      expect(ctx.localConstants.some((c) => c.name === 'hash')).toBe(false)
+    })
   })
 
   describe('jsxToIR', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -252,11 +252,15 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
     ctx.jsxReturn = node
   }
 
-  // Skip recursion into function bodies (arrow functions, function expressions)
+  // Skip recursion into function bodies (arrow functions, function expressions, function declarations)
   // to avoid collecting inner local variables
   ts.forEachChild(node, (child) => {
-    // Don't recurse into arrow functions or function expressions
-    if (ts.isArrowFunction(child) || ts.isFunctionExpression(child)) {
+    // Don't recurse into function bodies - their variables are function-scoped
+    if (
+      ts.isArrowFunction(child) ||
+      ts.isFunctionExpression(child) ||
+      ts.isFunctionDeclaration(child)
+    ) {
       return
     }
     visitComponentBody(child, ctx)


### PR DESCRIPTION
## Summary

- Add `ts.isFunctionDeclaration(child)` to skip condition in `visitComponentBody()` to prevent collecting inner variables as `localConstants`
- Previously only `ArrowFunction` and `FunctionExpression` were skipped, causing variables inside `function` declarations to leak to top-level

Fixes #223

## Test plan

- [x] Added test case for component with nested function declaration containing browser-only variable
- [x] Verified existing tests pass (`npm test` in packages/jsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)