### PR TITLE
feat: Block-body filter SSR via ParsedStatement AST

### DIFF
--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -47,8 +47,8 @@ export { generateClientJs } from './ir-to-client-js'
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString } from './expression-parser'
-export type { ParsedExpr, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+export { parseExpression, isSupported, exprToString, parseBlockBody } from './expression-parser'
+export type { ParsedExpr, ParsedStatement, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -4,7 +4,7 @@
  * JSX-independent intermediate representation for multi-backend support.
  */
 
-import type { ParsedExpr } from './expression-parser'
+import type { ParsedExpr, ParsedStatement } from './expression-parser'
 
 // =============================================================================
 // Source Location (for Error Reporting)
@@ -169,10 +169,15 @@ export interface IRLoop {
    * Filter predicate for filter().map() pattern.
    * When present, the loop renders with an if-condition wrapping each iteration.
    * Example: todos.filter(t => !t.done).map(...) stores { param: 't', predicate: ParsedExpr, raw: '!t.done' }
+   *
+   * For block-body filters like:
+   *   filter(t => { const f = filter(); if (f === 'active') return !t.done; return true })
+   * The blockBody field contains the parsed statements.
    */
   filterPredicate?: {
     param: string
-    predicate: ParsedExpr
+    predicate?: ParsedExpr        // Expression body
+    blockBody?: ParsedStatement[] // Block body (mutually exclusive with predicate)
     raw: string  // Original string for error messages
   }
 


### PR DESCRIPTION
## Summary

- Add ParsedStatement AST for parsing block-body arrow functions in filter predicates
- Support complex filter patterns like TodoApp's filter logic for SSR rendering
- Consolidate duplicate predicate rendering methods

## Changes

### Phase 1: Block-body Filter SSR
- **expression-parser.ts**: Add `ParsedStatement` type and `parseBlockBody()` for parsing block-body arrow functions (var-decl, return, if statements)
- **jsx-to-ir.ts**: Extract `blockBody` from filter predicates
- **go-template-adapter.ts**: Render block body conditions with `or`/`and`/`not`
- **ir-to-client-js.ts**: Apply `filterPredicate` to `reconcileList` calls

### Phase 2: Refactoring
- Merge `renderPredicateExpr` into `renderFilterExpr` (unified method)
- Extract `renderHigherOrderExpr` for `bf_filter`/`bf_every`/`bf_some` generation
- Extract `renderFilterLengthExpr` for `filter().length` handling
- Remove ~60 lines of duplicated code

## Test plan

- [x] All 188 unit tests pass
- [x] All 47 Playwright e2e tests pass
- [x] Manual verification of filter functionality in browser (All/Active/Completed filters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)