### PR TITLE
Add Collapsible component

### DIFF
--- a/site/ui/components/collapsible-demo.tsx
+++ b/site/ui/components/collapsible-demo.tsx
@@ -1,0 +1,122 @@
+"use client"
+/**
+ * CollapsibleDemo Components
+ *
+ * Interactive demos for Collapsible component.
+ * Used in collapsible documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@ui/components/ui/collapsible'
+import { Button } from '@ui/components/ui/button'
+import { ChevronDownIcon } from '@ui/components/ui/icon'
+
+/**
+ * Basic collapsible with defaultOpen and toggle button.
+ * Shows a repository's starred files list.
+ */
+export function CollapsibleBasicDemo() {
+  return (
+    <div className="w-full max-w-sm">
+      <Collapsible defaultOpen class="space-y-2">
+        <div className="flex items-center justify-between space-x-4">
+          <h4 className="text-sm font-semibold">
+            @barefootjs/dom has 3 repositories
+          </h4>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-9 p-0">
+              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <span className="sr-only">Toggle</span>
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+        <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+          @barefootjs/dom
+        </div>
+        <CollapsibleContent class="space-y-2">
+          <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+            @barefootjs/jsx
+          </div>
+          <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+            @barefootjs/hono
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  )
+}
+
+/**
+ * Controlled collapsible with external state management.
+ * Demonstrates controlled mode with open/onOpenChange props.
+ */
+export function CollapsibleControlledDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div className="w-full max-w-sm space-y-4">
+      <Collapsible open={open()} onOpenChange={setOpen} class="space-y-2">
+        <div className="flex items-center justify-between space-x-4">
+          <h4 className="text-sm font-semibold">
+            Starred Repositories
+          </h4>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-9 p-0">
+              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <span className="sr-only">Toggle</span>
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+        <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+          solidjs/solid
+        </div>
+        <CollapsibleContent class="space-y-2">
+          <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+            honojs/hono
+          </div>
+          <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+            unjs/nitro
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+      <p className="text-sm text-muted-foreground" data-testid="collapsible-controlled-state">
+        State: {open() ? 'open' : 'closed'}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Disabled collapsible that cannot be toggled.
+ */
+export function CollapsibleDisabledDemo() {
+  return (
+    <div className="w-full max-w-sm">
+      <Collapsible disabled class="space-y-2">
+        <div className="flex items-center justify-between space-x-4">
+          <h4 className="text-sm font-semibold text-muted-foreground">
+            Archived Repositories (disabled)
+          </h4>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-9 p-0" disabled>
+              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <span className="sr-only">Toggle</span>
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+        <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs opacity-50">
+          @barefootjs/legacy
+        </div>
+        <CollapsibleContent class="space-y-2">
+          <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+            @barefootjs/old-adapter
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -12,6 +12,7 @@ export const componentOrder = [
   { slug: 'button', title: 'Button' },
   { slug: 'card', title: 'Card' },
   { slug: 'checkbox', title: 'Checkbox' },
+  { slug: 'collapsible', title: 'Collapsible' },
   { slug: 'dialog', title: 'Dialog' },
   { slug: 'dropdown-menu', title: 'Dropdown Menu' },
   { slug: 'input', title: 'Input' },

--- a/site/ui/e2e/collapsible.spec.ts
+++ b/site/ui/e2e/collapsible.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Collapsible Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/collapsible')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Collapsible')
+    await expect(page.locator('text=An interactive component which expands/collapses a panel')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Basic Demo', () => {
+    test('displays basic example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('starts open by default (defaultOpen)', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      const collapsible = section.locator('[data-slot="collapsible"]')
+      await expect(collapsible).toHaveAttribute('data-state', 'open')
+    })
+
+    test('content is visible when open', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      const content = section.locator('[data-slot="collapsible-content"]')
+      await expect(content).toHaveAttribute('data-state', 'open')
+      await expect(content).toHaveClass(/grid-rows-\[1fr\]/)
+    })
+
+    test('clicking trigger closes the content', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="collapsible-trigger"]')
+      const content = section.locator('[data-slot="collapsible-content"]')
+
+      // Click to close
+      await trigger.click()
+      await expect(content).toHaveAttribute('data-state', 'closed')
+      await expect(content).toHaveClass(/grid-rows-\[0fr\]/)
+    })
+
+    test('clicking trigger toggles open/closed', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="collapsible-trigger"]')
+      const content = section.locator('[data-slot="collapsible-content"]')
+
+      // Close
+      await trigger.click()
+      await expect(content).toHaveAttribute('data-state', 'closed')
+
+      // Open
+      await trigger.click()
+      await expect(content).toHaveAttribute('data-state', 'open')
+    })
+
+    test('trigger has aria-expanded attribute', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="collapsible-trigger"]')
+
+      // Open by default
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+      // Close
+      await trigger.click()
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+  })
+
+  test.describe('Controlled Demo', () => {
+    test('displays controlled example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Controlled")')).toBeVisible()
+      const section = page.locator('[bf-s^="CollapsibleControlledDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('starts closed', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleControlledDemo_"]:not([data-slot])').first()
+      const content = section.locator('[data-slot="collapsible-content"]')
+      await expect(content).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('shows state label', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleControlledDemo_"]:not([data-slot])').first()
+      await expect(section.locator('[data-testid="collapsible-controlled-state"]')).toContainText('closed')
+    })
+
+    test('clicking trigger opens and updates state label', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleControlledDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="collapsible-trigger"]')
+      const content = section.locator('[data-slot="collapsible-content"]')
+
+      await trigger.click()
+      await expect(content).toHaveAttribute('data-state', 'open')
+      await expect(section.locator('[data-testid="collapsible-controlled-state"]')).toContainText('open')
+    })
+  })
+
+  test.describe('Disabled Demo', () => {
+    test('displays disabled example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Disabled")')).toBeVisible()
+      const section = page.locator('[bf-s^="CollapsibleDisabledDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('collapsible has data-disabled attribute', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleDisabledDemo_"]:not([data-slot])').first()
+      const collapsible = section.locator('[data-slot="collapsible"]')
+      await expect(collapsible).toHaveAttribute('data-disabled', '')
+    })
+
+    test('content stays closed when trigger is clicked', async ({ page }) => {
+      const section = page.locator('[bf-s^="CollapsibleDisabledDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="collapsible-trigger"]')
+      const content = section.locator('[data-slot="collapsible-content"]')
+
+      await trigger.click({ force: true })
+      await expect(content).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays Collapsible props', async ({ page }) => {
+      await expect(page.locator('h3').filter({ hasText: /^Collapsible$/ })).toBeVisible()
+      const tables = page.locator('table')
+      await expect(tables.first().locator('td').filter({ hasText: /^open$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^defaultOpen$/ })).toBeVisible()
+      await expect(tables.first().locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
+    })
+
+    test('displays CollapsibleTrigger props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("CollapsibleTrigger")')).toBeVisible()
+    })
+
+    test('displays CollapsibleContent section', async ({ page }) => {
+      await expect(page.locator('h3:has-text("CollapsibleContent")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/collapsible.tsx
+++ b/site/ui/pages/collapsible.tsx
@@ -1,0 +1,246 @@
+/**
+ * Collapsible Documentation Page
+ */
+
+import { CollapsibleBasicDemo, CollapsibleControlledDemo, CollapsibleDisabledDemo } from '@/components/collapsible-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'controlled', title: 'Controlled', branch: 'child' },
+  { id: 'disabled', title: 'Disabled', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'
+import { Button } from '@/components/ui/button'
+import { ChevronDownIcon } from '@/components/ui/icon'
+
+function CollapsibleBasic() {
+  return (
+    <Collapsible defaultOpen class="space-y-2">
+      <div className="flex items-center justify-between space-x-4">
+        <h4 className="text-sm font-semibold">
+          @barefootjs/dom has 3 repositories
+        </h4>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" className="w-9 p-0">
+            <ChevronDownIcon size="sm" />
+            <span className="sr-only">Toggle</span>
+          </Button>
+        </CollapsibleTrigger>
+      </div>
+      <div className="rounded-md border px-4 py-2 font-mono text-sm">
+        @barefootjs/dom
+      </div>
+      <CollapsibleContent class="space-y-2">
+        <div className="rounded-md border px-4 py-2 font-mono text-sm">
+          @barefootjs/jsx
+        </div>
+        <div className="rounded-md border px-4 py-2 font-mono text-sm">
+          @barefootjs/hono
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}`
+
+const controlledCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'
+import { Button } from '@/components/ui/button'
+import { ChevronDownIcon } from '@/components/ui/icon'
+
+function CollapsibleControlled() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div className="space-y-4">
+      <Collapsible open={open()} onOpenChange={setOpen} class="space-y-2">
+        <div className="flex items-center justify-between space-x-4">
+          <h4 className="text-sm font-semibold">
+            Starred Repositories
+          </h4>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-9 p-0">
+              <ChevronDownIcon size="sm" />
+              <span className="sr-only">Toggle</span>
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+        <div className="rounded-md border px-4 py-2 font-mono text-sm">
+          solidjs/solid
+        </div>
+        <CollapsibleContent class="space-y-2">
+          <div className="rounded-md border px-4 py-2 font-mono text-sm">
+            honojs/hono
+          </div>
+          <div className="rounded-md border px-4 py-2 font-mono text-sm">
+            unjs/nitro
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+      <p className="text-sm text-muted-foreground">
+        State: {open() ? 'open' : 'closed'}
+      </p>
+    </div>
+  )
+}`
+
+const disabledCode = `"use client"
+
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'
+import { Button } from '@/components/ui/button'
+import { ChevronDownIcon } from '@/components/ui/icon'
+
+function CollapsibleDisabled() {
+  return (
+    <Collapsible disabled class="space-y-2">
+      <div className="flex items-center justify-between space-x-4">
+        <h4 className="text-sm font-semibold text-muted-foreground">
+          Archived Repositories (disabled)
+        </h4>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" className="w-9 p-0" disabled>
+            <ChevronDownIcon size="sm" />
+            <span className="sr-only">Toggle</span>
+          </Button>
+        </CollapsibleTrigger>
+      </div>
+      <div className="rounded-md border px-4 py-2 font-mono text-sm opacity-50">
+        @barefootjs/legacy
+      </div>
+      <CollapsibleContent class="space-y-2">
+        <div className="rounded-md border px-4 py-2 font-mono text-sm">
+          @barefootjs/old-adapter
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}`
+
+// Props definitions
+const collapsibleProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    description: 'The controlled open state of the collapsible.',
+  },
+  {
+    name: 'defaultOpen',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'The open state when initially rendered. Use when you do not need to control the open state.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Event handler called when the open state changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'When true, prevents the user from interacting with the collapsible.',
+  },
+]
+
+const collapsibleTriggerProps: PropDefinition[] = [
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
+  },
+]
+
+const collapsibleContentProps: PropDefinition[] = []
+
+export function CollapsiblePage() {
+  return (
+    <DocPage slug="collapsible" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Collapsible"
+          description="An interactive component which expands/collapses a panel."
+          {...getNavLinks('collapsible')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<Collapsible>...</Collapsible>`}>
+          <CollapsibleBasicDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add collapsible" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <CollapsibleBasicDemo />
+            </Example>
+
+            <Example title="Controlled" code={controlledCode}>
+              <CollapsibleControlledDemo />
+            </Example>
+
+            <Example title="Disabled" code={disabledCode}>
+              <CollapsibleDisabledDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Collapsible</h3>
+              <PropsTable props={collapsibleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CollapsibleTrigger</h3>
+              <PropsTable props={collapsibleTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CollapsibleContent</h3>
+              <PropsTable props={collapsibleContentProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -77,6 +77,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Button', href: '/docs/components/button' },
       { title: 'Card', href: '/docs/components/card' },
       { title: 'Checkbox', href: '/docs/components/checkbox' },
+      { title: 'Collapsible', href: '/docs/components/collapsible' },
       { title: 'Dialog', href: '/docs/components/dialog' },
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
       { title: 'Input', href: '/docs/components/input' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -18,6 +18,7 @@ import { LabelPage } from './pages/label'
 import { SliderPage } from './pages/slider'
 import { SwitchPage } from './pages/switch'
 import { AccordionPage } from './pages/accordion'
+import { CollapsiblePage } from './pages/collapsible'
 import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
 import { DropdownMenuPage } from './pages/dropdown-menu'
@@ -197,6 +198,11 @@ export function createApp() {
   // Card documentation
   app.get('/docs/components/card', (c) => {
     return c.render(<CardPage />)
+  })
+
+  // Collapsible documentation
+  app.get('/docs/components/collapsible', (c) => {
+    return c.render(<CollapsiblePage />)
   })
 
   // Checkbox documentation

--- a/ui/components/ui/collapsible.tsx
+++ b/ui/components/ui/collapsible.tsx
@@ -1,0 +1,212 @@
+"use client"
+
+/**
+ * Collapsible Components
+ *
+ * An interactive component which expands/collapses a panel.
+ * Simpler than Accordion — single panel, no multi-item management.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ *
+ * @example Basic collapsible
+ * ```tsx
+ * const [open, setOpen] = createSignal(false)
+ *
+ * <Collapsible open={open()} onOpenChange={setOpen}>
+ *   <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+ *   <CollapsibleContent>Hidden content here</CollapsibleContent>
+ * </Collapsible>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Context for Collapsible → children state sharing
+interface CollapsibleContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+  disabled: () => boolean
+}
+
+const CollapsibleContext = createContext<CollapsibleContextValue>()
+
+// CollapsibleContent base classes (uses CSS grid animation)
+const collapsibleContentBaseClasses = 'grid transition-[grid-template-rows,visibility] duration-normal ease-out'
+
+// CollapsibleContent open classes
+const collapsibleContentOpenClasses = 'grid-rows-[1fr] visible'
+
+// CollapsibleContent closed classes
+const collapsibleContentClosedClasses = 'grid-rows-[0fr] invisible'
+
+// CollapsibleContent inner classes
+const collapsibleContentInnerClasses = 'overflow-hidden'
+
+/**
+ * Props for Collapsible component.
+ */
+interface CollapsibleProps {
+  /** Controlled open state */
+  open?: boolean
+  /** Default open state for uncontrolled mode */
+  defaultOpen?: boolean
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void
+  /** Whether the collapsible is disabled */
+  disabled?: boolean
+  /** Child components */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Collapsible root component.
+ * Manages open/closed state and provides context to children.
+ */
+function Collapsible(props: CollapsibleProps) {
+  const [internalOpen, setInternalOpen] = createSignal(props.defaultOpen ?? false)
+
+  const isControlled = () => props.open !== undefined
+  const open = () => isControlled() ? props.open! : internalOpen()
+
+  const handleOpenChange = (value: boolean) => {
+    if (props.disabled) return
+    if (!isControlled()) {
+      setInternalOpen(value)
+    }
+    props.onOpenChange?.(value)
+  }
+
+  const handleMount = (el: HTMLElement) => {
+    createEffect(() => {
+      el.dataset.state = open() ? 'open' : 'closed'
+    })
+  }
+
+  return (
+    <CollapsibleContext.Provider value={{
+      open,
+      onOpenChange: handleOpenChange,
+      disabled: () => props.disabled ?? false,
+    }}>
+      <div
+        data-slot="collapsible"
+        data-state={props.defaultOpen ? 'open' : 'closed'}
+        data-disabled={props.disabled || undefined}
+        className={props.class ?? ''}
+        ref={handleMount}
+      >
+        {props.children}
+      </div>
+    </CollapsibleContext.Provider>
+  )
+}
+
+/**
+ * Props for CollapsibleTrigger component.
+ */
+interface CollapsibleTriggerProps {
+  /** Render child element as trigger instead of built-in button */
+  asChild?: boolean
+  /** Trigger content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Clickable trigger that toggles the collapsible content.
+ * Reads open state from CollapsibleContext.
+ */
+function CollapsibleTrigger(props: CollapsibleTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CollapsibleContext)
+
+    // Reactive aria-expanded
+    createEffect(() => {
+      el.setAttribute('aria-expanded', String(ctx.open()))
+    })
+
+    // Click handler
+    el.addEventListener('click', (e: Event) => {
+      e.stopPropagation()
+      if (!ctx.disabled()) {
+        ctx.onOpenChange(!ctx.open())
+      }
+    })
+  }
+
+  if (props.asChild) {
+    return (
+      <span
+        data-slot="collapsible-trigger"
+        style="display:contents"
+        aria-expanded="false"
+        ref={handleMount}
+      >
+        {props.children}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      data-slot="collapsible-trigger"
+      type="button"
+      className={props.class ?? ''}
+      aria-expanded="false"
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+/**
+ * Props for CollapsibleContent component.
+ */
+interface CollapsibleContentProps {
+  /** Content to display */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Collapsible content panel.
+ * Uses CSS grid animation for smooth expand/collapse.
+ */
+function CollapsibleContent(props: CollapsibleContentProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CollapsibleContext)
+
+    createEffect(() => {
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${collapsibleContentBaseClasses} ${isOpen ? collapsibleContentOpenClasses : collapsibleContentClosedClasses}`
+    })
+  }
+
+  const className = props.class ?? ''
+
+  return (
+    <div
+      data-slot="collapsible-content"
+      role="region"
+      data-state="closed"
+      className={`${collapsibleContentBaseClasses} ${collapsibleContentClosedClasses}`}
+      ref={handleMount}
+    >
+      <div className={collapsibleContentInnerClasses}>
+        <div className={className}>
+          {props.children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+export type { CollapsibleProps, CollapsibleTriggerProps, CollapsibleContentProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -16,6 +16,12 @@
       "description": "A button component with variants and sizes"
     },
     {
+      "name": "collapsible",
+      "type": "registry:ui",
+      "title": "Collapsible",
+      "description": "An interactive component which expands/collapses a panel"
+    },
+    {
       "name": "textarea",
       "type": "registry:ui",
       "title": "Textarea",


### PR DESCRIPTION
## Summary

- Port shadcn/ui Collapsible component to BarefootJS with native ARIA + `data-state` + signals
- Three sub-components: `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`
- CSS grid animation (`grid-rows-[1fr]`/`grid-rows-[0fr]`) for smooth expand/collapse
- Supports controlled/uncontrolled modes, `defaultOpen`, `disabled`, and `asChild`
- Documentation page with Basic, Controlled, and Disabled demos
- 19 E2E tests (all passing)

Related https://github.com/kfly8/barefootjs/issues/128

## Test plan

- [x] `bunx playwright test e2e/collapsible.spec.ts` — 19/19 passed
- [ ] Visual check on `/docs/components/collapsible`

🤖 Generated with [Claude Code](https://claude.com/claude-code)