### PR TITLE
Add RadioGroup component

### DIFF
--- a/site/ui/components/radio-group-demo.tsx
+++ b/site/ui/components/radio-group-demo.tsx
@@ -1,0 +1,143 @@
+"use client"
+/**
+ * RadioGroupDemo Components
+ *
+ * Interactive demos for RadioGroup component.
+ * Based on shadcn/ui patterns for practical use cases.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
+
+/**
+ * Basic radio group example
+ * Shows simple usage with display density options and selected value display
+ */
+export function RadioGroupBasicDemo() {
+  const [density, setDensity] = createSignal('default')
+
+  return (
+    <div className="space-y-4">
+      <RadioGroup defaultValue="default" onValueChange={setDensity}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="default" />
+          <span className="text-sm font-medium leading-none">Default</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="comfortable" />
+          <span className="text-sm font-medium leading-none">Comfortable</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="compact" />
+          <span className="text-sm font-medium leading-none">Compact</span>
+        </div>
+      </RadioGroup>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Selected: {density()}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Form example with multiple radio groups
+ * Notification settings pattern with two independent RadioGroups
+ */
+export function RadioGroupFormDemo() {
+  const [notifyType, setNotifyType] = createSignal('all')
+  const [theme, setTheme] = createSignal('system')
+
+  const summary = createMemo(() =>
+    `Notifications: ${notifyType()}, Theme: ${theme()}`
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium leading-none">Notify me about...</h4>
+        <RadioGroup defaultValue="all" onValueChange={setNotifyType}>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="all" />
+            <span className="text-sm leading-none">All new messages</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="mentions" />
+            <span className="text-sm leading-none">Direct messages and mentions</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="none" />
+            <span className="text-sm leading-none">Nothing</span>
+          </div>
+        </RadioGroup>
+      </div>
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium leading-none">Theme</h4>
+        <RadioGroup defaultValue="system" onValueChange={setTheme}>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="light" />
+            <span className="text-sm leading-none">Light</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="dark" />
+            <span className="text-sm leading-none">Dark</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="system" />
+            <span className="text-sm leading-none">System</span>
+          </div>
+        </RadioGroup>
+      </div>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        {summary()}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Card-style radio group
+ * Plan selection pattern with rich card options
+ */
+export function RadioGroupCardDemo() {
+  const [plan, setPlan] = createSignal('startup')
+
+  return (
+    <div className="space-y-4">
+      <RadioGroup defaultValue="startup" onValueChange={setPlan} class="grid-cols-1 sm:grid-cols-3">
+        <div className="relative">
+          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+            <RadioGroupItem value="startup" />
+            <div className="space-y-1">
+              <span className="text-sm font-medium leading-none">Startup</span>
+              <p className="text-xl font-bold text-foreground">$29<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
+              <p className="text-sm text-muted-foreground">For small teams getting started</p>
+            </div>
+          </div>
+        </div>
+        <div className="relative">
+          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+            <RadioGroupItem value="business" />
+            <div className="space-y-1">
+              <span className="text-sm font-medium leading-none">Business</span>
+              <p className="text-xl font-bold text-foreground">$99<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
+              <p className="text-sm text-muted-foreground">For growing companies</p>
+            </div>
+          </div>
+        </div>
+        <div className="relative">
+          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+            <RadioGroupItem value="enterprise" />
+            <div className="space-y-1">
+              <span className="text-sm font-medium leading-none">Enterprise</span>
+              <p className="text-xl font-bold text-foreground">$299<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
+              <p className="text-sm text-muted-foreground">For large organizations</p>
+            </div>
+          </div>
+        </div>
+      </RadioGroup>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Selected plan: {plan()}
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -17,6 +17,7 @@ export const componentOrder = [
   { slug: 'input', title: 'Input' },
   { slug: 'label', title: 'Label' },
   { slug: 'portal', title: 'Portal' },
+  { slug: 'radio-group', title: 'Radio Group' },
   { slug: 'select', title: 'Select' },
   { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },

--- a/site/ui/e2e/radio-group.spec.ts
+++ b/site/ui/e2e/radio-group.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('RadioGroup Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/radio-group')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Radio Group')
+    await expect(page.locator('text=A set of checkable buttons where only one can be checked')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('RadioGroup Rendering', () => {
+    test('displays radio elements', async ({ page }) => {
+      const radios = page.locator('button[role="radio"]')
+      await expect(radios.first()).toBeVisible()
+    })
+
+    test('has multiple radio examples', async ({ page }) => {
+      const radios = page.locator('button[role="radio"]')
+      // Should have radios on the page (preview + examples)
+      expect(await radios.count()).toBeGreaterThan(3)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three radio items', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios).toHaveCount(3)
+    })
+
+    test('first radio starts checked (defaultValue)', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'true')
+      await expect(radios.first()).toHaveAttribute('data-state', 'checked')
+    })
+
+    test('other radios start unchecked', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'false')
+      await expect(radios.nth(2)).toHaveAttribute('aria-checked', 'false')
+    })
+
+    test('clicking selects a radio and deselects others (exclusive selection)', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+
+      // Initially "default" is selected
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'true')
+
+      // Click "comfortable" (second radio)
+      await radios.nth(1).click()
+
+      // Second should be checked, first should be unchecked
+      await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'true')
+      await expect(radios.nth(1)).toHaveAttribute('data-state', 'checked')
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'false')
+      await expect(radios.first()).toHaveAttribute('data-state', 'unchecked')
+    })
+
+    test('shows selected value text', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Selected:')).toBeVisible()
+      // Use first() since "default" appears in radio label and selected text
+      await expect(section.locator('text=default').first()).toBeVisible()
+    })
+
+    test('updates selected text when clicking another option', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupBasicDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+
+      // Click "compact" (third radio)
+      await radios.nth(2).click()
+      await expect(section.locator('text=/Selected:.*compact/')).toBeVisible()
+    })
+  })
+
+  test.describe('Form', () => {
+    test('displays form example with two radio groups', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Form")')).toBeVisible()
+      const section = page.locator('[bf-s^="RadioGroupFormDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      // Should have 6 radio items total (3 for notify + 3 for theme)
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios).toHaveCount(6)
+    })
+
+    test('shows notification and theme headings', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupFormDemo_"]:not([data-slot])').first()
+      await expect(section.locator('h4:has-text("Notify me about")')).toBeVisible()
+      await expect(section.locator('h4:has-text("Theme")')).toBeVisible()
+    })
+
+    test('default values are selected', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupFormDemo_"]:not([data-slot])').first()
+      const radioGroups = section.locator('[data-slot="radio-group"]')
+
+      // First group: "all" selected (first radio)
+      const notifyRadios = radioGroups.first().locator('button[role="radio"]')
+      await expect(notifyRadios.first()).toHaveAttribute('aria-checked', 'true')
+
+      // Second group: "system" selected (third radio)
+      const themeRadios = radioGroups.nth(1).locator('button[role="radio"]')
+      await expect(themeRadios.nth(2)).toHaveAttribute('aria-checked', 'true')
+    })
+
+    test('independent radio groups do not interfere', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupFormDemo_"]:not([data-slot])').first()
+      const radioGroups = section.locator('[data-slot="radio-group"]')
+
+      const notifyRadios = radioGroups.first().locator('button[role="radio"]')
+      const themeRadios = radioGroups.nth(1).locator('button[role="radio"]')
+
+      // Change notification to "mentions"
+      await notifyRadios.nth(1).click()
+      await expect(notifyRadios.nth(1)).toHaveAttribute('aria-checked', 'true')
+
+      // Theme should still be "system"
+      await expect(themeRadios.nth(2)).toHaveAttribute('aria-checked', 'true')
+
+      // Change theme to "dark"
+      await themeRadios.nth(1).click()
+      await expect(themeRadios.nth(1)).toHaveAttribute('aria-checked', 'true')
+
+      // Notification should still be "mentions"
+      await expect(notifyRadios.nth(1)).toHaveAttribute('aria-checked', 'true')
+    })
+
+    test('shows summary text', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupFormDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Notifications:')).toBeVisible()
+    })
+  })
+
+  test.describe('Card', () => {
+    test('displays card example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Card")')).toBeVisible()
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three plan radio items', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios).toHaveCount(3)
+    })
+
+    test('startup plan is selected by default', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'true')
+      await expect(section.locator('text=/Selected plan:.*startup/')).toBeVisible()
+    })
+
+    test('clicking another plan selects it', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+
+      // Click "business" (second plan)
+      await radios.nth(1).click()
+      await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'true')
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'false')
+      await expect(section.locator('text=/Selected plan:.*business/')).toBeVisible()
+    })
+
+    test('displays plan details', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      await expect(section.locator('text=Startup').first()).toBeVisible()
+      await expect(section.locator('text=$29/mo').first()).toBeVisible()
+      await expect(section.locator('text=Business').first()).toBeVisible()
+      await expect(section.locator('text=$99/mo')).toBeVisible()
+      await expect(section.locator('text=Enterprise').first()).toBeVisible()
+      await expect(section.locator('text=$299/mo')).toBeVisible()
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays RadioGroup and RadioGroupItem props tables', async ({ page }) => {
+      await expect(page.locator('h3').filter({ hasText: /^RadioGroup$/ })).toBeVisible()
+      await expect(page.locator('h3').filter({ hasText: /^RadioGroupItem$/ })).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
+    })
+
+    test('displays key props', async ({ page }) => {
+      const tables = page.locator('table')
+      await expect(tables.first().locator('td').filter({ hasText: /^defaultValue$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
+      await expect(tables.nth(1).locator('td').filter({ hasText: /^value$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/radio-group.tsx
+++ b/site/ui/pages/radio-group.tsx
@@ -1,0 +1,248 @@
+/**
+ * RadioGroup Documentation Page
+ */
+
+import {
+  RadioGroupBasicDemo,
+  RadioGroupFormDemo,
+  RadioGroupCardDemo,
+} from '@/components/radio-group-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  getHighlightedCommands,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'form', title: 'Form', branch: 'child' },
+  { id: 'card', title: 'Card', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples - Preview (Form Demo)
+const formCode = `"use client"
+
+import { createSignal, createMemo } from "@barefootjs/dom"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+
+export function RadioGroupFormDemo() {
+  const [notifyType, setNotifyType] = createSignal("all")
+  const [theme, setTheme] = createSignal("system")
+
+  const summary = createMemo(() =>
+    \`Notifications: \${notifyType()}, Theme: \${theme()}\`
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium leading-none">Notify me about...</h4>
+        <RadioGroup defaultValue="all" onValueChange={setNotifyType}>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="all" />
+            <span className="text-sm leading-none">All new messages</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="mentions" />
+            <span className="text-sm leading-none">Direct messages and mentions</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="none" />
+            <span className="text-sm leading-none">Nothing</span>
+          </div>
+        </RadioGroup>
+      </div>
+      <div className="space-y-3">
+        <h4 className="text-sm font-medium leading-none">Theme</h4>
+        <RadioGroup defaultValue="system" onValueChange={setTheme}>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="light" />
+            <span className="text-sm leading-none">Light</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="dark" />
+            <span className="text-sm leading-none">Dark</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="system" />
+            <span className="text-sm leading-none">System</span>
+          </div>
+        </RadioGroup>
+      </div>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        {summary()}
+      </div>
+    </div>
+  )
+}`
+
+const basicCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+
+export function RadioGroupBasicDemo() {
+  const [density, setDensity] = createSignal("default")
+
+  return (
+    <div className="space-y-4">
+      <RadioGroup defaultValue="default" onValueChange={setDensity}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="default" />
+          <span className="text-sm font-medium leading-none">Default</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="comfortable" />
+          <span className="text-sm font-medium leading-none">Comfortable</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="compact" />
+          <span className="text-sm font-medium leading-none">Compact</span>
+        </div>
+      </RadioGroup>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Selected: {density()}
+      </div>
+    </div>
+  )
+}`
+
+const cardCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+
+const plans = [
+  { value: "startup", name: "Startup", price: "$29", description: "For small teams getting started" },
+  { value: "business", name: "Business", price: "$99", description: "For growing companies" },
+  { value: "enterprise", name: "Enterprise", price: "$299", description: "For large organizations" },
+]
+
+export function RadioGroupCardDemo() {
+  const [plan, setPlan] = createSignal("startup")
+
+  return (
+    <div className="space-y-4">
+      <RadioGroup defaultValue="startup" onValueChange={setPlan} class="grid-cols-1 sm:grid-cols-3">
+        {plans.map((p) => (
+          <div key={p.value} className="relative">
+            <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+              <RadioGroupItem value={p.value} />
+              <div className="space-y-1">
+                <span className="text-sm font-medium leading-none">{p.name}</span>
+                <p className="text-xl font-bold text-foreground">
+                  {p.price}<span className="text-sm font-normal text-muted-foreground">/mo</span>
+                </p>
+                <p className="text-sm text-muted-foreground">{p.description}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </RadioGroup>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Selected plan: {plan()}
+      </div>
+    </div>
+  )
+}`
+
+// Props definitions
+const radioGroupProps: PropDefinition[] = [
+  {
+    name: 'defaultValue',
+    type: 'string',
+    description: 'The initial selected value for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled selected value. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Event handler called when the selected value changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the entire radio group is disabled.',
+  },
+]
+
+const radioGroupItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value of this radio item. Required.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this radio item is disabled.',
+  },
+]
+
+export function RadioGroupPage() {
+  const installCommands = getHighlightedCommands('barefoot add radio-group')
+
+  return (
+    <DocPage slug="radio-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Radio Group"
+          description="A set of checkable buttons where only one can be checked at a time."
+          {...getNavLinks('radio-group')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={formCode}>
+          <RadioGroupFormDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add radio-group" highlightedCommands={installCommands} />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <RadioGroupBasicDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <RadioGroupFormDemo />
+            </Example>
+
+            <Example title="Card" code={cardCode}>
+              <RadioGroupCardDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <h3 className="text-lg font-semibold mb-4">RadioGroup</h3>
+          <PropsTable props={radioGroupProps} />
+          <h3 className="text-lg font-semibold mb-4 mt-8">RadioGroupItem</h3>
+          <PropsTable props={radioGroupItemProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -81,6 +81,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
       { title: 'Input', href: '/docs/components/input' },
       { title: 'Label', href: '/docs/components/label' },
+      { title: 'Radio Group', href: '/docs/components/radio-group' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -27,6 +27,7 @@ import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
 import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
+import { RadioGroupPage } from './pages/radio-group'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -270,6 +271,11 @@ export function createApp() {
   // Portal documentation
   app.get('/docs/components/portal', (c) => {
     return c.render(<PortalPage />)
+  })
+
+  // Radio Group documentation
+  app.get('/docs/components/radio-group', (c) => {
+    return c.render(<RadioGroupPage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/radio-group.tsx
+++ b/ui/components/ui/radio-group.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+/**
+ * RadioGroup Component
+ *
+ * A set of checkable buttons where only one can be checked at a time.
+ * Supports both controlled and uncontrolled modes.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Uncontrolled (internal state)
+ * ```tsx
+ * <RadioGroup defaultValue="default">
+ *   <RadioGroupItem value="default" />
+ *   <RadioGroupItem value="comfortable" />
+ *   <RadioGroupItem value="compact" />
+ * </RadioGroup>
+ * ```
+ *
+ * @example Controlled (external state)
+ * ```tsx
+ * <RadioGroup value={selected()} onValueChange={setSelected}>
+ *   <RadioGroupItem value="option-1" />
+ *   <RadioGroupItem value="option-2" />
+ * </RadioGroup>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect, createMemo } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Context for parent-child state sharing
+interface RadioGroupContextValue {
+  value: () => string
+  onValueChange: (value: string) => void
+  disabled: () => boolean
+}
+
+const RadioGroupContext = createContext<RadioGroupContextValue>()
+
+// CSS classes for RadioGroupItem (module-level constants)
+const itemBaseClasses = 'aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none'
+const itemFocusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+const itemStateClasses = '[&[data-state=unchecked]]:border-input [&[data-state=unchecked]]:text-primary dark:[&[data-state=unchecked]]:bg-input/30 [&[data-state=checked]]:border-primary [&[data-state=checked]]:text-primary'
+const itemErrorClasses = 'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+const itemDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+const itemClasses = `${itemBaseClasses} ${itemFocusClasses} ${itemStateClasses} ${itemErrorClasses} ${itemDisabledClasses} grid place-content-center`
+
+/**
+ * Props for the RadioGroup component.
+ */
+interface RadioGroupProps {
+  /** Default selected value (for uncontrolled mode). */
+  defaultValue?: string
+  /** Controlled selected value. When provided, component is in controlled mode. */
+  value?: string
+  /** Callback when the selected value changes. */
+  onValueChange?: (value: string) => void
+  /** Whether the entire group is disabled. */
+  disabled?: boolean
+  /** Additional CSS classes. */
+  class?: string
+  /** RadioGroupItem children. */
+  children?: Child
+}
+
+/**
+ * RadioGroup component for single selection.
+ * Manages value state and provides context to RadioGroupItem children.
+ */
+function RadioGroup(props: RadioGroupProps) {
+  // Internal state for uncontrolled mode
+  const [internalValue, setInternalValue] = createSignal(props.defaultValue ?? '')
+
+  // Controlled state
+  const [controlledValue, setControlledValue] = createSignal<string | undefined>(props.value)
+
+  // Track if component is in controlled mode
+  const isControlled = createMemo(() => props.value !== undefined)
+
+  // Determine current value
+  const currentValue = createMemo(() => isControlled() ? (controlledValue() ?? '') : internalValue())
+
+  return (
+    <RadioGroupContext.Provider value={{
+      value: currentValue,
+      onValueChange: (newValue: string) => {
+        if (isControlled()) {
+          setControlledValue(newValue)
+        } else {
+          setInternalValue(newValue)
+        }
+        props.onValueChange?.(newValue)
+      },
+      disabled: () => props.disabled ?? false,
+    }}>
+      <div
+        data-slot="radio-group"
+        role="radiogroup"
+        className={`grid gap-3 ${props.class ?? ''}`}
+      >
+        {props.children}
+      </div>
+    </RadioGroupContext.Provider>
+  )
+}
+
+/**
+ * Props for the RadioGroupItem component.
+ */
+interface RadioGroupItemProps {
+  /** Value for this radio item. */
+  value: string
+  /** Whether this item is disabled. */
+  disabled?: boolean
+  /** Additional CSS classes. */
+  class?: string
+}
+
+/**
+ * RadioGroupItem component.
+ * A single radio button within a RadioGroup.
+ */
+function RadioGroupItem(props: RadioGroupItemProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(RadioGroupContext)
+
+    createEffect(() => {
+      const isSelected = ctx.value() === props.value
+      el.setAttribute('aria-checked', String(isSelected))
+      el.setAttribute('data-state', isSelected ? 'checked' : 'unchecked')
+
+      // Update indicator dot visibility
+      const indicator = el.querySelector('[data-slot="radio-group-indicator"]') as HTMLElement
+      if (indicator) {
+        const circle = indicator.querySelector('circle')
+        if (isSelected && !circle) {
+          indicator.innerHTML = '<svg class="size-3.5 fill-primary" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" /></svg>'
+        } else if (!isSelected && circle) {
+          indicator.innerHTML = ''
+        }
+      }
+    })
+
+    el.addEventListener('click', () => {
+      if (el.hasAttribute('disabled') || ctx.disabled()) return
+      ctx.onValueChange(props.value)
+    })
+  }
+
+  return (
+    <button
+      data-slot="radio-group-item"
+      data-state="unchecked"
+      role="radio"
+      aria-checked="false"
+      disabled={props.disabled ?? false}
+      className={`${itemClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      <span data-slot="radio-group-indicator" className="flex items-center justify-center">
+        {/* Dot indicator rendered reactively via effect */}
+      </span>
+    </button>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }
+export type { RadioGroupProps, RadioGroupItemProps }


### PR DESCRIPTION
## Summary

- Add `RadioGroup` and `RadioGroupItem` components ported from shadcn/ui with context-based parent-child communication
- Add 3 interactive demos: Basic (density selection), Form (notification + theme settings), Card (plan selection)
- Add documentation page with installation, examples, and API reference sections
- Add 25 E2E tests covering rendering, state management, exclusive selection, and independent radio groups
- Card demo uses unrolled JSX as workaround for compiler issue #360

## Test plan

- [x] All 25 E2E tests pass (`radio-group.spec.ts`)
- [ ] Visual review of Radio Group documentation page
- [ ] Verify sidebar navigation ordering (after Label, before Select)

🤖 Generated with [Claude Code](https://claude.com/claude-code)