### PR TITLE
feat: emit BF021 compile error for unsupported filter predicates

### DIFF
--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unsupported Expression Error Tests
+ *
+ * Tests for BF021: Emit compile error when a filter predicate cannot be
+ * compiled to server template and @client is not present.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSXSync } from '../compiler'
+import { ErrorCodes } from '../errors'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+/**
+ * Helper: analyze and transform to IR, returning errors from ctx.
+ */
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, 'Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('Unsupported Expression Error (BF021)', () => {
+  // Use `typeof t` in filter predicate — typeof expressions are unsupported
+  // by the expression parser for server-side rendering.
+  const unsupportedSource = `
+    'use client'
+    import { createSignal } from '@barefootjs/dom'
+
+    export function TodoList() {
+      const [items, setItems] = createSignal<any[]>([])
+      return (
+        <ul>
+          {items().filter(t => typeof t === 'string').map(t => (
+            <li>{t}</li>
+          ))}
+        </ul>
+      )
+    }
+  `
+
+  test('emits BF021 error for unsupported filter predicate', () => {
+    const { errors } = compileToIR(unsupportedSource)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].severity).toBe('error')
+  })
+
+  test('@client suppresses BF021 error', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {/* @client */ items().filter(t => typeof t === 'string').map(t => (
+              <li>{t}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(0)
+  })
+
+  test('no BF021 error for supported filter predicate', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function TodoList() {
+        const [todos, setTodos] = createSignal<any[]>([])
+        return (
+          <ul>
+            {todos().filter(t => !t.done).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(0)
+  })
+
+  test('error message includes the unsupported reason', () => {
+    const { errors } = compileToIR(unsupportedSource)
+    const bf021 = errors.find(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toBeDefined()
+    expect(bf021!.message).toContain('Expression cannot be compiled to server template')
+  })
+
+  test('error includes suggestion to add @client', () => {
+    const { errors } = compileToIR(unsupportedSource)
+    const bf021 = errors.find(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toBeDefined()
+    expect(bf021!.suggestion).toBeDefined()
+    expect(bf021!.suggestion!.message).toContain('@client')
+  })
+
+  test('IR is still produced despite BF021 error (graceful degradation)', () => {
+    const { ir, errors } = compileToIR(unsupportedSource)
+
+    // Error is emitted
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+
+    // But IR is still produced
+    expect(ir).not.toBeNull()
+    expect(ir!.type).toBe('element')
+  })
+
+  test('compileJSXSync includes IR-phase BF021 errors in result', () => {
+    const result = compileJSXSync(unsupportedSource, 'TodoList.tsx', { adapter })
+    const bf021 = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].severity).toBe('error')
+    expect(bf021[0].message).toContain('Expression cannot be compiled to server template')
+  })
+})

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -49,13 +49,15 @@ export async function compileJSX(
 
   // Single component flow
   const ctx = analyzeComponent(source, entryPath)
-  errors.push(...ctx.errors)
 
   if (!ctx.jsxReturn) {
+    errors.push(...ctx.errors)  // Only analyzer errors
     return { files, errors }
   }
 
   const ir = jsxToIR(ctx)
+  errors.push(...ctx.errors)  // All errors: analyzer + IR phase
+
   if (!ir) {
     return { files, errors }
   }
@@ -115,11 +117,14 @@ function compileMultipleComponentsSync(
 
   for (const componentName of componentNames) {
     const ctx = analyzeComponent(source, filePath, componentName)
-    errors.push(...ctx.errors)
 
-    if (!ctx.jsxReturn) continue
+    if (!ctx.jsxReturn) {
+      errors.push(...ctx.errors)  // Only analyzer errors
+      continue
+    }
 
     const ir = jsxToIR(ctx)
+    errors.push(...ctx.errors)  // All errors: analyzer + IR phase
     if (!ir) continue
 
     const componentIR: ComponentIR = {
@@ -313,13 +318,15 @@ export function compileJSXSync(
 
   // Single component flow
   const ctx = analyzeComponent(source, filePath)
-  errors.push(...ctx.errors)
 
   if (!ctx.jsxReturn) {
+    errors.push(...ctx.errors)  // Only analyzer errors
     return { files, errors }
   }
 
   const ir = jsxToIR(ctx)
+  errors.push(...ctx.errors)  // All errors: analyzer + IR phase
+
   if (!ir) {
     return { files, errors }
   }


### PR DESCRIPTION
## Summary

- Emit a **BF021** compile error when a filter predicate cannot be compiled to a server template (e.g., `typeof` expressions, unsupported syntax), instead of silently falling back to client-only evaluation
- Add `/* @client */` as an explicit opt-in to suppress the error and acknowledge client-only evaluation
- Fix error collection timing in `compiler.ts` so IR-phase errors are included in `CompileResult`

Closes #284

## Changes

| File | Description |
|------|-------------|
| `packages/jsx/src/jsx-to-ir.ts` | New `FilterExtractionResult` type with `unsupportedReason`; `extractFilterPredicate()` returns structured result; `transformMapCall()` emits BF021 |
| `packages/jsx/src/compiler.ts` | Move `errors.push(...ctx.errors)` to after `jsxToIR()` in 3 places |
| `packages/jsx/src/__tests__/unsupported-expression.test.ts` | 7 test cases covering error emission, suppression, message content, graceful degradation, and integration |
| `spec/compiler.md` | Document BF021 behavior and `@client` suppression |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/unsupported-expression.test.ts` — 7 tests pass
- [x] `bun test packages/jsx/` — 125 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)