### PR TITLE
Add Textarea component

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -59,7 +59,10 @@ export function emitPropsExtraction(
       const prop = ctx.propsParams.find((p) => p.name === propName)
       const defaultVal = prop?.defaultValue
       if (defaultVal) {
-        lines.push(`  const ${propName} = props.${propName} ?? ${defaultVal}`)
+        // Wrap arrow function defaults in parentheses to avoid operator precedence issues
+        // e.g., `props.onInput ?? () => {}` is a syntax error; must be `props.onInput ?? (() => {})`
+        const wrappedDefault = defaultVal.includes('=>') ? `(${defaultVal})` : defaultVal
+        lines.push(`  const ${propName} = props.${propName} ?? ${wrappedDefault}`)
       } else if (propsUsedAsLoopArrays.has(propName)) {
         lines.push(`  const ${propName} = props.${propName} ?? []`)
       } else if (propsWithPropertyAccess.has(propName) && !propsUsedAsConditions.has(propName)) {

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -19,6 +19,7 @@ export const componentOrder = [
   { slug: 'select', title: 'Select' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'tabs', title: 'Tabs' },
+  { slug: 'textarea', title: 'Textarea' },
   { slug: 'toast', title: 'Toast' },
   { slug: 'tooltip', title: 'Tooltip' },
 ]

--- a/site/ui/components/textarea-demo.tsx
+++ b/site/ui/components/textarea-demo.tsx
@@ -1,0 +1,29 @@
+"use client"
+/**
+ * TextareaDemo Components
+ *
+ * Interactive demos for Textarea component.
+ * Used in textarea documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Textarea } from '@ui/components/ui/textarea'
+
+/**
+ * Value binding example with character count
+ */
+export function TextareaBindingDemo() {
+  const [value, setValue] = createSignal('')
+  return (
+    <div className="space-y-2">
+      <Textarea
+        textareaValue={value()}
+        onInput={(e) => setValue(e.target.value)}
+        textareaPlaceholder="Type your message here."
+      />
+      <p className="text-sm text-muted-foreground">
+        <span className="char-count font-medium">{value().length}</span> characters
+      </p>
+    </div>
+  )
+}

--- a/site/ui/e2e/textarea.spec.ts
+++ b/site/ui/e2e/textarea.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Textarea Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/textarea')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Textarea')
+    await expect(page.locator('text=Displays a multi-line text input field.')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Textarea Rendering', () => {
+    test('displays textarea elements', async ({ page }) => {
+      const textareas = page.locator('textarea[data-slot="textarea"]')
+      await expect(textareas.first()).toBeVisible()
+    })
+
+    test('has multiple textarea examples', async ({ page }) => {
+      const textareas = page.locator('textarea[data-slot="textarea"]')
+      // Should have textareas on the page (preview + examples)
+      expect(await textareas.count()).toBeGreaterThanOrEqual(4)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+    })
+
+    test('has placeholder text', async ({ page }) => {
+      const textareas = page.locator('textarea[data-slot="textarea"]')
+      await expect(textareas.first()).toHaveAttribute('placeholder', 'Type your message here.')
+    })
+  })
+
+  test.describe('Disabled', () => {
+    test('displays disabled example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Disabled")')).toBeVisible()
+    })
+
+    test('has disabled textarea', async ({ page }) => {
+      const disabledTextarea = page.locator('textarea[data-slot="textarea"][disabled]')
+      await expect(disabledTextarea.first()).toBeVisible()
+    })
+  })
+
+  test.describe('Value Binding', () => {
+    test('displays value binding example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Value Binding")')).toBeVisible()
+    })
+
+    test('updates character count on input', async ({ page }) => {
+      const section = page.locator('[bf-s^="TextareaBindingDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const textarea = section.locator('textarea[data-slot="textarea"]')
+      const charCount = section.locator('.char-count')
+
+      // Initially 0 characters
+      await expect(charCount).toContainText('0')
+
+      // Click to focus and type using keyboard
+      await textarea.click()
+      await page.keyboard.type('Hello')
+      await expect(charCount).toContainText('5')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^placeholder$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^rows$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^onInput$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/textarea.tsx
+++ b/site/ui/pages/textarea.tsx
@@ -1,0 +1,190 @@
+/**
+ * Textarea Documentation Page
+ */
+
+import { Textarea } from '@/components/ui/textarea'
+import { TextareaBindingDemo } from '@/components/textarea-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'disabled', title: 'Disabled', branch: 'child' },
+  { id: 'value-binding', title: 'Value Binding', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { Textarea } from '@/components/ui/textarea'
+
+function TextareaBasic() {
+  return (
+    <div className="max-w-sm">
+      <Textarea placeholder="Type your message here." />
+    </div>
+  )
+}`
+
+const disabledCode = `"use client"
+
+import { Textarea } from '@/components/ui/textarea'
+
+function TextareaDisabled() {
+  return (
+    <div className="flex flex-col gap-2 max-w-sm">
+      <Textarea disabled placeholder="Disabled textarea" />
+      <Textarea readOnly value="Read-only content" />
+    </div>
+  )
+}`
+
+const bindingCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import { Textarea } from '@/components/ui/textarea'
+
+function TextareaBinding() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <div className="max-w-sm space-y-2">
+      <Textarea
+        value={value()}
+        onInput={(e) => setValue(e.target.value)}
+        placeholder="Type your message here."
+      />
+      <p className="text-sm text-muted-foreground">
+        {value().length} characters
+      </p>
+    </div>
+  )
+}`
+
+// Props definition
+const textareaProps: PropDefinition[] = [
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text shown when textarea is empty.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled value of the textarea.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the textarea is disabled.',
+  },
+  {
+    name: 'readOnly',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the textarea is read-only.',
+  },
+  {
+    name: 'error',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the textarea is in an error state.',
+  },
+  {
+    name: 'rows',
+    type: 'number',
+    description: 'Number of visible text rows.',
+  },
+  {
+    name: 'onInput',
+    type: '(e: Event) => void',
+    description: 'Event handler called on each input change.',
+  },
+  {
+    name: 'onChange',
+    type: '(e: Event) => void',
+    description: 'Event handler called when textarea value changes and loses focus.',
+  },
+  {
+    name: 'onBlur',
+    type: '(e: Event) => void',
+    description: 'Event handler called when textarea loses focus.',
+  },
+  {
+    name: 'onFocus',
+    type: '(e: Event) => void',
+    description: 'Event handler called when textarea gains focus.',
+  },
+]
+
+export function TextareaPage() {
+  const installCommands = getHighlightedCommands('barefoot add textarea')
+
+  return (
+    <DocPage slug="textarea" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Textarea"
+          description="Displays a multi-line text input field."
+          {...getNavLinks('textarea')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<Textarea placeholder="Type your message here." />`}>
+          <div className="max-w-sm">
+            <Textarea placeholder="Type your message here." />
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add textarea" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <div className="max-w-sm">
+                <Textarea placeholder="Type your message here." />
+              </div>
+            </Example>
+
+            <Example title="Disabled" code={disabledCode}>
+              <div className="flex flex-col gap-2 max-w-sm">
+                <Textarea disabled placeholder="Disabled textarea" />
+                <Textarea readOnly value="Read-only content" />
+              </div>
+            </Example>
+
+            <Example title="Value Binding" code={bindingCode}>
+              <div className="max-w-sm">
+                <TextareaBindingDemo />
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={textareaProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -22,6 +22,7 @@ import { DropdownMenuPage } from './pages/dropdown-menu'
 import { ToastPage } from './pages/toast'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
+import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
 
 // Form pattern pages
@@ -229,6 +230,11 @@ export function createApp() {
   // Select documentation
   app.get('/docs/components/select', (c) => {
     return c.render(<SelectPage />)
+  })
+
+  // Textarea documentation
+  app.get('/docs/components/textarea', (c) => {
+    return c.render(<TextareaPage />)
   })
 
   // Portal documentation

--- a/ui/components/ui/textarea.tsx
+++ b/ui/components/ui/textarea.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+/**
+ * Textarea Component
+ *
+ * A styled multi-line text input component with error state support.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Textarea placeholder="Type your message here." />
+ * ```
+ *
+ * @example With value binding
+ * ```tsx
+ * <Textarea value={message} onInput={(e) => setMessage(e.target.value)} />
+ * ```
+ *
+ * @example With error state
+ * ```tsx
+ * <Textarea error describedBy="error-message" />
+ * ```
+ */
+
+import type { TextareaHTMLAttributes } from '@barefootjs/jsx'
+
+// Base classes (aligned with shadcn/ui)
+const baseClasses = 'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
+// Focus state classes
+const focusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+
+// Error state classes
+const errorClasses = 'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+
+/**
+ * Props for the Textarea component.
+ */
+interface TextareaProps extends Pick<TextareaHTMLAttributes, 'onInput' | 'onChange' | 'onBlur' | 'onFocus'> {
+  /**
+   * Additional CSS class names.
+   */
+  className?: string
+  /**
+   * Placeholder text shown when textarea is empty.
+   * @default ''
+   */
+  placeholder?: string
+  /**
+   * Current value of the textarea.
+   * @default ''
+   */
+  value?: string
+  /**
+   * Whether the textarea is disabled.
+   * @default false
+   */
+  disabled?: boolean
+  /**
+   * Whether the textarea is read-only.
+   * @default false
+   */
+  readOnly?: boolean
+  /**
+   * Whether the textarea is in an error state.
+   * @default false
+   */
+  error?: boolean
+  /**
+   * ID of the element that describes this textarea (for accessibility).
+   */
+  describedBy?: string
+  /**
+   * Number of visible text rows.
+   */
+  rows?: number
+}
+
+/**
+ * Textarea component with error state support.
+ *
+ * @param props.placeholder - Placeholder text
+ * @param props.value - Current value
+ * @param props.disabled - Whether disabled
+ * @param props.readOnly - Whether read-only
+ * @param props.error - Whether in error state
+ * @param props.describedBy - ID of describing element for accessibility
+ * @param props.rows - Number of visible text rows
+ */
+function Textarea({
+  className = '',
+  placeholder = '',
+  value = '',
+  disabled = false,
+  readOnly = false,
+  error = false,
+  describedBy,
+  rows,
+  onInput = () => {},
+  onChange = () => {},
+  onBlur = () => {},
+  onFocus = () => {},
+}: TextareaProps) {
+  const classes = `${baseClasses} ${focusClasses} ${errorClasses} ${className}`
+
+  return (
+    <textarea
+      data-slot="textarea"
+      className={classes}
+      placeholder={placeholder}
+      value={value}
+      disabled={disabled}
+      readonly={readOnly}
+      rows={rows}
+      aria-invalid={error || undefined}
+      {...(describedBy ? { 'aria-describedby': describedBy } : {})}
+      onInput={onInput}
+      onChange={onChange}
+      onBlur={onBlur}
+      onFocus={onFocus}
+    />
+  )
+}
+
+export { Textarea }
+export type { TextareaProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -16,6 +16,12 @@
       "description": "A button component with variants and sizes"
     },
     {
+      "name": "textarea",
+      "type": "registry:ui",
+      "title": "Textarea",
+      "description": "A multi-line text input field with error state support"
+    },
+    {
       "name": "tooltip",
       "type": "registry:ui",
       "title": "Tooltip",


### PR DESCRIPTION
## Summary

- Port shadcn/ui Textarea as a stateless multi-line input component following the existing Input pattern
- Fix compiler bug: arrow function defaults in prop destructuring generated invalid JS (`props.x ?? () => {}` → `props.x ?? (() => {})`)
- Add documentation page with Basic, Disabled, and Value Binding examples
- Add 13 E2E tests covering rendering, interaction, and API reference

## Test plan

- [x] Compiler unit tests pass (343 tests)
- [x] Textarea E2E tests pass (13 tests): `PORT=3003 bunx playwright test e2e/textarea.spec.ts`
- [ ] Verify page at `/docs/components/textarea` renders correctly
- [ ] Verify prev/next navigation links work (Tabs ← Textarea → Toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)