### PR TITLE
Fix compiler bugs breaking Resizable drag

### DIFF
--- a/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
+++ b/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
@@ -42,6 +42,18 @@ describe('stripTypeScriptSyntax', () => {
         stripTypeScriptSyntax('someElement.closest(\'[data-slot="trigger"]\') as HTMLElement | null')
       ).toBe('someElement.closest(\'[data-slot="trigger"]\')')
     })
+
+    test('strips string literal union type assertion', () => {
+      expect(
+        stripTypeScriptSyntax("handleOrientationClasses[groupDir as 'horizontal' | 'vertical']")
+      ).toBe('handleOrientationClasses[groupDir]')
+    })
+
+    test('strips single string literal type assertion', () => {
+      expect(
+        stripTypeScriptSyntax("value as 'active'")
+      ).toBe('value')
+    })
   })
 
   describe('arrow function parameter types', () => {

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -275,7 +275,8 @@ export function emitReactiveAttributeUpdates(lines: string[], ctx: ClientJsConte
           lines.push(`      if (${attr.expression}) _${slotId}.setAttribute('${htmlAttrName}', '')`)
           lines.push(`      else _${slotId}.removeAttribute('${htmlAttrName}')`)
         } else {
-          lines.push(`      _${slotId}.setAttribute('${htmlAttrName}', String(${attr.expression}))`)
+          // Handle null/undefined: remove attribute instead of setting "undefined"
+          lines.push(`      { const __v = ${attr.expression}; if (__v != null) _${slotId}.setAttribute('${htmlAttrName}', String(__v)); else _${slotId}.removeAttribute('${htmlAttrName}') }`)
         }
       }
       lines.push(`    }`)
@@ -621,7 +622,8 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
         } else if (isBooleanAttr(prop.attrName)) {
           lines.push(`      ${varName}.${prop.attrName} = !!(${prop.expression})`)
         } else {
-          lines.push(`      ${varName}.setAttribute('${prop.attrName}', ${prop.expression})`)
+          // Handle null/undefined: remove attribute instead of setting "undefined"
+          lines.push(`      { const __v = ${prop.expression}; if (__v != null) ${varName}.setAttribute('${prop.attrName}', String(__v)); else ${varName}.removeAttribute('${prop.attrName}') }`)
         }
       }
       lines.push(`    }`)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -27,7 +27,7 @@ export function irToHtmlTemplate(node: IRNode): string {
           if (a.dynamic && a.presenceOrUndefined) {
             return `\${${a.value} ? '${attrName}' : ''}`
           }
-          if (a.dynamic) return `${attrName}="\${${a.value}}"`
+          if (a.dynamic) return `\${(${a.value}) != null ? '${attrName}="' + (${a.value}) + '"' : ''}`
           return `${attrName}="${a.value}"`
         })
         .filter(Boolean)
@@ -164,7 +164,7 @@ export function irToComponentTemplate(
           if (a.dynamic && valueStr && a.presenceOrUndefined) {
             return `\${${transformExpr(valueStr)} ? '${attrName}' : ''}`
           }
-          if (a.dynamic && valueStr) return `${attrName}="\${${transformExpr(valueStr)}}"`
+          if (a.dynamic && valueStr) return `\${(${transformExpr(valueStr)}) != null ? '${attrName}="' + (${transformExpr(valueStr)}) + '"' : ''}`
           if (valueStr) return `${attrName}="${valueStr}"`
           return attrName
         })

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -144,7 +144,9 @@ export function stripTypeScriptSyntax(code: string): string {
   let result = code.replace(/(\w)!(?!=)/g, '$1')
 
   // Type assertions: "expr as Type" or "expr as Type | Type2 | ..."
-  result = result.replace(/\s+as\s+[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\[\])?(?:\s*\|\s*[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\[\])?)*/g, '')
+  // Supports identifier types (HTMLElement), string literal types ('horizontal'), and generics (Set<string>)
+  const tsTypeAtom = `(?:[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?(?:\\[\\])?|'[^']*'|"[^"]*")`
+  result = result.replace(new RegExp(`\\s+as\\s+${tsTypeAtom}(?:\\s*\\|\\s*${tsTypeAtom})*`, 'g'), '')
 
   // Parameter type annotations: (param: Type) or (param: Type | Type2) => (param)
   // Only match TypeScript types (uppercase initial or type keyword) to avoid matching object properties


### PR DESCRIPTION
## Summary

- Fix `stripTypeScriptSyntax()` to handle string literal union types (`as 'horizontal' | 'vertical'`), which caused a `SyntaxError` that blocked the entire Resizable client JS from loading
- Fix dynamic attribute emission to handle `null`/`undefined` values — previously `String(undefined)` produced the string `"undefined"`, causing `parseFloat("undefined")` → `NaN` in drag calculations
- Apply the undefined-attribute fix to both client-side `setAttribute` calls and SSR template generation

## Test plan

- [x] All 221 compiler unit tests pass (including 2 new tests for string literal type stripping)
- [x] All 785 E2E tests pass with no regressions
- [x] Resizable drag verified working via PointerEvent simulation in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)