### PR TITLE
feat: add createContext/useContext to @barefootjs/dom (#279)

### DIFF
--- a/packages/dom/__tests__/context.test.ts
+++ b/packages/dom/__tests__/context.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect } from 'bun:test'
+import { createContext, useContext, provideContext } from '../src/context'
+import { createSignal, createEffect } from '../src/reactive'
+
+describe('createContext', () => {
+  test('creates context with unique id', () => {
+    const ctx1 = createContext<string>()
+    const ctx2 = createContext<string>()
+    expect(typeof ctx1.id).toBe('symbol')
+    expect(ctx1.id).not.toBe(ctx2.id)
+  })
+
+  test('stores default value', () => {
+    const ctx = createContext('hello')
+    expect(ctx.defaultValue).toBe('hello')
+  })
+
+  test('default is undefined when not provided', () => {
+    const ctx = createContext<string>()
+    expect(ctx.defaultValue).toBeUndefined()
+  })
+
+  test('distinguishes explicit undefined from no default', () => {
+    const withExplicit = createContext<string | undefined>(undefined)
+    const withoutDefault = createContext<string>()
+    expect(withExplicit._hasDefault).toBe(true)
+    expect(withoutDefault._hasDefault).toBe(false)
+  })
+})
+
+describe('useContext', () => {
+  test('returns default value when no provider', () => {
+    const ctx = createContext('fallback')
+    expect(useContext(ctx)).toBe('fallback')
+  })
+
+  test('throws when no provider and no default', () => {
+    const ctx = createContext<string>()
+    expect(() => useContext(ctx)).toThrow('useContext: no provider found and no default value')
+  })
+
+  test('returns explicit undefined default without throwing', () => {
+    const ctx = createContext<string | undefined>(undefined)
+    expect(useContext(ctx)).toBeUndefined()
+  })
+})
+
+describe('provideContext + useContext', () => {
+  test('round-trip with simple value', () => {
+    const ctx = createContext<number>()
+    provideContext(ctx, 42)
+    expect(useContext(ctx)).toBe(42)
+  })
+
+  test('round-trip with object', () => {
+    const ctx = createContext<{ name: string }>()
+    const value = { name: 'test' }
+    provideContext(ctx, value)
+    expect(useContext(ctx)).toBe(value)
+  })
+
+  test('round-trip with signal values', () => {
+    const ctx = createContext<{ open: () => boolean; setOpen: (v: boolean) => void }>()
+    const [open, setOpen] = createSignal(false)
+    provideContext(ctx, { open, setOpen })
+
+    const result = useContext(ctx)
+    expect(result.open()).toBe(false)
+
+    result.setOpen(true)
+    expect(result.open()).toBe(true)
+  })
+
+  test('provided value overrides default', () => {
+    const ctx = createContext('default')
+    provideContext(ctx, 'provided')
+    expect(useContext(ctx)).toBe('provided')
+  })
+
+  test('multiple independent contexts', () => {
+    const ctx1 = createContext<string>()
+    const ctx2 = createContext<number>()
+
+    provideContext(ctx1, 'hello')
+    provideContext(ctx2, 99)
+
+    expect(useContext(ctx1)).toBe('hello')
+    expect(useContext(ctx2)).toBe(99)
+  })
+
+  test('null as valid value', () => {
+    const ctx = createContext<string | null>('default')
+    provideContext(ctx, null)
+    expect(useContext(ctx)).toBeNull()
+  })
+
+  test('0 as valid value', () => {
+    const ctx = createContext<number>(999)
+    provideContext(ctx, 0)
+    expect(useContext(ctx)).toBe(0)
+  })
+
+  test('false as valid value', () => {
+    const ctx = createContext<boolean>(true)
+    provideContext(ctx, false)
+    expect(useContext(ctx)).toBe(false)
+  })
+
+  test('empty string as valid value', () => {
+    const ctx = createContext<string>('default')
+    provideContext(ctx, '')
+    expect(useContext(ctx)).toBe('')
+  })
+
+  test('reactivity propagates through context', () => {
+    const ctx = createContext<() => number>()
+    const [count, setCount] = createSignal(0)
+    provideContext(ctx, count)
+
+    const getter = useContext(ctx)
+    expect(getter()).toBe(0)
+
+    setCount(10)
+    expect(getter()).toBe(10)
+  })
+
+  test('useContext captures value at call time', () => {
+    const ctx = createContext<number>()
+
+    provideContext(ctx, 1)
+    const val1 = useContext(ctx)
+
+    provideContext(ctx, 2)
+    const val2 = useContext(ctx)
+
+    // val1 captured the value 1, val2 captured 2
+    expect(val1).toBe(1)
+    expect(val2).toBe(2)
+  })
+})

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -1,0 +1,60 @@
+/**
+ * Context API for parent-child state sharing.
+ *
+ * Provides createContext, useContext, and provideContext for
+ * compound component patterns (DropdownMenu, Tabs, Dialog, etc.).
+ *
+ * Uses a global context store (Map<symbol, unknown>).
+ * Since hydration is synchronous (initChild calls are sequential),
+ * provideContext() before initChild() guarantees children see the correct value.
+ */
+
+export type Context<T> = {
+  readonly id: symbol
+  readonly defaultValue: T | undefined
+  /** Internal flag: true when default was explicitly provided (even if undefined) */
+  readonly _hasDefault: boolean
+}
+
+const contextStore = new Map<symbol, unknown>()
+
+/**
+ * Create a new context with an optional default value.
+ *
+ * When no default is provided, useContext() will throw if no provider is found.
+ * When a default is provided (even if `undefined`), useContext() returns that default.
+ */
+export function createContext<T>(defaultValue?: T): Context<T> {
+  return {
+    id: Symbol(),
+    defaultValue,
+    _hasDefault: arguments.length > 0,
+  }
+}
+
+/**
+ * Read the current value of a context.
+ *
+ * Returns the provided value if provideContext() was called,
+ * falls back to the context's default value,
+ * or throws if neither exists.
+ */
+export function useContext<T>(context: Context<T>): T {
+  if (contextStore.has(context.id)) {
+    return contextStore.get(context.id) as T
+  }
+  if (context._hasDefault) {
+    return context.defaultValue as T
+  }
+  throw new Error('useContext: no provider found and no default value')
+}
+
+/**
+ * Provide a value for a context.
+ *
+ * Must be called before initChild() so child components
+ * can access the value via useContext().
+ */
+export function provideContext<T>(context: Context<T>, value: T): void {
+  contextStore.set(context.id, value)
+}

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -23,6 +23,8 @@ export {
 
 export { reconcileList, type RenderItemFn } from './list'
 
+export { createContext, useContext, provideContext, type Context } from './context'
+
 // Template registry for client-side component creation
 export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './template'
 

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -24,6 +24,7 @@ import type {
   ParsedExpr,
   ParsedStatement,
   IRIfStatement,
+  IRProvider,
 } from '@barefootjs/jsx'
 import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, isBooleanAttr, parseExpression, isSupported } from '@barefootjs/jsx'
 
