### PR TITLE
feat: support .sort()/.toSorted() chained with .map() in compiler

### DIFF
--- a/packages/go-template/runtime/bf_test.go
+++ b/packages/go-template/runtime/bf_test.go
@@ -242,6 +242,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_add", "bf_sub", "bf_mul", "bf_div", "bf_mod", "bf_neg",
 		"bf_lower", "bf_upper", "bf_trim", "bf_contains", "bf_join",
 		"bf_len", "bf_at", "bf_includes", "bf_first", "bf_last",
+		"bf_every", "bf_some", "bf_filter", "bf_sort",
 		"bfComment", "bfPortalHTML",
 	}
 
@@ -407,6 +408,114 @@ func TestPortalCollector_Render_Multiple(t *testing.T) {
 // helper function for string contains check
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+// =============================================================================
+// Sort Tests
+// =============================================================================
+
+type sortItem struct {
+	Name     string
+	Priority int
+	Price    float64
+}
+
+func TestSort_AscendingByInt(t *testing.T) {
+	items := []sortItem{
+		{Name: "C", Priority: 3},
+		{Name: "A", Priority: 1},
+		{Name: "B", Priority: 2},
+	}
+
+	result := Sort(items, "priority", "asc")
+
+	if len(result) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(result))
+	}
+	if result[0].(sortItem).Name != "A" {
+		t.Errorf("Sort asc: first item = %v, want A", result[0].(sortItem).Name)
+	}
+	if result[1].(sortItem).Name != "B" {
+		t.Errorf("Sort asc: second item = %v, want B", result[1].(sortItem).Name)
+	}
+	if result[2].(sortItem).Name != "C" {
+		t.Errorf("Sort asc: third item = %v, want C", result[2].(sortItem).Name)
+	}
+}
+
+func TestSort_DescendingByInt(t *testing.T) {
+	items := []sortItem{
+		{Name: "A", Priority: 1},
+		{Name: "C", Priority: 3},
+		{Name: "B", Priority: 2},
+	}
+
+	result := Sort(items, "priority", "desc")
+
+	if len(result) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(result))
+	}
+	if result[0].(sortItem).Name != "C" {
+		t.Errorf("Sort desc: first item = %v, want C", result[0].(sortItem).Name)
+	}
+	if result[2].(sortItem).Name != "A" {
+		t.Errorf("Sort desc: last item = %v, want A", result[2].(sortItem).Name)
+	}
+}
+
+func TestSort_ByFloat(t *testing.T) {
+	items := []sortItem{
+		{Name: "Expensive", Price: 99.99},
+		{Name: "Cheap", Price: 9.99},
+		{Name: "Mid", Price: 49.99},
+	}
+
+	result := Sort(items, "price", "asc")
+
+	if len(result) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(result))
+	}
+	if result[0].(sortItem).Name != "Cheap" {
+		t.Errorf("Sort by float asc: first = %v, want Cheap", result[0].(sortItem).Name)
+	}
+	if result[2].(sortItem).Name != "Expensive" {
+		t.Errorf("Sort by float asc: last = %v, want Expensive", result[2].(sortItem).Name)
+	}
+}
+
+func TestSort_EmptySlice(t *testing.T) {
+	var items []sortItem
+	result := Sort(items, "priority", "asc")
+
+	if result == nil {
+		t.Error("Sort of empty slice should return empty slice, not nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("Sort of empty slice returned %d items, want 0", len(result))
+	}
+}
+
+func TestSort_NilSlice(t *testing.T) {
+	result := Sort(nil, "priority", "asc")
+
+	if result != nil {
+		t.Errorf("Sort of nil should return nil, got %v", result)
+	}
+}
+
+func TestSort_NonMutating(t *testing.T) {
+	items := []sortItem{
+		{Name: "C", Priority: 3},
+		{Name: "A", Priority: 1},
+		{Name: "B", Priority: 2},
+	}
+
+	Sort(items, "priority", "asc")
+
+	// Original slice should be unchanged
+	if items[0].Name != "C" {
+		t.Errorf("Sort mutated original: first = %v, want C", items[0].Name)
+	}
 }
 
 func containsHelper(s, substr string) bool {

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -1252,4 +1252,95 @@ describe('GoTemplateAdapter', () => {
       expect(result).toContain('TodoItem')
     })
   })
