### PR TITLE
Rewrite Tooltip component to match shadcn/ui v4

### DIFF
--- a/site/ui/components/tooltip-demo.tsx
+++ b/site/ui/components/tooltip-demo.tsx
@@ -14,11 +14,13 @@ import { Button } from '@ui/components/ui/button'
  */
 export function TooltipBasicDemo() {
   return (
-    <Tooltip content="This is a tooltip" id="tooltip-basic">
-      <span className="underline decoration-dotted cursor-help">
-        Hover me
-      </span>
-    </Tooltip>
+    <span>
+      <Tooltip content="This is a tooltip" id="tooltip-basic">
+        <span className="underline decoration-dotted cursor-help">
+          Hover me
+        </span>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -27,9 +29,11 @@ export function TooltipBasicDemo() {
  */
 export function TooltipButtonDemo() {
   return (
-    <Tooltip content="Keyboard accessible tooltip" id="tooltip-button">
-      <Button>Hover or Focus</Button>
-    </Tooltip>
+    <span>
+      <Tooltip content="Keyboard accessible tooltip" id="tooltip-button">
+        <Button>Hover or Focus</Button>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -38,9 +42,11 @@ export function TooltipButtonDemo() {
  */
 export function TooltipTopDemo() {
   return (
-    <Tooltip content="Top placement" placement="top" id="tooltip-top">
-      <Button variant="outline">Top</Button>
-    </Tooltip>
+    <span>
+      <Tooltip content="Top placement" placement="top" id="tooltip-top">
+        <Button variant="outline">Top</Button>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -49,9 +55,11 @@ export function TooltipTopDemo() {
  */
 export function TooltipRightDemo() {
   return (
-    <Tooltip content="Right placement" placement="right" id="tooltip-right">
-      <Button variant="outline">Right</Button>
-    </Tooltip>
+    <span>
+      <Tooltip content="Right placement" placement="right" id="tooltip-right">
+        <Button variant="outline">Right</Button>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -60,9 +68,11 @@ export function TooltipRightDemo() {
  */
 export function TooltipBottomDemo() {
   return (
-    <Tooltip content="Bottom placement" placement="bottom" id="tooltip-bottom">
-      <Button variant="outline">Bottom</Button>
-    </Tooltip>
+    <span>
+      <Tooltip content="Bottom placement" placement="bottom" id="tooltip-bottom">
+        <Button variant="outline">Bottom</Button>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -71,9 +81,11 @@ export function TooltipBottomDemo() {
  */
 export function TooltipLeftDemo() {
   return (
-    <Tooltip content="Left placement" placement="left" id="tooltip-left">
-      <Button variant="outline">Left</Button>
-    </Tooltip>
+    <span>
+      <Tooltip content="Left placement" placement="left" id="tooltip-left">
+        <Button variant="outline">Left</Button>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -82,11 +94,13 @@ export function TooltipLeftDemo() {
  */
 export function TooltipDelayDemo() {
   return (
-    <Tooltip content="This tooltip has a 700ms delay" delayDuration={700} id="tooltip-delay">
-      <span className="underline decoration-dotted cursor-help">
-        Hover me (700ms delay)
-      </span>
-    </Tooltip>
+    <span>
+      <Tooltip content="This tooltip has a 700ms delay" delayDuration={700} id="tooltip-delay">
+        <span className="underline decoration-dotted cursor-help">
+          Hover me (700ms delay)
+        </span>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -95,10 +109,37 @@ export function TooltipDelayDemo() {
  */
 export function TooltipNoDelayDemo() {
   return (
-    <Tooltip content="This tooltip appears immediately" delayDuration={0} id="tooltip-no-delay">
-      <span className="underline decoration-dotted cursor-help">
-        Hover me (no delay)
-      </span>
-    </Tooltip>
+    <span>
+      <Tooltip content="This tooltip appears immediately" delayDuration={0} id="tooltip-no-delay">
+        <span className="underline decoration-dotted cursor-help">
+          Hover me (no delay)
+        </span>
+      </Tooltip>
+    </span>
+  )
+}
+
+/**
+ * Tooltip on icon buttons (practical UI pattern)
+ */
+export function TooltipIconDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Tooltip content="Bold" id="tooltip-icon-bold">
+        <Button variant="outline" size="icon">
+          <span className="font-bold">B</span>
+        </Button>
+      </Tooltip>
+      <Tooltip content="Italic" id="tooltip-icon-italic">
+        <Button variant="outline" size="icon">
+          <span className="italic">I</span>
+        </Button>
+      </Tooltip>
+      <Tooltip content="Underline" id="tooltip-icon-underline">
+        <Button variant="outline" size="icon">
+          <span className="underline">U</span>
+        </Button>
+      </Tooltip>
+    </div>
   )
 }

--- a/site/ui/e2e/tooltip.spec.ts
+++ b/site/ui/e2e/tooltip.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-// Skip: Focus on Button during issue #126 design phase
-test.describe.skip('Tooltip Documentation Page', () => {
+test.describe('Tooltip Documentation Page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/docs/components/tooltip')
   })
@@ -13,55 +12,45 @@ test.describe.skip('Tooltip Documentation Page', () => {
 
   test('displays installation section', async ({ page }) => {
     await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx barefoot add tooltip')).toBeVisible()
-  })
-
-  test('displays usage section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Usage")')).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Hover trigger")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Focus trigger")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Placement options")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
   })
 
   test.describe('Basic Tooltip', () => {
     test('shows tooltip on hover', async ({ page }) => {
-      const basicDemo = page.locator('[bf-s^="TooltipBasicDemo_"]').first()
-      const trigger = basicDemo.locator('[data-tooltip-trigger]')
-      const tooltip = basicDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipBasicDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
-      // Initially hidden
-      await expect(tooltip).not.toBeVisible()
+      // Initially closed
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
 
       // Hover to show
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('This is a tooltip')
     })
 
     test('hides tooltip on mouse leave', async ({ page }) => {
-      const basicDemo = page.locator('[bf-s^="TooltipBasicDemo_"]').first()
-      const trigger = basicDemo.locator('[data-tooltip-trigger]')
-      const tooltip = basicDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipBasicDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       // Hover to show
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
 
       // Move mouse away to hide
       await page.mouse.move(0, 0)
-      await expect(tooltip).not.toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
     })
 
     test('has correct accessibility attributes', async ({ page }) => {
-      const basicDemo = page.locator('[bf-s^="TooltipBasicDemo_"]').first()
-      const trigger = basicDemo.locator('[data-tooltip-trigger]')
-      const tooltip = basicDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipBasicDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
-      // Check aria-describedby
+      // Check aria-describedby on trigger
       await expect(trigger).toHaveAttribute('aria-describedby', 'tooltip-basic')
 
       // Check tooltip has correct id
@@ -69,75 +58,135 @@ test.describe.skip('Tooltip Documentation Page', () => {
     })
   })
 
-  test.describe('Button with Hover Support', () => {
+  test.describe('Button Focus', () => {
     test('shows tooltip on hover', async ({ page }) => {
-      const buttonDemo = page.locator('[bf-s^="TooltipButtonDemo_"]').first()
-      const trigger = buttonDemo.locator('[data-tooltip-trigger]')
-      const tooltip = buttonDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipButtonDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
-      // Initially hidden
-      await expect(tooltip).not.toBeVisible()
+      // Initially closed
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
 
       // Hover to show
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('Keyboard accessible tooltip')
     })
 
     test('hides tooltip on mouse leave', async ({ page }) => {
-      const buttonDemo = page.locator('[bf-s^="TooltipButtonDemo_"]').first()
-      const trigger = buttonDemo.locator('[data-tooltip-trigger]')
-      const tooltip = buttonDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipButtonDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       // Hover to show
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
 
       // Move mouse away to hide
       await page.mouse.move(0, 0)
-      await expect(tooltip).not.toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('Icon Buttons', () => {
+    test('shows tooltip on icon button hover', async ({ page }) => {
+      const demo = page.locator('[bf-s^="TooltipIconDemo_"]:not([data-slot])').first()
+      const tooltips = demo.locator('[data-slot="tooltip"]')
+      const firstTooltip = demo.locator('[role="tooltip"]').first()
+
+      // Hover first icon button
+      await tooltips.first().hover()
+      await expect(firstTooltip).toHaveAttribute('data-state', 'open')
+      await expect(firstTooltip).toContainText('Bold')
     })
   })
 
   test.describe('Placement Options', () => {
     test('top placement shows tooltip above trigger', async ({ page }) => {
-      const topDemo = page.locator('[bf-s^="TooltipTopDemo_"]').first()
-      const trigger = topDemo.locator('[data-tooltip-trigger]')
-      const tooltip = topDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipTopDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('Top placement')
     })
 
     test('right placement shows tooltip to the right', async ({ page }) => {
-      const rightDemo = page.locator('[bf-s^="TooltipRightDemo_"]').first()
-      const trigger = rightDemo.locator('[data-tooltip-trigger]')
-      const tooltip = rightDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipRightDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('Right placement')
     })
 
     test('bottom placement shows tooltip below trigger', async ({ page }) => {
-      const bottomDemo = page.locator('[bf-s^="TooltipBottomDemo_"]').first()
-      const trigger = bottomDemo.locator('[data-tooltip-trigger]')
-      const tooltip = bottomDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipBottomDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('Bottom placement')
     })
 
     test('left placement shows tooltip to the left', async ({ page }) => {
-      const leftDemo = page.locator('[bf-s^="TooltipLeftDemo_"]').first()
-      const trigger = leftDemo.locator('[data-tooltip-trigger]')
-      const tooltip = leftDemo.locator('[role="tooltip"]')
+      const demo = page.locator('[bf-s^="TooltipLeftDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
 
       await trigger.hover()
-      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
       await expect(tooltip).toContainText('Left placement')
+    })
+  })
+
+  test.describe('Delay', () => {
+    test('does not show tooltip before delay duration', async ({ page }) => {
+      const demo = page.locator('[bf-s^="TooltipDelayDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
+
+      // Initially closed
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
+
+      // Hover and immediately check - should NOT be open yet
+      await trigger.hover()
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
+
+      // Wait for delay + buffer
+      await page.waitForTimeout(800)
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
+    })
+
+    test('cancels open timer on mouse leave before delay', async ({ page }) => {
+      const demo = page.locator('[bf-s^="TooltipDelayDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
+
+      // Hover briefly then leave by hovering on page header
+      await trigger.hover()
+      await page.waitForTimeout(300) // Less than 700ms delay
+      await page.locator('h1').hover()
+
+      // Wait past original delay - should still not appear
+      await page.waitForTimeout(600)
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('immediate tooltip shows without delay when delayDuration is 0', async ({ page }) => {
+      const demo = page.locator('[bf-s^="TooltipNoDelayDemo_"]:not([data-slot])').first()
+      const trigger = demo.locator('[data-slot="tooltip"]')
+      const tooltip = demo.locator('[role="tooltip"]')
+
+      // Initially closed
+      await expect(tooltip).toHaveAttribute('data-state', 'closed')
+
+      // Hover and immediately check - should be open
+      await trigger.hover()
+      await expect(tooltip).toHaveAttribute('data-state', 'open')
     })
   })
 
@@ -146,79 +195,33 @@ test.describe.skip('Tooltip Documentation Page', () => {
       await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
     })
 
-    test('displays TooltipTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("TooltipTrigger")')).toBeVisible()
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
     })
 
-    test('displays TooltipContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("TooltipContent")')).toBeVisible()
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^content$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^placement$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^delayDuration$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^closeDelay$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^id$/ })).toBeVisible()
     })
   })
 })
 
-// Skip: Focus on Button during issue #126 design phase
-test.describe.skip('Tooltip with Delay', () => {
-  test.beforeEach(async ({ page }) => {
+test.describe('Navigation - Tooltip Link', () => {
+  test('displays Tooltip link in sidebar navigation', async ({ page }) => {
     await page.goto('/docs/components/tooltip')
+    await expect(page.locator('nav a[href="/docs/components/tooltip"]').last()).toBeVisible()
   })
 
-  test('does not show tooltip before delay duration', async ({ page }) => {
-    const delayDemo = page.locator('[bf-s^="TooltipDelayDemo_"]').first()
-    const trigger = delayDemo.locator('[data-tooltip-trigger]')
-    const tooltip = delayDemo.locator('[role="tooltip"]')
-
-    // Initially hidden
-    await expect(tooltip).not.toBeVisible()
-
-    // Hover and immediately check - should NOT be visible yet
-    await trigger.hover()
-    await expect(tooltip).not.toBeVisible()
-
-    // Wait for delay + buffer
-    await page.waitForTimeout(800)
-    await expect(tooltip).toBeVisible()
-  })
-
-  test('cancels open timer on mouse leave before delay', async ({ page }) => {
-    const delayDemo = page.locator('[bf-s^="TooltipDelayDemo_"]').first()
-    const trigger = delayDemo.locator('[data-tooltip-trigger]')
-    const tooltip = delayDemo.locator('[role="tooltip"]')
-
-    // Hover briefly then leave
-    await trigger.hover()
-    await page.waitForTimeout(300) // Less than 700ms delay
-    await page.mouse.move(0, 0)
-
-    // Wait past original delay - should still not appear
-    await page.waitForTimeout(500)
-    await expect(tooltip).not.toBeVisible()
-  })
-
-  test('immediate tooltip shows without delay when delayDuration is 0', async ({ page }) => {
-    const noDelayDemo = page.locator('[bf-s^="TooltipNoDelayDemo_"]').first()
-    const trigger = noDelayDemo.locator('[data-tooltip-trigger]')
-    const tooltip = noDelayDemo.locator('[role="tooltip"]')
-
-    // Initially hidden
-    await expect(tooltip).not.toBeVisible()
-
-    // Hover and immediately check - should be visible
-    await trigger.hover()
-    await expect(tooltip).toBeVisible()
-  })
-})
-
-// Skip: Focus on Button during issue #126 design phase
-test.describe.skip('Home Page - Tooltip Link', () => {
-  test('displays Tooltip component link', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('a[href="/docs/components/tooltip"]')).toBeVisible()
-    await expect(page.locator('a[href="/docs/components/tooltip"] h2')).toContainText('Tooltip')
-  })
-
-  test('navigates to Tooltip page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.click('a[href="/docs/components/tooltip"]')
+  test('navigates to Tooltip page from sidebar', async ({ page }) => {
+    await page.goto('/docs/components/switch')
+    await page.locator('nav a[href="/docs/components/tooltip"]').last().click()
     await expect(page).toHaveURL('/docs/components/tooltip')
     await expect(page.locator('h1')).toContainText('Tooltip')
   })

--- a/site/ui/pages/tooltip.tsx
+++ b/site/ui/pages/tooltip.tsx
@@ -11,6 +11,7 @@ import {
   TooltipLeftDemo,
   TooltipDelayDemo,
   TooltipNoDelayDemo,
+  TooltipIconDemo,
 } from '@/components/tooltip-demo'
 import {
   DocPage,
@@ -28,191 +29,142 @@ import { getNavLinks } from '../components/shared/PageNavigation'
 // Table of contents items
 const tocItems: TocItem[] = [
   { id: 'installation', title: 'Installation' },
-  { id: 'features', title: 'Features' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'button-focus', title: 'Button Focus', branch: 'child' },
+  { id: 'icon-buttons', title: 'Icon Buttons', branch: 'child' },
   { id: 'placement', title: 'Placement', branch: 'child' },
   { id: 'delay', title: 'Delay', branch: 'end' },
-  { id: 'accessibility', title: 'Accessibility' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
 // Code examples
-const basicCode = `"use client"
+const previewCode = `import { Tooltip } from "@/components/ui/tooltip"
 
-import { createSignal } from '@barefootjs/dom'
-import { TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+<Tooltip content="This is a tooltip">
+  <span className="underline decoration-dotted cursor-help">
+    Hover me
+  </span>
+</Tooltip>`
 
-function TooltipBasic() {
-  const [open, setOpen] = createSignal(false)
+const basicCode = `import { Tooltip } from "@/components/ui/tooltip"
 
+export function TooltipBasicDemo() {
   return (
-    <div className="relative inline-block">
-      <TooltipTrigger
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        ariaDescribedby="tooltip-basic"
-      >
-        <span className="underline decoration-dotted cursor-help">
-          Hover me
-        </span>
-      </TooltipTrigger>
-      <TooltipContent open={open()} id="tooltip-basic">
-        This is a tooltip
-      </TooltipContent>
-    </div>
+    <Tooltip content="This is a tooltip" id="tooltip-basic">
+      <span className="underline decoration-dotted cursor-help">
+        Hover me
+      </span>
+    </Tooltip>
   )
 }`
 
-const buttonCode = `"use client"
+const buttonCode = `import { Tooltip } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
 
-import { createSignal } from '@barefootjs/dom'
-import { Button } from '@/components/ui/button'
-import { TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-
-function TooltipButton() {
-  const [open, setOpen] = createSignal(false)
-
+export function TooltipButtonDemo() {
   return (
-    <div className="relative inline-block">
-      <TooltipTrigger
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        ariaDescribedby="tooltip-button"
-      >
-        <Button variant="outline">
-          Hover or Focus
+    <Tooltip content="Keyboard accessible tooltip" id="tooltip-button">
+      <Button>Hover or Focus</Button>
+    </Tooltip>
+  )
+}`
+
+const iconCode = `import { Tooltip } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+
+export function TooltipIconDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Tooltip content="Bold" id="tooltip-icon-bold">
+        <Button variant="outline" size="icon">
+          <span className="font-bold">B</span>
         </Button>
-      </TooltipTrigger>
-      <TooltipContent open={open()} id="tooltip-button">
-        Keyboard accessible tooltip
-      </TooltipContent>
+      </Tooltip>
+      <Tooltip content="Italic" id="tooltip-icon-italic">
+        <Button variant="outline" size="icon">
+          <span className="italic">I</span>
+        </Button>
+      </Tooltip>
+      <Tooltip content="Underline" id="tooltip-icon-underline">
+        <Button variant="outline" size="icon">
+          <span className="underline">U</span>
+        </Button>
+      </Tooltip>
     </div>
   )
 }`
 
-const placementCode = `"use client"
+const placementCode = `import { Tooltip } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
 
-import { createSignal } from '@barefootjs/dom'
-import { TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-
-function TooltipPlacement() {
-  const [open, setOpen] = createSignal(false)
-
+export function TooltipPlacementDemo() {
   return (
-    <div className="relative inline-block">
-      <TooltipTrigger
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-      >
-        <span>Hover me</span>
-      </TooltipTrigger>
-      {/* Top placement (default) */}
-      <TooltipContent open={open()}>Top</TooltipContent>
-      {/* Right placement */}
-      <TooltipContent placement="right" open={open()}>Right</TooltipContent>
-      {/* Bottom placement */}
-      <TooltipContent placement="bottom" open={open()}>Bottom</TooltipContent>
-      {/* Left placement */}
-      <TooltipContent placement="left" open={open()}>Left</TooltipContent>
+    <div className="flex flex-wrap gap-4">
+      <Tooltip content="Top placement" placement="top">
+        <Button variant="outline">Top</Button>
+      </Tooltip>
+      <Tooltip content="Right placement" placement="right">
+        <Button variant="outline">Right</Button>
+      </Tooltip>
+      <Tooltip content="Bottom placement" placement="bottom">
+        <Button variant="outline">Bottom</Button>
+      </Tooltip>
+      <Tooltip content="Left placement" placement="left">
+        <Button variant="outline">Left</Button>
+      </Tooltip>
     </div>
   )
 }`
 
-const delayCode = `"use client"
+const delayCode = `import { Tooltip } from "@/components/ui/tooltip"
 
-import { createSignal } from '@barefootjs/dom'
-import { TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-
-function TooltipDelay() {
-  const [open, setOpen] = createSignal(false)
-
+export function TooltipDelayDemo() {
   return (
-    <div className="relative inline-block">
-      {/* With 700ms delay (default) */}
-      <TooltipTrigger
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        delayDuration={700}
-      >
-        <span>Default delay (700ms)</span>
-      </TooltipTrigger>
-      <TooltipContent open={open()}>Delayed tooltip</TooltipContent>
-
-      {/* No delay (immediate) */}
-      <TooltipTrigger
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        delayDuration={0}
-      >
-        <span>No delay</span>
-      </TooltipTrigger>
-      <TooltipContent open={open()}>Immediate tooltip</TooltipContent>
+    <div className="flex flex-wrap gap-8">
+      <Tooltip content="This tooltip has a 700ms delay" delayDuration={700}>
+        <span className="underline decoration-dotted cursor-help">
+          Hover me (700ms delay)
+        </span>
+      </Tooltip>
+      <Tooltip content="This tooltip appears immediately" delayDuration={0}>
+        <span className="underline decoration-dotted cursor-help">
+          Hover me (no delay)
+        </span>
+      </Tooltip>
     </div>
   )
 }`
 
-// Props definitions
-const tooltipTriggerProps: PropDefinition[] = [
+// Props definition
+const tooltipProps: PropDefinition[] = [
   {
-    name: 'onMouseEnter',
-    type: '() => void',
-    description: 'Event handler called when mouse enters the trigger.',
-  },
-  {
-    name: 'onMouseLeave',
-    type: '() => void',
-    description: 'Event handler called when mouse leaves the trigger.',
-  },
-  {
-    name: 'onFocus',
-    type: '() => void',
-    description: 'Event handler called when the trigger receives focus.',
-  },
-  {
-    name: 'onBlur',
-    type: '() => void',
-    description: 'Event handler called when the trigger loses focus.',
-  },
-  {
-    name: 'ariaDescribedby',
+    name: 'content',
     type: 'string',
-    description: 'ID of the tooltip element for accessibility.',
+    description: 'The text content displayed in the tooltip.',
+  },
+  {
+    name: 'placement',
+    type: "'top' | 'right' | 'bottom' | 'left'",
+    defaultValue: "'top'",
+    description: 'Position of the tooltip relative to the trigger element.',
   },
   {
     name: 'delayDuration',
     type: 'number',
-    defaultValue: '700',
-    description: 'Delay in ms before showing tooltip on hover.',
+    defaultValue: '0',
+    description: 'Delay in milliseconds before showing the tooltip on hover.',
   },
   {
     name: 'closeDelay',
     type: 'number',
     defaultValue: '0',
-    description: 'Delay in ms before hiding tooltip after mouse leave.',
-  },
-]
-
-const tooltipContentProps: PropDefinition[] = [
-  {
-    name: 'placement',
-    type: "'top' | 'right' | 'bottom' | 'left'",
-    defaultValue: "'top'",
-    description: 'Position of the tooltip relative to the trigger.',
-  },
-  {
-    name: 'open',
-    type: 'boolean',
-    defaultValue: 'false',
-    description: 'Whether the tooltip is visible.',
+    description: 'Delay in milliseconds before hiding the tooltip after mouse leave.',
   },
   {
     name: 'id',
     type: 'string',
-    description: 'ID for aria-describedby reference.',
+    description: 'ID for aria-describedby accessibility linking.',
   },
 ]
 
@@ -229,7 +181,7 @@ export function TooltipPage() {
         />
 
         {/* Preview */}
-        <Example title="" code={`<TooltipContent open={open()}>...</TooltipContent>`}>
+        <Example title="" code={previewCode}>
           <div className="flex gap-4">
             <TooltipBasicDemo />
           </div>
@@ -238,17 +190,6 @@ export function TooltipPage() {
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add tooltip" highlightedCommands={installCommands} />
-        </Section>
-
-        {/* Features */}
-        <Section id="features" title="Features">
-          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li><strong className="text-foreground">Hover trigger</strong> - Shows tooltip on mouse enter, hides on mouse leave</li>
-            <li><strong className="text-foreground">Focus trigger</strong> - Shows tooltip on focus for keyboard accessibility</li>
-            <li><strong className="text-foreground">Placement options</strong> - Top, right, bottom, or left positioning</li>
-            <li><strong className="text-foreground">Arrow indicator</strong> - Visual arrow pointing to the trigger</li>
-            <li><strong className="text-foreground">Accessibility</strong> - role="tooltip", aria-describedby for screen readers</li>
-          </ul>
         </Section>
 
         {/* Examples */}
@@ -260,6 +201,10 @@ export function TooltipPage() {
 
             <Example title="Button Focus" code={buttonCode}>
               <TooltipButtonDemo />
+            </Example>
+
+            <Example title="Icon Buttons" code={iconCode}>
+              <TooltipIconDemo />
             </Example>
 
             <Example title="Placement" code={placementCode}>
@@ -280,32 +225,9 @@ export function TooltipPage() {
           </div>
         </Section>
 
-        {/* Accessibility */}
-        <Section id="accessibility" title="Accessibility">
-          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li><strong className="text-foreground">Keyboard Support</strong> - Tooltip shows on focus for keyboard users</li>
-            <li><strong className="text-foreground">ARIA</strong> - role="tooltip" on content, aria-describedby on trigger links to tooltip</li>
-            <li><strong className="text-foreground">Screen Readers</strong> - Tooltip content is announced when trigger receives focus</li>
-            <li><strong className="text-foreground">Delay</strong> - Configurable delay prevents tooltips from appearing during quick mouse movements</li>
-            <li><strong className="text-foreground">Visual Indicator</strong> - Arrow points to the trigger element for clear association</li>
-          </ul>
-        </Section>
-
         {/* API Reference */}
         <Section id="api-reference" title="API Reference">
-          <div className="space-y-6">
-            <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">TooltipTrigger</h3>
-              <PropsTable props={tooltipTriggerProps} />
-            </div>
-            <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">TooltipContent</h3>
-              <p className="text-muted-foreground text-sm mb-4">
-                The tooltip popup. Use the placement prop to control positioning.
-              </p>
-              <PropsTable props={tooltipContentProps} />
-            </div>
-          </div>
+          <PropsTable props={tooltipProps} />
         </Section>
       </div>
     </DocPage>

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -14,6 +14,12 @@
       "type": "registry:ui",
       "title": "Button",
       "description": "A button component with variants and sizes"
+    },
+    {
+      "name": "tooltip",
+      "type": "registry:ui",
+      "title": "Tooltip",
+      "description": "A popup that displays contextual information on hover or focus"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Rewrite Tooltip component CSS to match shadcn/ui v4 (`text-xs`, `whitespace-nowrap`, no `shadow-md`)
- Add fade/scale animation using `transition-[opacity,transform]` pattern (consistent with Dialog/DropdownMenu)
- Fix BF043 violation: props destructuring → `props.xxx` pattern for stateful component
- Store timer IDs on DOM dataset to ensure reliable cross-handler sharing after hydration
- Remove deprecated `TooltipTrigger`/`TooltipContent` exports (~100 lines)
- Rewrite doc page with new API code examples and correct props table
- Add `TooltipIconDemo` (icon button + tooltip practical pattern)
- Rewrite E2E tests: remove `test.describe.skip`, update selectors to `data-slot`/`data-state`
- Register tooltip in `ui/registry.json`

## Test plan

- [x] `site/ui` build succeeds
- [x] All 20 tooltip E2E tests pass
- [x] Full E2E suite (298 tests) passes with no regressions
- [ ] Visual check: hover/focus shows tooltip with animation
- [ ] Visual check: 4 placements (top/right/bottom/left) render correctly
- [ ] Visual check: delay (700ms) and no-delay (0ms) work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)