### PR TITLE
Add ScrollArea and Resizable components

### DIFF
--- a/site/ui/components/resizable-demo.tsx
+++ b/site/ui/components/resizable-demo.tsx
@@ -1,0 +1,115 @@
+"use client"
+/**
+ * Resizable Demo Components
+ *
+ * Interactive demos for Resizable panel components.
+ * Based on shadcn/ui examples.
+ */
+
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@ui/components/ui/resizable'
+
+/**
+ * Horizontal two-panel layout (Preview).
+ */
+export function ResizableHorizontalDemo() {
+  return (
+    <ResizablePanelGroup
+      direction="horizontal"
+      class="max-w-md rounded-lg border"
+    >
+      <ResizablePanel defaultSize={50}>
+        <div className="flex h-[200px] items-center justify-center p-6">
+          <span className="font-semibold">One</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={50}>
+        <div className="flex h-[200px] items-center justify-center p-6">
+          <span className="font-semibold">Two</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}
+
+/**
+ * Vertical stacked layout.
+ */
+export function ResizableVerticalDemo() {
+  return (
+    <ResizablePanelGroup
+      direction="vertical"
+      class="min-h-[200px] max-w-md rounded-lg border"
+    >
+      <ResizablePanel defaultSize={25}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Header</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={75}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}
+
+/**
+ * With visible grip handle.
+ */
+export function ResizableWithHandleDemo() {
+  return (
+    <ResizablePanelGroup
+      direction="horizontal"
+      class="min-h-[200px] max-w-md rounded-lg border"
+    >
+      <ResizablePanel defaultSize={25}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Sidebar</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={75}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}
+
+/**
+ * Three-panel layout with min/max constraints.
+ */
+export function ResizableThreePanelDemo() {
+  return (
+    <ResizablePanelGroup
+      direction="horizontal"
+      class="min-h-[200px] rounded-lg border"
+    >
+      <ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Sidebar</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={55} minSize={30}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={25} minSize={15} maxSize={35}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Aside</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}

--- a/site/ui/components/scroll-area-demo.tsx
+++ b/site/ui/components/scroll-area-demo.tsx
@@ -1,0 +1,91 @@
+"use client"
+/**
+ * ScrollArea Demo Components
+ *
+ * Interactive demos for ScrollArea component.
+ * Based on shadcn/ui examples.
+ */
+
+import { ScrollArea } from '@ui/components/ui/scroll-area'
+
+const tags = Array.from({ length: 50 }).map(
+  (_, i, a) => `v1.2.0-beta.${a.length - i}`
+)
+
+/**
+ * Tags list — classic shadcn/ui scroll-area example.
+ * Fixed-height container with vertical scroll.
+ */
+export function ScrollAreaTagsDemo() {
+  return (
+    <ScrollArea class="h-72 w-48 rounded-md border">
+      <div className="p-4">
+        <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
+        {tags.map((tag) => (
+          <div>
+            <div className="text-sm" data-tag={tag}>{tag}</div>
+            <div className="bg-border shrink-0 h-px w-full my-2" />
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}
+
+/**
+ * Horizontal scroll — artwork gallery.
+ */
+export function ScrollAreaHorizontalDemo() {
+  const works = [
+    { artist: 'Ornella Binni', title: 'Sunset Horizon' },
+    { artist: 'Tom Byrom', title: 'Mountain Peak' },
+    { artist: 'Vladimir Malyutin', title: 'City Lights' },
+    { artist: 'Ornella Binni', title: 'Ocean Waves' },
+    { artist: 'Tom Byrom', title: 'Forest Trail' },
+    { artist: 'Vladimir Malyutin', title: 'Night Sky' },
+    { artist: 'Ornella Binni', title: 'Desert Dunes' },
+  ]
+
+  return (
+    <ScrollArea class="w-96 whitespace-nowrap rounded-md border">
+      <div className="flex w-max space-x-4 p-4">
+        {works.map((work) => (
+          <figure className="shrink-0">
+            <div className="overflow-hidden rounded-md">
+              <div className="h-[150px] w-[200px] bg-muted flex items-center justify-center">
+                <span className="text-xs text-muted-foreground">{work.title}</span>
+              </div>
+            </div>
+            <figcaption className="pt-2 text-xs text-muted-foreground">
+              Photo by{' '}
+              <span className="font-semibold text-foreground">{work.artist}</span>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}
+
+/**
+ * Both axes — content wider and taller than container.
+ */
+export function ScrollAreaBothAxesDemo() {
+  return (
+    <ScrollArea class="h-64 w-80 rounded-md border">
+      <div className="p-4" style="width: 600px;">
+        <h4 className="mb-4 text-sm font-medium leading-none">Changelog</h4>
+        <div className="space-y-4">
+          {Array.from({ length: 20 }).map((_, i) => (
+            <div className="whitespace-nowrap">
+              <div className="text-sm font-medium">Release v{20 - i}.0.0</div>
+              <p className="text-sm text-muted-foreground">
+                Added new features, fixed bugs, and improved performance across multiple modules and packages.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -22,6 +22,8 @@ export const componentOrder = [
   { slug: 'popover', title: 'Popover' },
   { slug: 'portal', title: 'Portal' },
   { slug: 'radio-group', title: 'Radio Group' },
+  { slug: 'resizable', title: 'Resizable' },
+  { slug: 'scroll-area', title: 'Scroll Area' },
   { slug: 'select', title: 'Select' },
   { slug: 'separator', title: 'Separator' },
   { slug: 'sheet', title: 'Sheet' },

--- a/site/ui/e2e/resizable.spec.ts
+++ b/site/ui/e2e/resizable.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Resizable Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/resizable')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Resizable')
+    await expect(page.locator('text=Accessible resizable panel groups')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Resizable Rendering', () => {
+    test('displays resizable panel groups', async ({ page }) => {
+      const groups = page.locator('[data-slot="resizable-panel-group"]')
+      await expect(groups.first()).toBeVisible()
+    })
+
+    test('has multiple examples', async ({ page }) => {
+      const groups = page.locator('[data-slot="resizable-panel-group"]')
+      // Preview + Horizontal + Vertical + With Handle + Three Panels
+      expect(await groups.count()).toBeGreaterThanOrEqual(4)
+    })
+  })
+
+  test.describe('Preview (Horizontal Demo)', () => {
+    test('displays two panels', async ({ page }) => {
+      const group = page.locator('[data-slot="resizable-panel-group"]').first()
+      await expect(group).toBeVisible()
+      await expect(group.locator('text=One')).toBeVisible()
+      await expect(group.locator('text=Two')).toBeVisible()
+    })
+
+    test('has resize handle', async ({ page }) => {
+      const group = page.locator('[data-slot="resizable-panel-group"]').first()
+      const handle = group.locator('[data-slot="resizable-handle"]')
+      // Handle is w-px (1px wide) so may not pass toBeVisible, check attached instead
+      await expect(handle).toBeAttached()
+    })
+
+    test('handle has separator role', async ({ page }) => {
+      const group = page.locator('[data-slot="resizable-panel-group"]').first()
+      const handle = group.locator('[role="separator"]')
+      await expect(handle).toBeAttached()
+    })
+
+    test('panels have initial sizes', async ({ page }) => {
+      const group = page.locator('[data-slot="resizable-panel-group"]').first()
+      const panels = group.locator('[data-slot="resizable-panel"]')
+      await expect(panels).toHaveCount(2)
+
+      // Both panels should have data-default-size attribute
+      const size1 = await panels.first().getAttribute('data-default-size')
+      const size2 = await panels.last().getAttribute('data-default-size')
+      expect(size1).toBe('50')
+      expect(size2).toBe('50')
+    })
+  })
+
+  test.describe('Vertical Demo', () => {
+    test('displays vertical layout', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Vertical")')).toBeVisible()
+      const group = page.locator('[data-panel-group-direction="vertical"]')
+      await expect(group.first()).toBeVisible()
+    })
+
+    test('has vertical direction', async ({ page }) => {
+      const group = page.locator('[data-panel-group-direction="vertical"]')
+      await expect(group.first()).toBeVisible()
+    })
+  })
+
+  test.describe('With Handle Demo', () => {
+    test('displays grip dots', async ({ page }) => {
+      await expect(page.locator('h3:has-text("With Handle")')).toBeVisible()
+
+      // Should have SVG grip icon inside a handle
+      const handles = page.locator('[data-slot="resizable-handle"] svg')
+      expect(await handles.count()).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  test.describe('Three Panels Demo', () => {
+    test('displays three panels with handles', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Three Panels")')).toBeVisible()
+
+      // The three-panel demo has 3 panels and 2 handles
+      // Find a group with 3 panels
+      const groups = page.locator('[data-slot="resizable-panel-group"][data-panel-group-direction="horizontal"]')
+      const groupCount = await groups.count()
+
+      // Find the one with 3 panels (three-panel demo)
+      let threePanelGroup = null
+      for (let i = 0; i < groupCount; i++) {
+        const group = groups.nth(i)
+        const panelCount = await group.locator('[data-slot="resizable-panel"]').count()
+        if (panelCount === 3) {
+          threePanelGroup = group
+          break
+        }
+      }
+      expect(threePanelGroup).toBeTruthy()
+      const panels = threePanelGroup!.locator('[data-slot="resizable-panel"]')
+      await expect(panels).toHaveCount(3)
+
+      const handles = threePanelGroup!.locator('[data-slot="resizable-handle"]')
+      await expect(handles).toHaveCount(2)
+    })
+
+    test('panels show correct labels', async ({ page }) => {
+      await expect(page.locator('text=Sidebar').first()).toBeVisible()
+      await expect(page.locator('text=Content').first()).toBeVisible()
+      await expect(page.locator('text=Aside').first()).toBeVisible()
+    })
+  })
+
+  test.describe('Keyboard Support', () => {
+    test('handle is focusable', async ({ page }) => {
+      const handle = page.locator('[data-slot="resizable-handle"]').first()
+      await expect(handle).toHaveAttribute('tabindex', '0')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays all three component props tables', async ({ page }) => {
+      await expect(page.getByRole('heading', { name: 'ResizablePanelGroup', exact: true })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'ResizablePanel', exact: true })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'ResizableHandle', exact: true })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/e2e/scroll-area.spec.ts
+++ b/site/ui/e2e/scroll-area.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Scroll Area Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/scroll-area')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Scroll Area')
+    await expect(page.locator('text=Augments native scroll functionality')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('ScrollArea Rendering', () => {
+    test('displays scroll area elements', async ({ page }) => {
+      const scrollAreas = page.locator('[data-slot="scroll-area"]')
+      await expect(scrollAreas.first()).toBeVisible()
+    })
+
+    test('has multiple scroll area examples', async ({ page }) => {
+      const scrollAreas = page.locator('[data-slot="scroll-area"]')
+      // Preview + Tags + Horizontal + Both Axes
+      expect(await scrollAreas.count()).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  test.describe('Preview (Tags Demo)', () => {
+    test('displays tags list in scrollable area', async ({ page }) => {
+      // ScrollArea root has data-slot="scroll-area", so use that directly
+      const scrollArea = page.locator('[data-slot="scroll-area"]').first()
+      await expect(scrollArea).toBeVisible()
+      await expect(scrollArea.locator('text=Tags')).toBeVisible()
+    })
+
+    test('shows version tags', async ({ page }) => {
+      const scrollArea = page.locator('[data-slot="scroll-area"]').first()
+      await expect(scrollArea.locator('[data-tag="v1.2.0-beta.50"]')).toBeVisible()
+    })
+
+    test('has scrollable viewport', async ({ page }) => {
+      const scrollArea = page.locator('[data-slot="scroll-area"]').first()
+      const viewport = scrollArea.locator('[data-slot="scroll-area-viewport"]')
+      await expect(viewport).toBeVisible()
+
+      // Viewport should have overflow scroll
+      const overflowStyle = await viewport.evaluate(
+        (el) => window.getComputedStyle(el).overflow
+      )
+      expect(overflowStyle).toContain('scroll')
+    })
+
+    test('has vertical scrollbar', async ({ page }) => {
+      const scrollArea = page.locator('[data-slot="scroll-area"]').first()
+      const scrollbar = scrollArea.locator('[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]')
+      await expect(scrollbar).toBeAttached()
+    })
+  })
+
+  test.describe('Horizontal Demo', () => {
+    test('displays horizontal scroll example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Horizontal Scrolling")')).toBeVisible()
+    })
+
+    test('shows artwork titles', async ({ page }) => {
+      // The horizontal demo has whitespace-nowrap content
+      await expect(page.locator('text=Sunset Horizon')).toBeVisible()
+    })
+  })
+
+  test.describe('Both Axes Demo', () => {
+    test('displays both axes example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Both Axes")')).toBeVisible()
+    })
+
+    test('shows changelog content', async ({ page }) => {
+      await expect(page.locator('h4:has-text("Changelog")')).toBeVisible()
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays props table headers', async ({ page }) => {
+      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
+      await expect(page.locator('th:has-text("Type")')).toBeVisible()
+      await expect(page.locator('th:has-text("Default")')).toBeVisible()
+      await expect(page.locator('th:has-text("Description")')).toBeVisible()
+    })
+
+    test('displays scroll area props', async ({ page }) => {
+      const propsTable = page.locator('table')
+      await expect(propsTable.locator('td').filter({ hasText: /^class$/ })).toBeVisible()
+      await expect(propsTable.locator('td').filter({ hasText: /^type$/ })).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/resizable.tsx
+++ b/site/ui/pages/resizable.tsx
@@ -1,0 +1,276 @@
+/**
+ * Resizable Documentation Page
+ */
+
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+import {
+  ResizableHorizontalDemo,
+  ResizableVerticalDemo,
+  ResizableWithHandleDemo,
+  ResizableThreePanelDemo,
+} from '@/components/resizable-demo'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'horizontal', title: 'Horizontal', branch: 'start' },
+  { id: 'vertical', title: 'Vertical', branch: 'child' },
+  { id: 'with-handle', title: 'With Handle', branch: 'child' },
+  { id: 'three-panels', title: 'Three Panels', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const horizontalCode = `"use client"
+
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@/components/ui/resizable'
+
+function ResizableHorizontal() {
+  return (
+    <ResizablePanelGroup direction="horizontal" class="max-w-md rounded-lg border">
+      <ResizablePanel defaultSize={50}>
+        <div className="flex h-[200px] items-center justify-center p-6">
+          <span className="font-semibold">One</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={50}>
+        <div className="flex h-[200px] items-center justify-center p-6">
+          <span className="font-semibold">Two</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}`
+
+const verticalCode = `"use client"
+
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@/components/ui/resizable'
+
+function ResizableVertical() {
+  return (
+    <ResizablePanelGroup direction="vertical" class="min-h-[200px] max-w-md rounded-lg border">
+      <ResizablePanel defaultSize={25}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Header</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={75}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}`
+
+const withHandleCode = `"use client"
+
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@/components/ui/resizable'
+
+function ResizableWithHandle() {
+  return (
+    <ResizablePanelGroup direction="horizontal" class="min-h-[200px] max-w-md rounded-lg border">
+      <ResizablePanel defaultSize={25}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Sidebar</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={75}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}`
+
+const threePanelsCode = `"use client"
+
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@/components/ui/resizable'
+
+function ResizableThreePanels() {
+  return (
+    <ResizablePanelGroup direction="horizontal" class="min-h-[200px] rounded-lg border">
+      <ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Sidebar</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={55} minSize={30}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Content</span>
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={25} minSize={15} maxSize={35}>
+        <div className="flex h-full items-center justify-center p-6">
+          <span className="font-semibold">Aside</span>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}`
+
+// Props definitions
+const panelGroupProps: PropDefinition[] = [
+  {
+    name: 'direction',
+    type: "'horizontal' | 'vertical'",
+    defaultValue: '-',
+    description: 'The layout direction of panels.',
+  },
+  {
+    name: 'class',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes.',
+  },
+  {
+    name: 'onLayout',
+    type: '(sizes: number[]) => void',
+    defaultValue: '-',
+    description: 'Callback fired when panel sizes change.',
+  },
+]
+
+const panelProps: PropDefinition[] = [
+  {
+    name: 'defaultSize',
+    type: 'number',
+    defaultValue: '-',
+    description: 'Initial size as percentage (0-100).',
+  },
+  {
+    name: 'minSize',
+    type: 'number',
+    defaultValue: '0',
+    description: 'Minimum size as percentage.',
+  },
+  {
+    name: 'maxSize',
+    type: 'number',
+    defaultValue: '100',
+    description: 'Maximum size as percentage.',
+  },
+  {
+    name: 'class',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes.',
+  },
+]
+
+const handleProps: PropDefinition[] = [
+  {
+    name: 'withHandle',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Show visible grip dots on the handle.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Disable drag interaction.',
+  },
+  {
+    name: 'class',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes.',
+  },
+]
+
+export function ResizablePage() {
+  return (
+    <DocPage slug="resizable" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Resizable"
+          description="Accessible resizable panel groups and layouts with drag and keyboard support."
+          {...getNavLinks('resizable')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={horizontalCode}>
+          <ResizableHorizontalDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add resizable" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Horizontal" code={horizontalCode}>
+              <ResizableHorizontalDemo />
+            </Example>
+
+            <Example title="Vertical" code={verticalCode}>
+              <ResizableVerticalDemo />
+            </Example>
+
+            <Example title="With Handle" code={withHandleCode}>
+              <ResizableWithHandleDemo />
+            </Example>
+
+            <Example title="Three Panels" code={threePanelsCode}>
+              <ResizableThreePanelDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ResizablePanelGroup</h3>
+              <PropsTable props={panelGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ResizablePanel</h3>
+              <PropsTable props={panelProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ResizableHandle</h3>
+              <PropsTable props={handleProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/scroll-area.tsx
+++ b/site/ui/pages/scroll-area.tsx
@@ -1,0 +1,163 @@
+/**
+ * ScrollArea Documentation Page
+ */
+
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+import {
+  ScrollAreaTagsDemo,
+  ScrollAreaHorizontalDemo,
+  ScrollAreaBothAxesDemo,
+} from '@/components/scroll-area-demo'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'tags', title: 'Tags', branch: 'start' },
+  { id: 'horizontal', title: 'Horizontal Scrolling', branch: 'child' },
+  { id: 'both-axes', title: 'Both Axes', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const tagsCode = `"use client"
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+
+const tags = Array.from({ length: 50 }).map(
+  (_, i, a) => \`v1.2.0-beta.\${a.length - i}\`
+)
+
+function ScrollAreaTags() {
+  return (
+    <ScrollArea class="h-72 w-48 rounded-md border">
+      <div className="p-4">
+        <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
+        {tags.map((tag) => (
+          <div>
+            <div className="text-sm">{tag}</div>
+            <Separator className="my-2" />
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}`
+
+const horizontalCode = `"use client"
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+function ScrollAreaHorizontal() {
+  return (
+    <ScrollArea class="w-96 whitespace-nowrap rounded-md border">
+      <div className="flex w-max space-x-4 p-4">
+        {works.map((work) => (
+          <figure className="shrink-0">
+            <div className="overflow-hidden rounded-md">
+              <div className="h-[150px] w-[200px] bg-muted" />
+            </div>
+            <figcaption className="pt-2 text-xs text-muted-foreground">
+              Photo by <span className="font-semibold text-foreground">{work.artist}</span>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </ScrollArea>
+  )
+}`
+
+const bothAxesCode = `"use client"
+
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+function ScrollAreaBothAxes() {
+  return (
+    <ScrollArea class="h-64 w-80 rounded-md border">
+      <div className="p-4" style="width: 600px;">
+        <h4 className="mb-4 text-sm font-medium leading-none">Changelog</h4>
+        <div className="space-y-4">
+          {entries.map((entry) => (
+            <div className="whitespace-nowrap">
+              <div className="text-sm font-medium">{entry.title}</div>
+              <p className="text-sm text-muted-foreground">{entry.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}`
+
+// Props definition
+const scrollAreaProps: PropDefinition[] = [
+  {
+    name: 'class',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes for the root element.',
+  },
+  {
+    name: 'type',
+    type: "'hover' | 'scroll' | 'auto' | 'always'",
+    defaultValue: "'hover'",
+    description: 'When to show scrollbars. hover: on mouse enter; scroll: while scrolling; auto: both; always: permanent.',
+  },
+]
+
+export function ScrollAreaPage() {
+  return (
+    <DocPage slug="scroll-area" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Scroll Area"
+          description="Augments native scroll functionality for custom, cross-browser styling."
+          {...getNavLinks('scroll-area')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={tagsCode}>
+          <ScrollAreaTagsDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add scroll-area" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Tags" code={tagsCode}>
+              <ScrollAreaTagsDemo />
+            </Example>
+
+            <Example title="Horizontal Scrolling" code={horizontalCode}>
+              <ScrollAreaHorizontalDemo />
+            </Example>
+
+            <Example title="Both Axes" code={bothAxesCode}>
+              <ScrollAreaBothAxesDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={scrollAreaProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -86,6 +86,8 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Pagination', href: '/docs/components/pagination' },
       { title: 'Popover', href: '/docs/components/popover' },
       { title: 'Radio Group', href: '/docs/components/radio-group' },
+      { title: 'Resizable', href: '/docs/components/resizable' },
+      { title: 'Scroll Area', href: '/docs/components/scroll-area' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Separator', href: '/docs/components/separator' },
       { title: 'Sheet', href: '/docs/components/sheet' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -28,6 +28,8 @@ import { TogglePage } from './pages/toggle'
 import { ToggleGroupPage } from './pages/toggle-group'
 import { TooltipPage } from './pages/tooltip'
 import { SelectPage } from './pages/select'
+import { ResizablePage } from './pages/resizable'
+import { ScrollAreaPage } from './pages/scroll-area'
 import { SeparatorPage } from './pages/separator'
 import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
@@ -313,6 +315,16 @@ export function createApp() {
   // Radio Group documentation
   app.get('/docs/components/radio-group', (c) => {
     return c.render(<RadioGroupPage />)
+  })
+
+  // Resizable documentation
+  app.get('/docs/components/resizable', (c) => {
+    return c.render(<ResizablePage />)
+  })
+
+  // Scroll Area documentation
+  app.get('/docs/components/scroll-area', (c) => {
+    return c.render(<ScrollAreaPage />)
   })
 
   // Sheet documentation

--- a/ui/components/ui/resizable.tsx
+++ b/ui/components/ui/resizable.tsx
@@ -1,0 +1,343 @@
+"use client"
+
+// No signal imports needed — this component uses imperative DOM manipulation via ref
+
+/**
+ * Resizable Panel Components
+ *
+ * Accessible resizable panel groups with drag and keyboard support.
+ * Inspired by shadcn/ui wrapping react-resizable-panels.
+ *
+ * @example
+ * ```tsx
+ * <ResizablePanelGroup direction="horizontal">
+ *   <ResizablePanel defaultSize={50}>Left</ResizablePanel>
+ *   <ResizableHandle />
+ *   <ResizablePanel defaultSize={50}>Right</ResizablePanel>
+ * </ResizablePanelGroup>
+ * ```
+ */
+
+// CSS classes matching shadcn/ui
+const groupBaseClasses = 'flex h-full w-full'
+const panelClasses = 'overflow-hidden'
+
+const handleBaseClasses = 'bg-border relative flex items-center justify-center after:absolute focus-visible:ring-ring focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[resize-handle-state=drag]:bg-ring/50'
+
+const handleOrientationClasses = {
+  horizontal: 'w-px after:inset-y-0 after:-left-1 after:-right-1',
+  vertical: 'h-px w-full after:inset-x-0 after:-top-1 after:-bottom-1',
+} as const
+
+const gripClasses = 'bg-border z-10 flex h-4 w-3 items-center justify-center rounded-sm border'
+
+interface ResizablePanelGroupProps {
+  /** Layout direction. */
+  direction: 'horizontal' | 'vertical'
+  /** Panel children. */
+  children?: any
+  /** Additional CSS classes. */
+  class?: string
+  /** Callback when panel sizes change. */
+  onLayout?: (sizes: number[]) => void
+}
+
+interface ResizablePanelProps {
+  /** Initial size as percentage (0-100). */
+  defaultSize?: number
+  /** Minimum size as percentage. */
+  minSize?: number
+  /** Maximum size as percentage. */
+  maxSize?: number
+  /** Panel content. */
+  children?: any
+  /** Additional CSS classes. */
+  class?: string
+}
+
+interface ResizableHandleProps {
+  /** Show visible grip dots. */
+  withHandle?: boolean
+  /** Disable drag interaction. */
+  disabled?: boolean
+  /** Additional CSS classes. */
+  class?: string
+}
+
+/**
+ * GripVertical icon — 6-dot pattern for resize handle indicator.
+ */
+function GripVerticalIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="size-2.5"
+    >
+      <circle cx="9" cy="12" r="1" />
+      <circle cx="9" cy="5" r="1" />
+      <circle cx="9" cy="19" r="1" />
+      <circle cx="15" cy="12" r="1" />
+      <circle cx="15" cy="5" r="1" />
+      <circle cx="15" cy="19" r="1" />
+    </svg>
+  )
+}
+
+/**
+ * Container for resizable panels. Manages layout and drag coordination.
+ */
+function ResizablePanelGroup(props: ResizablePanelGroupProps) {
+  const direction = props.direction
+
+  const handleMount = (el: HTMLElement) => {
+    // Initialize panel sizes from defaultSize attributes
+    const panels = el.querySelectorAll(':scope > [data-slot="resizable-panel"]') as NodeListOf<HTMLElement>
+    if (panels.length === 0) return
+
+    // Collect default sizes
+    const sizes: number[] = []
+    let totalExplicit = 0
+    let implicitCount = 0
+
+    panels.forEach((panel) => {
+      const defaultSize = panel.getAttribute('data-default-size')
+      if (defaultSize) {
+        const size = parseFloat(defaultSize)
+        sizes.push(size)
+        totalExplicit += size
+      } else {
+        sizes.push(-1)
+        implicitCount++
+      }
+    })
+
+    // Distribute remaining space to panels without explicit size
+    const remaining = 100 - totalExplicit
+    const implicitSize = implicitCount > 0 ? remaining / implicitCount : 0
+    for (let i = 0; i < sizes.length; i++) {
+      if (sizes[i] === -1) sizes[i] = implicitSize
+    }
+
+    // Apply sizes
+    const applyPanelSizes = (panelSizes: number[]) => {
+      panels.forEach((panel, i) => {
+        const size = panelSizes[i] ?? 0
+        if (direction === 'horizontal') {
+          panel.style.flexBasis = `${size}%`
+          panel.style.flexGrow = '0'
+          panel.style.flexShrink = '0'
+        } else {
+          panel.style.flexBasis = `${size}%`
+          panel.style.flexGrow = '0'
+          panel.style.flexShrink = '0'
+        }
+        panel.setAttribute('data-panel-size', String(Math.round(size * 10) / 10))
+      })
+    }
+
+    applyPanelSizes(sizes)
+
+    // Notify parent
+    props.onLayout?.(sizes)
+
+    // Set up drag handlers on each handle
+    const handles = el.querySelectorAll(':scope > [data-slot="resizable-handle"]') as NodeListOf<HTMLElement>
+
+    handles.forEach((handle, handleIndex) => {
+      if (handle.getAttribute('data-disabled') === 'true') return
+
+      const panelBefore = panels[handleIndex]
+      const panelAfter = panels[handleIndex + 1]
+      if (!panelBefore || !panelAfter) return
+
+      const getMinMax = (panel: HTMLElement) => {
+        const min = parseFloat(panel.getAttribute('data-min-size') || '0')
+        const max = parseFloat(panel.getAttribute('data-max-size') || '100')
+        return { min, max }
+      }
+
+      // Pointer drag
+      handle.addEventListener('pointerdown', (e: PointerEvent) => {
+        if (handle.getAttribute('data-disabled') === 'true') return
+        e.preventDefault()
+        handle.setPointerCapture(e.pointerId)
+        handle.setAttribute('data-resize-handle-state', 'drag')
+
+        const groupRect = el.getBoundingClientRect()
+        const sizeBefore = parseFloat(panelBefore.getAttribute('data-panel-size') || '50')
+        const sizeAfter = parseFloat(panelAfter.getAttribute('data-panel-size') || '50')
+        const totalSize = sizeBefore + sizeAfter
+        const startPos = direction === 'horizontal' ? e.clientX : e.clientY
+        const groupSize = direction === 'horizontal' ? groupRect.width : groupRect.height
+
+        const onMove = (me: PointerEvent) => {
+          const currentPos = direction === 'horizontal' ? me.clientX : me.clientY
+          const delta = currentPos - startPos
+          const deltaPct = (delta / groupSize) * 100
+
+          const { min: minBefore, max: maxBefore } = getMinMax(panelBefore)
+          const { min: minAfter, max: maxAfter } = getMinMax(panelAfter)
+
+          let newBefore = sizeBefore + deltaPct
+          let newAfter = sizeAfter - deltaPct
+
+          // Clamp
+          newBefore = Math.max(minBefore, Math.min(maxBefore, newBefore))
+          newAfter = totalSize - newBefore
+          newAfter = Math.max(minAfter, Math.min(maxAfter, newAfter))
+          newBefore = totalSize - newAfter
+
+          // Re-clamp (handles edge cases)
+          newBefore = Math.max(minBefore, Math.min(maxBefore, newBefore))
+
+          // Update current sizes array
+          const currentSizes = Array.from(panels).map(
+            (p) => parseFloat(p.getAttribute('data-panel-size') || '0')
+          )
+          currentSizes[handleIndex] = newBefore
+          currentSizes[handleIndex + 1] = newAfter
+          applyPanelSizes(currentSizes)
+          props.onLayout?.(currentSizes)
+        }
+
+        const onUp = () => {
+          handle.removeEventListener('pointermove', onMove)
+          handle.removeEventListener('pointerup', onUp)
+          handle.setAttribute('data-resize-handle-state', 'inactive')
+        }
+
+        handle.addEventListener('pointermove', onMove)
+        handle.addEventListener('pointerup', onUp)
+      })
+
+      // Hover states
+      handle.addEventListener('mouseenter', () => {
+        if (handle.getAttribute('data-resize-handle-state') !== 'drag') {
+          handle.setAttribute('data-resize-handle-state', 'hover')
+        }
+      })
+      handle.addEventListener('mouseleave', () => {
+        if (handle.getAttribute('data-resize-handle-state') !== 'drag') {
+          handle.setAttribute('data-resize-handle-state', 'inactive')
+        }
+      })
+
+      // Keyboard support: arrow keys resize by 5%
+      handle.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (handle.getAttribute('data-disabled') === 'true') return
+
+        const step = 5
+        let delta = 0
+
+        if (direction === 'horizontal') {
+          if (e.key === 'ArrowLeft') delta = -step
+          else if (e.key === 'ArrowRight') delta = step
+          else return
+        } else {
+          if (e.key === 'ArrowUp') delta = -step
+          else if (e.key === 'ArrowDown') delta = step
+          else return
+        }
+
+        e.preventDefault()
+
+        const { min: minBefore, max: maxBefore } = getMinMax(panelBefore)
+        const { min: minAfter, max: maxAfter } = getMinMax(panelAfter)
+
+        const currentBefore = parseFloat(panelBefore.getAttribute('data-panel-size') || '50')
+        const currentAfter = parseFloat(panelAfter.getAttribute('data-panel-size') || '50')
+        const total = currentBefore + currentAfter
+
+        let newBefore = currentBefore + delta
+        let newAfter = currentAfter - delta
+
+        newBefore = Math.max(minBefore, Math.min(maxBefore, newBefore))
+        newAfter = total - newBefore
+        newAfter = Math.max(minAfter, Math.min(maxAfter, newAfter))
+        newBefore = total - newAfter
+        newBefore = Math.max(minBefore, Math.min(maxBefore, newBefore))
+
+        const currentSizes = Array.from(panels).map(
+          (p) => parseFloat(p.getAttribute('data-panel-size') || '0')
+        )
+        currentSizes[handleIndex] = newBefore
+        currentSizes[handleIndex + 1] = newAfter
+        applyPanelSizes(currentSizes)
+        props.onLayout?.(currentSizes)
+      })
+    })
+  }
+
+  return (
+    <div
+      data-slot="resizable-panel-group"
+      data-panel-group-direction={direction}
+      className={`${groupBaseClasses} ${direction === 'vertical' ? 'flex-col' : ''} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * A panel within a ResizablePanelGroup.
+ */
+function ResizablePanel(props: ResizablePanelProps) {
+  return (
+    <div
+      data-slot="resizable-panel"
+      data-default-size={props.defaultSize}
+      data-min-size={props.minSize}
+      data-max-size={props.maxSize}
+      className={`${panelClasses} ${props.class ?? ''}`}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * A draggable handle between ResizablePanels.
+ */
+function ResizableHandle(props: ResizableHandleProps) {
+  // Determine orientation from parent (defaults to horizontal group → vertical handle)
+  // The parent sets data-panel-group-direction; handle reads it at mount
+  const handleRef = (el: HTMLElement) => {
+    const group = el.closest('[data-slot="resizable-panel-group"]')
+    const groupDir = group?.getAttribute('data-panel-group-direction') || 'horizontal'
+    // For horizontal groups, the handle divider is vertical (w-px)
+    // For vertical groups, the handle divider is horizontal (h-px)
+    const orientationClass = handleOrientationClasses[groupDir as 'horizontal' | 'vertical']
+    el.classList.add(...orientationClass.split(' '))
+  }
+
+  return (
+    <div
+      data-slot="resizable-handle"
+      data-resize-handle-state="inactive"
+      data-disabled={props.disabled || undefined}
+      role="separator"
+      tabindex={props.disabled ? -1 : 0}
+      className={`${handleBaseClasses} ${props.class ?? ''}`}
+      ref={handleRef}
+    >
+      {props.withHandle && (
+        <div className={gripClasses}>
+          <GripVerticalIcon />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+export type { ResizablePanelGroupProps, ResizablePanelProps, ResizableHandleProps }

--- a/ui/components/ui/scroll-area.tsx
+++ b/ui/components/ui/scroll-area.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import { createSignal, onCleanup } from '@barefootjs/dom'
+
+/**
+ * ScrollArea Component
+ *
+ * Augments native scroll with custom, cross-browser styled scrollbars.
+ * Hides native scrollbars and renders overlay thumb indicators.
+ *
+ * @example
+ * ```tsx
+ * <ScrollArea class="h-72 w-48 rounded-md border">
+ *   <div className="p-4">{content}</div>
+ * </ScrollArea>
+ * ```
+ */
+
+// CSS classes matching shadcn/ui
+const rootClasses = 'relative overflow-hidden'
+const viewportClasses = 'h-full w-full rounded-[inherit]'
+
+const scrollbarOrientationClasses = {
+  vertical: 'flex w-2.5 border-l border-l-transparent p-px touch-none select-none transition-opacity',
+  horizontal: 'flex h-2.5 flex-col border-t border-t-transparent p-px touch-none select-none transition-opacity',
+} as const
+
+const thumbClasses = 'bg-border relative rounded-full flex-1'
+
+type ScrollAreaType = 'hover' | 'scroll' | 'auto' | 'always'
+
+interface ScrollAreaProps {
+  /** Content to display inside the scrollable area. */
+  children?: any
+  /** Additional CSS classes for the root element. */
+  class?: string
+  /** When to show scrollbars. @default 'hover' */
+  type?: ScrollAreaType
+}
+
+interface ScrollBarProps {
+  /** Scroll direction. @default 'vertical' */
+  orientation?: 'vertical' | 'horizontal'
+  /** Additional CSS classes. */
+  class?: string
+}
+
+/**
+ * ScrollArea renders a scrollable viewport with custom overlay scrollbars.
+ */
+function ScrollArea(props: ScrollAreaProps) {
+  const type = props.type ?? 'hover'
+  const [hovered, setHovered] = createSignal(false)
+  const [scrolling, setScrolling] = createSignal(false)
+  const [thumbVSize, setThumbVSize] = createSignal(0)
+  const [thumbVPos, setThumbVPos] = createSignal(0)
+  const [thumbHSize, setThumbHSize] = createSignal(0)
+  const [thumbHPos, setThumbHPos] = createSignal(0)
+  const [canScrollV, setCanScrollV] = createSignal(false)
+  const [canScrollH, setCanScrollH] = createSignal(false)
+
+  let scrollTimeout: ReturnType<typeof setTimeout> | undefined
+
+  const updateScrollMetrics = (viewport: HTMLElement) => {
+    const { scrollTop, scrollLeft, scrollHeight, scrollWidth, clientHeight, clientWidth } = viewport
+
+    // Vertical
+    const vRatio = clientHeight / scrollHeight
+    setCanScrollV(vRatio < 1)
+    const vSize = Math.max(vRatio * 100, 10)
+    setThumbVSize(vSize)
+    setThumbVPos(scrollHeight > clientHeight ? (scrollTop / (scrollHeight - clientHeight)) * (100 - vSize) : 0)
+
+    // Horizontal
+    const hRatio = clientWidth / scrollWidth
+    setCanScrollH(hRatio < 1)
+    const hSize = Math.max(hRatio * 100, 10)
+    setThumbHSize(hSize)
+    setThumbHPos(scrollWidth > clientWidth ? (scrollLeft / (scrollWidth - clientWidth)) * (100 - hSize) : 0)
+  }
+
+  const handleScroll = (e: Event) => {
+    const viewport = e.currentTarget as HTMLElement
+    updateScrollMetrics(viewport)
+
+    setScrolling(true)
+    if (scrollTimeout) clearTimeout(scrollTimeout)
+    scrollTimeout = setTimeout(() => setScrolling(false), 1000)
+  }
+
+  const handleMouseEnter = () => setHovered(true)
+  const handleMouseLeave = () => setHovered(false)
+
+  const handleMount = (root: HTMLElement) => {
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement
+    if (viewport) {
+      updateScrollMetrics(viewport)
+
+      // Observe content size changes
+      const observer = new ResizeObserver(() => updateScrollMetrics(viewport))
+      observer.observe(viewport)
+      if (viewport.firstElementChild) {
+        observer.observe(viewport.firstElementChild)
+      }
+      onCleanup(() => observer.disconnect())
+    }
+  }
+
+  const isVisible = () => {
+    if (type === 'always') return true
+    if (type === 'hover') return hovered()
+    if (type === 'scroll') return scrolling()
+    // auto: show on hover or scroll
+    return hovered() || scrolling()
+  }
+
+  // Thumb drag for vertical scrollbar
+  const handleThumbPointerDownV = (e: PointerEvent) => {
+    e.preventDefault()
+    const thumb = e.currentTarget as HTMLElement
+    const scrollbar = thumb.parentElement as HTMLElement
+    const root = scrollbar.closest('[data-slot="scroll-area"]') as HTMLElement
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement
+    if (!viewport) return
+
+    thumb.setPointerCapture(e.pointerId)
+    const startY = e.clientY
+    const startScrollTop = viewport.scrollTop
+
+    const onMove = (me: PointerEvent) => {
+      const scrollbarRect = scrollbar.getBoundingClientRect()
+      const delta = me.clientY - startY
+      const scrollableHeight = viewport.scrollHeight - viewport.clientHeight
+      const ratio = delta / (scrollbarRect.height * (1 - thumbVSize() / 100))
+      viewport.scrollTop = startScrollTop + ratio * scrollableHeight
+    }
+
+    const onUp = () => {
+      thumb.removeEventListener('pointermove', onMove)
+      thumb.removeEventListener('pointerup', onUp)
+    }
+
+    thumb.addEventListener('pointermove', onMove)
+    thumb.addEventListener('pointerup', onUp)
+  }
+
+  // Thumb drag for horizontal scrollbar
+  const handleThumbPointerDownH = (e: PointerEvent) => {
+    e.preventDefault()
+    const thumb = e.currentTarget as HTMLElement
+    const scrollbar = thumb.parentElement as HTMLElement
+    const root = scrollbar.closest('[data-slot="scroll-area"]') as HTMLElement
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement
+    if (!viewport) return
+
+    thumb.setPointerCapture(e.pointerId)
+    const startX = e.clientX
+    const startScrollLeft = viewport.scrollLeft
+
+    const onMove = (me: PointerEvent) => {
+      const scrollbarRect = scrollbar.getBoundingClientRect()
+      const delta = me.clientX - startX
+      const scrollableWidth = viewport.scrollWidth - viewport.clientWidth
+      const ratio = delta / (scrollbarRect.width * (1 - thumbHSize() / 100))
+      viewport.scrollLeft = startScrollLeft + ratio * scrollableWidth
+    }
+
+    const onUp = () => {
+      thumb.removeEventListener('pointermove', onMove)
+      thumb.removeEventListener('pointerup', onUp)
+    }
+
+    thumb.addEventListener('pointermove', onMove)
+    thumb.addEventListener('pointerup', onUp)
+  }
+
+  onCleanup(() => {
+    if (scrollTimeout) clearTimeout(scrollTimeout)
+  })
+
+  const vBarVisible = () => canScrollV() && isVisible()
+  const hBarVisible = () => canScrollH() && isVisible()
+
+  return (
+    <div
+      data-slot="scroll-area"
+      className={`${rootClasses} ${props.class ?? ''}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      ref={handleMount}
+    >
+      <div
+        data-slot="scroll-area-viewport"
+        className={viewportClasses}
+        style="overflow: scroll; scrollbar-width: none; -ms-overflow-style: none;"
+        onScroll={handleScroll}
+      >
+        {props.children}
+      </div>
+
+      {/* Vertical scrollbar */}
+      <div
+        data-slot="scroll-area-scrollbar"
+        data-orientation="vertical"
+        data-state={vBarVisible() ? 'visible' : 'hidden'}
+        className={`absolute right-0 top-0 bottom-0 ${scrollbarOrientationClasses.vertical}`}
+        style={`opacity: ${vBarVisible() ? 1 : 0}; ${canScrollV() ? '' : 'display: none;'}`}
+      >
+        <div
+          data-slot="scroll-area-thumb"
+          className={thumbClasses}
+          style={`height: ${thumbVSize()}%; top: ${thumbVPos()}%; position: absolute; width: 100%;`}
+          onPointerDown={handleThumbPointerDownV}
+        />
+      </div>
+
+      {/* Horizontal scrollbar */}
+      <div
+        data-slot="scroll-area-scrollbar"
+        data-orientation="horizontal"
+        data-state={hBarVisible() ? 'visible' : 'hidden'}
+        className={`absolute bottom-0 left-0 right-0 ${scrollbarOrientationClasses.horizontal}`}
+        style={`opacity: ${hBarVisible() ? 1 : 0}; ${canScrollH() ? '' : 'display: none;'}`}
+      >
+        <div
+          data-slot="scroll-area-thumb"
+          className={thumbClasses}
+          style={`width: ${thumbHSize()}%; left: ${thumbHPos()}%; position: absolute; height: 100%;`}
+          onPointerDown={handleThumbPointerDownH}
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * ScrollBar — standalone scrollbar component for custom configurations.
+ * Not typically used directly; ScrollArea includes both scrollbars.
+ */
+function ScrollBar(props: ScrollBarProps) {
+  const orientation = props.orientation ?? 'vertical'
+  const posClasses = orientation === 'vertical'
+    ? 'absolute right-0 top-0 bottom-0'
+    : 'absolute bottom-0 left-0 right-0'
+
+  return (
+    <div
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      className={`${posClasses} ${scrollbarOrientationClasses[orientation]} ${props.class ?? ''}`}
+    >
+      <div data-slot="scroll-area-thumb" className={thumbClasses} />
+    </div>
+  )
+}
+
+export { ScrollArea, ScrollBar }
+export type { ScrollAreaProps, ScrollBarProps, ScrollAreaType }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -68,6 +68,18 @@
       "type": "registry:ui",
       "title": "Tooltip",
       "description": "A popup that displays contextual information on hover or focus"
+    },
+    {
+      "name": "resizable",
+      "type": "registry:ui",
+      "title": "Resizable",
+      "description": "Accessible resizable panel groups and layouts with drag and keyboard support"
+    },
+    {
+      "name": "scroll-area",
+      "type": "registry:ui",
+      "title": "Scroll Area",
+      "description": "Augments native scroll functionality for custom, cross-browser styling"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Port **ScrollArea** component from shadcn/ui: custom overlay scrollbars with pointer-drag support, vertical/horizontal/both-axes scrolling
- Port **Resizable** component from shadcn/ui: drag and keyboard panel resizing with min/max constraints
- Add demo components, documentation pages, E2E tests, and site registration for both

## Test plan
- [x] All 31 new E2E tests pass (15 scroll-area + 16 resizable)
- [x] Full test suite: 505 passed, 0 failed, no regressions
- [x] Dev server starts and both doc pages render correctly
- [ ] Visual review of ScrollArea page at `/docs/components/scroll-area`
- [ ] Visual review of Resizable page at `/docs/components/resizable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)