### PR TITLE
fix: add index parameter to template-string reconcileList callback

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -498,6 +498,36 @@ describe('Compiler', () => {
     })
   })
 
+  describe('map with index parameter', () => {
+    test('includes index parameter in reconcileList callback', () => {
+      const source = `
+        'use client'
+        import { createMemo } from '@barefootjs/dom'
+
+        export function List() {
+          const items = createMemo(() => ['a', 'b', 'c'])
+          return (
+            <div>
+              {items().map((item, i) => (
+                <div key={i} className={\`item-\${i}\`}>{item}</div>
+              ))}
+            </div>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // Should include index param in callback (not just item without index)
+      expect(clientJs?.content).toContain('(item, i) => `')
+    })
+  })
+
   describe('local constants arrow function detection', () => {
     test('type cast expression starting with ( should NOT become arrow function stub', () => {
       // Issue #212: Type casts like "(array as Type).method()" were incorrectly

--- a/packages/jsx/src/ir-to-client-js.ts
+++ b/packages/jsx/src/ir-to-client-js.ts
@@ -1993,9 +1993,10 @@ function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, siblingCom
         ? `${elem.array}.filter(${elem.filterPredicate.param} => ${elem.filterPredicate.raw})`
         : elem.array
 
+      const indexParamTemplate = elem.index || '__idx'
       lines.push(`  createEffect(() => {`)
       lines.push(`    const __arr = ${filterExprTemplate}`)
-      lines.push(`    reconcileList(_${elem.slotId}, __arr, ${keyFn}, (${elem.param}) => \`${elem.template}\`)`)
+      lines.push(`    reconcileList(_${elem.slotId}, __arr, ${keyFn}, (${elem.param}, ${indexParamTemplate}) => \`${elem.template}\`)`)
       lines.push(`  })`)
     }
     lines.push('')


### PR DESCRIPTION
## Summary
- Fix missing index parameter in template-string based loop rendering
- The `reconcileList` callback was missing the index param, causing index variables to be undefined at runtime

## Changes
- `ir-to-client-js.ts`: Add index parameter (`elem.index || '__idx'`) to template-string callback
- `compiler.test.ts`: Add test case for map with index parameter

Fixes #234

## Test plan
- [x] `bun test packages/jsx/src/__tests__/compiler.test.ts` passes
- [x] Manual verification with a component using `.map((item, i) => ...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)