### PR TITLE
Add Breadcrumb component

### DIFF
--- a/site/ui/components/breadcrumb-demo.tsx
+++ b/site/ui/components/breadcrumb-demo.tsx
@@ -1,0 +1,111 @@
+/**
+ * Breadcrumb Demo Components
+ *
+ * Stateless demos — no signals, no "use client" needed.
+ */
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from '@ui/components/ui/breadcrumb'
+
+/**
+ * Preview demo: simple 3-level breadcrumb.
+ */
+export function BreadcrumbPreviewDemo() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+/**
+ * Basic demo: breadcrumb with links.
+ */
+export function BreadcrumbBasicDemo() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Documents</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current Document</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+/**
+ * Ellipsis demo: truncated path with BreadcrumbEllipsis.
+ */
+export function BreadcrumbEllipsisDemo() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+/**
+ * Custom separator demo: using "/" as separator.
+ */
+export function BreadcrumbCustomSeparatorDemo() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>/</BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>/</BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -9,6 +9,7 @@
 export const componentOrder = [
   { slug: 'accordion', title: 'Accordion' },
   { slug: 'badge', title: 'Badge' },
+  { slug: 'breadcrumb', title: 'Breadcrumb' },
   { slug: 'button', title: 'Button' },
   { slug: 'card', title: 'Card' },
   { slug: 'checkbox', title: 'Checkbox' },

--- a/site/ui/e2e/breadcrumb.spec.ts
+++ b/site/ui/e2e/breadcrumb.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Breadcrumb Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/breadcrumb')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Breadcrumb')
+    await expect(page.getByRole('main').getByText('Displays the path to the current resource')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test('displays examples section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
+  })
+
+  test.describe('Breadcrumb Structure', () => {
+    test('renders breadcrumb navigation with correct ARIA attributes', async ({ page }) => {
+      const breadcrumb = page.locator('[data-slot="breadcrumb"]').first()
+      await expect(breadcrumb).toBeVisible()
+      await expect(breadcrumb).toHaveAttribute('aria-label', 'breadcrumb')
+
+      // Should be a <nav> element
+      const tagName = await breadcrumb.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('nav')
+    })
+
+    test('renders breadcrumb list', async ({ page }) => {
+      const list = page.locator('[data-slot="breadcrumb-list"]').first()
+      await expect(list).toBeVisible()
+
+      // Should be an <ol> element
+      const tagName = await list.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('ol')
+    })
+
+    test('renders breadcrumb items', async ({ page }) => {
+      const items = page.locator('[data-slot="breadcrumb-item"]')
+      // Preview has 3 items (Home, Components, Breadcrumb)
+      const count = await items.count()
+      expect(count).toBeGreaterThanOrEqual(3)
+    })
+
+    test('renders breadcrumb links', async ({ page }) => {
+      const links = page.locator('[data-slot="breadcrumb-link"]')
+      const count = await links.count()
+      expect(count).toBeGreaterThanOrEqual(2)
+
+      // First link should contain "Home"
+      await expect(links.first()).toContainText('Home')
+    })
+
+    test('renders current page with correct ARIA attributes', async ({ page }) => {
+      const currentPage = page.locator('[data-slot="breadcrumb-page"]').first()
+      await expect(currentPage).toBeVisible()
+      await expect(currentPage).toHaveAttribute('aria-current', 'page')
+      await expect(currentPage).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    test('renders separators between items', async ({ page }) => {
+      const separators = page.locator('[data-slot="breadcrumb-separator"]')
+      const count = await separators.count()
+      expect(count).toBeGreaterThanOrEqual(2)
+
+      // Separators should have correct ARIA attributes
+      const firstSeparator = separators.first()
+      await expect(firstSeparator).toHaveAttribute('aria-hidden', 'true')
+      await expect(firstSeparator).toHaveAttribute('role', 'presentation')
+    })
+  })
+
+  test.describe('Breadcrumb Ellipsis', () => {
+    test('renders ellipsis with sr-only text', async ({ page }) => {
+      const ellipsis = page.locator('[data-slot="breadcrumb-ellipsis"]').first()
+      await expect(ellipsis).toBeVisible()
+      await expect(ellipsis).toHaveAttribute('aria-hidden', 'true')
+
+      // Should contain sr-only "More" text
+      const srOnly = ellipsis.locator('.sr-only')
+      await expect(srOnly).toHaveText('More')
+    })
+  })
+
+  test.describe('Custom Separator', () => {
+    test('renders custom separator text', async ({ page }) => {
+      // Find separator containing "/" text
+      const customSeparator = page.locator('[data-slot="breadcrumb-separator"]:has-text("/")')
+      const count = await customSeparator.count()
+      expect(count).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
+      await expect(page.locator('th:has-text("Description")').first()).toBeVisible()
+    })
+
+    test('displays sub-component sections', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Breadcrumb")').first()).toBeVisible()
+      await expect(page.locator('h3:has-text("BreadcrumbList")')).toBeVisible()
+      await expect(page.locator('h3:has-text("BreadcrumbItem")')).toBeVisible()
+      await expect(page.locator('h3:has-text("BreadcrumbLink")')).toBeVisible()
+      await expect(page.locator('h3:has-text("BreadcrumbPage")')).toBeVisible()
+      await expect(page.locator('h3:has-text("BreadcrumbSeparator")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/breadcrumb.tsx
+++ b/site/ui/pages/breadcrumb.tsx
@@ -1,0 +1,289 @@
+/**
+ * Breadcrumb Documentation Page
+ */
+
+import {
+  BreadcrumbPreviewDemo,
+  BreadcrumbBasicDemo,
+  BreadcrumbEllipsisDemo,
+  BreadcrumbCustomSeparatorDemo,
+} from '@/components/breadcrumb-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'ellipsis', title: 'Ellipsis', branch: 'child' },
+  { id: 'custom-separator', title: 'Custom Separator', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const previewCode = `import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+function BreadcrumbPreview() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}`
+
+const basicCode = `import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+function BreadcrumbBasic() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Documents</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current Document</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}`
+
+const ellipsisCode = `import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from '@/components/ui/breadcrumb'
+
+function BreadcrumbWithEllipsis() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}`
+
+const customSeparatorCode = `import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+function BreadcrumbCustomSeparator() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>/</BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>/</BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}`
+
+// Props definitions
+const breadcrumbProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The breadcrumb content (typically BreadcrumbList).',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS classes.',
+  },
+]
+
+const breadcrumbListProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The list items (BreadcrumbItem, BreadcrumbSeparator).',
+  },
+]
+
+const breadcrumbItemProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The item content (BreadcrumbLink or BreadcrumbPage).',
+  },
+]
+
+const breadcrumbLinkProps: PropDefinition[] = [
+  {
+    name: 'href',
+    type: 'string',
+    description: 'The URL for the link.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element with link styling instead of <a>.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The link text.',
+  },
+]
+
+const breadcrumbPageProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The current page text.',
+  },
+]
+
+const breadcrumbSeparatorProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'Custom separator content. Defaults to ChevronRightIcon.',
+  },
+]
+
+export function BreadcrumbPage() {
+  return (
+    <DocPage slug="breadcrumb" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Breadcrumb"
+          description="Displays the path to the current resource using a hierarchy of links."
+          {...getNavLinks('breadcrumb')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <BreadcrumbPreviewDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add breadcrumb" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <BreadcrumbBasicDemo />
+            </Example>
+
+            <Example title="Ellipsis" code={ellipsisCode}>
+              <BreadcrumbEllipsisDemo />
+            </Example>
+
+            <Example title="Custom Separator" code={customSeparatorCode}>
+              <BreadcrumbCustomSeparatorDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">Breadcrumb</h3>
+              <PropsTable props={breadcrumbProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BreadcrumbList</h3>
+              <PropsTable props={breadcrumbListProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BreadcrumbItem</h3>
+              <PropsTable props={breadcrumbItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BreadcrumbLink</h3>
+              <PropsTable props={breadcrumbLinkProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BreadcrumbPage</h3>
+              <PropsTable props={breadcrumbPageProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BreadcrumbSeparator</h3>
+              <PropsTable props={breadcrumbSeparatorProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -74,6 +74,7 @@ const menuEntries: SidebarEntry[] = [
     links: [
       { title: 'Accordion', href: '/docs/components/accordion' },
       { title: 'Badge', href: '/docs/components/badge' },
+      { title: 'Breadcrumb', href: '/docs/components/breadcrumb' },
       { title: 'Button', href: '/docs/components/button' },
       { title: 'Card', href: '/docs/components/card' },
       { title: 'Checkbox', href: '/docs/components/checkbox' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -10,6 +10,7 @@ import { renderer } from './renderer'
 
 // Component pages
 import { BadgePage } from './pages/badge'
+import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
 import { CardPage } from './pages/card'
 import { CheckboxPage } from './pages/checkbox'
@@ -184,6 +185,11 @@ export function createApp() {
   // Badge documentation
   app.get('/docs/components/badge', (c) => {
     return c.render(<BadgePage />)
+  })
+
+  // Breadcrumb documentation
+  app.get('/docs/components/breadcrumb', (c) => {
+    return c.render(<BreadcrumbPage />)
   })
 
   // Button documentation

--- a/ui/components/ui/breadcrumb.tsx
+++ b/ui/components/ui/breadcrumb.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+/**
+ * Breadcrumb Components
+ *
+ * A composable breadcrumb navigation component.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Breadcrumb>
+ *   <BreadcrumbList>
+ *     <BreadcrumbItem>
+ *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbPage>Current Page</BreadcrumbPage>
+ *     </BreadcrumbItem>
+ *   </BreadcrumbList>
+ * </Breadcrumb>
+ * ```
+ *
+ * @example With asChild link
+ * ```tsx
+ * <BreadcrumbLink asChild>
+ *   <a href="/docs">Documentation</a>
+ * </BreadcrumbLink>
+ * ```
+ */
+
+import type { Child } from '../../types'
+import { Slot } from './slot'
+import { ChevronRightIcon, EllipsisIcon } from './icon'
+
+// BreadcrumbList classes
+const breadcrumbListClasses = 'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words'
+
+// BreadcrumbItem classes
+const breadcrumbItemClasses = 'inline-flex items-center gap-1'
+
+// BreadcrumbLink classes
+const breadcrumbLinkClasses = 'hover:text-foreground transition-colors'
+
+// BreadcrumbPage classes
+const breadcrumbPageClasses = 'text-foreground font-normal'
+
+// BreadcrumbSeparator classes
+const breadcrumbSeparatorClasses = '[&>svg]:size-3.5'
+
+// BreadcrumbEllipsis classes
+const breadcrumbEllipsisClasses = 'flex size-5 items-center justify-center [&>svg]:size-4'
+
+/**
+ * Props for Breadcrumb component.
+ */
+interface BreadcrumbProps {
+  /** Breadcrumb content (typically BreadcrumbList) */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Breadcrumb navigation wrapper.
+ */
+function Breadcrumb({ children, className = '' }: BreadcrumbProps) {
+  return (
+    <nav data-slot="breadcrumb" aria-label="breadcrumb" className={className || undefined}>
+      {children}
+    </nav>
+  )
+}
+
+/**
+ * Props for BreadcrumbList component.
+ */
+interface BreadcrumbListProps {
+  /** List items */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Ordered list wrapper for breadcrumb items.
+ */
+function BreadcrumbList({ children, className = '' }: BreadcrumbListProps) {
+  return (
+    <ol data-slot="breadcrumb-list" className={`${breadcrumbListClasses} ${className}`}>
+      {children}
+    </ol>
+  )
+}
+
+/**
+ * Props for BreadcrumbItem component.
+ */
+interface BreadcrumbItemProps {
+  /** Item content */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Individual breadcrumb item.
+ */
+function BreadcrumbItem({ children, className = '' }: BreadcrumbItemProps) {
+  return (
+    <li data-slot="breadcrumb-item" className={`${breadcrumbItemClasses} ${className}`}>
+      {children}
+    </li>
+  )
+}
+
+/**
+ * Props for BreadcrumbLink component.
+ */
+interface BreadcrumbLinkProps {
+  /** Link URL */
+  href?: string
+  /** When true, renders child element with link styling instead of `<a>`. */
+  asChild?: boolean
+  /** Link content */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Breadcrumb link element.
+ */
+function BreadcrumbLink({ className = '', asChild = false, children, ...props }: BreadcrumbLinkProps) {
+  const classes = `${breadcrumbLinkClasses} ${className}`
+
+  if (asChild) {
+    return <Slot className={classes} {...props}>{children}</Slot>
+  }
+  return <a data-slot="breadcrumb-link" className={classes} {...props}>{children}</a>
+}
+
+/**
+ * Props for BreadcrumbPage component.
+ */
+interface BreadcrumbPageProps {
+  /** Page title */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Current page indicator in breadcrumb.
+ */
+function BreadcrumbPage({ children, className = '' }: BreadcrumbPageProps) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={`${breadcrumbPageClasses} ${className}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+/**
+ * Props for BreadcrumbSeparator component.
+ */
+interface BreadcrumbSeparatorProps {
+  /** Custom separator content. Defaults to ChevronRightIcon. */
+  children?: Child
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Separator between breadcrumb items.
+ */
+function BreadcrumbSeparator({ children, className = '' }: BreadcrumbSeparatorProps) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={`${breadcrumbSeparatorClasses} ${className}`}
+    >
+      {children ?? <ChevronRightIcon />}
+    </li>
+  )
+}
+
+/**
+ * Props for BreadcrumbEllipsis component.
+ */
+interface BreadcrumbEllipsisProps {
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Ellipsis indicator for truncated breadcrumb paths.
+ */
+function BreadcrumbEllipsis({ className = '' }: BreadcrumbEllipsisProps) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={`${breadcrumbEllipsisClasses} ${className}`}
+    >
+      <EllipsisIcon />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}
+export type {
+  BreadcrumbProps,
+  BreadcrumbListProps,
+  BreadcrumbItemProps,
+  BreadcrumbLinkProps,
+  BreadcrumbPageProps,
+  BreadcrumbSeparatorProps,
+  BreadcrumbEllipsisProps,
+}

--- a/ui/components/ui/icon.tsx
+++ b/ui/components/ui/icon.tsx
@@ -62,6 +62,7 @@ const strokePaths = {
   'menu': 'M4 6h16M4 12h16M4 18h16',
   'arrow-left': 'm12 19-7-7 7-7M19 12H5',
   'arrow-right': 'M5 12h14m-7-7 7 7-7 7',
+  'ellipsis': 'M5 12h.01M12 12h.01M19 12h.01',
 } as const
 
 export type IconName = keyof typeof strokePaths | 'github' | 'search' | 'settings' | 'globe' | 'log-out' | 'circle-help'
@@ -218,6 +219,15 @@ export function ArrowRightIcon({ size, class: className = '' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true">
       <path d={strokePaths['arrow-right']} />
+    </svg>
+  )
+}
+
+export function EllipsisIcon({ size, class: className = '' }: IconProps) {
+  const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true">
+      <path d={strokePaths['ellipsis']} />
     </svg>
   )
 }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -10,6 +10,12 @@
       "description": "A polymorphic component that merges props with child element"
     },
     {
+      "name": "breadcrumb",
+      "type": "registry:ui",
+      "title": "Breadcrumb",
+      "description": "Displays the path to the current resource using a hierarchy of links"
+    },
+    {
       "name": "button",
       "type": "registry:ui",
       "title": "Button",


### PR DESCRIPTION
## Summary

- Port Breadcrumb from shadcn/ui as a stateless composable navigation component
- Add 7 sub-components: `Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis`
- Add `EllipsisIcon` to `icon.tsx` (Lucide ellipsis path)

Related #128

## Test plan

- [x] `bun run build` passes
- [x] E2E tests pass (14 tests): structure, ARIA attributes, ellipsis, custom separator, API reference
- [x] Breadcrumb page renders at `/docs/components/breadcrumb`
- [x] Sidebar navigation shows Breadcrumb in alphabetical order (between Badge and Button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)