### PR TITLE
Fix Deploy Docs CI by building packages before docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Build packages
+        run: bun run --filter '@barefootjs/dom' build && bun run --filter '@barefootjs/jsx' build
+
       - name: Build documentation site
         run: cd site/docs && bun run build
 


### PR DESCRIPTION
## Summary
- Add "Build packages" step to `deploy-docs.yml` that builds `@barefootjs/dom` and `@barefootjs/jsx` before the docs site build
- The docs build imports `@barefootjs/jsx` which resolves to `dist/index.js`, so the package must be compiled first
- Build order: `dom` → `jsx` (jsx depends on dom)

## Test plan
- [ ] Re-run the Deploy Docs workflow and verify the build step succeeds
- [ ] Verify docs site deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)