+
+  describe('sort().map() rendering', () => {
+    test('renders sort().map() with bf_sort', () => {
+      const loop: IRLoop = {
+        type: 'loop',
+        array: 'items',
+        arrayType: null,
+        itemType: null,
+        param: 'item',
+        index: null,
+        key: null,
+        children: [{ type: 'text', value: 'Item', loc }],
+        slotId: null,
+        isStaticArray: true,
+        sortComparator: {
+          paramA: 'a',
+          paramB: 'b',
+          field: 'price',
+          direction: 'asc',
+          raw: 'a.price - b.price',
+          method: 'sort',
+        },
+        loc,
+      }
+
+      const result = adapter.renderLoop(loop)
+      expect(result).toBe('{{range $_, $item := (bf_sort .Items "price" "asc")}}Item{{end}}')
+    })
+
+    test('renders sort().map() with desc direction', () => {
+      const loop: IRLoop = {
+        type: 'loop',
+        array: 'items',
+        arrayType: null,
+        itemType: null,
+        param: 'item',
+        index: null,
+        key: null,
+        children: [{ type: 'text', value: 'Item', loc }],
+        slotId: null,
+        isStaticArray: true,
+        sortComparator: {
+          paramA: 'a',
+          paramB: 'b',
+          field: 'priority',
+          direction: 'desc',
+          raw: 'b.priority - a.priority',
+          method: 'toSorted',
+        },
+        loc,
+      }
+
+      const result = adapter.renderLoop(loop)
+      expect(result).toBe('{{range $_, $item := (bf_sort .Items "priority" "desc")}}Item{{end}}')
+    })
+
+    test('renders sort().filter().map() with bf_sort + if condition', () => {
+      const loop: IRLoop = {
+        type: 'loop',
+        array: 'todos',
+        arrayType: null,
+        itemType: null,
+        param: 'todo',
+        index: null,
+        key: null,
+        children: [{ type: 'text', value: 'TodoItem', loc }],
+        slotId: null,
+        isStaticArray: true,
+        sortComparator: {
+          paramA: 'a',
+          paramB: 'b',
+          field: 'priority',
+          direction: 'asc',
+          raw: 'a.priority - b.priority',
+          method: 'sort',
+        },
+        filterPredicate: {
+          param: 't',
+          predicate: { kind: 'not', operand: { kind: 'property-access', object: 't', property: 'done' }, raw: '!t.done' },
+          raw: '!t.done',
+        },
+        chainOrder: 'sort-filter',
+        loc,
+      }
+
+      const result = adapter.renderLoop(loop)
+      expect(result).toContain('bf_sort')
+      expect(result).toContain('{{if')
+      expect(result).toContain('{{end}}{{end}}')
+    })
+  })
 })

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -1887,6 +1887,11 @@ export class GoTemplateAdapter extends BaseAdapter {
     const children = this.renderChildren(loop.children)
     this.inLoop = false
 
+    // Apply sort if present: wrap array with bf_sort pipeline
+    if (loop.sortComparator) {
+      goArray = `(bf_sort ${goArray} "${loop.sortComparator.field}" "${loop.sortComparator.direction}")`
+    }
+
     // Handle filter().map() pattern by adding if-condition
     if (loop.filterPredicate) {
       let filterCond: string

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -1254,4 +1254,180 @@ describe('Compiler', () => {
       }
     })
   })
