### PR TITLE
feat: update header navigation links and active state

### DIFF
--- a/docs/ui/components/header.tsx
+++ b/docs/ui/components/header.tsx
@@ -54,7 +54,7 @@ export function Header() {
               className="relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-foreground"
             >
               UI
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-emerald-500 rounded-full" />
+              <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full" style="background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end))" />
             </a>
           </nav>
         </div>

--- a/docs/ui/components/header.tsx
+++ b/docs/ui/components/header.tsx
@@ -24,17 +24,7 @@ function GitHubStarsPlaceholder() {
   )
 }
 
-export interface HeaderProps {
-  currentPath?: string
-}
-
-export function Header({ currentPath = '/' }: HeaderProps) {
-  // Check if a nav item is active
-  const isActive = (path: string) => {
-    if (path === '/') return currentPath === '/'
-    return currentPath.startsWith(path)
-  }
-
+export function Header() {
   return (
     <header className="hidden sm:block fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border">
       <div className="px-6 h-14 flex items-center justify-between gap-4">
@@ -54,24 +44,17 @@ export function Header({ currentPath = '/' }: HeaderProps) {
           {/* Navigation links */}
           <nav className="hidden sm:flex items-center gap-1">
             <a
-              href="/docs/core"
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline ${
-                isActive('/docs/core')
-                  ? 'bg-accent text-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-              }`}
+              href="https://docs.barefootjs.dev"
+              className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
-              core
+              docs
             </a>
             <a
               href="/"
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline ${
-                isActive('/components') || isActive('/forms')
-                  ? 'bg-accent text-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
-              }`}
+              className="relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-foreground"
             >
-              ui
+              UI
+              <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-emerald-500 rounded-full" />
             </a>
           </nav>
         </div>

--- a/docs/ui/components/mobile-header.tsx
+++ b/docs/ui/components/mobile-header.tsx
@@ -33,7 +33,7 @@ export function MobileHeader() {
     <header className="sm:hidden fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border">
       <div className="px-4 h-14 flex items-center justify-between">
         <a
-          href="/"
+          href="https://barefootjs.dev"
           className="flex items-center text-foreground no-underline"
           aria-label="Barefoot.js Home"
         >

--- a/docs/ui/renderer.tsx
+++ b/docs/ui/renderer.tsx
@@ -112,7 +112,7 @@ export const renderer = jsxRenderer(
             `}</style>
           </head>
           <body>
-            <Header currentPath={currentPath} />
+            <Header />
             <MobileHeader />
             <MobileMenu />
             <MobilePageNav currentPath={currentPath} />

--- a/docs/ui/routes.tsx
+++ b/docs/ui/routes.tsx
@@ -64,7 +64,7 @@ export function createApp() {
         {/* Hero */}
         <div className="space-y-4 max-w-2xl">
           <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-foreground">
-            Ready-made components for BarefootJS
+            <span className="gradient-text">Ready-made</span> components for BarefootJS
           </h1>
           <p className="text-muted-foreground text-lg">
             Pick a component. Copy the code. Make it yours.

--- a/docs/ui/styles/globals.css
+++ b/docs/ui/styles/globals.css
@@ -62,6 +62,10 @@
   --info: oklch(0.623 0.214 259.815);
   --info-foreground: oklch(0.985 0 0);
 
+  /* Gradient - emerald/yellow-green (brand accent) */
+  --gradient-start: oklch(0.65 0.18 145);
+  --gradient-end: oklch(0.55 0.15 165);
+
   /* Border/Input/Ring */
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
@@ -131,6 +135,10 @@
   /* Info */
   --info: oklch(0.623 0.214 259.815);
   --info-foreground: oklch(0.985 0 0);
+
+  /* Gradient - emerald/yellow-green (brand accent) */
+  --gradient-start: oklch(0.70 0.18 145);
+  --gradient-end: oklch(0.60 0.15 165);
 
   /* Border/Input/Ring */
   --border: oklch(1 0 0 / 10%);
@@ -245,6 +253,14 @@ html {
 /* Ensure hidden attribute works with flexbox items */
 [hidden] {
   display: none !important;
+}
+
+/* Gradient text */
+.gradient-text {
+  background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 /* Card hover action - show action button only on card hover */

--- a/site/components/header.tsx
+++ b/site/components/header.tsx
@@ -27,7 +27,7 @@ export function Header() {
           {/* Navigation links */}
           <nav className="hidden sm:flex items-center gap-1">
             <a
-              href="/docs/core"
+              href="https://docs.barefootjs.dev"
               className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
               docs
@@ -36,7 +36,7 @@ export function Header() {
               href="https://ui.barefootjs.dev"
               className="px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
-              ui
+              UI
             </a>
           </nav>
         </div>


### PR DESCRIPTION
## Summary
- docs/ui: Logo links to `barefootjs.dev` instead of `/`
- docs/ui: Rename "core" → "docs", linking to `docs.barefootjs.dev`
- docs/ui: "UI" nav item always active with gradient underline indicator
- site: "docs" link points to `docs.barefootjs.dev`
- Both: Rename "ui" → "UI"
- docs/ui: Add brand gradient to "Ready-made" hero heading (matching site)
- docs/ui: Add gradient CSS variables and `.gradient-text` class (light/dark)

## Test plan
- [ ] docs/ui: Click logo → navigates to barefootjs.dev
- [ ] docs/ui: Click "docs" → navigates to docs.barefootjs.dev
- [ ] docs/ui: "UI" shows gradient underline and links to `/`
- [ ] docs/ui: "Ready-made" text has green gradient in light and dark mode
- [ ] site: "docs" link goes to docs.barefootjs.dev
- [ ] site: "UI" label displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)