### PR TITLE
fix(go-template): generate data-bf-props scripts for single child components

### DIFF
--- a/examples/echo/build.ts
+++ b/examples/echo/build.ts
@@ -67,6 +67,16 @@ for (const componentPath of components) {
   const typeParts: string[] = []
   let mainComponentIR: ComponentIR | null = null
 
+  // Find the default export component name (used as scriptBaseName for non-default exports)
+  let defaultExportName: string | null = null
+  for (const name of allComponentNames) {
+    const ctx = analyzeComponent(source, componentPath, name)
+    if (ctx.hasDefaultExport) {
+      defaultExportName = name
+      break
+    }
+  }
+
   for (const targetComponentName of allComponentNames) {
     // Analyze each component
     const ctx = analyzeComponent(source, componentPath, targetComponentName)
@@ -108,10 +118,10 @@ for (const componentPath of components) {
     }
 
     // Generate template
-    // Skip script registration for non-default-export components
-    // (they are bundled in the main component's .client.js file)
+    // For non-default exports, use the default export's name for script registration
+    // (all components in a file share the same .client.js file named after the default export)
     const output = adapter.generate(ir, {
-      skipScriptRegistration: !ctx.hasDefaultExport
+      scriptBaseName: ctx.hasDefaultExport ? undefined : (defaultExportName || undefined)
     })
     templateParts.push(output.template)
 

--- a/examples/shared/e2e/reactive-props.spec.ts
+++ b/examples/shared/e2e/reactive-props.spec.ts
@@ -132,10 +132,6 @@ export function reactivePropsTests(baseUrl: string) {
    * - destructured props: loses reactivity (captures initial value)
    */
   test.describe('Props Reactivity Comparison', () => {
-    // Skip on echo (Go template) - child component hydration not yet implemented
-    // See: https://github.com/kfly8/barefootjs/issues/247
-    test.skip(() => baseUrl.includes(':8080'), 'Skip on echo - child hydration not implemented (#247)')
-
     test.beforeEach(async ({ page }) => {
       await page.goto(`${baseUrl}/props-reactivity`)
     })

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -167,7 +167,7 @@ describe('GoTemplateAdapter', () => {
       }
 
       const result = adapter.renderElement(element)
-      expect(result).toBe('<div data-bf-scope="{{.ScopeID}}"></div>')
+      expect(result).toBe('<div data-bf-scope="{{.ScopeID}}" {{bfIsChild .ScopeID}}></div>')
     })
 
     test('renders element with slot marker', () => {

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -23,6 +23,8 @@ export interface AdapterOutput {
 export interface AdapterGenerateOptions {
   /** Skip script registration (for child components bundled in parent's .client.js) */
   skipScriptRegistration?: boolean
+  /** Base name for script registration (for non-default exports sharing parent's .client.js) */
+  scriptBaseName?: string
 }
 
 export interface TemplateAdapter {


### PR DESCRIPTION
## Summary

- Fix #247: Child components now get their `data-bf-props` scripts generated
- Add `data-bf-child` attribute to prevent auto-hydration of child components
- Support `scriptBaseName` option for non-default exports sharing parent's `.client.js`

## Changes

### `packages/go-template/runtime/bf.go`
- Add `findSingleChildComponents()` to detect single struct child props (not arrays)
- Add `setScriptsOnSingle()` to inject ScriptCollector into single children
- Add `buildSingleChildPropsScript()` to generate JSON script tags
- Add `bfIsChild()` helper function to mark child components with `data-bf-child` attribute
- Modify `Render()` to process single child components

### `packages/go-template/src/adapter/go-template-adapter.ts`
- Update `renderScopeMarker()` to include `{{bfIsChild .ScopeID}}`
- Add `scriptBaseName` parameter support in `generateScriptRegistrations()`

### `packages/jsx/src/adapters/interface.ts`
- Add `scriptBaseName` option to `AdapterGenerateOptions`

### `examples/echo/build.ts`
- Track default export name and pass as `scriptBaseName` for non-default exports

### `examples/shared/e2e/reactive-props.spec.ts`
- Remove temporary test.skip for echo

## Test plan

- [x] All 75 echo e2e tests pass
- [x] All 80 hono e2e tests pass
- [x] Props Reactivity Comparison tests now pass on echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)