### PR TITLE
Fix child components inside .map() not initialized with initChild()

### DIFF
--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -359,6 +359,9 @@ function transformComponentElement(
   // (createSignal, createMemo) that requires hydration via findScope().
   const slotId = generateSlotId(ctx)
 
+  // Propagate slotId to loop children so they use the parent's marker
+  propagateSlotIdToLoops(children, slotId)
+
   return {
     type: 'component',
     name,


### PR DESCRIPTION
## Summary

Closes #344.

- Add missing `propagateSlotIdToLoops(children, slotId)` call in `transformComponentElement` (`jsx-to-ir.ts`)
- HTML elements already propagated slotId to child loops, but component elements did not — causing `IRLoop` nodes to keep `slotId: null`, which meant `collect-elements` skipped them entirely and no `initChild()` or `reconcileList`/`createComponent` calls were generated
- Add 3 compiler tests covering static array (nested + direct) and dynamic signal array patterns

## Test plan

- [x] New compiler tests pass (`bun test packages/jsx/src/__tests__/compiler.test.ts`)
- [ ] CI passes
- [ ] Verify RadioGroup Card demo hydrates child components correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)