+
+  describe('sort().map() / toSorted().map()', () => {
+    test('sort((a, b) => a.price - b.price).map() produces sortComparator (asc)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function ProductList() {
+          const [products, setProducts] = createSignal<any[]>([])
+          return (
+            <ul>
+              {products().sort((a, b) => a.price - b.price).map(p => (
+                <li>{p.name}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'ProductList.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      const ul = ir!
+      expect(ul.type).toBe('element')
+      if (ul.type === 'element') {
+        const loop = ul.children.find(c => c.type === 'loop')
+        expect(loop).toBeDefined()
+        if (loop?.type === 'loop') {
+          expect(loop.sortComparator).toBeDefined()
+          expect(loop.sortComparator!.field).toBe('price')
+          expect(loop.sortComparator!.direction).toBe('asc')
+          expect(loop.sortComparator!.method).toBe('sort')
+          expect(loop.sortComparator!.paramA).toBe('a')
+          expect(loop.sortComparator!.paramB).toBe('b')
+          expect(loop.array).toBe('products()')
+        }
+      }
+    })
+
+    test('toSorted((a, b) => b.price - a.price).map() produces sortComparator (desc)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function ProductList() {
+          const [products, setProducts] = createSignal<any[]>([])
+          return (
+            <ul>
+              {products().toSorted((a, b) => b.price - a.price).map(p => (
+                <li>{p.name}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'ProductList.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      const ul = ir!
+      if (ul.type === 'element') {
+        const loop = ul.children.find(c => c.type === 'loop')
+        expect(loop).toBeDefined()
+        if (loop?.type === 'loop') {
+          expect(loop.sortComparator).toBeDefined()
+          expect(loop.sortComparator!.field).toBe('price')
+          expect(loop.sortComparator!.direction).toBe('desc')
+          expect(loop.sortComparator!.method).toBe('toSorted')
+        }
+      }
+    })
+
+    test('filter().sort().map() produces both filterPredicate and sortComparator', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function TodoList() {
+          const [todos, setTodos] = createSignal<any[]>([])
+          return (
+            <ul>
+              {todos().filter(t => !t.done).sort((a, b) => a.priority - b.priority).map(t => (
+                <li>{t.text}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'TodoList.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        const loop = ir!.children.find(c => c.type === 'loop')
+        expect(loop).toBeDefined()
+        if (loop?.type === 'loop') {
+          expect(loop.filterPredicate).toBeDefined()
+          expect(loop.filterPredicate!.param).toBe('t')
+          expect(loop.sortComparator).toBeDefined()
+          expect(loop.sortComparator!.field).toBe('priority')
+          expect(loop.sortComparator!.direction).toBe('asc')
+          expect(loop.chainOrder).toBe('filter-sort')
+          expect(loop.array).toBe('todos()')
+        }
+      }
+    })
+
+    test('sort().filter().map() produces both with correct chainOrder', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function TodoList() {
+          const [todos, setTodos] = createSignal<any[]>([])
+          return (
+            <ul>
+              {todos().sort((a, b) => a.priority - b.priority).filter(t => !t.done).map(t => (
+                <li>{t.text}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'TodoList.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        const loop = ir!.children.find(c => c.type === 'loop')
+        expect(loop).toBeDefined()
+        if (loop?.type === 'loop') {
+          expect(loop.filterPredicate).toBeDefined()
+          expect(loop.sortComparator).toBeDefined()
+          expect(loop.chainOrder).toBe('sort-filter')
+          expect(loop.array).toBe('todos()')
+        }
+      }
+    })
+
+    test('complex sort comparator with @client keeps sort in array', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function TodoList() {
+          const [items, setItems] = createSignal<any[]>([])
+          return (
+            <ul>
+              {/* @client */ items().sort((a, b) => a.name.localeCompare(b.name)).map(t => (
+                <li>{t.name}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'TodoList.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        const loop = ir!.children.find(c => c.type === 'loop')
+        expect(loop).toBeDefined()
+        if (loop?.type === 'loop') {
+          // @client: sort kept in array string, no sortComparator extracted
+          expect(loop.sortComparator).toBeUndefined()
+          expect(loop.clientOnly).toBe(true)
+          expect(loop.array).toContain('sort')
+        }
+      }
+    })
+  })
 })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -66,7 +66,7 @@ export interface SupportResult {
 const UNSUPPORTED_METHODS = new Set([
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
   'find', 'findIndex', 'findLast', 'findLastIndex',
-  'forEach', 'flatMap', 'flat', 'sort', 'toSorted',
+  'forEach', 'flatMap', 'flat',
 ])
 
 // =============================================================================

--- a/packages/jsx/src/ir-to-client-js.ts
+++ b/packages/jsx/src/ir-to-client-js.ts
@@ -148,6 +148,12 @@ interface LoopElement {
     param: string
     raw: string  // Original filter predicate expression or block body
   }
+  sortComparator?: {
+    paramA: string
+    paramB: string
+    raw: string  // Full comparator body for client JS
+  }
+  chainOrder?: 'filter-sort' | 'sort-filter'
 }
 
 interface RefElement {
@@ -186,6 +192,33 @@ interface ClientOnlyConditional {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/**
+ * Build the chained array expression for reconcileList.
+ * Chains .toSorted() and .filter() in the correct order based on chainOrder.
+ * Always uses .toSorted() (non-mutating) regardless of source method.
+ */
+function buildChainedArrayExpr(elem: LoopElement): string {
+  const sortExpr = elem.sortComparator
+    ? `.toSorted((${elem.sortComparator.paramA}, ${elem.sortComparator.paramB}) => ${elem.sortComparator.raw})`
+    : ''
+  const filterExpr = elem.filterPredicate
+    ? `.filter(${elem.filterPredicate.param} => ${elem.filterPredicate.raw})`
+    : ''
+
+  if (!sortExpr && !filterExpr) return elem.array
+
+  if (elem.chainOrder === 'sort-filter') {
+    // sort first, then filter
+    return `${elem.array}${sortExpr}${filterExpr}`
+  } else if (elem.chainOrder === 'filter-sort') {
+    // filter first, then sort
+    return `${elem.array}${filterExpr}${sortExpr}`
+  } else {
+    // Only one of sort or filter
+    return `${elem.array}${sortExpr}${filterExpr}`
+  }
+}
 
 /**
  * Map of JSX event names to DOM event property names.
@@ -413,6 +446,12 @@ function collectElements(node: IRNode, ctx: ClientJsContext, insideConditional =
             param: node.filterPredicate.param,
             raw: node.filterPredicate.raw,
           } : undefined,
+          sortComparator: node.sortComparator ? {
+            paramA: node.sortComparator.paramA,
+            paramB: node.sortComparator.paramB,
+            raw: node.sortComparator.raw,
+          } : undefined,
+          chainOrder: node.chainOrder,
         })
       }
       // Don't traverse into loop children for interactive elements collection
@@ -2143,26 +2182,22 @@ function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, siblingCom
       const keyExpr = elem.key || '__idx'
       const indexParam = elem.index || '__idx'
 
-      // Apply filter predicate if present
-      const filterExpr = elem.filterPredicate
-        ? `${elem.array}.filter(${elem.filterPredicate.param} => ${elem.filterPredicate.raw})`
-        : elem.array
+      // Build chained array expression with filter/sort
+      const chainedExpr = buildChainedArrayExpr(elem)
 
       lines.push(`  createEffect(() => {`)
-      lines.push(`    reconcileList(_${elem.slotId}, ${filterExpr}, ${keyFn}, (${elem.param}, ${indexParam}) =>`)
+      lines.push(`    reconcileList(_${elem.slotId}, ${chainedExpr}, ${keyFn}, (${elem.param}, ${indexParam}) =>`)
       lines.push(`      createComponent('${name}', ${propsExpr}, ${keyExpr})`)
       lines.push(`    )`)
       lines.push(`  })`)
     } else {
       // Template string-based rendering (original implementation)
-      // Apply filter predicate if present
-      const filterExprTemplate = elem.filterPredicate
-        ? `${elem.array}.filter(${elem.filterPredicate.param} => ${elem.filterPredicate.raw})`
-        : elem.array
+      // Build chained array expression with filter/sort
+      const chainedExprTemplate = buildChainedArrayExpr(elem)
 
       const indexParamTemplate = elem.index || '__idx'
       lines.push(`  createEffect(() => {`)
-      lines.push(`    const __arr = ${filterExprTemplate}`)
+      lines.push(`    const __arr = ${chainedExprTemplate}`)
       lines.push(`    reconcileList(_${elem.slotId}, __arr, ${keyFn}, (${elem.param}, ${indexParamTemplate}) => \`${elem.template}\`)`)
       lines.push(`  })`)
     }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -192,6 +192,27 @@ export interface IRLoop {
   }
 
   /**
+   * Sort comparator for sort().map() / toSorted().map() pattern.
+   * When present, the loop array is sorted before iteration.
+   * Example: todos.sort((a, b) => a.priority - b.priority).map(...)
+   */
+  sortComparator?: {
+    paramA: string          // e.g., 'a'
+    paramB: string          // e.g., 'b'
+    field: string           // e.g., 'priority'
+    direction: 'asc' | 'desc'
+    raw: string             // Full comparator body for client JS
+    method: 'sort' | 'toSorted'
+  }
+
+  /**
+   * When both filter and sort are chained, indicates the order of operations.
+   * 'filter-sort': filter first, then sort (e.g., filter().sort().map())
+   * 'sort-filter': sort first, then filter (e.g., sort().filter().map())
+   */
+  chainOrder?: 'filter-sort' | 'sort-filter'
+
+  /**
    * When true, loop should be evaluated on client side only.
    * SSR adapters should skip rendering and output placeholder markers.
    */


### PR DESCRIPTION
## Summary

Closes #286

- Add sort comparator extraction to the JSX-to-IR pipeline, following the existing `filter().map()` architecture
- Support four chaining patterns: `sort().map()`, `toSorted().map()`, `filter().sort().map()`, and `sort().filter().map()`
- Add `bf_sort` Go runtime function for server-side sort rendering
- Emit BF021 compile error for unsupported sort comparators (e.g., `localeCompare`, block body), with `@client` suppression

### Changes

| Area | Change |
|------|--------|
| **IR types** | Add `sortComparator` and `chainOrder` fields to `IRLoop` |
| **JSX→IR** | Add `isSortCall()`, `extractSortComparator()`, extend `transformMapCall()` for sort chains |
| **Client JS** | Generate `.toSorted()` chains in `reconcileList` output |
| **Go runtime** | Add `bf_sort` function using `sort.SliceStable` + reflection |
| **Go adapter** | Render `(bf_sort .Items "field" "dir")` in `renderLoop()` |
| **Expression parser** | Remove `sort`/`toSorted` from `UNSUPPORTED_METHODS` |
| **Spec** | Document sort support and BF021 for sort comparators |

### Supported patterns

```tsx
// Simple sort
{items().sort((a, b) => a.price - b.price).map(item => <li>{item.name}</li>)}

// toSorted (non-mutating)
{items().toSorted((a, b) => b.priority - a.priority).map(item => <li>{item.name}</li>)}

// Filter + sort chaining
{todos().filter(t => !t.done).sort((a, b) => a.priority - b.priority).map(t => <li>{t.text}</li>)}

// Sort + filter chaining
{todos().sort((a, b) => a.priority - b.priority).filter(t => !t.done).map(t => <li>{t.text}</li>)}

// Complex comparators with @client fallback
{/* @client */ items().sort((a, b) => a.name.localeCompare(b.name)).map(t => <li>{t.name}</li>)}
```

## Test plan

- [x] `bun test packages/` — 299 tests pass (compiler, unsupported expression, go-template adapter)
- [x] `go test -run "TestSort|TestFuncMap"` — Go runtime Sort tests pass (asc, desc, float, empty, nil, non-mutating)
- [ ] Manual verification with a component using `sort().map()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)