@@ -890,6 +891,8 @@ export class GoTemplateAdapter extends BaseAdapter {
         return this.renderSlot(node as IRSlot)
       case 'if-statement':
         return this.renderIfStatement(node as IRIfStatement)
+      case 'provider':
+        return this.renderChildren((node as IRProvider).children)
       default:
         return ''
     }

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -15,6 +15,7 @@ import {
   type IRComponent,
   type IRFragment,
   type IRIfStatement,
+  type IRProvider,
   type IRTemplateLiteral,
   type ParamInfo,
   type AdapterOutput,
@@ -535,6 +536,8 @@ export class HonoAdapter implements TemplateAdapter {
         // If-statements are rendered at the component level, not inline
         // This case shouldn't normally be hit, but return empty for safety
         return ''
+      case 'provider':
+        return this.renderChildren((node as IRProvider).children)
       default:
         return ''
     }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -22,6 +22,7 @@ export type {
   IRFragment,
   IRSlot,
   IRIfStatement,
+  IRProvider,
   IRMetadata,
   IRTemplateLiteral,
   IRTemplatePart,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -83,6 +83,7 @@ export type IRNode =
   | IRSlot
   | IRFragment
   | IRIfStatement
+  | IRProvider
 
 export interface IRElement {
   type: 'element'
@@ -219,6 +220,14 @@ export interface IRFragment {
   children: IRNode[]
   /** When true, this fragment just passes through children (Context Provider pattern) */
   transparent?: boolean
+  loc: SourceLocation
+}
+
+export interface IRProvider {
+  type: 'provider'
+  contextName: string   // "MenuContext" (extracted from X.Provider)
+  valueProp: IRProp     // The 'value' prop expression
+  children: IRNode[]
   loc: SourceLocation
 }
 


### PR DESCRIPTION
## Summary

- Add Context API (`createContext`, `useContext`, `provideContext`) to `@barefootjs/dom` for parent-child state sharing in compound components (DropdownMenu, Tabs, Dialog, etc.)
- Add compiler support to detect `<X.Provider value={...}>` JSX syntax and generate `provideContext()` calls in client JS, placed before `initChild()` to ensure children see the correct value
- Add `IRProvider` node type to IR, with support in both Hono and Go template adapters (transparent pass-through rendering)

## Test plan

- [x] `packages/dom`: 18 new context tests — createContext defaults, useContext fallback/throw, provideContext round-trip (simple values, objects, signals), falsy values (null/0/false/""), reactivity propagation
- [x] `packages/jsx`: 5 new compiler tests — IRProvider detection, children preservation, provideContext in client JS, ordering before initChild, self-closing Provider
- [x] All existing tests pass (107 dom, 114 jsx)
- [x] Clean builds for both packages

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)