### PR TITLE
feat: add root-level workspace scripts with correct build order

### DIFF
--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "bun run build.ts",
     "dev": "go run .",
-    "deps": "go mod tidy",
+    "setup": "go mod tidy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "site"
   ],
   "scripts": {
-    "setup": "bun install && bun run --filter 'barefootjs-echo-example' deps",
+    "setup": "bun install && bun run --filter 'barefootjs-echo-example' setup",
     "build": "bun run --filter '@barefootjs/dom' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' build && bun run --filter '*' build",
     "test": "bun test --cwd . packages/",
     "test:e2e": "bun run --filter '*' test:e2e",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
     "site"
   ],
   "scripts": {
+    "setup": "bun install && bun run --filter 'barefootjs-echo-example' deps",
+    "build": "bun run --filter '@barefootjs/dom' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' build && bun run --filter '*' build",
     "test": "bun test --cwd . packages/",
-    "build": "bun run --filter '*' build"
+    "test:e2e": "bun run --filter '*' test:e2e",
+    "clean": "bun run --filter '*' clean"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.0.11",


### PR DESCRIPTION
## Summary
- Add `setup` script: runs `bun install` for all JS workspace deps + `go mod tidy` for examples/echo
- Fix `build` script: build in dependency order (dom → jsx → hono/go-template → rest) to prevent module resolution failures
- Add `test:e2e` script: run E2E tests across all packages
- Add `clean` script: remove build artifacts from all packages

## Available scripts
| Script | Description |
|---|---|
| `bun run setup` | Install all dependencies (JS workspaces + Go) |
| `bun run build` | Build all packages in correct dependency order |
| `bun run test` | Run unit tests (existing) |
| `bun run test:e2e` | Run E2E tests across all packages |
| `bun run clean` | Remove build artifacts |

## Test plan
- [x] `bun run clean` removes dist/ from all packages
- [x] `bun run build` succeeds after clean (dependency order verified)
- [x] `bun run setup` installs deps and runs go mod tidy

🤖 Generated with [Claude Code](https://claude.com/claude-code)