### PR TITLE
refactor(compiler): remove unused PropReference infrastructure

### DIFF
--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -23,7 +23,6 @@ import type {
   IRTemplatePart,
   SourceLocation,
   TypeInfo,
-  PropReference,
 } from './types'
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
@@ -52,34 +51,6 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
 
 function generateSlotId(ctx: TransformContext): string {
   return `slot_${ctx.slotIdCounter++}`
-}
-
-// =============================================================================
-// Prop Reference Extraction
-// =============================================================================
-
-/**
- * Extract prop references from an expression using TypeScript AST.
- *
- * Per spec/compiler.md:
- * - Destructured props ({ open }: Props) are captured once and static
- * - Props object (props: Props) already uses props.xxx pattern
- *
- * In both cases, NO transformation is needed in createEffect:
- * - Destructured: const open = props.open (captured once), then use 'open'
- * - Props object: use props.open directly (already has prefix)
- *
- * Therefore, this function always returns empty array.
- */
-function extractPropReferences(
-  _exprNode: ts.Expression,
-  _exprText: string,
-  _ctx: TransformContext
-): PropReference[] {
-  // No transformation needed - always return empty
-  // - Destructured props: captured once at hydration, used as-is
-  // - Props object: already uses props.xxx syntax
-  return []
 }
 
 // =============================================================================
@@ -460,13 +431,9 @@ function transformExpression(
   const needsSlot = reactive || isClientOnly
   const slotId = needsSlot ? generateSlotId(ctx) : null
 
-  // Extract prop references for semantic tracking
-  const propRefs = extractPropReferences(expr, exprText, ctx)
-
   return {
     type: 'expression',
     expr: exprText,
-    propRefs: propRefs.length > 0 ? propRefs : undefined,
     typeInfo: inferExpressionType(expr, ctx),
     reactive,
     slotId,
@@ -484,7 +451,6 @@ function transformConditional(
   ctx: TransformContext
 ): IRConditional {
   const condition = node.condition.getText(ctx.sourceFile)
-  const conditionPropRefs = extractPropReferences(node.condition, condition, ctx)
   const reactive = isReactiveExpression(condition, ctx)
   const slotId = reactive ? generateSlotId(ctx) : null
 
@@ -495,7 +461,6 @@ function transformConditional(
   return {
     type: 'conditional',
     condition,
-    conditionPropRefs: conditionPropRefs.length > 0 ? conditionPropRefs : undefined,
     conditionType: null,
     reactive,
     whenTrue,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -69,17 +69,6 @@ export interface ParamInfo {
   defaultValue?: string
 }
 
-/**
- * Reference to a destructured prop in an expression.
- * Tracks position for position-based replacement instead of regex.
- */
-export interface PropReference {
-  propName: string // The prop name (e.g., "open")
-  start: number // Start position in expression string (0-indexed)
-  end: number // End position (exclusive)
-  defaultValue?: string // Default value if prop is optional
-}
-
 // =============================================================================
 // IR Node Types
 // =============================================================================
@@ -116,8 +105,6 @@ export interface IRText {
 export interface IRExpression {
   type: 'expression'
   expr: string
-  /** Semantic prop references with positions for position-based replacement */
-  propRefs?: PropReference[]
   typeInfo: TypeInfo | null
   reactive: boolean
   slotId: string | null
@@ -129,8 +116,6 @@ export interface IRExpression {
 export interface IRConditional {
   type: 'conditional'
   condition: string
-  /** Semantic prop references in condition with positions */
-  conditionPropRefs?: PropReference[]
   conditionType: TypeInfo | null
   reactive: boolean
   whenTrue: IRNode


### PR DESCRIPTION
## Summary
- Remove unused `PropReference` type and related fields from IR types
- Remove `extractPropReferences()` function from jsx-to-ir.ts
- Remove `replacePropReferences*()` functions from ir-to-client-js.ts
- Simplify `expandDynamicPropValue()` to only handle local constants

Closes #264

## Changes
| File | Changes |
|------|---------|
| `types.ts` | Removed `PropReference` type, `propRefs` from `IRExpression`, `conditionPropRefs` from `IRConditional` |
| `jsx-to-ir.ts` | Removed `extractPropReferences()` function |
| `ir-to-client-js.ts` | Removed `replacePropReferences*()` functions, simplified `expandDynamicPropValue()` |

## Test plan
- [x] `pnpm test` passes (104 tests)
- [x] `pnpm build` succeeds
- [x] Existing `prop-references.test.ts` tests pass (test names kept for documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)