### PR TITLE
Add Toggle component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -22,6 +22,7 @@ export const componentOrder = [
   { slug: 'tabs', title: 'Tabs' },
   { slug: 'textarea', title: 'Textarea' },
   { slug: 'toast', title: 'Toast' },
+  { slug: 'toggle', title: 'Toggle' },
   { slug: 'tooltip', title: 'Tooltip' },
 ]
 

--- a/site/ui/components/toggle-demo.tsx
+++ b/site/ui/components/toggle-demo.tsx
@@ -1,0 +1,125 @@
+"use client"
+/**
+ * ToggleDemo Components
+ *
+ * Interactive demos for Toggle component.
+ * Based on shadcn/ui patterns for practical use cases.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Toggle } from '@ui/components/ui/toggle'
+
+/**
+ * Basic toggle example
+ * Shows default, pressed, and disabled states with icons
+ */
+export function ToggleBasicDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Toggle aria-label="Toggle bold">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 4h8a4 4 0 014 4 4 4 0 01-4 4H6z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 12h9a4 4 0 014 4 4 4 0 01-4 4H6z" />
+        </svg>
+      </Toggle>
+      <Toggle defaultPressed aria-label="Toggle italic">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 4h-9M14 20H5M15 4L9 20" />
+        </svg>
+      </Toggle>
+      <Toggle disabled aria-label="Toggle underline">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v7a6 6 0 006 6 6 6 0 006-6V3" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 21h16" />
+        </svg>
+      </Toggle>
+    </div>
+  )
+}
+
+/**
+ * Outline variant example
+ * Shows outline variant toggles
+ */
+export function ToggleOutlineDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Toggle variant="outline" aria-label="Toggle bold">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 4h8a4 4 0 014 4 4 4 0 01-4 4H6z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 12h9a4 4 0 014 4 4 4 0 01-4 4H6z" />
+        </svg>
+      </Toggle>
+      <Toggle variant="outline" aria-label="Toggle italic">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 4h-9M14 20H5M15 4L9 20" />
+        </svg>
+      </Toggle>
+      <Toggle variant="outline" aria-label="Toggle underline">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v7a6 6 0 006 6 6 6 0 006-6V3" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 21h16" />
+        </svg>
+      </Toggle>
+    </div>
+  )
+}
+
+/**
+ * Text editor toolbar example
+ * Multiple toggles for formatting with active summary
+ */
+export function ToggleToolbarDemo() {
+  const [bold, setBold] = createSignal(false)
+  const [italic, setItalic] = createSignal(false)
+  const [underline, setUnderline] = createSignal(false)
+
+  const activeCount = createMemo(() =>
+    [bold(), italic(), underline()].filter(Boolean).length
+  )
+  const activeNames = createMemo(() =>
+    [bold() && 'Bold', italic() && 'Italic', underline() && 'Underline'].filter(Boolean).join(', ') || 'None'
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-1 rounded-md border border-input p-1">
+        <Toggle
+          pressed={bold()}
+          onPressedChange={setBold}
+          size="sm"
+          aria-label="Toggle bold"
+        >
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 4h8a4 4 0 014 4 4 4 0 01-4 4H6z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 12h9a4 4 0 014 4 4 4 0 01-4 4H6z" />
+          </svg>
+        </Toggle>
+        <Toggle
+          pressed={italic()}
+          onPressedChange={setItalic}
+          size="sm"
+          aria-label="Toggle italic"
+        >
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 4h-9M14 20H5M15 4L9 20" />
+          </svg>
+        </Toggle>
+        <Toggle
+          pressed={underline()}
+          onPressedChange={setUnderline}
+          size="sm"
+          aria-label="Toggle underline"
+        >
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v7a6 6 0 006 6 6 6 0 006-6V3" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 21h16" />
+          </svg>
+        </Toggle>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        Active formatting: {activeNames()} ({activeCount()} selected)
+      </div>
+    </div>
+  )
+}

