### PR TITLE
Remove backtick quotes from docs page titles

### DIFF
--- a/docs/core/reactivity/create-effect.md
+++ b/docs/core/reactivity/create-effect.md
@@ -1,4 +1,4 @@
-# `createEffect`
+# createEffect
 
 Runs a function immediately and re-runs it whenever any signal read inside it changes.
 

--- a/docs/core/reactivity/create-memo.md
+++ b/docs/core/reactivity/create-memo.md
@@ -1,4 +1,4 @@
-# `createMemo`
+# createMemo
 
 Creates a cached derived value. Recomputes only when its dependencies change.
 

--- a/docs/core/reactivity/create-signal.md
+++ b/docs/core/reactivity/create-signal.md
@@ -1,4 +1,4 @@
-# `createSignal`
+# createSignal
 
 Creates a reactive value. Returns a getter/setter pair.
 

--- a/docs/core/reactivity/on-cleanup.md
+++ b/docs/core/reactivity/on-cleanup.md
@@ -1,4 +1,4 @@
-# `onCleanup`
+# onCleanup
 
 Registers a cleanup function in the current reactive context. Called when the owning effect re-runs or the component is destroyed.
 

--- a/docs/core/reactivity/on-mount.md
+++ b/docs/core/reactivity/on-mount.md
@@ -1,4 +1,4 @@
-# `onMount`
+# onMount
 
 Runs once when the component initializes. Signal accesses inside are **not** tracked.
 

--- a/docs/core/reactivity/untrack.md
+++ b/docs/core/reactivity/untrack.md
@@ -1,4 +1,4 @@
-# `untrack`
+# untrack
 
 Executes a function without tracking signal dependencies. Signal reads inside the function do not register the current effect as a subscriber.
 

--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -1,4 +1,4 @@
-# `/* @client */` Directive
+# /* @client */ Directive
 
 The `/* @client */` comment directive marks a JSX expression for **client-only evaluation**. The server renders a placeholder; the browser evaluates the expression at runtime.
 


### PR DESCRIPTION
## Summary
- Remove backtick formatting from H1 headings in 7 docs pages (reactivity APIs and client directive)
- The `extractTitleFromBody()` in `site/core/lib/markdown.ts` uses H1 text as the HTML `<title>`, so backticks like `` `createEffect` `` were appearing literally in browser tab titles
- Affected pages: createSignal, createEffect, createMemo, onMount, onCleanup, untrack, `/* @client */` Directive

## Test plan
- [ ] Verify page titles in browser tabs no longer show backtick characters
- [ ] Verify H1 headings still render correctly on the docs pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)