### PR TITLE
feat: add asChild support to Trigger components (#277)

### DIFF
--- a/docs/ui/components/accordion-demo.tsx
+++ b/docs/ui/components/accordion-demo.tsx
@@ -51,6 +51,44 @@ export function AccordionSingleOpenDemo() {
 }
 
 /**
+ * Accordion with asChild trigger (mixed-mode: one asChild, one standard)
+ * Tests keyboard navigation between display:contents and button triggers.
+ */
+export function AccordionAsChildDemo() {
+  const [openItem, setOpenItem] = createSignal<string | null>(null)
+
+  return (
+    <div>
+      <Accordion>
+        <AccordionItem value="custom" open={openItem() === 'custom'} onOpenChange={(v) => setOpenItem(v ? 'custom' : null)}>
+          <AccordionTrigger asChild>
+            <button
+              type="button"
+              data-testid="accordion-aschild-trigger"
+              className="flex flex-1 items-center justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all hover:underline focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
+            >
+              Custom Trigger
+            </button>
+          </AccordionTrigger>
+          <AccordionContent>
+            This item uses a custom trigger element via asChild.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="standard" open={openItem() === 'standard'} onOpenChange={(v) => setOpenItem(v ? 'standard' : null)}>
+          <AccordionTrigger>
+            Standard Trigger
+          </AccordionTrigger>
+          <AccordionContent>
+            This item uses the default button trigger.
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <span data-testid="accordion-aschild-state">{openItem() === 'custom' ? 'open' : 'closed'}</span>
+    </div>
+  )
+}
+
+/**
  * Multiple open accordion (each item manages its own state)
  */
 export function AccordionMultipleOpenDemo() {

--- a/docs/ui/components/badge-as-child-demo.tsx
+++ b/docs/ui/components/badge-as-child-demo.tsx
@@ -1,0 +1,42 @@
+"use client"
+/**
+ * BadgeAsChildDemo Component
+ *
+ * Interactive demo for Badge asChild pattern with reactive bindings.
+ * Verifies that conditional JSX returns (if/else in Badge) preserve
+ * reactive attribute updates and event handlers.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Badge } from '@ui/components/ui/badge'
+
+/**
+ * Badge asChild demo with reactive click counter.
+ * The Badge component uses if/else to switch between <Slot> and <span>.
+ */
+export function BadgeAsChildDemo() {
+  const [count, setCount] = createSignal(0)
+
+  return (
+    <div className="flex items-center gap-4">
+      <Badge asChild>
+        <a
+          href="#"
+          data-testid="badge-aschild-link"
+          onClick={(e: Event) => { e.preventDefault(); setCount(count() + 1) }}
+        >
+          Clicked {count()} times
+        </a>
+      </Badge>
+      <Badge variant="outline" asChild>
+        <a
+          href="#"
+          data-testid="badge-aschild-outline"
+          onClick={(e: Event) => e.preventDefault()}
+        >
+          Outline Link
+        </a>
+      </Badge>
+    </div>
+  )
+}

--- a/docs/ui/e2e/accordion.spec.ts
+++ b/docs/ui/e2e/accordion.spec.ts
@@ -208,6 +208,72 @@ test.describe('Accordion Documentation Page', () => {
   })
 })
 
