### PR TITLE
Add Label component with docs and E2E tests

### DIFF
--- a/site/ui/components/label-demo.tsx
+++ b/site/ui/components/label-demo.tsx
@@ -1,0 +1,29 @@
+import { Label } from '@ui/components/ui/label'
+
+const inputClasses = 'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
+export function LabelFormDemo() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <div className="grid w-full items-center gap-1.5">
+        <Label for="label-name">Name</Label>
+        <input id="label-name" type="text" placeholder="Enter your name" className={inputClasses} />
+      </div>
+      <div className="grid w-full items-center gap-1.5">
+        <Label for="label-email">Email</Label>
+        <input id="label-email" type="email" placeholder="Enter your email" className={inputClasses} />
+      </div>
+    </div>
+  )
+}
+
+export function LabelDisabledDemo() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <div className="group grid w-full items-center gap-1.5" data-disabled="true">
+        <Label for="label-disabled">Disabled field</Label>
+        <input id="label-disabled" type="text" disabled placeholder="Cannot edit" className={inputClasses} />
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -15,6 +15,7 @@ export const componentOrder = [
   { slug: 'dialog', title: 'Dialog' },
   { slug: 'dropdown-menu', title: 'Dropdown Menu' },
   { slug: 'input', title: 'Input' },
+  { slug: 'label', title: 'Label' },
   { slug: 'portal', title: 'Portal' },
   { slug: 'select', title: 'Select' },
   { slug: 'switch', title: 'Switch' },

--- a/site/ui/e2e/label.spec.ts
+++ b/site/ui/e2e/label.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Label Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/label')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Label')
+    await expect(page.locator('text=Renders an accessible label associated with controls')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Preview', () => {
+    test('displays label with data-slot', async ({ page }) => {
+      const label = page.locator('label[data-slot="label"]').first()
+      await expect(label).toBeVisible()
+      await expect(label).toContainText('Your email address')
+    })
+  })
+
+  test.describe('Form Example', () => {
+    test('displays form example heading', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Form")')).toBeVisible()
+    })
+
+    test('has labels with for attribute', async ({ page }) => {
+      const nameLabel = page.locator('label[data-slot="label"][for="label-name"]')
+      await expect(nameLabel).toBeVisible()
+      await expect(nameLabel).toContainText('Name')
+
+      const emailLabel = page.locator('label[data-slot="label"][for="label-email"]')
+      await expect(emailLabel).toBeVisible()
+      await expect(emailLabel).toContainText('Email')
+    })
+
+    test('labels are associated with inputs via for/id', async ({ page }) => {
+      const nameInput = page.locator('input#label-name')
+      await expect(nameInput).toBeVisible()
+
+      const emailInput = page.locator('input#label-email')
+      await expect(emailInput).toBeVisible()
+    })
+  })
+
+  test.describe('Disabled Example', () => {
+    test('displays disabled example heading', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Disabled")')).toBeVisible()
+    })
+
+    test('shows disabled input', async ({ page }) => {
+      const input = page.locator('input#label-disabled')
+      await expect(input).toBeDisabled()
+    })
+
+    test('label has disabled styling via group', async ({ page }) => {
+      const label = page.locator('label[data-slot="label"][for="label-disabled"]')
+      await expect(label).toBeVisible()
+      await expect(label).toContainText('Disabled field')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^for$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^className$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^children$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/label.tsx
+++ b/site/ui/pages/label.tsx
@@ -1,0 +1,118 @@
+import { Label } from '@/components/ui/label'
+import { LabelFormDemo, LabelDisabledDemo } from '@/components/label-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'form', title: 'Form', branch: 'start' },
+  { id: 'disabled', title: 'Disabled', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const previewCode = `import { Label } from '@/components/ui/label'
+
+function LabelPreview() {
+  return <Label for="email">Your email address</Label>
+}`
+
+const formCode = `import { Label } from '@/components/ui/label'
+
+function LabelForm() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <div className="grid w-full items-center gap-1.5">
+        <Label for="name">Name</Label>
+        <input id="name" type="text" placeholder="Enter your name" />
+      </div>
+      <div className="grid w-full items-center gap-1.5">
+        <Label for="email">Email</Label>
+        <input id="email" type="email" placeholder="Enter your email" />
+      </div>
+    </div>
+  )
+}`
+
+const disabledCode = `import { Label } from '@/components/ui/label'
+
+function LabelDisabled() {
+  return (
+    <div className="group" data-disabled="true">
+      <Label for="disabled-input">Disabled field</Label>
+      <input id="disabled-input" type="text" disabled placeholder="Cannot edit" />
+    </div>
+  )
+}`
+
+const labelProps: PropDefinition[] = [
+  {
+    name: 'for',
+    type: 'string',
+    description: 'The ID of the form element this label is associated with.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Label content.',
+  },
+]
+
+export function LabelPage() {
+  const installCommands = getHighlightedCommands('barefoot add label')
+
+  return (
+    <DocPage slug="label" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Label"
+          description="Renders an accessible label associated with controls."
+          {...getNavLinks('label')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <Label for="email-preview">Your email address</Label>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add label" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Form" code={formCode}>
+              <LabelFormDemo />
+            </Example>
+
+            <Example title="Disabled" code={disabledCode}>
+              <LabelDisabledDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={labelProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -79,6 +79,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Dialog', href: '/docs/components/dialog' },
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
       { title: 'Input', href: '/docs/components/input' },
+      { title: 'Label', href: '/docs/components/label' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Tabs', href: '/docs/components/tabs' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -14,6 +14,7 @@ import { ButtonPage } from './pages/button'
 import { CardPage } from './pages/card'
 import { CheckboxPage } from './pages/checkbox'
 import { InputPage } from './pages/input'
+import { LabelPage } from './pages/label'
 import { SwitchPage } from './pages/switch'
 import { AccordionPage } from './pages/accordion'
 import { TabsPage } from './pages/tabs'
@@ -189,6 +190,11 @@ export function createApp() {
   // Input documentation
   app.get('/docs/components/input', (c) => {
     return c.render(<InputPage />)
+  })
+
+  // Label documentation
+  app.get('/docs/components/label', (c) => {
+    return c.render(<LabelPage />)
   })
 
   // Switch documentation

--- a/ui/components/ui/label.tsx
+++ b/ui/components/ui/label.tsx
@@ -1,64 +1,23 @@
-"use client"
-
-/**
- * Label Component
- *
- * A styled label component for form inputs.
- * Inspired by shadcn/ui with CSS variable theming support.
- *
- * @example Basic usage
- * ```tsx
- * <Label htmlFor="email">Email</Label>
- * <Input id="email" type="email" />
- * ```
- *
- * @example With required indicator
- * ```tsx
- * <Label htmlFor="name">
- *   Name <span className="text-destructive">*</span>
- * </Label>
- * ```
- */
-
+import type { LabelHTMLAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../types'
 
-// Label classes (aligned with shadcn/ui)
 const labelClasses = 'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50'
 
-/**
- * Props for the Label component.
- */
-interface LabelProps {
-  /**
-   * Additional CSS class names.
-   */
+interface LabelProps extends LabelHTMLAttributes {
   className?: string
-  /**
-   * The ID of the form element this label is for.
-   */
-  htmlFor?: string
-  /**
-   * Label content.
-   */
   children?: Child
 }
 
-/**
- * Label component for form inputs.
- *
- * @param props.htmlFor - ID of the associated form element
- * @param props.children - Label content
- */
 function Label({
   className = '',
-  htmlFor,
   children,
+  ...props
 }: LabelProps) {
   return (
     <label
       data-slot="label"
-      for={htmlFor}
       className={`${labelClasses} ${className}`}
+      {...props}
     >
       {children}
     </label>


### PR DESCRIPTION
## Summary

- Update `ui/components/ui/label.tsx` to extend `LabelHTMLAttributes` with spread props and remove `"use client"` (stateless component)
- Add documentation page at `/docs/components/label` with preview, form example, disabled example, and API reference
- Add navigation entry between Input and Portal (alphabetical order)
- Add 12 E2E tests covering page header, installation, form association (`for`/`id`), disabled state, and API reference

## Test plan

- [x] `bun run build` succeeds in `site/ui/`
- [x] Dev server responds 200 at `/docs/components/label`
- [x] All 12 E2E tests pass (`bunx playwright test e2e/label.spec.ts`)
- [ ] Verify navigation links (prev: Input, next: Portal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)