### PR TITLE
feat(runtime): support portal-aware element detection

### DIFF
--- a/packages/dom/__tests__/portal.test.ts
+++ b/packages/dom/__tests__/portal.test.ts
@@ -251,4 +251,49 @@ describe('createPortal', () => {
       expect(() => createPortal(emptyJsx, container)).toThrow('createPortal: Invalid HTML provided')
     })
   })
+
+  describe('with ownerScope option', () => {
+    test('sets data-bf-portal-owner when ownerScope has scope ID', () => {
+      const ownerScope = document.createElement('div')
+      ownerScope.dataset.bfScope = 'Dialog_abc123'
+
+      const portal = createPortal('<div class="modal">Content</div>', container, { ownerScope })
+
+      expect(portal.element.getAttribute('data-bf-portal-owner')).toBe('Dialog_abc123')
+    })
+
+    test('does not set data-bf-portal-owner when ownerScope is missing scope ID', () => {
+      const ownerScope = document.createElement('div')
+      // No data-bf-scope attribute
+
+      const portal = createPortal('<div class="modal">Content</div>', container, { ownerScope })
+
+      expect(portal.element.hasAttribute('data-bf-portal-owner')).toBe(false)
+    })
+
+    test('does not set data-bf-portal-owner when options not provided', () => {
+      const portal = createPortal('<div class="modal">Content</div>', container)
+
+      expect(portal.element.hasAttribute('data-bf-portal-owner')).toBe(false)
+    })
+
+    test('does not set data-bf-portal-owner when ownerScope is undefined', () => {
+      const portal = createPortal('<div class="modal">Content</div>', container, { ownerScope: undefined })
+
+      expect(portal.element.hasAttribute('data-bf-portal-owner')).toBe(false)
+    })
+
+    test('works with HTMLElement children', () => {
+      const ownerScope = document.createElement('div')
+      ownerScope.dataset.bfScope = 'DialogContent_xyz789'
+
+      const modalEl = document.createElement('div')
+      modalEl.className = 'dialog-content'
+
+      const portal = createPortal(modalEl, container, { ownerScope })
+
+      expect(portal.element.getAttribute('data-bf-portal-owner')).toBe('DialogContent_xyz789')
+      expect(portal.element.className).toBe('dialog-content')
+    })
+  })
 })

--- a/packages/dom/__tests__/runtime.test.ts
+++ b/packages/dom/__tests__/runtime.test.ts
@@ -162,6 +162,103 @@ describe('find', () => {
     expect(el?.textContent).toBe('child')
     expect(el).not.toBe(scope)
   })
