### PR TITLE
Add path filtering to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'examples/**'
+      - 'site/ui/**'
+      - 'ui/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'examples/**'
+      - 'site/ui/**'
+      - 'ui/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Add `paths` filter to CI workflow (`ci.yml`) so tests only run when relevant files change
- Paths that trigger CI: `packages/**`, `examples/**`, `site/ui/**`, `ui/**`, `.github/workflows/ci.yml`
- Changes to `docs/`, `site/core/`, `site/shared/`, `spec/`, etc. will no longer trigger CI

## Test plan

- [ ] Verify a PR touching only `docs/core/` does not trigger CI
- [ ] Verify a PR touching `packages/` triggers all CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)