### PR TITLE
Fix mobile page navigation layout alignment

### DIFF
--- a/site/core/components/mobile-page-nav.tsx
+++ b/site/core/components/mobile-page-nav.tsx
@@ -59,7 +59,7 @@ export function MobilePageNav({ prev, next }: MobilePageNavProps) {
   if (!prev && !next) return null
 
   return (
-    <div className="fixed bottom-6 left-18 right-4 z-[10000] sm:hidden flex items-center justify-end gap-2">
+    <div className="fixed bottom-6 left-18 right-4 z-[10000] sm:hidden flex items-center gap-2">
       {prev && (
         <a href={prev.href} className={navLinkClass} aria-label={`Previous: ${prev.title}`}>
           <ChevronLeftSmall />
@@ -67,7 +67,7 @@ export function MobilePageNav({ prev, next }: MobilePageNavProps) {
         </a>
       )}
       {next && (
-        <a href={next.href} className={navLinkClass} aria-label={`Next: ${next.title}`}>
+        <a href={next.href} className={`${navLinkClass} ml-auto`} aria-label={`Next: ${next.title}`}>
           <span className="flex-1 text-center text-xs truncate">{next.title}</span>
           <ChevronRightSmall />
         </a>


### PR DESCRIPTION
## Summary
Adjusted the mobile page navigation component to properly align previous and next navigation links when both are present.

## Key Changes
- Removed `justify-end` from the container's flex layout to allow natural flex distribution
- Added `ml-auto` margin utility to the next link to push it to the right side of the container

## Implementation Details
This change ensures that when both previous and next navigation links are displayed on mobile, the previous link appears on the left and the next link appears on the right with proper spacing between them. The previous approach of using `justify-end` on the container would have pushed both links to the right side. By using `ml-auto` on the next link instead, we achieve the intended layout where the links are distributed across the available space.

https://claude.ai/code/session_013XErBQNySEyjhGBUmaDpu8