### PR TITLE
fix: update UI links to point to ui.barefootjs.dev

### DIFF
--- a/docs/ui/components/header.tsx
+++ b/docs/ui/components/header.tsx
@@ -64,7 +64,7 @@ export function Header({ currentPath = '/' }: HeaderProps) {
               core
             </a>
             <a
-              href="/components"
+              href="/"
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline ${
                 isActive('/components') || isActive('/forms')
                   ? 'bg-accent text-foreground'

--- a/site/components/header.tsx
+++ b/site/components/header.tsx
@@ -33,7 +33,7 @@ export function Header() {
               docs
             </a>
             <a
-              href="/components"
+              href="https://ui.barefootjs.dev"
               className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
               ui

--- a/site/components/links.tsx
+++ b/site/components/links.tsx
@@ -13,7 +13,7 @@ const links = [
   {
     title: 'UI Components',
     description: 'Pre-built components using Barefoot.js.',
-    href: 'https://barefootjs-ui.pages.dev/',
+    href: 'https://ui.barefootjs.dev/',
   },
   {
     title: 'GitHub',


### PR DESCRIPTION
## Summary
- Update header UI links across site and docs/ui to point to `ui.barefootjs.dev`
- Replace old `barefootjs-ui.pages.dev` URL in links section

## Changes
- `site/components/header.tsx`: `/components` → `https://ui.barefootjs.dev`
- `docs/ui/components/header.tsx`: `/components` → `/`
- `site/components/links.tsx`: `https://barefootjs-ui.pages.dev/` → `https://ui.barefootjs.dev/`

## Test plan
- [ ] Verify the "ui" link in the site header navigates to ui.barefootjs.dev
- [ ] Verify the "ui" link in the docs/ui header navigates to the root
- [ ] Verify the "UI Components" link in the site Resources section is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)