### PR TITLE
Add ToggleGroup component with live preview demos

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -25,6 +25,7 @@ export const componentOrder = [
   { slug: 'textarea', title: 'Textarea' },
   { slug: 'toast', title: 'Toast' },
   { slug: 'toggle', title: 'Toggle' },
+  { slug: 'toggle-group', title: 'Toggle Group' },
   { slug: 'tooltip', title: 'Tooltip' },
 ]
 

--- a/site/ui/components/toggle-group-demo.tsx
+++ b/site/ui/components/toggle-group-demo.tsx
@@ -1,0 +1,102 @@
+"use client"
+/**
+ * ToggleGroupDemo Components
+ *
+ * Interactive demos for ToggleGroup component.
+ * Each demo shows a visual preview that responds to selection changes.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { ToggleGroup, ToggleGroupItem } from '@ui/components/ui/toggle-group'
+
+/**
+ * Basic single-select example: text alignment picker with live preview
+ */
+export function ToggleGroupBasicDemo() {
+  const [alignment, setAlignment] = createSignal('center')
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="single" defaultValue="center" onValueChange={(v: string | string[]) => setAlignment(v as string)}>
+        <ToggleGroupItem value="left" aria-label="Align left">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M3 12h10M3 18h14" />
+          </svg>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M7 12h10M5 18h14" />
+          </svg>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M11 12h10M7 18h14" />
+          </svg>
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div data-testid="alignment-preview" className={`${alignment() === 'left' ? 'text-left' : alignment() === 'right' ? 'text-right' : 'text-center'} rounded-md border p-4 text-sm`}>
+        <p>The quick brown fox jumps over the lazy dog. This sentence demonstrates how text alignment affects the readability and visual flow of your content.</p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Outline variant example: font size selector with live preview
+ */
+export function ToggleGroupOutlineDemo() {
+  const [fontSize, setFontSize] = createSignal('M')
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="single" variant="outline" defaultValue="M" onValueChange={(v: string | string[]) => setFontSize(v as string)}>
+        <ToggleGroupItem value="S" aria-label="Small font">
+          S
+        </ToggleGroupItem>
+        <ToggleGroupItem value="M" aria-label="Medium font">
+          M
+        </ToggleGroupItem>
+        <ToggleGroupItem value="L" aria-label="Large font">
+          L
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div data-testid="fontsize-preview" className={`${fontSize() === 'S' ? 'text-sm' : fontSize() === 'L' ? 'text-lg' : 'text-base'} rounded-md border p-4`}>
+        <p>The quick brown fox jumps over the lazy dog.</p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Multiple selection example: text formatting toolbar with live preview
+ */
+export function ToggleGroupMultipleDemo() {
+  const [formats, setFormats] = createSignal<string[]>([])
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="multiple" onValueChange={(v: string | string[]) => setFormats(v as string[])}>
+        <ToggleGroupItem value="Bold" aria-label="Toggle bold">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 4h8a4 4 0 014 4 4 4 0 01-4 4H6z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 12h9a4 4 0 014 4 4 4 0 01-4 4H6z" />
+          </svg>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Italic" aria-label="Toggle italic">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 4h-9M14 20H5M15 4L9 20" />
+          </svg>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Underline" aria-label="Toggle underline">
+          <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v7a6 6 0 006 6 6 6 0 006-6V3" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 21h16" />
+          </svg>
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div data-testid="format-preview" className={`${formats().includes('Bold') ? 'font-bold' : ''} ${formats().includes('Italic') ? 'italic' : ''} ${formats().includes('Underline') ? 'underline' : ''} rounded-md border p-4 text-sm`}>
+        <p>The quick brown fox jumps over the lazy dog. Toggle the formatting options above to see the effect on this text.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/ui/e2e/toggle-group.spec.ts
+++ b/site/ui/e2e/toggle-group.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Toggle Group Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/toggle-group')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Toggle Group')
+    await expect(page.locator('text=A set of two-state buttons that can be toggled on or off.')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Toggle Group Rendering', () => {
+    test('displays toggle-group elements with data-slot', async ({ page }) => {
+      const groups = page.locator('[data-slot="toggle-group"]')
+      await expect(groups.first()).toBeVisible()
+    })
+
+    test('has toggle-group-item elements', async ({ page }) => {
+      const items = page.locator('[data-slot="toggle-group-item"]')
+      expect(await items.count()).toBeGreaterThan(3)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three toggle items', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      await expect(items).toHaveCount(3)
+    })
+
+    test('center item starts selected (defaultValue)', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      // center is the second item (index 1)
+      await expect(items.nth(1)).toHaveAttribute('aria-pressed', 'true')
+      await expect(items.nth(1)).toHaveAttribute('data-state', 'on')
+    })
+
+    test('other items start unselected', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      await expect(items.nth(0)).toHaveAttribute('aria-pressed', 'false')
+      await expect(items.nth(0)).toHaveAttribute('data-state', 'off')
+      await expect(items.nth(2)).toHaveAttribute('aria-pressed', 'false')
+      await expect(items.nth(2)).toHaveAttribute('data-state', 'off')
+    })
+
+    test('single select: clicking one deselects others', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Center (index 1) is initially selected
+      await expect(items.nth(1)).toHaveAttribute('aria-pressed', 'true')
+
+      // Click left (index 0)
+      await items.nth(0).click()
+
+      // Left should be selected, center should be deselected
+      await expect(items.nth(0)).toHaveAttribute('aria-pressed', 'true')
+      await expect(items.nth(0)).toHaveAttribute('data-state', 'on')
+      await expect(items.nth(1)).toHaveAttribute('aria-pressed', 'false')
+      await expect(items.nth(1)).toHaveAttribute('data-state', 'off')
+    })
+
+    test('preview text alignment changes with selection', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupBasicDemo_"]:not([data-slot])').first()
+      const preview = section.locator('[data-testid="alignment-preview"]')
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Default: center alignment
+      await expect(preview).toHaveClass(/text-center/)
+
+      // Click left
+      await items.nth(0).click()
+      await expect(preview).toHaveClass(/text-left/)
+
+      // Click right
+      await items.nth(2).click()
+      await expect(preview).toHaveClass(/text-right/)
+    })
+  })
+
+  test.describe('Outline', () => {
+    test('displays outline example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Outline")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleGroupOutlineDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three toggle items', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupOutlineDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      await expect(items).toHaveCount(3)
+    })
+
+    test('group has outline variant attribute', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupOutlineDemo_"]:not([data-slot])').first()
+      const group = section.locator('[data-slot="toggle-group"]')
+      await expect(group).toHaveAttribute('data-variant', 'outline')
+    })
+
+    test('preview font size changes with selection', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupOutlineDemo_"]:not([data-slot])').first()
+      const preview = section.locator('[data-testid="fontsize-preview"]')
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Default: M (text-base)
+      await expect(preview).toHaveClass(/text-base/)
+
+      // Click S
+      await items.nth(0).click()
+      await expect(preview).toHaveClass(/text-sm/)
+
+      // Click L
+      await items.nth(2).click()
+      await expect(preview).toHaveClass(/text-lg/)
+    })
+  })
+
+  test.describe('Multiple', () => {
+    test('displays multiple example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Multiple")')).toBeVisible()
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('has three toggle items', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      await expect(items).toHaveCount(3)
+    })
+
+    test('all items start unselected', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+      for (let i = 0; i < 3; i++) {
+        await expect(items.nth(i)).toHaveAttribute('aria-pressed', 'false')
+      }
+    })
+
+    test('multiple items can be active simultaneously', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Click Bold and Italic
+      await items.nth(0).click()
+      await items.nth(1).click()
+
+      // Both should be selected
+      await expect(items.nth(0)).toHaveAttribute('aria-pressed', 'true')
+      await expect(items.nth(0)).toHaveAttribute('data-state', 'on')
+      await expect(items.nth(1)).toHaveAttribute('aria-pressed', 'true')
+      await expect(items.nth(1)).toHaveAttribute('data-state', 'on')
+      // Third should still be unselected
+      await expect(items.nth(2)).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    test('clicking active item deselects it', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Select Bold
+      await items.nth(0).click()
+      await expect(items.nth(0)).toHaveAttribute('aria-pressed', 'true')
+
+      // Deselect Bold
+      await items.nth(0).click()
+      await expect(items.nth(0)).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    test('preview text formatting changes with selection', async ({ page }) => {
+      const section = page.locator('[bf-s^="ToggleGroupMultipleDemo_"]:not([data-slot])').first()
+      const preview = section.locator('[data-testid="format-preview"]')
+      const items = section.locator('[data-slot="toggle-group-item"]')
+
+      // Initially no formatting
+      await expect(preview).not.toHaveClass(/font-bold/)
+      await expect(preview).not.toHaveClass(/italic/)
+      await expect(preview).not.toHaveClass(/underline/)
+
+      // Click Bold
+      await items.nth(0).click()
+      await expect(preview).toHaveClass(/font-bold/)
+
+      // Click Italic
+      await items.nth(1).click()
+      await expect(preview).toHaveClass(/font-bold/)
+      await expect(preview).toHaveClass(/italic/)
+
+      // Click Underline
+      await items.nth(2).click()
+      await expect(preview).toHaveClass(/font-bold/)
+      await expect(preview).toHaveClass(/italic/)
+      await expect(preview).toHaveClass(/underline/)
+
+      // Deselect Bold
+      await items.nth(0).click()
+      await expect(preview).not.toHaveClass(/font-bold/)
+      await expect(preview).toHaveClass(/italic/)
+      await expect(preview).toHaveClass(/underline/)
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Default")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Description")').first()).toBeVisible()
+    })
+
+    test('displays ToggleGroup props', async ({ page }) => {
+      await expect(page.getByRole('heading', { name: 'ToggleGroup', exact: true })).toBeVisible()
+      const tables = page.locator('table')
+      await expect(tables.first().locator('td').filter({ hasText: /^type$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^size$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
+    })
+
+    test('displays ToggleGroupItem props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("ToggleGroupItem")')).toBeVisible()
+      const tables = page.locator('table')
+      await expect(tables.nth(1).locator('td').filter({ hasText: /^value$/ })).toBeVisible()
+      await expect(tables.nth(1).locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/toggle-group.tsx
+++ b/site/ui/pages/toggle-group.tsx
@@ -1,0 +1,220 @@
+/**
+ * Toggle Group Documentation Page
+ */
+
+import {
+  ToggleGroupBasicDemo,
+  ToggleGroupOutlineDemo,
+  ToggleGroupMultipleDemo,
+} from '@/components/toggle-group-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'outline', title: 'Outline', branch: 'child' },
+  { id: 'multiple', title: 'Multiple', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+export function ToggleGroupBasicDemo() {
+  const [alignment, setAlignment] = createSignal("center")
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="single" defaultValue="center" onValueChange={setAlignment}>
+        <ToggleGroupItem value="left" aria-label="Align left">
+          <AlignLeftIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center">
+          <AlignCenterIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right">
+          <AlignRightIcon />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div className={\`\${alignment() === "left" ? "text-left" : alignment() === "right" ? "text-right" : "text-center"} rounded-md border p-4\`}>
+        <p>The quick brown fox jumps over the lazy dog.</p>
+      </div>
+    </div>
+  )
+}`
+
+const outlineCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+export function ToggleGroupOutlineDemo() {
+  const [fontSize, setFontSize] = createSignal("M")
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="single" variant="outline" defaultValue="M" onValueChange={setFontSize}>
+        <ToggleGroupItem value="S">S</ToggleGroupItem>
+        <ToggleGroupItem value="M">M</ToggleGroupItem>
+        <ToggleGroupItem value="L">L</ToggleGroupItem>
+      </ToggleGroup>
+      <div className={\`\${fontSize() === "S" ? "text-sm" : fontSize() === "L" ? "text-lg" : "text-base"} rounded-md border p-4\`}>
+        <p>The quick brown fox jumps over the lazy dog.</p>
+      </div>
+    </div>
+  )
+}`
+
+const multipleCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+export function ToggleGroupMultipleDemo() {
+  const [formats, setFormats] = createSignal<string[]>([])
+
+  return (
+    <div className="space-y-4">
+      <ToggleGroup type="multiple" onValueChange={setFormats}>
+        <ToggleGroupItem value="Bold" aria-label="Toggle bold">
+          <BoldIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Italic" aria-label="Toggle italic">
+          <ItalicIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Underline" aria-label="Toggle underline">
+          <UnderlineIcon />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div className={\`\${formats().includes("Bold") ? "font-bold" : ""} \${formats().includes("Italic") ? "italic" : ""} \${formats().includes("Underline") ? "underline" : ""} rounded-md border p-4\`}>
+        <p>The quick brown fox jumps over the lazy dog.</p>
+      </div>
+    </div>
+  )
+}`
+
+// Props definitions
+const toggleGroupProps: PropDefinition[] = [
+  {
+    name: 'type',
+    type: "'single' | 'multiple'",
+    description: 'The selection mode. "single" allows one item, "multiple" allows many.',
+  },
+  {
+    name: 'defaultValue',
+    type: 'string | string[]',
+    description: 'The default selected value(s) for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'string | string[]',
+    description: 'The controlled selected value(s). When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string | string[]) => void',
+    description: 'Event handler called when the selection changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the entire group is disabled.',
+  },
+  {
+    name: 'variant',
+    type: "'default' | 'outline'",
+    defaultValue: "'default'",
+    description: 'The visual variant applied to all items.',
+  },
+  {
+    name: 'size',
+    type: "'default' | 'sm' | 'lg'",
+    defaultValue: "'default'",
+    description: 'The size applied to all items.',
+  },
+]
+
+const toggleGroupItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this toggle item.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this item is disabled.',
+  },
+]
+
+export function ToggleGroupPage() {
+  return (
+    <DocPage slug="toggle-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Toggle Group"
+          description="A set of two-state buttons that can be toggled on or off."
+          {...getNavLinks('toggle-group')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={basicCode}>
+          <ToggleGroupBasicDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add toggle-group" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <ToggleGroupBasicDemo />
+            </Example>
+
+            <Example title="Outline" code={outlineCode}>
+              <ToggleGroupOutlineDemo />
+            </Example>
+
+            <Example title="Multiple" code={multipleCode}>
+              <ToggleGroupMultipleDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ToggleGroup</h3>
+              <PropsTable props={toggleGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ToggleGroupItem</h3>
+              <PropsTable props={toggleGroupItemProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -89,6 +89,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Textarea', href: '/docs/components/textarea' },
       { title: 'Toast', href: '/docs/components/toast' },
       { title: 'Toggle', href: '/docs/components/toggle' },
+      { title: 'Toggle Group', href: '/docs/components/toggle-group' },
       { title: 'Tooltip', href: '/docs/components/tooltip' },
     ],
   },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -23,6 +23,7 @@ import { DialogPage } from './pages/dialog'
 import { DropdownMenuPage } from './pages/dropdown-menu'
 import { ToastPage } from './pages/toast'
 import { TogglePage } from './pages/toggle'
+import { ToggleGroupPage } from './pages/toggle-group'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
 import { TextareaPage } from './pages/textarea'
@@ -251,6 +252,11 @@ export function createApp() {
   // Toggle documentation
   app.get('/docs/components/toggle', (c) => {
     return c.render(<TogglePage />)
+  })
+
+  // Toggle Group documentation
+  app.get('/docs/components/toggle-group', (c) => {
+    return c.render(<ToggleGroupPage />)
   })
 
   // Tooltip documentation

--- a/ui/components/ui/toggle-group.tsx
+++ b/ui/components/ui/toggle-group.tsx
@@ -1,0 +1,234 @@
+"use client"
+
+/**
+ * ToggleGroup Component
+ *
+ * A group of toggle buttons where selection can be single or multiple.
+ * Supports both controlled and uncontrolled modes.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Single selection (uncontrolled)
+ * ```tsx
+ * <ToggleGroup type="single" defaultValue="center">
+ *   <ToggleGroupItem value="left">Left</ToggleGroupItem>
+ *   <ToggleGroupItem value="center">Center</ToggleGroupItem>
+ *   <ToggleGroupItem value="right">Right</ToggleGroupItem>
+ * </ToggleGroup>
+ * ```
+ *
+ * @example Multiple selection (controlled)
+ * ```tsx
+ * <ToggleGroup type="multiple" value={formats()} onValueChange={setFormats}>
+ *   <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
+ *   <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
+ * </ToggleGroup>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect, createMemo } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Toggle styling (same classes as Toggle component — kept independent for standalone installability)
+type ToggleVariant = 'default' | 'outline'
+type ToggleSize = 'default' | 'sm' | 'lg'
+
+// Base classes from shadcn/ui toggleVariants
+const toggleBaseClasses = 'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted hover:text-muted-foreground'
+
+const toggleVariantClasses: Record<ToggleVariant, string> = {
+  default: 'bg-transparent',
+  outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+}
+
+const toggleSizeClasses: Record<ToggleSize, string> = {
+  default: 'h-9 px-2 min-w-9',
+  sm: 'h-8 px-1.5 min-w-8',
+  lg: 'h-10 px-2.5 min-w-10',
+}
+
+// ToggleGroupItem extra classes from shadcn/ui (applied on top of toggle base)
+const toggleGroupItemClasses = 'w-auto min-w-0 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l'
+
+// Context for parent-child state sharing
+interface ToggleGroupContextValue {
+  type: () => 'single' | 'multiple'
+  value: () => string[]
+  onItemToggle: (itemValue: string) => void
+  disabled: () => boolean
+  variant: () => ToggleVariant
+  size: () => ToggleSize
+}
+
+const ToggleGroupContext = createContext<ToggleGroupContextValue>()
+
+/**
+ * Props for the ToggleGroup component.
+ */
+interface ToggleGroupProps {
+  /** Selection mode: 'single' allows one item, 'multiple' allows many. */
+  type: 'single' | 'multiple'
+  /** Default selected value(s) for uncontrolled mode. */
+  defaultValue?: string | string[]
+  /** Controlled selected value(s). */
+  value?: string | string[]
+  /** Callback when value changes. */
+  onValueChange?: (value: string | string[]) => void
+  /** Whether the entire group is disabled. */
+  disabled?: boolean
+  /** Visual variant applied to all items. */
+  variant?: ToggleVariant
+  /** Size applied to all items. */
+  size?: ToggleSize
+  /** Additional CSS classes. */
+  class?: string
+  /** ToggleGroupItem children. */
+  children?: Child
+}
+
+/**
+ * ToggleGroup component.
+ * Manages selection state and provides context to ToggleGroupItem children.
+ */
+function ToggleGroup(props: ToggleGroupProps) {
+  // Inline array normalization (avoids hoisting issues with compiled JS)
+  const defaultArr: string[] = props.defaultValue === undefined ? []
+    : Array.isArray(props.defaultValue) ? props.defaultValue
+    : props.defaultValue ? [props.defaultValue] : []
+
+  // Internal state for uncontrolled mode
+  const [internalValue, setInternalValue] = createSignal(defaultArr)
+
+  // Controlled state
+  const controlledArr: string[] | undefined = props.value !== undefined
+    ? (Array.isArray(props.value) ? props.value : props.value ? [props.value] : [])
+    : undefined
+  const [controlledValue, setControlledValue] = createSignal<string[] | undefined>(controlledArr)
+
+  // Track if component is in controlled mode
+  const isControlled = createMemo(() => props.value !== undefined)
+
+  // Determine current value
+  const currentValue = createMemo(() => isControlled() ? (controlledValue() ?? []) : internalValue())
+
+  // Group classes — use props.variant directly to avoid compiler inlining issues with intermediate variables
+  const groupClasses = `group/toggle-group flex w-fit items-center rounded-md ${(props.variant ?? 'default') === 'outline' ? 'shadow-xs' : ''} ${props.class ?? ''}`
+
+  const handleItemToggle = (itemValue: string) => {
+    const current = currentValue()
+    let newValue: string[]
+
+    if (props.type === 'single') {
+      // Single mode: toggle off if same, otherwise select new
+      newValue = current.includes(itemValue) ? [] : [itemValue]
+    } else {
+      // Multiple mode: toggle item in/out
+      newValue = current.includes(itemValue)
+        ? current.filter((v: string) => v !== itemValue)
+        : [...current, itemValue]
+    }
+
+    if (isControlled()) {
+      setControlledValue(newValue)
+    } else {
+      setInternalValue(newValue)
+    }
+
+    // Notify parent with appropriate type
+    if (props.onValueChange) {
+      if (props.type === 'single') {
+        props.onValueChange(newValue[0] ?? '')
+      } else {
+        props.onValueChange(newValue)
+      }
+    }
+  }
+
+  return (
+    <ToggleGroupContext.Provider value={{
+      type: () => props.type,
+      value: currentValue,
+      onItemToggle: handleItemToggle,
+      disabled: () => props.disabled ?? false,
+      variant: () => (props.variant ?? 'default') as ToggleVariant,
+      size: () => (props.size ?? 'default') as ToggleSize,
+    }}>
+      <div
+        data-slot="toggle-group"
+        data-variant={props.variant ?? 'default'}
+        data-size={props.size ?? 'default'}
+        role="group"
+        className={groupClasses}
+      >
+        {props.children}
+      </div>
+    </ToggleGroupContext.Provider>
+  )
+}
+
+/**
+ * Props for the ToggleGroupItem component.
+ */
+interface ToggleGroupItemProps {
+  /** Value for this toggle item. */
+  value: string
+  /** Whether this item is disabled. */
+  disabled?: boolean
+  /** Additional CSS classes. */
+  class?: string
+  /** Children to render inside the toggle item. */
+  children?: Child
+}
+
+/**
+ * ToggleGroupItem component.
+ * A single toggle button within a ToggleGroup.
+ */
+function ToggleGroupItem(props: ToggleGroupItemProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ToggleGroupContext)
+
+    const variant: ToggleVariant = ctx.variant()
+    const size: ToggleSize = ctx.size()
+
+    // Apply variant/size classes at mount time
+    const variantClass = toggleVariantClasses[variant]
+    const sizeClass = toggleSizeClasses[size]
+    for (const cls of variantClass.split(' ')) {
+      if (cls) el.classList.add(cls)
+    }
+    for (const cls of sizeClass.split(' ')) {
+      if (cls) el.classList.add(cls)
+    }
+
+    // Set data-variant for CSS styling (outline border handling)
+    el.setAttribute('data-variant', variant)
+    el.setAttribute('data-size', size)
+
+    createEffect(() => {
+      const isSelected = ctx.value().includes(props.value)
+      el.setAttribute('aria-pressed', String(isSelected))
+      el.setAttribute('data-state', isSelected ? 'on' : 'off')
+    })
+
+    el.addEventListener('click', () => {
+      if (el.hasAttribute('disabled') || ctx.disabled()) return
+      ctx.onItemToggle(props.value)
+    })
+  }
+
+  return (
+    <button
+      data-slot="toggle-group-item"
+      data-state="off"
+      aria-pressed="false"
+      disabled={props.disabled ?? false}
+      className={`${toggleBaseClasses} ${toggleGroupItemClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }
+export type { ToggleGroupProps, ToggleGroupItemProps, ToggleVariant, ToggleSize }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -22,6 +22,12 @@
       "description": "A multi-line text input field with error state support"
     },
     {
+      "name": "toggle-group",
+      "type": "registry:ui",
+      "title": "Toggle Group",
+      "description": "A set of two-state buttons that can be toggled on or off"
+    },
+    {
       "name": "tooltip",
       "type": "registry:ui",
       "title": "Tooltip",


### PR DESCRIPTION
## Summary

- Add `ToggleGroup` and `ToggleGroupItem` components (shadcn/ui-based) with single/multiple selection, controlled/uncontrolled state, variant and size props
- Implement three demos with live visual previews: text alignment (Basic), font size (Outline), bold/italic/underline formatting (Multiple)
- Register component in site navigation, routes, and registry
- Add 24 E2E tests covering defaultValue initialization, click interactions, and preview updates

## Compiler workarounds

Works around two compiler bugs filed as issues:
- **#365** — Function declarations hoisted after usage: inlined array initialization instead of helper function
- **#366** — Multi-level variable inlining corrupts SSR templates: use `props.variant` directly instead of intermediate variables

## Test plan

- [x] `bun run build` succeeds
- [x] Compiled JS has no `toArray` helper (hoisting bug avoided)
- [x] Compiled SSR template has valid JavaScript (no `props.(props.(...)` corruption)
- [x] 24 E2E tests pass (`bunx playwright test site/ui/e2e/toggle-group.spec.ts`)
  - defaultValue="center" initializes correctly (center item has `data-state="on"`)
  - Single select: clicking deselects others
  - Multiple select: multiple items active simultaneously
  - Preview text alignment/font size/formatting changes with selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)