### PR TITLE
Fix wrangler dev failures in site/docs

### DIFF
--- a/site/docs/build.ts
+++ b/site/docs/build.ts
@@ -17,7 +17,7 @@ import { compileJSX } from '@barefootjs/jsx'
 import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { mkdir, readdir } from 'node:fs/promises'
 import { dirname, resolve, join, relative } from 'node:path'
-import { loadContentFromDisk } from './lib/content'
+import { loadContentFromDisk } from './lib/content-loader'
 
 const ROOT_DIR = dirname(import.meta.path)
 const CONTENT_DIR = resolve(ROOT_DIR, '../../docs/core')

--- a/site/docs/lib/content-loader.ts
+++ b/site/docs/lib/content-loader.ts
@@ -1,0 +1,57 @@
+/**
+ * Build/dev-time content loading (requires Node.js APIs).
+ *
+ * This module uses node:fs and node:path to read markdown files from disk.
+ * It must NOT be imported in Cloudflare Worker bundles.
+ */
+
+import { readdir } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+
+import type { Page, ContentMap } from './content'
+export type { Page, ContentMap }
+
+/**
+ * Recursively discover all .md files under a directory.
+ */
+async function discoverFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await discoverFiles(fullPath))
+    } else if (entry.name.endsWith('.md')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+/**
+ * Build page list and content map by reading from the filesystem.
+ * Used by: dev server (reads fresh on startup) and build script (generates bundle).
+ */
+export async function loadContentFromDisk(contentDir: string): Promise<{ pages: Page[]; content: ContentMap }> {
+  const files = await discoverFiles(contentDir)
+  const pages: Page[] = []
+  const content: ContentMap = {}
+
+  for (const filePath of files) {
+    const rel = relative(contentDir, filePath)
+    const name = rel.replace(/\.md$/, '').split('/').pop() || ''
+    const slug = rel === 'README.md' ? '' : rel.replace(/\.md$/, '')
+
+    pages.push({ slug, name })
+    content[slug] = await Bun.file(filePath).text()
+  }
+
+  // Sort: index first, then alphabetically
+  pages.sort((a, b) => {
+    if (a.slug === '') return -1
+    if (b.slug === '') return 1
+    return a.slug.localeCompare(b.slug)
+  })
+
+  return { pages, content }
+}

--- a/site/docs/lib/content.ts
+++ b/site/docs/lib/content.ts
@@ -1,12 +1,9 @@
 /**
- * Content discovery and loading.
+ * Runtime-safe content types and utilities.
  *
- * - Dev mode:  reads markdown files from docs/core/ on disk
- * - Prod mode: uses a pre-bundled content map generated at build time
+ * This module has NO Node.js dependencies and is safe for Cloudflare Workers.
+ * For build/dev-time content loading, use ./content-loader.
  */
-
-import { readdir } from 'node:fs/promises'
-import { join, relative } from 'node:path'
 
 export interface Page {
   /** URL slug, e.g. "advanced/performance". Empty string for index (README.md). */
@@ -17,51 +14,6 @@ export interface Page {
 
 /** slug → raw markdown content */
 export type ContentMap = Record<string, string>
-
-/**
- * Recursively discover all .md files under a directory.
- */
-async function discoverFiles(dir: string): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true })
-  const files: string[] = []
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      files.push(...await discoverFiles(fullPath))
-    } else if (entry.name.endsWith('.md')) {
-      files.push(fullPath)
-    }
-  }
-  return files
-}
-
-/**
- * Build page list and content map by reading from the filesystem.
- * Used by: dev server (reads fresh on startup) and build script (generates bundle).
- */
-export async function loadContentFromDisk(contentDir: string): Promise<{ pages: Page[]; content: ContentMap }> {
-  const files = await discoverFiles(contentDir)
-  const pages: Page[] = []
-  const content: ContentMap = {}
-
-  for (const filePath of files) {
-    const rel = relative(contentDir, filePath)
-    const name = rel.replace(/\.md$/, '').split('/').pop() || ''
-    const slug = rel === 'README.md' ? '' : rel.replace(/\.md$/, '')
-
-    pages.push({ slug, name })
-    content[slug] = await Bun.file(filePath).text()
-  }
-
-  // Sort: index first, then alphabetically
-  pages.sort((a, b) => {
-    if (a.slug === '') return -1
-    if (b.slug === '') return 1
-    return a.slug.localeCompare(b.slug)
-  })
-
-  return { pages, content }
-}
 
 /**
  * Build page list from a pre-loaded content map (for Workers).

--- a/site/docs/lib/markdown.ts
+++ b/site/docs/lib/markdown.ts
@@ -1,10 +1,29 @@
 /**
  * Markdown processing with frontmatter parsing and Shiki syntax highlighting.
+ *
+ * Uses fine-grained bundles and JavaScript RegExp engine for Cloudflare Workers compatibility.
+ * The JavaScript engine avoids WASM which has restrictions in Workers environments.
  */
 
 import { Marked } from 'marked'
