### PR TITLE
fix(e2e): resolve flaky dialog focus trap test

### DIFF
--- a/docs/ui/e2e/dialog.spec.ts
+++ b/docs/ui/e2e/dialog.spec.ts
@@ -138,11 +138,14 @@ test.describe('Dialog Documentation Page', () => {
       const dialog = page.locator('[role="dialog"][aria-labelledby="dialog-title"][data-state="open"]')
       await expect(dialog).toBeVisible()
 
-      // Focus on dialog
-      await dialog.focus()
-
       // Get focusable elements - first is the title input
       const titleInput = dialog.locator('input#task-title')
+
+      // Wait for autofocus to complete before manually focusing the dialog container
+      await expect(titleInput).toBeFocused()
+
+      // Focus on dialog container
+      await dialog.focus()
 
       // Tab should move focus to the first focusable element (title input)
       await page.keyboard.press('Tab')


### PR DESCRIPTION
## Summary
- Fix race condition in `dialog.spec.ts` "traps focus within dialog" test
- Wait for autofocus (`setTimeout(..., 0)`) to complete before manually focusing the dialog container, preventing focus from unexpectedly shifting after `dialog.focus()`

## Test plan
- [ ] Verify `e2e/dialog.spec.ts` passes consistently on CI (no more flaky failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)