### PR TITLE
Fix duplicate variable declaration when .map() shares slot ID with parent component (#360)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -275,6 +275,14 @@ export function generateElementRefs(ctx: ClientJsContext): string {
     }
   }
 
+  // Component slots take precedence over regular slots (#360).
+  // When a component contains a loop that inherits the component's slot ID
+  // (via propagateSlotIdToLoops), both need the same DOM element reference.
+  // Component elements use bf-s attributes, so $c() is the correct selector.
+  for (const slotId of componentSlots) {
+    regularSlots.delete(slotId)
+  }
+
   if (regularSlots.size === 0 && componentSlots.size === 0) return ''
 
   const refLines: string[] = []


### PR DESCRIPTION
## Summary

- Fix `SyntaxError: Identifier '_sN' has already been declared` caused by `generateElementRefs()` emitting both `$()` and `$c()` declarations for the same slot ID
- When a component element contains a `.map()` loop, `propagateSlotIdToLoops()` assigns the component's slot ID to the loop, causing both `regularSlots` and `componentSlots` to contain the same ID
- Component slots (`$c`) now take precedence: any slot in `componentSlots` is removed from `regularSlots` before emission
- Add regression test verifying no duplicate `const _sN =` declarations

Fixes #360

## Test plan

- [x] All 180 compiler tests pass (`bun test`)
- [x] Regression test covers component-wrapping-loop scenario
- [x] Existing `.map()` + child component tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)