### PR TITLE
feat: support complex predicates in every()/some() for Go template adapter

### DIFF
--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -312,6 +312,20 @@ describe('expression-parser', () => {
       expect(result.level).toBe('L5')
     })
 
+    test('L5: every() with complex predicate IS supported', () => {
+      const expr = parseExpression('items().every(t => t.price > 100)')
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L5')
+    })
+
+    test('L5: some() with complex predicate IS supported', () => {
+      const expr = parseExpression('items().some(t => t.price > 100 && t.active)')
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L5')
+    })
+
     test('L5: find() with simple predicate IS supported', () => {
       const expr = parseExpression('users().find(u => u.id === selectedId())')
       const result = isSupported(expr)


### PR DESCRIPTION
## Summary

- Add `renderEverySomeTemplateBlock` to handle complex predicates (e.g., `t.price > 100`) in `every()`/`some()` using `{{range}}{{if}}` with Go template variable reassignment (`$bf_result`)
- Simple predicates (`t.done`) continue using `bf_every`/`bf_some` runtime functions (no behavior change)
- Update `convertConditionToGo` to return `{ condition, preamble }` so template blocks are emitted before `{{if}}` when used in conditions

Closes #297

## Test plan

- [x] `every()` with comparison: `items().every(t => t.price > 100)`
- [x] `some()` with comparison: `items().some(t => t.price > 100)`
- [x] `every()` with logical AND: `items().every(t => t.price > 100 && t.active)`
- [x] `some()` with mixed predicate + signal: `items().some(t => t.price > minPrice() && t.category === type())`
- [x] Regression: simple `every(t => t.done)` still uses `bf_every`
- [x] Complex predicate in condition context (preamble splitting)
- [x] Expression parser support level tests for complex predicates
- [x] Full test suite passes (325 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)