### PR TITLE
Add Slider component ported from shadcn/ui

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -18,6 +18,7 @@ export const componentOrder = [
   { slug: 'label', title: 'Label' },
   { slug: 'portal', title: 'Portal' },
   { slug: 'select', title: 'Select' },
+  { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'tabs', title: 'Tabs' },
   { slug: 'toast', title: 'Toast' },

--- a/site/ui/components/slider-demo.tsx
+++ b/site/ui/components/slider-demo.tsx
@@ -1,0 +1,166 @@
+"use client"
+/**
+ * SliderDemo Components
+ *
+ * Interactive demos for Slider component.
+ * Based on shadcn/ui patterns for practical use cases.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Slider } from '@ui/components/ui/slider'
+
+/**
+ * Volume control example (Preview)
+ * Controlled slider with live value display
+ */
+export function SliderPreviewDemo() {
+  const [volume, setVolume] = createSignal(50)
+
+  return (
+    <div className="space-y-4 w-full max-w-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium leading-none">Volume</span>
+        <span className="text-sm text-muted-foreground tabular-nums">{volume()}%</span>
+      </div>
+      <Slider value={volume()} onValueChange={setVolume} />
+    </div>
+  )
+}
+
+/**
+ * Basic slider example
+ * Shows simple usage with defaultValue and disabled states
+ */
+export function SliderBasicDemo() {
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Default</span>
+        <Slider />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">With initial value</span>
+        <Slider defaultValue={50} />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Disabled</span>
+        <Slider defaultValue={33} disabled />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Display settings form with multiple controlled sliders
+ * Shows controlled mode with reset functionality
+ */
+export function SliderFormDemo() {
+  const [brightness, setBrightness] = createSignal(75)
+  const [contrast, setContrast] = createSignal(100)
+  const [saturation, setSaturation] = createSignal(100)
+
+  const isDefault = createMemo(() =>
+    brightness() === 75 && contrast() === 100 && saturation() === 100
+  )
+
+  const resetDefaults = () => {
+    setBrightness(75)
+    setContrast(100)
+    setSaturation(100)
+  }
+
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-1">
+        <h4 className="text-sm font-medium leading-none">Display Settings</h4>
+        <p className="text-sm text-muted-foreground">
+          Adjust brightness, contrast, and saturation.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Brightness</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{brightness()}%</span>
+          </div>
+          <Slider value={brightness()} onValueChange={setBrightness} />
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Contrast</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{contrast()}%</span>
+          </div>
+          <Slider value={contrast()} max={200} onValueChange={setContrast} />
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Saturation</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{saturation()}%</span>
+          </div>
+          <Slider value={saturation()} max={200} onValueChange={setSaturation} />
+        </div>
+      </div>
+      <button
+        className="inline-flex items-center justify-center rounded-md text-sm font-medium h-9 px-4 py-2 border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+        disabled={isDefault()}
+        onClick={resetDefaults}
+      >
+        Reset to defaults
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Custom range demo
+ * Shows min/max/step customization with different configurations
+ */
+export function SliderStepDemo() {
+  const [fontSize, setFontSize] = createSignal(16)
+  const [opacity, setOpacity] = createSignal(100)
+
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Font Size</span>
+          <span className="text-sm text-muted-foreground tabular-nums">{fontSize()}px</span>
+        </div>
+        <Slider
+          value={fontSize()}
+          min={8}
+          max={32}
+          step={1}
+          onValueChange={setFontSize}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>8px</span>
+          <span>32px</span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Opacity</span>
+          <span className="text-sm text-muted-foreground tabular-nums">{opacity()}%</span>
+        </div>
+        <Slider
+          value={opacity()}
+          min={0}
+          max={100}
+          step={5}
+          onValueChange={setOpacity}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>0%</span>
+          <span>100%</span>
+        </div>
+      </div>
+      <div
+        className="rounded-md border border-border p-4 text-center text-sm"
+        style={`font-size: ${fontSize()}px; opacity: ${opacity() / 100}`}
+      >
+        Preview text
+      </div>
+    </div>
+  )
+}

--- a/site/ui/e2e/slider.spec.ts
+++ b/site/ui/e2e/slider.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Slider Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/slider')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Slider')
+    await expect(page.locator('text=An input where the user selects a value')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Slider Rendering', () => {
+    test('displays slider elements', async ({ page }) => {
+      const sliders = page.locator('[role="slider"]')
+      await expect(sliders.first()).toBeVisible()
+    })
+
+    test('has multiple slider examples', async ({ page }) => {
+      const sliders = page.locator('[role="slider"]')
+      expect(await sliders.count()).toBeGreaterThan(3)
+    })
+  })
+
+  test.describe('Preview (Volume Demo)', () => {
+    test('displays preview with slider and value', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderPreviewDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+      await expect(section.locator('[role="slider"]')).toBeVisible()
+      await expect(section.locator('text=Volume')).toBeVisible()
+    })
+
+    test('shows initial volume value of 50%', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderPreviewDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=50%')).toBeVisible()
+    })
+
+    test('slider has correct ARIA attributes', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderPreviewDemo_"]:not([data-slot])').first()
+      const slider = section.locator('[role="slider"]')
+
+      await expect(slider).toHaveAttribute('aria-valuemin', '0')
+      await expect(slider).toHaveAttribute('aria-valuemax', '100')
+      await expect(slider).toHaveAttribute('aria-valuenow', '50')
+    })
+
+    test('clicking on track changes value', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderPreviewDemo_"]:not([data-slot])').first()
+      const track = section.locator('[data-slot="slider-track"]')
+      const slider = section.locator('[role="slider"]')
+
+      // Click near the left edge of the track (approximately 10%)
+      const trackBox = await track.boundingBox()
+      if (trackBox) {
+        await page.mouse.click(trackBox.x + trackBox.width * 0.1, trackBox.y + trackBox.height / 2)
+      }
+
+      // Value should change (no longer 50)
+      const valuenow = await slider.getAttribute('aria-valuenow')
+      expect(Number(valuenow)).toBeLessThan(50)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three sliders', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const sliders = section.locator('[role="slider"]')
+      await expect(sliders).toHaveCount(3)
+    })
+
+    test('first slider starts at 0 (default)', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const sliders = section.locator('[role="slider"]')
+      await expect(sliders.first()).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    test('second slider starts at 50 (defaultValue)', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const sliders = section.locator('[role="slider"]')
+      await expect(sliders.nth(1)).toHaveAttribute('aria-valuenow', '50')
+    })
+
+    test('third slider is disabled', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const sliderRoots = section.locator('[data-slot="slider"]')
+      await expect(sliderRoots.nth(2)).toHaveClass(/pointer-events-none/)
+      await expect(sliderRoots.nth(2)).toHaveClass(/opacity-50/)
+    })
+
+    test('third slider has value 33', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const sliders = section.locator('[role="slider"]')
+      await expect(sliders.nth(2)).toHaveAttribute('aria-valuenow', '33')
+    })
+
+    test('keyboard navigation works on slider', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderBasicDemo_"]:not([data-slot])').first()
+      const slider = section.locator('[role="slider"]').nth(1)
+
+      // Focus the slider
+      await slider.focus()
+      await expect(slider).toHaveAttribute('aria-valuenow', '50')
+
+      // Press ArrowRight to increase
+      await page.keyboard.press('ArrowRight')
+      await expect(slider).toHaveAttribute('aria-valuenow', '51')
+
+      // Press ArrowLeft to decrease
+      await page.keyboard.press('ArrowLeft')
+      await expect(slider).toHaveAttribute('aria-valuenow', '50')
+
+      // Press Home to go to min
+      await page.keyboard.press('Home')
+      await expect(slider).toHaveAttribute('aria-valuenow', '0')
+
+      // Press End to go to max
+      await page.keyboard.press('End')
+      await expect(slider).toHaveAttribute('aria-valuenow', '100')
+    })
+  })
+
+  test.describe('Form (Display Settings)', () => {
+    test('displays form example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Form")')).toBeVisible()
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('shows display settings heading', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      await expect(section.locator('h4:has-text("Display Settings")')).toBeVisible()
+      await expect(section.locator('text=Adjust brightness')).toBeVisible()
+    })
+
+    test('has three sliders', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      const sliders = section.locator('[role="slider"]')
+      await expect(sliders).toHaveCount(3)
+    })
+
+    test('shows initial values', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=75%').first()).toBeVisible()
+      await expect(section.locator('text=100%').first()).toBeVisible()
+    })
+
+    test('reset button is disabled at default values', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      const resetButton = section.locator('button:has-text("Reset to defaults")')
+      await expect(resetButton).toBeDisabled()
+    })
+
+    test('clicking track changes value and enables reset', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderFormDemo_"]:not([data-slot])').first()
+      const slider = section.locator('[role="slider"]').first()
+      const resetButton = section.locator('button:has-text("Reset to defaults")')
+
+      // Use keyboard to change brightness value (more reliable than click coordinates)
+      await slider.focus()
+      await page.keyboard.press('ArrowLeft')
+
+      // Reset button should be enabled since value changed from default
+      await expect(resetButton).toBeEnabled()
+    })
+  })
+
+  test.describe('Custom Range', () => {
+    test('displays custom range example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Custom Range")')).toBeVisible()
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('shows font size slider with initial value', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Font Size')).toBeVisible()
+      await expect(section.locator('text=16px').first()).toBeVisible()
+    })
+
+    test('font size slider has correct min/max', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      const slider = section.locator('[role="slider"]').first()
+      await expect(slider).toHaveAttribute('aria-valuemin', '8')
+      await expect(slider).toHaveAttribute('aria-valuemax', '32')
+      await expect(slider).toHaveAttribute('aria-valuenow', '16')
+    })
+
+    test('opacity slider has step=5', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      const slider = section.locator('[role="slider"]').nth(1)
+
+      // Focus and use keyboard to verify step
+      await slider.focus()
+      await expect(slider).toHaveAttribute('aria-valuenow', '100')
+
+      await page.keyboard.press('ArrowLeft')
+      await expect(slider).toHaveAttribute('aria-valuenow', '95')
+
+      await page.keyboard.press('ArrowLeft')
+      await expect(slider).toHaveAttribute('aria-valuenow', '90')
+    })
+
+    test('shows preview text section', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Preview text')).toBeVisible()
+    })
+
+    test('shows range labels', async ({ page }) => {
+      const section = page.locator('[bf-s^="SliderStepDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=8px').first()).toBeVisible()
+      await expect(section.locator('text=32px')).toBeVisible()
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^defaultValue$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^value$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^min$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^max$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^step$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
+    })
+  })
+})
+
+test.describe('Home Page - Slider Link', () => {
+  test('displays Slider preview card', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('#components a[href="/docs/components/slider"]')).toBeVisible()
+  })
+
+  test('navigates to Slider page on click', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('#components a[href="/docs/components/slider"]').click()
+    await expect(page).toHaveURL('/docs/components/slider')
+    await expect(page.locator('h1')).toContainText('Slider')
+  })
+})

