### PR TITLE
feat: add Submenu, CheckboxItem, RadioGroup, Destructive to DropdownMenu

### DIFF
--- a/docs/ui/components/dropdown-menu-demo.tsx
+++ b/docs/ui/components/dropdown-menu-demo.tsx
@@ -16,6 +16,12 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuGroup,
@@ -24,35 +30,32 @@ import {
 import { SettingsIcon, GlobeIcon, LogOutIcon, CircleHelpIcon } from '@ui/components/ui/icon'
 
 /**
- * asChild demo - custom button element as trigger via asChild prop
+ * Basic demo - simple menu with a few items
  */
-export function DropdownMenuAsChildDemo() {
+export function DropdownMenuBasicDemo() {
   const [open, setOpen] = createSignal(false)
 
   return (
     <DropdownMenu open={open()} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <button
+      <DropdownMenuTrigger>
+        <span
           className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
-          aria-label="Actions"
         >
-          <SettingsIcon size="sm" />
-          <span>Actions</span>
-        </button>
+          Open Menu
+        </span>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuItem>
-          <SettingsIcon size="sm" />
-          <span>Settings</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <GlobeIcon size="sm" />
-          <span>Language</span>
-        </DropdownMenuItem>
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <LogOutIcon size="sm" />
-          <span>Log out</span>
+          <span>Copy</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <span>Paste</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">
+          <span>Delete</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -60,10 +63,45 @@ export function DropdownMenuAsChildDemo() {
 }
 
 /**
+ * Checkbox demo - toggle options without closing the menu
+ */
+export function DropdownMenuCheckboxDemo() {
+  const [open, setOpen] = createSignal(false)
+  const [showStatus, setShowStatus] = createSignal(true)
+  const [showActivity, setShowActivity] = createSignal(false)
+
+  return (
+    <DropdownMenu open={open()} onOpenChange={setOpen}>
+      <DropdownMenuTrigger>
+        <span
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent"
+        >
+          View
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Toggle Panels</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem checked={showStatus()} onCheckedChange={setShowStatus}>
+          <span>Status Bar</span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked={showActivity()} onCheckedChange={setShowActivity}>
+          <span>Activity Panel</span>
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/**
  * Profile menu demo - avatar trigger with account actions
+ * Features: submenu, checkbox items, radio items, destructive variant
  */
 export function DropdownMenuProfileDemo() {
   const [open, setOpen] = createSignal(false)
+  const [showBookmarks, setShowBookmarks] = createSignal(true)
+  const [showToolbar, setShowToolbar] = createSignal(false)
+  const [language, setLanguage] = createSignal('en')
 
   return (
     <DropdownMenu open={open()} onOpenChange={setOpen}>
@@ -84,17 +122,41 @@ export function DropdownMenuProfileDemo() {
             <span>Settings</span>
             <DropdownMenuShortcut>⇧⌘,</DropdownMenuShortcut>
           </DropdownMenuItem>
-          <DropdownMenuItem>
-            <GlobeIcon size="sm" />
-            <span>Language</span>
-          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <GlobeIcon size="sm" />
+              <span>Language</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup value={language()} onValueChange={setLanguage}>
+                <DropdownMenuRadioItem value="en">
+                  <span>English</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="ja">
+                  <span>Japanese</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="fr">
+                  <span>French</span>
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuItem>
             <CircleHelpIcon size="sm" />
             <span>Help</span>
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
+        <DropdownMenuGroup>
+          <DropdownMenuCheckboxItem checked={showBookmarks()} onCheckedChange={setShowBookmarks}>
+            <span>Show Bookmarks Bar</span>
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showToolbar()} onCheckedChange={setShowToolbar}>
+            <span>Show Toolbar</span>
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">
           <LogOutIcon size="sm" />
           <span>Log out</span>
         </DropdownMenuItem>

--- a/docs/ui/e2e/dropdown-menu.spec.ts
+++ b/docs/ui/e2e/dropdown-menu.spec.ts
@@ -19,8 +19,126 @@ test.describe('DropdownMenu Documentation Page', () => {
     await expect(page.locator('h2:has-text("Features")')).toBeVisible()
     await expect(page.locator('strong:has-text("Props-based state")')).toBeVisible()
     await expect(page.locator('strong:has-text("Flexible trigger")')).toBeVisible()
-    await expect(page.locator('strong:has-text("ESC key to close")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Accessibility")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Submenu")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Checkbox items")')).toBeVisible()
+    await expect(page.locator('strong:has-text("Destructive variant")')).toBeVisible()
+  })
+
+  test.describe('Basic Demo', () => {
+    test('opens menu and shows items', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('text=Copy')).toBeVisible()
+      await expect(content.locator('text=Paste')).toBeVisible()
+      await expect(content.locator('text=Delete')).toBeVisible()
+    })
+
+    test('has label and separators', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      await expect(content.locator('[data-slot="dropdown-menu-label"]')).toContainText('Actions')
+      expect(await content.locator('[data-slot="dropdown-menu-separator"]').count()).toBeGreaterThanOrEqual(1)
+    })
+
+    test('destructive item has correct styling', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const deleteItem = content.locator('[data-slot="dropdown-menu-item"]').filter({ hasText: 'Delete' })
+      await expect(deleteItem).toHaveClass(/text-destructive/)
+    })
+
+    test('closes on item click', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      await content.locator('[data-slot="dropdown-menu-item"]').filter({ hasText: 'Copy' }).click()
+
+      await expect(content).toHaveCount(0)
+    })
+
+    test('closes on ESC', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.keyboard.press('Escape')
+      await expect(content).toHaveCount(0)
+    })
+  })
+
+  test.describe('Checkbox Demo', () => {
+    test('opens menu and shows checkbox items', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuCheckboxDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      const checkboxItems = content.locator('[role="menuitemcheckbox"]')
+      expect(await checkboxItems.count()).toBe(2)
+    })
+
+    test('toggles checkbox on click', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuCheckboxDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const statusItem = content.locator('[role="menuitemcheckbox"]').filter({ hasText: 'Status Bar' })
+
+      // Initially checked
+      await expect(statusItem).toHaveAttribute('aria-checked', 'true')
+
+      // Click to uncheck
+      await statusItem.click()
+      await expect(statusItem).toHaveAttribute('aria-checked', 'false')
+
+      // Menu should still be open
+      await expect(content).toBeVisible()
+    })
+
+    test('checkbox item does not close menu', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuCheckboxDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const activityItem = content.locator('[role="menuitemcheckbox"]').filter({ hasText: 'Activity Panel' })
+
+      // Initially unchecked
+      await expect(activityItem).toHaveAttribute('aria-checked', 'false')
+
+      // Click to check
+      await activityItem.click()
+      await expect(activityItem).toHaveAttribute('aria-checked', 'true')
+
+      // Menu should still be open
+      await expect(content).toBeVisible()
+    })
   })
 
   test.describe('Profile Menu Demo', () => {
@@ -123,8 +241,9 @@ test.describe('DropdownMenu Documentation Page', () => {
       await trigger.click()
 
       const openContent = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
-      const item = openContent.locator('[data-slot="dropdown-menu-item"]').first()
-      await item.click()
+      // Click Settings (a regular menuitem, not checkbox/radio)
+      const settingsItem = openContent.locator('[data-slot="dropdown-menu-item"][role="menuitem"]:not([data-sub-trigger])').filter({ hasText: 'Settings' })
+      await settingsItem.click()
 
       await expect(openContent).toHaveCount(0)
     })
@@ -175,70 +294,266 @@ test.describe('DropdownMenu Documentation Page', () => {
     })
   })
 
