### PR TITLE
Add @barefootjs/test for IR-based component testing

### DIFF
--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '../src/index'
+
+// Read real UI component sources
+const uiDir = resolve(__dirname, '../../../ui/components/ui')
+const buttonSource = readFileSync(resolve(uiDir, 'button.tsx'), 'utf-8')
+const checkboxSource = readFileSync(resolve(uiDir, 'checkbox.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Button (stateless — destructured props, no signals)
+// ---------------------------------------------------------------------------
+
+describe('Button', () => {
+  const result = renderToTest(buttonSource, 'button.tsx')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Button', () => {
+    expect(result.componentName).toBe('Button')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('root is an if-statement (asChild branch)', () => {
+    // Button has: if (asChild) return <Slot ...>; return <button ...>
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a <button> element', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+  })
+
+  test('button has dynamic className (from classes variable)', () => {
+    const button = result.find({ tag: 'button' })!
+    // className is a dynamic expression referencing the `classes` local variable
+    expect(button.classes).toContain('classes')
+  })
+
+  test('contains a Slot component for asChild', () => {
+    const slot = result.find({ componentName: 'Slot' })
+    expect(slot).not.toBeNull()
+  })
+
+  test('toStructure() returns non-empty string', () => {
+    const structure = result.toStructure()
+    expect(structure.length).toBeGreaterThan(0)
+    expect(structure).toContain('button')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Checkbox (stateful — signals, events, aria)
+// ---------------------------------------------------------------------------
+
+describe('Checkbox', () => {
+  const result = renderToTest(checkboxSource, 'checkbox.tsx')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Checkbox', () => {
+    expect(result.componentName).toBe('Checkbox')
+  })
+
+  test('has signals: internalChecked, controlledChecked', () => {
+    expect(result.signals).toContain('internalChecked')
+    expect(result.signals).toContain('controlledChecked')
+  })
+
+  test('renders as <button>', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+  })
+
+  test('has role=checkbox', () => {
+    const button = result.find({ role: 'checkbox' })
+    expect(button).not.toBeNull()
+    expect(button!.tag).toBe('button')
+  })
+
+  test('has aria-checked attribute', () => {
+    const button = result.find({ role: 'checkbox' })!
+    expect(button.aria).toHaveProperty('checked')
+  })
+
+  test('has data-state attribute', () => {
+    const button = result.find({ role: 'checkbox' })!
+    expect(button.dataState).not.toBeNull()
+  })
+
+  test('has click event handler', () => {
+    const button = result.find({ role: 'checkbox' })!
+    expect(button.events).toContain('click')
+  })
+
+  test('contains conditional SVG child (checkmark)', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+  })
+
+  test('toStructure() includes role and aria info', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('[role=checkbox]')
+    expect(structure).toContain('[aria-checked]')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error detection
+// ---------------------------------------------------------------------------
+
+describe('Error detection', () => {
+  test('missing "use client" reports BF001', () => {
+    const source = `
+import { createSignal } from '@barefootjs/dom'
+
+function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+}
+
+export { Counter }
+`
+    const result = renderToTest(source, 'counter.tsx')
+    const errorCodes = result.errors.map(e => e.code)
+    expect(errorCodes).toContain('BF001')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// toStructure() snapshots
+// ---------------------------------------------------------------------------
+
+describe('toStructure()', () => {
+  test('Button structure snapshot', () => {
+    const result = renderToTest(buttonSource, 'button.tsx')
+    const structure = result.toStructure()
+    // Verify key structural elements are present
+    expect(structure).toContain('button')
+    expect(structure).toContain('<Slot>')
+    // Tree connectors
+    expect(structure).toMatch(/[├└]/)
+  })
+
+  test('Checkbox structure snapshot', () => {
+    const result = renderToTest(checkboxSource, 'checkbox.tsx')
+    const structure = result.toStructure()
+    expect(structure).toContain('[role=checkbox]')
+    expect(structure).toContain('[aria-checked]')
+    expect(structure).toContain('(click)')
+    expect(structure).toContain('svg')
+    expect(structure).toContain('path')
+  })
+})

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@barefootjs/test",
+  "version": "0.0.1",
+  "description": "Test utilities for BarefootJS - IR-based component testing without a browser",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "test": "bun test",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "test",
+    "barefoot",
+    "jsx",
+    "compiler"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kfly8/barefootjs",
+    "directory": "packages/test"
+  },
+  "dependencies": {
+    "@barefootjs/jsx": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @barefootjs/test — IR-based component testing without a browser.
+ */
+
+export { renderToTest } from './render'
+export type { TestResult } from './render'
+
+export { TestNode } from './test-node'
+export type { TestNodeData, TestNodeQuery } from './test-node'
+
+export { toStructure } from './structure'

--- a/packages/test/src/render.ts
+++ b/packages/test/src/render.ts
@@ -1,0 +1,124 @@
+/**
+ * renderToTest — compile a TSX source string to a TestNode tree.
+ *
+ * Pipeline: source → analyzeComponent → jsxToIR → buildMetadata → irNodeToTestNode
+ * Does NOT go through any adapter; operates on IR directly.
+ */
+
+import { analyzeComponent, jsxToIR } from '@barefootjs/jsx'
+import type { IRMetadata, CompilerError } from '@barefootjs/jsx'
+import { TestNode, type TestNodeQuery } from './test-node'
+import { irNodeToTestNode } from './ir-to-test-node'
+import { toStructure } from './structure'
+
+export interface TestResult {
+  root: TestNode
+  componentName: string
+  isClient: boolean
+  signals: string[]
+  errors: Array<{ code: string; message: string; line: number }>
+
+  // Delegated to root
+  find: (query: TestNodeQuery) => TestNode | null
+  findAll: (query: TestNodeQuery) => TestNode[]
+  findByText: (text: string) => TestNode | null
+
+  // Debug
+  toStructure(): string
+}
+
+export function renderToTest(source: string, filePath: string): TestResult {
+  const ctx = analyzeComponent(source, filePath)
+
+  // Collect errors from analysis phase
+  const errors: TestResult['errors'] = ctx.errors.map(toSimpleError)
+
+  if (!ctx.jsxReturn) {
+    // No JSX return found — return a minimal result with errors
+    return emptyResult(ctx.componentName || 'Unknown', ctx.hasUseClientDirective, errors)
+  }
+
+  const ir = jsxToIR(ctx)
+
+  // Collect any additional errors from IR phase
+  const allErrors = ctx.errors.map(toSimpleError)
+
+  if (!ir) {
+    return emptyResult(ctx.componentName || 'Unknown', ctx.hasUseClientDirective, allErrors)
+  }
+
+  const metadata = buildMetadata(ctx)
+  const root = irNodeToTestNode(ir)
+  const signals = metadata.signals.map(s => s.getter)
+
+  return {
+    root,
+    componentName: metadata.componentName,
+    isClient: metadata.isClientComponent,
+    signals,
+    errors: allErrors,
+    find: (query) => root.find(query),
+    findAll: (query) => root.findAll(query),
+    findByText: (text) => root.findByText(text),
+    toStructure: () => toStructure(root),
+  }
+}
+
+function buildMetadata(
+  ctx: ReturnType<typeof analyzeComponent>
+): IRMetadata {
+  return {
+    componentName: ctx.componentName || 'Unknown',
+    hasDefaultExport: ctx.hasDefaultExport,
+    isClientComponent: ctx.hasUseClientDirective,
+    typeDefinitions: ctx.typeDefinitions,
+    propsType: ctx.propsType,
+    propsParams: ctx.propsParams,
+    propsObjectName: ctx.propsObjectName,
+    restPropsName: ctx.restPropsName,
+    signals: ctx.signals,
+    memos: ctx.memos,
+    effects: ctx.effects,
+    onMounts: ctx.onMounts,
+    imports: ctx.imports,
+    localFunctions: ctx.localFunctions,
+    localConstants: ctx.localConstants,
+  }
+}
+
+function toSimpleError(err: CompilerError): TestResult['errors'][number] {
+  return { code: err.code, message: err.message, line: err.loc.start.line }
+}
+
+function emptyResult(
+  componentName: string,
+  isClient: boolean,
+  errors: TestResult['errors']
+): TestResult {
+  const root = new TestNode({
+    tag: null,
+    type: 'fragment',
+    children: [],
+    text: null,
+    props: {},
+    classes: [],
+    role: null,
+    aria: {},
+    dataState: null,
+    events: [],
+    reactive: false,
+    componentName: null,
+  })
+
+  return {
+    root,
+    componentName,
+    isClient,
+    signals: [],
+    errors,
+    find: () => null,
+    findAll: () => [],
+    findByText: () => null,
+    toStructure: () => '',
+  }
+}

--- a/packages/test/src/structure.ts
+++ b/packages/test/src/structure.ts
@@ -1,0 +1,93 @@
+/**
+ * toStructure — tree display for debugging and snapshot testing.
+ *
+ * Format:
+ *   button [role=checkbox] [aria-checked] (click)
+ *   ├── svg.size-3.5.text-current
+ *   │   └── path
+ *   └── {expression}
+ */
+
+import type { TestNode } from './test-node'
+
+export function toStructure(node: TestNode): string {
+  const lines: string[] = []
+  renderNode(node, '', true, lines)
+  return lines.join('\n')
+}
+
+function renderNode(
+  node: TestNode,
+  prefix: string,
+  isLast: boolean,
+  lines: string[],
+  isRoot: boolean = true
+): void {
+  const label = nodeLabel(node)
+
+  if (isRoot) {
+    lines.push(label)
+  } else {
+    const connector = isLast ? '└── ' : '├── '
+    lines.push(prefix + connector + label)
+  }
+
+  const childPrefix = isRoot ? '' : prefix + (isLast ? '    ' : '│   ')
+
+  for (let i = 0; i < node.children.length; i++) {
+    const child = node.children[i]
+    const childIsLast = i === node.children.length - 1
+    renderNode(child, childPrefix, childIsLast, lines, false)
+  }
+}
+
+function nodeLabel(node: TestNode): string {
+  const parts: string[] = []
+
+  // Tag or expression
+  if (node.type === 'text') {
+    parts.push(JSON.stringify(node.text))
+    return parts.join(' ')
+  }
+
+  if (node.type === 'expression') {
+    parts.push(`{${node.text}}`)
+    return parts.join(' ')
+  }
+
+  if (node.type === 'conditional') {
+    parts.push(`?{${node.text}}`)
+  } else if (node.type === 'loop') {
+    parts.push(`*{${node.text}}`)
+  } else if (node.type === 'component') {
+    parts.push(`<${node.componentName}>`)
+  } else if (node.type === 'fragment') {
+    parts.push('<>')
+  } else if (node.tag) {
+    // Element: tag with first 3 classes
+    const classStr = node.classes.slice(0, 3).map(c => `.${c}`).join('')
+    parts.push(node.tag + classStr)
+  }
+
+  // Role
+  if (node.role) {
+    parts.push(`[role=${node.role}]`)
+  }
+
+  // Aria attributes
+  for (const key of Object.keys(node.aria).sort()) {
+    parts.push(`[aria-${key}]`)
+  }
+
+  // data-state
+  if (node.dataState) {
+    parts.push(`[data-state]`)
+  }
+
+  // Events
+  if (node.events.length > 0) {
+    parts.push(`(${node.events.join(', ')})`)
+  }
+
+  return parts.join(' ')
+}

--- a/packages/test/src/test-node.ts
+++ b/packages/test/src/test-node.ts
@@ -1,0 +1,97 @@
+/**
+ * TestNode — Queryable representation of a compiled BarefootJS component.
+ *
+ * Produced by converting the compiler IR into a flat, assertion-friendly shape.
+ */
+
+export interface TestNodeData {
+  tag: string | null
+  type: 'element' | 'text' | 'expression' | 'conditional' | 'loop' | 'component' | 'fragment'
+  children: TestNode[]
+  text: string | null
+  props: Record<string, string | boolean | null>
+  classes: string[]
+  role: string | null
+  aria: Record<string, string>
+  dataState: string | null
+  events: string[]
+  reactive: boolean
+  componentName: string | null
+}
+
+export interface TestNodeQuery {
+  tag?: string
+  role?: string
+  componentName?: string
+}
+
+export class TestNode implements TestNodeData {
+  tag: string | null
+  type: TestNodeData['type']
+  children: TestNode[]
+  text: string | null
+  props: Record<string, string | boolean | null>
+  classes: string[]
+  role: string | null
+  aria: Record<string, string>
+  dataState: string | null
+  events: string[]
+  reactive: boolean
+  componentName: string | null
+
+  constructor(data: TestNodeData) {
+    this.tag = data.tag
+    this.type = data.type
+    this.children = data.children
+    this.text = data.text
+    this.props = data.props
+    this.classes = data.classes
+    this.role = data.role
+    this.aria = data.aria
+    this.dataState = data.dataState
+    this.events = data.events
+    this.reactive = data.reactive
+    this.componentName = data.componentName
+  }
+
+  /** Return the first descendant (or self) matching the query. */
+  find(query: TestNodeQuery): TestNode | null {
+    if (this.matches(query)) return this
+    for (const child of this.children) {
+      const found = child.find(query)
+      if (found) return found
+    }
+    return null
+  }
+
+  /** Return all descendants (and self) matching the query. */
+  findAll(query: TestNodeQuery): TestNode[] {
+    const results: TestNode[] = []
+    this.collectMatches(query, results)
+    return results
+  }
+
+  /** Return the first descendant whose text contains the given string. */
+  findByText(text: string): TestNode | null {
+    if (this.text !== null && this.text.includes(text)) return this
+    for (const child of this.children) {
+      const found = child.findByText(text)
+      if (found) return found
+    }
+    return null
+  }
+
+  private matches(query: TestNodeQuery): boolean {
+    if (query.tag !== undefined && this.tag !== query.tag) return false
+    if (query.role !== undefined && this.role !== query.role) return false
+    if (query.componentName !== undefined && this.componentName !== query.componentName) return false
+    return true
+  }
+
+  private collectMatches(query: TestNodeQuery, results: TestNode[]): void {
+    if (this.matches(query)) results.push(this)
+    for (const child of this.children) {
+      child.collectMatches(query, results)
+    }
+  }
+}

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}


### PR DESCRIPTION
## Summary

- Add `@barefootjs/test` package that converts compiler IR to queryable `TestNode` trees
- Enable browser-free component verification (structure, a11y, reactivity) in milliseconds
- Test against real UI components (Button, Checkbox) with 23 passing tests

## API

```typescript
import { renderToTest } from '@barefootjs/test'

const result = renderToTest(source, 'checkbox.tsx')
result.find({ role: 'checkbox' })   // TestNode
result.signals                      // ['internalChecked', 'controlledChecked']
result.toStructure()                // tree display for snapshots
```

## Test plan

- [x] Button: stateless component structure, className, Slot branch
- [x] Checkbox: signals, role, aria-checked, data-state, click event, conditional SVG
- [x] Error detection: missing "use client" → BF001
- [x] toStructure() snapshot verification
- [x] All 425 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)