### PR TITLE
Optimize bf-p: flat format, usedProps filtering, skip when no init

### DIFF
--- a/packages/dom/__tests__/runtime.test.ts
+++ b/packages/dom/__tests__/runtime.test.ts
@@ -322,7 +322,7 @@ describe('hydrate', () => {
     const initialized: Array<{ props: Record<string, unknown>; scope: Element }> = []
 
     document.body.innerHTML = `
-      <div bf-s="Counter_abc" bf-p='{"Counter": {"count": 5}}'>content</div>
+      <div bf-s="Counter_abc" bf-p='{"count": 5}'>content</div>
     `
 
     hydrate('Counter', (props, idx, scope) => {

--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -274,10 +274,9 @@ export function hydrate(
       // Mark as initialized immediately to prevent duplicate init
       scopeEl.setAttribute(BF_HYDRATED, 'true')
 
-      // Read props from bf-p attribute (namespaced format: {"CompA": {...}, "CompB": {...}})
+      // Read props from bf-p attribute (flat format: {"propName": value, ...})
       const propsJson = scopeEl.getAttribute(BF_PROPS)
-      const parsed = propsJson ? JSON.parse(propsJson) : {}
-      const props = parsed[name] ?? {}
+      const props = propsJson ? JSON.parse(propsJson) : {}
 
       init(props, 0, scopeEl)
     }

--- a/packages/go-template/runtime/bf.go
+++ b/packages/go-template/runtime/bf.go
@@ -533,19 +533,10 @@ func ScopeComment(props interface{}) template.HTML {
 	scopeAttr := ScopeAttr(props)
 	propsJSON := ""
 	if getBoolField(props, "BfIsRoot") {
-		// Build namespaced props JSON (same as BfPropsAttr but without the attribute wrapper)
-		scopeID := getStringField(props, "ScopeID")
-		componentName := extractComponentName(scopeID)
-		if componentName != "" {
-			pJSON, err := json.Marshal(props)
-			if err == nil {
-				nsJSON, err := json.Marshal(map[string]json.RawMessage{
-					componentName: pJSON,
-				})
-				if err == nil {
-					propsJSON = "|" + string(nsJSON)
-				}
-			}
+		// Build flat props JSON (same as BfPropsAttr but without the attribute wrapper)
+		pJSON, err := json.Marshal(props)
+		if err == nil {
+			propsJSON = "|" + string(pJSON)
 		}
 	}
 	return template.HTML("<!--bf-scope:" + scopeAttr + propsJSON + "-->")

--- a/packages/go-template/runtime/bf.go
+++ b/packages/go-template/runtime/bf.go
@@ -91,8 +91,8 @@ func IsChild(props interface{}) template.HTMLAttr {
 	return ""
 }
 
-// BfPropsAttr returns a bf-p attribute with the JSON-serialized props in namespaced format.
-// Output format: bf-p='{"ComponentName": {...props...}}'
+// BfPropsAttr returns a bf-p attribute with the JSON-serialized props in flat format.
+// Output format: bf-p='{"propName": value, ...}'
 // Only emits the attribute for root components (BfIsRoot == true).
 // Child components receive props from their parent via initChild().
 func BfPropsAttr(props interface{}) template.HTMLAttr {
@@ -101,38 +101,13 @@ func BfPropsAttr(props interface{}) template.HTMLAttr {
 		return ""
 	}
 
-	// Extract component name from ScopeID (format: "ComponentName_randomID")
-	scopeID := getStringField(props, "ScopeID")
-	componentName := extractComponentName(scopeID)
-	if componentName == "" {
-		return ""
-	}
-
 	propsJSON, err := json.Marshal(props)
 	if err != nil {
 		return ""
 	}
 
-	// Wrap in namespaced format: {"ComponentName": {...props...}}
-	namespacedJSON, err := json.Marshal(map[string]json.RawMessage{
-		componentName: propsJSON,
-	})
-	if err != nil {
-		return ""
-	}
-
-	escaped := template.HTMLEscapeString(string(namespacedJSON))
+	escaped := template.HTMLEscapeString(string(propsJSON))
 	return template.HTMLAttr(`bf-p="` + escaped + `"`)
-}
-
-// extractComponentName extracts the component name from a ScopeID.
-// ScopeID format: "ComponentName_randomID" (e.g., "Toggle_abc123" → "Toggle")
-func extractComponentName(scopeID string) string {
-	lastUnderscore := strings.LastIndex(scopeID, "_")
-	if lastUnderscore <= 0 {
-		return ""
-	}
-	return scopeID[:lastUnderscore]
 }
 
 // =============================================================================

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -14,7 +14,7 @@ import type {
 import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listExportedComponents } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
-import { generateClientJs } from './ir-to-client-js'
+import { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
 
 /**
  * Extended compile options with required adapter
@@ -68,6 +68,9 @@ export async function compileJSX(
     root: ir,
     errors: [],
   }
+
+  // Pre-compute client JS analysis for adapter optimization
+  componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
 
   if (options?.outputIR) {
     files.push({
@@ -133,6 +136,9 @@ function compileMultipleComponentsSync(
       root: ir,
       errors: [],
     }
+
+    // Pre-compute client JS analysis for adapter optimization
+    componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
 
     const adapterOutput = adapter.generate(componentIR)
     const fullContent = adapterOutput.template
@@ -337,6 +343,9 @@ export function compileJSXSync(
     root: ir,
     errors: [],
   }
+
+  // Pre-compute client JS analysis for adapter optimization
+  componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
 
   if (options.outputIR) {
     files.push({

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -44,7 +44,7 @@ export { BaseAdapter } from './adapters/interface'
 export type { TemplateAdapter, AdapterOutput, AdapterGenerateOptions } from './adapters/interface'
 
 // Client JS Generator
-export { generateClientJs } from './ir-to-client-js'
+export { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
 
 // Client JS Combiner (for build scripts)
 export { combineParentChildClientJs } from './combine-client-js'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -396,6 +396,11 @@ export interface IRMetadata {
   imports: ImportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
+  /** Pre-computed client JS analysis for adapter use */
+  clientAnalysis?: {
+    needsInit: boolean
+    usedProps: string[]
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Replace namespaced bf-p format (`{"ComponentName": {...}}`) with flat JSON (`{"prop": value}`) — only one component per element reads bf-p via `hydrate()`
- Add `analyzeClientNeeds()` pre-pass to determine which props client JS actually reads, so the adapter only serializes those
- Components without init functions no longer emit bf-p at all

## Changes

| Area | Change |
|---|---|
| `ir-to-client-js/index.ts` | New `analyzeClientNeeds()` returning `{ needsInit, usedProps }` |
| `compiler.ts` | Call pre-pass before `adapter.generate()` (3 paths) |
| `hono-adapter.ts` | Filter by `usedProps`, skip bf-p when `!needsInit`, flat JSON, rename `__bfParentPropsNs` → `__bfParentProps` |
| `runtime.ts` | `hydrate()` parses flat JSON directly (no namespace lookup) |
| `bf.go` | Remove namespace wrapping and `extractComponentName()` |
| `types.ts` | Add `clientAnalysis?` to `IRMetadata` |

## Example: Breadcrumb components

| Component | Before | After |
|---|---|---|
| Breadcrumb | `{"Breadcrumb":{"className":"","children":"..."}}` | _(no bf-p — no init)_ |
| BreadcrumbList | `{"BreadcrumbList":{"className":"","children":"..."}}` | _(no bf-p — no init)_ |
| BreadcrumbEllipsis | `{"BreadcrumbEllipsis":{"className":""}}` | _(no bf-p — init reads no props)_ |
| BreadcrumbLink | `{"BreadcrumbLink":{"className":"...","asChild":false,...}}` | `{"className":"..."}` |

## Test plan

- [x] Unit tests: 370/370 pass
- [x] E2E tests: 591/591 pass (128 skipped, pre-existing)
- [x] Go tests: pass
- [x] Verified bf-p output in built components (Breadcrumb, Checkbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)