### PR TITLE
Add Command component

### DIFF
--- a/site/ui/components/command-demo.tsx
+++ b/site/ui/components/command-demo.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+/**
+ * Command Demo Components
+ *
+ * Interactive demos for Command component documentation.
+ */
+
+import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+  CommandDialog,
+} from '@ui/components/ui/command'
+
+/**
+ * Preview demo — inline command menu with groups, icons, and shortcuts.
+ */
+export function CommandPreviewDemo() {
+  return (
+    <Command class="rounded-lg border shadow-md md:min-w-[450px]">
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem value="Calendar">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2" ry="2" /><line x1="16" x2="16" y1="2" y2="6" /><line x1="8" x2="8" y1="2" y2="6" /><line x1="3" x2="21" y1="10" y2="10" /></svg>
+            <span>Calendar</span>
+          </CommandItem>
+          <CommandItem value="Search Emoji">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><path d="M8 14s1.5 2 4 2 4-2 4-2" /><line x1="9" x2="9.01" y1="9" y2="9" /><line x1="15" x2="15.01" y1="9" y2="9" /></svg>
+            <span>Search Emoji</span>
+          </CommandItem>
+          <CommandItem value="Calculator">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="16" height="20" x="4" y="2" rx="2" /><line x1="8" x2="16" y1="6" y2="6" /><line x1="16" x2="16" y1="14" y2="18" /><path d="M16 10h.01" /><path d="M12 10h.01" /><path d="M8 10h.01" /><path d="M12 14h.01" /><path d="M8 14h.01" /><path d="M12 18h.01" /><path d="M8 18h.01" /></svg>
+            <span>Calculator</span>
+          </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Settings">
+          <CommandItem value="Profile">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg>
+            <span>Profile</span>
+            <CommandShortcut>⌘P</CommandShortcut>
+          </CommandItem>
+          <CommandItem value="Billing">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="5" rx="2" /><line x1="2" x2="22" y1="10" y2="10" /></svg>
+            <span>Billing</span>
+            <CommandShortcut>⌘B</CommandShortcut>
+          </CommandItem>
+          <CommandItem value="Settings">
+            <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" /><circle cx="12" cy="12" r="3" /></svg>
+            <span>Settings</span>
+            <CommandShortcut>⌘S</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+/**
+ * Dialog demo — Cmd+K triggered command palette.
+ */
+export function CommandDialogDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  createEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'j' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen(prev => !prev)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
+  })
+
+  return (
+    <div>
+      <p className="text-sm text-muted-foreground">
+        Press{' '}
+        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+          <span className="text-xs">⌘</span>J
+        </kbd>
+        {' '}or click the button below.
+      </p>
+      <button
+        type="button"
+        className="mt-4 inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2"
+        data-command-dialog-trigger
+        ref={(el: HTMLElement) => {
+          el.addEventListener('click', () => setOpen(true))
+        }}
+      >
+        Open Command Palette
+      </button>
+      <CommandDialog open={open()} onOpenChange={setOpen}>
+        <CommandInput placeholder="Type a command or search..." />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading="Suggestions">
+            <CommandItem value="Calendar">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2" ry="2" /><line x1="16" x2="16" y1="2" y2="6" /><line x1="8" x2="8" y1="2" y2="6" /><line x1="3" x2="21" y1="10" y2="10" /></svg>
+              <span>Calendar</span>
+            </CommandItem>
+            <CommandItem value="Search Emoji">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><path d="M8 14s1.5 2 4 2 4-2 4-2" /><line x1="9" x2="9.01" y1="9" y2="9" /><line x1="15" x2="15.01" y1="9" y2="9" /></svg>
+              <span>Search Emoji</span>
+            </CommandItem>
+            <CommandItem value="Calculator">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="16" height="20" x="4" y="2" rx="2" /><line x1="8" x2="16" y1="6" y2="6" /><line x1="16" x2="16" y1="14" y2="18" /><path d="M16 10h.01" /><path d="M12 10h.01" /><path d="M8 10h.01" /><path d="M12 14h.01" /><path d="M8 14h.01" /><path d="M12 18h.01" /><path d="M8 18h.01" /></svg>
+              <span>Calculator</span>
+            </CommandItem>
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Settings">
+            <CommandItem value="Profile">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg>
+              <span>Profile</span>
+              <CommandShortcut>⌘P</CommandShortcut>
+            </CommandItem>
+            <CommandItem value="Billing">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="5" rx="2" /><line x1="2" x2="22" y1="10" y2="10" /></svg>
+              <span>Billing</span>
+              <CommandShortcut>⌘B</CommandShortcut>
+            </CommandItem>
+            <CommandItem value="Settings">
+              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" /><circle cx="12" cy="12" r="3" /></svg>
+              <span>Settings</span>
+              <CommandShortcut>⌘S</CommandShortcut>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </div>
+  )
+}
+
+/**
+ * Custom filter demo — prefix match instead of default substring match.
+ */
+export function CommandFilterDemo() {
+  const prefixFilter = (value: string, search: string) => {
+    if (!search) return true
+    return value.toLowerCase().startsWith(search.toLowerCase())
+  }
+
+  return (
+    <Command filter={prefixFilter} class="rounded-lg border shadow-md md:min-w-[450px]">
+      <CommandInput placeholder="Try prefix matching..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Fruits">
+          <CommandItem value="Apple">Apple</CommandItem>
+          <CommandItem value="Apricot">Apricot</CommandItem>
+          <CommandItem value="Banana">Banana</CommandItem>
+          <CommandItem value="Blueberry">Blueberry</CommandItem>
+          <CommandItem value="Cherry">Cherry</CommandItem>
+          <CommandItem value="Cranberry">Cranberry</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}

--- a/site/ui/components/command-palette.tsx
+++ b/site/ui/components/command-palette.tsx
@@ -26,6 +26,7 @@ const componentItems = [
   { id: 'button', title: 'Button', href: '/docs/components/button', category: 'Components' },
   { id: 'card', title: 'Card', href: '/docs/components/card', category: 'Components' },
   { id: 'checkbox', title: 'Checkbox', href: '/docs/components/checkbox', category: 'Components' },
+  { id: 'command', title: 'Command', href: '/docs/components/command', category: 'Components' },
   { id: 'dialog', title: 'Dialog', href: '/docs/components/dialog', category: 'Components' },
   { id: 'dropdown-menu', title: 'Dropdown Menu', href: '/docs/components/dropdown-menu', category: 'Components' },
   { id: 'input', title: 'Input', href: '/docs/components/input', category: 'Components' },

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -15,6 +15,7 @@ export const componentOrder = [
   { slug: 'card', title: 'Card' },
   { slug: 'checkbox', title: 'Checkbox' },
   { slug: 'collapsible', title: 'Collapsible' },
+  { slug: 'command', title: 'Command' },
   { slug: 'context-menu', title: 'Context Menu' },
   { slug: 'dialog', title: 'Dialog' },
   { slug: 'drawer', title: 'Drawer' },

--- a/site/ui/e2e/command.spec.ts
+++ b/site/ui/e2e/command.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Command Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/command')
+  })
+
+  test('displays page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Command')
+    await expect(page.locator('text=A command menu with search')).toBeVisible()
+  })
+
+  test('displays installation section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
+    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
+    await expect(page.locator('button:has-text("bun")')).toBeVisible()
+  })
+
+  test.describe('Preview Demo', () => {
+    test('displays command input', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      await expect(section).toBeVisible()
+      const input = section.locator('input[data-slot="command-input"]')
+      await expect(input).toBeVisible()
+    })
+
+    test('displays groups with headings', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      await expect(section.locator('[data-slot="command-group-heading"]').first()).toBeVisible()
+      await expect(section.locator('[data-slot="command-group-heading"]')).toHaveCount(2)
+    })
+
+    test('displays command items', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      await expect(section.locator('[data-slot="command-item"]')).toHaveCount(6)
+    })
+
+    test('displays keyboard shortcuts', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      await expect(section.locator('[data-slot="command-shortcut"]')).toHaveCount(3)
+    })
+
+    test('filtering hides non-matching items', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      const input = section.locator('input[data-slot="command-input"]')
+
+      await input.fill('cal')
+      // Wait for reactive effects + rAF
+      await page.waitForTimeout(300)
+
+      // "Calendar" and "Calculator" should be visible (contain "cal")
+      const visibleItems = section.locator('[data-slot="command-item"]:visible')
+      await expect(visibleItems).toHaveCount(2)
+    })
+
+    test('filtering shows empty state when no matches', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      const input = section.locator('input[data-slot="command-input"]')
+
+      await input.fill('zzzzz')
+      await page.waitForTimeout(300)
+
+      await expect(section.locator('[data-slot="command-empty"]')).toBeVisible()
+    })
+
+    test('arrow key navigation changes selected item', async ({ page }) => {
+      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
+      const input = section.locator('input[data-slot="command-input"]')
+
+      // Type something to trigger auto-selection, then clear
+      await input.click()
+      await input.fill('a')
+      await page.waitForTimeout(200)
+      await input.fill('')
+      await page.waitForTimeout(200)
+
+      // Press ArrowDown and verify selection changes
+      await page.keyboard.press('ArrowDown')
+      await page.waitForTimeout(100)
+
+      // Second item should now be selected
+      const items = section.locator('[data-slot="command-item"]')
+      await expect(items.nth(1)).toHaveAttribute('data-selected', 'true')
+    })
+  })
+
+  test.describe('Dialog Demo', () => {
+    test('displays dialog trigger button', async ({ page }) => {
+      await expect(page.locator('[data-command-dialog-trigger]')).toBeVisible()
+    })
+
+    test('opens dialog on button click', async ({ page }) => {
+      await page.locator('[data-command-dialog-trigger]').click()
+      await page.waitForTimeout(200)
+
+      const dialog = page.locator('[role="dialog"]')
+      await expect(dialog).toBeVisible()
+      const input = dialog.locator('input[data-slot="command-input"]')
+      await expect(input).toBeVisible()
+    })
+
+    test('closes dialog on ESC', async ({ page }) => {
+      await page.locator('[data-command-dialog-trigger]').click()
+      await page.waitForTimeout(200)
+
+      await expect(page.locator('[role="dialog"]')).toBeVisible()
+
+      await page.keyboard.press('Escape')
+      await page.waitForTimeout(200)
+
+      const dialog = page.locator('[data-slot="dialog-content"]')
+      await expect(dialog).toHaveAttribute('data-state', 'closed')
+    })
+  })
+
+  test.describe('API Reference', () => {
+    test('displays API Reference section', async ({ page }) => {
+      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
+    })
+
+    test('displays Command props table', async ({ page }) => {
+      await expect(page.locator('h3').filter({ hasText: /^Command$/ })).toBeVisible()
+    })
+
+    test('displays CommandInput props table', async ({ page }) => {
+      await expect(page.locator('h3:has-text("CommandInput")')).toBeVisible()
+    })
+
+    test('displays CommandItem props table', async ({ page }) => {
+      await expect(page.locator('h3:has-text("CommandItem")')).toBeVisible()
+    })
+  })
+})
+
+test.describe('Home Page', () => {
+  test('displays Command card', async ({ page }) => {
+    await page.goto('/')
+    const card = page.locator('#components a[href="/docs/components/command"]')
+    await expect(card).toBeVisible()
+    await expect(card.locator('h3')).toContainText('Command')
+  })
+})

