### PR TITLE
feat(compiler): warn on props destructuring in function parameters

### DIFF
--- a/docs/ui/build.ts
+++ b/docs/ui/build.ts
@@ -187,9 +187,22 @@ for (const entryPath of componentFiles) {
     return await Bun.file(path).text()
   }, { adapter })
 
-  if (result.errors.length > 0) {
+  // Separate errors and warnings
+  const errors = result.errors.filter(e => e.severity === 'error')
+  const warnings = result.errors.filter(e => e.severity === 'warning')
+
+  // Show warnings but continue
+  if (warnings.length > 0) {
+    console.warn(`Warnings compiling ${entryPath}:`)
+    for (const warning of warnings) {
+      console.warn(`  ${warning.message}`)
+    }
+  }
+
+  // Only skip on actual errors
+  if (errors.length > 0) {
     console.error(`Errors compiling ${entryPath}:`)
-    for (const error of result.errors) {
+    for (const error of errors) {
       console.error(`  ${error.message}`)
     }
     continue

--- a/examples/echo/build.ts
+++ b/examples/echo/build.ts
@@ -70,9 +70,23 @@ for (const componentPath of components) {
   for (const targetComponentName of allComponentNames) {
     // Analyze each component
     const ctx = analyzeComponent(source, componentPath, targetComponentName)
-    if (ctx.errors.length > 0) {
+
+    // Separate errors and warnings
+    const errors = ctx.errors.filter(e => e.severity === 'error')
+    const warnings = ctx.errors.filter(e => e.severity === 'warning')
+
+    // Show warnings but continue
+    if (warnings.length > 0) {
+      console.warn(`Warnings compiling ${targetComponentName} in ${componentPath}:`)
+      for (const warning of warnings) {
+        console.warn(`  ${warning.message}`)
+      }
+    }
+
+    // Only skip on actual errors
+    if (errors.length > 0) {
       console.error(`Errors compiling ${targetComponentName} in ${componentPath}:`)
-      for (const error of ctx.errors) {
+      for (const error of errors) {
         console.error(`  ${error.message}`)
       }
       continue
@@ -195,7 +209,9 @@ for (const componentPath of components) {
 
     for (const targetComponentName of allComponentNames) {
       const ctx = analyzeComponent(source, componentPath, targetComponentName)
-      if (ctx.errors.length > 0) continue
+      // Skip only on actual errors (not warnings)
+      const errors = ctx.errors.filter(e => e.severity === 'error')
+      if (errors.length > 0) continue
 
       const root = jsxToIR(ctx)
       if (!root) continue

--- a/examples/hono/build.ts
+++ b/examples/hono/build.ts
@@ -93,9 +93,22 @@ for (const entryPath of componentFiles) {
     return await Bun.file(path).text()
   }, { adapter })
 
-  if (result.errors.length > 0) {
+  // Separate errors and warnings
+  const errors = result.errors.filter(e => e.severity === 'error')
+  const warnings = result.errors.filter(e => e.severity === 'warning')
+
+  // Show warnings but continue
+  if (warnings.length > 0) {
+    console.warn(`Warnings compiling ${entryPath}:`)
+    for (const warning of warnings) {
+      console.warn(`  ${warning.message}`)
+    }
+  }
+
+  // Only skip on actual errors
+  if (errors.length > 0) {
     console.error(`Errors compiling ${entryPath}:`)
-    for (const error of result.errors) {
+    for (const error of errors) {
       console.error(`  ${error.message}`)
     }
     continue

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -254,8 +254,8 @@ describe('Compiler', () => {
           onClick?: () => void
         }
 
-        export function Button({ onClick }: ButtonProps) {
-          return <button onClick={onClick}>Click</button>
+        export function Button(props: ButtonProps) {
+          return <button onClick={props.onClick}>Click</button>
         }
       `
 
@@ -265,8 +265,8 @@ describe('Compiler', () => {
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
-      // Should extract onClick from props
-      expect(clientJs?.content).toContain('const onClick = props.onClick')
+      // Should use props.onClick directly
+      expect(clientJs?.content).toContain('props.onClick')
     })
 
     test('extracts props and props-dependent constants in client JS', () => {
@@ -280,9 +280,9 @@ describe('Compiler', () => {
           command: string
         }
 
-        export function CommandDisplay({ command }: Props) {
+        export function CommandDisplay(props: Props) {
           const [show, setShow] = createSignal(true)
-          const fullCommand = \`npx \${command}\`
+          const fullCommand = \`npx \${props.command}\`
 
           return (
             <div>
@@ -299,10 +299,8 @@ describe('Compiler', () => {
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
-      // Should extract command prop
-      expect(clientJs?.content).toContain('const command = props.command')
-      // Should include fullCommand constant that depends on command prop
-      expect(clientJs?.content).toContain('const fullCommand = `npx ${command}`')
+      // Should use props.command directly in fullCommand constant
+      expect(clientJs?.content).toContain('const fullCommand = `npx ${props.command}`')
     })
 
     test('outputs IR JSON when requested', () => {
@@ -388,11 +386,11 @@ describe('Compiler', () => {
           label: string
         }
 
-        export function Counter({ initial = 0, label }: CounterProps) {
-          const [count, setCount] = createSignal(initial)
+        export function Counter(props: CounterProps) {
+          const [count, setCount] = createSignal(props.initial ?? 0)
           return (
             <button onClick={() => setCount(n => n + 1)}>
-              {label}: {count()}
+              {props.label}: {count()}
             </button>
           )
         }
@@ -539,9 +537,9 @@ describe('Compiler', () => {
         const iconNames = ['chevron', 'arrow'] as const
         type IconName = typeof iconNames[number]
 
-        export function Icon({ name }: { name: IconName }) {
+        export function Icon(props: { name: IconName }) {
           const [active, setActive] = createSignal(false)
-          const linecap = (iconNames as readonly string[]).includes(name) ? 'butt' : 'round'
+          const linecap = (iconNames as readonly string[]).includes(props.name) ? 'butt' : 'round'
           return (
             <svg stroke-linecap={linecap} onClick={() => setActive(true)}>
               <path d="M0 0" />

--- a/packages/jsx/src/__tests__/props-destructuring.test.ts
+++ b/packages/jsx/src/__tests__/props-destructuring.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Props Destructuring Warning Tests
+ *
+ * Tests for BF043: Props destructuring in function parameters breaks reactivity
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { ErrorCodes } from '../errors'
+
+describe('Props Destructuring Warning (BF043)', () => {
+  test('warns on destructured props', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      export function Component({ checked }: Props) {
+        return <div>{checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(1)
+    expect(propsWarnings[0].severity).toBe('warning')
+    expect(propsWarnings[0].suggestion?.message).toContain('props object')
+  })
+
+  test('warns on rest props', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      export function Component({ ...props }: Props) {
+        return <div>{props.checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(1)
+  })
+
+  test('warns on partial destructuring with rest props', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        onClick: () => void
+        checked: boolean
+      }
+
+      export function Component({ onClick, ...rest }: Props) {
+        return <div onClick={onClick}>{rest.checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(1)
+  })
+
+  test('no warning with @bf-ignore props-destructuring', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      // @bf-ignore props-destructuring
+      export function Component({ checked }: Props) {
+        return <div>{checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(0)
+  })
+
+  test('no warning when props object is used', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      export function Component(props: Props) {
+        return <div>{props.checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(0)
+  })
+
+  test('no warning when no props parameter', () => {
+    const source = `
+      'use client'
+
+      export function Component() {
+        return <div>Hello</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(0)
+  })
+
+  test('warns on arrow function component with destructuring', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      export const Component = ({ checked }: Props) => {
+        return <div>{checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(1)
+  })
+
+  test('no warning on arrow function with @bf-ignore', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+      }
+
+      // @bf-ignore props-destructuring
+      export const Component = ({ checked }: Props) => {
+        return <div>{checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(0)
+  })
+
+  test('warns on multiple destructured props', () => {
+    const source = `
+      'use client'
+
+      interface Props {
+        checked: boolean
+        onChange: () => void
+        label: string
+      }
+
+      export function Component({ checked, onChange, label }: Props) {
+        return <div onClick={onChange}>{label}: {checked}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    const propsWarnings = ctx.errors.filter((e) => e.code === ErrorCodes.PROPS_DESTRUCTURING)
+    expect(propsWarnings).toHaveLength(1) // One warning per component, not per prop
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -38,6 +38,7 @@ export const ErrorCodes = {
   COMPONENT_NOT_FOUND: 'BF040',
   CIRCULAR_DEPENDENCY: 'BF041',
   INVALID_COMPONENT_NAME: 'BF042',
+  PROPS_DESTRUCTURING: 'BF043',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -72,6 +73,8 @@ const errorMessages: Record<ErrorCode, string> = {
   [ErrorCodes.CIRCULAR_DEPENDENCY]: 'Circular dependency detected',
   [ErrorCodes.INVALID_COMPONENT_NAME]:
     'Component name must start with uppercase letter',
+  [ErrorCodes.PROPS_DESTRUCTURING]:
+    'Props destructuring in function parameters breaks reactivity. Use props object directly.',
 }
 
 // =============================================================================

--- a/site/build.ts
+++ b/site/build.ts
@@ -139,9 +139,22 @@ for (const entryPath of componentFiles) {
     return await Bun.file(path).text()
   }, { adapter })
 
-  if (result.errors.length > 0) {
+  // Separate errors and warnings
+  const errors = result.errors.filter(e => e.severity === 'error')
+  const warnings = result.errors.filter(e => e.severity === 'warning')
+
+  // Show warnings but continue
+  if (warnings.length > 0) {
+    console.warn(`Warnings compiling ${entryPath}:`)
+    for (const warning of warnings) {
+      console.warn(`  ${warning.message}`)
+    }
+  }
+
+  // Only skip on actual errors
+  if (errors.length > 0) {
     console.error(`Errors compiling ${entryPath}:`)
-    for (const error of result.errors) {
+    for (const error of errors) {
       console.error(`  ${error.message}`)
     }
     continue

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -270,6 +270,7 @@ interface TemplateAdapter {
 | BF021 | Unsupported JSX pattern |
 | BF030 | Type inference failed |
 | BF031 | Props type mismatch |
+| BF043 | Props destructuring breaks reactivity |
 
 ### Error Format
 
@@ -283,6 +284,23 @@ error[BF001]: 'use client' directive required for components with createSignal
    |
    = help: Add 'use client' at the top of the file
 ```
+
+### Suppressing Warnings
+
+Use `@bf-ignore` comment directive to suppress specific warnings:
+
+```tsx
+// @bf-ignore props-destructuring
+function Component({ checked }: Props) {
+  // Warning suppressed for this component
+}
+```
+
+**Available rules:**
+
+| Rule ID | Error Code | Description |
+|---------|------------|-------------|
+| `props-destructuring` | BF043 | Props destructuring in function parameters |
 
 ---
 
@@ -520,4 +538,3 @@ This matches SolidJS behavior where props must be accessed via the props object 
 1. **Type inference depth** - How deeply to resolve types like `Pick<T, K>`?
 2. **Source maps** - Generate source maps for Client JS debugging?
 3. **Constant ordering** - How to handle dependencies more robustly?
-4. **Lint rule** - Add ESLint rule to warn about destructured props in reactive contexts?


### PR DESCRIPTION
## Summary

- Add BF043 warning when props are destructured at function parameter level (breaks reactivity)
- Add `@bf-ignore props-destructuring` comment directive to suppress warnings
- Support both regular functions and arrow function components

## Changes

| File | Description |
|------|-------------|
| `packages/jsx/src/errors.ts` | Add `PROPS_DESTRUCTURING: 'BF043'` error code |
| `packages/jsx/src/analyzer.ts` | Add `hasIgnoreDirective()` and warning logic |
| `packages/jsx/src/__tests__/props-destructuring.test.ts` | New tests (9 cases) |
| `spec/compiler.md` | Document BF043 and `@bf-ignore` directive |

## Usage

```tsx
// ⚠️ Warning: BF043
function Component({ checked }: Props) { ... }

// ✅ No warning (suppressed)
// @bf-ignore props-destructuring
function Component({ checked }: Props) { ... }

// ✅ No warning (recommended pattern)
function Component(props: Props) { ... }
```

## Test plan

- [x] `pnpm test` passes (209 tests)
- [x] New tests cover warning and directive functionality

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)