### PR TITLE
fix(docs): dark mode text color for button and form elements

### DIFF
--- a/docs/ui/styles/globals.css
+++ b/docs/ui/styles/globals.css
@@ -186,6 +186,16 @@ button {
   border-width: 0;
   border-style: solid;
   background-color: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+/* Reset form element browser defaults */
+input,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
 }
 
 /* Monospace code elements */


### PR DESCRIPTION
## Summary
- Add `color: inherit` and `font: inherit` to `button` reset in `docs/ui/styles/globals.css`
- Add `color: inherit` and `font: inherit` reset for `input`, `select`, `textarea` elements
- Fixes dark mode where browser default text color (black) was used instead of inheriting `--foreground` CSS variable

## Context
Browser user-agent stylesheets set explicit text color on form elements (`button`, `input`, `select`, `textarea`), which prevents CSS variable inheritance from `body { color: var(--foreground) }`. In dark mode, this caused black text on dark backgrounds, making accordion triggers and card login form inputs unreadable.

## Test plan
- [ ] Verify accordion text is readable in dark mode
- [ ] Verify card login form input text is readable in dark mode
- [ ] Verify no visual regression in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)