### PR TITLE
Enable 5 remaining skipped E2E tests

### DIFF
--- a/packages/dom/src/runtime.ts
+++ b/packages/dom/src/runtime.ts
@@ -600,8 +600,14 @@ export function bind(
       if (key === 'value') {
         createEffect(() => {
           const val = String(getter() ?? '')
-          if ((el as HTMLInputElement).value !== val) {
-            ;(el as HTMLInputElement).value = val
+          const input = el as HTMLInputElement
+          if (input.value !== val) {
+            const start = input.selectionStart
+            const end = input.selectionEnd
+            input.value = val
+            if (document.activeElement === el && start !== null) {
+              input.setSelectionRange(start, end)
+            }
           }
         })
       } else if (BOOLEAN_PROPS.includes(key)) {

--- a/site/ui/e2e/checkbox.spec.ts
+++ b/site/ui/e2e/checkbox.spec.ts
@@ -300,10 +300,7 @@ test.describe('Checkbox Documentation Page', () => {
       }
     })
 
-    // TODO: This test reveals an issue with conditional rendering in current implementation
-    // The "Mark as read" element uses {selectedCount() > 0 && ...} pattern
-    // which may not work correctly with the current signal system
-    test.skip('"Mark as read" appears only when selection > 0', async ({ page }) => {
+    test('"Mark as read" appears only when selection > 0', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
 

--- a/site/ui/e2e/controlled-input.spec.ts
+++ b/site/ui/e2e/controlled-input.spec.ts
@@ -48,10 +48,7 @@ test.describe('Controlled Input Documentation Page', () => {
       await expect(display).toHaveText('abcdefghij')
     })
 
-    // Skip: Known edge case - cursor position is not preserved during controlled input updates.
-    // When value is synchronized via signal, cursor moves to end of input.
-    // This is a validation finding for Issue #75.
-    test.skip('handles typing in middle of text', async ({ page }) => {
+    test('handles typing in middle of text', async ({ page }) => {
       const demo = page.locator('[bf-s^="BasicControlledDemo_"]')
       const input = demo.locator('input')
       const display = demo.locator('.current-value')
@@ -59,13 +56,10 @@ test.describe('Controlled Input Documentation Page', () => {
       await input.fill('Hello World')
       await expect(display).toHaveText('Hello World')
 
-      // Move cursor to middle and type
+      // Move cursor to position 5 (after "Hello") and type
       await input.focus()
-      await input.press('Home')
-      for (let i = 0; i < 5; i++) {
-        await input.press('ArrowRight')
-      }
-      await input.type(' Beautiful')
+      await input.evaluate((el: HTMLInputElement) => el.setSelectionRange(5, 5))
+      await input.pressSequentially(' Beautiful')
       await expect(display).toHaveText('Hello Beautiful World')
     })
   })

--- a/site/ui/e2e/pagination.spec.ts
+++ b/site/ui/e2e/pagination.spec.ts
@@ -81,10 +81,7 @@ test.describe('Pagination Documentation Page', () => {
       await expect(page1Link).toHaveAttribute('data-active', 'true')
     })
 
-    // Compiler limitation: reactive prop updates to stateless child components
-    // (PaginationLink) don't propagate to data-active attribute.
-    // The compiled JS sets setAttribute('isActive', ...) but doesn't update data-active.
-    test.skip('clicking page link updates active state', async ({ page }) => {
+    test('clicking page link updates active state', async ({ page }) => {
       const section = page.locator('[bf-s^="PaginationDynamicDemo_"]:not([data-slot])').first()
 
       const page2Link = section.locator('[data-slot="pagination-link"]', { hasText: '2' })
@@ -96,8 +93,7 @@ test.describe('Pagination Documentation Page', () => {
       await expect(page1Link).toHaveAttribute('data-active', 'false')
     })
 
-    // Same compiler limitation as above
-    test.skip('clicking Next button updates active state', async ({ page }) => {
+    test('clicking Next button updates active state', async ({ page }) => {
       const section = page.locator('[bf-s^="PaginationDynamicDemo_"]:not([data-slot])').first()
 
       const nextBtn = section.locator('a[aria-label="Go to next page"]')

--- a/site/ui/e2e/toast.spec.ts
+++ b/site/ui/e2e/toast.spec.ts
@@ -200,7 +200,7 @@ test.describe('Toast Documentation Page', () => {
       await expect(toast.locator('svg').first()).toBeVisible()
     })
 
-    test.skip('default toast has no variant icon', async ({ page }) => {
+    test('default toast has no variant icon', async ({ page }) => {
       const demo = page.locator('[bf-s^="ToastDefaultDemo_"]').first()
       const trigger = demo.locator('button:has-text("Default")')
 
@@ -209,6 +209,9 @@ test.describe('Toast Documentation Page', () => {
       const toast = page.locator('[data-slot="toast"][data-variant="default"][data-state="visible"]').first()
       await expect(toast).toBeVisible()
       // Default variant should not have a variant icon (only the close button icon)
+      // The close button's SVG is inside [data-slot="toast-close"], so variant icons are direct children
+      const variantIcon = toast.locator(':scope > svg')
+      await expect(variantIcon).toHaveCount(0)
     })
   })
 

--- a/ui/components/ui/pagination.tsx
+++ b/ui/components/ui/pagination.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * Pagination Component
  *
@@ -97,25 +99,21 @@ interface PaginationLinkProps {
   'aria-label'?: string
 }
 
-function PaginationLink({
-  className = '',
-  isActive,
-  size = 'icon',
-  children,
-  ...props
-}: PaginationLinkProps) {
-  const variant = isActive ? 'outline' : 'ghost'
-  const classes = `${buttonBaseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`
+function PaginationLink(props: PaginationLinkProps) {
+  const size = props.size ?? 'icon'
+  const className = props.className ?? ''
 
   return (
     <a
-      aria-current={isActive ? 'page' : undefined}
+      aria-current={props.isActive ? 'page' : undefined}
       data-slot="pagination-link"
-      data-active={isActive}
-      className={classes}
-      {...props}
+      data-active={props.isActive}
+      className={`${buttonBaseClasses} ${props.isActive ? variantClasses.outline : variantClasses.ghost} ${sizeClasses[size]} ${className}`}
+      href={props.href}
+      onClick={props.onClick}
+      aria-label={props['aria-label']}
     >
-      {children}
+      {props.children}
     </a>
   )
 }
@@ -128,37 +126,35 @@ interface PaginationPrevNextProps {
   'aria-label'?: string
 }
 
-function PaginationPrevious({
-  className = '',
-  ...props
-}: PaginationPrevNextProps) {
+function PaginationPrevious(props: PaginationPrevNextProps) {
+  const className = props.className ?? ''
   return (
-    <PaginationLink
+    <a
       aria-label="Go to previous page"
-      size="default"
-      className={`gap-1 px-2.5 sm:pl-2.5 ${className}`}
-      {...props}
+      data-slot="pagination-link"
+      className={`${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pl-2.5 ${className}`}
+      href={props.href}
+      onClick={props.onClick}
     >
       <ChevronLeftIcon size="sm" />
       <span className="hidden sm:block">Previous</span>
-    </PaginationLink>
+    </a>
   )
 }
 
-function PaginationNext({
-  className = '',
-  ...props
-}: PaginationPrevNextProps) {
+function PaginationNext(props: PaginationPrevNextProps) {
+  const className = props.className ?? ''
   return (
-    <PaginationLink
+    <a
       aria-label="Go to next page"
-      size="default"
-      className={`gap-1 px-2.5 sm:pr-2.5 ${className}`}
-      {...props}
+      data-slot="pagination-link"
+      className={`${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pr-2.5 ${className}`}
+      href={props.href}
+      onClick={props.onClick}
     >
       <span className="hidden sm:block">Next</span>
       <ChevronRightIcon size="sm" />
-    </PaginationLink>
+    </a>
   )
 }
 


### PR DESCRIPTION
## Summary

Resolves the remaining 5 `test.skip` from #385 across 4 test files:

- **Toast** (`toast.spec.ts`): Remove skip, add assertion that default toast has no variant icon SVG
- **Checkbox** (`checkbox.spec.ts`): Remove skip — conditional rendering with `selectedCount() > 0 &&` already works
- **Controlled Input** (`controlled-input.spec.ts`): Fix `bind()` in runtime to preserve cursor position (`selectionStart`/`selectionEnd`) during value sync; update test to use reliable cursor positioning
- **Pagination** (`pagination.spec.ts`, 2 tests): Add `'use client'` directive, use `props.xxx` pattern for reactivity tracking in `PaginationLink`, inline `<a>` in `PaginationPrevious`/`PaginationNext` to avoid nested-component scope resolution issue

## Test plan

- [x] All 5 previously-skipped tests now pass
- [x] Full E2E suite: 776 passed, 0 failed
- [x] No regressions in toast (24), checkbox (34), controlled-input (21), pagination (19) tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)