### PR TITLE
refactor: use Context pattern for Dialog and Accordion

### DIFF
--- a/docs/ui/components/accordion-demo.tsx
+++ b/docs/ui/components/accordion-demo.tsx
@@ -6,7 +6,7 @@
  * Used in accordion documentation page.
  */
 
-import { createSignal, createMemo } from '@barefootjs/dom'
+import { createSignal } from '@barefootjs/dom'
 import {
   Accordion,
   AccordionItem,
@@ -20,50 +20,29 @@ import {
 export function AccordionSingleOpenDemo() {
   const [openItem, setOpenItem] = createSignal<string | null>('item-1')
 
-  // Computed open states for each item
-  const isItem1Open = createMemo(() => openItem() === 'item-1')
-  const isItem2Open = createMemo(() => openItem() === 'item-2')
-  const isItem3Open = createMemo(() => openItem() === 'item-3')
-
-  const toggle = (value: string) => {
-    setOpenItem(openItem() === value ? null : value)
-  }
-
   return (
     <Accordion>
-      <AccordionItem value="item-1">
-        <AccordionTrigger
-          open={isItem1Open()}
-          disabled={false}
-          onClick={() => toggle('item-1')}
-        >
+      <AccordionItem value="item-1" open={openItem() === 'item-1'} onOpenChange={(v) => setOpenItem(v ? 'item-1' : null)}>
+        <AccordionTrigger>
           Is it accessible?
         </AccordionTrigger>
-        <AccordionContent open={isItem1Open()}>
+        <AccordionContent>
           Yes. It adheres to the WAI-ARIA design pattern.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger
-          open={isItem2Open()}
-          disabled={false}
-          onClick={() => toggle('item-2')}
-        >
+      <AccordionItem value="item-2" open={openItem() === 'item-2'} onOpenChange={(v) => setOpenItem(v ? 'item-2' : null)}>
+        <AccordionTrigger>
           Is it styled?
         </AccordionTrigger>
-        <AccordionContent open={isItem2Open()}>
+        <AccordionContent>
           Yes. It comes with default styles that match the other components' aesthetic.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger
-          open={isItem3Open()}
-          disabled={false}
-          onClick={() => toggle('item-3')}
-        >
+      <AccordionItem value="item-3" open={openItem() === 'item-3'} onOpenChange={(v) => setOpenItem(v ? 'item-3' : null)}>
+        <AccordionTrigger>
           Is it animated?
         </AccordionTrigger>
-        <AccordionContent open={isItem3Open()}>
+        <AccordionContent>
           Yes. It uses CSS transitions for smooth open/close animations.
         </AccordionContent>
       </AccordionItem>
@@ -81,39 +60,27 @@ export function AccordionMultipleOpenDemo() {
 
   return (
     <Accordion>
-      <AccordionItem value="item-1">
-        <AccordionTrigger
-          open={item1Open()}
-          disabled={false}
-          onClick={() => setItem1Open(!item1Open())}
-        >
+      <AccordionItem value="item-1" open={item1Open()} onOpenChange={setItem1Open}>
+        <AccordionTrigger>
           First Item
         </AccordionTrigger>
-        <AccordionContent open={item1Open()}>
+        <AccordionContent>
           This accordion allows multiple items to be open at once.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger
-          open={item2Open()}
-          disabled={false}
-          onClick={() => setItem2Open(!item2Open())}
-        >
+      <AccordionItem value="item-2" open={item2Open()} onOpenChange={setItem2Open}>
+        <AccordionTrigger>
           Second Item
         </AccordionTrigger>
-        <AccordionContent open={item2Open()}>
+        <AccordionContent>
           Each item manages its own open/close state independently.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger
-          open={item3Open()}
-          disabled={false}
-          onClick={() => setItem3Open(!item3Open())}
-        >
+      <AccordionItem value="item-3" open={item3Open()} onOpenChange={setItem3Open}>
+        <AccordionTrigger>
           Third Item
         </AccordionTrigger>
-        <AccordionContent open={item3Open()}>
+        <AccordionContent>
           Click any trigger to toggle that item without affecting others.
         </AccordionContent>
       </AccordionItem>

--- a/docs/ui/components/dialog-demo.tsx
+++ b/docs/ui/components/dialog-demo.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
 import {
-  DialogRoot,
+  Dialog,
   DialogTrigger,
   DialogOverlay,
   DialogContent,
@@ -27,14 +27,12 @@ export function DialogBasicDemo() {
 
   return (
     <div>
-      <DialogRoot>
-        <DialogTrigger onClick={() => setOpen(true)}>
+      <Dialog open={open()} onOpenChange={setOpen}>
+        <DialogTrigger>
           Create Task
         </DialogTrigger>
-        <DialogOverlay open={open()} onClick={() => setOpen(false)} />
+        <DialogOverlay />
         <DialogContent
-          open={open()}
-          onClose={() => setOpen(false)}
           ariaLabelledby="dialog-title"
           ariaDescribedby="dialog-description"
         >
@@ -69,11 +67,11 @@ export function DialogBasicDemo() {
             </div>
           </div>
           <DialogFooter>
-            <DialogClose onClick={() => setOpen(false)}>Cancel</DialogClose>
-            <DialogTrigger onClick={() => setOpen(false)}>Create</DialogTrigger>
+            <DialogClose>Cancel</DialogClose>
+            <DialogClose>Create</DialogClose>
           </DialogFooter>
         </DialogContent>
-      </DialogRoot>
+      </Dialog>
     </div>
   )
 }
@@ -99,9 +97,9 @@ export function DialogFormDemo() {
     }
   }
 
-  const handleClose = () => {
-    setOpen(false)
-    setConfirmText('')
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen)
+    if (!isOpen) setConfirmText('')
   }
 
   // Set up handlers for Portal elements after they're mounted
@@ -140,18 +138,17 @@ export function DialogFormDemo() {
 
   return (
     <div>
-      <DialogRoot>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 px-4 py-2 bg-destructive text-destructive-foreground hover:bg-destructive/90"
-        >
-          Delete Project
-        </button>
-        <DialogOverlay open={open()} onClick={handleClose} />
+      <Dialog open={open()} onOpenChange={handleOpenChange}>
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 px-4 py-2 bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete Project
+          </button>
+        </DialogTrigger>
+        <DialogOverlay />
         <DialogContent
-          open={open()}
-          onClose={handleClose}
           ariaLabelledby="delete-dialog-title"
           ariaDescribedby="delete-dialog-description"
         >
@@ -175,7 +172,7 @@ export function DialogFormDemo() {
             />
           </div>
           <DialogFooter>
-            <DialogClose onClick={handleClose}>Cancel</DialogClose>
+            <DialogClose>Cancel</DialogClose>
             <button
               type="button"
               id="delete-project-button"
@@ -187,7 +184,7 @@ export function DialogFormDemo() {
             </button>
           </DialogFooter>
         </DialogContent>
-      </DialogRoot>
+      </Dialog>
     </div>
   )
 }
@@ -200,14 +197,12 @@ export function DialogLongContentDemo() {
 
   return (
     <div>
-      <DialogRoot>
-        <DialogTrigger onClick={() => setOpen(true)}>
+      <Dialog open={open()} onOpenChange={setOpen}>
+        <DialogTrigger>
           Open Long Content Dialog
         </DialogTrigger>
-        <DialogOverlay open={open()} onClick={() => setOpen(false)} />
+        <DialogOverlay />
         <DialogContent
-          open={open()}
-          onClose={() => setOpen(false)}
           ariaLabelledby="long-dialog-title"
           ariaDescribedby="long-dialog-description"
           class="max-h-[66vh]"
@@ -245,11 +240,11 @@ export function DialogLongContentDemo() {
             </p>
           </div>
           <DialogFooter class="flex-shrink-0">
-            <DialogClose onClick={() => setOpen(false)}>Decline</DialogClose>
-            <DialogTrigger onClick={() => setOpen(false)}>Accept</DialogTrigger>
+            <DialogClose>Decline</DialogClose>
+            <DialogClose>Accept</DialogClose>
           </DialogFooter>
         </DialogContent>
-      </DialogRoot>
+      </Dialog>
     </div>
   )
 }

--- a/docs/ui/pages/accordion.tsx
+++ b/docs/ui/pages/accordion.tsx
@@ -40,42 +40,23 @@ import {
 function AccordionSingle() {
   const [openItem, setOpenItem] = createSignal<string | null>('item-1')
 
-  const toggle = (value: string) => {
-    setOpenItem(openItem() === value ? null : value)
-  }
-
   return (
     <Accordion>
-      <AccordionItem value="item-1">
-        <AccordionTrigger
-          open={openItem() === 'item-1'}
-          onClick={() => toggle('item-1')}
-        >
-          Is it accessible?
-        </AccordionTrigger>
-        <AccordionContent open={openItem() === 'item-1'}>
+      <AccordionItem value="item-1" open={openItem() === 'item-1'} onOpenChange={(v) => setOpenItem(v ? 'item-1' : null)}>
+        <AccordionTrigger>Is it accessible?</AccordionTrigger>
+        <AccordionContent>
           Yes. It adheres to the WAI-ARIA design pattern.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger
-          open={openItem() === 'item-2'}
-          onClick={() => toggle('item-2')}
-        >
-          Is it styled?
-        </AccordionTrigger>
-        <AccordionContent open={openItem() === 'item-2'}>
+      <AccordionItem value="item-2" open={openItem() === 'item-2'} onOpenChange={(v) => setOpenItem(v ? 'item-2' : null)}>
+        <AccordionTrigger>Is it styled?</AccordionTrigger>
+        <AccordionContent>
           Yes. It comes with default styles that match your theme.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger
-          open={openItem() === 'item-3'}
-          onClick={() => toggle('item-3')}
-        >
-          Is it animated?
-        </AccordionTrigger>
-        <AccordionContent open={openItem() === 'item-3'}>
+      <AccordionItem value="item-3" open={openItem() === 'item-3'} onOpenChange={(v) => setOpenItem(v ? 'item-3' : null)}>
+        <AccordionTrigger>Is it animated?</AccordionTrigger>
+        <AccordionContent>
           Yes. It's animated by default with CSS transitions.
         </AccordionContent>
       </AccordionItem>
@@ -101,36 +82,21 @@ function AccordionMultiple() {
 
   return (
     <Accordion>
-      <AccordionItem value="item-1">
-        <AccordionTrigger
-          open={item1Open()}
-          onClick={() => setItem1Open(!item1Open())}
-        >
-          First Item
-        </AccordionTrigger>
-        <AccordionContent open={item1Open()}>
+      <AccordionItem value="item-1" open={item1Open()} onOpenChange={setItem1Open}>
+        <AccordionTrigger>First Item</AccordionTrigger>
+        <AccordionContent>
           Content for first item.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger
-          open={item2Open()}
-          onClick={() => setItem2Open(!item2Open())}
-        >
-          Second Item
-        </AccordionTrigger>
-        <AccordionContent open={item2Open()}>
+      <AccordionItem value="item-2" open={item2Open()} onOpenChange={setItem2Open}>
+        <AccordionTrigger>Second Item</AccordionTrigger>
+        <AccordionContent>
           Content for second item.
         </AccordionContent>
       </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger
-          open={item3Open()}
-          onClick={() => setItem3Open(!item3Open())}
-        >
-          Third Item
-        </AccordionTrigger>
-        <AccordionContent open={item3Open()}>
+      <AccordionItem value="item-3" open={item3Open()} onOpenChange={setItem3Open}>
+        <AccordionTrigger>Third Item</AccordionTrigger>
+        <AccordionContent>
           Content for third item.
         </AccordionContent>
       </AccordionItem>
@@ -166,32 +132,14 @@ const accordionItemProps: PropDefinition[] = [
 
 const accordionTriggerProps: PropDefinition[] = [
   {
-    name: 'open',
-    type: 'boolean',
-    defaultValue: 'false',
-    description: 'Whether the trigger indicates an open state.',
-  },
-  {
     name: 'disabled',
     type: 'boolean',
     defaultValue: 'false',
     description: 'Whether the trigger is disabled.',
   },
-  {
-    name: 'onClick',
-    type: '() => void',
-    description: 'Event handler called when the trigger is clicked.',
-  },
 ]
 
-const accordionContentProps: PropDefinition[] = [
-  {
-    name: 'open',
-    type: 'boolean',
-    defaultValue: 'false',
-    description: 'Whether the content is visible.',
-  },
-]
+const accordionContentProps: PropDefinition[] = []
 
 export function AccordionPage() {
   const installCommands = getHighlightedCommands('barefoot add accordion')

--- a/docs/ui/pages/dialog.tsx
+++ b/docs/ui/pages/dialog.tsx
@@ -31,6 +31,7 @@ const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
 import {
+  Dialog,
   DialogTrigger,
   DialogOverlay,
   DialogContent,
@@ -45,14 +46,10 @@ function CreateTaskDialog() {
   const [open, setOpen] = createSignal(false)
 
   return (
-    <div>
-      <DialogTrigger onClick={() => setOpen(true)}>
-        Create Task
-      </DialogTrigger>
-      <DialogOverlay open={open()} onClick={() => setOpen(false)} />
+    <Dialog open={open()} onOpenChange={setOpen}>
+      <DialogTrigger>Create Task</DialogTrigger>
+      <DialogOverlay />
       <DialogContent
-        open={open()}
-        onClose={() => setOpen(false)}
         ariaLabelledby="dialog-title"
         ariaDescribedby="dialog-description"
       >
@@ -87,11 +84,11 @@ function CreateTaskDialog() {
           </div>
         </div>
         <DialogFooter>
-          <DialogClose onClick={() => setOpen(false)}>Cancel</DialogClose>
-          <DialogTrigger onClick={() => setOpen(false)}>Create</DialogTrigger>
+          <DialogClose>Cancel</DialogClose>
+          <DialogClose>Create</DialogClose>
         </DialogFooter>
       </DialogContent>
-    </div>
+    </Dialog>
   )
 }`
 
@@ -99,6 +96,7 @@ const deleteCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
 import {
+  Dialog,
   DialogTrigger,
   DialogOverlay,
   DialogContent,
@@ -116,18 +114,18 @@ function DeleteConfirmDialog() {
 
   const isConfirmed = () => confirmText() === projectName
 
-  const handleClose = () => {
-    setOpen(false)
-    setConfirmText('')
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen)
+    if (!isOpen) setConfirmText('')
   }
 
   return (
-    <div>
-      <DialogTrigger onClick={() => setOpen(true)} class="bg-destructive ...">
-        Delete Project
+    <Dialog open={open()} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button class="bg-destructive ...">Delete Project</button>
       </DialogTrigger>
-      <DialogOverlay open={open()} onClick={handleClose} />
-      <DialogContent open={open()} onClose={handleClose} ...>
+      <DialogOverlay />
+      <DialogContent ariaLabelledby="delete-dialog-title" ...>
         <DialogHeader>
           <DialogTitle>Delete Project</DialogTitle>
           <DialogDescription>
@@ -147,9 +145,9 @@ function DeleteConfirmDialog() {
           />
         </div>
         <DialogFooter>
-          <DialogClose onClick={handleClose}>Cancel</DialogClose>
+          <DialogClose>Cancel</DialogClose>
           <button
-            onClick={handleClose}
+            onClick={() => { setOpen(false); setConfirmText('') }}
             disabled={!isConfirmed()}
             class="bg-destructive ..."
           >
@@ -157,7 +155,7 @@ function DeleteConfirmDialog() {
           </button>
         </DialogFooter>
       </DialogContent>
-    </div>
+    </Dialog>
   )
 }`
 
@@ -165,6 +163,7 @@ const longContentCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
 import {
+  Dialog,
   DialogTrigger,
   DialogOverlay,
   DialogContent,
@@ -179,14 +178,10 @@ function DialogLongContent() {
   const [open, setOpen] = createSignal(false)
 
   return (
-    <div>
-      <DialogTrigger onClick={() => setOpen(true)}>
-        Open Long Content Dialog
-      </DialogTrigger>
-      <DialogOverlay open={open()} onClick={() => setOpen(false)} />
+    <Dialog open={open()} onOpenChange={setOpen}>
+      <DialogTrigger>Open Long Content Dialog</DialogTrigger>
+      <DialogOverlay />
       <DialogContent
-        open={open()}
-        onClose={() => setOpen(false)}
         ariaLabelledby="long-dialog-title"
         ariaDescribedby="long-dialog-description"
         class="max-h-[66vh]"
@@ -202,44 +197,16 @@ function DialogLongContent() {
           {/* Multiple paragraphs - only this area scrolls */}
         </div>
         <DialogFooter class="flex-shrink-0">
-          <DialogClose onClick={() => setOpen(false)}>Decline</DialogClose>
-          <DialogTrigger onClick={() => setOpen(false)}>Accept</DialogTrigger>
+          <DialogClose>Decline</DialogClose>
+          <DialogClose>Accept</DialogClose>
         </DialogFooter>
       </DialogContent>
-    </div>
+    </Dialog>
   )
 }`
 
 // Props definitions
-const dialogTriggerProps: PropDefinition[] = [
-  {
-    name: 'onClick',
-    type: '() => void',
-    description: 'Event handler called when the trigger is clicked.',
-  },
-  {
-    name: 'disabled',
-    type: 'boolean',
-    defaultValue: 'false',
-    description: 'Whether the trigger is disabled.',
-  },
-]
-
-const dialogOverlayProps: PropDefinition[] = [
-  {
-    name: 'open',
-    type: 'boolean',
-    defaultValue: 'false',
-    description: 'Whether the overlay is visible.',
-  },
-  {
-    name: 'onClick',
-    type: '() => void',
-    description: 'Event handler called when the overlay is clicked (typically to close the dialog).',
-  },
-]
-
-const dialogContentProps: PropDefinition[] = [
+const dialogProps: PropDefinition[] = [
   {
     name: 'open',
     type: 'boolean',
@@ -247,10 +214,30 @@ const dialogContentProps: PropDefinition[] = [
     description: 'Whether the dialog is open.',
   },
   {
-    name: 'onClose',
-    type: '() => void',
-    description: 'Event handler called when the dialog should close (ESC key).',
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Event handler called when the open state should change.',
   },
+]
+
+const dialogTriggerProps: PropDefinition[] = [
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the trigger is disabled.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
+  },
+]
+
+const dialogOverlayProps: PropDefinition[] = []
+
+const dialogContentProps: PropDefinition[] = [
   {
     name: 'ariaLabelledby',
     type: 'string',
@@ -279,13 +266,7 @@ const dialogDescriptionProps: PropDefinition[] = [
   },
 ]
 
-const dialogCloseProps: PropDefinition[] = [
-  {
-    name: 'onClick',
-    type: '() => void',
-    description: 'Event handler called when the close button is clicked.',
-  },
-]
+const dialogCloseProps: PropDefinition[] = []
 
 export function DialogPage() {
   const installCommands = getHighlightedCommands('barefoot add dialog')
@@ -339,6 +320,10 @@ export function DialogPage() {
         {/* API Reference */}
         <Section id="api-reference" title="API Reference">
           <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Dialog</h3>
+              <PropsTable props={dialogProps} />
+            </div>
             <div>
               <h3 className="text-lg font-medium text-foreground mb-4">DialogTrigger</h3>
               <PropsTable props={dialogTriggerProps} />

--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -6,6 +6,9 @@
  * A modal dialog that displays content in a layer above the page.
  * Inspired by shadcn/ui with CSS variable theming support.
  *
+ * State management uses createContext/useContext for parent-child communication.
+ * Dialog root manages open state, children consume via context.
+ *
  * Features:
  * - ESC key to close
  * - Click outside (overlay) to close
@@ -14,74 +17,39 @@
  *
  * @example Basic dialog
  * ```tsx
- * const [open, setOpen] = useState(false)
+ * const [open, setOpen] = createSignal(false)
  *
- * <>
- *   <DialogTrigger onClick={() => setOpen(true)}>Open Dialog</DialogTrigger>
- *   <DialogOverlay open={open} onClick={() => setOpen(false)} />
- *   <DialogContent
- *     open={open}
- *     onClose={() => setOpen(false)}
- *     ariaLabelledby="dialog-title"
- *   >
+ * <Dialog open={open()} onOpenChange={setOpen}>
+ *   <DialogTrigger>Open Dialog</DialogTrigger>
+ *   <DialogOverlay />
+ *   <DialogContent ariaLabelledby="dialog-title">
  *     <DialogHeader>
  *       <DialogTitle id="dialog-title">Dialog Title</DialogTitle>
  *       <DialogDescription>Dialog description here.</DialogDescription>
  *     </DialogHeader>
  *     <DialogFooter>
- *       <DialogClose onClick={() => setOpen(false)}>Cancel</DialogClose>
+ *       <DialogClose>Cancel</DialogClose>
  *       <Button onClick={handleAction}>Confirm</Button>
  *     </DialogFooter>
  *   </DialogContent>
- * </>
+ * </Dialog>
  * ```
  */
 
-import { createEffect, onCleanup, createPortal, isSSRPortal } from '@barefootjs/dom'
+import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
 import type { Child } from '../../types'
 
+// Context for Dialog → children state sharing
+interface DialogContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const DialogContext = createContext<DialogContextValue>()
+
 // Scope ID context for SSR portal support
-// This is set by DialogRoot and used by DialogOverlay/DialogContent
+// This is set by Dialog and used by DialogOverlay/DialogContent
 let currentDialogScopeId: string | undefined = undefined
-
-/**
- * Props for DialogRoot component.
- */
-interface DialogRootProps {
-  /** Scope ID for SSR portal support (explicit) */
-  scopeId?: string
-  /** Scope ID from compiler (auto-passed via hydration props) */
-  __instanceId?: string
-  /** Scope ID from compiler in loops (auto-passed via hydration props) */
-  __bfScope?: string
-  /** Dialog content */
-  children?: Child
-}
-
-/**
- * Root component that provides scope context for Dialog components.
- * Wrap your Dialog usage with this to enable SSR portal support.
- *
- * The scopeId is automatically received from the compiler via `__instanceId`
- * or `__bfScope` props. You can also pass it explicitly via `scopeId` prop.
- *
- * @example
- * ```tsx
- * <DialogRoot>
- *   <DialogTrigger onClick={() => setOpen(true)}>Open</DialogTrigger>
- *   <DialogOverlay open={open()} onClick={() => setOpen(false)} />
- *   <DialogContent open={open()} onClose={() => setOpen(false)}>
- *     ...
- *   </DialogContent>
- * </DialogRoot>
- * ```
- */
-function DialogRoot(props: DialogRootProps) {
-  // Set the scope ID for child components to use
-  // Prefer explicit scopeId, fallback to compiler-injected hydration props
-  currentDialogScopeId = props.scopeId || props.__instanceId || props.__bfScope
-  return <>{props.children}</>
-}
 
 // DialogTrigger classes
 const dialogTriggerClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50'
@@ -119,13 +87,54 @@ const dialogFooterClasses = 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-
 const dialogCloseClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-border bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2'
 
 /**
+ * Props for Dialog component.
+ */
+interface DialogProps {
+  /** Whether the dialog is open */
+  open?: boolean
+  /** Callback when open state should change */
+  onOpenChange?: (open: boolean) => void
+  /** Scope ID for SSR portal support (explicit) */
+  scopeId?: string
+  /** Scope ID from compiler (auto-passed via hydration props) */
+  __instanceId?: string
+  /** Scope ID from compiler in loops (auto-passed via hydration props) */
+  __bfScope?: string
+  /** Dialog content */
+  children?: Child
+}
+
+/**
+ * Dialog root component.
+ * Provides open state to children via context.
+ *
+ * @param props.open - Whether the dialog is open
+ * @param props.onOpenChange - Callback when open state should change
+ */
+function Dialog(props: DialogProps) {
+  // Set the scope ID for child components to use
+  currentDialogScopeId = props.scopeId || props.__instanceId || props.__bfScope
+  return (
+    <DialogContext.Provider value={{
+      open: () => props.open ?? false,
+      onOpenChange: props.onOpenChange ?? (() => {}),
+    }}>
+      {props.children}
+    </DialogContext.Provider>
+  )
+}
+
+// Keep DialogRoot as alias for backward compatibility
+const DialogRoot = Dialog
+
+/**
  * Props for DialogTrigger component.
  */
 interface DialogTriggerProps {
-  /** Click handler to open dialog */
-  onClick?: () => void
   /** Whether disabled */
   disabled?: boolean
+  /** Render child element as trigger instead of built-in button */
+  asChild?: boolean
   /** Button content */
   children?: Child
   /** Additional CSS classes */
@@ -134,18 +143,39 @@ interface DialogTriggerProps {
 
 /**
  * Button that triggers the dialog to open.
+ * Reads open state from context and toggles via onOpenChange.
  *
- * @param props.onClick - Click handler
- * @param props.disabled - Whether disabled (supports reactive values)
+ * @param props.disabled - Whether disabled
+ * @param props.asChild - Render child as trigger
  */
 function DialogTrigger(props: DialogTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(DialogContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(!ctx.open())
+    })
+  }
+
+  if (props.asChild) {
+    return (
+      <span
+        data-slot="dialog-trigger"
+        style="display:contents"
+        ref={handleMount}
+      >
+        {props.children}
+      </span>
+    )
+  }
+
   return (
     <button
       data-slot="dialog-trigger"
       type="button"
       className={`${dialogTriggerClasses} ${props.class ?? ''}`}
       disabled={props.disabled ?? false}
-      onClick={props.onClick}
+      ref={handleMount}
     >
       {props.children}
     </button>
@@ -156,10 +186,6 @@ function DialogTrigger(props: DialogTriggerProps) {
  * Props for DialogOverlay component.
  */
 interface DialogOverlayProps {
-  /** Whether the dialog is open */
-  open?: boolean
-  /** Click handler to close dialog */
-  onClick?: () => void
   /** Additional CSS classes */
   class?: string
 }
@@ -167,28 +193,36 @@ interface DialogOverlayProps {
 /**
  * Semi-transparent overlay behind the dialog.
  * Portals to document.body to avoid z-index issues with fixed headers.
- *
- * @param props.open - Whether visible
- * @param props.onClick - Click handler to close
+ * Reads open state from context.
  */
 function DialogOverlay(props: DialogOverlayProps) {
-  // Move element to document.body on mount (portal behavior)
-  // Uses createPortal with ownerScope for scope-based element detection
-  // Skip if element is already in an SSR portal (content already at body)
-  const moveToBody = (el: HTMLElement) => {
+  const handleMount = (el: HTMLElement) => {
+    // Portal to body
     if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
       const ownerScope = el.closest('[data-bf-scope]') ?? undefined
       createPortal(el, document.body, { ownerScope })
     }
+
+    const ctx = useContext(DialogContext)
+
+    // Reactive show/hide + click-to-close
+    createEffect(() => {
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${dialogOverlayBaseClasses} ${isOpen ? dialogOverlayOpenClasses : dialogOverlayClosedClasses} ${props.class ?? ''}`
+    })
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
   }
 
   return (
     <div
       data-slot="dialog-overlay"
-      data-state={(props.open ?? false) ? 'open' : 'closed'}
-      className={`${dialogOverlayBaseClasses} ${(props.open ?? false) ? dialogOverlayOpenClasses : dialogOverlayClosedClasses} ${props.class ?? ''}`}
-      onClick={props.onClick}
-      ref={moveToBody}
+      data-state="closed"
+      className={`${dialogOverlayBaseClasses} ${dialogOverlayClosedClasses} ${props.class ?? ''}`}
+      ref={handleMount}
     />
   )
 }
@@ -197,10 +231,6 @@ function DialogOverlay(props: DialogOverlayProps) {
  * Props for DialogContent component.
  */
 interface DialogContentProps {
-  /** Whether the dialog is open */
-  open?: boolean
-  /** Callback to close the dialog */
-  onClose?: () => void
   /** Dialog content */
   children?: Child
   /** ID of the title element for aria-labelledby */
@@ -214,91 +244,94 @@ interface DialogContentProps {
 /**
  * Main content container for the dialog.
  * Portals to document.body to avoid z-index issues with fixed headers.
+ * Reads open state from context.
  *
- * @param props.open - Whether visible
- * @param props.onClose - Close callback
  * @param props.ariaLabelledby - ID of title for accessibility
  * @param props.ariaDescribedby - ID of description for accessibility
  */
 function DialogContent(props: DialogContentProps) {
-  // Use object to store ref (const object can be mutated)
-  const ref = { current: null as HTMLElement | null }
-
-  // Scroll lock: prevent body scroll when dialog is open
-  createEffect(() => {
-    if (props.open) {
-      const originalOverflow = document.body.style.overflow
-      document.body.style.overflow = 'hidden'
-      onCleanup(() => {
-        document.body.style.overflow = originalOverflow
-      })
-    }
-  })
-
-  // Focus first focusable element when dialog opens
-  createEffect(() => {
-    if (props.open && ref.current) {
-      const focusableElements = ref.current.querySelectorAll(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )
-      const firstElement = focusableElements[0] as HTMLElement
-      setTimeout(() => firstElement?.focus(), 0)
-    }
-  })
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && props.onClose) {
-      props.onClose()
-      return
-    }
-
-    // Focus trap
-    if (e.key === 'Tab') {
-      const dialog = e.currentTarget as HTMLElement
-      const focusableElements = dialog.querySelectorAll(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )
-      const firstElement = focusableElements[0] as HTMLElement
-      const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
-
-      if (e.shiftKey) {
-        if (document.activeElement === firstElement || document.activeElement === dialog) {
-          e.preventDefault()
-          lastElement?.focus()
-        }
-      } else {
-        if (document.activeElement === lastElement) {
-          e.preventDefault()
-          firstElement?.focus()
-        }
-      }
-    }
-  }
-
-  // Move element to document.body on mount (portal behavior)
-  // Uses createPortal with ownerScope for scope-based element detection
-  // Skip if element is already in an SSR portal (content already at body)
   const handleMount = (el: HTMLElement) => {
-    ref.current = el
-    // Portal: move to body with ownerScope for find() support
-    // Skip if already in SSR portal (content already at correct position)
+    // Portal to body
     if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
       const ownerScope = el.closest('[data-bf-scope]') ?? undefined
       createPortal(el, document.body, { ownerScope })
     }
+
+    const ctx = useContext(DialogContext)
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + scroll lock + focus trap + ESC key
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${dialogContentBaseClasses} ${isOpen ? dialogContentOpenClasses : dialogContentClosedClasses} ${props.class ?? ''}`
+
+      if (isOpen) {
+        // Scroll lock
+        const originalOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+
+        // Focus first focusable element
+        const focusableSelector = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        setTimeout(() => {
+          const focusableElements = el.querySelectorAll(focusableSelector)
+          const firstElement = focusableElements[0] as HTMLElement
+          firstElement?.focus()
+        }, 0)
+
+        // ESC key to close
+        const handleKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            return
+          }
+
+          // Focus trap
+          if (e.key === 'Tab') {
+            const focusableElements = el.querySelectorAll(focusableSelector)
+            const firstElement = focusableElements[0] as HTMLElement
+            const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+            if (e.shiftKey) {
+              if (document.activeElement === firstElement || document.activeElement === el) {
+                e.preventDefault()
+                lastElement?.focus()
+              }
+            } else {
+              if (document.activeElement === lastElement) {
+                e.preventDefault()
+                firstElement?.focus()
+              }
+            }
+          }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        cleanupFns.push(
+          () => { document.body.style.overflow = originalOverflow },
+          () => document.removeEventListener('keydown', handleKeyDown),
+        )
+      }
+    })
   }
 
   return (
     <div
       data-slot="dialog-content"
-      data-state={(props.open ?? false) ? 'open' : 'closed'}
+      data-state="closed"
       role="dialog"
       aria-modal="true"
       aria-labelledby={props.ariaLabelledby}
       aria-describedby={props.ariaDescribedby}
       tabindex={-1}
-      className={`${dialogContentBaseClasses} ${(props.open ?? false) ? dialogContentOpenClasses : dialogContentClosedClasses} ${props.class ?? ''}`}
-      onKeyDown={handleKeyDown}
+      className={`${dialogContentBaseClasses} ${dialogContentClosedClasses} ${props.class ?? ''}`}
       ref={handleMount}
     >
       {props.children}
@@ -406,8 +439,6 @@ function DialogFooter({ class: className = '', children }: DialogFooterProps) {
  * Props for DialogClose component.
  */
 interface DialogCloseProps {
-  /** Click handler to close dialog */
-  onClick?: () => void
   /** Button content */
   children?: Child
   /** Additional CSS classes */
@@ -416,23 +447,31 @@ interface DialogCloseProps {
 
 /**
  * Close button for the dialog.
- *
- * @param props.onClick - Close handler
+ * Reads context and calls onOpenChange(false) on click.
  */
-function DialogClose({ class: className = '', onClick, children }: DialogCloseProps) {
+function DialogClose(props: DialogCloseProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(DialogContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
   return (
     <button
       data-slot="dialog-close"
       type="button"
-      className={`${dialogCloseClasses} ${className}`}
-      onClick={onClick}
+      className={`${dialogCloseClasses} ${props.class ?? ''}`}
+      ref={handleMount}
     >
-      {children}
+      {props.children}
     </button>
   )
 }
 
 export {
+  Dialog,
   DialogRoot,
   DialogTrigger,
   DialogOverlay,
@@ -444,7 +483,7 @@ export {
   DialogClose,
 }
 export type {
-  DialogRootProps,
+  DialogProps,
   DialogTriggerProps,
   DialogOverlayProps,
   DialogContentProps,

--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -119,7 +119,9 @@ function Dialog(props: DialogProps) {
       open: () => props.open ?? false,
       onOpenChange: props.onOpenChange ?? (() => {}),
     }}>
-      {props.children}
+      <div data-slot="dialog" style="display:contents">
+        {props.children}
+      </div>
     </DialogContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
- Replace props-based state management (`onClick`, `open`, `onClose`) in Dialog and Accordion with `createContext`/`useContext` pattern, aligning with the existing DropdownMenu architecture
- Simplifies consumer API: children no longer need explicit `open`/`onClick` props — state is shared via context from `AccordionItem` and `Dialog` root components
- Add `asChild` support for `DialogTrigger`, enabling custom trigger elements (e.g., destructive buttons)
- Rename `DialogRoot` → `Dialog` (backward-compatible alias kept)

### Before (Dialog)
```tsx
<DialogRoot>
  <DialogTrigger onClick={() => setOpen(true)}>Open</DialogTrigger>
  <DialogOverlay open={open()} onClick={() => setOpen(false)} />
  <DialogContent open={open()} onClose={() => setOpen(false)}>
    <DialogClose onClick={() => setOpen(false)}>Cancel</DialogClose>
  </DialogContent>
</DialogRoot>
```

### After (Dialog)
```tsx
<Dialog open={open()} onOpenChange={setOpen}>
  <DialogTrigger>Open</DialogTrigger>
  <DialogOverlay />
  <DialogContent>
    <DialogClose>Cancel</DialogClose>
  </DialogContent>
</Dialog>
```

## Test plan
- [x] Accordion e2e tests: 29/29 passed
- [x] Dialog e2e tests: 29/29 passed
- [ ] Visual check: dev server — accordion expand/collapse + chevron rotation
- [ ] Visual check: dev server — dialog open/close/ESC/overlay-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)