### PR TITLE
feat(portal): add Portal documentation and E2E tests

### DIFF
--- a/docs/ui/components/portal-demo.tsx
+++ b/docs/ui/components/portal-demo.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+/**
+ * Portal Demo Components
+ *
+ * Demonstrates the createPortal-like behavior using direct DOM manipulation.
+ * The actual createPortal utility from @barefootjs/dom works the same way.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+
+/**
+ * Basic portal demo - shows content rendering at document.body
+ */
+export function PortalBasicDemo() {
+  const [open, setOpen] = createSignal(false)
+  const state = { el: null }
+
+  const showPortal = () => {
+    if (state.el) {
+      state.el.remove()
+    }
+
+    const el = document.createElement('div')
+    el.setAttribute('data-portal-content', '')
+    el.className = 'fixed bottom-4 right-4 bg-background border border-border rounded-lg p-4 shadow-lg z-50'
+    el.innerHTML = `
+      <p class="text-sm text-foreground mb-2">Portal content at document.body</p>
+      <button data-portal-close class="text-sm text-primary hover:underline">Close</button>
+    `
+
+    document.body.appendChild(el)
+    state.el = el
+
+    el.querySelector('[data-portal-close]')?.addEventListener('click', hidePortal)
+    setOpen(true)
+  }
+
+  const hidePortal = () => {
+    if (state.el) {
+      state.el.remove()
+      state.el = null
+    }
+    setOpen(false)
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={showPortal}
+        disabled={open()}
+        className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50"
+      >
+        Show Portal
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Portal with custom container demo
+ */
+export function PortalCustomContainerDemo() {
+  const [open, setOpen] = createSignal(false)
+  const state = { el: null, container: null }
+
+  const showPortal = () => {
+    if (!state.container) return
+
+    if (state.el) {
+      state.el.remove()
+    }
+
+    const el = document.createElement('div')
+    el.setAttribute('data-portal-content', '')
+    el.className = 'bg-accent text-accent-foreground p-3 rounded-md text-sm'
+    el.textContent = 'Rendered inside custom container'
+
+    state.container.appendChild(el)
+    state.el = el
+    setOpen(true)
+  }
+
+  const hidePortal = () => {
+    if (state.el) {
+      state.el.remove()
+      state.el = null
+    }
+    setOpen(false)
+  }
+
+  const setContainerRef = (el: HTMLElement) => {
+    state.container = el
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={showPortal}
+          disabled={open()}
+          className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50"
+        >
+          Show in Container
+        </button>
+        <button
+          type="button"
+          onClick={hidePortal}
+          disabled={!open()}
+          className="inline-flex items-center justify-center rounded-md text-sm font-medium border border-border bg-background hover:bg-accent h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50"
+        >
+          Hide
+        </button>
+      </div>
+      <div
+        ref={setContainerRef}
+        data-portal-container
+        className="min-h-20 border border-dashed border-border rounded-lg p-4 flex items-center justify-center"
+      >
+        {!open() && <span className="text-muted-foreground text-sm">Portal container (empty)</span>}
+      </div>
+    </div>
+  )
+}

--- a/docs/ui/components/portal-demo.tsx
+++ b/docs/ui/components/portal-demo.tsx
@@ -3,43 +3,38 @@
 /**
  * Portal Demo Components
  *
- * Demonstrates the createPortal-like behavior using direct DOM manipulation.
- * The actual createPortal utility from @barefootjs/dom works the same way.
+ * Demonstrates the createPortal utility from @barefootjs/dom.
  */
 
-import { createSignal } from '@barefootjs/dom'
+import { createSignal, createPortal } from '@barefootjs/dom'
 
 /**
  * Basic portal demo - shows content rendering at document.body
  */
 export function PortalBasicDemo() {
   const [open, setOpen] = createSignal(false)
-  const state = { el: null }
+  const state = { portal: null }
 
   const showPortal = () => {
-    if (state.el) {
-      state.el.remove()
+    if (state.portal) {
+      state.portal.unmount()
     }
 
-    const el = document.createElement('div')
-    el.setAttribute('data-portal-content', '')
-    el.className = 'fixed bottom-4 right-4 bg-background border border-border rounded-lg p-4 shadow-lg z-50'
-    el.innerHTML = `
-      <p class="text-sm text-foreground mb-2">Portal content at document.body</p>
-      <button data-portal-close class="text-sm text-primary hover:underline">Close</button>
-    `
+    state.portal = createPortal(`
+      <div data-portal-content class="fixed bottom-4 right-4 bg-background border border-border rounded-lg p-4 shadow-lg z-50">
+        <p class="text-sm text-foreground mb-2">Portal content at document.body</p>
+        <button data-portal-close class="text-sm text-primary hover:underline">Close</button>
+      </div>
+    `)
 
-    document.body.appendChild(el)
-    state.el = el
-
-    el.querySelector('[data-portal-close]')?.addEventListener('click', hidePortal)
+    state.portal.element.querySelector('[data-portal-close]')?.addEventListener('click', hidePortal)
     setOpen(true)
   }
 
   const hidePortal = () => {
-    if (state.el) {
-      state.el.remove()
-      state.el = null
+    if (state.portal) {
+      state.portal.unmount()
+      state.portal = null
     }
     setOpen(false)
   }
@@ -63,34 +58,31 @@ export function PortalBasicDemo() {
  */
 export function PortalCustomContainerDemo() {
   const [open, setOpen] = createSignal(false)
-  const state = { el: null, container: null }
+  const state = { portal: null, container: null }
 
   const showPortal = () => {
     if (!state.container) return
 
-    if (state.el) {
-      state.el.remove()
+    if (state.portal) {
+      state.portal.unmount()
     }
 
-    const el = document.createElement('div')
-    el.setAttribute('data-portal-content', '')
-    el.className = 'bg-accent text-accent-foreground p-3 rounded-md text-sm'
-    el.textContent = 'Rendered inside custom container'
-
-    state.container.appendChild(el)
-    state.el = el
+    state.portal = createPortal(
+      `<div data-portal-content class="bg-accent text-accent-foreground p-3 rounded-md text-sm">Rendered inside custom container</div>`,
+      state.container
+    )
     setOpen(true)
   }
 
   const hidePortal = () => {
-    if (state.el) {
-      state.el.remove()
-      state.el = null
+    if (state.portal) {
+      state.portal.unmount()
+      state.portal = null
     }
     setOpen(false)
   }
 
-  const setContainerRef = (el: HTMLElement) => {
+  const setContainerRef = (el) => {
     state.container = el
   }
 

--- a/docs/ui/components/shared/PageNavigation.tsx
+++ b/docs/ui/components/shared/PageNavigation.tsx
@@ -64,6 +64,7 @@ export const componentOrder = [
   { slug: 'dialog', title: 'Dialog' },
   { slug: 'dropdown', title: 'Dropdown' },
   { slug: 'input', title: 'Input' },
+  { slug: 'portal', title: 'Portal' },
   { slug: 'select', title: 'Select' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'tabs', title: 'Tabs' },

--- a/docs/ui/e2e/portal.spec.ts
+++ b/docs/ui/e2e/portal.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Portal Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/portal')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Portal')
+    await expect(page.locator('text=Renders children into a different part')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+  })
+
+  test('displays features section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
+    await expect(page.locator('strong:has-text("DOM escape")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Custom container")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Flexible input")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Cleanup")')).toBeVisible()
+  })
+
+  test.describe('Basic Portal', () => {
+    test('shows portal content when button clicked', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope^="PortalBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Show Portal")')
+
+      await trigger.click()
+
+      // Portal content renders at document.body, so look globally
+      const portalContent = page.locator('[data-portal-content]')
+      await expect(portalContent).toBeVisible()
+      await expect(portalContent).toContainText('Portal content at document.body')
+    })
+
+    test('hides portal when close clicked', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope^="PortalBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Show Portal")')
+
+      await trigger.click()
+
+      const portalContent = page.locator('[data-portal-content]')
+      await expect(portalContent).toBeVisible()
+
+      // Click close button inside portal
+      const closeButton = page.locator('[data-portal-close]')
+      await closeButton.click()
+
+      await expect(portalContent).not.toBeVisible()
+    })
+
+    test('portal renders outside demo scope', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope^="PortalBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Show Portal")')
+
+      await trigger.click()
+
+      // Verify portal content is NOT inside the demo scope
+      const portalInsideDemo = basicDemo.locator('[data-portal-content]')
+      await expect(portalInsideDemo).toHaveCount(0)
+
+      // But exists globally
+      const portalGlobal = page.locator('[data-portal-content]')
+      await expect(portalGlobal).toBeVisible()
+    })
+
+    test('disables button while portal is open', async ({ page }) => {
+      const basicDemo = page.locator('[data-bf-scope^="PortalBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Show Portal")')
+
+      // Initially enabled
+      await expect(trigger).not.toBeDisabled()
+
+      await trigger.click()
+
+      // Should be disabled while portal is open
+      await expect(trigger).toBeDisabled()
+
+      // Close the portal
+      const closeButton = page.locator('[data-portal-close]')
+      await closeButton.click()
+
+      // Should be enabled again
+      await expect(trigger).not.toBeDisabled()
+    })
+  })
+
+  test.describe('Custom Container Portal', () => {
+    test('renders portal inside custom container', async ({ page }) => {
+      const containerDemo = page.locator('[data-bf-scope^="PortalCustomContainerDemo_"]').first()
+      const trigger = containerDemo.locator('button:has-text("Show in Container")')
+      const container = containerDemo.locator('[data-portal-container]')
+
+      await trigger.click()
+
+      // Portal should be inside the custom container
+      const portalContent = container.locator('[data-portal-content]')
+      await expect(portalContent).toBeVisible()
+      await expect(portalContent).toContainText('Rendered inside custom container')
+    })
+
+    test('hides portal on hide button click', async ({ page }) => {
+      const containerDemo = page.locator('[data-bf-scope^="PortalCustomContainerDemo_"]').first()
+      const showTrigger = containerDemo.locator('button:has-text("Show in Container")')
+      const hideTrigger = containerDemo.locator('button:has-text("Hide")')
+
+      await showTrigger.click()
+
+      const portalContent = containerDemo.locator('[data-portal-content]')
+      await expect(portalContent).toBeVisible()
+
+      await hideTrigger.click()
+      await expect(portalContent).not.toBeVisible()
+    })
+
+    test('hide button is disabled when portal is not visible', async ({ page }) => {
+      const containerDemo = page.locator('[data-bf-scope^="PortalCustomContainerDemo_"]').first()
+      const showTrigger = containerDemo.locator('button:has-text("Show in Container")')
+      const hideTrigger = containerDemo.locator('button:has-text("Hide")')
+
+      // Initially hide button should be disabled
+      await expect(hideTrigger).toBeDisabled()
+
+      await showTrigger.click()
+
+      // Now hide button should be enabled
+      await expect(hideTrigger).not.toBeDisabled()
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays createPortal function heading', async ({ page }) => {
+      await expect(page.locator('h3:has-text("createPortal")')).toBeVisible()
+    })
+
+    test('displays parameters table', async ({ page }) => {
+      await expect(page.locator('h4:has-text("Parameters")')).toBeVisible()
+      // Check for the first cell in parameters table
+      await expect(page.locator('td:has-text("children")').first()).toBeVisible()
+    })
+
+    test('displays return value table', async ({ page }) => {
+      await expect(page.locator('h4:has-text("Return Value")')).toBeVisible()
+      // Check for table cells in return value table
+      await expect(page.locator('td:has-text("unmount")').first()).toBeVisible()
+    })
+  })
+})
+
+test.describe('Home Page - Portal Link', () => {
+  test('displays Portal component link', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('a[href="/docs/components/portal"]')).toBeVisible()
+  })
+
+  test('navigates to Portal page on click', async ({ page }) => {
+    await page.goto('/')
+    await page.click('a[href="/docs/components/portal"]')
+    await expect(page).toHaveURL('/docs/components/portal')
+    await expect(page.locator('h1')).toContainText('Portal')
+  })
+})