--- a/site/ui/pages/command.tsx
+++ b/site/ui/pages/command.tsx
@@ -1,0 +1,301 @@
+/**
+ * Command Documentation Page
+ */
+
+import { CommandPreviewDemo, CommandDialogDemo, CommandFilterDemo } from '@/components/command-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'dialog', title: 'Dialog', branch: 'start' },
+  { id: 'custom-filter', title: 'Custom Filter', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const previewCode = `"use client"
+
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from '@/components/ui/command'
+
+function CommandMenu() {
+  return (
+    <Command class="rounded-lg border shadow-md md:min-w-[450px]">
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem value="Calendar">Calendar</CommandItem>
+          <CommandItem value="Search Emoji">Search Emoji</CommandItem>
+          <CommandItem value="Calculator">Calculator</CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Settings">
+          <CommandItem value="Profile">
+            Profile
+            <CommandShortcut>⌘P</CommandShortcut>
+          </CommandItem>
+          <CommandItem value="Billing">
+            Billing
+            <CommandShortcut>⌘B</CommandShortcut>
+          </CommandItem>
+          <CommandItem value="Settings">
+            Settings
+            <CommandShortcut>⌘S</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}`
+
+const dialogCode = `"use client"
+
+import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from '@/components/ui/command'
+
+function CommandDialogDemo() {
+  const [open, setOpen] = createSignal(false)
+
+  createEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'j' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen(prev => !prev)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
+  })
+
+  return (
+    <>
+      <p className="text-sm text-muted-foreground">
+        Press <kbd>⌘J</kbd> or click the button.
+      </p>
+      <button onClick={() => setOpen(true)}>
+        Open Command Palette
+      </button>
+      <CommandDialog open={open()} onOpenChange={setOpen}>
+        <CommandInput placeholder="Type a command or search..." />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading="Suggestions">
+            <CommandItem>Calendar</CommandItem>
+            <CommandItem>Search Emoji</CommandItem>
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Settings">
+            <CommandItem>Profile<CommandShortcut>⌘P</CommandShortcut></CommandItem>
+            <CommandItem>Settings<CommandShortcut>⌘S</CommandShortcut></CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
+  )
+}`
+
+const filterCode = `import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command'
+
+function CommandFilterDemo() {
+  // Prefix match: only show items starting with the search string
+  const prefixFilter = (value: string, search: string) => {
+    if (!search) return true
+    return value.toLowerCase().startsWith(search.toLowerCase())
+  }
+
+  return (
+    <Command filter={prefixFilter} class="rounded-lg border shadow-md">
+      <CommandInput placeholder="Try prefix matching..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Fruits">
+          <CommandItem value="Apple">Apple</CommandItem>
+          <CommandItem value="Apricot">Apricot</CommandItem>
+          <CommandItem value="Banana">Banana</CommandItem>
+          <CommandItem value="Blueberry">Blueberry</CommandItem>
+          <CommandItem value="Cherry">Cherry</CommandItem>
+          <CommandItem value="Cranberry">Cranberry</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}`
+
+// Props definitions
+const commandProps: PropDefinition[] = [
+  {
+    name: 'filter',
+    type: '(value: string, search: string, keywords?: string[]) => boolean',
+    description: 'Custom filter function. Default is case-insensitive substring match.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when selected item changes.',
+  },
+]
+
+const commandInputProps: PropDefinition[] = [
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text for the search input.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the input is disabled.',
+  },
+]
+
+const commandItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Value for filtering and selection. Defaults to textContent.',
+  },
+  {
+    name: 'keywords',
+    type: 'string[]',
+    description: 'Additional keywords for search matching.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the item is disabled.',
+  },
+  {
+    name: 'onSelect',
+    type: '(value: string) => void',
+    description: 'Callback when the item is selected.',
+  },
+]
+
+const commandGroupProps: PropDefinition[] = [
+  {
+    name: 'heading',
+    type: 'string',
+    description: 'Heading text for the group.',
+  },
+]
+
+const commandDialogProps: PropDefinition[] = [
+  {
+    name: 'open',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the dialog is open.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Callback when the open state should change.',
+  },
+  {
+    name: 'filter',
+    type: '(value: string, search: string, keywords?: string[]) => boolean',
+    description: 'Custom filter function passed to Command.',
+  },
+]
+
+export function CommandPage() {
+  return (
+    <DocPage slug="command" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Command"
+          description="A command menu with search, keyboard navigation, and filtering. Use it as an inline menu or inside a dialog for a command palette experience."
+          {...getNavLinks('command')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <CommandPreviewDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add command" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Dialog" code={dialogCode}>
+              <CommandDialogDemo />
+            </Example>
+
+            <Example title="Custom Filter" code={filterCode}>
+              <CommandFilterDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">Command</h3>
+              <PropsTable props={commandProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CommandInput</h3>
+              <PropsTable props={commandInputProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CommandItem</h3>
+              <PropsTable props={commandItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CommandGroup</h3>
+              <PropsTable props={commandGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">CommandDialog</h3>
+              <PropsTable props={commandDialogProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -80,6 +80,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Card', href: '/docs/components/card' },
       { title: 'Checkbox', href: '/docs/components/checkbox' },
       { title: 'Collapsible', href: '/docs/components/collapsible' },
+      { title: 'Command', href: '/docs/components/command' },
       { title: 'Context Menu', href: '/docs/components/context-menu' },
       { title: 'Dialog', href: '/docs/components/dialog' },
       { title: 'Drawer', href: '/docs/components/drawer' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -21,6 +21,7 @@ import { SliderPage } from './pages/slider'
 import { SwitchPage } from './pages/switch'
 import { AccordionPage } from './pages/accordion'
 import { CollapsiblePage } from './pages/collapsible'
+import { CommandPage } from './pages/command'
 import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
 import { ContextMenuPage } from './pages/context-menu'
@@ -109,6 +110,10 @@ export function createApp() {
             <a href="/docs/components/collapsible" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Collapsible</h3>
               <p className="text-xs text-muted-foreground">Expandable content section</p>
+            </a>
+            <a href="/docs/components/command" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Command</h3>
+              <p className="text-xs text-muted-foreground">Search and command menu</p>
             </a>
             <a href="/docs/components/context-menu" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Context Menu</h3>
@@ -282,6 +287,11 @@ export function createApp() {
   // Collapsible documentation
   app.get('/docs/components/collapsible', (c) => {
     return c.render(<CollapsiblePage />)
+  })
+
+  // Command documentation
+  app.get('/docs/components/command', (c) => {
+    return c.render(<CommandPage />)
   })
 
   // Checkbox documentation

--- a/ui/components/ui/__tests__/command.test.ts
+++ b/ui/components/ui/__tests__/command.test.ts
@@ -1,0 +1,258 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const commandSource = readFileSync(resolve(__dirname, '../command.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Command (stateful — search signal, selected signal, keyboard nav, context)
+// ---------------------------------------------------------------------------
+
+describe('Command', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'Command')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Command', () => {
+    expect(result.componentName).toBe('Command')
+  })
+
+  test('renders as Provider wrapping a div', () => {
+    // The root is Provider, find the div inside
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('command')
+  })
+
+  test('has resolved CSS classes', () => {
+    const div = result.find({ tag: 'div' })!
+    expect(div.classes).toContain('flex')
+    expect(div.classes).toContain('flex-col')
+    expect(div.classes).toContain('overflow-hidden')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandInput (stateful — writes to context search signal)
+// ---------------------------------------------------------------------------
+
+describe('CommandInput', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandInput')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandInput', () => {
+    expect(result.componentName).toBe('CommandInput')
+  })
+
+  test('renders wrapper with data-slot=command-input-wrapper', () => {
+    expect(result.root.props['data-slot']).toBe('command-input-wrapper')
+  })
+
+  test('contains an input element', () => {
+    const input = result.find({ tag: 'input' })
+    expect(input).not.toBeNull()
+    expect(input!.props['data-slot']).toBe('command-input')
+  })
+
+  test('contains a search icon (svg)', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+  })
+
+  test('input has resolved CSS classes', () => {
+    const input = result.find({ tag: 'input' })!
+    expect(input.classes).toContain('text-sm')
+    expect(input.classes).toContain('bg-transparent')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandList (stateless — scrollable container)
+// ---------------------------------------------------------------------------
+
+describe('CommandList', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandList')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandList', () => {
+    expect(result.componentName).toBe('CommandList')
+  })
+
+  test('renders as div with data-slot=command-list', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('command-list')
+  })
+
+  test('has role=listbox', () => {
+    expect(result.root.role).toBe('listbox')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('overflow-y-auto')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandEmpty (stateful — checks visible items to toggle visibility)
+// ---------------------------------------------------------------------------
+
+describe('CommandEmpty', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandEmpty')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandEmpty', () => {
+    expect(result.componentName).toBe('CommandEmpty')
+  })
+
+  test('renders as div with data-slot=command-empty', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('command-empty')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-center')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandGroup (stateful — auto-hides when all items filtered)
+// ---------------------------------------------------------------------------
+
+describe('CommandGroup', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandGroup')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandGroup', () => {
+    expect(result.componentName).toBe('CommandGroup')
+  })
+
+  test('renders as div with data-slot=command-group', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('command-group')
+  })
+
+  test('has role=group', () => {
+    expect(result.root.role).toBe('group')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('overflow-hidden')
+    expect(result.root.classes).toContain('p-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandItem (stateful — self-filters, selected highlight, click handler)
+// ---------------------------------------------------------------------------
+
+describe('CommandItem', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandItem', () => {
+    expect(result.componentName).toBe('CommandItem')
+  })
+
+  test('renders as div with data-slot=command-item', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('command-item')
+  })
+
+  test('has role=option', () => {
+    expect(result.root.role).toBe('option')
+  })
+
+  test('has data-selected attribute', () => {
+    expect(result.root.props['data-selected']).toBe('false')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+    expect(result.root.classes).toContain('rounded-sm')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandSeparator (stateless)
+// ---------------------------------------------------------------------------
+
+describe('CommandSeparator', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandSeparator')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandSeparator', () => {
+    expect(result.componentName).toBe('CommandSeparator')
+  })
+
+  test('renders as div with data-slot=command-separator', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('command-separator')
+  })
+
+  test('has role=separator', () => {
+    expect(result.root.role).toBe('separator')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('bg-border')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CommandShortcut (stateless)
+// ---------------------------------------------------------------------------
+
+describe('CommandShortcut', () => {
+  const result = renderToTest(commandSource, 'command.tsx', 'CommandShortcut')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CommandShortcut', () => {
+    expect(result.componentName).toBe('CommandShortcut')
+  })
+
+  test('renders as span with data-slot=command-shortcut', () => {
+    expect(result.root.tag).toBe('span')
+    expect(result.root.props['data-slot']).toBe('command-shortcut')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('ml-auto')
+    expect(result.root.classes).toContain('text-xs')
+    expect(result.root.classes).toContain('tracking-widest')
+  })
+})

--- a/ui/components/ui/command.tsx
+++ b/ui/components/ui/command.tsx
@@ -1,0 +1,502 @@
+"use client"
+
+/**
+ * Command Components
+ *
+ * A command menu with search and keyboard navigation.
+ * Inspired by shadcn/ui Command (cmdk-based) with CSS variable theming support.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Command root manages search/selected state, children consume via context.
+ *
+ * Features:
+ * - Search filtering (case-insensitive substring by default)
+ * - Arrow key navigation
+ * - Enter to select
+ * - Auto-selection of first visible item on search change
+ * - CommandDialog wraps Command in Dialog for Cmd+K style usage
+ * - Accessibility (role="listbox", role="option")
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Command>
+ *   <CommandInput placeholder="Type a command..." />
+ *   <CommandList>
+ *     <CommandEmpty>No results found.</CommandEmpty>
+ *     <CommandGroup heading="Suggestions">
+ *       <CommandItem>Calendar</CommandItem>
+ *       <CommandItem>Search</CommandItem>
+ *     </CommandGroup>
+ *   </CommandList>
+ * </Command>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect } from '@barefootjs/dom'
+import {
+  Dialog,
+  DialogOverlay,
+  DialogContent,
+} from './dialog'
+import type { Child } from '../../types'
+
+// Context for Command → children state sharing
+interface CommandContextValue {
+  search: () => string
+  onSearchChange: (value: string) => void
+  selectedValue: () => string
+  onSelect: (value: string) => void
+  registerItem: (el: HTMLElement) => void
+  unregisterItem: (el: HTMLElement) => void
+  filter: (value: string, search: string, keywords?: string[]) => boolean
+}
+
+const CommandContext = createContext<CommandContextValue>()
+
+// CSS classes (aligned with shadcn/ui)
+const commandRootClasses = 'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground'
+const commandInputWrapperClasses = 'flex items-center border-b px-3'
+const commandInputClasses = 'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50'
+const commandListClasses = 'max-h-[300px] overflow-y-auto overflow-x-hidden'
+const commandGroupClasses = 'overflow-hidden p-1 text-foreground [&_[data-slot=command-group-heading]]:px-2 [&_[data-slot=command-group-heading]]:py-1.5 [&_[data-slot=command-group-heading]]:text-xs [&_[data-slot=command-group-heading]]:font-medium [&_[data-slot=command-group-heading]]:text-muted-foreground'
+const commandItemClasses = 'relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0'
+const commandEmptyClasses = 'py-6 text-center text-sm'
+const commandSeparatorClasses = '-mx-1 h-px bg-border'
+const commandShortcutClasses = 'ml-auto text-xs tracking-widest text-muted-foreground'
+
+// CommandDialog classes
+const commandDialogContentClasses = 'overflow-hidden p-0'
+const commandDialogCommandClasses = '[&_[data-slot=command-input-wrapper]]:h-12'
+
+// --- Props ---
+
+interface CommandProps {
+  /** Custom filter function */
+  filter?: (value: string, search: string, keywords?: string[]) => boolean
+  /** Callback when an item is selected */
+  onValueChange?: (value: string) => void
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandInputProps {
+  /** Placeholder text */
+  placeholder?: string
+  /** Whether disabled */
+  disabled?: boolean
+  /** Additional CSS classes */
+  class?: string
+}
+
+interface CommandListProps {
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandEmptyProps {
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandGroupProps {
+  /** Group heading text */
+  heading?: string
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandItemProps {
+  /** Value for filtering and selection (defaults to textContent) */
+  value?: string
+  /** Keywords for search matching */
+  keywords?: string[]
+  /** Whether disabled */
+  disabled?: boolean
+  /** Callback when selected */
+  onSelect?: (value: string) => void
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandSeparatorProps {
+  /** Additional CSS classes */
+  class?: string
+}
+
+interface CommandShortcutProps {
+  /** Additional CSS classes */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+interface CommandDialogProps {
+  /** Whether the dialog is open */
+  open?: boolean
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void
+  /** Command filter function */
+  filter?: (value: string, search: string, keywords?: string[]) => boolean
+  /** Additional CSS classes for Command */
+  class?: string
+  /** Children */
+  children?: Child
+}
+
+/**
+ * Command root component.
+ * Manages search state, selected item, and keyboard navigation.
+ */
+function Command(props: CommandProps) {
+  const [search, setSearch] = createSignal('')
+  const [selectedValue, setSelectedValue] = createSignal('')
+  const items = new Set<HTMLElement>()
+
+  const filterFn = props.filter ?? ((value: string, search: string) => {
+    if (!search) return true
+    return value.toLowerCase().includes(search.toLowerCase())
+  })
+
+  const handleMount = (el: HTMLElement) => {
+    // Auto-select first visible item when search changes
+    createEffect(() => {
+      search() // track dependency
+      // Use rAF to run after item effects have updated visibility
+      requestAnimationFrame(() => {
+        const visibleItems = Array.from(el.querySelectorAll('[data-slot="command-item"]:not([hidden])')) as HTMLElement[]
+        if (visibleItems.length > 0) {
+          const firstValue = visibleItems[0].getAttribute('data-value') ?? ''
+          setSelectedValue(firstValue)
+        } else {
+          setSelectedValue('')
+        }
+      })
+    })
+
+    // Keyboard navigation
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      const visibleItems = Array.from(el.querySelectorAll('[data-slot="command-item"]:not([hidden])')) as HTMLElement[]
+      if (visibleItems.length === 0) return
+
+      const currentValue = selectedValue()
+      const currentIndex = visibleItems.findIndex(item => item.getAttribute('data-value') === currentValue)
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault()
+          const nextIndex = currentIndex < visibleItems.length - 1 ? currentIndex + 1 : 0
+          const nextValue = visibleItems[nextIndex].getAttribute('data-value') ?? ''
+          setSelectedValue(nextValue)
+          visibleItems[nextIndex].scrollIntoView({ block: 'nearest' })
+          break
+        }
+        case 'ArrowUp': {
+          e.preventDefault()
+          const prevIndex = currentIndex > 0 ? currentIndex - 1 : visibleItems.length - 1
+          const prevValue = visibleItems[prevIndex].getAttribute('data-value') ?? ''
+          setSelectedValue(prevValue)
+          visibleItems[prevIndex].scrollIntoView({ block: 'nearest' })
+          break
+        }
+        case 'Enter': {
+          e.preventDefault()
+          const selected = visibleItems[currentIndex]
+          if (selected && selected.getAttribute('data-disabled') !== 'true') {
+            selected.click()
+          }
+          break
+        }
+      }
+    })
+  }
+
+  return (
+    <CommandContext.Provider value={{
+      search,
+      onSearchChange: setSearch,
+      selectedValue,
+      onSelect: (value: string) => {
+        setSelectedValue(value)
+        props.onValueChange?.(value)
+      },
+      registerItem: (el: HTMLElement) => items.add(el),
+      unregisterItem: (el: HTMLElement) => items.delete(el),
+      filter: filterFn,
+    }}>
+      <div
+        data-slot="command"
+        className={`${commandRootClasses} ${props.class ?? ''}`}
+        ref={handleMount}
+      >
+        {props.children}
+      </div>
+    </CommandContext.Provider>
+  )
+}
+
+/**
+ * Search input for the command menu.
+ * Writes to context's onSearchChange.
+ */
+function CommandInput(props: CommandInputProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CommandContext)
+    const input = el.querySelector('input') as HTMLInputElement
+    if (!input) return
+
+    input.addEventListener('input', () => {
+      ctx.onSearchChange(input.value)
+    })
+
+    // Keep input in sync with search state
+    createEffect(() => {
+      const val = ctx.search()
+      if (input.value !== val) {
+        input.value = val
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className={commandInputWrapperClasses}
+      ref={handleMount}
+    >
+      <svg className="mr-2 size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+      <input
+        data-slot="command-input"
+        type="text"
+        placeholder={props.placeholder}
+        disabled={props.disabled ?? false}
+        className={`${commandInputClasses} ${props.class ?? ''}`}
+        autocomplete="off"
+      />
+    </div>
+  )
+}
+
+/**
+ * Scrollable container for command items and groups.
+ */
+function CommandList({ class: className = '', children }: CommandListProps) {
+  return (
+    <div
+      data-slot="command-list"
+      role="listbox"
+      className={`${commandListClasses} ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * "No results" message. Auto-shows when no items are visible.
+ */
+function CommandEmpty(props: CommandEmptyProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CommandContext)
+
+    createEffect(() => {
+      ctx.search() // track dependency
+      // Check after items have updated their visibility
+      requestAnimationFrame(() => {
+        const list = el.closest('[data-slot="command-list"]') ?? el.closest('[data-slot="command"]')
+        if (!list) return
+        const visibleItems = list.querySelectorAll('[data-slot="command-item"]:not([hidden])')
+        el.hidden = visibleItems.length > 0
+      })
+    })
+  }
+
+  return (
+    <div
+      data-slot="command-empty"
+      hidden
+      className={`${commandEmptyClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Group of related command items with an optional heading.
+ * Auto-hides when all items within are filtered out.
+ */
+function CommandGroup(props: CommandGroupProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CommandContext)
+
+    createEffect(() => {
+      ctx.search() // track dependency
+      // Check after items have updated their visibility
+      requestAnimationFrame(() => {
+        const items = el.querySelectorAll('[data-slot="command-item"]')
+        const visibleItems = el.querySelectorAll('[data-slot="command-item"]:not([hidden])')
+        // Hide the group if it has items but none are visible
+        el.hidden = items.length > 0 && visibleItems.length === 0
+      })
+    })
+  }
+
+  return (
+    <div
+      data-slot="command-group"
+      role="group"
+      className={`${commandGroupClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.heading && (
+        <div data-slot="command-group-heading" aria-hidden="true">
+          {props.heading}
+        </div>
+      )}
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Individual selectable item in the command menu.
+ * Self-filters based on search context. Shows data-selected highlight.
+ */
+function CommandItem(props: CommandItemProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(CommandContext)
+
+    // Resolve value from prop or textContent
+    const resolveValue = () => {
+      return props.value ?? el.textContent?.trim() ?? ''
+    }
+
+    // Set data-value for keyboard nav
+    const value = resolveValue()
+    el.setAttribute('data-value', value)
+
+    ctx.registerItem(el)
+
+    // Self-filter based on search
+    createEffect(() => {
+      const s = ctx.search()
+      const v = resolveValue()
+      const visible = ctx.filter(v, s, props.keywords)
+      el.hidden = !visible
+    })
+
+    // Selected state
+    createEffect(() => {
+      const isSelected = ctx.selectedValue() === resolveValue()
+      el.setAttribute('data-selected', String(isSelected))
+    })
+
+    // Click handler
+    el.addEventListener('click', () => {
+      if (el.getAttribute('data-disabled') === 'true') return
+      const v = resolveValue()
+      ctx.onSelect(v)
+      props.onSelect?.(v)
+    })
+
+    // Hover to select
+    el.addEventListener('pointerenter', () => {
+      if (el.getAttribute('data-disabled') === 'true') return
+      const v = resolveValue()
+      ctx.onSelect(v)
+    })
+  }
+
+  const isDisabled = props.disabled ?? false
+
+  return (
+    <div
+      data-slot="command-item"
+      role="option"
+      data-disabled={isDisabled || undefined}
+      data-selected="false"
+      className={`${commandItemClasses} ${props.class ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Visual separator between command groups.
+ */
+function CommandSeparator({ class: className = '' }: CommandSeparatorProps) {
+  return (
+    <div
+      data-slot="command-separator"
+      role="separator"
+      className={`${commandSeparatorClasses} ${className}`}
+    />
+  )
+}
+
+/**
+ * Keyboard shortcut label displayed alongside a command item.
+ */
+function CommandShortcut({ class: className = '', children }: CommandShortcutProps) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={`${commandShortcutClasses} ${className}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+/**
+ * Command menu wrapped in a Dialog.
+ * Provides a Cmd+K style command palette experience.
+ */
+function CommandDialog(props: CommandDialogProps) {
+  return (
+    <Dialog open={props.open ?? false} onOpenChange={props.onOpenChange ?? (() => {})}>
+      <DialogOverlay />
+      <DialogContent class={`${commandDialogContentClasses} max-w-lg p-0`}>
+        <Command filter={props.filter} class={commandDialogCommandClasses}>
+          {props.children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+  CommandDialog,
+}
+export type {
+  CommandProps,
+  CommandInputProps,
+  CommandListProps,
+  CommandEmptyProps,
+  CommandGroupProps,
+  CommandItemProps,
+  CommandSeparatorProps,
+  CommandShortcutProps,
+  CommandDialogProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -34,6 +34,12 @@
       "description": "An interactive component which expands/collapses a panel"
     },
     {
+      "name": "command",
+      "type": "registry:ui",
+      "title": "Command",
+      "description": "A command menu with search, keyboard navigation, and filtering"
+    },
+    {
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",


### PR DESCRIPTION
## Summary
- Port shadcn/ui Command (cmdk-based) to BarefootJS with context-based state management
- 9 sub-components: Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandSeparator, CommandShortcut, CommandDialog
- Features: search filtering, arrow key navigation, Enter to select, auto-selection of first visible item, dialog mode (Cmd+K style)
- 3 demos: inline preview, dialog trigger, custom prefix-match filter
- Documentation page with installation, examples, and API reference
- Registered in site navigation, sidebar, page nav, command palette, and registry

## Test plan
- [x] IR tests: 39 tests covering all sub-components (data-slot, roles, CSS classes, compiler errors)
- [x] E2E tests: 17 tests covering rendering, filtering, keyboard navigation, dialog open/close, empty state, API reference section, and home page card

🤖 Generated with [Claude Code](https://claude.com/claude-code)