### PR TITLE
Fix data-disabled attribute not correctly handled for boolean props

### DIFF
--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -2218,7 +2218,7 @@ export class GoTemplateAdapter extends BaseAdapter {
         parts.push(`${attrName}="${output}"`)
       } else if (attr.dynamic) {
         const value = attr.value as string
-        if (isBooleanAttr(attrName)) {
+        if (isBooleanAttr(attrName) || attr.booleanPresence) {
           // Boolean attrs: render attr name only when truthy, omit when falsy
           const { condition: goCond, preamble } = this.convertConditionToGo(value)
           parts.push(`${preamble}{{if ${goCond}}}${attrName}{{end}}`)

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -2218,7 +2218,7 @@ export class GoTemplateAdapter extends BaseAdapter {
         parts.push(`${attrName}="${output}"`)
       } else if (attr.dynamic) {
         const value = attr.value as string
-        if (isBooleanAttr(attrName) || attr.booleanPresence) {
+        if (isBooleanAttr(attrName) || attr.presenceOrUndefined) {
           // Boolean attrs: render attr name only when truthy, omit when falsy
           const { condition: goCond, preamble } = this.convertConditionToGo(value)
           parts.push(`${preamble}{{if ${goCond}}}${attrName}{{end}}`)

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -798,7 +798,7 @@ export class HonoAdapter implements TemplateAdapter {
         parts.push(`${attrName}={${output}}`)
       } else if (attr.dynamic) {
         // Dynamic attribute
-        if (isBooleanAttr(attrName)) {
+        if (isBooleanAttr(attrName) || attr.booleanPresence) {
           // Boolean attrs: pass undefined when falsy so Hono omits the attribute
           // Wrap in parentheses to avoid syntax error when value contains ?? operator
           parts.push(`${attrName}={(${attr.value}) || undefined}`)

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -798,7 +798,7 @@ export class HonoAdapter implements TemplateAdapter {
         parts.push(`${attrName}={${output}}`)
       } else if (attr.dynamic) {
         // Dynamic attribute
-        if (isBooleanAttr(attrName) || attr.booleanPresence) {
+        if (isBooleanAttr(attrName) || attr.presenceOrUndefined) {
           // Boolean attrs: pass undefined when falsy so Hono omits the attribute
           // Wrap in parentheses to avoid syntax error when value contains ?? operator
           parts.push(`${attrName}={(${attr.value}) || undefined}`)

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -256,6 +256,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
             slotId: element.slotId,
             attrName: attr.name,
             expression: valueStr,
+            booleanPresence: attr.booleanPresence,
           })
         }
       }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -256,7 +256,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
             slotId: element.slotId,
             attrName: attr.name,
             expression: valueStr,
-            booleanPresence: attr.booleanPresence,
+            presenceOrUndefined: attr.presenceOrUndefined,
           })
         }
       }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -271,7 +271,7 @@ export function emitReactiveAttributeUpdates(lines: string[], ctx: ClientJsConte
           lines.push(`      if (_${slotId}.value !== __val) _${slotId}.value = __val`)
         } else if (isBooleanAttr(htmlAttrName)) {
           lines.push(`      _${slotId}.${htmlAttrName} = !!(${attr.expression})`)
-        } else if (attr.booleanPresence) {
+        } else if (attr.presenceOrUndefined) {
           lines.push(`      if (${attr.expression}) _${slotId}.setAttribute('${htmlAttrName}', '')`)
           lines.push(`      else _${slotId}.removeAttribute('${htmlAttrName}')`)
         } else {

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -271,6 +271,9 @@ export function emitReactiveAttributeUpdates(lines: string[], ctx: ClientJsConte
           lines.push(`      if (_${slotId}.value !== __val) _${slotId}.value = __val`)
         } else if (isBooleanAttr(htmlAttrName)) {
           lines.push(`      _${slotId}.${htmlAttrName} = !!(${attr.expression})`)
+        } else if (attr.booleanPresence) {
+          lines.push(`      if (${attr.expression}) _${slotId}.setAttribute('${htmlAttrName}', '')`)
+          lines.push(`      else _${slotId}.removeAttribute('${htmlAttrName}')`)
         } else {
           lines.push(`      _${slotId}.setAttribute('${htmlAttrName}', String(${attr.expression}))`)
         }

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -18,6 +18,9 @@ export function irToHtmlTemplate(node: IRNode): string {
           if (a.dynamic && isBooleanAttr(attrName)) {
             return `\${${a.value} ? '${attrName}' : ''}`
           }
+          if (a.dynamic && a.booleanPresence) {
+            return `\${${a.value} ? '${attrName}' : ''}`
+          }
           if (a.dynamic) return `${attrName}="\${${a.value}}"`
           return `${attrName}="${a.value}"`
         })
@@ -129,6 +132,9 @@ export function irToComponentTemplate(node: IRNode, propNames: Set<string>): str
           if (a.value === null) return attrName
           const valueStr = attrValueToString(a.value)
           if (a.dynamic && valueStr && isBooleanAttr(attrName)) {
+            return `\${${transformExpr(valueStr)} ? '${attrName}' : ''}`
+          }
+          if (a.dynamic && valueStr && a.booleanPresence) {
             return `\${${transformExpr(valueStr)} ? '${attrName}' : ''}`
           }
           if (a.dynamic && valueStr) return `${attrName}="\${${transformExpr(valueStr)}}"`

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -18,7 +18,7 @@ export function irToHtmlTemplate(node: IRNode): string {
           if (a.dynamic && isBooleanAttr(attrName)) {
             return `\${${a.value} ? '${attrName}' : ''}`
           }
-          if (a.dynamic && a.booleanPresence) {
+          if (a.dynamic && a.presenceOrUndefined) {
             return `\${${a.value} ? '${attrName}' : ''}`
           }
           if (a.dynamic) return `${attrName}="\${${a.value}}"`
@@ -134,7 +134,7 @@ export function irToComponentTemplate(node: IRNode, propNames: Set<string>): str
           if (a.dynamic && valueStr && isBooleanAttr(attrName)) {
             return `\${${transformExpr(valueStr)} ? '${attrName}' : ''}`
           }
-          if (a.dynamic && valueStr && a.booleanPresence) {
+          if (a.dynamic && valueStr && a.presenceOrUndefined) {
             return `\${${transformExpr(valueStr)} ? '${attrName}' : ''}`
           }
           if (a.dynamic && valueStr) return `${attrName}="\${${transformExpr(valueStr)}}"`

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -139,6 +139,7 @@ export interface ReactiveAttribute {
   slotId: string
   attrName: string
   expression: string
+  booleanPresence?: boolean
 }
 
 export interface ClientOnlyElement {

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -139,7 +139,7 @@ export interface ReactiveAttribute {
   slotId: string
   attrName: string
   expression: string
-  booleanPresence?: boolean
+  presenceOrUndefined?: boolean
 }
 
 export interface ClientOnlyElement {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1208,14 +1208,14 @@ function processAttributes(
     }
 
     // Regular attribute
-    const { value, dynamic, isLiteral, booleanPresence } = getAttributeValue(attr, ctx)
+    const { value, dynamic, isLiteral, presenceOrUndefined } = getAttributeValue(attr, ctx)
     attrs.push({
       name,
       value,
       dynamic,
       isLiteral,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-      booleanPresence,
+      presenceOrUndefined,
     })
   }
 
@@ -1225,7 +1225,7 @@ function processAttributes(
 function getAttributeValue(
   attr: ts.JsxAttribute,
   ctx: TransformContext
-): { value: string | IRTemplateLiteral | null; dynamic: boolean; isLiteral: boolean; booleanPresence?: boolean } {
+): { value: string | IRTemplateLiteral | null; dynamic: boolean; isLiteral: boolean; presenceOrUndefined?: boolean } {
   // Boolean attribute: <button disabled />
   if (!attr.initializer) {
     return { value: null, dynamic: false, isLiteral: false }
@@ -1271,7 +1271,7 @@ function getAttributeValue(
     if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
       if (ts.isIdentifier(expr.right) && expr.right.text === 'undefined') {
         const baseExpr = expr.left.getText(ctx.sourceFile)
-        return { value: baseExpr, dynamic: true, isLiteral: false, booleanPresence: true }
+        return { value: baseExpr, dynamic: true, isLiteral: false, presenceOrUndefined: true }
       }
     }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -293,7 +293,7 @@ export interface IRAttribute {
   dynamic: boolean
   isLiteral: boolean // true if value came from a string literal attribute
   loc: SourceLocation
-  booleanPresence?: boolean // true when `expr || undefined` pattern is detected
+  presenceOrUndefined?: boolean // true when `expr || undefined` pattern is detected
 }
 
 export interface IREvent {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -293,6 +293,7 @@ export interface IRAttribute {
   dynamic: boolean
   isLiteral: boolean // true if value came from a string literal attribute
   loc: SourceLocation
+  booleanPresence?: boolean // true when `expr || undefined` pattern is detected
 }
 
 export interface IREvent {


### PR DESCRIPTION
## Summary

- Detect `expr || undefined` pattern at AST level in Phase 1 (JSX → IR) and mark attributes with a `presenceOrUndefined` flag
- Generate `setAttribute('', '')`/`removeAttribute()` in client JS instead of `setAttribute(String(...))` for presence-or-undefined attributes
- Propagate the flag through HTML template generation and both adapters (Hono, Go Template)

Fixes #351

## Changes

| File | Change |
|------|--------|
| `packages/jsx/src/types.ts` | Add `presenceOrUndefined?: boolean` to `IRAttribute` |
| `packages/jsx/src/ir-to-client-js/types.ts` | Add `presenceOrUndefined?: boolean` to `ReactiveAttribute` |
| `packages/jsx/src/jsx-to-ir.ts` | Detect `|| undefined` in `getAttributeValue()`, strip it, set flag |
| `packages/jsx/src/ir-to-client-js/collect-elements.ts` | Propagate flag to `reactiveAttrs` |
| `packages/jsx/src/ir-to-client-js/emit-init-sections.ts` | Generate `setAttribute/removeAttribute` for `presenceOrUndefined` |
| `packages/jsx/src/ir-to-client-js/html-template.ts` | Conditional rendering for `presenceOrUndefined` in both template functions |
| `packages/hono/src/adapter/hono-adapter.ts` | Extend boolean attr branch to include `presenceOrUndefined` |
| `packages/go-template/src/adapter/go-template-adapter.ts` | Extend boolean attr branch to include `presenceOrUndefined` |

## Test plan

- [x] New test: `data-disabled={props.disabled || undefined}` generates `setAttribute/removeAttribute` (not `String()`)
- [x] New test: `data-state={open() || undefined}` same behavior
- [x] All 165 existing compiler tests pass
- [ ] Manual verification with a component using the `|| undefined` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)