--- a/docs/ui/pages/portal.tsx
+++ b/docs/ui/pages/portal.tsx
@@ -1,0 +1,184 @@
+/**
+ * Portal Documentation Page
+ */
+
+import { PortalBasicDemo, PortalCustomContainerDemo } from '@/components/portal-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'features', title: 'Features' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'custom-container', title: 'Custom Container', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal, createPortal } from '@barefootjs/dom'
+
+function PortalBasic() {
+  const [open, setOpen] = createSignal(false)
+  let portal = null
+
+  const showPortal = () => {
+    portal = createPortal(
+      '<div class="modal">Portal content at document.body</div>'
+    )
+    setOpen(true)
+  }
+
+  const hidePortal = () => {
+    portal?.unmount()
+    portal = null
+    setOpen(false)
+  }
+
+  return (
+    <div>
+      <button onClick={showPortal} disabled={open()}>
+        Show Portal
+      </button>
+    </div>
+  )
+}`
+
+const customContainerCode = `"use client"
+
+import { createSignal, createPortal } from '@barefootjs/dom'
+
+function PortalCustomContainer() {
+  const [open, setOpen] = createSignal(false)
+  let portal = null
+  let containerRef = null
+
+  const showPortal = () => {
+    if (!containerRef) return
+    portal = createPortal(
+      '<div>Rendered inside custom container</div>',
+      containerRef  // Custom container element
+    )
+    setOpen(true)
+  }
+
+  return (
+    <div>
+      <button onClick={showPortal}>Show in Container</button>
+      <div ref={(el) => containerRef = el}>
+        {/* Portal will render here */}
+      </div>
+    </div>
+  )
+}`
+
+// Props definitions
+const createPortalProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'HTMLElement | string | Renderable',
+    description: 'Content to mount in the portal. Can be an HTMLElement, HTML string, or object with toString() method (like JSX).',
+  },
+  {
+    name: 'container',
+    type: 'HTMLElement',
+    defaultValue: 'document.body',
+    description: 'Target container element where the portal content will be mounted.',
+  },
+]
+
+const portalReturnProps: PropDefinition[] = [
+  {
+    name: 'element',
+    type: 'HTMLElement',
+    description: 'Reference to the mounted DOM element.',
+  },
+  {
+    name: 'unmount',
+    type: '() => void',
+    description: 'Function to remove the portal content from the DOM. Safe to call multiple times.',
+  },
+]
+
+export function PortalPage() {
+  const installCommands = getHighlightedCommands('barefoot add portal')
+
+  return (
+    <DocPage slug="portal" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Portal"
+          description="Renders children into a different part of the DOM tree. Useful for modals, tooltips, and dropdowns."
+          {...getNavLinks('portal')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`createPortal('<div>content</div>', document.body)`}>
+          <div className="flex gap-4">
+            <PortalBasicDemo />
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add portal" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Features */}
+        <Section id="features" title="Features">
+          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
+            <li><strong className="text-foreground">DOM escape</strong> - Render content outside the parent DOM hierarchy</li>
+            <li><strong className="text-foreground">Custom container</strong> - Mount to any DOM element, not just document.body</li>
+            <li><strong className="text-foreground">Flexible input</strong> - Accepts HTMLElement, HTML string, or JSX</li>
+            <li><strong className="text-foreground">Cleanup</strong> - Built-in unmount function for proper cleanup</li>
+            <li><strong className="text-foreground">Z-index freedom</strong> - Avoid stacking context issues with overlays</li>
+          </ul>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <PortalBasicDemo />
+            </Example>
+
+            <Example title="Custom Container" code={customContainerCode}>
+              <PortalCustomContainerDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">createPortal(children, container?)</h3>
+              <p className="text-muted-foreground text-sm mb-4">
+                Creates a portal to mount content at a specific container. Returns a Portal object with element reference and unmount method.
+              </p>
+              <h4 className="text-md font-medium text-foreground mb-3">Parameters</h4>
+              <PropsTable props={createPortalProps} />
+            </div>
+            <div>
+              <h4 className="text-md font-medium text-foreground mb-3">Return Value</h4>
+              <PropsTable props={portalReturnProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/docs/ui/routes.tsx
+++ b/docs/ui/routes.tsx
@@ -22,6 +22,7 @@ import { DropdownPage } from './pages/dropdown'
 import { ToastPage } from './pages/toast'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
+import { PortalPage } from './pages/portal'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -36,6 +37,7 @@ const components = [
   { name: 'Card', path: '/docs/components/card', description: 'Displays a card with header, content, and footer.' },
   { name: 'Checkbox', path: '/docs/components/checkbox', description: 'A control that allows the user to toggle between checked and unchecked states.' },
   { name: 'Input', path: '/docs/components/input', description: 'Displays an input field for user text entry.' },
+  { name: 'Portal', path: '/docs/components/portal', description: 'Renders children into a different part of the DOM tree.' },
   { name: 'Switch', path: '/docs/components/switch', description: 'A control that allows the user to toggle between checked and not checked.' },
   { name: 'Accordion', path: '/docs/components/accordion', description: 'A vertically stacked set of interactive headings that each reveal content.' },
   { name: 'Tabs', path: '/docs/components/tabs', description: 'A set of layered sections of content displayed one at a time.' },
@@ -170,6 +172,11 @@ export function createApp() {
   // Select documentation
   app.get('/docs/components/select', (c) => {
     return c.render(<SelectPage />)
+  })
+
+  // Portal documentation
+  app.get('/docs/components/portal', (c) => {
+    return c.render(<PortalPage />)
   })
 
   // Controlled Input pattern documentation

--- a/packages/jsx/src/ir-to-client-js.ts
+++ b/packages/jsx/src/ir-to-client-js.ts
@@ -1396,8 +1396,29 @@ function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, siblingCom
   const lines: string[] = []
   const name = ctx.componentName
 
-  // Imports
-  lines.push(`import { createSignal, createMemo, createEffect, onCleanup, onMount, findScope, find, hydrate, cond, insert, reconcileList, createComponent, registerComponent, registerTemplate, initChild, updateClientMarker } from '@barefootjs/dom'`)
+  // Standard imports from @barefootjs/dom
+  const standardImports = [
+    'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
+    'findScope', 'find', 'hydrate', 'cond', 'insert', 'reconcileList',
+    'createComponent', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker'
+  ]
+
+  // Collect user-defined imports from @barefootjs/dom
+  const userDomImports: string[] = []
+  for (const imp of _ir.metadata.imports) {
+    if (imp.source === '@barefootjs/dom' && !imp.isTypeOnly) {
+      for (const spec of imp.specifiers) {
+        const importName = spec.alias || spec.name
+        if (!spec.isDefault && !spec.isNamespace && !standardImports.includes(importName)) {
+          userDomImports.push(spec.alias ? `${spec.name} as ${spec.alias}` : spec.name)
+        }
+      }
+    }
+  }
+
+  // Merge standard and user-defined imports
+  const allImports = [...standardImports, ...userDomImports]
+  lines.push(`import { ${allImports.join(', ')} } from '@barefootjs/dom'`)
 
   // Add child component imports for loops with createComponent and initChild calls
   // Skip siblings (components in the same file)

--- a/ui/components/ui/portal.tsx
+++ b/ui/components/ui/portal.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+/**
+ * Portal Component
+ *
+ * A component that renders its children into a different part of the DOM tree.
+ * Useful for modals, tooltips, and dropdowns that need to render outside
+ * their parent container to avoid overflow or z-index issues.
+ *
+ * Uses @barefootjs/dom's createPortal utility for client-side portal mounting.
+ *
+ * @example Basic usage with createPortal
+ * ```tsx
+ * import { createPortal } from '@barefootjs/dom'
+ *
+ * function Modal() {
+ *   const portal = createPortal(
+ *     '<div class="modal">Modal content</div>',
+ *     document.body
+ *   )
+ *
+ *   // Later: cleanup
+ *   portal.unmount()
+ * }
+ * ```
+ */
+
+import type { Child } from '../../types'
+
+/**
+ * Props for the Portal component.
+ */
+interface PortalProps {
+  /** Content to render in the portal */
+  children?: Child
+  /** Target container element (defaults to document.body) */
+  container?: HTMLElement | null
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Portal component placeholder for SSR rendering.
+ *
+ * On SSR, children are rendered inline with data-portal attribute.
+ * For actual portal functionality, use createPortal from @barefootjs/dom directly.
+ *
+ * @param props.children - Content to render
+ * @param props.className - Additional CSS classes
+ */
+function Portal({
+  children,
+  className = '',
+}: PortalProps) {
+  return (
+    <div
+      data-slot="portal"
+      data-portal="true"
+      className={className}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { Portal }
+export type { PortalProps }


### PR DESCRIPTION
## Summary
- Add Portal UI component placeholder for SSR
- Add portal-demo.tsx with BasicDemo and CustomContainerDemo showing createPortal behavior
- Add portal.tsx documentation page with API reference
- Add portal.spec.ts E2E tests (16 tests all passing)
- Update routes.tsx and PageNavigation.tsx for navigation

## Test plan
- [x] Run E2E tests: `cd docs/ui && bun run test:e2e -- portal` (16 passed)
- [x] Build: `cd docs/ui && bun run build`
- [x] Manual browser testing: http://localhost:3002/docs/components/portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)