### PR TITLE
Namespace bf-p props, fix RadioGroup card clicks and yarn command

### DIFF
--- a/packages/dom/__tests__/runtime.test.ts
+++ b/packages/dom/__tests__/runtime.test.ts
@@ -322,7 +322,7 @@ describe('hydrate', () => {
     const initialized: Array<{ props: Record<string, unknown>; scope: Element }> = []
 
     document.body.innerHTML = `
-      <div bf-s="Counter_abc" bf-p='{"count": 5}'>content</div>
+      <div bf-s="Counter_abc" bf-p='{"Counter": {"count": 5}}'>content</div>
     `
 
     hydrate('Counter', (props, idx, scope) => {

--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -274,9 +274,10 @@ export function hydrate(
       // Mark as initialized immediately to prevent duplicate init
       scopeEl.setAttribute(BF_HYDRATED, 'true')
 
-      // Read props from bf-p attribute on the scope element
+      // Read props from bf-p attribute (namespaced format: {"CompA": {...}, "CompB": {...}})
       const propsJson = scopeEl.getAttribute(BF_PROPS)
-      const props = propsJson ? JSON.parse(propsJson) : {}
+      const parsed = propsJson ? JSON.parse(propsJson) : {}
+      const props = parsed[name] ?? {}
 
       init(props, 0, scopeEl)
     }

--- a/site/ui/components/package-manager-tabs.tsx
+++ b/site/ui/components/package-manager-tabs.tsx
@@ -5,125 +5,48 @@
  * A tabbed interface for displaying installation commands
  * for different package managers (pnpm, npm, yarn, bun).
  *
- * This component is compiled by BarefootJS to enable client-side
- * interactivity (tab switching).
+ * Uses value switching (single code display area) instead of
+ * HTML switching (4 separate TabsContent panels) to minimize
+ * serialized props and client JS complexity.
  */
 
 import { createSignal, createMemo } from '@barefootjs/dom'
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from '@ui/components/ui/tabs'
 import { CopyButton } from './copy-button'
-
-interface HighlightedCommands {
-  pnpm: string
-  npm: string
-  yarn: string
-  bun: string
-}
 
 interface PackageManagerTabsProps {
   command: string
-  /** Pre-highlighted HTML for each package manager command (server-side rendered) */
-  highlightedCommands?: HighlightedCommands
 }
 
-export function PackageManagerTabs({ command, highlightedCommands }: PackageManagerTabsProps) {
+const tabTriggerBase = 'inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none'
+const tabTriggerFocus = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+const tabTriggerActive = 'bg-background text-foreground shadow-sm dark:border-input dark:bg-input/30'
+const tabTriggerInactive = 'text-foreground dark:text-muted-foreground'
+
+export function PackageManagerTabs(props: PackageManagerTabsProps) {
   const [selected, setSelected] = createSignal('bun')
 
-  const isPnpmSelected = createMemo(() => selected() === 'pnpm')
-  const isNpmSelected = createMemo(() => selected() === 'npm')
-  const isYarnSelected = createMemo(() => selected() === 'yarn')
-  const isBunSelected = createMemo(() => selected() === 'bun')
-
-  const pnpmCommand = `pnpm dlx ${command}`
-  const npmCommand = `npx ${command}`
-  const yarnCommand = `yarn dlx ${command}`
-  const bunCommand = `bunx --bun ${command}`
+  const fullCommand = createMemo(() => {
+    const prefix = selected() === 'bun' ? 'bunx --bun'
+      : selected() === 'pnpm' ? 'pnpm dlx'
+      : selected() === 'yarn' ? 'yarn dlx'
+      : 'npx'
+    return `${prefix} ${props.command}`
+  })
 
   return (
-    <Tabs value={selected()} onValueChange={(v) => setSelected(v)}>
-      <TabsList>
-        <TabsTrigger
-          value="pnpm"
-          selected={isPnpmSelected()}
-          onClick={() => setSelected('pnpm')}
-        >
-          pnpm
-        </TabsTrigger>
-        <TabsTrigger
-          value="npm"
-          selected={isNpmSelected()}
-          onClick={() => setSelected('npm')}
-        >
-          npm
-        </TabsTrigger>
-        <TabsTrigger
-          value="yarn"
-          selected={isYarnSelected()}
-          onClick={() => setSelected('yarn')}
-        >
-          yarn
-        </TabsTrigger>
-        <TabsTrigger
-          value="bun"
-          selected={isBunSelected()}
-          onClick={() => setSelected('bun')}
-        >
-          bun
-        </TabsTrigger>
-      </TabsList>
-      <TabsContent value="pnpm" selected={isPnpmSelected()}>
-        <div className="relative group">
-          <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border border-border">
-            {highlightedCommands ? (
-              <code dangerouslySetInnerHTML={{ __html: highlightedCommands.pnpm }} />
-            ) : (
-              <code>{pnpmCommand}</code>
-            )}
-          </pre>
-          <CopyButton code={pnpmCommand} />
-        </div>
-      </TabsContent>
-      <TabsContent value="npm" selected={isNpmSelected()}>
-        <div className="relative group">
-          <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border border-border">
-            {highlightedCommands ? (
-              <code dangerouslySetInnerHTML={{ __html: highlightedCommands.npm }} />
-            ) : (
-              <code>{npmCommand}</code>
-            )}
-          </pre>
-          <CopyButton code={npmCommand} />
-        </div>
-      </TabsContent>
-      <TabsContent value="yarn" selected={isYarnSelected()}>
-        <div className="relative group">
-          <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border border-border">
-            {highlightedCommands ? (
-              <code dangerouslySetInnerHTML={{ __html: highlightedCommands.yarn }} />
-            ) : (
-              <code>{yarnCommand}</code>
-            )}
-          </pre>
-          <CopyButton code={yarnCommand} />
-        </div>
-      </TabsContent>
-      <TabsContent value="bun" selected={isBunSelected()}>
-        <div className="relative group">
-          <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border border-border">
-            {highlightedCommands ? (
-              <code dangerouslySetInnerHTML={{ __html: highlightedCommands.bun }} />
-            ) : (
-              <code>{bunCommand}</code>
-            )}
-          </pre>
-          <CopyButton code={bunCommand} />
-        </div>
-      </TabsContent>
-    </Tabs>
+    <div className="flex flex-col gap-2 w-full">
+      <div role="tablist" className="bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]">
+        <button role="tab" aria-selected={selected() === 'bun'} data-state={selected() === 'bun' ? 'active' : 'inactive'} onClick={() => setSelected('bun')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'bun' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'bun' ? 0 : -1}>bun</button>
+        <button role="tab" aria-selected={selected() === 'npm'} data-state={selected() === 'npm' ? 'active' : 'inactive'} onClick={() => setSelected('npm')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'npm' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'npm' ? 0 : -1}>npm</button>
+        <button role="tab" aria-selected={selected() === 'pnpm'} data-state={selected() === 'pnpm' ? 'active' : 'inactive'} onClick={() => setSelected('pnpm')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'pnpm' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'pnpm' ? 0 : -1}>pnpm</button>
+        <button role="tab" aria-selected={selected() === 'yarn'} data-state={selected() === 'yarn' ? 'active' : 'inactive'} onClick={() => setSelected('yarn')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'yarn' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'yarn' ? 0 : -1}>yarn</button>
+      </div>
+      <div className="relative group">
+        <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border border-border">
+          <code>{fullCommand()}</code>
+        </pre>
+        <CopyButton code={fullCommand()} />
+      </div>
+    </div>
   )
 }

--- a/site/ui/components/package-manager-tabs.tsx
+++ b/site/ui/components/package-manager-tabs.tsx
@@ -41,7 +41,7 @@ export function PackageManagerTabs({ command, highlightedCommands }: PackageMana
 
   const pnpmCommand = `pnpm dlx ${command}`
   const npmCommand = `npx ${command}`
-  const yarnCommand = `npx ${command}`
+  const yarnCommand = `yarn dlx ${command}`
   const bunCommand = `bunx --bun ${command}`
 
   return (

--- a/site/ui/components/radio-group-demo.tsx
+++ b/site/ui/components/radio-group-demo.tsx
@@ -105,34 +105,34 @@ export function RadioGroupCardDemo() {
     <div className="space-y-4">
       <RadioGroup defaultValue="startup" onValueChange={setPlan} class="grid-cols-1 sm:grid-cols-3">
         <div className="relative">
-          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+          <label className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
             <RadioGroupItem value="startup" />
             <div className="space-y-1">
               <span className="text-sm font-medium leading-none">Startup</span>
               <p className="text-xl font-bold text-foreground">$29<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
               <p className="text-sm text-muted-foreground">For small teams getting started</p>
             </div>
-          </div>
+          </label>
         </div>
         <div className="relative">
-          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+          <label className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
             <RadioGroupItem value="business" />
             <div className="space-y-1">
               <span className="text-sm font-medium leading-none">Business</span>
               <p className="text-xl font-bold text-foreground">$99<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
               <p className="text-sm text-muted-foreground">For growing companies</p>
             </div>
-          </div>
+          </label>
         </div>
         <div className="relative">
-          <div className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
+          <label className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
             <RadioGroupItem value="enterprise" />
             <div className="space-y-1">
               <span className="text-sm font-medium leading-none">Enterprise</span>
               <p className="text-xl font-bold text-foreground">$299<span className="text-sm font-normal text-muted-foreground">/mo</span></p>
               <p className="text-sm text-muted-foreground">For large organizations</p>
             </div>
-          </div>
+          </label>
         </div>
       </RadioGroup>
       <div className="text-sm text-muted-foreground pt-2 border-t">

--- a/site/ui/components/shared/docs.tsx
+++ b/site/ui/components/shared/docs.tsx
@@ -33,7 +33,7 @@ export function getHighlightedCommands(command: string): HighlightedCommands {
   return {
     pnpm: highlight(`pnpm dlx ${command}`, 'bash'),
     npm: highlight(`npx ${command}`, 'bash'),
-    yarn: highlight(`npx ${command}`, 'bash'),
+    yarn: highlight(`yarn dlx ${command}`, 'bash'),
     bun: highlight(`bunx --bun ${command}`, 'bash'),
   }
 }

--- a/site/ui/components/shared/docs.tsx
+++ b/site/ui/components/shared/docs.tsx
@@ -17,27 +17,6 @@ import { PageNav } from '../../../shared/components/page-nav'
 // Re-export TocItem for convenience
 export type { TocItem }
 
-// Type for pre-highlighted commands (matches PackageManagerTabs prop)
-export interface HighlightedCommands {
-  pnpm: string
-  npm: string
-  yarn: string
-  bun: string
-}
-
-/**
- * Generate pre-highlighted HTML for package manager commands.
- * Use this on server-side pages to pass to PackageManagerTabs.
- */
-export function getHighlightedCommands(command: string): HighlightedCommands {
-  return {
-    pnpm: highlight(`pnpm dlx ${command}`, 'bash'),
-    npm: highlight(`npx ${command}`, 'bash'),
-    yarn: highlight(`yarn dlx ${command}`, 'bash'),
-    bun: highlight(`bunx --bun ${command}`, 'bash'),
-  }
-}
-
 // Documentation page wrapper with TOC sidebar and footer navigation
 export interface DocPageProps {
   slug: string

--- a/site/ui/e2e/installation-tabs.spec.ts
+++ b/site/ui/e2e/installation-tabs.spec.ts
@@ -25,9 +25,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await expect(page.locator('text=bunx --bun barefoot add checkbox')).toBeVisible()
   })
 
-  // Skip: tabs click behavior not working consistently
-  // Same issue as tabs.spec.ts - child component init issue
-  test.skip('clicking npm tab switches content', async ({ page }) => {
+  test('clicking npm tab switches content', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
     const npmTab = tablist.getByRole('tab', { name: 'npm', exact: true })
 
@@ -37,7 +35,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await expect(page.locator('text=npx barefoot add checkbox')).toBeVisible()
   })
 
-  test.skip('clicking pnpm tab switches content', async ({ page }) => {
+  test('clicking pnpm tab switches content', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
     const pnpmTab = tablist.getByRole('tab', { name: 'pnpm' })
 
@@ -47,7 +45,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await expect(page.locator('text=pnpm dlx barefoot add checkbox')).toBeVisible()
   })
 
-  test.skip('clicking yarn tab switches content', async ({ page }) => {
+  test('clicking yarn tab switches content', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
     const yarnTab = tablist.getByRole('tab', { name: 'yarn' })
 
@@ -57,7 +55,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await expect(page.locator('text=yarn dlx barefoot add checkbox')).toBeVisible()
   })
 
-  test.skip('switching tabs updates aria-selected correctly', async ({ page }) => {
+  test('switching tabs updates aria-selected correctly', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
     const bunTab = tablist.getByRole('tab', { name: 'bun' })
     const npmTab = tablist.getByRole('tab', { name: 'npm', exact: true })

--- a/site/ui/e2e/radio-group.spec.ts
+++ b/site/ui/e2e/radio-group.spec.ts
@@ -179,6 +179,20 @@ test.describe('RadioGroup Documentation Page', () => {
       await expect(section.locator('text=/Selected plan:.*business/')).toBeVisible()
     })
 
+    test('clicking card area selects the radio', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
+      const radios = section.locator('button[role="radio"]')
+
+      // Click on the card text area (label), not the radio button directly
+      const cardLabels = section.locator('label.flex')
+      await cardLabels.nth(1).click()
+
+      // "business" (second radio) should now be selected
+      await expect(radios.nth(1)).toHaveAttribute('aria-checked', 'true')
+      await expect(radios.first()).toHaveAttribute('aria-checked', 'false')
+      await expect(section.locator('text=/Selected plan:.*business/')).toBeVisible()
+    })
+
     test('displays plan details', async ({ page }) => {
       const section = page.locator('[bf-s^="RadioGroupCardDemo_"]:not([data-slot])').first()
       await expect(section.locator('text=Startup').first()).toBeVisible()

--- a/site/ui/pages/accordion.tsx
+++ b/site/ui/pages/accordion.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -182,8 +181,6 @@ const accordionTriggerProps: PropDefinition[] = [
 const accordionContentProps: PropDefinition[] = []
 
 export function AccordionPage() {
-  const installCommands = getHighlightedCommands('barefoot add accordion')
-
   return (
     <DocPage slug="accordion" toc={tocItems}>
       <div className="space-y-12">
@@ -202,7 +199,7 @@ export function AccordionPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add accordion" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add accordion" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/badge.tsx
+++ b/site/ui/pages/badge.tsx
@@ -11,7 +11,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -106,8 +105,6 @@ const badgeProps: PropDefinition[] = [
 ]
 
 export function BadgePage() {
-  const installCommands = getHighlightedCommands('barefoot add badge')
-
   return (
     <DocPage slug="badge" toc={tocItems}>
       <div className="space-y-12">
@@ -124,7 +121,7 @@ export function BadgePage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add badge" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add badge" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/button.tsx
+++ b/site/ui/pages/button.tsx
@@ -13,7 +13,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -95,9 +94,6 @@ const buttonProps: PropDefinition[] = [
 ]
 
 export function ButtonPage() {
-  // Generate highlighted commands inside component (after Shiki is initialized)
-  const installCommands = getHighlightedCommands('barefoot add button')
-
   return (
     <DocPage slug="button" toc={tocItems}>
       <div className="space-y-12">
@@ -130,7 +126,7 @@ function ButtonExample() {
         </Example>
 
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add button" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add button" />
         </Section>
 
         <Section id="examples" title="Examples">

--- a/site/ui/pages/card.tsx
+++ b/site/ui/pages/card.tsx
@@ -22,7 +22,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -342,8 +341,6 @@ const cardFooterProps: PropDefinition[] = [
 ]
 
 export function CardPage() {
-  const installCommands = getHighlightedCommands('barefoot add card')
-
   return (
     <DocPage slug="card" toc={tocItems}>
       <div className="space-y-12">
@@ -376,7 +373,7 @@ export function CardPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add card" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add card" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/checkbox.tsx
+++ b/site/ui/pages/checkbox.tsx
@@ -15,7 +15,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -222,8 +221,6 @@ const checkboxProps: PropDefinition[] = [
 ]
 
 export function CheckboxPage() {
-  const installCommands = getHighlightedCommands('barefoot add checkbox')
-
   return (
     <DocPage slug="checkbox" toc={tocItems}>
       <div className="space-y-12">
@@ -240,7 +237,7 @@ export function CheckboxPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add checkbox" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add checkbox" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/dialog.tsx
+++ b/site/ui/pages/dialog.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -269,8 +268,6 @@ const dialogDescriptionProps: PropDefinition[] = [
 const dialogCloseProps: PropDefinition[] = []
 
 export function DialogPage() {
-  const installCommands = getHighlightedCommands('barefoot add dialog')
-
   return (
     <DocPage slug="dialog" toc={tocItems}>
       <div className="space-y-12">
@@ -289,7 +286,7 @@ export function DialogPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add dialog" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add dialog" />
         </Section>
 
         {/* Features */}

--- a/site/ui/pages/dropdown-menu.tsx
+++ b/site/ui/pages/dropdown-menu.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -237,8 +236,6 @@ const dropdownMenuShortcutProps: PropDefinition[] = [
 ]
 
 export function DropdownMenuPage() {
-  const installCommands = getHighlightedCommands('barefoot add dropdown-menu')
-
   return (
     <DocPage slug="dropdown-menu" toc={tocItems}>
       <div className="space-y-12">
@@ -257,7 +254,7 @@ export function DropdownMenuPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add dropdown-menu" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add dropdown-menu" />
         </Section>
 
         {/* Features */}

--- a/site/ui/pages/input.tsx
+++ b/site/ui/pages/input.tsx
@@ -11,7 +11,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -149,8 +148,6 @@ const inputProps: PropDefinition[] = [
 ]
 
 export function InputPage() {
-  const installCommands = getHighlightedCommands('barefoot add input')
-
   return (
     <DocPage slug="input" toc={tocItems}>
       <div className="space-y-12">
@@ -167,7 +164,7 @@ export function InputPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add input" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add input" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/label.tsx
+++ b/site/ui/pages/label.tsx
@@ -7,7 +7,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -74,8 +73,6 @@ const labelProps: PropDefinition[] = [
 ]
 
 export function LabelPage() {
-  const installCommands = getHighlightedCommands('barefoot add label')
-
   return (
     <DocPage slug="label" toc={tocItems}>
       <div className="space-y-12">
@@ -92,7 +89,7 @@ export function LabelPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add label" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add label" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/portal.tsx
+++ b/site/ui/pages/portal.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -114,8 +113,6 @@ const portalReturnProps: PropDefinition[] = [
 ]
 
 export function PortalPage() {
-  const installCommands = getHighlightedCommands('barefoot add portal')
-
   return (
     <DocPage slug="portal" toc={tocItems}>
       <div className="space-y-12">
@@ -134,7 +131,7 @@ export function PortalPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add portal" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add portal" />
         </Section>
 
         {/* Features */}

--- a/site/ui/pages/radio-group.tsx
+++ b/site/ui/pages/radio-group.tsx
@@ -14,7 +14,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -197,8 +196,6 @@ const radioGroupItemProps: PropDefinition[] = [
 ]
 
 export function RadioGroupPage() {
-  const installCommands = getHighlightedCommands('barefoot add radio-group')
-
   return (
     <DocPage slug="radio-group" toc={tocItems}>
       <div className="space-y-12">
@@ -215,7 +212,7 @@ export function RadioGroupPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add radio-group" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add radio-group" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/select.tsx
+++ b/site/ui/pages/select.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -201,8 +200,6 @@ const selectItemProps: PropDefinition[] = [
 ]
 
 export function SelectPage() {
-  const installCommands = getHighlightedCommands('barefoot add select')
-
   return (
     <DocPage slug="select" toc={tocItems}>
       <div className="space-y-12">
@@ -219,7 +216,7 @@ export function SelectPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add select" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add select" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/slider.tsx
+++ b/site/ui/pages/slider.tsx
@@ -15,7 +15,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -234,8 +233,6 @@ const sliderProps: PropDefinition[] = [
 ]
 
 export function SliderPage() {
-  const installCommands = getHighlightedCommands('barefoot add slider')
-
   return (
     <DocPage slug="slider" toc={tocItems}>
       <div className="space-y-12">
@@ -252,7 +249,7 @@ export function SliderPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add slider" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add slider" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/switch.tsx
+++ b/site/ui/pages/switch.tsx
@@ -15,7 +15,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -215,8 +214,6 @@ const switchProps: PropDefinition[] = [
 ]
 
 export function SwitchPage() {
-  const installCommands = getHighlightedCommands('barefoot add switch')
-
   return (
     <DocPage slug="switch" toc={tocItems}>
       <div className="space-y-12">
@@ -233,7 +230,7 @@ export function SwitchPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add switch" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add switch" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/tabs.tsx
+++ b/site/ui/pages/tabs.tsx
@@ -10,7 +10,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -193,8 +192,6 @@ const tabsContentProps: PropDefinition[] = [
 ]
 
 export function TabsPage() {
-  const installCommands = getHighlightedCommands('barefoot add tabs')
-
   return (
     <DocPage slug="tabs" toc={tocItems}>
       <div className="space-y-12">
@@ -213,7 +210,7 @@ export function TabsPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add tabs" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add tabs" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/textarea.tsx
+++ b/site/ui/pages/textarea.tsx
@@ -11,7 +11,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -133,8 +132,6 @@ const textareaProps: PropDefinition[] = [
 ]
 
 export function TextareaPage() {
-  const installCommands = getHighlightedCommands('barefoot add textarea')
-
   return (
     <DocPage slug="textarea" toc={tocItems}>
       <div className="space-y-12">
@@ -153,7 +150,7 @@ export function TextareaPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add textarea" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add textarea" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/toast.tsx
+++ b/site/ui/pages/toast.tsx
@@ -18,7 +18,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -169,8 +168,6 @@ const toastActionProps: PropDefinition[] = [
 ]
 
 export function ToastPage() {
-  const installCommands = getHighlightedCommands('barefoot add toast')
-
   return (
     <DocPage slug="toast" toc={tocItems}>
       <div className="space-y-12">
@@ -189,7 +186,7 @@ export function ToastPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add toast" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add toast" />
         </Section>
 
         {/* Features */}

--- a/site/ui/pages/toggle.tsx
+++ b/site/ui/pages/toggle.tsx
@@ -14,7 +14,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -151,8 +150,6 @@ const toggleProps: PropDefinition[] = [
 ]
 
 export function TogglePage() {
-  const installCommands = getHighlightedCommands('barefoot add toggle')
-
   return (
     <DocPage slug="toggle" toc={tocItems}>
       <div className="space-y-12">
@@ -169,7 +166,7 @@ export function TogglePage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add toggle" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add toggle" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/tooltip.tsx
+++ b/site/ui/pages/tooltip.tsx
@@ -20,7 +20,6 @@ import {
   Example,
   PropsTable,
   PackageManagerTabs,
-  getHighlightedCommands,
   type PropDefinition,
   type TocItem,
 } from '../components/shared/docs'
@@ -169,8 +168,6 @@ const tooltipProps: PropDefinition[] = [
 ]
 
 export function TooltipPage() {
-  const installCommands = getHighlightedCommands('barefoot add tooltip')
-
   return (
     <DocPage slug="tooltip" toc={tocItems}>
       <div className="space-y-12">
@@ -189,7 +186,7 @@ export function TooltipPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="barefoot add tooltip" highlightedCommands={installCommands} />
+          <PackageManagerTabs command="barefoot add tooltip" />
         </Section>
 
         {/* Examples */}


### PR DESCRIPTION
## Summary

- **Namespaced `bf-p`**: When a client component's root JSX is another component (e.g., PackageManagerTabs → Tabs), the parent's props were lost because `bf-p` on the shared DOM element only contained the child component's props. Now each component writes props under its own name key (`{"CompA": {...}, "CompB": {...}}`), and `hydrate()` extracts by component name.
- **RadioGroup card click fix**: Card wrapper `<div>` → `<label>` so clicks on card text area reach the `<RadioGroupItem>` button.
- **Yarn command fix**: `npx` → `yarn dlx` in both `PackageManagerTabs` and `getHighlightedCommands`.
- **PackageManagerTabs refactor**: Replace 4 `TabsContent` panels with conditional Shiki HTML with a single reactive code display. Eliminates `highlightedCommands` from `bf-p` (thousands of chars of serialized Shiki HTML), simplifies client JS (1 text update vs 4× insert branches), and removes redundant state (156 lines net reduction across 21 files).

## Changed files

| File | Change |
|------|--------|
| `packages/dom/src/runtime.ts` | `hydrate()`: extract namespaced props by component name |
| `packages/hono/src/adapter/hono-adapter.ts` | Add `__bfParentPropsNs`, namespace props JSON, pass through root child |
| `site/ui/components/radio-group-demo.tsx` | Card wrapper `<div>` → `<label>` |
| `site/ui/components/package-manager-tabs.tsx` | Rewrite: 4 TabsContent panels → single reactive `<code>{fullCommand()}</code>`, remove Tabs/Shiki deps |
| `site/ui/components/shared/docs.tsx` | Remove `getHighlightedCommands` and `HighlightedCommands` type |
| `site/ui/pages/*.tsx` (19 files) | Remove `getHighlightedCommands` import, `installCommands` variable, and `highlightedCommands` prop |
| `site/ui/e2e/installation-tabs.spec.ts` | Enable 4 previously skipped tests |
| `site/ui/e2e/radio-group.spec.ts` | Add card area click test |

## Test plan

- [x] All 439 E2E tests pass (0 failures)
- [x] 4 previously skipped installation-tabs tests now enabled and passing
- [x] New RadioGroup card area click test passing
- [x] Full site build succeeds
- [x] `bf-p` attribute confirmed to contain only `command` string (no Shiki HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)