### PR TITLE
Fix: strip `as X | Y` union type casts completely

### DIFF
--- a/examples/shared/e2e/counter.spec.ts
+++ b/examples/shared/e2e/counter.spec.ts
@@ -46,7 +46,9 @@ export function counterTests(baseUrl: string) {
 
     test('handles multiple operations', async ({ page }) => {
       await page.click('.btn-increment')
+      await expect(page.locator('.counter-value')).toHaveText('1')
       await page.click('.btn-increment')
+      await expect(page.locator('.counter-value')).toHaveText('2')
       await page.click('.btn-increment')
       await expect(page.locator('.counter-value')).toHaveText('3')
       await expect(page.locator('.counter-doubled')).toContainText('6')

--- a/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
+++ b/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
@@ -20,6 +20,30 @@ describe('stripTypeScriptSyntax', () => {
     })
   })
 
+  describe('type assertions (as)', () => {
+    test('strips simple type assertion', () => {
+      expect(stripTypeScriptSyntax('e.target as HTMLElement')).toBe('e.target')
+    })
+
+    test('strips union type assertion', () => {
+      expect(stripTypeScriptSyntax('document.activeElement as HTMLElement | null')).toBe('document.activeElement')
+    })
+
+    test('strips 3+ union type assertion', () => {
+      expect(stripTypeScriptSyntax('value as string | number | null')).toBe('value')
+    })
+
+    test('strips generic + union type assertion', () => {
+      expect(stripTypeScriptSyntax('value as Set<string> | null')).toBe('value')
+    })
+
+    test('strips union type assertion in method call result (issue #308)', () => {
+      expect(
+        stripTypeScriptSyntax('someElement.closest(\'[data-slot="trigger"]\') as HTMLElement | null')
+      ).toBe('someElement.closest(\'[data-slot="trigger"]\')')
+    })
+  })
+
   describe('variable declarations with initializer', () => {
     test('strips type annotation but keeps initializer', () => {
       expect(stripTypeScriptSyntax("let x: string = ''")).toBe("let x = ''")

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -131,8 +131,8 @@ export function stripTypeScriptSyntax(code: string): string {
   // Non-null assertions: x! => x (but not !== or !=)
   let result = code.replace(/(\w)!(?!=)/g, '$1')
 
-  // Type assertions: "expr as Type"
-  result = result.replace(/\s+as\s+[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\[\])?/g, '')
+  // Type assertions: "expr as Type" or "expr as Type | Type2 | ..."
+  result = result.replace(/\s+as\s+[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\[\])?(?:\s*\|\s*[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\[\])?)*/g, '')
 
   // Parameter type annotations: (param: Type) => (param)
   // Only match TypeScript types (uppercase initial or type keyword) to avoid matching object properties


### PR DESCRIPTION
## Summary

- Fix regex in `stripTypeScriptSyntax()` to match union type assertions (`as X | Y | Z`), not just single types
- Previously `as HTMLElement | null` left `| null` in client JS output, which became a bitwise OR evaluating to `0` at runtime
- Add 5 test cases covering simple, union, 3+ union, generic+union, and issue #308 reproduction

Closes #308

## Test plan

- [x] `bun test packages/jsx/src/__tests__/strip-typescript-syntax.test.ts` — all 11 tests pass
- [x] Existing single-type `as` casts still stripped correctly (regex uses `*` quantifier, backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)