### PR TITLE
feat(jsx): preserve if statements in component functions

### DIFF
--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -20,6 +20,20 @@ import type {
   ParamInfo,
 } from './types'
 
+/**
+ * Represents an if statement with a JSX return in a component function.
+ */
+export interface ConditionalReturn {
+  /** The condition expression node */
+  condition: ts.Expression
+  /** The JSX return statement found in the if block */
+  jsxReturn: ts.JsxElement | ts.JsxFragment | ts.JsxSelfClosingElement
+  /** Variables declared in the if block scope */
+  scopeVariables: ts.VariableDeclaration[]
+  /** The original if statement node */
+  ifStatement: ts.IfStatement
+}
+
 export interface AnalyzerContext {
   sourceFile: ts.SourceFile
   filePath: string
@@ -46,6 +60,9 @@ export interface AnalyzerContext {
 
   // JSX return
   jsxReturn: ts.JsxElement | ts.JsxFragment | ts.JsxSelfClosingElement | null
+
+  // Conditional returns (if statements with JSX returns)
+  conditionalReturns: ConditionalReturn[]
 
   // Errors
   errors: CompilerError[]
@@ -80,6 +97,7 @@ export function createAnalyzerContext(
     restPropsName: null,
 
     jsxReturn: null,
+    conditionalReturns: [],
 
     errors: [],
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -21,6 +21,7 @@ export type {
   IRComponent,
   IRFragment,
   IRSlot,
+  IRIfStatement,
   IRMetadata,
   IRTemplateLiteral,
   IRTemplatePart,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -82,6 +82,7 @@ export type IRNode =
   | IRComponent
   | IRSlot
   | IRFragment
+  | IRIfStatement
 
 export interface IRElement {
   type: 'element'
@@ -208,6 +209,23 @@ export interface IRSlot {
 export interface IRFragment {
   type: 'fragment'
   children: IRNode[]
+  loc: SourceLocation
+}
+
+/**
+ * If statement node for component-level conditional returns.
+ * Preserves if-else structure from source code (early returns).
+ */
+export interface IRIfStatement {
+  type: 'if-statement'
+  /** The condition expression (e.g., "name === 'github'") */
+  condition: string
+  /** The JSX return in the then branch */
+  consequent: IRNode
+  /** The else branch: either another IRIfStatement (else if) or IRNode (final else) */
+  alternate: IRNode | null
+  /** Variables declared in the if block scope */
+  scopeVariables: Array<{ name: string; initializer: string }>
   loc: SourceLocation
 }
 


### PR DESCRIPTION
## Summary

- Add support for early return patterns in component functions (fixes #178)
- Previously, only the final return statement was captured, causing if statements with JSX returns to be ignored
- The if statement structure is now preserved and rendered directly in the Hono adapter output

## Changes

| File | Change |
|------|--------|
| `packages/jsx/src/types.ts` | Add `IRIfStatement` type |
| `packages/jsx/src/analyzer-context.ts` | Add `ConditionalReturn` type and `conditionalReturns` field |
| `packages/jsx/src/analyzer.ts` | Add if statement detection logic |
| `packages/jsx/src/jsx-to-ir.ts` | Add `buildIfStatementChain` function |
| `packages/hono/src/adapter/hono-adapter.ts` | Add `renderIfStatement` method |

## Test plan

- [x] Unit tests pass (70 tests in packages/jsx)
- [x] E2E tests pass (examples/hono: 52 tests, docs/ui: 86 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)