### PR TITLE
Add Separator component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -19,6 +19,7 @@ export const componentOrder = [
   { slug: 'portal', title: 'Portal' },
   { slug: 'radio-group', title: 'Radio Group' },
   { slug: 'select', title: 'Select' },
+  { slug: 'separator', title: 'Separator' },
   { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'tabs', title: 'Tabs' },

--- a/site/ui/e2e/separator.spec.ts
+++ b/site/ui/e2e/separator.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Separator Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/separator')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Separator')
+    await expect(page.getByRole('main').getByText('Visually or semantically separates content')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test('displays examples section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
+  })
+
+  test.describe('Separator Rendering', () => {
+    const separatorSelector = '[data-slot="separator"]'
+
+    test('renders horizontal separators', async ({ page }) => {
+      const horizontalSeparators = page.locator(`${separatorSelector}[data-orientation="horizontal"]`)
+      await expect(horizontalSeparators.first()).toBeVisible()
+    })
+
+    test('renders vertical separators', async ({ page }) => {
+      const verticalSeparators = page.locator(`${separatorSelector}[data-orientation="vertical"]`)
+      await expect(verticalSeparators.first()).toBeVisible()
+    })
+
+    test('horizontal separator has correct styling', async ({ page }) => {
+      const separator = page.locator(`${separatorSelector}[data-orientation="horizontal"]`).first()
+      await expect(separator).toHaveClass(/bg-border/)
+      await expect(separator).toHaveClass(/h-px/)
+      await expect(separator).toHaveClass(/w-full/)
+    })
+
+    test('vertical separator has correct styling', async ({ page }) => {
+      const separator = page.locator(`${separatorSelector}[data-orientation="vertical"]`).first()
+      await expect(separator).toHaveClass(/bg-border/)
+      await expect(separator).toHaveClass(/w-px/)
+      await expect(separator).toHaveClass(/self-stretch/)
+    })
+
+    test('decorative separator has role="none"', async ({ page }) => {
+      const separator = page.locator(`${separatorSelector}`).first()
+      await expect(separator).toHaveAttribute('role', 'none')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays all props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^orientation$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^decorative$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^className$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/separator.tsx
+++ b/site/ui/pages/separator.tsx
@@ -1,0 +1,229 @@
+/**
+ * Separator Documentation Page
+ */
+
+import { Separator } from '@/components/ui/separator'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'horizontal', title: 'Horizontal', branch: 'start' },
+  { id: 'vertical', title: 'Vertical', branch: 'child' },
+  { id: 'menu', title: 'Menu', branch: 'child' },
+  { id: 'list', title: 'List', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const horizontalCode = `import { Separator } from '@/components/ui/separator'
+
+function SeparatorHorizontal() {
+  return (
+    <div>
+      <div className="space-y-1">
+        <h4 className="text-sm font-medium leading-none">BarefootJS</h4>
+        <p className="text-sm text-muted-foreground">An open-source UI component library.</p>
+      </div>
+      <Separator className="my-4" />
+      <div className="flex h-5 items-center space-x-4 text-sm">
+        <div>Docs</div>
+        <Separator orientation="vertical" />
+        <div>Source</div>
+        <Separator orientation="vertical" />
+        <div>Blog</div>
+      </div>
+    </div>
+  )
+}`
+
+const verticalCode = `import { Separator } from '@/components/ui/separator'
+
+function SeparatorVertical() {
+  return (
+    <div className="flex h-5 items-center space-x-4 text-sm">
+      <div>Docs</div>
+      <Separator orientation="vertical" />
+      <div>Source</div>
+      <Separator orientation="vertical" />
+      <div>Blog</div>
+    </div>
+  )
+}`
+
+const menuCode = `import { Separator } from '@/components/ui/separator'
+
+function SeparatorMenu() {
+  return (
+    <div className="w-48 rounded-md border border-border p-1">
+      <div className="px-2 py-1.5 text-sm font-semibold">My Account</div>
+      <Separator className="my-1" />
+      <div className="px-2 py-1.5 text-sm">Profile</div>
+      <div className="px-2 py-1.5 text-sm">Settings</div>
+      <div className="px-2 py-1.5 text-sm">Billing</div>
+      <Separator className="my-1" />
+      <div className="px-2 py-1.5 text-sm">Log out</div>
+    </div>
+  )
+}`
+
+const listCode = `import { Separator } from '@/components/ui/separator'
+
+function SeparatorList() {
+  return (
+    <div className="w-full max-w-md">
+      <div className="flex items-center justify-between py-3">
+        <span className="text-sm font-medium">Notifications</span>
+        <span className="text-sm text-muted-foreground">On</span>
+      </div>
+      <Separator />
+      <div className="flex items-center justify-between py-3">
+        <span className="text-sm font-medium">Sound</span>
+        <span className="text-sm text-muted-foreground">Default</span>
+      </div>
+      <Separator />
+      <div className="flex items-center justify-between py-3">
+        <span className="text-sm font-medium">Language</span>
+        <span className="text-sm text-muted-foreground">English</span>
+      </div>
+    </div>
+  )
+}`
+
+// Props definition
+const separatorProps: PropDefinition[] = [
+  {
+    name: 'orientation',
+    type: "'horizontal' | 'vertical'",
+    defaultValue: "'horizontal'",
+    description: 'The orientation of the separator.',
+  },
+  {
+    name: 'decorative',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'When true, renders with role="none" (purely visual). When false, renders with role="separator" for accessibility.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes to apply.',
+  },
+]
+
+export function SeparatorPage() {
+  return (
+    <DocPage slug="separator" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Separator"
+          description="Visually or semantically separates content."
+          {...getNavLinks('separator')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<Separator />`}>
+          <div className="w-full max-w-sm">
+            <div className="space-y-1">
+              <h4 className="text-sm font-medium leading-none">BarefootJS</h4>
+              <p className="text-sm text-muted-foreground">An open-source UI component library.</p>
+            </div>
+            <Separator className="my-4" />
+            <div className="flex h-5 items-center space-x-4 text-sm">
+              <div>Docs</div>
+              <Separator orientation="vertical" />
+              <div>Source</div>
+              <Separator orientation="vertical" />
+              <div>Blog</div>
+            </div>
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add separator" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Horizontal" code={horizontalCode}>
+              <div className="w-full max-w-sm">
+                <div className="space-y-1">
+                  <h4 className="text-sm font-medium leading-none">BarefootJS</h4>
+                  <p className="text-sm text-muted-foreground">An open-source UI component library.</p>
+                </div>
+                <Separator className="my-4" />
+                <div className="flex h-5 items-center space-x-4 text-sm">
+                  <div>Docs</div>
+                  <Separator orientation="vertical" />
+                  <div>Source</div>
+                  <Separator orientation="vertical" />
+                  <div>Blog</div>
+                </div>
+              </div>
+            </Example>
+
+            <Example title="Vertical" code={verticalCode}>
+              <div className="flex h-5 items-center space-x-4 text-sm">
+                <div>Docs</div>
+                <Separator orientation="vertical" />
+                <div>Source</div>
+                <Separator orientation="vertical" />
+                <div>Blog</div>
+              </div>
+            </Example>
+
+            <Example title="Menu" code={menuCode}>
+              <div className="w-48 rounded-md border border-border p-1">
+                <div className="px-2 py-1.5 text-sm font-semibold">My Account</div>
+                <Separator className="my-1" />
+                <div className="px-2 py-1.5 text-sm">Profile</div>
+                <div className="px-2 py-1.5 text-sm">Settings</div>
+                <div className="px-2 py-1.5 text-sm">Billing</div>
+                <Separator className="my-1" />
+                <div className="px-2 py-1.5 text-sm">Log out</div>
+              </div>
+            </Example>
+
+            <Example title="List" code={listCode}>
+              <div className="w-full max-w-md">
+                <div className="flex items-center justify-between py-3">
+                  <span className="text-sm font-medium">Notifications</span>
+                  <span className="text-sm text-muted-foreground">On</span>
+                </div>
+                <Separator />
+                <div className="flex items-center justify-between py-3">
+                  <span className="text-sm font-medium">Sound</span>
+                  <span className="text-sm text-muted-foreground">Default</span>
+                </div>
+                <Separator />
+                <div className="flex items-center justify-between py-3">
+                  <span className="text-sm font-medium">Language</span>
+                  <span className="text-sm text-muted-foreground">English</span>
+                </div>
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={separatorProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -83,6 +83,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Label', href: '/docs/components/label' },
       { title: 'Radio Group', href: '/docs/components/radio-group' },
       { title: 'Select', href: '/docs/components/select' },
+      { title: 'Separator', href: '/docs/components/separator' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Tabs', href: '/docs/components/tabs' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -26,6 +26,7 @@ import { TogglePage } from './pages/toggle'
 import { ToggleGroupPage } from './pages/toggle-group'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
+import { SeparatorPage } from './pages/separator'
 import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
 import { RadioGroupPage } from './pages/radio-group'
@@ -267,6 +268,11 @@ export function createApp() {
   // Select documentation
   app.get('/docs/components/select', (c) => {
     return c.render(<SelectPage />)
+  })
+
+  // Separator documentation
+  app.get('/docs/components/separator', (c) => {
+    return c.render(<SeparatorPage />)
   })
 
   // Textarea documentation

--- a/ui/components/ui/separator.tsx
+++ b/ui/components/ui/separator.tsx
@@ -1,0 +1,33 @@
+type SeparatorOrientation = 'horizontal' | 'vertical'
+
+const baseClasses = 'bg-border shrink-0'
+
+const orientationClasses: Record<SeparatorOrientation, string> = {
+  horizontal: 'h-px w-full',
+  vertical: 'w-px self-stretch',
+}
+
+interface SeparatorProps {
+  orientation?: SeparatorOrientation
+  decorative?: boolean
+  className?: string
+}
+
+function Separator({
+  orientation = 'horizontal',
+  decorative = true,
+  className = '',
+}: SeparatorProps) {
+  return (
+    <div
+      data-slot="separator"
+      data-orientation={orientation}
+      role={decorative ? 'none' : 'separator'}
+      aria-orientation={decorative ? undefined : orientation}
+      className={`${baseClasses} ${orientationClasses[orientation]} ${className}`}
+    />
+  )
+}
+
+export { Separator }
+export type { SeparatorOrientation, SeparatorProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -22,6 +22,12 @@
       "description": "A multi-line text input field with error state support"
     },
     {
+      "name": "separator",
+      "type": "registry:ui",
+      "title": "Separator",
+      "description": "A visual divider that separates content horizontally or vertically"
+    },
+    {
       "name": "toggle-group",
       "type": "registry:ui",
       "title": "Toggle Group",


### PR DESCRIPTION
## Summary

- Port the shadcn/ui Separator component as a stateless presentational divider
- Support horizontal/vertical orientation and decorative/semantic (`role="none"` / `role="separator"`) modes
- Add documentation page with 4 examples (Horizontal, Vertical, Menu, List) and API reference
- Add 11 E2E tests (all passing)
- Register in sidebar navigation, routes, page navigation, and component registry

## Test plan

- [x] `bun run build` succeeds
- [x] E2E tests pass: `cd site/ui && bunx playwright test e2e/separator.spec.ts` (11 passed)
- [ ] Navigate to `/docs/components/separator` and verify horizontal/vertical separators render
- [ ] Verify sidebar shows Separator between Select and Slider
- [ ] Verify prev/next page navigation links work (Select ← Separator → Slider)

Related: https://github.com/kfly8/barefootjs/issues/128

🤖 Generated with [Claude Code](https://claude.com/claude-code)