### PR TITLE
Fix named function references in provideContext lost in client JS

### DIFF
--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -163,6 +163,11 @@ export function collectUsedIdentifiers(ctx: ClientJsContext): Set<string> {
     extractIdentifiers(attr.expression, used)
   }
 
+  for (const provider of ctx.providerSetups) {
+    extractIdentifiers(provider.contextName, used)
+    extractIdentifiers(provider.valueExpr, used)
+  }
+
   return used
 }
 


### PR DESCRIPTION
## Summary

- `collectUsedIdentifiers()` in `identifiers.ts` did not scan `ctx.providerSetups`, causing named functions referenced only in provider value expressions (e.g., `handleValueChange` in `<Ctx.Provider value={{ handleValueChange }}>`) to be silently dropped from generated client JS
- Added `providerSetups` scanning (both `contextName` and `valueExpr`) to `collectUsedIdentifiers()`, following the same pattern used by `childInits` and `reactiveAttrs`
- Added regression test verifying the function is emitted and defined before the `provideContext()` call

Fixes #342

## Test plan

- [x] New test case: named function reference in provider value appears in client JS and is defined before `provideContext()` call
- [x] Compiler tests pass (66 tests)
- [x] Full jsx + dom package tests pass (283 tests, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)