--- a/site/ui/pages/slider.tsx
+++ b/site/ui/pages/slider.tsx
@@ -1,0 +1,282 @@
+/**
+ * Slider Documentation Page
+ */
+
+import {
+  SliderPreviewDemo,
+  SliderBasicDemo,
+  SliderFormDemo,
+  SliderStepDemo,
+} from '@/components/slider-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'form', title: 'Form', branch: 'child' },
+  { id: 'custom-range', title: 'Custom Range', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples - Preview (Volume Control)
+const previewCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Slider } from "@/components/ui/slider"
+
+export function SliderPreviewDemo() {
+  const [volume, setVolume] = createSignal(50)
+
+  return (
+    <div className="space-y-4 w-full max-w-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium leading-none">Volume</span>
+        <span className="text-sm text-muted-foreground tabular-nums">{volume()}%</span>
+      </div>
+      <Slider value={volume()} onValueChange={setVolume} />
+    </div>
+  )
+}`
+
+const basicCode = `import { Slider } from "@/components/ui/slider"
+
+export function SliderBasicDemo() {
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Default</span>
+        <Slider />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">With initial value</span>
+        <Slider defaultValue={50} />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Disabled</span>
+        <Slider defaultValue={33} disabled />
+      </div>
+    </div>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal, createMemo } from "@barefootjs/dom"
+import { Slider } from "@/components/ui/slider"
+
+export function SliderFormDemo() {
+  const [brightness, setBrightness] = createSignal(75)
+  const [contrast, setContrast] = createSignal(100)
+  const [saturation, setSaturation] = createSignal(100)
+
+  const isDefault = createMemo(() =>
+    brightness() === 75 && contrast() === 100 && saturation() === 100
+  )
+
+  const resetDefaults = () => {
+    setBrightness(75)
+    setContrast(100)
+    setSaturation(100)
+  }
+
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-1">
+        <h4 className="text-sm font-medium leading-none">Display Settings</h4>
+        <p className="text-sm text-muted-foreground">
+          Adjust brightness, contrast, and saturation.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Brightness</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{brightness()}%</span>
+          </div>
+          <Slider value={brightness()} onValueChange={setBrightness} />
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Contrast</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{contrast()}%</span>
+          </div>
+          <Slider value={contrast()} max={200} onValueChange={setContrast} />
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Saturation</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{saturation()}%</span>
+          </div>
+          <Slider value={saturation()} max={200} onValueChange={setSaturation} />
+        </div>
+      </div>
+      <button
+        className="inline-flex items-center justify-center rounded-md text-sm font-medium h-9 px-4 py-2 border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+        disabled={isDefault()}
+        onClick={resetDefaults}
+      >
+        Reset to defaults
+      </button>
+    </div>
+  )
+}`
+
+const stepCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Slider } from "@/components/ui/slider"
+
+export function SliderStepDemo() {
+  const [fontSize, setFontSize] = createSignal(16)
+  const [opacity, setOpacity] = createSignal(100)
+
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Font Size</span>
+          <span className="text-sm text-muted-foreground tabular-nums">{fontSize()}px</span>
+        </div>
+        <Slider
+          value={fontSize()}
+          min={8}
+          max={32}
+          step={1}
+          onValueChange={setFontSize}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>8px</span>
+          <span>32px</span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Opacity</span>
+          <span className="text-sm text-muted-foreground tabular-nums">{opacity()}%</span>
+        </div>
+        <Slider
+          value={opacity()}
+          min={0}
+          max={100}
+          step={5}
+          onValueChange={setOpacity}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>0%</span>
+          <span>100%</span>
+        </div>
+      </div>
+      <div
+        className="rounded-md border border-border p-4 text-center text-sm"
+        style={\`font-size: \${fontSize()}px; opacity: \${opacity() / 100}\`}
+      >
+        Preview text
+      </div>
+    </div>
+  )
+}`
+
+// Props definition
+const sliderProps: PropDefinition[] = [
+  {
+    name: 'defaultValue',
+    type: 'number',
+    defaultValue: '0',
+    description: 'The initial value for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'number',
+    description: 'The controlled value of the slider. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'min',
+    type: 'number',
+    defaultValue: '0',
+    description: 'The minimum value of the slider.',
+  },
+  {
+    name: 'max',
+    type: 'number',
+    defaultValue: '100',
+    description: 'The maximum value of the slider.',
+  },
+  {
+    name: 'step',
+    type: 'number',
+    defaultValue: '1',
+    description: 'The step increment for value changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the slider is disabled.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: number) => void',
+    description: 'Event handler called when the slider value changes.',
+  },
+]
+
+export function SliderPage() {
+  const installCommands = getHighlightedCommands('barefoot add slider')
+
+  return (
+    <DocPage slug="slider" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Slider"
+          description="An input where the user selects a value from within a given range."
+          {...getNavLinks('slider')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <SliderPreviewDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add slider" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <SliderBasicDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <SliderFormDemo />
+            </Example>
+
+            <Example title="Custom Range" code={stepCode}>
+              <SliderStepDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={sliderProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -81,6 +81,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Input', href: '/docs/components/input' },
       { title: 'Label', href: '/docs/components/label' },
       { title: 'Select', href: '/docs/components/select' },
+      { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Tabs', href: '/docs/components/tabs' },
       { title: 'Toast', href: '/docs/components/toast' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -15,6 +15,7 @@ import { CardPage } from './pages/card'
 import { CheckboxPage } from './pages/checkbox'
 import { InputPage } from './pages/input'
 import { LabelPage } from './pages/label'
+import { SliderPage } from './pages/slider'
 import { SwitchPage } from './pages/switch'
 import { AccordionPage } from './pages/accordion'
 import { TabsPage } from './pages/tabs'
@@ -108,6 +109,18 @@ export function createApp() {
               </div>
             </PreviewCard>
 
+            {/* Slider */}
+            <PreviewCard name="Slider" path="/docs/components/slider">
+              <div className="w-full max-w-48 space-y-3">
+                <div className="relative flex w-full items-center h-5">
+                  <div className="bg-muted relative grow overflow-hidden rounded-full h-1.5 w-full">
+                    <div className="bg-primary absolute h-full" style="width: 60%" />
+                  </div>
+                  <span className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 border-primary block size-4 rounded-full border bg-white shadow-sm" style="left: 60%" />
+                </div>
+              </div>
+            </PreviewCard>
+
             {/* Switch */}
             <PreviewCard name="Switch" path="/docs/components/switch">
               <div className="flex flex-col gap-3">
@@ -195,6 +208,11 @@ export function createApp() {
   // Label documentation
   app.get('/docs/components/label', (c) => {
     return c.render(<LabelPage />)
+  })
+
+  // Slider documentation
+  app.get('/docs/components/slider', (c) => {
+    return c.render(<SliderPage />)
   })
 
   // Switch documentation

--- a/ui/components/ui/slider.tsx
+++ b/ui/components/ui/slider.tsx
@@ -1,0 +1,260 @@
+"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+
+/**
+ * Slider Component
+ *
+ * An input for selecting a numeric value from a range.
+ * Supports both controlled and uncontrolled modes.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Uncontrolled (internal state)
+ * ```tsx
+ * <Slider />
+ * <Slider defaultValue={50} />
+ * ```
+ *
+ * @example Controlled (external state)
+ * ```tsx
+ * <Slider value={volume()} onValueChange={setVolume} />
+ * ```
+ *
+ * @example Custom range and step
+ * ```tsx
+ * <Slider min={0} max={10} step={0.5} defaultValue={5} />
+ * ```
+ */
+
+// Root classes (matching shadcn/ui)
+const rootBaseClasses = 'relative flex w-full touch-none items-center select-none'
+
+// Track classes
+const trackClasses = 'bg-muted relative grow overflow-hidden rounded-full h-1.5 w-full'
+
+// Range classes (filled portion)
+const rangeClasses = 'bg-primary absolute h-full'
+
+// Thumb classes (matching shadcn/ui exactly)
+const thumbBaseClasses = 'border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50'
+
+/**
+ * Props for the Slider component.
+ */
+interface SliderProps {
+  /**
+   * Default value (for uncontrolled mode).
+   * @default 0
+   */
+  defaultValue?: number
+  /**
+   * Controlled value. When provided, the component is in controlled mode.
+   */
+  value?: number
+  /**
+   * Minimum value.
+   * @default 0
+   */
+  min?: number
+  /**
+   * Maximum value.
+   * @default 100
+   */
+  max?: number
+  /**
+   * Step increment.
+   * @default 1
+   */
+  step?: number
+  /**
+   * Whether the slider is disabled.
+   * @default false
+   */
+  disabled?: boolean
+  /**
+   * Callback when the value changes.
+   */
+  onValueChange?: (value: number) => void
+  /**
+   * Additional CSS classes for the root element.
+   */
+  class?: string
+}
+
+/**
+ * Slider component for selecting a numeric value from a range.
+ * Supports both controlled and uncontrolled modes.
+ */
+function Slider(props: SliderProps) {
+  const min = props.min ?? 0
+  const max = props.max ?? 100
+  const step = props.step ?? 1
+
+  // Internal state for uncontrolled mode
+  const [internalValue, setInternalValue] = createSignal(props.defaultValue ?? min)
+
+  // Controlled state - synced from parent via DOM attribute
+  // When parent passes value={signal()}, the compiler generates a sync effect
+  // that updates this signal when the parent's value changes
+  const [controlledValue, setControlledValue] = createSignal<number | undefined>(props.value)
+
+  // Track if component is in controlled mode
+  const isControlled = createMemo(() => props.value !== undefined)
+
+  // Determine current value
+  const currentValue = createMemo(() => isControlled() ? controlledValue() : internalValue())
+
+  // Compute percentage for positioning
+  const percentage = createMemo(() => {
+    if (max <= min) return 0
+    return Math.max(0, Math.min(100, ((currentValue() - min) / (max - min)) * 100))
+  })
+
+  // Snap a raw value to the nearest step
+  const snapToStep = (rawValue: number): number => {
+    const stepped = Math.round((rawValue - min) / step) * step + min
+    // Round to avoid floating point issues
+    const decimals = (step.toString().split('.')[1] || '').length
+    const rounded = parseFloat(stepped.toFixed(decimals))
+    return Math.max(min, Math.min(max, rounded))
+  }
+
+  // Calculate value from pointer position relative to track
+  const getValueFromPointer = (clientX: number, trackRect: DOMRect): number => {
+    const pct = (clientX - trackRect.left) / trackRect.width
+    const rawValue = min + pct * (max - min)
+    return snapToStep(rawValue)
+  }
+
+  // Update DOM elements to reflect current value
+  const updateSliderUI = (root: HTMLElement, value: number) => {
+    const pct = ((value - min) / (max - min)) * 100
+    const thumb = root.querySelector('[data-slot="slider-thumb"]') as HTMLElement
+    const range = root.querySelector('[data-slot="slider-range"]') as HTMLElement
+
+    if (thumb) {
+      thumb.style.left = `${pct}%`
+      thumb.setAttribute('aria-valuenow', String(value))
+    }
+    if (range) {
+      range.style.width = `${pct}%`
+    }
+  }
+
+  // Set value, update UI, and notify parent
+  const setValue = (root: HTMLElement, newValue: number) => {
+    if (isControlled()) {
+      setControlledValue(newValue)
+    } else {
+      setInternalValue(newValue)
+    }
+    updateSliderUI(root, newValue)
+
+    // Notify parent if callback provided
+    const scope = root.closest('[bf-s]')
+    // @ts-ignore - onvalueChange is set by parent during hydration
+    const scopeCallback = scope?.onvalueChange
+    const handler = props.onValueChange || scopeCallback
+    handler?.(newValue)
+  }
+
+  // Handle pointer down on root (covers both track and thumb clicks)
+  const handlePointerDown = (e: PointerEvent) => {
+    if (props.disabled) return
+    e.preventDefault()
+
+    const root = e.currentTarget as HTMLElement
+    const track = root.querySelector('[data-slot="slider-track"]') as HTMLElement
+    const trackRect = track.getBoundingClientRect()
+
+    // Calculate and set value from click position
+    const newValue = getValueFromPointer(e.clientX, trackRect)
+    setValue(root, newValue)
+
+    // Set pointer capture for smooth dragging
+    root.setPointerCapture(e.pointerId)
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const moveValue = getValueFromPointer(moveEvent.clientX, trackRect)
+      setValue(root, moveValue)
+    }
+
+    const handlePointerUp = () => {
+      root.removeEventListener('pointermove', handlePointerMove)
+      root.removeEventListener('pointerup', handlePointerUp)
+      root.releasePointerCapture(e.pointerId)
+    }
+
+    root.addEventListener('pointermove', handlePointerMove)
+    root.addEventListener('pointerup', handlePointerUp)
+  }
+
+  // Handle keyboard navigation on thumb
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (props.disabled) return
+
+    const thumb = e.currentTarget as HTMLElement
+    const root = thumb.closest('[data-slot="slider"]') as HTMLElement
+    const current = parseFloat(thumb.getAttribute('aria-valuenow') || String(currentValue()))
+
+    let newValue: number | null = null
+
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        newValue = snapToStep(current + step)
+        break
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        newValue = snapToStep(current - step)
+        break
+      case 'Home':
+        newValue = min
+        break
+      case 'End':
+        newValue = max
+        break
+      default:
+        return
+    }
+
+    e.preventDefault()
+    setValue(root, newValue)
+  }
+
+  const rootClasses = `${rootBaseClasses} ${props.disabled ? 'opacity-50 pointer-events-none' : ''} ${props.class ?? ''}`
+  const thumbClasses = `absolute top-1/2 -translate-y-1/2 -translate-x-1/2 ${thumbBaseClasses}`
+
+  return (
+    <div
+      data-slot="slider"
+      className={rootClasses}
+      onPointerDown={handlePointerDown}
+    >
+      <div
+        data-slot="slider-track"
+        className={trackClasses}
+      >
+        <div
+          data-slot="slider-range"
+          className={rangeClasses}
+          style={`width: ${percentage()}%`}
+        />
+      </div>
+      <span
+        data-slot="slider-thumb"
+        role="slider"
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={currentValue()}
+        tabindex={props.disabled ? -1 : 0}
+        className={thumbClasses}
+        style={`left: ${percentage()}%`}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  )
+}
+
+export { Slider }
+export type { SliderProps }


### PR DESCRIPTION
## Summary
- Port Slider component from shadcn/ui with full keyboard and pointer interaction support
- Add four demos: Volume preview (controlled), Basic (default/defaultValue/disabled), Display Settings form (multi-slider with reset), Custom Range (min/max/step with live preview)
- Add documentation page with installation, examples, and API reference table
- Add 32 E2E tests covering ARIA attributes, keyboard navigation, pointer interaction, and page structure

## Notable implementation details
- Controlled and uncontrolled modes via `value`/`defaultValue` props
- Pointer drag with `setPointerCapture` for smooth sliding
- Keyboard: ArrowRight/Left (±step), Home (min), End (max)
- Step snapping with floating-point precision handling
- Disabled state uses CSS classes (`opacity-50 pointer-events-none`) instead of `data-disabled` attribute due to compiler limitation with boolean attribute serialization

Closes #127

## Test plan
- [x] All 32 E2E tests pass (`slider.spec.ts`)
- [x] Slider appears in sidebar navigation and home page component grid
- [x] Keyboard navigation works (Arrow keys, Home, End)
- [x] Pointer drag works across full track width
- [x] Controlled mode updates parent state via `onValueChange`
- [x] Disabled state prevents interaction
- [x] Custom min/max/step respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)