-import { createHighlighter, type Highlighter } from 'shiki'
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import type { TocItem } from '../../shared/components/table-of-contents'
+
+// Fine-grained theme imports
+import githubLight from '@shikijs/themes/github-light'
+import githubDark from '@shikijs/themes/github-dark'
+
+// Fine-grained language imports
+import langTypescript from '@shikijs/langs/typescript'
+import langJavascript from '@shikijs/langs/javascript'
+import langTsx from '@shikijs/langs/tsx'
+import langJsx from '@shikijs/langs/jsx'
+import langShellscript from '@shikijs/langs/shellscript'
+import langJson from '@shikijs/langs/json'
+import langHtml from '@shikijs/langs/html'
+import langCss from '@shikijs/langs/css'
+import langGo from '@shikijs/langs/go'
 
 export type { TocItem }
 
@@ -21,16 +40,17 @@ export interface ParsedMarkdown {
   toc: TocItem[]
 }
 
-let highlighter: Highlighter | null = null
+let highlighter: HighlighterCore | null = null
 
 export async function initHighlighter(): Promise<void> {
   if (highlighter) return
-  highlighter = await createHighlighter({
-    themes: ['github-light', 'github-dark'],
+  highlighter = await createHighlighterCore({
+    themes: [githubLight, githubDark],
     langs: [
-      'typescript', 'javascript', 'tsx', 'jsx',
-      'bash', 'shell', 'json', 'html', 'css', 'go',
+      langTypescript, langJavascript, langTsx, langJsx,
+      langShellscript, langJson, langHtml, langCss, langGo,
     ],
+    engine: createJavaScriptRegexEngine(),
   })
 }
 

--- a/site/docs/package.json
+++ b/site/docs/package.json
@@ -12,6 +12,8 @@
     "@barefootjs/hono": "workspace:*",
     "@barefootjs/site-shared": "workspace:*",
     "hono": "^4",
+    "@shikijs/langs": "^3.21.0",
+    "@shikijs/themes": "^3.21.0",
     "marked": "^15",
     "shiki": "^3.20.0"
   },

--- a/site/docs/server.tsx
+++ b/site/docs/server.tsx
@@ -6,7 +6,7 @@
 import { serveStatic } from 'hono/bun'
 import { resolve, dirname } from 'node:path'
 import { createApp } from './app'
-import { loadContentFromDisk } from './lib/content'
+import { loadContentFromDisk } from './lib/content-loader'
 
 const CONTENT_DIR = resolve(dirname(import.meta.path), '../../docs/core')
 const { pages, content } = await loadContentFromDisk(CONTENT_DIR)


### PR DESCRIPTION
## Summary

- Split `lib/content.ts` into runtime-safe types (`content.ts`) and build-time loader (`content-loader.ts`) to eliminate `node:fs/promises` / `node:path` imports from the Worker bundle
- Switch Shiki from default WASM engine to JavaScript RegExp engine (`shiki/core` + `shiki/engine/javascript`) with fine-grained theme/language imports, matching `site/ui`'s approach
- Add `@shikijs/langs` and `@shikijs/themes` dependencies

## Test plan

- [x] `cd site/docs && bunx wrangler dev` starts without errors
- [x] `cd site/docs && bun run --watch server.tsx` dev server works
- [ ] `cd site/docs && bun run build.ts` build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)