### PR TITLE
Add BF044: emit error when signal/memo getter is passed without calling it

### DIFF
--- a/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
+++ b/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Signal/Memo Getter Not Called Error Tests
+ *
+ * Tests for BF044: Emit compile error when a signal or memo getter
+ * is passed without calling it (e.g., value={count} instead of value={count()}).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSXSync } from '../compiler'
+import { ErrorCodes } from '../errors'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+/**
+ * Helper: analyze and transform to IR, returning errors from ctx.
+ */
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, 'Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('Signal Getter Not Called (BF044)', () => {
+  describe('positive cases — should emit BF044', () => {
+    test('signal getter as attribute value', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(1)
+      expect(bf044[0].severity).toBe('error')
+      expect(bf044[0].message).toContain("'count'")
+    })
+
+    test('signal getter in JSX children', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div>{count}</div>
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(1)
+      expect(bf044[0].message).toContain("'count'")
+    })
+
+    test('memo as attribute value', () => {
+      const source = `
+        'use client'
+        import { createSignal, createMemo } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          const doubled = createMemo(() => count() * 2)
+          return <div value={doubled} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(1)
+      expect(bf044[0].message).toContain("'doubled'")
+    })
+
+    test('memo in JSX children', () => {
+      const source = `
+        'use client'
+        import { createSignal, createMemo } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          const doubled = createMemo(() => count() * 2)
+          return <div>{doubled}</div>
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(1)
+      expect(bf044[0].message).toContain("'doubled'")
+    })
+
+    test('error suggestion includes corrected call syntax', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.find(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toBeDefined()
+      expect(bf044!.suggestion).toBeDefined()
+      expect(bf044!.suggestion!.message).toContain('count()')
+      expect(bf044!.suggestion!.replacement).toBe('count()')
+    })
+  })
+
+  describe('negative cases — should NOT emit BF044', () => {
+    test('correct signal call: value={count()}', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count()} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+
+    test('correct memo call: value={doubled()}', () => {
+      const source = `
+        'use client'
+        import { createSignal, createMemo } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          const doubled = createMemo(() => count() * 2)
+          return <div value={doubled()} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+
+    test('non-signal identifier: value={someLocal}', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          const someLocal = "hello"
+          return <div value={someLocal} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+
+    test('props access: value={props.checked}', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter(props: { checked: boolean }) {
+          const [count, setCount] = createSignal(0)
+          return <div value={props.checked} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+
+    test('complex expression: value={count() + 1}', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count() + 1} />
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+
+    test('setter passed to event handler: onChange={setCount}', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={setCount}>{count()}</button>
+        }
+      `
+
+      const { errors } = compileToIR(source)
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(0)
+    })
+  })
+
+  describe('integration', () => {
+    test('IR is still produced despite BF044 error', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count} />
+        }
+      `
+
+      const { ir, errors } = compileToIR(source)
+
+      const bf044 = errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+      expect(bf044).toHaveLength(1)
+
+      expect(ir).not.toBeNull()
+      expect(ir!.type).toBe('element')
+    })
+
+    test('compileJSXSync includes BF044 in result errors', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count} />
+        }
+      `
+
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const bf044 = result.errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
+
+      expect(bf044).toHaveLength(1)
+      expect(bf044[0].severity).toBe('error')
+    })
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -39,6 +39,7 @@ export const ErrorCodes = {
   CIRCULAR_DEPENDENCY: 'BF041',
   INVALID_COMPONENT_NAME: 'BF042',
   PROPS_DESTRUCTURING: 'BF043',
+  SIGNAL_GETTER_NOT_CALLED: 'BF044',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -75,6 +76,8 @@ const errorMessages: Record<ErrorCode, string> = {
     'Component name must start with uppercase letter',
   [ErrorCodes.PROPS_DESTRUCTURING]:
     'Props destructuring in function parameters breaks reactivity. Use props object directly.',
+  [ErrorCodes.SIGNAL_GETTER_NOT_CALLED]:
+    'Signal/memo getter passed without calling it. Use getter() to read the value.',
 }
 
 // =============================================================================

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -293,6 +293,7 @@ interface TemplateAdapter {
 | BF030 | Type inference failed |
 | BF031 | Props type mismatch |
 | BF043 | Props destructuring breaks reactivity |
+| BF044 | Signal/memo getter passed without calling it |
 
 ### Error Format
 
@@ -369,6 +370,34 @@ error[BF021]: Expression cannot be compiled to server template: Sort comparator 
 ```
 
 When `@client` is present, the compiler skips SSR for that expression without emitting an error.
+
+### Signal/Memo Getter Not Called (BF044)
+
+When a signal getter or memo is passed as a bare identifier (without calling it), the compiler emits a **BF044** error. This catches the common mistake of writing `value={count}` instead of `value={count()}`.
+
+```
+error[BF044]: Signal getter 'count' passed without calling it
+
+  --> src/components/Counter.tsx:7:24
+   |
+ 7 |           return <div value={count} />
+   |                        ^^^^^
+   |
+   = help: Signal getters must be called to read the value. Use `count()` instead of `count`.
+```
+
+**Detected patterns:**
+
+| Pattern | Detected? | Reason |
+|---------|-----------|--------|
+| `value={count}` | Yes (BF044) | Signal getter without `()` |
+| `{count}` | Yes (BF044) | Signal getter in JSX children |
+| `value={doubled}` | Yes (BF044) | Memo without `()` |
+| `value={count()}` | No | Correct usage |
+| `onClick={handler}` | No | Event handlers filtered before check |
+| `onChange={setCount}` | No | Setter, not getter |
+| `value={props.checked}` | No | Property access, not bare identifier |
+| `value={count() + 1}` | No | Expression, not bare identifier |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `BF044` error code to detect bare signal/memo getter identifiers in JSX (e.g., `value={count}` instead of `value={count()}`)
- Implement `checkBareSignalOrMemoIdentifier()` helper in `jsx-to-ir.ts` with checks in both `getAttributeValue()` and `transformExpression()`
- Add 13 tests covering positive cases (signal/memo in attrs and children), negative cases (correct calls, non-signal identifiers, setters, props), and integration
- Document BF044 in `spec/compiler.md` with error format and detected pattern table

## Test plan

- [x] `bun test src/__tests__/signal-getter-not-called.test.ts` — 13/13 pass
- [x] `bun test` (full suite) — 241/241 pass
- [x] Verified no false positives: setters (`setCount`), event handlers (`onClick`), props access (`props.checked`), and complex expressions (`count() + 1`) are not flagged

Closes #419