### PR TITLE
Fix: strip TypeScript type annotations from uninitialized variable declarations

### DIFF
--- a/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
+++ b/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'bun:test'
+import { stripTypeScriptSyntax } from '../ir-to-client-js/utils'
+
+describe('stripTypeScriptSyntax', () => {
+  describe('variable declarations without initializer', () => {
+    test('strips simple type annotation', () => {
+      expect(stripTypeScriptSyntax('let enterExitClass: string')).toBe('let enterExitClass')
+    })
+
+    test('strips union type annotation', () => {
+      expect(stripTypeScriptSyntax('let x: number | null')).toBe('let x')
+    })
+
+    test('strips complex generic type annotation', () => {
+      expect(stripTypeScriptSyntax('let timer: ReturnType<typeof setTimeout> | null')).toBe('let timer')
+    })
+
+    test('strips var declaration type annotation', () => {
+      expect(stripTypeScriptSyntax('var x: string')).toBe('var x')
+    })
+  })
+
+  describe('variable declarations with initializer', () => {
+    test('strips type annotation but keeps initializer', () => {
+      expect(stripTypeScriptSyntax("let x: string = ''")).toBe("let x = ''")
+    })
+
+    test('strips type annotation from const with initializer', () => {
+      expect(stripTypeScriptSyntax('const count: number = 0')).toBe('const count = 0')
+    })
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -150,6 +150,9 @@ export function stripTypeScriptSyntax(code: string): string {
   // Variable type annotations: let/const x: Type = value
   result = result.replace(/(let|const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[^\n=]+=(?!=)/g, '$1 $2 =')
 
+  // Variable type annotations without initializer: let x: Type => let x
+  result = result.replace(/(let|var)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:[^\n;=]+/g, '$1 $2')
+
   // Multi-variable type annotations: let x: number, y: number
   result = result.replace(/(let|const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[A-Za-z_][A-Za-z0-9_<>\[\]|&\s]*,/g, '$1 $2,')
   result = result.replace(/,\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[A-Za-z_][A-Za-z0-9_<>\[\]|&\s]*(?=[,\n;)])/g, ', $1')


### PR DESCRIPTION
## Summary

- Fix `stripTypeScriptSyntax()` to handle variable declarations without initializers (`let x: string` → `let x`)
- Previously, type annotations on uninitialized variables leaked into client JS output, causing runtime errors (e.g., `let enterExitClass: string` is invalid JS)
- Add unit tests covering simple types, union types, complex generics, and `var` declarations

Closes #307

## Test plan

- [x] New `strip-typescript-syntax.test.ts` tests pass (6 cases)
- [x] All 152 existing tests pass (`bun test` in `packages/jsx`)
- [ ] Verify toast component compiles without type annotation leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)