-  test.describe('asChild Trigger', () => {
-    test('renders trigger with ARIA attributes via display:contents wrapper', async ({ page }) => {
-      const demo = page.locator('[data-bf-scope^="DropdownMenuAsChildDemo_"]').first()
+  test.describe('Submenu', () => {
+    test('opens submenu on hover', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
       const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
 
-      await expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
-      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
-
-      // Child button is inside the trigger wrapper
-      const childButton = trigger.locator('button')
-      await expect(childButton).toHaveAttribute('aria-label', 'Actions')
-    })
-
-    test('aria-expanded updates reactively on asChild trigger', async ({ page }) => {
-      const demo = page.locator('[data-bf-scope^="DropdownMenuAsChildDemo_"]').first()
-      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
-      const childButton = trigger.locator('button')
-
-      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
-
-      await childButton.click()
-      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
-
-      await childButton.click()
-      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
-    })
-
-    test('click toggles menu open/close on asChild trigger', async ({ page }) => {
-      const demo = page.locator('[data-bf-scope^="DropdownMenuAsChildDemo_"]').first()
-      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
-      const childButton = trigger.locator('button')
-
-      await childButton.click()
-      const openContent = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
-      await expect(openContent).toBeVisible()
-
-      await childButton.click()
-      await expect(openContent).toHaveCount(0)
-    })
-
-    test('keyboard navigation works with asChild trigger', async ({ page }) => {
-      const demo = page.locator('[data-bf-scope^="DropdownMenuAsChildDemo_"]').first()
-      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
-      const childButton = trigger.locator('button')
-
-      await childButton.click()
+      await trigger.click()
 
       const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
-      await content.focus()
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+      await expect(subTrigger).toBeVisible()
 
-      await page.keyboard.press('ArrowDown')
-      const firstItem = content.locator('[data-slot="dropdown-menu-item"]').first()
-      await expect(firstItem).toBeFocused()
+      // Hover over sub trigger
+      await subTrigger.hover()
 
+      // Wait for submenu to open (100ms delay + buffer)
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      // Submenu should contain language options
+      await expect(subContent.locator('text=English')).toBeVisible()
+      await expect(subContent.locator('text=Japanese')).toBeVisible()
+      await expect(subContent.locator('text=French')).toBeVisible()
+    })
+
+    test('opens submenu with ArrowRight key', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+
+      // Focus the sub trigger
+      await subTrigger.focus()
+      await page.keyboard.press('ArrowRight')
+
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+    })
+
+    test('closes submenu with ArrowLeft key', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+
+      // Open submenu
+      await subTrigger.hover()
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      // Focus a sub item and press ArrowLeft
+      const subItem = subContent.locator('[data-slot="dropdown-menu-item"]').first()
+      await subItem.focus()
+      await page.keyboard.press('ArrowLeft')
+
+      // Submenu should close
+      await expect(subContent).toHaveCount(0)
+
+      // Focus should return to sub trigger
+      await expect(subTrigger).toBeFocused()
+    })
+
+    test('ESC closes only submenu, not parent menu', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+
+      // Open submenu
+      await subTrigger.hover()
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      // Focus a sub item and press ESC
+      const subItem = subContent.locator('[data-slot="dropdown-menu-item"]').first()
+      await subItem.focus()
       await page.keyboard.press('Escape')
-      await expect(content).toHaveCount(0)
+
+      // Submenu should close
+      await expect(subContent).toHaveCount(0)
+
+      // Parent menu should remain open
+      await expect(content).toBeVisible()
+    })
+
+    test('sub trigger has chevron icon and aria attributes', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+
+      await expect(subTrigger).toHaveAttribute('aria-haspopup', 'menu')
+      await expect(subTrigger).toHaveAttribute('aria-expanded', 'false')
+
+      // Should contain a chevron SVG (last svg is the chevron icon)
+      await expect(subTrigger.locator('svg').last()).toBeVisible()
     })
   })
 
