### PR TITLE
Add Sheet component ported from shadcn/ui

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -23,6 +23,7 @@ export const componentOrder = [
   { slug: 'radio-group', title: 'Radio Group' },
   { slug: 'select', title: 'Select' },
   { slug: 'separator', title: 'Separator' },
+  { slug: 'sheet', title: 'Sheet' },
   { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'tabs', title: 'Tabs' },

--- a/site/ui/components/sheet-demo.tsx
+++ b/site/ui/components/sheet-demo.tsx
@@ -1,0 +1,197 @@
+"use client"
+/**
+ * SheetDemo Components
+ *
+ * Interactive demos for Sheet component.
+ * Used in sheet documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+} from '@ui/components/ui/sheet'
+
+/**
+ * Basic sheet demo - opens from right side with title and description
+ */
+export function SheetBasicDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div>
+      <Sheet open={open()} onOpenChange={setOpen}>
+        <SheetTrigger>
+          Open Sheet
+        </SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="right"
+          ariaLabelledby="sheet-basic-title"
+          ariaDescribedby="sheet-basic-description"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-basic-title">Sheet Title</SheetTitle>
+            <SheetDescription id="sheet-basic-description">
+              This is a basic sheet that slides in from the right edge of the screen.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="py-4 text-sm text-muted-foreground">
+            <p>
+              Sheets are useful for navigation menus, settings panels, and forms
+              that complement the main content.
+            </p>
+          </div>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+/**
+ * Side variants demo - shows all 4 side options
+ */
+export function SheetSideDemo() {
+  const [openTop, setOpenTop] = createSignal(false)
+  const [openRight, setOpenRight] = createSignal(false)
+  const [openBottom, setOpenBottom] = createSignal(false)
+  const [openLeft, setOpenLeft] = createSignal(false)
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Sheet open={openTop()} onOpenChange={setOpenTop}>
+        <SheetTrigger>Top</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="top"
+          ariaLabelledby="sheet-top-title"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-top-title">Top Sheet</SheetTitle>
+            <SheetDescription>This sheet slides in from the top.</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={openRight()} onOpenChange={setOpenRight}>
+        <SheetTrigger>Right</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="right"
+          ariaLabelledby="sheet-right-title"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-right-title">Right Sheet</SheetTitle>
+            <SheetDescription>This sheet slides in from the right.</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={openBottom()} onOpenChange={setOpenBottom}>
+        <SheetTrigger>Bottom</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="bottom"
+          ariaLabelledby="sheet-bottom-title"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-bottom-title">Bottom Sheet</SheetTitle>
+            <SheetDescription>This sheet slides in from the bottom.</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={openLeft()} onOpenChange={setOpenLeft}>
+        <SheetTrigger>Left</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="left"
+          ariaLabelledby="sheet-left-title"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-left-title">Left Sheet</SheetTitle>
+            <SheetDescription>This sheet slides in from the left.</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+/**
+ * Profile edit form inside sheet demo
+ */
+export function SheetFormDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div>
+      <Sheet open={open()} onOpenChange={setOpen}>
+        <SheetTrigger>Edit Profile</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent
+          side="right"
+          ariaLabelledby="sheet-form-title"
+          ariaDescribedby="sheet-form-description"
+        >
+          <SheetHeader>
+            <SheetTitle id="sheet-form-title">Edit Profile</SheetTitle>
+            <SheetDescription id="sheet-form-description">
+              Make changes to your profile here. Click save when you're done.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <label for="sheet-name" className="text-right text-sm font-medium">
+                Name
+              </label>
+              <input
+                id="sheet-name"
+                type="text"
+                value="John Doe"
+                className="col-span-3 flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <label for="sheet-username" className="text-right text-sm font-medium">
+                Username
+              </label>
+              <input
+                id="sheet-username"
+                type="text"
+                value="@johndoe"
+                className="col-span-3 flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+            </div>
+          </div>
+          <SheetFooter>
+            <SheetClose>Cancel</SheetClose>
+            <SheetClose>Save changes</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}

--- a/site/ui/e2e/sheet.spec.ts
+++ b/site/ui/e2e/sheet.spec.ts
@@ -1,0 +1,307 @@
+import { test, expect } from '@playwright/test'
+
+// Click position for overlay outside the sheet area.
+// Sheets are positioned at edges, so clicking near the opposite edge hits the overlay.
+const OVERLAY_CLICK_POSITION = { x: 10, y: 10 }
+
+test.describe('Sheet Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/sheet')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Sheet')
+    await expect(page.locator('text=A panel that slides in from the edge')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+  })
+
+  test.describe('Basic Sheet', () => {
+    test('opens sheet when trigger is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      // Sheet is portaled to body
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Sheet Title')).toBeVisible()
+    })
+
+    test('closes sheet when close button (X) is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      // Click the X close button
+      const closeButton = sheet.locator('[data-slot="sheet-close-button"]')
+      await closeButton.click()
+
+      // Sheet should transition to closed state
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes sheet when SheetClose button is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      // Click the Close button in footer
+      const closeBtn = sheet.locator('[data-slot="sheet-close"]:has-text("Close")')
+      await closeBtn.click()
+
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes sheet when ESC key is pressed', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      await page.keyboard.press('Escape')
+
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes sheet when overlay is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      // Click overlay
+      const overlay = page.locator('[data-slot="sheet-overlay"][data-state="open"]').first()
+      await overlay.click({ position: OVERLAY_CLICK_POSITION })
+
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('has correct accessibility attributes', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet).toHaveAttribute('aria-modal', 'true')
+      await expect(sheet).toHaveAttribute('aria-labelledby', 'sheet-basic-title')
+      await expect(sheet).toHaveAttribute('aria-describedby', 'sheet-basic-description')
+    })
+
+    test('traps focus within sheet', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      // Focus on sheet container
+      await sheet.focus()
+
+      // Tab should move focus to the first focusable element inside the sheet
+      await page.keyboard.press('Tab')
+      const focused = await page.evaluate(() => {
+        const el = document.activeElement
+        return el ? el.closest('[role="dialog"]')?.getAttribute('aria-labelledby') : null
+      })
+      expect(focused).toBe('sheet-basic-title')
+    })
+  })
+
+  test.describe('Sheet Slide Animation', () => {
+    test('right sheet slides in from right', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Sheet")')
+
+      // Before opening, sheet should be translated off-screen (translate-x-full)
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
+      const closedTransform = await closedSheet.evaluate((el) => getComputedStyle(el).transform)
+      // translate-x-full means transform matrix with positive x translation
+      expect(closedTransform).not.toBe('none')
+
+      await trigger.click()
+
+      const openSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="open"]')
+      await expect(openSheet).toBeVisible()
+
+      // Verify the sheet has translate-x-0 class applied (no x-translation from slide)
+      await expect(openSheet).toHaveClass(/translate-x-0/)
+    })
+  })
+
+  test.describe('Side Variants', () => {
+    test('opens left sheet', async ({ page }) => {
+      const sideDemo = page.locator('[bf-s^="SheetSideDemo_"]').first()
+      const trigger = sideDemo.locator('button:has-text("Left")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-left-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Left Sheet')).toBeVisible()
+
+      // Left sheet should be positioned on the left
+      await expect(sheet).toHaveCSS('left', '0px')
+    })
+
+    test('opens right sheet', async ({ page }) => {
+      const sideDemo = page.locator('[bf-s^="SheetSideDemo_"]').first()
+      const trigger = sideDemo.locator('button:has-text("Right")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-right-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Right Sheet')).toBeVisible()
+
+      // Right sheet should be positioned on the right
+      await expect(sheet).toHaveCSS('right', '0px')
+    })
+
+    test('opens top sheet', async ({ page }) => {
+      const sideDemo = page.locator('[bf-s^="SheetSideDemo_"]').first()
+      const trigger = sideDemo.locator('button:has-text("Top")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-top-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Top Sheet')).toBeVisible()
+
+      // Top sheet should be at the top
+      await expect(sheet).toHaveCSS('top', '0px')
+    })
+
+    test('opens bottom sheet', async ({ page }) => {
+      const sideDemo = page.locator('[bf-s^="SheetSideDemo_"]').first()
+      const trigger = sideDemo.locator('button:has-text("Bottom")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-bottom-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Bottom Sheet')).toBeVisible()
+
+      // Bottom sheet should be at the bottom
+      await expect(sheet).toHaveCSS('bottom', '0px')
+    })
+
+    test('closes side sheet via ESC', async ({ page }) => {
+      const sideDemo = page.locator('[bf-s^="SheetSideDemo_"]').first()
+      const trigger = sideDemo.locator('button:has-text("Left")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-left-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      await page.keyboard.press('Escape')
+
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-left-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('Form Sheet', () => {
+    test('opens form sheet with input fields', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="SheetFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Edit Profile")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-form-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+      await expect(sheet.locator('text=Edit Profile').first()).toBeVisible()
+
+      // Check input fields are present
+      const nameInput = sheet.locator('input#sheet-name')
+      await expect(nameInput).toBeVisible()
+
+      const usernameInput = sheet.locator('input#sheet-username')
+      await expect(usernameInput).toBeVisible()
+    })
+
+    test('can interact with form fields inside sheet', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="SheetFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Edit Profile")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-form-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      // Clear and type in name input
+      const nameInput = sheet.locator('input#sheet-name')
+      await nameInput.click()
+      await nameInput.fill('Jane Smith')
+      await expect(nameInput).toHaveValue('Jane Smith')
+    })
+
+    test('closes form sheet when Cancel is clicked', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="SheetFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Edit Profile")')
+
+      await trigger.click()
+
+      const sheet = page.locator('[role="dialog"][aria-labelledby="sheet-form-title"][data-state="open"]')
+      await expect(sheet).toBeVisible()
+
+      const cancelButton = sheet.locator('[data-slot="sheet-close"]:has-text("Cancel")')
+      await cancelButton.click()
+
+      const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-form-title"][data-state="closed"]').first()
+      await expect(closedSheet).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays SheetTrigger props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("SheetTrigger")')).toBeVisible()
+    })
+
+    test('displays SheetContent props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("SheetContent")')).toBeVisible()
+    })
+
+    test('displays SheetTitle props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("SheetTitle")')).toBeVisible()
+    })
+
+    test('displays SheetDescription props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("SheetDescription")')).toBeVisible()
+    })
+
+    test('displays SheetClose props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("SheetClose")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/sheet.tsx
+++ b/site/ui/pages/sheet.tsx
@@ -1,0 +1,320 @@
+/**
+ * Sheet Documentation Page
+ */
+
+import { SheetBasicDemo, SheetSideDemo, SheetFormDemo } from '@/components/sheet-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'side-variants', title: 'Side Variants', branch: 'start' },
+  { id: 'form', title: 'Form', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+} from '@/components/ui/sheet'
+
+function BasicSheet() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Sheet open={open()} onOpenChange={setOpen}>
+      <SheetTrigger>Open Sheet</SheetTrigger>
+      <SheetOverlay />
+      <SheetContent
+        side="right"
+        ariaLabelledby="sheet-title"
+        ariaDescribedby="sheet-description"
+      >
+        <SheetHeader>
+          <SheetTitle id="sheet-title">Sheet Title</SheetTitle>
+          <SheetDescription id="sheet-description">
+            This is a basic sheet that slides in from the right.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="py-4 text-sm text-muted-foreground">
+          <p>Sheet content goes here.</p>
+        </div>
+        <SheetFooter>
+          <SheetClose>Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}`
+
+const sideCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+} from '@/components/ui/sheet'
+
+function SheetSides() {
+  const [openTop, setOpenTop] = createSignal(false)
+  const [openRight, setOpenRight] = createSignal(false)
+  const [openBottom, setOpenBottom] = createSignal(false)
+  const [openLeft, setOpenLeft] = createSignal(false)
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Sheet open={openTop()} onOpenChange={setOpenTop}>
+        <SheetTrigger>Top</SheetTrigger>
+        <SheetOverlay />
+        <SheetContent side="top" ariaLabelledby="top-title">
+          <SheetHeader>
+            <SheetTitle id="top-title">Top Sheet</SheetTitle>
+            <SheetDescription>Slides from the top.</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <SheetClose>Close</SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      {/* Repeat for right, bottom, left with side="right|bottom|left" */}
+    </div>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+} from '@/components/ui/sheet'
+
+function EditProfileSheet() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Sheet open={open()} onOpenChange={setOpen}>
+      <SheetTrigger>Edit Profile</SheetTrigger>
+      <SheetOverlay />
+      <SheetContent
+        side="right"
+        ariaLabelledby="form-title"
+        ariaDescribedby="form-description"
+      >
+        <SheetHeader>
+          <SheetTitle id="form-title">Edit Profile</SheetTitle>
+          <SheetDescription id="form-description">
+            Make changes to your profile here.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <label for="name" className="text-right text-sm font-medium">
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              defaultValue="John Doe"
+              className="col-span-3 flex h-10 w-full rounded-md border ..."
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <label for="username" className="text-right text-sm font-medium">
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              defaultValue="@johndoe"
+              className="col-span-3 flex h-10 w-full rounded-md border ..."
+            />
+          </div>
+        </div>
+        <SheetFooter>
+          <SheetClose>Cancel</SheetClose>
+          <SheetClose>Save changes</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}`
+
+// Props definitions
+const sheetProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the sheet is open.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Event handler called when the open state should change.',
+  },
+]
+
+const sheetTriggerProps: PropDefinition[] = [
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the trigger is disabled.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
+  },
+]
+
+const sheetContentProps: PropDefinition[] = [
+  {
+    name: 'side',
+    type: "'top' | 'right' | 'bottom' | 'left'",
+    defaultValue: "'right'",
+    description: 'Which edge of the screen the sheet slides from.',
+  },
+  {
+    name: 'showCloseButton',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Whether to show the built-in close button (X) in the top-right corner.',
+  },
+  {
+    name: 'ariaLabelledby',
+    type: 'string',
+    description: 'ID of the element that labels the sheet (typically SheetTitle).',
+  },
+  {
+    name: 'ariaDescribedby',
+    type: 'string',
+    description: 'ID of the element that describes the sheet (typically SheetDescription).',
+  },
+]
+
+const sheetTitleProps: PropDefinition[] = [
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID for aria-labelledby reference.',
+  },
+]
+
+const sheetDescriptionProps: PropDefinition[] = [
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID for aria-describedby reference.',
+  },
+]
+
+const sheetCloseProps: PropDefinition[] = []
+
+export function SheetPage() {
+  return (
+    <DocPage slug="sheet" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Sheet"
+          description="A panel that slides in from the edge of the screen. Extends the Dialog pattern with side-based positioning and slide animations."
+          {...getNavLinks('sheet')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={basicCode}>
+          <div className="flex gap-4">
+            <SheetBasicDemo />
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add sheet" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Side Variants" code={sideCode}>
+              <SheetSideDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <SheetFormDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Sheet</h3>
+              <PropsTable props={sheetProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">SheetTrigger</h3>
+              <PropsTable props={sheetTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">SheetContent</h3>
+              <PropsTable props={sheetContentProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">SheetTitle</h3>
+              <PropsTable props={sheetTitleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">SheetDescription</h3>
+              <PropsTable props={sheetDescriptionProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">SheetClose</h3>
+              <PropsTable props={sheetCloseProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -87,6 +87,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Radio Group', href: '/docs/components/radio-group' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Separator', href: '/docs/components/separator' },
+      { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Tabs', href: '/docs/components/tabs' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -33,6 +33,7 @@ import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
 import { PaginationPage } from './pages/pagination'
 import { RadioGroupPage } from './pages/radio-group'
+import { SheetPage } from './pages/sheet'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -306,6 +307,11 @@ export function createApp() {
   // Radio Group documentation
   app.get('/docs/components/radio-group', (c) => {
     return c.render(<RadioGroupPage />)
+  })
+
+  // Sheet documentation
+  app.get('/docs/components/sheet', (c) => {
+    return c.render(<SheetPage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -1,0 +1,542 @@
+"use client"
+
+/**
+ * Sheet Components
+ *
+ * A panel that slides in from the edge of the screen.
+ * Extends the Dialog pattern with side-based positioning and slide animations.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Sheet root manages open state, children consume via context.
+ *
+ * Features:
+ * - ESC key to close
+ * - Click outside (overlay) to close
+ * - Focus trap (Tab/Shift+Tab cycles within panel)
+ * - Accessibility (role="dialog", aria-modal="true")
+ * - Slide animation from any edge (top, right, bottom, left)
+ * - Built-in close button (configurable via showCloseButton)
+ *
+ * @example Basic sheet
+ * ```tsx
+ * const [open, setOpen] = createSignal(false)
+ *
+ * <Sheet open={open()} onOpenChange={setOpen}>
+ *   <SheetTrigger>Open Sheet</SheetTrigger>
+ *   <SheetOverlay />
+ *   <SheetContent side="right" ariaLabelledby="sheet-title">
+ *     <SheetHeader>
+ *       <SheetTitle id="sheet-title">Sheet Title</SheetTitle>
+ *       <SheetDescription>Sheet description here.</SheetDescription>
+ *     </SheetHeader>
+ *     <SheetFooter>
+ *       <SheetClose>Close</SheetClose>
+ *     </SheetFooter>
+ *   </SheetContent>
+ * </Sheet>
+ * ```
+ */
+
+import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Context for Sheet -> children state sharing
+interface SheetContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const SheetContext = createContext<SheetContextValue>()
+
+// Side variants
+type SheetSide = 'top' | 'right' | 'bottom' | 'left'
+
+// SheetTrigger classes
+const sheetTriggerClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50'
+
+// SheetOverlay base classes
+const sheetOverlayBaseClasses = 'fixed inset-0 z-50 bg-black/80 transition-opacity duration-200'
+
+// SheetOverlay open/closed classes
+const sheetOverlayOpenClasses = 'opacity-100'
+const sheetOverlayClosedClasses = 'opacity-0 pointer-events-none'
+
+// SheetContent base classes
+const sheetContentBaseClasses = 'z-50 flex flex-col gap-4 bg-background p-6 shadow-lg transition-transform duration-200'
+
+// Side-specific positioning classes
+const sideClasses: Record<SheetSide, string> = {
+  top: 'fixed inset-x-0 top-0 w-full border-b',
+  right: 'fixed inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+  bottom: 'fixed inset-x-0 bottom-0 w-full border-t',
+  left: 'fixed inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+}
+
+// Side-specific open state classes (slide to final position)
+const sideOpenClasses: Record<SheetSide, string> = {
+  top: 'translate-y-0',
+  right: 'translate-x-0',
+  bottom: 'translate-y-0',
+  left: 'translate-x-0',
+}
+
+// Side-specific closed state classes (slide off-screen)
+const sideClosedClasses: Record<SheetSide, string> = {
+  top: '-translate-y-full',
+  right: 'translate-x-full',
+  bottom: 'translate-y-full',
+  left: '-translate-x-full',
+}
+
+// SheetHeader classes
+const sheetHeaderClasses = 'flex flex-col gap-2 text-center sm:text-left'
+
+// SheetTitle classes
+const sheetTitleClasses = 'text-lg leading-none font-semibold'
+
+// SheetDescription classes
+const sheetDescriptionClasses = 'text-muted-foreground text-sm'
+
+// SheetFooter classes
+const sheetFooterClasses = 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end'
+
+// SheetClose classes
+const sheetCloseClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-border bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2'
+
+// Close button (X) classes
+const closeButtonClasses = 'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none'
+
+/**
+ * Props for Sheet component.
+ */
+interface SheetProps {
+  /** Whether the sheet is open */
+  open?: boolean
+  /** Callback when open state should change */
+  onOpenChange?: (open: boolean) => void
+  /** Scope ID for SSR portal support (explicit) */
+  scopeId?: string
+  /** Scope ID from compiler (auto-passed via hydration props) */
+  __instanceId?: string
+  /** Scope ID from compiler in loops (auto-passed via hydration props) */
+  __bfScope?: string
+  /** Sheet content */
+  children?: Child
+}
+
+/**
+ * Sheet root component.
+ * Provides open state to children via context.
+ *
+ * @param props.open - Whether the sheet is open
+ * @param props.onOpenChange - Callback when open state should change
+ */
+function Sheet(props: SheetProps) {
+  return (
+    <SheetContext.Provider value={{
+      open: () => props.open ?? false,
+      onOpenChange: props.onOpenChange ?? (() => {}),
+    }}>
+      {props.children}
+    </SheetContext.Provider>
+  )
+}
+
+/**
+ * Props for SheetTrigger component.
+ */
+interface SheetTriggerProps {
+  /** Whether disabled */
+  disabled?: boolean
+  /** Render child element as trigger instead of built-in button */
+  asChild?: boolean
+  /** Button content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Button that triggers the sheet to open.
+ * Reads open state from context and toggles via onOpenChange.
+ *
+ * @param props.disabled - Whether disabled
+ * @param props.asChild - Render child as trigger
+ */
+function SheetTrigger(props: SheetTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(SheetContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(!ctx.open())
+    })
+  }
+
+  if (props.asChild) {
+    return (
+      <span
+        data-slot="sheet-trigger"
+        style="display:contents"
+        ref={handleMount}
+      >
+        {props.children}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      data-slot="sheet-trigger"
+      type="button"
+      className={`${sheetTriggerClasses} ${props.class ?? ''}`}
+      disabled={props.disabled ?? false}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+/**
+ * Props for SheetOverlay component.
+ */
+interface SheetOverlayProps {
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Semi-transparent overlay behind the sheet.
+ * Portals to document.body to avoid z-index issues with fixed headers.
+ * Reads open state from context.
+ */
+function SheetOverlay(props: SheetOverlayProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Portal to body
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(SheetContext)
+
+    // Reactive show/hide + click-to-close
+    createEffect(() => {
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${sheetOverlayBaseClasses} ${isOpen ? sheetOverlayOpenClasses : sheetOverlayClosedClasses} ${props.class ?? ''}`
+    })
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <div
+      data-slot="sheet-overlay"
+      data-state="closed"
+      className={`${sheetOverlayBaseClasses} ${sheetOverlayClosedClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    />
+  )
+}
+
+/**
+ * Props for SheetContent component.
+ */
+interface SheetContentProps {
+  /** Sheet content */
+  children?: Child
+  /** Which edge the sheet slides from */
+  side?: SheetSide
+  /** Whether to show the built-in close button (X) */
+  showCloseButton?: boolean
+  /** ID of the title element for aria-labelledby */
+  ariaLabelledby?: string
+  /** ID of the description element for aria-describedby */
+  ariaDescribedby?: string
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Main content container for the sheet.
+ * Portals to document.body to avoid z-index issues with fixed headers.
+ * Reads open state from context.
+ *
+ * @param props.side - Which edge to slide from (default: 'right')
+ * @param props.showCloseButton - Show built-in X close button (default: true)
+ * @param props.ariaLabelledby - ID of title for accessibility
+ * @param props.ariaDescribedby - ID of description for accessibility
+ */
+function SheetContent(props: SheetContentProps) {
+  const side = props.side ?? 'right'
+  const showClose = props.showCloseButton !== false
+
+  const handleMount = (el: HTMLElement) => {
+    // Portal to body
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(SheetContext)
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + scroll lock + focus trap + ESC key
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${sheetContentBaseClasses} ${sideClasses[side]} ${isOpen ? sideOpenClasses[side] : sideClosedClasses[side]} ${props.class ?? ''}`
+
+      if (isOpen) {
+        // Scroll lock
+        const originalOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+
+        // Focus first focusable element
+        const focusableSelector = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        setTimeout(() => {
+          const focusableElements = el.querySelectorAll(focusableSelector)
+          const firstElement = focusableElements[0] as HTMLElement
+          firstElement?.focus()
+        }, 0)
+
+        // ESC key to close
+        const handleKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            return
+          }
+
+          // Focus trap
+          if (e.key === 'Tab') {
+            const focusableElements = el.querySelectorAll(focusableSelector)
+            const firstElement = focusableElements[0] as HTMLElement
+            const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+            if (e.shiftKey) {
+              if (document.activeElement === firstElement || document.activeElement === el) {
+                e.preventDefault()
+                lastElement?.focus()
+              }
+            } else {
+              if (document.activeElement === lastElement) {
+                e.preventDefault()
+                firstElement?.focus()
+              }
+            }
+          }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        cleanupFns.push(
+          () => { document.body.style.overflow = originalOverflow },
+          () => document.removeEventListener('keydown', handleKeyDown),
+        )
+      }
+    })
+  }
+
+  // Close button handler
+  const handleCloseMount = (el: HTMLElement) => {
+    const ctx = useContext(SheetContext)
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <div
+      data-slot="sheet-content"
+      data-state="closed"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={props.ariaLabelledby}
+      aria-describedby={props.ariaDescribedby}
+      tabindex={-1}
+      className={`${sheetContentBaseClasses} ${sideClasses[side]} ${sideClosedClasses[side]} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+      {showClose && (
+        <button
+          data-slot="sheet-close-button"
+          type="button"
+          className={closeButtonClasses}
+          ref={handleCloseMount}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+          <span className="sr-only">Close</span>
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Props for SheetHeader component.
+ */
+interface SheetHeaderProps {
+  /** Header content (typically SheetTitle and SheetDescription) */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Header section of the sheet.
+ *
+ * @param props.children - Header content
+ */
+function SheetHeader({ class: className = '', children }: SheetHeaderProps) {
+  return (
+    <div data-slot="sheet-header" className={`${sheetHeaderClasses} ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Props for SheetTitle component.
+ */
+interface SheetTitleProps {
+  /** ID for aria-labelledby reference */
+  id?: string
+  /** Title text */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Title of the sheet.
+ *
+ * @param props.id - ID for accessibility
+ */
+function SheetTitle({ class: className = '', id, children }: SheetTitleProps) {
+  return (
+    <h2 data-slot="sheet-title" id={id} className={`${sheetTitleClasses} ${className}`}>
+      {children}
+    </h2>
+  )
+}
+
+/**
+ * Props for SheetDescription component.
+ */
+interface SheetDescriptionProps {
+  /** ID for aria-describedby reference */
+  id?: string
+  /** Description text */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Description text for the sheet.
+ *
+ * @param props.id - ID for accessibility
+ */
+function SheetDescription({ class: className = '', id, children }: SheetDescriptionProps) {
+  return (
+    <p data-slot="sheet-description" id={id} className={`${sheetDescriptionClasses} ${className}`}>
+      {children}
+    </p>
+  )
+}
+
+/**
+ * Props for SheetFooter component.
+ */
+interface SheetFooterProps {
+  /** Footer content (typically action buttons) */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Footer section of the sheet.
+ *
+ * @param props.children - Footer content
+ */
+function SheetFooter({ class: className = '', children }: SheetFooterProps) {
+  return (
+    <div data-slot="sheet-footer" className={`${sheetFooterClasses} ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Props for SheetClose component.
+ */
+interface SheetCloseProps {
+  /** Button content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Close button for the sheet.
+ * Reads context and calls onOpenChange(false) on click.
+ */
+function SheetClose(props: SheetCloseProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(SheetContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <button
+      data-slot="sheet-close"
+      type="button"
+      className={`${sheetCloseClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  SheetClose,
+}
+export type {
+  SheetProps,
+  SheetTriggerProps,
+  SheetOverlayProps,
+  SheetContentProps,
+  SheetHeaderProps,
+  SheetTitleProps,
+  SheetDescriptionProps,
+  SheetFooterProps,
+  SheetCloseProps,
+  SheetSide,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -46,6 +46,12 @@
       "description": "A visual divider that separates content horizontally or vertically"
     },
     {
+      "name": "sheet",
+      "type": "registry:ui",
+      "title": "Sheet",
+      "description": "A panel that slides in from the edge of the screen"
+    },
+    {
       "name": "toggle-group",
       "type": "registry:ui",
       "title": "Toggle Group",


### PR DESCRIPTION
## Summary
- Add Sheet component — a panel that slides in from screen edges (top/right/bottom/left)
- Extends Dialog pattern with side-based positioning and slide animations
- Includes compound components: Sheet, SheetTrigger, SheetOverlay, SheetContent, SheetHeader, SheetTitle, SheetDescription, SheetFooter, SheetClose

## New files
- `ui/components/ui/sheet.tsx` — Component implementation
- `site/ui/components/sheet-demo.tsx` — Demo components (Basic, Side Variants, Form)
- `site/ui/pages/sheet.tsx` — Documentation page
- `site/ui/e2e/sheet.spec.ts` — E2E tests (24 tests)

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 24 E2E tests pass (`bunx playwright test e2e/sheet.spec.ts`)
- [ ] Visual review at `/docs/components/sheet`
- [ ] Verify all 4 side variants (top/right/bottom/left)
- [ ] Verify ESC key, overlay click, close button interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)