### PR TITLE
Add mobile page navigation component for prev/next links

### DIFF
--- a/site/core/components/mobile-page-nav.tsx
+++ b/site/core/components/mobile-page-nav.tsx
@@ -1,0 +1,75 @@
+/**
+ * Mobile Page Navigation Component
+ *
+ * Fixed bottom navigation for mobile devices with prev/next buttons.
+ * Uses inline SVGs to avoid dependency on UI icon library.
+ */
+
+export interface MobilePageNavLink {
+  href: string
+  title: string
+}
+
+interface MobilePageNavProps {
+  prev?: MobilePageNavLink
+  next?: MobilePageNavLink
+}
+
+function ChevronLeftSmall() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="shrink-0"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function ChevronRightSmall() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="shrink-0"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  )
+}
+
+const navLinkClass = 'flex items-center px-2 py-1.5 w-28 bg-background/95 backdrop-blur rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors no-underline'
+
+export function MobilePageNav({ prev, next }: MobilePageNavProps) {
+  if (!prev && !next) return null
+
+  return (
+    <div className="fixed bottom-6 left-18 right-4 z-[10000] sm:hidden flex items-center justify-end gap-2">
+      {prev && (
+        <a href={prev.href} className={navLinkClass} aria-label={`Previous: ${prev.title}`}>
+          <ChevronLeftSmall />
+          <span className="flex-1 text-center text-xs truncate">{prev.title}</span>
+        </a>
+      )}
+      {next && (
+        <a href={next.href} className={navLinkClass} aria-label={`Next: ${next.title}`}>
+          <span className="flex-1 text-center text-xs truncate">{next.title}</span>
+          <ChevronRightSmall />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/site/core/renderer.tsx
+++ b/site/core/renderer.tsx
@@ -110,6 +110,7 @@ import { Header } from '../shared/components/header'
 import { SearchPlaceholder } from '../shared/components/search-placeholder'
 import { ThemeSwitcher } from '@/components/theme-switcher'
 import { MobileMenu } from '@/components/mobile-menu'
+import { MobilePageNav } from '@/components/mobile-page-nav'
 
 export const renderer = jsxRenderer(
   ({ children, title, description, meta, slug, toc, prev, next }) => {
@@ -154,6 +155,7 @@ export const renderer = jsxRenderer(
             />
 
             <MobileMenu />
+            <MobilePageNav prev={prev} next={next} />
             <Sidebar currentSlug={currentSlug} />
 
             <main class="main-content">


### PR DESCRIPTION
## Summary
Added a new mobile-optimized page navigation component that displays previous and next page links in a fixed bottom navigation bar on mobile devices.

## Key Changes
- **New Component**: Created `MobilePageNav` component (`site/core/components/mobile-page-nav.tsx`)
  - Fixed bottom navigation bar that appears only on mobile devices (hidden on sm+ screens)
  - Displays optional previous and next page links with chevron icons
  - Uses inline SVG icons to avoid external icon library dependencies
  - Includes proper accessibility labels for screen readers
  - Styled with Tailwind CSS using backdrop blur and smooth transitions

- **Integration**: Updated `site/core/renderer.tsx` to integrate the new component
  - Imported `MobilePageNav` component
  - Added component to the page layout, passing `prev` and `next` props from the renderer context

## Implementation Details
- The component gracefully handles missing prev/next links by returning null if neither is provided
- Navigation links are styled with truncation to handle long titles on small screens
- Uses semantic HTML with proper `aria-label` attributes for accessibility
- Positioned at `bottom-6 left-18 right-4` with high z-index (10000) to ensure visibility above other content
- Responsive design: only visible on mobile (`sm:hidden`) to avoid duplication with desktop navigation

https://claude.ai/code/session_01Suuj3tnGdtBYgZ18Bxs54s