-  test.describe('Accessibility', () => {
-    test('displays accessibility section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("Accessibility")')).toBeVisible()
-      await expect(page.locator('strong:has-text("Keyboard Navigation")')).toBeVisible()
-      await expect(page.locator('strong:has-text("ARIA")')).toBeVisible()
+  test.describe('Checkbox Items (Profile)', () => {
+    test('toggles checkbox item on click', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const checkboxItems = content.locator('[role="menuitemcheckbox"]')
+      expect(await checkboxItems.count()).toBe(2)
+
+      // "Show Bookmarks Bar" should be initially checked
+      const bookmarksItem = checkboxItems.filter({ hasText: 'Show Bookmarks Bar' })
+      await expect(bookmarksItem).toHaveAttribute('aria-checked', 'true')
+
+      // Click to uncheck
+      await bookmarksItem.click()
+      await expect(bookmarksItem).toHaveAttribute('aria-checked', 'false')
+
+      // Menu should still be open (checkbox doesn't close menu)
+      await expect(content).toBeVisible()
+    })
+
+    test('checkbox item does not close menu', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const toolbarItem = content.locator('[role="menuitemcheckbox"]').filter({ hasText: 'Show Toolbar' })
+
+      // "Show Toolbar" should be initially unchecked
+      await expect(toolbarItem).toHaveAttribute('aria-checked', 'false')
+
+      // Click to check
+      await toolbarItem.click()
+      await expect(toolbarItem).toHaveAttribute('aria-checked', 'true')
+
+      // Menu should still be open
+      await expect(content).toBeVisible()
+    })
+  })
+
+  test.describe('Radio Items', () => {
+    test('selects radio item on click', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      // Open submenu to access radio items
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+      await subTrigger.hover()
+
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      const radioItems = subContent.locator('[role="menuitemradio"]')
+      expect(await radioItems.count()).toBe(3)
+
+      // "English" should be initially selected
+      const englishItem = radioItems.filter({ hasText: 'English' })
+      await expect(englishItem).toHaveAttribute('aria-checked', 'true')
+
+      // Click "Japanese" to select
+      const japaneseItem = radioItems.filter({ hasText: 'Japanese' })
+      await japaneseItem.click()
+      await expect(japaneseItem).toHaveAttribute('aria-checked', 'true')
+
+      // "English" should now be deselected
+      await expect(englishItem).toHaveAttribute('aria-checked', 'false')
+    })
+
+    test('radio items are mutually exclusive', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+      await subTrigger.hover()
+
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      const radioItems = subContent.locator('[role="menuitemradio"]')
+
+      // Click French
+      const frenchItem = radioItems.filter({ hasText: 'French' })
+      await frenchItem.click()
+
+      // Only French should be checked
+      const checkedItems = subContent.locator('[role="menuitemradio"][aria-checked="true"]')
+      expect(await checkedItems.count()).toBe(1)
+      await expect(frenchItem).toHaveAttribute('aria-checked', 'true')
+    })
+
+    test('radio item does not close menu', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const subTrigger = content.locator('[data-sub-trigger="true"]')
+      await subTrigger.hover()
+
+      const subContent = page.locator('[data-slot="dropdown-menu-sub-content"][data-state="open"]')
+      await expect(subContent).toBeVisible({ timeout: 2000 })
+
+      const japaneseItem = subContent.locator('[role="menuitemradio"]').filter({ hasText: 'Japanese' })
+      await japaneseItem.click()
+
+      // Submenu should still be open
+      await expect(subContent).toBeVisible()
+      // Parent menu should still be open
+      await expect(content).toBeVisible()
+    })
+  })
+
+  test.describe('Destructive Variant', () => {
+    test('destructive item has correct styling class', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const logoutItem = content.locator('[data-slot="dropdown-menu-item"]').filter({ hasText: 'Log out' })
+
+      // Should have text-destructive class
+      await expect(logoutItem).toHaveClass(/text-destructive/)
+    })
+
+    test('destructive item closes menu on click', async ({ page }) => {
+      const demo = page.locator('[data-bf-scope^="DropdownMenuProfileDemo_"]').first()
+      const trigger = demo.locator('[data-slot="dropdown-menu-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="dropdown-menu-content"][data-state="open"]')
+      const logoutItem = content.locator('[data-slot="dropdown-menu-item"]').filter({ hasText: 'Log out' })
+
+      await logoutItem.click()
+
+      // Menu should close
+      await expect(content).toHaveCount(0)
     })
   })
 

