### PR TITLE
Add Popover component ported from shadcn/ui

### DIFF
--- a/site/ui/components/popover-demo.tsx
+++ b/site/ui/components/popover-demo.tsx
@@ -1,0 +1,174 @@
+"use client"
+/**
+ * PopoverDemo Components
+ *
+ * Interactive demos for Popover component.
+ * Used in popover documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverClose,
+} from '@ui/components/ui/popover'
+
+/**
+ * Preview demo - Dimensions settings popover (similar to shadcn/ui example)
+ */
+export function PopoverPreviewDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Popover open={open()} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <span
+          className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          Open popover
+        </span>
+      </PopoverTrigger>
+      <PopoverContent class="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Dimensions</h4>
+            <p className="text-sm text-muted-foreground">
+              Set the dimensions for the layer.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            <div className="grid grid-cols-3 items-center gap-4">
+              <span className="text-sm">Width</span>
+              <input
+                className="col-span-2 h-8 rounded-md border border-border bg-background px-3 text-sm"
+                value="100%"
+              />
+            </div>
+            <div className="grid grid-cols-3 items-center gap-4">
+              <span className="text-sm">Max. width</span>
+              <input
+                className="col-span-2 h-8 rounded-md border border-border bg-background px-3 text-sm"
+                value="300px"
+              />
+            </div>
+            <div className="grid grid-cols-3 items-center gap-4">
+              <span className="text-sm">Height</span>
+              <input
+                className="col-span-2 h-8 rounded-md border border-border bg-background px-3 text-sm"
+                value="25px"
+              />
+            </div>
+            <div className="grid grid-cols-3 items-center gap-4">
+              <span className="text-sm">Max. height</span>
+              <input
+                className="col-span-2 h-8 rounded-md border border-border bg-background px-3 text-sm"
+                value="none"
+              />
+            </div>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * Basic demo - simple text content popover
+ */
+export function PopoverBasicDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Popover open={open()} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <span
+          className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          Click me
+        </span>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="space-y-2">
+          <h4 className="font-medium leading-none">About</h4>
+          <p className="text-sm text-muted-foreground">
+            This is a basic popover with simple text content. It opens on click and closes when you click outside or press ESC.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * Form demo - popover with notification preferences form
+ */
+export function PopoverFormDemo() {
+  const [open, setOpen] = createSignal(false)
+  const [saved, setSaved] = createSignal(false)
+
+  const handleSave = () => {
+    setSaved(true)
+    setTimeout(() => {
+      setSaved(false)
+      setOpen(false)
+    }, 1500)
+  }
+
+  return (
+    <Popover open={open()} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <span
+          className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+          <span>Settings</span>
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="start" class="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Notifications</h4>
+            <p className="text-sm text-muted-foreground">
+              Configure how you receive notifications.
+            </p>
+          </div>
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between">
+              <label className="text-sm" for="popover-email">Email</label>
+              <input
+                id="popover-email"
+                type="email"
+                placeholder="you@example.com"
+                className="h-8 w-48 rounded-md border border-border bg-background px-3 text-sm"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label className="text-sm" for="popover-frequency">Frequency</label>
+              <select
+                id="popover-frequency"
+                className="h-8 w-48 rounded-md border border-border bg-background px-3 text-sm"
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+            </div>
+          </div>
+          <div className="flex justify-between">
+            <PopoverClose class="inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-1.5 text-sm hover:bg-accent">
+              <span>Cancel</span>
+            </PopoverClose>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+              onClick={handleSave}
+            >
+              {saved() ? 'Saved!' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -19,6 +19,7 @@ export const componentOrder = [
   { slug: 'input', title: 'Input' },
   { slug: 'label', title: 'Label' },
   { slug: 'pagination', title: 'Pagination' },
+  { slug: 'popover', title: 'Popover' },
   { slug: 'portal', title: 'Portal' },
   { slug: 'radio-group', title: 'Radio Group' },
   { slug: 'select', title: 'Select' },

--- a/site/ui/e2e/popover.spec.ts
+++ b/site/ui/e2e/popover.spec.ts
@@ -24,7 +24,7 @@ test.describe('Popover Documentation Page', () => {
 
       const content = page.locator('[data-slot="popover-content"][data-state="open"]')
       await expect(content).toBeVisible()
-      await expect(content.locator('text=Dimensions')).toBeVisible()
+      await expect(content.getByRole('heading', { name: 'Dimensions' })).toBeVisible()
     })
 
     test('closes on ESC', async ({ page }) => {
@@ -91,8 +91,8 @@ test.describe('Popover Documentation Page', () => {
       await trigger.click()
 
       const content = page.locator('[data-slot="popover-content"][data-state="open"]')
-      await expect(content.locator('text=Width')).toBeVisible()
-      await expect(content.locator('text=Height')).toBeVisible()
+      await expect(content.getByText('Width', { exact: true })).toBeVisible()
+      await expect(content.getByText('Height', { exact: true })).toBeVisible()
     })
   })
 
@@ -118,7 +118,7 @@ test.describe('Popover Documentation Page', () => {
 
       const content = page.locator('[data-slot="popover-content"][data-state="open"]')
       await expect(content).toBeVisible()
-      await expect(content.locator('text=Notifications')).toBeVisible()
+      await expect(content.getByRole('heading', { name: 'Notifications' })).toBeVisible()
     })
 
     test('PopoverClose button closes popover', async ({ page }) => {

--- a/site/ui/e2e/popover.spec.ts
+++ b/site/ui/e2e/popover.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Popover Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/popover')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Popover')
+    await expect(page.locator('text=A floating panel that appears relative to a trigger element')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('text=bunx --bun barefoot add popover').first()).toBeVisible()
+  })
+
+  test.describe('Preview Demo', () => {
+    test('opens popover on trigger click', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('text=Dimensions')).toBeVisible()
+    })
+
+    test('closes on ESC', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.keyboard.press('Escape')
+      await expect(content).toHaveCount(0)
+    })
+
+    test('closes on click outside', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      // Click outside the popover (on the page header)
+      await page.locator('h1').click()
+      await expect(content).toHaveCount(0)
+    })
+
+    test('has correct data-state transitions', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      // Initially closed
+      const content = page.locator('[data-slot="popover-content"]').first()
+      await expect(content).toHaveAttribute('data-state', 'closed')
+
+      // Open
+      await trigger.click()
+      await expect(content).toHaveAttribute('data-state', 'open')
+
+      // Close
+      await page.keyboard.press('Escape')
+      await expect(content).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('has correct aria-expanded on trigger', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+      await trigger.click()
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+      await page.keyboard.press('Escape')
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    test('contains form fields', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content.locator('text=Width')).toBeVisible()
+      await expect(content.locator('text=Height')).toBeVisible()
+    })
+  })
+
+  test.describe('Basic Demo', () => {
+    test('opens and shows content', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverBasicDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('text=About')).toBeVisible()
+    })
+  })
+
+  test.describe('Form Demo', () => {
+    test('opens and shows form', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverFormDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('text=Notifications')).toBeVisible()
+    })
+
+    test('PopoverClose button closes popover', async ({ page }) => {
+      const demo = page.locator('[bf-s^="PopoverFormDemo_"]').first()
+      const trigger = demo.locator('[data-slot="popover-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="popover-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      // Click the Cancel button (PopoverClose)
+      const closeBtn = content.locator('[data-slot="popover-close"]')
+      await closeBtn.click()
+
+      await expect(content).toHaveCount(0)
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+      await expect(page.locator('h3:text-is("Popover")')).toBeVisible()
+      await expect(page.locator('h3:has-text("PopoverTrigger")')).toBeVisible()
+      await expect(page.locator('h3:has-text("PopoverContent")')).toBeVisible()
+      await expect(page.locator('h3:has-text("PopoverClose")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/popover.tsx
+++ b/site/ui/pages/popover.tsx
@@ -1,0 +1,222 @@
+/**
+ * Popover Documentation Page
+ */
+
+import { PopoverPreviewDemo, PopoverBasicDemo, PopoverFormDemo } from '@/components/popover-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'form', title: 'Form', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover'
+
+function BasicPopover() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Popover open={open()} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <span className="inline-flex items-center rounded-md border px-4 py-2 text-sm">
+          Click me
+        </span>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="space-y-2">
+          <h4 className="font-medium leading-none">About</h4>
+          <p className="text-sm text-muted-foreground">
+            This is a basic popover with simple text content.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverClose,
+} from '@/components/ui/popover'
+
+function FormPopover() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Popover open={open()} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <span className="inline-flex items-center rounded-md border px-4 py-2 text-sm">
+          Settings
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="start" class="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Notifications</h4>
+            <p className="text-sm text-muted-foreground">
+              Configure how you receive notifications.
+            </p>
+          </div>
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between">
+              <label className="text-sm">Email</label>
+              <input
+                type="email"
+                placeholder="you@example.com"
+                className="h-8 w-48 rounded-md border px-3 text-sm"
+              />
+            </div>
+          </div>
+          <div className="flex justify-between">
+            <PopoverClose class="rounded-md border px-3 py-1.5 text-sm">
+              Cancel
+            </PopoverClose>
+            <button className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground">
+              Save
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}`
+
+// Props definitions
+const popoverProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the popover is open.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Callback when open state should change.',
+  },
+]
+
+const popoverTriggerProps: PropDefinition[] = [
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the trigger is disabled.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
+  },
+]
+
+const popoverContentProps: PropDefinition[] = [
+  {
+    name: 'align',
+    type: "'start' | 'center' | 'end'",
+    defaultValue: "'center'",
+    description: 'Alignment relative to the trigger element.',
+  },
+  {
+    name: 'side',
+    type: "'top' | 'bottom'",
+    defaultValue: "'bottom'",
+    description: 'Which side of the trigger to position the popover.',
+  },
+]
+
+const popoverCloseProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The button content.',
+  },
+]
+
+export function PopoverPage() {
+  return (
+    <DocPage slug="popover" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Popover"
+          description="A floating panel that appears relative to a trigger element."
+          {...getNavLinks('popover')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<Popover open={open()} onOpenChange={setOpen}><PopoverTrigger>...</PopoverTrigger><PopoverContent>...</PopoverContent></Popover>`}>
+          <div className="flex gap-4">
+            <PopoverPreviewDemo />
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add popover" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <PopoverBasicDemo />
+            </Example>
+            <Example title="Form" code={formCode}>
+              <PopoverFormDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Popover</h3>
+              <PropsTable props={popoverProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">PopoverTrigger</h3>
+              <PropsTable props={popoverTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">PopoverContent</h3>
+              <PropsTable props={popoverContentProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">PopoverClose</h3>
+              <PropsTable props={popoverCloseProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -84,6 +84,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Input', href: '/docs/components/input' },
       { title: 'Label', href: '/docs/components/label' },
       { title: 'Pagination', href: '/docs/components/pagination' },
+      { title: 'Popover', href: '/docs/components/popover' },
       { title: 'Radio Group', href: '/docs/components/radio-group' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Separator', href: '/docs/components/separator' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -32,6 +32,7 @@ import { SeparatorPage } from './pages/separator'
 import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
 import { PaginationPage } from './pages/pagination'
+import { PopoverPage } from './pages/popover'
 import { RadioGroupPage } from './pages/radio-group'
 
 // Form pattern pages
@@ -301,6 +302,11 @@ export function createApp() {
   // Pagination documentation
   app.get('/docs/components/pagination', (c) => {
     return c.render(<PaginationPage />)
+  })
+
+  // Popover documentation
+  app.get('/docs/components/popover', (c) => {
+    return c.render(<PopoverPage />)
   })
 
   // Radio Group documentation

--- a/ui/components/ui/popover.tsx
+++ b/ui/components/ui/popover.tsx
@@ -1,0 +1,322 @@
+"use client"
+
+/**
+ * Popover Components
+ *
+ * A floating panel that appears relative to a trigger element.
+ * Inspired by shadcn/ui Popover with CSS variable theming support.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Root Popover manages open state, children consume via context.
+ *
+ * Features:
+ * - ESC key to close
+ * - Click outside to close
+ * - Non-modal (no scroll lock, no focus trap)
+ * - Accessibility (aria-expanded, data-state)
+ *
+ * @example Basic popover
+ * ```tsx
+ * const [open, setOpen] = createSignal(false)
+ *
+ * <Popover open={open()} onOpenChange={setOpen}>
+ *   <PopoverTrigger>
+ *     <button>Open</button>
+ *   </PopoverTrigger>
+ *   <PopoverContent>
+ *     <p>Popover content here.</p>
+ *   </PopoverContent>
+ * </Popover>
+ * ```
+ */
+
+import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Context for parent-child state sharing
+interface PopoverContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const PopoverContext = createContext<PopoverContextValue>()
+
+// Store Content -> Trigger element mapping for positioning after portal
+const contentTriggerMap = new WeakMap<HTMLElement, HTMLElement>()
+
+// Popover container classes
+const popoverClasses = 'relative inline-block'
+
+// PopoverTrigger classes
+const popoverTriggerClasses = 'inline-flex items-center disabled:pointer-events-none disabled:opacity-50'
+
+// PopoverContent base classes (from shadcn/ui)
+const popoverContentBaseClasses = 'fixed z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-hidden transform-gpu origin-top transition-[opacity,transform] duration-normal ease-out'
+
+// PopoverContent open/closed classes
+const popoverContentOpenClasses = 'opacity-100 scale-100'
+const popoverContentClosedClasses = 'opacity-0 scale-95 pointer-events-none'
+
+/**
+ * Props for Popover component.
+ */
+interface PopoverProps {
+  /** Whether the popover is open */
+  open?: boolean
+  /** Callback when open state should change */
+  onOpenChange?: (open: boolean) => void
+  /** PopoverTrigger and PopoverContent */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Popover root component.
+ * Provides open state to children via context.
+ *
+ * @param props.open - Whether the popover is open
+ * @param props.onOpenChange - Callback when open state should change
+ */
+function Popover(props: PopoverProps) {
+  return (
+    <PopoverContext.Provider value={{
+      open: () => props.open ?? false,
+      onOpenChange: props.onOpenChange ?? (() => {}),
+    }}>
+      <div data-slot="popover" className={`${popoverClasses} ${props.class ?? ''}`}>
+        {props.children}
+      </div>
+    </PopoverContext.Provider>
+  )
+}
+
+/**
+ * Props for PopoverTrigger component.
+ */
+interface PopoverTriggerProps {
+  /** Whether disabled */
+  disabled?: boolean
+  /** Render child element as trigger instead of built-in button */
+  asChild?: boolean
+  /** Trigger content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Button that toggles the popover.
+ * Reads open state from context and toggles via onOpenChange.
+ *
+ * @param props.disabled - Whether disabled
+ * @param props.asChild - Render child as trigger
+ */
+function PopoverTrigger(props: PopoverTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(PopoverContext)
+
+    createEffect(() => {
+      el.setAttribute('aria-expanded', String(ctx.open()))
+    })
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(!ctx.open())
+    })
+  }
+
+  if (props.asChild) {
+    return (
+      <span
+        data-slot="popover-trigger"
+        aria-expanded="false"
+        style="display:contents"
+        ref={handleMount}
+      >
+        {props.children}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      data-slot="popover-trigger"
+      type="button"
+      aria-expanded="false"
+      disabled={props.disabled ?? false}
+      className={`${popoverTriggerClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+/**
+ * Props for PopoverContent component.
+ */
+interface PopoverContentProps {
+  /** Popover content */
+  children?: Child
+  /** Alignment relative to trigger */
+  align?: 'start' | 'center' | 'end'
+  /** Side relative to trigger */
+  side?: 'top' | 'bottom'
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Content container for the popover.
+ * Portaled to body. Reads open state from context.
+ *
+ * @param props.align - Alignment ('start', 'center', or 'end')
+ * @param props.side - Side ('top' or 'bottom')
+ */
+function PopoverContent(props: PopoverContentProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Get trigger ref before portal (while still inside Popover container)
+    const triggerEl = el.parentElement?.querySelector('[data-slot="popover-trigger"]') as HTMLElement
+    if (triggerEl) contentTriggerMap.set(el, triggerEl)
+
+    // Portal to body to escape overflow clipping
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(PopoverContext)
+
+    // Position content relative to trigger
+    const updatePosition = () => {
+      if (!triggerEl) return
+      const rect = triggerEl.getBoundingClientRect()
+      const align = props.align ?? 'center'
+      const side = props.side ?? 'bottom'
+
+      if (side === 'bottom') {
+        el.style.top = `${rect.bottom + 4}px`
+      } else {
+        el.style.top = `${rect.top - el.offsetHeight - 4}px`
+      }
+
+      if (align === 'start') {
+        el.style.left = `${rect.left}px`
+      } else if (align === 'end') {
+        el.style.left = `${rect.right - el.offsetWidth}px`
+      } else {
+        // center
+        el.style.left = `${rect.left + rect.width / 2 - el.offsetWidth / 2}px`
+      }
+    }
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + positioning + global listeners
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${popoverContentBaseClasses} ${isOpen ? popoverContentOpenClasses : popoverContentClosedClasses} ${props.class ?? ''}`
+
+      if (isOpen) {
+        updatePosition()
+
+        // Close on click outside (content or trigger)
+        const handleClickOutside = (e: MouseEvent) => {
+          if (!el.contains(e.target as Node) && !triggerEl?.contains(e.target as Node)) {
+            ctx.onOpenChange(false)
+          }
+        }
+
+        // Close on ESC
+        const handleKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            triggerEl?.focus()
+          }
+        }
+
+        // Reposition on scroll and resize
+        const handleScroll = () => updatePosition()
+
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('keydown', handleKeyDown)
+        window.addEventListener('scroll', handleScroll, true)
+        window.addEventListener('resize', handleScroll)
+
+        cleanupFns.push(
+          () => document.removeEventListener('mousedown', handleClickOutside),
+          () => document.removeEventListener('keydown', handleKeyDown),
+          () => window.removeEventListener('scroll', handleScroll, true),
+          () => window.removeEventListener('resize', handleScroll),
+        )
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="popover-content"
+      data-state="closed"
+      tabindex={-1}
+      className={`${popoverContentBaseClasses} ${popoverContentClosedClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for PopoverClose component.
+ */
+interface PopoverCloseProps {
+  /** Button content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Close button for the popover.
+ * Reads context and calls onOpenChange(false) on click.
+ */
+function PopoverClose(props: PopoverCloseProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(PopoverContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <button
+      data-slot="popover-close"
+      type="button"
+      className={props.class ?? ''}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverClose,
+}
+
+export type {
+  PopoverProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverCloseProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -34,6 +34,12 @@
       "description": "Pagination with page navigation, next and previous links"
     },
     {
+      "name": "popover",
+      "type": "registry:ui",
+      "title": "Popover",
+      "description": "A floating panel that appears relative to a trigger element"
+    },
+    {
       "name": "textarea",
       "type": "registry:ui",
       "title": "Textarea",


### PR DESCRIPTION
## Summary
- Add Popover component (`ui/components/ui/popover.tsx`) with `Popover`, `PopoverTrigger`, `PopoverContent`, and `PopoverClose` sub-components
- Follow DropdownMenu pattern for portal/positioning and Dialog pattern for composable context-based state sharing
- Non-modal: no scroll lock, no focus trap (unlike Dialog)
- Add documentation page with three demos: Dimensions settings (preview), basic text, and notification form
- Add E2E tests covering open/close, ESC, click outside, PopoverClose, aria-expanded, and data-state transitions
- Register in site navigation (renderer, routes, PageNavigation, registry)

## Test plan
- [ ] `bun run build` passes
- [ ] Page renders at `/docs/components/popover`
- [ ] Click trigger opens popover, ESC closes, click outside closes
- [ ] PopoverClose button works in Form demo
- [ ] `bunx playwright test site/ui/e2e/popover.spec.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)