### PR TITLE
Trigger deploy-docs workflow on its own file changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'docs/core/**'
       - 'site/docs/**'
+      - '.github/workflows/deploy-docs.yml'
 
   # Allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy-docs.yml` to the `paths` trigger so edits to the workflow file itself also run the deploy-docs pipeline

## Test plan
- [ ] Verify that pushing changes to `deploy-docs.yml` triggers the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)