+
+  describe('with portals', () => {
+    test('finds element in portal owned by scope', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Dialog_abc123">
+          <button data-bf="trigger">Open</button>
+        </div>
+        <div data-bf-portal-owner="Dialog_abc123">
+          <input data-bf="input" />
+        </div>
+      `
+      const scope = document.querySelector('[data-bf-scope]')
+      const input = find(scope, '[data-bf="input"]')
+      expect(input).not.toBeNull()
+      expect(input?.tagName.toLowerCase()).toBe('input')
+    })
+
+    test('prioritizes scope over portal for same selector', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Test_1">
+          <span data-bf="item">Scope</span>
+        </div>
+        <div data-bf-portal-owner="Test_1">
+          <span data-bf="item">Portal</span>
+        </div>
+      `
+      const scope = document.querySelector('[data-bf-scope]')
+      const item = find(scope, '[data-bf="item"]')
+      expect(item?.textContent).toBe('Scope')
+    })
+
+    test('finds element in portal when not in scope', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Dialog_xyz">
+          <button data-bf="trigger">Open</button>
+        </div>
+        <div data-bf-portal-owner="Dialog_xyz">
+          <div class="content">
+            <input data-bf="email" type="email" />
+            <button data-bf="submit">Submit</button>
+          </div>
+        </div>
+      `
+      const scope = document.querySelector('[data-bf-scope]')
+      const email = find(scope, '[data-bf="email"]')
+      const submit = find(scope, '[data-bf="submit"]')
+      expect(email).not.toBeNull()
+      expect(submit).not.toBeNull()
+      expect(email?.getAttribute('type')).toBe('email')
+    })
+
+    test('does not find element in portal owned by different scope', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Dialog_1">
+          <button data-bf="trigger">Open</button>
+        </div>
+        <div data-bf-portal-owner="Dialog_2">
+          <input data-bf="input" />
+        </div>
+      `
+      const scope = document.querySelector('[data-bf-scope="Dialog_1"]')
+      const input = find(scope, '[data-bf="input"]')
+      expect(input).toBeNull()
+    })
+
+    test('finds multiple elements across multiple portals', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Dialog_multi">
+          <button data-bf="trigger">Open</button>
+        </div>
+        <div data-bf-portal-owner="Dialog_multi">
+          <div data-bf="overlay" class="overlay"></div>
+        </div>
+        <div data-bf-portal-owner="Dialog_multi">
+          <div data-bf="content" class="content"></div>
+        </div>
+      `
+      const scope = document.querySelector('[data-bf-scope]')
+      const overlay = find(scope, '[data-bf="overlay"]')
+      const content = find(scope, '[data-bf="content"]')
+      expect(overlay).not.toBeNull()
+      expect(content).not.toBeNull()
+    })
+
+    test('finds portal element itself when it matches selector', () => {
+      document.body.innerHTML = `
+        <div data-bf-scope="Dialog_self">
+          <button data-bf="trigger">Open</button>
+        </div>
+        <div data-bf-portal-owner="Dialog_self" data-bf="portal-root"></div>
+      `
+      const scope = document.querySelector('[data-bf-scope]')
+      const portalRoot = find(scope, '[data-bf="portal-root"]')
+      expect(portalRoot).not.toBeNull()
+      expect(portalRoot?.getAttribute('data-bf-portal-owner')).toBe('Dialog_self')
+    })
+  })
 })
 
 describe('hydrate', () => {

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   createPortal,
   type Portal,
+  type PortalOptions,
   type Renderable,
   type PortalChildren,
 } from './portal'

--- a/packages/dom/src/portal.ts
+++ b/packages/dom/src/portal.ts
@@ -14,6 +14,18 @@ export type Portal = {
   unmount: () => void
 }
 
+/**
+ * Options for createPortal
+ */
+export interface PortalOptions {
+  /**
+   * The scope element that owns this portal.
+   * When provided, the portal element will have a data-bf-portal-owner attribute
+   * set to the scope ID, allowing find() to locate elements inside the portal.
+   */
+  ownerScope?: Element
+}
+
 /** Anything that can be converted to HTML string via toString() */
 export type Renderable = { toString(): string }
 
@@ -28,6 +40,7 @@ export type PortalChildren = HTMLElement | string | Renderable
  *
  * @param children - Element to mount (HTMLElement, HTML string, or JSX.Element)
  * @param container - Target container element (defaults to document.body)
+ * @param options - Optional configuration including ownerScope for scope-based find()
  * @returns Portal object with element reference and unmount method
  *
  * @example
@@ -48,6 +61,9 @@ export type PortalChildren = HTMLElement | string | Renderable
  * // With JSX.Element (Hono)
  * const portal = createPortal(<Modal />, document.body)
  *
+ * // With ownerScope for scope-based element detection
+ * const portal = createPortal(modalEl, document.body, { ownerScope: scopeElement })
+ *
  * // Access the mounted element
  * console.log(portal.element)
  *
@@ -56,7 +72,8 @@ export type PortalChildren = HTMLElement | string | Renderable
  */
 export function createPortal(
   children: PortalChildren,
-  container: HTMLElement = document.body
+  container: HTMLElement = document.body,
+  options?: PortalOptions
 ): Portal {
   let element: HTMLElement
 
@@ -75,6 +92,14 @@ export function createPortal(
     }
 
     element = parsed
+  }
+
+  // Set portal owner for scope-based find()
+  if (options?.ownerScope) {
+    const scopeId = (options.ownerScope as HTMLElement).dataset?.bfScope
+    if (scopeId) {
+      element.setAttribute('data-bf-portal-owner', scopeId)
+    }
   }
 
   container.appendChild(element)

--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -178,6 +178,22 @@ export function find(
         if (siblingFound) return siblingFound
       }
     }
+
+    // Search in portals owned by this scope
+    // Portals are elements with data-bf-portal-owner matching this scope's ID
+    const portals = document.querySelectorAll(`[data-bf-portal-owner="${scopeId}"]`)
+    for (const portal of portals) {
+      if (portal.matches?.(selector)) return portal
+      // Search within portal, excluding elements inside nested component scopes
+      const matches = portal.querySelectorAll(selector)
+      for (const match of matches) {
+        const nearestScope = match.closest('[data-bf-scope]')
+        // Include if no nested scope, or if the match is inside a portal-specific scope
+        if (!nearestScope) {
+          return match
+        }
+      }
+    }
   }
 
   return null

--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -37,7 +37,7 @@
  * ```
  */
 
-import { createEffect, onCleanup } from '@barefootjs/dom'
+import { createEffect, onCleanup, createPortal } from '@barefootjs/dom'
 import type { Child } from '../../types'
 
 // DialogTrigger classes
@@ -130,9 +130,11 @@ interface DialogOverlayProps {
  */
 function DialogOverlay(props: DialogOverlayProps) {
   // Move element to document.body on mount (portal behavior)
+  // Uses createPortal with ownerScope for scope-based element detection
   const moveToBody = (el: HTMLElement) => {
     if (el && el.parentNode !== document.body) {
-      document.body.appendChild(el)
+      const ownerScope = el.closest('[data-bf-scope]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
     }
   }
 
@@ -230,11 +232,13 @@ function DialogContent(props: DialogContentProps) {
   }
 
   // Move element to document.body on mount (portal behavior)
+  // Uses createPortal with ownerScope for scope-based element detection
   const handleMount = (el: HTMLElement) => {
     ref.current = el
-    // Portal: move to body
+    // Portal: move to body with ownerScope for find() support
     if (el && el.parentNode !== document.body) {
-      document.body.appendChild(el)
+      const ownerScope = el.closest('[data-bf-scope]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `ownerScope` option to `createPortal()` for scope-based element detection
- Extend `find()` to search portals owned by a scope via `data-bf-portal-owner` attribute
- Update Dialog components to use `createPortal` with `ownerScope`

## Test plan

- [x] Unit tests for `createPortal` with `ownerScope` option
- [x] Unit tests for `find()` with portal search
- [x] E2E tests for Dialog component (29 tests pass)

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)