### PR TITLE
Rebuild Select component with custom dropdown architecture

### DIFF
--- a/site/ui/components/select-demo.tsx
+++ b/site/ui/components/select-demo.tsx
@@ -3,32 +3,42 @@
  * SelectDemo Components
  *
  * Interactive demos for Select component.
- * Used in select documentation page.
+ * Based on shadcn/ui patterns for practical use cases.
  */
 
-import { createSignal } from '@barefootjs/dom'
-import { Select, type SelectOption } from '@ui/components/ui/select'
-
-const fruitOptions: SelectOption[] = [
-  { value: 'apple', label: 'Apple' },
-  { value: 'banana', label: 'Banana' },
-  { value: 'orange', label: 'Orange' },
-  { value: 'grape', label: 'Grape' },
-]
+import { createSignal, createMemo } from '@barefootjs/dom'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectGroup,
+  SelectLabel,
+  SelectSeparator,
+} from '@ui/components/ui/select'
 
 /**
- * Value binding example
+ * Basic select example
+ * Fruit selector with placeholder, disabled item, and value display
  */
-export function SelectBindingDemo() {
+export function SelectBasicDemo() {
   const [value, setValue] = createSignal('')
+
   return (
-    <div className="space-y-2">
-      <Select
-        options={fruitOptions}
-        selectValue={value()}
-        selectPlaceholder="Select a fruit..."
-        onChange={(e) => setValue(e.target.value)}
-      />
+    <div className="space-y-3">
+      <Select value={value()} onValueChange={setValue}>
+        <SelectTrigger class="w-[280px]">
+          <SelectValue placeholder="Select a fruit..." />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="blueberry" disabled>Blueberry</SelectItem>
+          <SelectItem value="grape">Grape</SelectItem>
+          <SelectItem value="pineapple">Pineapple</SelectItem>
+        </SelectContent>
+      </Select>
       <p className="text-sm text-muted-foreground">
         Selected: <span className="selected-value font-medium">{value() || 'None'}</span>
       </p>
@@ -37,20 +47,115 @@ export function SelectBindingDemo() {
 }
 
 /**
- * Focus/blur state example
+ * Form example with multiple selects
+ * Developer profile form with framework, role, and experience selects
  */
-export function SelectFocusDemo() {
-  const [focused, setFocused] = createSignal(false)
+export function SelectFormDemo() {
+  const [framework, setFramework] = createSignal('')
+  const [role, setRole] = createSignal('')
+  const [experience, setExperience] = createSignal('')
+
+  const summary = createMemo(() => {
+    const parts: string[] = []
+    if (role()) parts.push(role())
+    if (framework()) parts.push(`using ${framework()}`)
+    if (experience()) parts.push(`with ${experience()} experience`)
+    return parts.length > 0 ? parts.join(' ') : 'No selections yet'
+  })
+
   return (
-    <div className="space-y-2">
-      <Select
-        options={fruitOptions}
-        selectPlaceholder="Focus me..."
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-      />
-      <p className="text-sm">
-        Status: <span className="focus-status font-medium">{focused() ? 'Focused' : 'Not focused'}</span>
+    <div className="space-y-4 max-w-sm">
+      <h4 className="text-sm font-medium leading-none">Developer Profile</h4>
+      <div className="grid gap-3">
+        <div className="space-y-1">
+          <span className="text-sm text-muted-foreground">Framework</span>
+          <Select value={framework()} onValueChange={setFramework}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select framework..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Next.js">Next.js</SelectItem>
+              <SelectItem value="Remix">Remix</SelectItem>
+              <SelectItem value="Astro">Astro</SelectItem>
+              <SelectItem value="Nuxt">Nuxt</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <span className="text-sm text-muted-foreground">Role</span>
+          <Select value={role()} onValueChange={setRole}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select role..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Frontend Developer">Frontend Developer</SelectItem>
+              <SelectItem value="Backend Developer">Backend Developer</SelectItem>
+              <SelectItem value="Full Stack Developer">Full Stack Developer</SelectItem>
+              <SelectItem value="Designer">Designer</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <span className="text-sm text-muted-foreground">Experience</span>
+          <Select value={experience()} onValueChange={setExperience}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select experience..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="0-1 years">0-1 years</SelectItem>
+              <SelectItem value="1-3 years">1-3 years</SelectItem>
+              <SelectItem value="3-5 years">3-5 years</SelectItem>
+              <SelectItem value="5+ years">5+ years</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Summary: <span className="summary-text font-medium">{summary()}</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Grouped select example
+ * Timezone selector with grouped options and separators
+ */
+export function SelectGroupedDemo() {
+  const [timezone, setTimezone] = createSignal('')
+
+  return (
+    <div className="space-y-3">
+      <Select value={timezone()} onValueChange={setTimezone}>
+        <SelectTrigger class="w-[280px]">
+          <SelectValue placeholder="Select timezone..." />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>North America</SelectLabel>
+            <SelectItem value="est">Eastern Standard Time (EST)</SelectItem>
+            <SelectItem value="cst">Central Standard Time (CST)</SelectItem>
+            <SelectItem value="mst">Mountain Standard Time (MST)</SelectItem>
+            <SelectItem value="pst">Pacific Standard Time (PST)</SelectItem>
+          </SelectGroup>
+          <SelectSeparator />
+          <SelectGroup>
+            <SelectLabel>Europe</SelectLabel>
+            <SelectItem value="gmt">Greenwich Mean Time (GMT)</SelectItem>
+            <SelectItem value="cet">Central European Time (CET)</SelectItem>
+            <SelectItem value="eet">Eastern European Time (EET)</SelectItem>
+          </SelectGroup>
+          <SelectSeparator />
+          <SelectGroup>
+            <SelectLabel>Asia</SelectLabel>
+            <SelectItem value="ist">India Standard Time (IST)</SelectItem>
+            <SelectItem value="cst_china">China Standard Time (CST)</SelectItem>
+            <SelectItem value="jst">Japan Standard Time (JST)</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <p className="text-sm text-muted-foreground">
+        Selected: <span className="selected-timezone font-medium">{timezone() || 'None'}</span>
       </p>
     </div>
   )

--- a/site/ui/pages/select.tsx
+++ b/site/ui/pages/select.tsx
@@ -2,8 +2,7 @@
  * Select Documentation Page
  */
 
-import { Select } from '@/components/ui/select'
-import { SelectBindingDemo, SelectFocusDemo } from '@/components/select-demo'
+import { SelectBasicDemo, SelectFormDemo, SelectGroupedDemo } from '@/components/select-demo'
 import {
   DocPage,
   PageHeader,
@@ -22,161 +21,182 @@ const tocItems: TocItem[] = [
   { id: 'installation', title: 'Installation' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
-  { id: 'disabled', title: 'Disabled', branch: 'child' },
-  { id: 'value-binding', title: 'Value Binding', branch: 'child' },
-  { id: 'focus-state', title: 'Focus State', branch: 'end' },
+  { id: 'form', title: 'Form', branch: 'child' },
+  { id: 'grouped', title: 'Grouped', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Options for examples
-const basicOptions = [
-  { value: 'option-a', label: 'Option A' },
-  { value: 'option-b', label: 'Option B' },
-  { value: 'option-c', label: 'Option C' },
-]
-
-const disabledOptionsExample = [
-  { value: 'available', label: 'Available' },
-  { value: 'unavailable', label: 'Unavailable (disabled)', disabled: true },
-  { value: 'coming-soon', label: 'Coming Soon' },
-]
-
 // Code examples
-const basicCode = `"use client"
-
-import { Select } from '@/components/ui/select'
-
-const options = [
-  { value: 'option-a', label: 'Option A' },
-  { value: 'option-b', label: 'Option B' },
-  { value: 'option-c', label: 'Option C' },
-]
-
-function SelectBasic() {
-  return (
-    <Select options={options} placeholder="Select an option..." />
-  )
-}`
-
-const disabledCode = `"use client"
-
-import { Select } from '@/components/ui/select'
-
-const options = [
-  { value: 'available', label: 'Available' },
-  { value: 'unavailable', label: 'Unavailable', disabled: true },
-  { value: 'coming-soon', label: 'Coming Soon' },
-]
-
-function SelectDisabled() {
-  return (
-    <div className="flex flex-col gap-2 max-w-sm">
-      <Select disabled options={options} placeholder="Disabled select" />
-      <Select options={options} placeholder="With disabled option" />
-    </div>
-  )
-}`
-
-const bindingCode = `"use client"
+const previewCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
-import { Select } from '@/components/ui/select'
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '@/components/ui/select'
 
-const options = [
-  { value: 'apple', label: 'Apple' },
-  { value: 'banana', label: 'Banana' },
-  { value: 'cherry', label: 'Cherry' },
-]
-
-function SelectBinding() {
+function SelectBasicDemo() {
   const [value, setValue] = createSignal('')
 
   return (
-    <div className="max-w-sm space-y-2">
-      <Select
-        options={options}
-        value={value()}
-        placeholder="Select a fruit..."
-        onChange={(e) => setValue(e.target.value)}
-      />
-      <p className="text-sm text-muted-foreground">
-        Selected: {value() || 'none'}
-      </p>
-    </div>
+    <Select value={value()} onValueChange={setValue}>
+      <SelectTrigger class="w-[280px]">
+        <SelectValue placeholder="Select a fruit..." />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="blueberry" disabled>Blueberry</SelectItem>
+        <SelectItem value="grape">Grape</SelectItem>
+        <SelectItem value="pineapple">Pineapple</SelectItem>
+      </SelectContent>
+    </Select>
   )
 }`
 
-const focusCode = `"use client"
+const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
-import { Select } from '@/components/ui/select'
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '@/components/ui/select'
 
-const options = [
-  { value: 'option-a', label: 'Option A' },
-  { value: 'option-b', label: 'Option B' },
-]
-
-function SelectFocus() {
-  const [focused, setFocused] = createSignal(false)
+function SelectBasicDemo() {
+  const [value, setValue] = createSignal('')
 
   return (
-    <div className="max-w-sm space-y-2">
-      <Select
-        options={options}
-        placeholder="Focus me..."
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-      />
+    <div className="space-y-3">
+      <Select value={value()} onValueChange={setValue}>
+        <SelectTrigger class="w-[280px]">
+          <SelectValue placeholder="Select a fruit..." />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="blueberry" disabled>Blueberry</SelectItem>
+          <SelectItem value="grape">Grape</SelectItem>
+          <SelectItem value="pineapple">Pineapple</SelectItem>
+        </SelectContent>
+      </Select>
       <p className="text-sm text-muted-foreground">
-        {focused() ? 'Select is focused' : 'Select is not focused'}
+        Selected: {value() || 'None'}
       </p>
     </div>
   )
 }`
 
-// Props definition
+const formCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '@/components/ui/select'
+
+function SelectFormDemo() {
+  const [framework, setFramework] = createSignal('')
+  const [role, setRole] = createSignal('')
+  const [experience, setExperience] = createSignal('')
+
+  const summary = createMemo(() => {
+    const parts: string[] = []
+    if (role()) parts.push(role())
+    if (framework()) parts.push(\`using \${framework()}\`)
+    if (experience()) parts.push(\`with \${experience()} experience\`)
+    return parts.length > 0 ? parts.join(' ') : 'No selections yet'
+  })
+
+  return (
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium">Developer Profile</h4>
+      <div className="grid gap-3">
+        <Select value={framework()} onValueChange={setFramework}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select framework..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Next.js">Next.js</SelectItem>
+            <SelectItem value="Remix">Remix</SelectItem>
+            <SelectItem value="Astro">Astro</SelectItem>
+            <SelectItem value="Nuxt">Nuxt</SelectItem>
+          </SelectContent>
+        </Select>
+        {/* ... more selects ... */}
+      </div>
+      <p>Summary: {summary()}</p>
+    </div>
+  )
+}`
+
+const groupedCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Select, SelectTrigger, SelectValue, SelectContent,
+  SelectItem, SelectGroup, SelectLabel, SelectSeparator,
+} from '@/components/ui/select'
+
+function SelectGroupedDemo() {
+  const [timezone, setTimezone] = createSignal('')
+
+  return (
+    <Select value={timezone()} onValueChange={setTimezone}>
+      <SelectTrigger class="w-[280px]">
+        <SelectValue placeholder="Select timezone..." />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>North America</SelectLabel>
+          <SelectItem value="est">Eastern Standard Time (EST)</SelectItem>
+          <SelectItem value="cst">Central Standard Time (CST)</SelectItem>
+          <SelectItem value="pst">Pacific Standard Time (PST)</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Europe</SelectLabel>
+          <SelectItem value="gmt">Greenwich Mean Time (GMT)</SelectItem>
+          <SelectItem value="cet">Central European Time (CET)</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Asia</SelectLabel>
+          <SelectItem value="jst">Japan Standard Time (JST)</SelectItem>
+          <SelectItem value="cst_china">China Standard Time (CST)</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  )
+}`
+
+// Props definitions
 const selectProps: PropDefinition[] = [
-  {
-    name: 'options',
-    type: 'SelectOption[]',
-    description: 'Array of options to display. Each option has value, label, and optional disabled.',
-  },
   {
     name: 'value',
     type: 'string',
-    description: 'The controlled value of the select.',
+    description: 'Controlled value of the select.',
   },
   {
-    name: 'placeholder',
-    type: 'string',
-    description: 'Placeholder text shown when no option is selected.',
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when the selected value changes.',
   },
   {
     name: 'disabled',
     type: 'boolean',
     defaultValue: 'false',
-    description: 'Whether the select is disabled.',
+    description: 'Whether the entire select is disabled.',
+  },
+]
+
+const selectItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this option (required).',
   },
   {
-    name: 'error',
+    name: 'disabled',
     type: 'boolean',
     defaultValue: 'false',
-    description: 'Whether the select is in an error state.',
-  },
-  {
-    name: 'onChange',
-    type: '(e: Event) => void',
-    description: 'Event handler called when selection changes.',
-  },
-  {
-    name: 'onFocus',
-    type: '(e: Event) => void',
-    description: 'Event handler called when select gains focus.',
-  },
-  {
-    name: 'onBlur',
-    type: '(e: Event) => void',
-    description: 'Event handler called when select loses focus.',
+    description: 'Whether this option is disabled.',
   },
 ]
 
@@ -188,13 +208,13 @@ export function SelectPage() {
       <div className="space-y-12">
         <PageHeader
           title="Select"
-          description="Displays a select dropdown for choosing from a list of options."
+          description="Displays a list of options for the user to pick from, triggered by a button."
           {...getNavLinks('select')}
         />
 
         {/* Preview */}
-        <Example title="" code={`<Select options={options} placeholder="Select an option..." />`}>
-          <Select options={basicOptions} placeholder="Select an option..." />
+        <Example title="" code={previewCode}>
+          <SelectBasicDemo />
         </Example>
 
         {/* Installation */}
@@ -206,35 +226,25 @@ export function SelectPage() {
         <Section id="examples" title="Examples">
           <div className="space-y-8">
             <Example title="Basic" code={basicCode}>
-              <div className="max-w-sm">
-                <Select options={basicOptions} placeholder="Select an option..." />
-              </div>
+              <SelectBasicDemo />
             </Example>
 
-            <Example title="Disabled" code={disabledCode}>
-              <div className="flex flex-col gap-2 max-w-sm">
-                <Select disabled options={basicOptions} placeholder="Disabled select" />
-                <Select options={disabledOptionsExample} placeholder="With disabled option" />
-              </div>
+            <Example title="Form" code={formCode}>
+              <SelectFormDemo />
             </Example>
 
-            <Example title="Value Binding" code={bindingCode}>
-              <div className="max-w-sm">
-                <SelectBindingDemo />
-              </div>
-            </Example>
-
-            <Example title="Focus State" code={focusCode}>
-              <div className="max-w-sm">
-                <SelectFocusDemo />
-              </div>
+            <Example title="Grouped" code={groupedCode}>
+              <SelectGroupedDemo />
             </Example>
           </div>
         </Section>
 
         {/* API Reference */}
         <Section id="api-reference" title="API Reference">
+          <h3 className="text-base font-semibold mb-2">Select</h3>
           <PropsTable props={selectProps} />
+          <h3 className="text-base font-semibold mt-6 mb-2">SelectItem</h3>
+          <PropsTable props={selectItemProps} />
         </Section>
       </div>
     </DocPage>

--- a/ui/components/ui/select.tsx
+++ b/ui/components/ui/select.tsx
@@ -1,142 +1,559 @@
 "use client"
 
 /**
- * Select Component
+ * Select Components
  *
- * A native select element with consistent styling.
- * Inspired by shadcn/ui with CSS variable theming support.
+ * A custom select dropdown with multiple sub-components.
+ * Inspired by shadcn/ui Select with CSS variable theming support.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Root Select manages open/value state, children consume via context.
+ *
+ * Features:
+ * - ESC key to close
+ * - Arrow key navigation
+ * - Type-ahead search
+ * - Accessibility (role="combobox", role="listbox", role="option")
+ * - Controlled/uncontrolled value
+ * - Portal for Content (escape overflow clipping)
+ * - data-state attribute-driven styling
  *
  * @example Basic usage
  * ```tsx
- * <Select
- *   options={[
- *     { value: 'apple', label: 'Apple' },
- *     { value: 'banana', label: 'Banana' },
- *   ]}
- *   value={fruit}
- *   onChange={(e) => setFruit(e.target.value)}
- * />
- * ```
+ * const [value, setValue] = createSignal('')
  *
- * @example With placeholder
- * ```tsx
- * <Select
- *   options={options}
- *   placeholder="Select a fruit..."
- * />
- * ```
- *
- * @example With error state
- * ```tsx
- * <Select options={options} error describedBy="error-message" />
+ * <Select value={value()} onValueChange={setValue}>
+ *   <SelectTrigger>
+ *     <SelectValue placeholder="Select a fruit..." />
+ *   </SelectTrigger>
+ *   <SelectContent>
+ *     <SelectItem value="apple">Apple</SelectItem>
+ *     <SelectItem value="banana">Banana</SelectItem>
+ *   </SelectContent>
+ * </Select>
  * ```
  */
 
-import type { SelectHTMLAttributes } from '@barefootjs/jsx'
+import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { Child } from '../../types'
 
-/**
- * Option type for Select component.
- */
-interface SelectOption {
-  /** The value submitted when this option is selected */
-  value: string
-  /** Display text for the option */
-  label: string
-  /** Whether this option is disabled */
-  disabled?: boolean
+// Context for parent-child state sharing
+interface SelectContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+  value: () => string
+  onValueChange: (value: string) => void
+  disabled: () => boolean
 }
 
-// Base classes for native select
-const baseClasses = 'flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm text-foreground shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30'
+const SelectContext = createContext<SelectContextValue>()
 
-// Error state classes
-const errorClasses = 'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+// Store Content -> Trigger element mapping for positioning after portal
+const contentTriggerMap = new WeakMap<HTMLElement, HTMLElement>()
 
-// Default border classes
-const defaultBorderClasses = 'border-input'
+// SelectTrigger classes (matches shadcn/ui select trigger)
+const selectTriggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
+const selectTriggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
+const selectTriggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+const selectTriggerDataStateClasses = 'data-[placeholder]:text-muted-foreground'
+
+// SelectContent classes
+const selectContentBaseClasses = 'fixed z-50 max-h-[min(var(--radix-select-content-available-height,384px),384px)] min-w-[8rem] overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md transform-gpu origin-top transition-[opacity,transform] duration-normal ease-out'
+const selectContentOpenClasses = 'opacity-100 scale-100'
+const selectContentClosedClasses = 'opacity-0 scale-95 pointer-events-none'
+
+// SelectItem classes
+const selectItemBaseClasses = 'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden'
+const selectItemDefaultClasses = 'text-popover-foreground hover:bg-accent/50 focus:bg-accent focus:text-accent-foreground'
+const selectItemDisabledClasses = 'pointer-events-none opacity-50'
+
+// Indicator container classes (CheckIcon)
+const selectIndicatorClasses = 'absolute left-2 flex size-3.5 shrink-0 items-center justify-center'
+
+// SelectLabel classes
+const selectLabelClasses = 'px-2 py-1.5 text-sm font-semibold text-foreground'
+
+// SelectSeparator classes
+const selectSeparatorClasses = '-mx-1 my-1 h-px bg-border'
 
 /**
- * Props for the Select component.
+ * Props for Select component.
  */
-interface SelectProps extends Pick<SelectHTMLAttributes, 'onChange' | 'onFocus' | 'onBlur' | 'class'> {
-  /**
-   * Array of options to display.
-   */
-  options: SelectOption[]
-  /**
-   * Current selected value.
-   * @default ''
-   */
+interface SelectProps {
+  /** Controlled value */
   value?: string
-  /**
-   * Placeholder text shown when no option is selected.
-   */
-  placeholder?: string
-  /**
-   * Whether the select is disabled.
-   * @default false
-   */
+  /** Callback when value changes */
+  onValueChange?: (value: string) => void
+  /** Whether the select is open (controlled) */
+  open?: boolean
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void
+  /** Whether the entire select is disabled */
   disabled?: boolean
-  /**
-   * Whether the select is in an error state.
-   * @default false
-   */
-  error?: boolean
-  /**
-   * ID of the element that describes this select (for accessibility).
-   */
-  describedBy?: string
+  /** SelectTrigger and SelectContent */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
 }
 
 /**
- * Native select component with error state support.
- *
- * @param props.options - Array of options to display
- * @param props.value - Current selected value
- * @param props.placeholder - Placeholder text
- * @param props.disabled - Whether disabled
- * @param props.error - Whether in error state
- * @param props.describedBy - ID of describing element for accessibility
+ * Select root component.
+ * Provides value/open state to children via context.
+ * Open state is managed internally. Value comes from props (parent manages it).
+ * Follows the same pattern as DropdownMenu.
  */
-function Select({
-  class: className = '',
-  options,
-  value = '',
-  placeholder,
-  disabled = false,
-  error = false,
-  describedBy,
-  onChange,
-  onFocus,
-  onBlur,
-}: SelectProps) {
-  const classes = `${baseClasses} ${errorClasses} ${defaultBorderClasses} ${className}`
+function Select(props: SelectProps) {
+  // Open state is always internal (like DropdownMenu)
+  const [open, setOpen] = createSignal(false)
 
   return (
-    <select
-      data-slot="select"
-      className={classes}
-      value={value}
-      disabled={disabled}
-      aria-invalid={error || undefined}
-      {...(describedBy ? { 'aria-describedby': describedBy } : {})}
-      onChange={onChange}
-      onFocus={onFocus}
-      onBlur={onBlur}
-    >
-      {placeholder && (
-        <option value="" disabled>
-          {placeholder}
-        </option>
-      )}
-      {options.map((option) => (
-        <option key={option.value} value={option.value} {...(option.disabled && { disabled: true })}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+    <SelectContext.Provider value={{
+      open,
+      onOpenChange: (v) => { setOpen(v); props.onOpenChange?.(v) },
+      value: () => props.value ?? '',
+      onValueChange: props.onValueChange ?? (() => {}),
+      disabled: () => props.disabled ?? false,
+    }}>
+      <div data-slot="select" className={`relative inline-block ${props.class ?? ''}`}>
+        {props.children}
+      </div>
+    </SelectContext.Provider>
   )
 }
 
-export { Select }
-export type { SelectOption, SelectProps }
+/**
+ * Props for SelectTrigger component.
+ */
+interface SelectTriggerProps {
+  /** Additional CSS classes */
+  class?: string
+  /** Trigger content (typically SelectValue) */
+  children?: Child
+}
+
+/**
+ * Button that toggles the select dropdown.
+ * Shows a chevron icon and reads state from context.
+ */
+function SelectTrigger(props: SelectTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(SelectContext)
+
+    createEffect(() => {
+      el.setAttribute('aria-expanded', String(ctx.open()))
+      el.dataset.state = ctx.open() ? 'open' : 'closed'
+    })
+
+    el.addEventListener('click', () => {
+      if (ctx.disabled()) return
+      ctx.onOpenChange(!ctx.open())
+    })
+
+    // Allow keyboard open/close
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (ctx.disabled()) return
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (!ctx.open()) {
+          ctx.onOpenChange(true)
+        }
+      }
+    })
+  }
+
+  const classes = `${selectTriggerBaseClasses} ${selectTriggerFocusClasses} ${selectTriggerDisabledClasses} ${selectTriggerDataStateClasses} ${props.class ?? ''}`
+
+  return (
+    <button
+      data-slot="select-trigger"
+      type="button"
+      role="combobox"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-autocomplete="none"
+      data-state="closed"
+      className={classes}
+      ref={handleMount}
+    >
+      {props.children}
+      <svg className="size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+  )
+}
+
+/**
+ * Props for SelectValue component.
+ */
+interface SelectValueProps {
+  /** Placeholder text when no value is selected */
+  placeholder?: string
+}
+
+/**
+ * Displays the selected value label or placeholder.
+ * Resolves the display text by querying portaled content DOM.
+ */
+function SelectValue(props: SelectValueProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(SelectContext)
+
+    createEffect(() => {
+      const val = ctx.value()
+      if (val) {
+        // Query the portaled content for the matching item's label
+        const itemEl = document.querySelector(`[data-slot="select-item"][data-value="${val}"]`) as HTMLElement
+        const label = itemEl?.textContent ?? val
+        el.textContent = label
+        // Remove placeholder attribute when value is selected
+        const trigger = el.closest('[data-slot="select-trigger"]')
+        trigger?.removeAttribute('data-placeholder')
+      } else {
+        el.textContent = props.placeholder ?? ''
+        // Set placeholder attribute for styling
+        const trigger = el.closest('[data-slot="select-trigger"]')
+        if (props.placeholder) {
+          trigger?.setAttribute('data-placeholder', '')
+        }
+      }
+    })
+  }
+
+  return (
+    <span data-slot="select-value" className="pointer-events-none truncate" ref={handleMount}>
+      {props.placeholder ?? ''}
+    </span>
+  )
+}
+
+/**
+ * Props for SelectContent component.
+ */
+interface SelectContentProps {
+  /** SelectItem, SelectGroup, SelectLabel, SelectSeparator components */
+  children?: Child
+  /** Alignment relative to trigger */
+  align?: 'start' | 'end'
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Content container for select items.
+ * Portaled to body. Reads open state from context.
+ */
+function SelectContent(props: SelectContentProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Get trigger ref before portal
+    const triggerEl = el.parentElement?.querySelector('[data-slot="select-trigger"]') as HTMLElement
+    if (triggerEl) contentTriggerMap.set(el, triggerEl)
+
+    // Portal to body to escape overflow clipping
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(SelectContext)
+
+    // Position content relative to trigger
+    const updatePosition = () => {
+      if (!triggerEl) return
+      const rect = triggerEl.getBoundingClientRect()
+      el.style.top = `${rect.bottom + 4}px`
+      // At least as wide as trigger, but can expand for longer items
+      el.style.minWidth = `${rect.width}px`
+      if (props.align === 'end') {
+        el.style.left = `${rect.right - el.offsetWidth}px`
+      } else {
+        el.style.left = `${rect.left}px`
+      }
+    }
+
+    // Type-ahead search state
+    let typeAheadQuery = ''
+    let typeAheadTimer: ReturnType<typeof setTimeout> | null = null
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + positioning + global listeners
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${selectContentBaseClasses} ${isOpen ? selectContentOpenClasses : selectContentClosedClasses} ${props.class ?? ''}`
+
+      if (isOpen) {
+        updatePosition()
+
+        // Focus the currently selected item or first item
+        setTimeout(() => {
+          const selectedItem = el.querySelector(`[data-slot="select-item"][data-state="checked"]`) as HTMLElement
+          const firstItem = el.querySelector('[data-slot="select-item"]:not([aria-disabled="true"])') as HTMLElement
+          ;(selectedItem ?? firstItem)?.focus()
+        }, 0)
+
+        // Close on click outside
+        const handleClickOutside = (e: MouseEvent) => {
+          if (!el.contains(e.target as Node) && !triggerEl?.contains(e.target as Node)) {
+            ctx.onOpenChange(false)
+          }
+        }
+
+        // Close on ESC
+        const handleGlobalKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            triggerEl?.focus()
+          }
+        }
+
+        // Reposition on scroll and resize
+        const handleScroll = () => updatePosition()
+
+        // Lock body scroll while open
+        const originalOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('keydown', handleGlobalKeyDown)
+        window.addEventListener('scroll', handleScroll, true)
+        window.addEventListener('resize', handleScroll)
+
+        cleanupFns.push(
+          () => { document.body.style.overflow = originalOverflow },
+          () => document.removeEventListener('mousedown', handleClickOutside),
+          () => document.removeEventListener('keydown', handleGlobalKeyDown),
+          () => window.removeEventListener('scroll', handleScroll, true),
+          () => window.removeEventListener('resize', handleScroll),
+        )
+      }
+    })
+
+    // Keyboard navigation within content
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      const items = el.querySelectorAll('[data-slot="select-item"]:not([aria-disabled="true"])')
+      const currentIndex = Array.from(items).findIndex(item => item === document.activeElement)
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          if (items.length > 0) {
+            const nextIndex = currentIndex < items.length - 1 ? currentIndex + 1 : 0
+            ;(items[nextIndex] as HTMLElement).focus()
+          }
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          if (items.length > 0) {
+            const prevIndex = currentIndex > 0 ? currentIndex - 1 : items.length - 1
+            ;(items[prevIndex] as HTMLElement).focus()
+          }
+          break
+        case 'Enter':
+        case ' ':
+          e.preventDefault()
+          if (document.activeElement && (document.activeElement as HTMLElement).dataset.slot === 'select-item') {
+            ;(document.activeElement as HTMLElement).click()
+          }
+          break
+        case 'Home':
+          e.preventDefault()
+          if (items.length > 0) {
+            ;(items[0] as HTMLElement).focus()
+          }
+          break
+        case 'End':
+          e.preventDefault()
+          if (items.length > 0) {
+            ;(items[items.length - 1] as HTMLElement).focus()
+          }
+          break
+        default:
+          // Type-ahead search
+          if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+            e.preventDefault()
+            typeAheadQuery += e.key.toLowerCase()
+            if (typeAheadTimer) clearTimeout(typeAheadTimer)
+            typeAheadTimer = setTimeout(() => { typeAheadQuery = '' }, 500)
+
+            const match = Array.from(items).find(item => {
+              const text = (item as HTMLElement).textContent?.toLowerCase() ?? ''
+              return text.startsWith(typeAheadQuery)
+            }) as HTMLElement
+            match?.focus()
+          }
+          break
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="select-content"
+      data-state="closed"
+      role="listbox"
+      tabindex={-1}
+      className={`${selectContentBaseClasses} ${selectContentClosedClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for SelectItem component.
+ */
+interface SelectItemProps {
+  /** The value for this item */
+  value: string
+  /** Whether this item is disabled */
+  disabled?: boolean
+  /** Item content (label text) */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Individual selectable option.
+ * Shows a check indicator when selected.
+ * Auto-closes the dropdown on select.
+ */
+function SelectItem(props: SelectItemProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(SelectContext)
+
+    createEffect(() => {
+      const isSelected = ctx.value() === props.value
+      el.setAttribute('aria-selected', String(isSelected))
+      el.dataset.state = isSelected ? 'checked' : 'unchecked'
+
+      // Update check indicator visibility
+      const indicator = el.querySelector('[data-slot="select-item-indicator"]') as HTMLElement
+      if (indicator) {
+        indicator.style.display = isSelected ? '' : 'none'
+      }
+    })
+
+    el.addEventListener('click', () => {
+      if (el.getAttribute('aria-disabled') === 'true') return
+      ctx.onValueChange(props.value)
+      ctx.onOpenChange(false)
+
+      // Focus return to trigger
+      const content = el.closest('[data-slot="select-content"]') as HTMLElement
+      const trigger = content ? contentTriggerMap.get(content) : null
+      setTimeout(() => trigger?.focus(), 0)
+    })
+  }
+
+  const isDisabled = props.disabled ?? false
+  const stateClasses = isDisabled ? selectItemDisabledClasses : selectItemDefaultClasses
+
+  return (
+    <div
+      data-slot="select-item"
+      data-value={props.value}
+      data-state="unchecked"
+      role="option"
+      aria-selected="false"
+      aria-disabled={isDisabled || undefined}
+      tabindex={isDisabled ? -1 : 0}
+      className={`${selectItemBaseClasses} ${stateClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      <span data-slot="select-item-indicator" className={selectIndicatorClasses} style="display:none">
+        <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+      </span>
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for SelectGroup component.
+ */
+interface SelectGroupProps {
+  /** Grouped items */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Semantic grouping of related select items.
+ */
+function SelectGroup(props: SelectGroupProps) {
+  return (
+    <div data-slot="select-group" role="group" className={props.class ?? ''}>
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for SelectLabel component.
+ */
+interface SelectLabelProps {
+  /** Label text */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Section label inside the select dropdown.
+ */
+function SelectLabel(props: SelectLabelProps) {
+  return (
+    <div data-slot="select-label" className={`${selectLabelClasses} ${props.class ?? ''}`}>
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for SelectSeparator component.
+ */
+interface SelectSeparatorProps {
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Visual separator between select item groups.
+ */
+function SelectSeparator(props: SelectSeparatorProps) {
+  return (
+    <div data-slot="select-separator" role="separator" className={`${selectSeparatorClasses} ${props.class ?? ''}`} />
+  )
+}
+
+export {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectGroup,
+  SelectLabel,
+  SelectSeparator,
+}
+
+export type {
+  SelectProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectContentProps,
+  SelectItemProps,
+  SelectGroupProps,
+  SelectLabelProps,
+  SelectSeparatorProps,
+}


### PR DESCRIPTION
## Summary

- Replace native `<select>` wrapper with full custom dropdown implementation using 8 sub-components (`Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, `SelectItem`, `SelectGroup`, `SelectLabel`, `SelectSeparator`)
- Context-based state management following DropdownMenu architecture pattern (portal rendering, WeakMap for trigger references, keyboard navigation, type-ahead search)
- 3 quality demos: Basic (fruit selector), Form (developer profile with 3 selects and summary), Grouped (timezone selector with groups/separators)
- Full E2E test coverage: 22 tests passing (placeholder, open/close, item selection, disabled items, ESC/click-outside close, ARIA roles, keyboard navigation, check indicator, form interaction, grouped selection)

## Test plan

- [x] All 22 Select E2E tests pass
- [x] All 300 existing tests pass (0 regressions)
- [ ] Manual verification of dropdown positioning and styling
- [ ] Manual verification of keyboard navigation (ArrowUp/Down, Enter, Escape, type-ahead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)