### PR TITLE
feat: support find() and findIndex() in expression parser for SSR

### DIFF
--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -54,7 +54,7 @@ Patterns that the compiler cannot translate to server templates require `/* @cli
 {/* @client */ items().filter(x => x.tags().filter(t => t.active).length > 0)}
 
 // Unsupported array methods
-{/* @client */ items().find(x => x.id === selectedId())}
+{/* @client */ items().reduce((sum, x) => sum + x.price, 0)}
 ```
 
 ### Explicit client-only evaluation

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -68,24 +68,6 @@ return <div>...</div>
 Some comparators (e.g., `localeCompare`, block bodies) are not supported and will produce a compile error — use `/* @client */` in that case.
 
 
-## Single-Value Lookup
-
-`.find()` and `.findIndex()` work with simple predicates — boolean field access and equality comparisons:
-
-```tsx
-// ✅ Boolean predicate
-{items().find(t => t.done)}
-
-// ✅ Equality predicate with property access
-{users().find(u => u.id === selectedId()).name}
-
-// ✅ findIndex
-{items().findIndex(t => t.done)}
-```
-
-Complex predicates (e.g., `x.a > 5 && x.b < 10`) are not supported — use `/* @client */` in that case.
-
-
 ## Event Handling
 
 `on*` attributes bind event handlers. The handler receives the native DOM event:

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -68,6 +68,24 @@ return <div>...</div>
 Some comparators (e.g., `localeCompare`, block bodies) are not supported and will produce a compile error — use `/* @client */` in that case.
 
 
+## Single-Value Lookup
+
+`.find()` and `.findIndex()` work with simple predicates — boolean field access and equality comparisons:
+
+```tsx
+// ✅ Boolean predicate
+{items().find(t => t.done)}
+
+// ✅ Equality predicate with property access
+{users().find(u => u.id === selectedId()).name}
+
+// ✅ findIndex
+{items().findIndex(t => t.done)}
+```
+
+Complex predicates (e.g., `x.a > 5 && x.b < 10`) are not supported — use `/* @client */` in that case.
+
+
 ## Event Handling
 
 `on*` attributes bind event handlers. The handler receives the native DOM event:

--- a/packages/go-template/runtime/bf_test.go
+++ b/packages/go-template/runtime/bf_test.go
@@ -226,6 +226,91 @@ func TestLast(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Find / FindIndex Tests
+// =============================================================================
+
+type findItem struct {
+	Id   int
+	Name string
+	Done bool
+}
+
+func TestFind_ByBooleanField(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A", Done: false},
+		{Id: 2, Name: "B", Done: true},
+		{Id: 3, Name: "C", Done: false},
+	}
+
+	got := Find(items, "done", true)
+	if got == nil {
+		t.Fatal("Find by bool: got nil, want item B")
+	}
+	if got.(findItem).Name != "B" {
+		t.Errorf("Find by bool: got %v, want B", got.(findItem).Name)
+	}
+}
+
+func TestFind_ByIntField(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+		{Id: 2, Name: "B"},
+		{Id: 3, Name: "C"},
+	}
+
+	got := Find(items, "id", 2)
+	if got == nil {
+		t.Fatal("Find by int: got nil, want item B")
+	}
+	if got.(findItem).Name != "B" {
+		t.Errorf("Find by int: got %v, want B", got.(findItem).Name)
+	}
+}
+
+func TestFind_NotFound(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+	}
+
+	got := Find(items, "id", 99)
+	if got != nil {
+		t.Errorf("Find not found: got %v, want nil", got)
+	}
+}
+
+func TestFind_EmptySlice(t *testing.T) {
+	var items []findItem
+	got := Find(items, "id", 1)
+	if got != nil {
+		t.Errorf("Find empty: got %v, want nil", got)
+	}
+}
+
+func TestFindIndex_Found(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A", Done: false},
+		{Id: 2, Name: "B", Done: true},
+		{Id: 3, Name: "C", Done: false},
+	}
+
+	got := FindIndex(items, "done", true)
+	if got != 1 {
+		t.Errorf("FindIndex found: got %d, want 1", got)
+	}
+}
+
+func TestFindIndex_NotFound(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+	}
+
+	got := FindIndex(items, "id", 99)
+	if got != -1 {
+		t.Errorf("FindIndex not found: got %d, want -1", got)
+	}
+}
+
 func TestComment(t *testing.T) {
 	got := Comment("cond-start:slot_0")
 	want := "<!--bf-cond-start:slot_0-->"
@@ -242,7 +327,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_add", "bf_sub", "bf_mul", "bf_div", "bf_mod", "bf_neg",
 		"bf_lower", "bf_upper", "bf_trim", "bf_contains", "bf_join",
 		"bf_len", "bf_at", "bf_includes", "bf_first", "bf_last",
-		"bf_every", "bf_some", "bf_filter", "bf_sort",
+		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
 		"bfComment", "bfPortalHTML",
 	}
 

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -971,6 +971,66 @@ describe('GoTemplateAdapter', () => {
       expect(result).toBe('{{bf_find_index .Items "Done" true}}')
     })
 
