### PR TITLE
Fix multi-level variable inlining corrupting SSR templates (#366)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -818,7 +818,7 @@ export function emitRegistrationAndHydration(
       let newValue = constValue
       for (const [otherName, otherValue] of inlinableConstants) {
         if (otherName === constName) continue
-        const replaced = newValue.replace(new RegExp(`\\b${otherName}\\b`, 'g'), `(${otherValue})`)
+        const replaced = newValue.replace(new RegExp(`(?<!\\.)\\b${otherName}\\b`, 'g'), `(${otherValue})`)
         if (replaced !== newValue) {
           newValue = replaced
           changed = true

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -124,7 +124,7 @@ export function irToComponentTemplate(
     // Parenthesized to prevent operator precedence issues
     if (inlinableConstants && inlinableConstants.size > 0) {
       for (const [constName, constValue] of inlinableConstants) {
-        result = result.replace(new RegExp(`\\b${constName}\\b`, 'g'), `(${constValue})`)
+        result = result.replace(new RegExp(`(?<!\\.)\\b${constName}\\b`, 'g'), `(${constValue})`)
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix constant substitution regex in `emit-init-sections.ts` and `html-template.ts` to add `(?<!\.)` negative lookbehind, preventing the regex from matching identifiers inside property access (e.g., `variant` inside `props.variant`)
- Without this fix, chained constant resolution recursively wraps prop accesses, producing invalid JS like `props.(props.(props.variant))` which breaks the entire module
- Add 4 test cases covering two-level chains, three-level chains, template literals, and constant names matching property suffixes

## Test plan

- [x] All 185 compiler tests pass (`bun test` in `packages/jsx`)
- [x] New `multi-level variable inlining (#366)` describe block with 4 tests:
  - Two-level chain (`props.variant` → `variant` → `outlineShadow`)
  - Three-level chain (`props.kind` → `kind` → `color` → `classes`)
  - Template literal with multi-level chain
  - Constant name matching property suffix (`const size` vs `props.size`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)