--- a/docs/ui/pages/dropdown-menu.tsx
+++ b/docs/ui/pages/dropdown-menu.tsx
@@ -2,7 +2,7 @@
  * Dropdown Menu Documentation Page
  */
 
-import { DropdownMenuProfileDemo, DropdownMenuAsChildDemo } from '@/components/dropdown-menu-demo'
+import { DropdownMenuProfileDemo, DropdownMenuBasicDemo, DropdownMenuCheckboxDemo } from '@/components/dropdown-menu-demo'
 import {
   DocPage,
   PageHeader,
@@ -21,14 +21,13 @@ const tocItems: TocItem[] = [
   { id: 'installation', title: 'Installation' },
   { id: 'features', title: 'Features' },
   { id: 'examples', title: 'Examples' },
-  { id: 'profile-menu', title: 'Profile Menu', branch: 'start' },
-  { id: 'as-child', title: 'As Child' },
-  { id: 'accessibility', title: 'Accessibility' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'checkbox-items', title: 'Checkbox Items', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
 // Code examples
-const profileMenuCode = `"use client"
+const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
 import {
@@ -38,86 +37,69 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuGroup,
-  DropdownMenuShortcut,
 } from '@/components/ui/dropdown-menu'
-import { SettingsIcon, GlobeIcon, LogOutIcon, CircleHelpIcon } from '@/components/ui/icon'
 
-function ProfileMenu() {
+function BasicMenu() {
   const [open, setOpen] = createSignal(false)
 
   return (
     <DropdownMenu open={open()} onOpenChange={setOpen}>
       <DropdownMenuTrigger>
-        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-medium">
-          KK
+        <span className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+          Open Menu
         </span>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuLabel>My Account</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          <DropdownMenuItem onSelect={() => console.log('settings')}>
-            <SettingsIcon size="sm" />
-            <span>Settings</span>
-            <DropdownMenuShortcut>⇧⌘,</DropdownMenuShortcut>
-          </DropdownMenuItem>
-          <DropdownMenuItem>
-            <GlobeIcon size="sm" />
-            <span>Language</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem>
-            <CircleHelpIcon size="sm" />
-            <span>Help</span>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <LogOutIcon size="sm" />
-          <span>Log out</span>
+          <span>Copy</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <span>Paste</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">
+          <span>Delete</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
 }`
 
-const asChildCode = `"use client"
+const checkboxCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
-import { SettingsIcon, GlobeIcon, LogOutIcon } from '@/components/ui/icon'
 
-function AsChildMenu() {
+function CheckboxMenu() {
   const [open, setOpen] = createSignal(false)
+  const [showStatus, setShowStatus] = createSignal(true)
+  const [showActivity, setShowActivity] = createSignal(false)
 
   return (
     <DropdownMenu open={open()} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <button className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
-          <SettingsIcon size="sm" />
-          <span>Actions</span>
-        </button>
+      <DropdownMenuTrigger>
+        <span className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+          View
+        </span>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuItem onSelect={() => console.log('settings')}>
-          <SettingsIcon size="sm" />
-          <span>Settings</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <GlobeIcon size="sm" />
-          <span>Language</span>
-        </DropdownMenuItem>
+        <DropdownMenuLabel>Toggle Panels</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
-          <LogOutIcon size="sm" />
-          <span>Log out</span>
-        </DropdownMenuItem>
+        <DropdownMenuCheckboxItem checked={showStatus()} onCheckedChange={setShowStatus}>
+          <span>Status Bar</span>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked={showActivity()} onCheckedChange={setShowActivity}>
+          <span>Activity Panel</span>
+        </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
@@ -174,6 +156,68 @@ const dropdownMenuItemProps: PropDefinition[] = [
     type: '() => void',
     description: 'Callback when the item is selected. Menu auto-closes after selection.',
   },
+  {
+    name: 'variant',
+    type: "'default' | 'destructive'",
+    defaultValue: "'default'",
+    description: 'Visual variant. Use "destructive" for dangerous actions like log out.',
+  },
+]
+
+const dropdownMenuCheckboxItemProps: PropDefinition[] = [
+  {
+    name: 'checked',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the checkbox is checked.',
+  },
+  {
+    name: 'onCheckedChange',
+    type: '(checked: boolean) => void',
+    description: 'Callback when checked state changes. Menu stays open.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the item is disabled.',
+  },
+]
+
+const dropdownMenuRadioGroupProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Currently selected value.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when value changes.',
+  },
+]
+
+const dropdownMenuRadioItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Value for this radio item.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the item is disabled.',
+  },
+]
+
+const dropdownMenuSubTriggerProps: PropDefinition[] = [
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the sub trigger is disabled.',
+  },
 ]
 
 const dropdownMenuLabelProps: PropDefinition[] = [
@@ -221,34 +265,25 @@ export function DropdownMenuPage() {
           <ul className="list-disc list-inside space-y-2 text-muted-foreground">
             <li><strong className="text-foreground">Props-based state</strong> - Parent controls open state with signals</li>
             <li><strong className="text-foreground">Flexible trigger</strong> - Use any element as the trigger (button, avatar, icon)</li>
-            <li><strong className="text-foreground">ESC key to close</strong> - Press Escape to close the menu</li>
-            <li><strong className="text-foreground">Arrow key navigation</strong> - Navigate items with keyboard</li>
-            <li><strong className="text-foreground">Accessibility</strong> - role="menu", role="menuitem", aria-expanded, aria-haspopup</li>
-            <li><strong className="text-foreground">Composable</strong> - Label, Separator, Shortcut, Group sub-components</li>
+            <li><strong className="text-foreground">Submenu</strong> - Nested submenus with hover and keyboard navigation</li>
+            <li><strong className="text-foreground">Checkbox items</strong> - Multi-select items with check indicator</li>
+            <li><strong className="text-foreground">Radio items</strong> - Single-select items within a group</li>
+            <li><strong className="text-foreground">Destructive variant</strong> - Red styling for dangerous actions</li>
+            <li><strong className="text-foreground">Keyboard navigation</strong> - Arrow keys, Home/End, Enter/Space, ESC</li>
+            <li><strong className="text-foreground">Composable</strong> - Label, Separator, Shortcut, Group, Sub sub-components</li>
           </ul>
         </Section>
 
         {/* Examples */}
         <Section id="examples" title="Examples">
           <div className="space-y-8">
-            <Example title="Profile Menu" code={profileMenuCode}>
-              <DropdownMenuProfileDemo />
+            <Example title="Basic" code={basicCode}>
+              <DropdownMenuBasicDemo />
             </Example>
-            <Example title="As Child" code={asChildCode}>
-              <DropdownMenuAsChildDemo />
+            <Example title="Checkbox Items" code={checkboxCode}>
+              <DropdownMenuCheckboxDemo />
             </Example>
           </div>
-        </Section>
-
-        {/* Accessibility */}
-        <Section id="accessibility" title="Accessibility">
-          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li><strong className="text-foreground">Keyboard Navigation</strong> - Arrow Up/Down to navigate, Home/End to jump, Enter/Space to select</li>
-            <li><strong className="text-foreground">Focus Return</strong> - Focus returns to trigger after action</li>
-            <li><strong className="text-foreground">ESC to Close</strong> - Press Escape to close the menu</li>
-            <li><strong className="text-foreground">ARIA</strong> - role="menu" on content, role="menuitem" on items</li>
-            <li><strong className="text-foreground">State Attributes</strong> - aria-expanded, aria-haspopup="menu", aria-disabled</li>
-          </ul>
         </Section>
 
         {/* API Reference */}
@@ -269,6 +304,30 @@ export function DropdownMenuPage() {
             <div>
               <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuItem</h3>
               <PropsTable props={dropdownMenuItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuCheckboxItem</h3>
+              <PropsTable props={dropdownMenuCheckboxItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuRadioGroup</h3>
+              <PropsTable props={dropdownMenuRadioGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuRadioItem</h3>
+              <PropsTable props={dropdownMenuRadioItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuSub</h3>
+              <p className="text-sm text-muted-foreground">Submenu container. Manages sub-open state internally. Wrap SubTrigger and SubContent.</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuSubTrigger</h3>
+              <PropsTable props={dropdownMenuSubTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuSubContent</h3>
+              <p className="text-sm text-muted-foreground">Content container for submenu items. Positioned to the right of the trigger.</p>
             </div>
             <div>
               <h3 className="text-lg font-medium text-foreground mb-4">DropdownMenuLabel</h3>


### PR DESCRIPTION
## Summary
- Add `DropdownMenuSub`, `DropdownMenuSubTrigger`, `DropdownMenuSubContent` for nested submenus with hover/keyboard (ArrowRight/ArrowLeft/ESC) navigation
- Add `DropdownMenuCheckboxItem` for multi-select toggle items (menu stays open on toggle)
- Add `DropdownMenuRadioGroup` / `DropdownMenuRadioItem` for single-select items within a group
- Add `variant="destructive"` on `DropdownMenuItem` with readable hover styling
- Replace AsChild/Profile/Accessibility doc examples with simpler Basic and Checkbox demos
- Add 34 comprehensive E2E tests covering all new features

## Test plan
- [x] `bun run build` passes
- [x] 34/34 E2E tests pass (`npx playwright test e2e/dropdown-menu.spec.ts`)
- [ ] Manual verification: destructive item text remains readable on hover
- [ ] Manual verification: ToC "Checkbox Items" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)