--- a/site/ui/e2e/toggle.spec.ts
+++ b/site/ui/e2e/toggle.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Toggle Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/toggle')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Toggle')
+    await expect(page.locator('text=A two-state button that can be either on or off.')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Toggle Rendering', () => {
+    test('displays toggle elements with data-slot', async ({ page }) => {
+      const toggles = page.locator('[data-slot="toggle"]')
+      await expect(toggles.first()).toBeVisible()
+    })
+
+    test('has multiple toggle examples', async ({ page }) => {
+      const toggles = page.locator('[data-slot="toggle"]')
+      expect(await toggles.count()).toBeGreaterThan(3)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three toggles', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+      await expect(toggles).toHaveCount(3)
+    })
+
+    test('first toggle starts unpressed', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+      await expect(toggles.first()).toHaveAttribute('aria-pressed', 'false')
+      await expect(toggles.first()).toHaveAttribute('data-state', 'off')
+    })
+
+    test('second toggle starts pressed (defaultPressed)', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+      await expect(toggles.nth(1)).toHaveAttribute('aria-pressed', 'true')
+      await expect(toggles.nth(1)).toHaveAttribute('data-state', 'on')
+    })
+
+    test('third toggle is disabled', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+      await expect(toggles.nth(2)).toBeDisabled()
+    })
+
+    test('clicking toggles aria-pressed and data-state', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleBasicDemo_"]:not([data-slot])').first()
+      const toggle = section.locator('[data-slot="toggle"]').first()
+
+      // Initially unpressed
+      await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      await expect(toggle).toHaveAttribute('data-state', 'off')
+
+      // Click to press
+      await toggle.click()
+      await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      await expect(toggle).toHaveAttribute('data-state', 'on')
+
+      // Click to unpress
+      await toggle.click()
+      await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      await expect(toggle).toHaveAttribute('data-state', 'off')
+    })
+  })
+
+  test.describe('Outline', () => {
+    test('displays outline example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Outline")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleOutlineDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('outline toggles have border class', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleOutlineDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+      await expect(toggles).toHaveCount(3)
+    })
+  })
+
+  test.describe('Toolbar', () => {
+    test('displays toolbar example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Toolbar")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleToolbarDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('shows active formatting summary', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleToolbarDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Active formatting:')).toBeVisible()
+      await expect(section.locator('text=None')).toBeVisible()
+    })
+
+    test('clicking toggle updates active formatting', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleToolbarDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+
+      // Click Bold toggle
+      await toggles.first().click()
+      await expect(section.locator('text=Bold')).toBeVisible()
+      await expect(section.locator('text=1 selected')).toBeVisible()
+    })
+
+    test('multiple toggles can be active', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleToolbarDemo_"]:not([data-slot])').first()
+      const toggles = section.locator('[data-slot="toggle"]')
+
+      await toggles.nth(0).click()
+      await toggles.nth(1).click()
+      await expect(section.locator('text=2 selected')).toBeVisible()
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^pressed$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^size$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^onPressedChange$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/toggle.tsx
+++ b/site/ui/pages/toggle.tsx
@@ -1,0 +1,199 @@
+/**
+ * Toggle Documentation Page
+ */
+
+import {
+  ToggleBasicDemo,
+  ToggleOutlineDemo,
+  ToggleToolbarDemo,
+} from '@/components/toggle-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'outline', title: 'Outline', branch: 'child' },
+  { id: 'toolbar', title: 'Toolbar', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `import { Toggle } from "@/components/ui/toggle"
+
+export function ToggleBasicDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Toggle aria-label="Toggle bold">
+        <BoldIcon />
+      </Toggle>
+      <Toggle defaultPressed aria-label="Toggle italic">
+        <ItalicIcon />
+      </Toggle>
+      <Toggle disabled aria-label="Toggle underline">
+        <UnderlineIcon />
+      </Toggle>
+    </div>
+  )
+}`
+
+const outlineCode = `import { Toggle } from "@/components/ui/toggle"
+
+export function ToggleOutlineDemo() {
+  return (
+    <div className="flex items-center gap-2">
+      <Toggle variant="outline" aria-label="Toggle bold">
+        <BoldIcon />
+      </Toggle>
+      <Toggle variant="outline" aria-label="Toggle italic">
+        <ItalicIcon />
+      </Toggle>
+      <Toggle variant="outline" aria-label="Toggle underline">
+        <UnderlineIcon />
+      </Toggle>
+    </div>
+  )
+}`
+
+const toolbarCode = `"use client"
+
+import { createSignal, createMemo } from "@barefootjs/dom"
+import { Toggle } from "@/components/ui/toggle"
+
+const formatOptions = [
+  { id: 0, name: 'Bold', label: 'Toggle bold' },
+  { id: 1, name: 'Italic', label: 'Toggle italic' },
+  { id: 2, name: 'Underline', label: 'Toggle underline' },
+]
+
+export function ToggleToolbarDemo() {
+  const [active, setActive] = createSignal(formatOptions.map(() => false))
+
+  const activeCount = createMemo(() => active().filter(Boolean).length)
+  const activeNames = createMemo(() =>
+    formatOptions.filter((_, i) => active()[i]).map(o => o.name).join(', ') || 'None'
+  )
+
+  const toggleFormat = (index: number) => {
+    setActive(prev => prev.map((v, i) => i === index ? !v : v))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-1 rounded-md border border-input p-1">
+        {formatOptions.map((option) => (
+          <Toggle
+            key={option.id}
+            pressed={active()[option.id]}
+            onPressedChange={() => toggleFormat(option.id)}
+            size="sm"
+            aria-label={option.label}
+          >
+            <Icon />
+          </Toggle>
+        ))}
+      </div>
+      <div className="text-sm text-muted-foreground">
+        Active formatting: {activeNames()} ({activeCount()} selected)
+      </div>
+    </div>
+  )
+}`
+
+// Props definition
+const toggleProps: PropDefinition[] = [
+  {
+    name: 'defaultPressed',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'The initial pressed state for uncontrolled mode.',
+  },
+  {
+    name: 'pressed',
+    type: 'boolean',
+    description: 'The controlled pressed state of the toggle. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the toggle is disabled.',
+  },
+  {
+    name: 'variant',
+    type: "'default' | 'outline'",
+    defaultValue: "'default'",
+    description: 'The visual variant of the toggle.',
+  },
+  {
+    name: 'size',
+    type: "'default' | 'sm' | 'lg'",
+    defaultValue: "'default'",
+    description: 'The size of the toggle.',
+  },
+  {
+    name: 'onPressedChange',
+    type: '(pressed: boolean) => void',
+    description: 'Event handler called when the toggle state changes.',
+  },
+]
+
+export function TogglePage() {
+  const installCommands = getHighlightedCommands('barefoot add toggle')
+
+  return (
+    <DocPage slug="toggle" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Toggle"
+          description="A two-state button that can be either on or off."
+          {...getNavLinks('toggle')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={basicCode}>
+          <ToggleBasicDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add toggle" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <ToggleBasicDemo />
+            </Example>
+
+            <Example title="Outline" code={outlineCode}>
+              <ToggleOutlineDemo />
+            </Example>
+
+            <Example title="Toolbar" code={toolbarCode}>
+              <ToggleToolbarDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={toggleProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -85,6 +85,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Tabs', href: '/docs/components/tabs' },
       { title: 'Textarea', href: '/docs/components/textarea' },
       { title: 'Toast', href: '/docs/components/toast' },
+      { title: 'Toggle', href: '/docs/components/toggle' },
       { title: 'Tooltip', href: '/docs/components/tooltip' },
     ],
   },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -21,6 +21,7 @@ import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
 import { DropdownMenuPage } from './pages/dropdown-menu'
 import { ToastPage } from './pages/toast'
+import { TogglePage } from './pages/toggle'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
 import { TextareaPage } from './pages/textarea'
@@ -226,6 +227,11 @@ export function createApp() {
   // Toast documentation
   app.get('/docs/components/toast', (c) => {
     return c.render(<ToastPage />)
+  })
+
+  // Toggle documentation
+  app.get('/docs/components/toggle', (c) => {
+    return c.render(<TogglePage />)
   })
 
   // Tooltip documentation

--- a/ui/components/ui/toggle.tsx
+++ b/ui/components/ui/toggle.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+
+/**
+ * Toggle Component
+ *
+ * A two-state button that can be either on or off.
+ * Supports both controlled and uncontrolled modes.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Uncontrolled (internal state)
+ * ```tsx
+ * <Toggle>Bold</Toggle>
+ * <Toggle defaultPressed>Italic</Toggle>
+ * ```
+ *
+ * @example Controlled (external state)
+ * ```tsx
+ * <Toggle pressed={isBold} onPressedChange={setIsBold}>Bold</Toggle>
+ * ```
+ *
+ * @example With variant
+ * ```tsx
+ * <Toggle variant="outline">Outline</Toggle>
+ * ```
+ */
+
+import type { Child } from '../../types'
+
+// Type definitions
+type ToggleVariant = 'default' | 'outline'
+type ToggleSize = 'default' | 'sm' | 'lg'
+
+// Base classes matching shadcn/ui v4
+const baseClasses = 'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted hover:text-muted-foreground'
+
+// Variant-specific classes
+const variantClasses: Record<ToggleVariant, string> = {
+  default: 'bg-transparent',
+  outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+}
+
+// Size-specific classes
+const sizeClasses: Record<ToggleSize, string> = {
+  default: 'h-9 px-2 min-w-9',
+  sm: 'h-8 px-1.5 min-w-8',
+  lg: 'h-10 px-2.5 min-w-10',
+}
+
+/**
+ * Props for the Toggle component.
+ */
+interface ToggleProps {
+  /**
+   * Default pressed state (for uncontrolled mode).
+   * @default false
+   */
+  defaultPressed?: boolean
+  /**
+   * Controlled pressed state. When provided, component is in controlled mode.
+   */
+  pressed?: boolean
+  /**
+   * Whether the toggle is disabled.
+   * @default false
+   */
+  disabled?: boolean
+  /**
+   * Visual variant of the toggle.
+   * @default 'default'
+   */
+  variant?: ToggleVariant
+  /**
+   * Size of the toggle.
+   * @default 'default'
+   */
+  size?: ToggleSize
+  /**
+   * Callback when the pressed state changes.
+   */
+  onPressedChange?: (pressed: boolean) => void
+  /**
+   * Additional CSS classes.
+   */
+  class?: string
+  /**
+   * Children to render inside the toggle.
+   */
+  children?: Child
+}
+
+/**
+ * Toggle component — a two-state button.
+ * Supports both controlled and uncontrolled modes.
+ *
+ * @param props.defaultPressed - Initial value for uncontrolled mode
+ * @param props.pressed - Controlled pressed state
+ * @param props.disabled - Whether disabled
+ * @param props.variant - Visual variant ('default' | 'outline')
+ * @param props.size - Size ('default' | 'sm' | 'lg')
+ * @param props.onPressedChange - Callback when pressed state changes
+ */
+function Toggle(props: ToggleProps) {
+  // Internal state for uncontrolled mode
+  const [internalPressed, setInternalPressed] = createSignal(props.defaultPressed ?? false)
+
+  // Controlled state - synced from parent via DOM attribute
+  const [controlledPressed, setControlledPressed] = createSignal<boolean | undefined>(props.pressed)
+
+  // Track if component is in controlled mode (pressed prop provided)
+  const isControlled = createMemo(() => props.pressed !== undefined)
+
+  // Determine current pressed state: use controlled if provided, otherwise internal
+  const isPressed = createMemo(() => isControlled() ? controlledPressed() : internalPressed())
+
+  // Resolve variant and size
+  const variant = props.variant ?? 'default'
+  const size = props.size ?? 'default'
+
+  // Classes
+  const classes = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${props.class ?? ''}`
+
+  // Click handler that works for both controlled and uncontrolled modes
+  const handleClick = (e: MouseEvent) => {
+    const target = e.currentTarget as HTMLElement
+    const currentPressed = target.getAttribute('aria-pressed') === 'true'
+    const newValue = !currentPressed
+
+    // Update state based on mode
+    if (isControlled()) {
+      setControlledPressed(newValue)
+    } else {
+      setInternalPressed(newValue)
+    }
+
+    // Update the UI visually
+    target.setAttribute('aria-pressed', String(newValue))
+    target.setAttribute('data-state', newValue ? 'on' : 'off')
+
+    // Notify parent if callback provided
+    const scope = target.closest('[bf-s]')
+    // @ts-ignore - onpressedChange is set by parent during hydration
+    const scopeCallback = scope?.onpressedChange
+    const handler = props.onPressedChange || scopeCallback
+    handler?.(newValue)
+  }
+
+  return (
+    <button
+      data-slot="toggle"
+      data-state={isPressed() ? 'on' : 'off'}
+      aria-pressed={isPressed()}
+      disabled={props.disabled ?? false}
+      className={classes}
+      onClick={handleClick}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export { Toggle }
+export type { ToggleVariant, ToggleSize, ToggleProps }


### PR DESCRIPTION
## Summary
- Add Toggle UI component (`ui/components/ui/toggle.tsx`) with controlled/uncontrolled modes, variant (`default`/`outline`), and size (`default`/`sm`/`lg`) props
- Add three demo components: Basic, Outline, and Toolbar (with formatting state summary)
- Add Toggle documentation page with installation, examples, and API reference sections
- Add Toggle to sidebar navigation menu
- Add 19 E2E tests covering rendering, interaction, and state management

## Test plan
- [x] All 19 E2E tests pass (`bunx playwright test e2e/toggle.spec.ts`)
- [ ] Visual review of Toggle documentation page at `/docs/components/toggle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)