### PR TITLE
Add Textarea to sidebar navigation

### DIFF
--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -83,6 +83,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Tabs', href: '/docs/components/tabs' },
+      { title: 'Textarea', href: '/docs/components/textarea' },
       { title: 'Toast', href: '/docs/components/toast' },
       { title: 'Tooltip', href: '/docs/components/tooltip' },
     ],


### PR DESCRIPTION
## Summary
- Add Textarea link to the Components section of the site/ui sidebar menu (alphabetical order, between Tabs and Toast)

## Test plan
- [ ] Navigate to the UI docs site and verify Textarea appears in the sidebar
- [ ] Click the Textarea link and confirm it navigates to `/docs/components/textarea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)