### PR TITLE
Simplify header logo to use single component

### DIFF
--- a/site/shared/components/header.tsx
+++ b/site/shared/components/header.tsx
@@ -7,7 +7,7 @@
  * Server component (NOT "use client") — interactive parts are passed via slots.
  */
 
-import { Logo, LogoIcon } from './logo'
+import { Logo } from './logo'
 
 export interface HeaderProps {
   activePage?: 'core' | 'ui'
@@ -51,13 +51,12 @@ export function Header({
         <div className="flex items-center gap-3 sm:gap-6">
           {leftSlot}
 
-          {/* Logo: full on sm+, icon on mobile */}
+          {/* Logo */}
           <a
             href={logoHref}
             className="text-foreground transition-colors no-underline"
           >
-            <span className="hidden sm:inline"><Logo /></span>
-            <span className="sm:hidden"><LogoIcon /></span>
+            <Logo />
           </a>
 
           {/* Navigation separator */}


### PR DESCRIPTION
## Summary
Removed the responsive logo switching logic in the header component, consolidating to use a single `Logo` component instead of conditionally rendering `Logo` and `LogoIcon` based on screen size.

## Changes
- Removed `LogoIcon` import from the logo module
- Eliminated responsive display logic that showed full logo on sm+ screens and icon-only on mobile
- Replaced dual-component rendering with a single `<Logo />` component
- Updated comment to reflect simplified implementation

## Implementation Details
The header previously used Tailwind's responsive classes (`hidden sm:inline` and `sm:hidden`) to switch between two different logo components at the mobile/tablet breakpoint. This change assumes the `Logo` component itself now handles any necessary responsive behavior, or that a single logo design is preferred across all screen sizes.

https://claude.ai/code/session_01N3pzeCzVZ16ECWpqs86oag