### PR TITLE
Fix bf slot marker collision in props.children

### DIFF
--- a/examples/echo/components.go
+++ b/examples/echo/components.go
@@ -286,8 +286,8 @@ type ReactivePropsProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Count int `json:"count"`
 	Doubled int `json:"doubled"`
+	ReactiveChildSlot5 ReactiveChildProps `json:"-"`
 	ReactiveChildSlot6 ReactiveChildProps `json:"-"`
-	ReactiveChildSlot7 ReactiveChildProps `json:"-"`
 }
 
 // NewReactivePropsProps creates ReactivePropsProps from ReactivePropsInput.
@@ -301,13 +301,13 @@ func NewReactivePropsProps(in ReactivePropsInput) ReactivePropsProps {
 		ScopeID: scopeID,
 		Count: 0,
 		Doubled: 0 * 2,
-		ReactiveChildSlot6: NewReactiveChildProps(ReactiveChildInput{
-			ScopeID: scopeID + "_s6",
+		ReactiveChildSlot5: NewReactiveChildProps(ReactiveChildInput{
+			ScopeID: scopeID + "_s5",
 			Value: 0,
 			Label: "Child A",
 		}),
-		ReactiveChildSlot7: NewReactiveChildProps(ReactiveChildInput{
-			ScopeID: scopeID + "_s7",
+		ReactiveChildSlot6: NewReactiveChildProps(ReactiveChildInput{
+			ScopeID: scopeID + "_s6",
 			Value: 0 * 2,
 			Label: "Child B (doubled)",
 		}),
@@ -392,8 +392,8 @@ type PropsReactivityComparisonProps struct {
 	BfIsChild bool `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
 	Count int `json:"count"`
-	PropsStyleChildSlot4 PropsStyleChildProps `json:"-"`
-	DestructuredStyleChildSlot5 DestructuredStyleChildProps `json:"-"`
+	PropsStyleChildSlot3 PropsStyleChildProps `json:"-"`
+	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
 }
 
 // NewPropsReactivityComparisonProps creates PropsReactivityComparisonProps from PropsReactivityComparisonInput.
@@ -406,13 +406,13 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 	return PropsReactivityComparisonProps{
 		ScopeID: scopeID,
 		Count: 1,
-		PropsStyleChildSlot4: NewPropsStyleChildProps(PropsStyleChildInput{
-			ScopeID: scopeID + "_s4",
+		PropsStyleChildSlot3: NewPropsStyleChildProps(PropsStyleChildInput{
+			ScopeID: scopeID + "_s3",
 			Value: 1,
 			Label: "Props Style",
 		}),
-		DestructuredStyleChildSlot5: NewDestructuredStyleChildProps(DestructuredStyleChildInput{
-			ScopeID: scopeID + "_s5",
+		DestructuredStyleChildSlot4: NewDestructuredStyleChildProps(DestructuredStyleChildInput{
+			ScopeID: scopeID + "_s4",
 			Value: 1,
 			Label: "Destructured",
 		}),

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1603,9 +1603,10 @@ function hasDynamicContent(children: IRNode[]): boolean {
     if (child.type === 'loop') {
       return true
     }
-    if (child.type === 'element' && hasDynamicContent(child.children)) {
-      return true
-    }
+    // Don't recurse into child elements — they handle their own dynamic content
+    // with their own slotIds. Propagating up would cause unnecessary bf markers
+    // on ancestor elements, risking ID collisions when those ancestors are passed
+    // as props.children into a child component scope.
     if (child.type === 'fragment' && hasDynamicContent(child.children)) {
       return true
     }


### PR DESCRIPTION
## Summary

- Remove element recursion from `hasDynamicContent()` in the JSX-to-IR compiler to prevent unnecessary `bf` slot markers on ancestor elements
- Fixes ScrollArea Both Axes demo where neither vertical nor horizontal scrolling worked due to a `bf="s1"` collision between the demo's content div and ScrollArea's internal thumb element
- Child elements already handle their own dynamic content with their own `slotId`; propagating markers up to ancestors is unnecessary and causes ID collisions when those ancestors are passed as `props.children`

## Details

`hasDynamicContent()` recursed into child `element` nodes, marking ancestor elements with `bf` attributes whenever any descendant had dynamic content (loops, reactive expressions). When these ancestor elements were passed as `props.children` into a child component (e.g., ScrollArea), their `bf` markers ended up inside the child component's DOM scope — colliding with the child's own internal `bf` IDs assigned from an independent counter.

In the ScrollArea Both Axes demo, the content `<div class="p-4" style="width: 600px;">` received `bf="s1"` from the demo's compiler pass. Inside ScrollArea, the vertical thumb `<div data-slot="scroll-area-thumb">` also had `bf="s1"`. The runtime's `$(__scope, 's1')` found the content div first (document order), so the thumb's reactive style (`position: absolute; height: N%; width: 100%`) was applied to the content div — overwriting `width: 600px` and collapsing both axes of overflow.

Fragment recursion is preserved since fragments have no DOM element and cannot hold their own `slotId`.

## Test plan

- [x] All 402 compiler unit tests pass
- [x] All 15 scroll-area E2E tests pass
- [x] All 785 E2E tests pass (full suite, no regressions)
- [x] Verified in browser: Both Axes demo scrolls vertically and horizontally
- [x] Verified: Tags and Horizontal demos unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)