### PR TITLE
Add Drawer component ported from shadcn/ui

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -319,7 +319,7 @@ function emitBranchBindings(
   }
 
   for (const ref of refs) {
-    lines.push(`      if (_${ref.slotId}) (${ref.callback})(_${ref.slotId})`)
+    lines.push(`      if (_${ref.slotId}) (${stripTypeScriptSyntax(ref.callback)})(_${ref.slotId})`)
   }
 }
 
@@ -614,7 +614,7 @@ export function emitRefCallbacks(
 ): void {
   for (const elem of ctx.refElements) {
     if (conditionalSlotIds.has(elem.slotId)) continue
-    lines.push(`  if (_${elem.slotId}) (${elem.callback})(_${elem.slotId})`)
+    lines.push(`  if (_${elem.slotId}) (${stripTypeScriptSyntax(elem.callback)})(_${elem.slotId})`)
   }
 }
 

--- a/site/ui/components/drawer-demo.tsx
+++ b/site/ui/components/drawer-demo.tsx
@@ -1,0 +1,224 @@
+"use client"
+/**
+ * DrawerDemo Components
+ *
+ * Interactive demos for Drawer component.
+ * Used in drawer documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHandle,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from '@ui/components/ui/drawer'
+
+/**
+ * Basic drawer demo - opens from bottom with handle and title
+ */
+export function DrawerBasicDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div>
+      <Drawer open={open()} onOpenChange={setOpen}>
+        <DrawerTrigger>
+          Open Drawer
+        </DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="bottom"
+          ariaLabelledby="drawer-basic-title"
+          ariaDescribedby="drawer-basic-description"
+        >
+          <DrawerHandle />
+          <DrawerHeader>
+            <DrawerTitle id="drawer-basic-title">Move Goal</DrawerTitle>
+            <DrawerDescription id="drawer-basic-description">
+              Set your daily move goal.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="p-4 pb-0">
+            <div className="flex items-center justify-center space-x-2">
+              <span className="text-7xl font-bold tracking-tighter">350</span>
+              <span className="text-muted-foreground text-sm pb-2">kcal/day</span>
+            </div>
+          </div>
+          <DrawerFooter>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full"
+            >
+              Submit
+            </button>
+            <DrawerClose>Cancel</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+/**
+ * Direction variants demo - shows all 4 direction options
+ */
+export function DrawerDirectionDemo() {
+  const [openTop, setOpenTop] = createSignal(false)
+  const [openRight, setOpenRight] = createSignal(false)
+  const [openBottom, setOpenBottom] = createSignal(false)
+  const [openLeft, setOpenLeft] = createSignal(false)
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Drawer open={openTop()} onOpenChange={setOpenTop}>
+        <DrawerTrigger>Top</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="top"
+          ariaLabelledby="drawer-top-title"
+        >
+          <DrawerHeader>
+            <DrawerTitle id="drawer-top-title">Top Drawer</DrawerTitle>
+            <DrawerDescription>This drawer slides in from the top.</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Drawer open={openRight()} onOpenChange={setOpenRight}>
+        <DrawerTrigger>Right</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="right"
+          ariaLabelledby="drawer-right-title"
+        >
+          <DrawerHeader>
+            <DrawerTitle id="drawer-right-title">Right Drawer</DrawerTitle>
+            <DrawerDescription>This drawer slides in from the right.</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Drawer open={openBottom()} onOpenChange={setOpenBottom}>
+        <DrawerTrigger>Bottom</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="bottom"
+          ariaLabelledby="drawer-bottom-title"
+        >
+          <DrawerHandle />
+          <DrawerHeader>
+            <DrawerTitle id="drawer-bottom-title">Bottom Drawer</DrawerTitle>
+            <DrawerDescription>This drawer slides in from the bottom.</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Drawer open={openLeft()} onOpenChange={setOpenLeft}>
+        <DrawerTrigger>Left</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="left"
+          ariaLabelledby="drawer-left-title"
+        >
+          <DrawerHeader>
+            <DrawerTitle id="drawer-left-title">Left Drawer</DrawerTitle>
+            <DrawerDescription>This drawer slides in from the left.</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+/**
+ * Goal adjustment control with reactive state.
+ * Separate component so its interactive elements have their own scope,
+ * which allows event handlers to work when rendered inside DrawerContent.
+ */
+export function GoalControl() {
+  const [goal, setGoal] = createSignal(350)
+
+  const adjustGoal = (amount: number) => {
+    setGoal((prev: number) => Math.max(100, prev + amount))
+  }
+
+  return (
+    <div className="p-4 pb-0">
+      <div className="flex items-center justify-center space-x-4">
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full border border-border bg-background hover:bg-accent h-10 w-10 text-lg"
+          aria-label="Decrease goal"
+          onClick={() => adjustGoal(-10)}
+        >
+          -
+        </button>
+        <div className="text-center">
+          <span className="text-7xl font-bold tracking-tighter">{goal()}</span>
+          <p className="text-muted-foreground text-sm mt-1">kcal/day</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full border border-border bg-background hover:bg-accent h-10 w-10 text-lg"
+          aria-label="Increase goal"
+          onClick={() => adjustGoal(10)}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Goal setting form inside drawer demo
+ */
+export function DrawerFormDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <div>
+      <Drawer open={open()} onOpenChange={setOpen}>
+        <DrawerTrigger>Set Goal</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent
+          direction="bottom"
+          ariaLabelledby="drawer-form-title"
+          ariaDescribedby="drawer-form-description"
+        >
+          <DrawerHandle />
+          <DrawerHeader>
+            <DrawerTitle id="drawer-form-title">Move Goal</DrawerTitle>
+            <DrawerDescription id="drawer-form-description">
+              Set your daily activity goal.
+            </DrawerDescription>
+          </DrawerHeader>
+          <GoalControl />
+          <DrawerFooter>
+            <DrawerClose class="bg-primary text-primary-foreground hover:bg-primary/90 border-0 w-full">Submit</DrawerClose>
+            <DrawerClose>Cancel</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -15,6 +15,7 @@ export const componentOrder = [
   { slug: 'checkbox', title: 'Checkbox' },
   { slug: 'collapsible', title: 'Collapsible' },
   { slug: 'dialog', title: 'Dialog' },
+  { slug: 'drawer', title: 'Drawer' },
   { slug: 'dropdown-menu', title: 'Dropdown Menu' },
   { slug: 'input', title: 'Input' },
   { slug: 'label', title: 'Label' },

--- a/site/ui/e2e/drawer.spec.ts
+++ b/site/ui/e2e/drawer.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '@playwright/test'
+
+// Click position for overlay outside the drawer area.
+// Drawers are positioned at edges, so clicking near the opposite edge hits the overlay.
+const OVERLAY_CLICK_POSITION = { x: 10, y: 10 }
+
+test.describe('Drawer Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/drawer')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Drawer')
+    await expect(page.locator('text=A panel that slides in from the edge')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+  })
+
+  test.describe('Basic Drawer', () => {
+    test('opens drawer when trigger is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      // Drawer is portaled to body
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Move Goal').first()).toBeVisible()
+    })
+
+    test('closes drawer when DrawerClose button is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      // Click the Cancel button in footer
+      const closeBtn = drawer.locator('[data-slot="drawer-close"]:has-text("Cancel")')
+      await closeBtn.click()
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes drawer when ESC key is pressed', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      await page.keyboard.press('Escape')
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes drawer when overlay is clicked', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      // Click overlay
+      const overlay = page.locator('[data-slot="drawer-overlay"][data-state="open"]').first()
+      await overlay.click({ position: OVERLAY_CLICK_POSITION })
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('has correct accessibility attributes', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer).toHaveAttribute('aria-modal', 'true')
+      await expect(drawer).toHaveAttribute('aria-labelledby', 'drawer-basic-title')
+      await expect(drawer).toHaveAttribute('aria-describedby', 'drawer-basic-description')
+    })
+
+    test('displays handle bar', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      const handle = drawer.locator('[data-slot="drawer-handle"]')
+      await expect(handle).toBeVisible()
+    })
+
+    test('does not show X close button', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      // Drawer should NOT have a close button (X) unlike Sheet
+      const closeButton = drawer.locator('[data-slot="drawer-close-button"]')
+      await expect(closeButton).toHaveCount(0)
+    })
+
+    test('traps focus within drawer', async ({ page }) => {
+      const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
+      const trigger = basicDemo.locator('button:has-text("Open Drawer")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-basic-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      // Focus on drawer container
+      await drawer.focus()
+
+      // Tab should move focus to the first focusable element inside the drawer
+      await page.keyboard.press('Tab')
+      const focused = await page.evaluate(() => {
+        const el = document.activeElement
+        return el ? el.closest('[role="dialog"]')?.getAttribute('aria-labelledby') : null
+      })
+      expect(focused).toBe('drawer-basic-title')
+    })
+  })
+
+  test.describe('Direction Variants', () => {
+    test('opens bottom drawer', async ({ page }) => {
+      const directionDemo = page.locator('[bf-s^="DrawerDirectionDemo_"]').first()
+      const trigger = directionDemo.locator('button:has-text("Bottom")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-bottom-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Bottom Drawer')).toBeVisible()
+
+      // Bottom drawer should be at the bottom
+      await expect(drawer).toHaveCSS('bottom', '0px')
+    })
+
+    test('opens top drawer', async ({ page }) => {
+      const directionDemo = page.locator('[bf-s^="DrawerDirectionDemo_"]').first()
+      const trigger = directionDemo.locator('button:has-text("Top")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-top-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Top Drawer')).toBeVisible()
+
+      // Top drawer should be at the top
+      await expect(drawer).toHaveCSS('top', '0px')
+    })
+
+    test('opens right drawer', async ({ page }) => {
+      const directionDemo = page.locator('[bf-s^="DrawerDirectionDemo_"]').first()
+      const trigger = directionDemo.locator('button:has-text("Right")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-right-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Right Drawer')).toBeVisible()
+
+      // Right drawer should be positioned on the right
+      await expect(drawer).toHaveCSS('right', '0px')
+    })
+
+    test('opens left drawer', async ({ page }) => {
+      const directionDemo = page.locator('[bf-s^="DrawerDirectionDemo_"]').first()
+      const trigger = directionDemo.locator('button:has-text("Left")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-left-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Left Drawer')).toBeVisible()
+
+      // Left drawer should be positioned on the left
+      await expect(drawer).toHaveCSS('left', '0px')
+    })
+
+    test('closes direction drawer via ESC', async ({ page }) => {
+      const directionDemo = page.locator('[bf-s^="DrawerDirectionDemo_"]').first()
+      const trigger = directionDemo.locator('button:has-text("Left")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-left-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      await page.keyboard.press('Escape')
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-left-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('Form Drawer', () => {
+    test('opens form drawer with goal controls', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="DrawerFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Set Goal")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+      await expect(drawer.locator('text=Move Goal').first()).toBeVisible()
+
+      // Check goal display
+      await expect(drawer.locator('text=350')).toBeVisible()
+      await expect(drawer.locator('text=kcal/day')).toBeVisible()
+    })
+
+    test('can adjust goal with buttons', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="DrawerFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Set Goal")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      // Click increase button
+      const increaseBtn = drawer.locator('button[aria-label="Increase goal"]')
+      await increaseBtn.click()
+
+      // Goal should increase by 10
+      await expect(drawer.locator('text=360')).toBeVisible()
+    })
+
+    test('closes form drawer when Cancel is clicked', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="DrawerFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Set Goal")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      const cancelButton = drawer.locator('[data-slot="drawer-close"]:has-text("Cancel")')
+      await cancelButton.click()
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+
+    test('closes form drawer when Submit is clicked', async ({ page }) => {
+      const formDemo = page.locator('[bf-s^="DrawerFormDemo_"]').first()
+      const trigger = formDemo.locator('button:has-text("Set Goal")')
+
+      await trigger.click()
+
+      const drawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="open"]')
+      await expect(drawer).toBeVisible()
+
+      const submitButton = drawer.locator('[data-slot="drawer-close"]:has-text("Submit")')
+      await submitButton.click()
+
+      const closedDrawer = page.locator('[role="dialog"][aria-labelledby="drawer-form-title"][data-state="closed"]').first()
+      await expect(closedDrawer).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays DrawerTrigger props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerTrigger")')).toBeVisible()
+    })
+
+    test('displays DrawerContent props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerContent")')).toBeVisible()
+    })
+
+    test('displays DrawerHandle props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerHandle")')).toBeVisible()
+    })
+
+    test('displays DrawerTitle props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerTitle")')).toBeVisible()
+    })
+
+    test('displays DrawerDescription props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerDescription")')).toBeVisible()
+    })
+
+    test('displays DrawerClose props', async ({ page }) => {
+      await expect(page.locator('h3:has-text("DrawerClose")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/drawer.tsx
+++ b/site/ui/pages/drawer.tsx
@@ -1,0 +1,332 @@
+/**
+ * Drawer Documentation Page
+ */
+
+import { DrawerBasicDemo, DrawerDirectionDemo, DrawerFormDemo } from '@/components/drawer-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'direction', title: 'Direction', branch: 'child' },
+  { id: 'form', title: 'Form', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHandle,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from '@/components/ui/drawer'
+
+function BasicDrawer() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Drawer open={open()} onOpenChange={setOpen}>
+      <DrawerTrigger>Open Drawer</DrawerTrigger>
+      <DrawerOverlay />
+      <DrawerContent
+        direction="bottom"
+        ariaLabelledby="drawer-title"
+        ariaDescribedby="drawer-description"
+      >
+        <DrawerHandle />
+        <DrawerHeader>
+          <DrawerTitle id="drawer-title">Move Goal</DrawerTitle>
+          <DrawerDescription id="drawer-description">
+            Set your daily move goal.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="p-4 pb-0">
+          <div className="flex items-center justify-center space-x-2">
+            <span className="text-7xl font-bold tracking-tighter">350</span>
+            <span className="text-muted-foreground text-sm pb-2">kcal/day</span>
+          </div>
+        </div>
+        <DrawerFooter>
+          <DrawerClose>Cancel</DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  )
+}`
+
+const directionCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHandle,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from '@/components/ui/drawer'
+
+function DrawerDirections() {
+  const [openBottom, setOpenBottom] = createSignal(false)
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Drawer open={openBottom()} onOpenChange={setOpenBottom}>
+        <DrawerTrigger>Bottom</DrawerTrigger>
+        <DrawerOverlay />
+        <DrawerContent direction="bottom" ariaLabelledby="bottom-title">
+          <DrawerHandle />
+          <DrawerHeader>
+            <DrawerTitle id="bottom-title">Bottom Drawer</DrawerTitle>
+            <DrawerDescription>Slides from the bottom.</DrawerDescription>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      {/* Repeat for top, right, left with direction="top|right|left" */}
+    </div>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHandle,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from '@/components/ui/drawer'
+
+// Interactive controls as a separate component with own scope
+function GoalControl() {
+  const [goal, setGoal] = createSignal(350)
+  const adjustGoal = (amount) => {
+    setGoal((prev) => Math.max(100, prev + amount))
+  }
+  return (
+    <div className="p-4 pb-0">
+      <div className="flex items-center justify-center space-x-4">
+        <button onClick={() => adjustGoal(-10)}>-</button>
+        <span className="text-7xl font-bold">{goal()}</span>
+        <button onClick={() => adjustGoal(10)}>+</button>
+      </div>
+      <p className="text-muted-foreground text-sm text-center mt-1">kcal/day</p>
+    </div>
+  )
+}
+
+function GoalDrawer() {
+  const [open, setOpen] = createSignal(false)
+
+  return (
+    <Drawer open={open()} onOpenChange={setOpen}>
+      <DrawerTrigger>Set Goal</DrawerTrigger>
+      <DrawerOverlay />
+      <DrawerContent
+        direction="bottom"
+        ariaLabelledby="form-title"
+        ariaDescribedby="form-description"
+      >
+        <DrawerHandle />
+        <DrawerHeader>
+          <DrawerTitle id="form-title">Move Goal</DrawerTitle>
+          <DrawerDescription id="form-description">
+            Set your daily activity goal.
+          </DrawerDescription>
+        </DrawerHeader>
+        <GoalControl />
+        <DrawerFooter>
+          <DrawerClose>Submit</DrawerClose>
+          <DrawerClose>Cancel</DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  )
+}`
+
+// Props definitions
+const drawerProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the drawer is open.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Event handler called when the open state should change.',
+  },
+]
+
+const drawerTriggerProps: PropDefinition[] = [
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the trigger is disabled.',
+  },
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element as trigger instead of built-in button.',
+  },
+]
+
+const drawerContentProps: PropDefinition[] = [
+  {
+    name: 'direction',
+    type: "'top' | 'right' | 'bottom' | 'left'",
+    defaultValue: "'bottom'",
+    description: 'Which edge of the screen the drawer slides from.',
+  },
+  {
+    name: 'ariaLabelledby',
+    type: 'string',
+    description: 'ID of the element that labels the drawer (typically DrawerTitle).',
+  },
+  {
+    name: 'ariaDescribedby',
+    type: 'string',
+    description: 'ID of the element that describes the drawer (typically DrawerDescription).',
+  },
+]
+
+const drawerHandleProps: PropDefinition[] = [
+  {
+    name: 'class',
+    type: 'string',
+    description: 'Additional CSS classes for the handle bar.',
+  },
+]
+
+const drawerTitleProps: PropDefinition[] = [
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID for aria-labelledby reference.',
+  },
+]
+
+const drawerDescriptionProps: PropDefinition[] = [
+  {
+    name: 'id',
+    type: 'string',
+    description: 'ID for aria-describedby reference.',
+  },
+]
+
+const drawerCloseProps: PropDefinition[] = []
+
+export function DrawerPage() {
+  return (
+    <DocPage slug="drawer" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Drawer"
+          description="A panel that slides in from the edge of the screen, typically from the bottom. Ideal for mobile-friendly interactions."
+          {...getNavLinks('drawer')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={basicCode}>
+          <div className="flex gap-4">
+            <DrawerBasicDemo />
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add drawer" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <DrawerBasicDemo />
+            </Example>
+
+            <Example title="Direction" code={directionCode}>
+              <DrawerDirectionDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <DrawerFormDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Drawer</h3>
+              <PropsTable props={drawerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerTrigger</h3>
+              <PropsTable props={drawerTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerContent</h3>
+              <PropsTable props={drawerContentProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerHandle</h3>
+              <PropsTable props={drawerHandleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerTitle</h3>
+              <PropsTable props={drawerTitleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerDescription</h3>
+              <PropsTable props={drawerDescriptionProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">DrawerClose</h3>
+              <PropsTable props={drawerCloseProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -80,6 +80,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Checkbox', href: '/docs/components/checkbox' },
       { title: 'Collapsible', href: '/docs/components/collapsible' },
       { title: 'Dialog', href: '/docs/components/dialog' },
+      { title: 'Drawer', href: '/docs/components/drawer' },
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
       { title: 'Input', href: '/docs/components/input' },
       { title: 'Label', href: '/docs/components/label' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -36,6 +36,7 @@ import { PortalPage } from './pages/portal'
 import { PaginationPage } from './pages/pagination'
 import { PopoverPage } from './pages/popover'
 import { RadioGroupPage } from './pages/radio-group'
+import { DrawerPage } from './pages/drawer'
 import { SheetPage } from './pages/sheet'
 
 // Form pattern pages
@@ -325,6 +326,11 @@ export function createApp() {
   // Scroll Area documentation
   app.get('/docs/components/scroll-area', (c) => {
     return c.render(<ScrollAreaPage />)
+  })
+
+  // Drawer documentation
+  app.get('/docs/components/drawer', (c) => {
+    return c.render(<DrawerPage />)
   })
 
   // Sheet documentation

--- a/ui/components/ui/drawer.tsx
+++ b/ui/components/ui/drawer.tsx
@@ -1,0 +1,539 @@
+"use client"
+
+/**
+ * Drawer Components
+ *
+ * A panel that slides in from the edge of the screen, typically from the bottom.
+ * Similar to Sheet but designed for mobile-friendly interactions with a handle bar.
+ * Inspired by shadcn/ui (Vaul-based) with CSS variable theming support.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Drawer root manages open state, children consume via context.
+ *
+ * Features:
+ * - ESC key to close
+ * - Click outside (overlay) to close
+ * - Focus trap (Tab/Shift+Tab cycles within panel)
+ * - Accessibility (role="dialog", aria-modal="true")
+ * - Slide animation from any edge (top, right, bottom, left)
+ * - Handle bar indicator (for top/bottom directions)
+ * - No built-in close button (X) by default
+ *
+ * @example Basic drawer
+ * ```tsx
+ * const [open, setOpen] = createSignal(false)
+ *
+ * <Drawer open={open()} onOpenChange={setOpen}>
+ *   <DrawerTrigger>Open Drawer</DrawerTrigger>
+ *   <DrawerOverlay />
+ *   <DrawerContent direction="bottom" ariaLabelledby="drawer-title">
+ *     <DrawerHandle />
+ *     <DrawerHeader>
+ *       <DrawerTitle id="drawer-title">Drawer Title</DrawerTitle>
+ *       <DrawerDescription>Drawer description here.</DrawerDescription>
+ *     </DrawerHeader>
+ *     <DrawerFooter>
+ *       <DrawerClose>Close</DrawerClose>
+ *     </DrawerFooter>
+ *   </DrawerContent>
+ * </Drawer>
+ * ```
+ */
+
+import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { Child } from '../../types'
+
+// Context for Drawer -> children state sharing
+interface DrawerContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const DrawerContext = createContext<DrawerContextValue>()
+
+// Direction variants
+type DrawerDirection = 'top' | 'right' | 'bottom' | 'left'
+
+// DrawerTrigger classes
+const drawerTriggerClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 disabled:pointer-events-none disabled:opacity-50'
+
+// DrawerOverlay base classes
+const drawerOverlayBaseClasses = 'fixed inset-0 z-50 bg-black/80 transition-opacity duration-200'
+
+// DrawerOverlay open/closed classes
+const drawerOverlayOpenClasses = 'opacity-100'
+const drawerOverlayClosedClasses = 'opacity-0 pointer-events-none'
+
+// DrawerContent base classes
+const drawerContentBaseClasses = 'z-50 flex flex-col bg-background shadow-lg transition-transform duration-200'
+
+// Direction-specific positioning classes
+const directionClasses: Record<DrawerDirection, string> = {
+  top: 'fixed inset-x-0 top-0 max-h-[80vh] rounded-b-lg',
+  right: 'fixed inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+  bottom: 'fixed inset-x-0 bottom-0 max-h-[80vh] rounded-t-lg',
+  left: 'fixed inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+}
+
+// Direction-specific open state classes (slide to final position)
+const directionOpenClasses: Record<DrawerDirection, string> = {
+  top: 'translate-y-0',
+  right: 'translate-x-0',
+  bottom: 'translate-y-0',
+  left: 'translate-x-0',
+}
+
+// Direction-specific closed state classes (slide off-screen)
+const directionClosedClasses: Record<DrawerDirection, string> = {
+  top: '-translate-y-full',
+  right: 'translate-x-full',
+  bottom: 'translate-y-full',
+  left: '-translate-x-full',
+}
+
+// DrawerHeader classes — centered text for vertical drawers
+const drawerHeaderClasses = 'flex flex-col gap-1.5 p-4 text-center'
+
+// DrawerTitle classes
+const drawerTitleClasses = 'text-foreground font-semibold'
+
+// DrawerDescription classes
+const drawerDescriptionClasses = 'text-muted-foreground text-sm'
+
+// DrawerFooter classes
+const drawerFooterClasses = 'mt-auto flex flex-col gap-2 p-4'
+
+// DrawerClose classes
+const drawerCloseClasses = 'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-border bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2'
+
+/**
+ * Props for Drawer component.
+ */
+interface DrawerProps {
+  /** Whether the drawer is open */
+  open?: boolean
+  /** Callback when open state should change */
+  onOpenChange?: (open: boolean) => void
+  /** Scope ID for SSR portal support (explicit) */
+  scopeId?: string
+  /** Scope ID from compiler (auto-passed via hydration props) */
+  __instanceId?: string
+  /** Scope ID from compiler in loops (auto-passed via hydration props) */
+  __bfScope?: string
+  /** Drawer content */
+  children?: Child
+}
+
+/**
+ * Drawer root component.
+ * Provides open state to children via context.
+ *
+ * @param props.open - Whether the drawer is open
+ * @param props.onOpenChange - Callback when open state should change
+ */
+function Drawer(props: DrawerProps) {
+  return (
+    <DrawerContext.Provider value={{
+      open: () => props.open ?? false,
+      onOpenChange: props.onOpenChange ?? (() => {}),
+    }}>
+      {props.children}
+    </DrawerContext.Provider>
+  )
+}
+
+/**
+ * Props for DrawerTrigger component.
+ */
+interface DrawerTriggerProps {
+  /** Whether disabled */
+  disabled?: boolean
+  /** Render child element as trigger instead of built-in button */
+  asChild?: boolean
+  /** Button content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Button that triggers the drawer to open.
+ * Reads open state from context and toggles via onOpenChange.
+ *
+ * @param props.disabled - Whether disabled
+ * @param props.asChild - Render child as trigger
+ */
+function DrawerTrigger(props: DrawerTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(DrawerContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(!ctx.open())
+    })
+  }
+
+  if (props.asChild) {
+    return (
+      <span
+        data-slot="drawer-trigger"
+        style="display:contents"
+        ref={handleMount}
+      >
+        {props.children}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      data-slot="drawer-trigger"
+      type="button"
+      className={`${drawerTriggerClasses} ${props.class ?? ''}`}
+      disabled={props.disabled ?? false}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+/**
+ * Props for DrawerOverlay component.
+ */
+interface DrawerOverlayProps {
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Semi-transparent overlay behind the drawer.
+ * Portals to document.body to avoid z-index issues with fixed headers.
+ * Reads open state from context.
+ */
+function DrawerOverlay(props: DrawerOverlayProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Portal to body
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(DrawerContext)
+
+    // Reactive show/hide + click-to-close
+    createEffect(() => {
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${drawerOverlayBaseClasses} ${isOpen ? drawerOverlayOpenClasses : drawerOverlayClosedClasses} ${props.class ?? ''}`
+    })
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <div
+      data-slot="drawer-overlay"
+      data-state="closed"
+      className={`${drawerOverlayBaseClasses} ${drawerOverlayClosedClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    />
+  )
+}
+
+/**
+ * Props for DrawerContent component.
+ */
+interface DrawerContentProps {
+  /** Drawer content */
+  children?: Child
+  /** Which edge the drawer slides from */
+  direction?: DrawerDirection
+  /** ID of the title element for aria-labelledby */
+  ariaLabelledby?: string
+  /** ID of the description element for aria-describedby */
+  ariaDescribedby?: string
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Main content container for the drawer.
+ * Portals to document.body to avoid z-index issues with fixed headers.
+ * Reads open state from context.
+ *
+ * @param props.direction - Which edge to slide from (default: 'bottom')
+ * @param props.ariaLabelledby - ID of title for accessibility
+ * @param props.ariaDescribedby - ID of description for accessibility
+ */
+function DrawerContent(props: DrawerContentProps) {
+  const direction = props.direction ?? 'bottom'
+
+  const handleMount = (el: HTMLElement) => {
+    // Portal to body
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(DrawerContext)
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + scroll lock + focus trap + ESC key
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${drawerContentBaseClasses} ${directionClasses[direction]} ${isOpen ? directionOpenClasses[direction] : directionClosedClasses[direction]} ${props.class ?? ''}`
+
+      if (isOpen) {
+        // Scroll lock
+        const originalOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+
+        // Focus first focusable element
+        const focusableSelector = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        setTimeout(() => {
+          const focusableElements = el.querySelectorAll(focusableSelector)
+          const firstElement = focusableElements[0] as HTMLElement
+          firstElement?.focus()
+        }, 0)
+
+        // ESC key to close
+        const handleKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            return
+          }
+
+          // Focus trap
+          if (e.key === 'Tab') {
+            const focusableElements = el.querySelectorAll(focusableSelector)
+            const firstElement = focusableElements[0] as HTMLElement
+            const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+            if (e.shiftKey) {
+              if (document.activeElement === firstElement || document.activeElement === el) {
+                e.preventDefault()
+                lastElement?.focus()
+              }
+            } else {
+              if (document.activeElement === lastElement) {
+                e.preventDefault()
+                firstElement?.focus()
+              }
+            }
+          }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        cleanupFns.push(
+          () => { document.body.style.overflow = originalOverflow },
+          () => document.removeEventListener('keydown', handleKeyDown),
+        )
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="drawer-content"
+      data-state="closed"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={props.ariaLabelledby}
+      aria-describedby={props.ariaDescribedby}
+      tabindex={-1}
+      className={`${drawerContentBaseClasses} ${directionClasses[direction]} ${directionClosedClasses[direction]} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Props for DrawerHandle component.
+ */
+interface DrawerHandleProps {
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Visual handle indicator for the drawer.
+ * Displays a small horizontal bar, typically at the top of bottom drawers.
+ */
+function DrawerHandle({ class: className = '' }: DrawerHandleProps) {
+  return (
+    <div
+      data-slot="drawer-handle"
+      className={`mx-auto mt-4 h-2 w-[100px] shrink-0 rounded-full bg-muted ${className}`}
+    />
+  )
+}
+
+/**
+ * Props for DrawerHeader component.
+ */
+interface DrawerHeaderProps {
+  /** Header content (typically DrawerTitle and DrawerDescription) */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Header section of the drawer.
+ * Text is centered by default (common for bottom drawers).
+ *
+ * @param props.children - Header content
+ */
+function DrawerHeader({ class: className = '', children }: DrawerHeaderProps) {
+  return (
+    <div data-slot="drawer-header" className={`${drawerHeaderClasses} ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Props for DrawerTitle component.
+ */
+interface DrawerTitleProps {
+  /** ID for aria-labelledby reference */
+  id?: string
+  /** Title text */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Title of the drawer.
+ *
+ * @param props.id - ID for accessibility
+ */
+function DrawerTitle({ class: className = '', id, children }: DrawerTitleProps) {
+  return (
+    <h2 data-slot="drawer-title" id={id} className={`${drawerTitleClasses} ${className}`}>
+      {children}
+    </h2>
+  )
+}
+
+/**
+ * Props for DrawerDescription component.
+ */
+interface DrawerDescriptionProps {
+  /** ID for aria-describedby reference */
+  id?: string
+  /** Description text */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Description text for the drawer.
+ *
+ * @param props.id - ID for accessibility
+ */
+function DrawerDescription({ class: className = '', id, children }: DrawerDescriptionProps) {
+  return (
+    <p data-slot="drawer-description" id={id} className={`${drawerDescriptionClasses} ${className}`}>
+      {children}
+    </p>
+  )
+}
+
+/**
+ * Props for DrawerFooter component.
+ */
+interface DrawerFooterProps {
+  /** Footer content (typically action buttons) */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Footer section of the drawer.
+ *
+ * @param props.children - Footer content
+ */
+function DrawerFooter({ class: className = '', children }: DrawerFooterProps) {
+  return (
+    <div data-slot="drawer-footer" className={`${drawerFooterClasses} ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Props for DrawerClose component.
+ */
+interface DrawerCloseProps {
+  /** Button content */
+  children?: Child
+  /** Additional CSS classes */
+  class?: string
+}
+
+/**
+ * Close button for the drawer.
+ * Reads context and calls onOpenChange(false) on click.
+ */
+function DrawerClose(props: DrawerCloseProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(DrawerContext)
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(false)
+    })
+  }
+
+  return (
+    <button
+      data-slot="drawer-close"
+      type="button"
+      className={`${drawerCloseClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export {
+  Drawer,
+  DrawerTrigger,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHandle,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+}
+export type {
+  DrawerProps,
+  DrawerTriggerProps,
+  DrawerOverlayProps,
+  DrawerContentProps,
+  DrawerHandleProps,
+  DrawerHeaderProps,
+  DrawerTitleProps,
+  DrawerDescriptionProps,
+  DrawerFooterProps,
+  DrawerCloseProps,
+  DrawerDirection,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -52,6 +52,12 @@
       "description": "A visual divider that separates content horizontally or vertically"
     },
     {
+      "name": "drawer",
+      "type": "registry:ui",
+      "title": "Drawer",
+      "description": "A draggable panel that slides from the edge of the screen"
+    },
+    {
       "name": "sheet",
       "type": "registry:ui",
       "title": "Sheet",


### PR DESCRIPTION
## Summary

- Port Drawer component from shadcn/ui with 4-direction support (top, right, bottom, left)
- Includes overlay, handle bar, focus trap, ESC key close, and scroll lock
- 3 interactive demos: Basic, Direction variants, Form with GoalControl
- Full E2E test coverage (26 tests)
- Fix compiler bug: `emitRefCallbacks()` now strips TypeScript type annotations via `stripTypeScriptSyntax()`

## Compiler fix

`ref` callbacks with TypeScript type annotations (e.g., `(el: HTMLElement) => { ... }`) were emitted as-is into client JS, causing `SyntaxError: Unexpected token ':'` in the browser. Fixed by applying `stripTypeScriptSyntax()` in `emitRefCallbacks()` and conditional branch ref emission.

## Related

- #379 — Scope boundary limitation: `ref`/`onClick` on native elements inside child component content are silently ignored

## Test plan

- [x] Compiler unit tests pass (187 tests)
- [x] Drawer E2E tests pass (26 tests)
- [x] All site/ui E2E tests pass (586 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)