### PR TITLE
Make dev server port configurable via PORT env var

### DIFF
--- a/site/core/server.tsx
+++ b/site/core/server.tsx
@@ -24,9 +24,11 @@ server.use('/static/*', serveStatic({
 const app = await createApp(content, pages)
 server.route('/', app)
 
+const port = Number(process.env.PORT) || 3001
+
 export default {
-  port: 3001,
+  port,
   fetch: server.fetch,
 }
 
-console.log('Site running at http://localhost:3001')
+console.log(`Site running at http://localhost:${port}`)

--- a/site/ui/playwright.config.ts
+++ b/site/ui/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const port = Number(process.env.PORT) || 3002
+const baseURL = `http://localhost:${port}`
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 15000,
@@ -9,7 +12,7 @@ export default defineConfig({
   workers: undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3002',
+    baseURL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -19,8 +22,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'bun run server.tsx',
-    url: 'http://localhost:3002',
+    command: `bun run server.tsx`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 10000,
   },

--- a/site/ui/server.tsx
+++ b/site/ui/server.tsx
@@ -26,4 +26,6 @@ app.use('/r/*', serveStatic({
   root: './dist',
 }))
 
-export default { port: 3002, fetch: app.fetch }
+const port = Number(process.env.PORT) || 3002
+
+export default { port, fetch: app.fetch }


### PR DESCRIPTION
## Summary

- Allow `site/ui` and `site/core` dev servers to use a custom port via `PORT` environment variable
- Update Playwright config to respect the same `PORT` variable for both `baseURL` and `webServer.url`
- Defaults remain unchanged (`3001` for site/core, `3002` for site/ui)

This enables multiple coding agents to run dev servers and E2E tests concurrently without port conflicts:

```bash
PORT=3003 bun run test:e2e
PORT=3004 bun run test:e2e
```

## Test plan

- [ ] `cd site/ui && bun run test:e2e` passes with default port (3002)
- [ ] `cd site/ui && PORT=3010 bun run test:e2e` passes with custom port
- [ ] `cd site/core && bun run dev` starts on default port (3001)
- [ ] `cd site/core && PORT=3010 bun run dev` starts on custom port

🤖 Generated with [Claude Code](https://claude.com/claude-code)