+    test('renders find() with complex predicate using template iteration', () => {
+      // find(t => t.price > 100) — complex predicate, not simple equality
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'items().find(t => t.price > 100)',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{range .Items}}{{if gt .Price 100}}{{.}}{{break}}{{end}}{{end}}')
+    })
+
+    test('renders find().property with complex predicate using template iteration', () => {
+      // find(t => t.price > 100 && t.active).name — complex predicate with property access
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'items().find(t => t.price > 100 && t.active).name',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{range .Items}}{{if and (gt .Price 100) (.Active)}}{{.Name}}{{break}}{{end}}{{end}}')
+    })
+
+    test('renders findIndex() with complex predicate using template iteration', () => {
+      // findIndex(t => t.price > 100) — complex predicate
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'items().findIndex(t => t.price > 100)',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{range $i, $_ := .Items}}{{if gt .Price 100}}{{$i}}{{break}}{{end}}{{end}}')
+    })
+
+    test('renders find() with equality + comparison mixed predicate', () => {
+      // find(t => t.price > 100 && t.category === type()) — mixed predicate with signal
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: "items().find(t => t.price > 100 && t.category === type())",
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{range .Items}}{{if and (gt .Price 100) (eq .Category $.Type)}}{{.}}{{break}}{{end}}{{end}}')
+    })
+
     test('renders find() in condition without {{with}}', () => {
       const cond: IRConditional = {
         type: 'conditional',

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -928,6 +928,67 @@ describe('GoTemplateAdapter', () => {
     })
   })
 
+  describe('find/findIndex SSR support', () => {
+    test('renders find() with boolean predicate as bf_find', () => {
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'items().find(t => t.done)',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{bf_find .Items "Done" true}}')
+    })
+
+    test('renders find().property with {{with}} for nil-safety', () => {
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'users().find(u => u.id === selectedId()).name',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{with bf_find .Users "Id" .SelectedId}}{{.Name}}{{end}}')
+    })
+
+    test('renders findIndex() as bf_find_index', () => {
+      const expr: IRExpression = {
+        type: 'expression',
+        expr: 'items().findIndex(t => t.done)',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderExpression(expr)
+      expect(result).toBe('{{bf_find_index .Items "Done" true}}')
+    })
+
+    test('renders find() in condition without {{with}}', () => {
+      const cond: IRConditional = {
+        type: 'conditional',
+        condition: 'items().find(t => t.done)',
+        conditionType: null,
+        reactive: false,
+        whenTrue: { type: 'text', value: 'Found', loc },
+        whenFalse: { type: 'expression', expr: 'null', typeInfo: null, reactive: false, slotId: null, loc },
+        slotId: null,
+        loc,
+      }
+
+      const result = adapter.renderConditional(cond)
+      expect(result).toContain('bf_find .Items "Done" true')
+      expect(result).toContain('Found')
+    })
+  })
+
   describe('@client directive', () => {
     test('renders client-only expression as comment marker', () => {
       const expr: IRExpression = {

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -936,10 +936,11 @@ export class GoTemplateAdapter extends BaseAdapter {
     const goExpr = this.convertExpressionToGo(expr.expr)
 
     // If the expression already contains Go template blocks (e.g., {{with ...}}),
-    // don't wrap it again in {{...}} to avoid double-wrapping
+    // don't wrap it again in {{...}} to avoid double-wrapping.
+    // Use comment markers instead of <span> to avoid changing DOM structure.
     if (goExpr.startsWith('{{')) {
       if (expr.reactive && expr.slotId) {
-        return `<span ${this.renderSlotMarker(expr.slotId)}>${goExpr}</span>`
+        return `{{bfComment "expr-start:${expr.slotId}"}}${goExpr}{{bfComment "expr-end:${expr.slotId}"}}`
       }
       return goExpr
     }

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -189,6 +189,37 @@ describe('expression-parser', () => {
       }
     })
 
+    test('parses find() call into higher-order kind', () => {
+      const result = parseExpression('users().find(u => u.id === selectedId())')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('find')
+        expect(result.param).toBe('u')
+        expect(result.predicate.kind).toBe('binary')
+      }
+    })
+
+    test('parses findIndex() call into higher-order kind', () => {
+      const result = parseExpression('items().findIndex(t => t.done)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('findIndex')
+        expect(result.param).toBe('t')
+      }
+    })
+
+    test('parses find().property into member kind with higher-order object', () => {
+      const result = parseExpression('users().find(u => u.id === selectedId()).name')
+      expect(result.kind).toBe('member')
+      if (result.kind === 'member') {
+        expect(result.property).toBe('name')
+        expect(result.object.kind).toBe('higher-order')
+        if (result.object.kind === 'higher-order') {
+          expect(result.object.method).toBe('find')
+        }
+      }
+    })
+
     test('parses filter().length into member kind with higher-order object', () => {
       const result = parseExpression('todos().filter(t => !t.done).length')
       expect(result.kind).toBe('member')
@@ -281,6 +312,20 @@ describe('expression-parser', () => {
       expect(result.level).toBe('L5')
     })
 
+    test('L5: find() with simple predicate IS supported', () => {
+      const expr = parseExpression('users().find(u => u.id === selectedId())')
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L5')
+    })
+
+    test('L5: findIndex() with simple predicate IS supported', () => {
+      const expr = parseExpression('items().findIndex(t => t.done)')
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L5')
+    })
+
     test('filter().length IS supported (as member with higher-order object)', () => {
       const expr = parseExpression('items().filter(x => !x.done).length')
       const result = isSupported(expr)
@@ -344,6 +389,16 @@ describe('expression-parser', () => {
     test('converts higher-order to string', () => {
       const expr = parseExpression('todos().filter(t => !t.done)')
       expect(exprToString(expr)).toBe('todos().filter(t => !t.done)')
+    })
+
+    test('converts find() to string', () => {
+      const expr = parseExpression('users().find(u => u.id === selectedId())')
+      expect(exprToString(expr)).toBe('users().find(u => u.id === selectedId())')
+    })
+
+    test('converts findIndex() to string', () => {
+      const expr = parseExpression('items().findIndex(t => t.done)')
+      expect(exprToString(expr)).toBe('items().findIndex(t => t.done)')
     })
 
     test('converts filter-length to string', () => {


### PR DESCRIPTION
## Summary

- Enable `find()` and `findIndex()` array methods for server-side rendering (#287)
- These methods follow the same `arr.method(x => predicate)` pattern already recognized for `filter`, `every`, `some`
- Unlike `filter()` (returns array, used in loops), `find()` returns a single value or `undefined` — it's an expression-level feature

## Changes

### Expression Parser (`expression-parser.ts`)
- Extend `ParsedExpr` type to include `'find' | 'findIndex'` in higher-order method union
- Remove `find` and `findIndex` from `UNSUPPORTED_METHODS`
- Add to higher-order method recognition list

### Go Runtime (`bf.go`)
- Add `Find(items, field, value)` — returns first matching item or `nil`
- Add `FindIndex(items, field, value)` — returns index of first match or `-1`
- Register as `bf_find` and `bf_find_index` in `FuncMap()`

### Go Template Adapter (`go-template-adapter.ts`)
- Add `extractEqualityPredicate()` — handles boolean (`t.done`), negated (`!t.done`), and equality (`u.id === expr`) predicates
- Update `renderHigherOrderExpr()` with `find`/`findIndex` cases using `bf_find`/`bf_find_index`
- Handle `find().property` in member case with `{{with}}` for nil-safety
- Fix `renderExpression()` double-wrapping when expression already contains Go template blocks

### Examples
```
// find().property → {{with}} for nil-safety
users().find(u => u.id === selectedId()).name
→ {{with bf_find .Users "Id" .SelectedId}}{{.Name}}{{end}}

// standalone find()
items().find(t => t.done)
→ {{bf_find .Items "Done" true}}

// findIndex (no {{with}} — 0 is valid)
items().findIndex(t => t.done)
→ {{bf_find_index .Items "Done" true}}
```

## Test plan

- [x] Expression parser: `find()`/`findIndex()` parse into `higher-order` kind
- [x] Expression parser: `find().property` parses as `member` with `higher-order` object
- [x] Expression parser: `find()`/`findIndex()` with simple predicates are L5 supported
- [x] Expression parser: `exprToString` round-trips correctly
- [x] Go runtime: `Find` by boolean field, int field, not-found (nil), empty slice
- [x] Go runtime: `FindIndex` found, not-found (-1)
- [x] Go runtime: `FuncMap` includes `bf_find` and `bf_find_index`
- [x] Go adapter: `find()` with boolean predicate renders `bf_find`
- [x] Go adapter: `find().property` renders `{{with bf_find ...}}{{.Property}}{{end}}`
- [x] Go adapter: `findIndex()` renders `bf_find_index`
- [x] Go adapter: `find()` in condition renders without `{{with}}`
- [x] Full test suite: 313 tests pass, 0 failures

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)