### PR TITLE
Fix: scope suffix-match collision in nested child slot IDs

### DIFF
--- a/packages/dom/__tests__/runtime.test.ts
+++ b/packages/dom/__tests__/runtime.test.ts
@@ -127,15 +127,15 @@ describe('find', () => {
   })
 
   test('finds child scope element before matching scope itself', () => {
-    // AccordionTrigger case: parent scope also matches the selector,
-    // but we want the child scope (ChevronDownIcon)
+    // AccordionTrigger case: parent scope also matches the suffix selector,
+    // but we want the child scope (ChevronDownIcon) returned first
     document.body.innerHTML = `
       <div data-bf-scope="AccordionTrigger_abc_s0">
-        <span data-bf-scope="AccordionTrigger_abc_s0_child">icon</span>
+        <span data-bf-scope="AccordionTrigger_abc_s0_s0">icon</span>
       </div>
     `
     const scope = document.querySelector('[data-bf-scope="AccordionTrigger_abc_s0"]')
-    const el = find(scope, '[data-bf-scope$="_s0_child"]')
+    const el = find(scope, '[data-bf-scope$="_s0"]')
     expect(el).not.toBeNull()
     expect(el?.textContent).toBe('icon')
   })
@@ -151,14 +151,14 @@ describe('find', () => {
   })
 
   test('prioritizes child scope over self-match for scope selectors', () => {
-    // Both parent and child match the selector, child should be returned
+    // Both parent and child match the suffix selector, child should be returned
     document.body.innerHTML = `
       <div data-bf-scope="Parent_abc_s0">
-        <div data-bf-scope="Parent_abc_s0_inner">child</div>
+        <div data-bf-scope="Parent_abc_s0_s0">child</div>
       </div>
     `
     const scope = document.querySelector('[data-bf-scope="Parent_abc_s0"]')
-    const el = find(scope, '[data-bf-scope$="_s0_inner"]')
+    const el = find(scope, '[data-bf-scope$="_s0"]')
     expect(el?.textContent).toBe('child')
     expect(el).not.toBe(scope)
   })

--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -95,9 +95,10 @@ function belongsToScope(
   const elementScope = (element as HTMLElement).dataset?.bfScope
   if (elementScope) {
     // When looking for child scope elements (data-bf-scope selectors),
-    // include them if they are within the scope (at any depth)
+    // only accept direct child scopes (no intermediate scope between element and search scope)
     if (isLookingForScope) {
-      return scope.contains(element)
+      const parentScope = element.parentElement?.closest('[data-bf-scope]')
+      return parentScope === scope
     }
     // When looking for slot elements (data-bf selectors),
     // exclude component roots to prevent slot ID collision

--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -95,10 +95,17 @@ function belongsToScope(
   const elementScope = (element as HTMLElement).dataset?.bfScope
   if (elementScope) {
     // When looking for child scope elements (data-bf-scope selectors),
-    // only accept direct child scopes (no intermediate scope between element and search scope)
+    // accept only scopes whose ID is parentScopeId + "_sN" (single slot suffix).
+    // Reject nested scopes like parentScopeId + "_sM_sN" which belong to an intermediate scope.
     if (isLookingForScope) {
-      const parentScope = element.parentElement?.closest('[data-bf-scope]')
-      return parentScope === scope
+      const scopeId = (scope as HTMLElement).dataset?.bfScope
+      if (scopeId && elementScope.startsWith(scopeId + '_')) {
+        const remainder = elementScope.slice(scopeId.length + 1)
+        return /^s\d+$/.test(remainder)
+      }
+      // For component name prefix matches (e.g., [data-bf-scope^="Counter_"]),
+      // element scope ID won't start with parent scope ID. Use containment check.
+      return scope.contains(element)
     }
     // When looking for slot elements (data-bf selectors),
     // exclude component roots to prevent slot ID collision


### PR DESCRIPTION
## Summary

- Fix `belongsToScope()` to prevent `$c(scope, 's3')` from matching grandchild scopes with the same suffix (e.g., `Parent_abc_s4_s3` colliding with `Parent_abc_s3`)
- The fix checks if element's scope ID equals `parentScopeId + "_sN"` (single slot suffix), rejecting nested scopes like `parentScopeId + "_sM_sN"` which belong to an intermediate scope
- For component name prefix lookups (e.g., `$c(scope, 'Counter')`), the existing containment check is preserved
- Update existing `find()` tests to use realistic `_sN` scope ID patterns matching compiler output
- Add `$c()` regression tests covering suffix-match collision, slot ID lookup, component name prefix lookup, and null scope

Closes #312

## How it works

The compiler generates **flat scope IDs** (`parentId_sN`) regardless of DOM nesting depth. A grandchild slot gets `parentId_sM_sN` — its parent is the intermediate scope `parentId_sM`, not the root scope.

```
Demo_abc              (scope)
├── Demo_abc_s3       → remainder "s3" matches /^s\d+$/ ✓ (direct child)
└── Demo_abc_s4
    └── Demo_abc_s4_s3 → remainder "s4_s3" fails /^s\d+$/ ✗ (belongs to _s4)
```

This approach correctly handles deeply nested DOM structures (e.g., Accordion with Trigger inside Item inside Accordion) because all children share the same parent scope ID prefix regardless of DOM depth.

## Test plan

- [x] `$c` regression test: DOM with `Demo_abc_s3` + `Demo_abc_s4_s3` — verifies only direct child is returned
- [x] Basic slot lookup, component name prefix match, null scope tests
- [x] All 111 unit tests pass (`cd packages/dom && bun test`)
- [x] All 93 echo E2E tests pass (`cd examples/echo && bunx playwright test`)
- [x] All 243 site/ui E2E tests pass (`cd site/ui && bunx playwright test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)