### PR TITLE
feat: unify adapter behavior and add shared e2e tests for Checkbox

### DIFF
--- a/examples/echo/build.ts
+++ b/examples/echo/build.ts
@@ -21,6 +21,7 @@ const components = [
   '../shared/components/TodoApp.tsx',
   '../shared/components/TodoAppSSR.tsx',
   '../shared/components/ReactiveProps.tsx',
+  '../shared/components/Form.tsx',
 ]
 
 // Output directories

--- a/examples/echo/components.go
+++ b/examples/echo/components.go
@@ -295,3 +295,28 @@ func NewReactivePropsProps(in ReactivePropsInput) ReactivePropsProps {
 		}),
 	}
 }
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		Accepted: false,
+	}
+}

--- a/examples/echo/e2e/form.spec.ts
+++ b/examples/echo/e2e/form.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Form E2E tests for Echo example
+ *
+ * Uses shared test suite from examples/shared/e2e
+ */
+
+import { formTests } from '../../shared/e2e/form.spec'
+
+formTests('http://localhost:8080')

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -101,6 +101,7 @@ func main() {
 	e.GET("/todos", todosHandler)
 	e.GET("/todos-ssr", todosSSRHandler)
 	e.GET("/reactive-props", reactivePropsHandler)
+	e.GET("/form", formHandler)
 
 	// Todo API endpoints
 	e.GET("/api/todos", getTodosAPI)
@@ -139,6 +140,7 @@ func indexHandler(c echo.Context) error {
         <li><a href="/todos">Todo (@client)</a></li>
         <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="/reactive-props">Reactive Props (Reactivity Model Test)</a></li>
+        <li><a href="/form">Form (Checkbox + Button)</a></li>
     </ul>
 </body>
 </html>
@@ -213,6 +215,15 @@ func reactivePropsHandler(c echo.Context) error {
 		Props:   &props,
 		Title:   "Reactive Props - BarefootJS",
 		Heading: "Reactive Props Test",
+	})
+}
+
+func formHandler(c echo.Context) error {
+	props := NewFormProps(FormInput{})
+	return c.Render(http.StatusOK, "Form", bf.RenderOptions{
+		Props:   &props,
+		Title:   "Form - BarefootJS",
+		Heading: "Form Example",
 	})
 }
 

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -139,8 +139,6 @@ func indexHandler(c echo.Context) error {
         <li><a href="/toggle">Toggle</a></li>
         <li><a href="/todos">Todo (@client)</a></li>
         <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
-        <li><a href="/reactive-props">Reactive Props (Reactivity Model Test)</a></li>
-        <li><a href="/form">Form (Checkbox + Button)</a></li>
     </ul>
 </body>
 </html>

--- a/examples/hono/e2e/form.spec.ts
+++ b/examples/hono/e2e/form.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Form E2E tests for Hono example
+ *
+ * Uses shared test suite from examples/shared/e2e
+ */
+
+import { formTests } from '../../shared/e2e/form.spec'
+
+formTests('http://localhost:3001')

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -53,8 +53,6 @@ app.get('/', (c) => {
           <li><a href="/todos">Todo (@client)</a></li>
           <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
           <li><a href="/async-counter">Async Counter (Suspense + BarefootJS)</a></li>
-          <li><a href="/reactive-props">Reactive Props (Reactivity Model Test)</a></li>
-          <li><a href="/form">Form (Checkbox + Button)</a></li>
         </ul>
       </nav>
     </div>

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -14,6 +14,7 @@ import Toggle from '@/components/Toggle'
 import TodoApp from '@/components/TodoApp'
 import TodoAppSSR from '@/components/TodoAppSSR'
 import ReactiveProps from '@/components/ReactiveProps'
+import Form from '@/components/Form'
 import { AsyncCounterWrapper } from './components/AsyncCounterWrapper'
 
 const app = new Hono()
@@ -53,6 +54,7 @@ app.get('/', (c) => {
           <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
           <li><a href="/async-counter">Async Counter (Suspense + BarefootJS)</a></li>
           <li><a href="/reactive-props">Reactive Props (Reactivity Model Test)</a></li>
+          <li><a href="/form">Form (Checkbox + Button)</a></li>
         </ul>
       </nav>
     </div>
@@ -108,6 +110,17 @@ app.get('/reactive-props', (c) => {
     <div>
       <h1>Reactive Props Test</h1>
       <ReactiveProps />
+      <p><a href="/">← Back</a></p>
+    </div>
+  )
+})
+
+// Form example (checkbox + button interaction)
+app.get('/form', (c) => {
+  return c.render(
+    <div>
+      <h1>Form Example</h1>
+      <Form />
       <p><a href="/">← Back</a></p>
     </div>
   )

--- a/examples/shared/components/Form.tsx
+++ b/examples/shared/components/Form.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+/**
+ * Form Component (Shared)
+ *
+ * A practical form demonstrating checkbox + button interaction.
+ * When the checkbox is checked, the submit button becomes enabled.
+ * This component tests:
+ * - Checkbox state toggle
+ * - Conditional button disabled attribute
+ * - Null branch rendering (SVG checkmark appears/disappears)
+ */
+
+import { createSignal } from '@barefootjs/dom'
+
+export function Form() {
+  const [accepted, setAccepted] = createSignal(false)
+
+  return (
+    <div className="form-container" style="padding: 24px; max-width: 400px; margin: 0 auto;">
+      <h2 style="margin-top: 0;">Terms and Conditions</h2>
+      <p style="color: #666; font-size: 14px;">
+        Please read and accept the terms before continuing.
+      </p>
+
+      <div className="checkbox-row" style="display: flex; align-items: center; gap: 12px; margin: 20px 0;">
+        <button
+          className="checkbox"
+          data-state={accepted() ? 'checked' : 'unchecked'}
+          onClick={() => setAccepted(!accepted())}
+          style={`width: 24px; height: 24px; border: 2px solid ${accepted() ? '#4caf50' : '#ccc'}; border-radius: 4px; background: ${accepted() ? '#4caf50' : 'white'}; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0;`}
+          aria-checked={accepted()}
+          role="checkbox"
+        >
+          {accepted() && (
+            <svg
+              className="checkmark"
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              style="display: block;"
+            >
+              <path
+                d="M3 8L6.5 11.5L13 5"
+                stroke="white"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          )}
+        </button>
+        <label className="checkbox-label" style="cursor: pointer; user-select: none;">
+          I agree to the terms and conditions
+        </label>
+      </div>
+
+      <button
+        className="submit-btn"
+        disabled={!accepted()}
+        style={`width: 100%; padding: 12px 24px; font-size: 16px; border: none; border-radius: 6px; cursor: ${accepted() ? 'pointer' : 'not-allowed'}; background: ${accepted() ? '#4caf50' : '#e0e0e0'}; color: ${accepted() ? 'white' : '#999'};`}
+      >
+        Continue
+      </button>
+    </div>
+  )
+}
+
+export default Form

--- a/examples/shared/e2e/form.spec.ts
+++ b/examples/shared/e2e/form.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared Form Component E2E Tests
+ *
+ * Tests checkbox + button interaction pattern.
+ * Verifies:
+ * - Initial state (unchecked checkbox, disabled button)
+ * - Checkbox toggle behavior
+ * - Button enabled/disabled state
+ * - SVG checkmark rendering (null branch fix)
+ * - ScopeID format
+ */
+
+import { test, expect } from '@playwright/test'
+
+/**
+ * Run form component E2E tests.
+ *
+ * @param baseUrl - The base URL of the server (e.g., 'http://localhost:3001')
+ */
+export function formTests(baseUrl: string) {
+  test.describe('Form Component', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${baseUrl}/form`)
+    })
+
+    test('displays form container with title', async ({ page }) => {
+      await expect(page.locator('h2:has-text("Terms and Conditions")')).toBeVisible()
+    })
+
+    test('checkbox starts unchecked', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+      await expect(checkbox).toHaveAttribute('data-state', 'unchecked')
+      await expect(checkbox).toHaveAttribute('aria-checked', 'false')
+    })
+
+    test('submit button starts disabled', async ({ page }) => {
+      const submitBtn = page.locator('.submit-btn')
+      await expect(submitBtn).toBeDisabled()
+    })
+
+    test('checkmark SVG is not visible when unchecked', async ({ page }) => {
+      const checkmark = page.locator('.checkbox .checkmark')
+      await expect(checkmark).toHaveCount(0)
+    })
+
+    test('checkbox toggles to checked on click', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+
+      await checkbox.click()
+
+      await expect(checkbox).toHaveAttribute('data-state', 'checked')
+      await expect(checkbox).toHaveAttribute('aria-checked', 'true')
+    })
+
+    test('checkmark SVG appears when checked', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+
+      await checkbox.click()
+
+      const checkmark = page.locator('.checkbox .checkmark')
+      await expect(checkmark).toBeVisible()
+    })
+
+    test('submit button becomes enabled when checkbox is checked', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+      const submitBtn = page.locator('.submit-btn')
+
+      await expect(submitBtn).toBeDisabled()
+
+      await checkbox.click()
+
+      await expect(submitBtn).toBeEnabled()
+    })
+
+    test('checkbox toggles back to unchecked on second click', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+
+      await checkbox.click()
+      await expect(checkbox).toHaveAttribute('data-state', 'checked')
+
+      await checkbox.click()
+      await expect(checkbox).toHaveAttribute('data-state', 'unchecked')
+    })
+
+    test('checkmark SVG disappears when unchecked again', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+
+      await checkbox.click()
+      await expect(page.locator('.checkbox .checkmark')).toBeVisible()
+
+      await checkbox.click()
+      await expect(page.locator('.checkbox .checkmark')).toHaveCount(0)
+    })
+
+    test('submit button becomes disabled when checkbox is unchecked again', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+      const submitBtn = page.locator('.submit-btn')
+
+      await checkbox.click()
+      await expect(submitBtn).toBeEnabled()
+
+      await checkbox.click()
+      await expect(submitBtn).toBeDisabled()
+    })
+
+    test('checkbox style changes with state', async ({ page }) => {
+      const checkbox = page.locator('.checkbox')
+
+      // Unchecked state - white/gray
+      await expect(checkbox).toHaveCSS('background-color', 'rgb(255, 255, 255)')
+
+      await checkbox.click()
+
+      // Checked state - green
+      await expect(checkbox).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+    })
+
+    test('Form has valid ScopeID format', async ({ page }) => {
+      // Form component should have ScopeID in format: Form_[6 random chars]
+      const scopeId = await page.locator('.form-container[data-bf-scope]').getAttribute('data-bf-scope')
+      expect(scopeId).toMatch(/^Form_[a-z0-9]{6}$/)
+    })
+  })
+}

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -295,6 +295,64 @@ describe('GoTemplateAdapter', () => {
       const result = adapter.renderConditional(cond)
       expect(result).toBe('{{if .IsLoggedIn}}Welcome{{else}}Please login{{end}}')
     })
+
+    test('renders reactive conditional with null false branch as comment markers', () => {
+      const cond: IRConditional = {
+        type: 'conditional',
+        condition: 'isChecked()',
+        conditionType: null,
+        reactive: true,
+        whenTrue: {
+          type: 'element',
+          tag: 'svg',
+          attrs: [],
+          events: [],
+          ref: null,
+          children: [],
+          slotId: null,
+          needsScope: false,
+          loc,
+        },
+        whenFalse: { type: 'expression', expr: 'null', typeInfo: null, reactive: false, slotId: null, loc },
+        slotId: 'slot_1',
+        loc,
+      }
+
+      const result = adapter.renderConditional(cond)
+      // Should output empty markers for null branch (for client hydration)
+      expect(result).toContain('{{else}}')
+      expect(result).toContain('{{bfComment "cond-start:slot_1"}}')
+      expect(result).toContain('{{bfComment "cond-end:slot_1"}}')
+    })
+
+    test('renders reactive conditional with undefined false branch as comment markers', () => {
+      const cond: IRConditional = {
+        type: 'conditional',
+        condition: 'isChecked()',
+        conditionType: null,
+        reactive: true,
+        whenTrue: {
+          type: 'element',
+          tag: 'svg',
+          attrs: [],
+          events: [],
+          ref: null,
+          children: [],
+          slotId: null,
+          needsScope: false,
+          loc,
+        },
+        whenFalse: { type: 'expression', expr: 'undefined', typeInfo: null, reactive: false, slotId: null, loc },
+        slotId: 'slot_1',
+        loc,
+      }
+
+      const result = adapter.renderConditional(cond)
+      // Should output empty markers for undefined branch (for client hydration)
+      expect(result).toContain('{{else}}')
+      expect(result).toContain('{{bfComment "cond-start:slot_1"}}')
+      expect(result).toContain('{{bfComment "cond-end:slot_1"}}')
+    })
   })
 
   describe('renderLoop', () => {

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -1522,10 +1522,14 @@ export class GoTemplateAdapter extends BaseAdapter {
       let result = `{{if ${goCondition}}}${whenTrueWrapped}`
 
       if (cond.whenFalse) {
-        // Skip null/undefined branches
+        // Handle null/undefined branches with empty comment markers for client hydration
         if (cond.whenFalse.type === 'expression') {
           const exprNode = cond.whenFalse as IRExpression
-          if (exprNode.expr !== 'null' && exprNode.expr !== 'undefined') {
+          if (exprNode.expr === 'null' || exprNode.expr === 'undefined') {
+            // Output empty comment markers so client can insert content later
+            const emptyMarkers = `{{bfComment "cond-start:${cond.slotId}"}}{{bfComment "cond-end:${cond.slotId}"}}`
+            result += `{{else}}${emptyMarkers}`
+          } else {
             const whenFalse = this.renderNode(cond.whenFalse)
             const whenFalseWrapped = this.wrapWithCondMarker(whenFalse, cond.slotId)
             result += `{{else}}${whenFalseWrapped}`


### PR DESCRIPTION
## Summary

This PR addresses all issues from #241:

1. **Scope ID Management**: Verified unified behavior across adapters (toggle.spec.ts ScopeID tests pass for both)
2. **Null Branch Issue**: Fixed go-template-adapter to output comment markers for null/undefined else branches
3. **Shared e2e Tests for Checkbox**: Added Form component with checkbox + button interaction tests

## Changes

### Null Branch Fix
- `packages/go-template/src/adapter/go-template-adapter.ts`: Add else branch with empty markers for null/undefined
- `packages/go-template/src/__tests__/go-template-adapter.test.ts`: Add test cases

### Form Component & Tests
- `examples/shared/components/Form.tsx`: Checkbox + Button form demo
- `examples/shared/e2e/form.spec.ts`: 12 test cases covering:
  - Checkbox toggle state (checked/unchecked)
  - Button disabled attribute changes dynamically
  - SVG checkmark appears/disappears (null branch)
  - ScopeID format validation
- `examples/hono/` and `examples/echo/`: Route handlers and test files

## Test plan

- [x] Unit tests pass (`bun run --cwd packages/go-template test`)
- [x] Hono e2e tests pass (74 tests)
- [x] Echo e2e tests pass (69 tests)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)