+test.describe('Accordion asChild', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/accordion')
+  })
+
+  test('renders child element as trigger', async ({ page }) => {
+    const trigger = page.locator('[data-testid="accordion-aschild-trigger"]')
+    await expect(trigger).toBeVisible()
+
+    // Should be a <button> tag (the custom child), not the default accordion button
+    const tagName = await trigger.evaluate((el) => el.tagName.toLowerCase())
+    expect(tagName).toBe('button')
+  })
+
+  test('toggles content on click with reactive state', async ({ page }) => {
+    const trigger = page.locator('[data-testid="accordion-aschild-trigger"]')
+    const stateEl = page.locator('[data-testid="accordion-aschild-state"]')
+
+    // Initially closed
+    await expect(stateEl).toContainText('closed')
+
+    // Click to open
+    await trigger.click()
+    await expect(stateEl).toContainText('open')
+
+    // Content should be visible
+    const demo = trigger.locator('xpath=ancestor::*[@data-slot="accordion"]')
+    await expect(demo.locator('text=This item uses a custom trigger element via asChild')).toBeVisible()
+  })
+
+  test('aria-expanded updates reactively', async ({ page }) => {
+    const triggerWrapper = page.locator('[data-testid="accordion-aschild-trigger"]').locator('xpath=ancestor::*[@data-slot="accordion-trigger"]')
+
+    // Initially closed
+    await expect(triggerWrapper).toHaveAttribute('aria-expanded', 'false')
+
+    // Click to open
+    await page.locator('[data-testid="accordion-aschild-trigger"]').click()
+
+    // aria-expanded should update
+    await expect(triggerWrapper).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('keyboard navigation between asChild and standard triggers', async ({ page }) => {
+    const asChildTrigger = page.locator('[data-testid="accordion-aschild-trigger"]')
+    const demo = asChildTrigger.locator('xpath=ancestor::*[@data-slot="accordion"]')
+    const standardTrigger = demo.locator('button:has-text("Standard Trigger")')
+
+    // Focus on the asChild trigger
+    await asChildTrigger.focus()
+    await expect(asChildTrigger).toBeFocused()
+
+    // ArrowDown should move to standard trigger
+    await page.keyboard.press('ArrowDown')
+    await expect(standardTrigger).toBeFocused()
+
+    // ArrowDown should wrap back to asChild trigger
+    await page.keyboard.press('ArrowDown')
+    await expect(asChildTrigger).toBeFocused()
+
+    // ArrowUp should wrap to standard trigger
+    await page.keyboard.press('ArrowUp')
+    await expect(standardTrigger).toBeFocused()
+  })
+})
+
 test.describe('Home Page - Accordion Link', () => {
   test('displays Accordion preview card', async ({ page }) => {
     await page.goto('/')

--- a/docs/ui/e2e/badge.spec.ts
+++ b/docs/ui/e2e/badge.spec.ts
@@ -54,6 +54,48 @@ test.describe('Badge Documentation Page', () => {
     })
   })
 
+  test.describe('Badge asChild', () => {
+    test('renders <a> tag with badge styling (not <span>)', async ({ page }) => {
+      const link = page.locator('[data-testid="badge-aschild-link"]')
+      await expect(link).toBeVisible()
+
+      // Should be an <a> tag
+      const tagName = await link.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('a')
+
+      // Should have badge styling classes
+      await expect(link).toHaveClass(/inline-flex/)
+      await expect(link).toHaveClass(/rounded-full/)
+    })
+
+    test('renders outline variant with asChild', async ({ page }) => {
+      const outlineLink = page.locator('[data-testid="badge-aschild-outline"]')
+      await expect(outlineLink).toBeVisible()
+
+      // Should be an <a> tag
+      const tagName = await outlineLink.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('a')
+
+      // Should have outline variant styling
+      await expect(outlineLink).toHaveClass(/text-foreground/)
+    })
+
+    test('reactive count updates on click', async ({ page }) => {
+      const link = page.locator('[data-testid="badge-aschild-link"]')
+
+      // Initially 0 clicks
+      await expect(link).toContainText('Clicked 0 times')
+
+      // Click to increment
+      await link.click()
+      await expect(link).toContainText('Clicked 1 times')
+
+      // Click again
+      await link.click()
+      await expect(link).toContainText('Clicked 2 times')
+    })
+  })
+
   test.describe('API Reference', () => {
     test('displays API Reference section', async ({ page }) => {
       await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()

--- a/docs/ui/e2e/dialog.spec.ts
+++ b/docs/ui/e2e/dialog.spec.ts
@@ -410,6 +410,61 @@ test.describe('Dialog Documentation Page', () => {
   })
 })
 
+test.describe('DialogTrigger asChild', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/dialog')
+  })
+
+  test('custom button renders as trigger with destructive styling', async ({ page }) => {
+    const deleteDemo = page.locator('[data-bf-scope^="DialogFormDemo_"]').first()
+    const trigger = deleteDemo.locator('button:has-text("Delete Project")')
+
+    await expect(trigger).toBeVisible()
+    // Should be a custom-styled button (destructive), not the default DialogTrigger styling
+    await expect(trigger).toHaveClass(/bg-destructive/)
+  })
+
+  test('display:contents wrapper is present on asChild trigger', async ({ page }) => {
+    const deleteDemo = page.locator('[data-bf-scope^="DialogFormDemo_"]').first()
+    const triggerWrapper = deleteDemo.locator('[data-slot="dialog-trigger"]')
+
+    await expect(triggerWrapper).toBeVisible()
+    // The wrapper should use display:contents
+    await expect(triggerWrapper).toHaveCSS('display', 'contents')
+  })
+
+  test('clicking asChild trigger opens dialog', async ({ page }) => {
+    const deleteDemo = page.locator('[data-bf-scope^="DialogFormDemo_"]').first()
+    const trigger = deleteDemo.locator('button:has-text("Delete Project")')
+
+    await trigger.click()
+
+    const dialog = page.locator('[role="dialog"][aria-labelledby="delete-dialog-title"]')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.locator('text=Delete Project').first()).toBeVisible()
+  })
+
+  test('dialog can be closed and reopened via asChild trigger', async ({ page }) => {
+    const deleteDemo = page.locator('[data-bf-scope^="DialogFormDemo_"]').first()
+    const trigger = deleteDemo.locator('button:has-text("Delete Project")')
+
+    // Open dialog
+    await trigger.click()
+    const dialog = page.locator('[role="dialog"][aria-labelledby="delete-dialog-title"]')
+    await expect(dialog).toBeVisible()
+
+    // Close via Cancel
+    const cancelButton = dialog.locator('button:has-text("Cancel")')
+    await cancelButton.click()
+    await expect(dialog).toHaveCSS('opacity', '0')
+
+    // Reopen
+    await trigger.click()
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveCSS('opacity', '1')
+  })
+})
+
 test.describe('Home Page - Dialog Link', () => {
   test('displays Dialog preview card', async ({ page }) => {
     await page.goto('/')

--- a/docs/ui/pages/accordion.tsx
+++ b/docs/ui/pages/accordion.tsx
@@ -2,7 +2,7 @@
  * Accordion Documentation Page
  */
 
-import { AccordionSingleOpenDemo, AccordionMultipleOpenDemo } from '@/components/accordion-demo'
+import { AccordionSingleOpenDemo, AccordionMultipleOpenDemo, AccordionAsChildDemo } from '@/components/accordion-demo'
 import {
   DocPage,
   PageHeader,
@@ -21,7 +21,8 @@ const tocItems: TocItem[] = [
   { id: 'installation', title: 'Installation' },
   { id: 'examples', title: 'Examples' },
   { id: 'single-open', title: 'Single Open', branch: 'start' },
-  { id: 'multiple-open', title: 'Multiple Open', branch: 'end' },
+  { id: 'multiple-open', title: 'Multiple Open', branch: 'child' },
+  { id: 'as-child', title: 'As Child', branch: 'end' },
   { id: 'accessibility', title: 'Accessibility' },
   { id: 'api-reference', title: 'API Reference' },
 ]
@@ -104,6 +105,39 @@ function AccordionMultiple() {
   )
 }`
 
+const asChildCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion'
+
+function AccordionAsChild() {
+  const [openItem, setOpenItem] = createSignal<string | null>(null)
+
+  return (
+    <Accordion>
+      <AccordionItem value="custom" open={openItem() === 'custom'} onOpenChange={(v) => setOpenItem(v ? 'custom' : null)}>
+        <AccordionTrigger asChild>
+          <button type="button" className="...">Custom Trigger</button>
+        </AccordionTrigger>
+        <AccordionContent>
+          This item uses a custom trigger element via asChild.
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="standard" open={openItem() === 'standard'} onOpenChange={(v) => setOpenItem(v ? 'standard' : null)}>
+        <AccordionTrigger>Standard Trigger</AccordionTrigger>
+        <AccordionContent>
+          This item uses the default button trigger.
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}`
+
 // Props definition
 const accordionItemProps: PropDefinition[] = [
   {
@@ -136,6 +170,12 @@ const accordionTriggerProps: PropDefinition[] = [
     type: 'boolean',
     defaultValue: 'false',
     description: 'Whether the trigger is disabled.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
   },
 ]
 
@@ -177,6 +217,12 @@ export function AccordionPage() {
             <Example title="Multiple Open" code={multipleCode}>
               <div className="w-full max-w-md">
                 <AccordionMultipleOpenDemo />
+              </div>
+            </Example>
+
+            <Example title="As Child" code={asChildCode}>
+              <div className="w-full max-w-md">
+                <AccordionAsChildDemo />
               </div>
             </Example>
           </div>

--- a/docs/ui/pages/badge.tsx
+++ b/docs/ui/pages/badge.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Badge } from '@/components/ui/badge'
+import { BadgeAsChildDemo } from '@/components/badge-as-child-demo'
 import {
   DocPage,
   PageHeader,
@@ -23,7 +24,8 @@ const tocItems: TocItem[] = [
   { id: 'default', title: 'Default', branch: 'start' },
   { id: 'secondary', title: 'Secondary', branch: 'child' },
   { id: 'destructive', title: 'Destructive', branch: 'child' },
-  { id: 'outline', title: 'Outline', branch: 'end' },
+  { id: 'outline', title: 'Outline', branch: 'child' },
+  { id: 'as-child', title: 'As Child', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
@@ -60,6 +62,28 @@ function BadgeOutline() {
   return <Badge variant="outline">Outline</Badge>
 }`
 
+const asChildCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import { Badge } from '@/components/ui/badge'
+
+function BadgeAsChild() {
+  const [count, setCount] = createSignal(0)
+
+  return (
+    <div className="flex items-center gap-4">
+      <Badge asChild>
+        <a href="#" onClick={() => setCount(count() + 1)}>
+          Clicked {count()} times
+        </a>
+      </Badge>
+      <Badge variant="outline" asChild>
+        <a href="#">Outline Link</a>
+      </Badge>
+    </div>
+  )
+}`
+
 // Props definition
 const badgeProps: PropDefinition[] = [
   {
@@ -67,6 +91,12 @@ const badgeProps: PropDefinition[] = [
     type: "'default' | 'secondary' | 'destructive' | 'outline'",
     defaultValue: "'default'",
     description: 'The visual style of the badge.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element with badge styling instead of <span>.',
   },
   {
     name: 'children',
@@ -114,6 +144,10 @@ export function BadgePage() {
 
             <Example title="Outline" code={outlineCode}>
               <Badge variant="outline">Outline</Badge>
+            </Example>
+
+            <Example title="As Child" code={asChildCode}>
+              <BadgeAsChildDemo />
             </Example>
           </div>
         </Section>


### PR DESCRIPTION
## Summary

- Add `asChild` prop to `AccordionTrigger` using the `display:contents` span wrapper pattern, with mixed-mode keyboard navigation support (handles both button and `display:contents` triggers)
- Add `asChild` demos and documentation for Accordion and Badge components
- Add E2E test coverage for `asChild` on `AccordionTrigger`, `Badge`, and `DialogTrigger`

## Changes

### Core implementation
- **`ui/components/ui/accordion.tsx`**: Add `asChild` prop to `AccordionTriggerProps`, move `handleKeyDown` into `handleMount` via `addEventListener` for `display:contents` event bubbling support, inline focus logic for mixed-mode triggers

### Demos & docs
- **`docs/ui/components/accordion-demo.tsx`**: Add `AccordionAsChildDemo` with mixed-mode triggers
- **`docs/ui/components/badge-as-child-demo.tsx`**: New `BadgeAsChildDemo` with reactive click counter
- **`docs/ui/pages/accordion.tsx`**: Add "As Child" example, code sample, and `asChild` API reference
- **`docs/ui/pages/badge.tsx`**: Add "As Child" example, code sample, and `asChild` API reference

### E2E tests
- **`docs/ui/e2e/accordion.spec.ts`**: 4 tests — render, toggle, aria-expanded, keyboard nav
- **`docs/ui/e2e/badge.spec.ts`**: 3 tests — `<a>` tag render, outline variant, reactive count
- **`docs/ui/e2e/dialog.spec.ts`**: 4 tests — destructive styling, display:contents, open/close, reopen

## Test plan

- [x] All 220 E2E tests pass with no regressions
- [x] `bunx playwright test e2e/accordion.spec.ts` — 33 passed
- [x] `bunx playwright test e2e/badge.spec.ts` — 14 passed
- [x] `bunx playwright test e2e/dialog.spec.ts` — 33 passed

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)