### PR TITLE
fix: auto-generate scope wrapper for provider-only components

### DIFF
--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -119,9 +119,7 @@ function Dialog(props: DialogProps) {
       open: () => props.open ?? false,
       onOpenChange: props.onOpenChange ?? (() => {}),
     }}>
-      <div data-slot="dialog" style="display:contents">
-        {props.children}
-      </div>
+      {props.children}
     </DialogContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary

- Auto-generate a synthetic `<div style="display:contents">` scope wrapper in `jsxToIR()` when a component's root is a Provider with children but no native HTML element. This ensures `findScope()` succeeds during hydration so `provideContext()` runs correctly.
- Remove the manual workaround wrapper from Dialog component (added in PR #288), since the compiler now handles this automatically.

Closes #290

## Changes

| File | Description |
|------|-------------|
| `packages/jsx/src/jsx-to-ir.ts` | Add `needsScopeWrapper()`, `hasProviderWithChildren()`, `hasRootScopeElement()`, `wrapInScopeElement()` helpers; modify `jsxToIR()` post-processing |
| `packages/jsx/src/__tests__/compiler.test.ts` | Add 3 test cases: auto-wrap provider-only root, no wrap when element child exists, e2e client JS generation |
| `ui/components/ui/dialog.tsx` | Remove manual `<div style="display:contents">` workaround |

## Test plan

- [x] Provider-only root auto-generates scope wrapper with `needsScope: true`
- [x] Provider with element child does NOT get wrapped (existing behavior preserved)
- [x] End-to-end: provider-only component generates `findScope` + `provideContext` in client JS
- [x] All 244 existing tests in `packages/jsx/` and `packages/dom/` pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)