### PR TITLE
chore: move CLAUDE.md to CLAUDE.local.md for personal overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ examples/*/bun.lock
 examples/*/package-lock.json
 examples/*/node_modules
 
+# Claude Code local overrides
+CLAUDE.local.md
+
 # Playwright
 playwright-report/
 test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,0 @@
-## Plan Mode
-
-- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
-- At the end of each plan, give me a list of unresolved questions to answer, if any.


### PR DESCRIPTION
## Summary
- Move CLAUDE.md contents to CLAUDE.local.md for personal Claude Code configuration
- Add CLAUDE.local.md to .gitignore so each contributor can maintain their own local overrides
- Remove shared CLAUDE.md (project instructions now live in CLAUDE.local.md per user)

## Test plan
- [x] CLAUDE.local.md is gitignored and not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)