### PR TITLE
Fix compiler generating invalid JS for hyphenated prop names

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode, IRElement, IREvent } from '../types'
 import type { ClientJsContext, LoopChildEvent } from './types'
-import { attrValueToString } from './utils'
+import { attrValueToString, quotePropName } from './utils'
 import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectLoopChildEvents } from './reactivity'
 import { irToHtmlTemplate } from './html-template'
 import { expandDynamicPropValue } from './prop-handling'
@@ -168,10 +168,10 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           prop.name.length > 2 &&
           prop.name[2] === prop.name[2].toUpperCase()
         if (isEventHandler) {
-          propsForInit.push(`${prop.name}: ${prop.value}`)
+          propsForInit.push(`${quotePropName(prop.name)}: ${prop.value}`)
         } else if (prop.dynamic) {
           const expandedValue = expandDynamicPropValue(prop.value, ctx)
-          propsForInit.push(`get ${prop.name}() { return ${expandedValue} }`)
+          propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
 
           const hasPropsRef = expandedValue.includes('props.')
           const hasReactiveExpr = isReactiveExpression(expandedValue, ctx)
@@ -186,9 +186,9 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
             })
           }
         } else if (prop.isLiteral) {
-          propsForInit.push(`${prop.name}: ${JSON.stringify(prop.value)}`)
+          propsForInit.push(`${quotePropName(prop.name)}: ${JSON.stringify(prop.value)}`)
         } else {
-          propsForInit.push(`${prop.name}: ${prop.value}`)
+          propsForInit.push(`${quotePropName(prop.name)}: ${prop.value}`)
         }
       }
       const propsExpr =

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -6,7 +6,7 @@
 import type { ComponentIR, ConstantInfo, SignalInfo } from '../types'
 import { isBooleanAttr } from '../html-constants'
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef } from './types'
-import { stripTypeScriptSyntax, inferDefaultValue, toHtmlAttrName, toDomEventProp, wrapHandlerInBlock, buildChainedArrayExpr } from './utils'
+import { stripTypeScriptSyntax, inferDefaultValue, toHtmlAttrName, toDomEventProp, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName } from './utils'
 import { addCondAttrToTemplate, canGenerateStaticTemplate, irToComponentTemplate } from './html-template'
 
 /**
@@ -385,11 +385,11 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
         for (const comp of elem.nestedComponents) {
           const propsEntries = comp.props.map((p) => {
             if (p.isEventHandler) {
-              return `${p.name}: ${p.value}`
+              return `${quotePropName(p.name)}: ${p.value}`
             } else if (p.isLiteral) {
-              return `${p.name}: ${JSON.stringify(p.value)}`
+              return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
             } else {
-              return `get ${p.name}() { return ${p.value} }`
+              return `get ${quotePropName(p.name)}() { return ${p.value} }`
             }
           })
           const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
@@ -421,11 +421,11 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
       const { name, props } = elem.childComponent
       const propsEntries = props.map((p) => {
         if (p.isEventHandler) {
-          return `${p.name}: ${p.value}`
+          return `${quotePropName(p.name)}: ${p.value}`
         } else if (p.isLiteral) {
-          return `get ${p.name}() { return ${JSON.stringify(p.value)} }`
+          return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
         } else {
-          return `get ${p.name}() { return ${p.value} }`
+          return `get ${quotePropName(p.name)}() { return ${p.value} }`
         }
       })
       const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -66,6 +66,18 @@ export function toDomEventProp(eventName: string): string {
 }
 
 /**
+ * Quote a prop name if it is not a valid JS identifier.
+ * Returns the name as-is for valid identifiers (e.g., "checked"),
+ * or JSON-quoted for names with hyphens etc. (e.g., '"aria-label"').
+ */
+export function quotePropName(name: string): string {
+  if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+    return name
+  }
+  return JSON.stringify(name)
+}
+
+/**
  * Convert JSX attribute name to HTML attribute name.
  * Handles React-style naming conventions (e.g., className → class).
  */


### PR DESCRIPTION
## Summary

- Add `quotePropName()` utility that quotes JS object property names containing hyphens (e.g., `aria-label`, `data-testid`) so they produce valid JS like `{ "aria-label": "Toggle bold" }` instead of the SyntaxError-causing `{ aria-label: "Toggle bold" }`
- Apply quoting in `collect-elements.ts` (4 sites: event handler, dynamic getter, literal prop, non-literal prop) and `emit-init-sections.ts` (6 sites: static array nested components + dynamic loop `createComponent`)
- Add 3 compiler tests verifying hyphenated props are quoted and camelCase props remain unquoted

Closes #346

## Test plan

- [x] All 163 unit tests pass (`bun test`)
- [x] E2E tests: 343 passed, 15 failed (all pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)