### PR TITLE
Fix function declarations hoisted after usage in compiled output

### DIFF
--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -168,6 +168,11 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 
   emitEarlyConstants(lines, earlyConstants)
 
+  // Emit functions/handlers before signals so that signal initializers can
+  // reference local functions (e.g. `createSignal(toArray(props.x))`).
+  // Arrow-function bodies are lazy and don't depend on signals at definition time. (#365)
+  emitFunctionsAndHandlers(lines, ctx, usedIdentifiers, outputConstants, usedFunctions, neededProps)
+
   const controlledSignals: Array<{ signal: typeof ctx.signals[0]; propName: string }> = []
   for (const signal of ctx.signals) {
     const controlledPropName = getControlledPropName(signal, ctx.propsParams)
@@ -176,8 +181,6 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
     }
   }
   emitSignalsAndMemos(lines, ctx, controlledSignals, lateConstants)
-
-  emitFunctionsAndHandlers(lines, ctx, usedIdentifiers, outputConstants, usedFunctions, neededProps)
 
   const elementRefs = generateElementRefs(ctx)
   if (elementRefs) {


### PR DESCRIPTION
## Summary

Fixes #365.

- Move `emitFunctionsAndHandlers` before `emitSignalsAndMemos` in `generate-init.ts` so that local function definitions (compiled as `const` arrow functions) are emitted before signal declarations that reference them
- Previously, `createSignal(toArray(props.defaultValue))` would fail with `ReferenceError` because `const toArray` was emitted after the `createSignal` call
- Add regression tests verifying that both `function` declarations and arrow-function constants used in `createSignal()` initializers are emitted before the signal

## Test plan

- [x] Compiler tests pass (294 pass, 0 fail)
- [x] Existing #342 test (function refs in provider value) still passes
- [x] New regression tests verify correct emission order

🤖 Generated with [Claude Code](https://claude.com/claude-code)