### PR TITLE
Replace class= with className= in JSX across UI components

### DIFF
--- a/site/ui/components/alert-dialog-demo.tsx
+++ b/site/ui/components/alert-dialog-demo.tsx
@@ -85,7 +85,7 @@ export function AlertDialogDestructiveDemo() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction class="bg-destructive text-white hover:bg-destructive/90">
+            <AlertDialogAction className="bg-destructive text-white hover:bg-destructive/90">
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/site/ui/components/collapsible-demo.tsx
+++ b/site/ui/components/collapsible-demo.tsx
@@ -22,14 +22,14 @@ import { ChevronDownIcon } from '@ui/components/ui/icon'
 export function CollapsibleBasicDemo() {
   return (
     <div className="w-full max-w-sm">
-      <Collapsible defaultOpen class="space-y-2">
+      <Collapsible defaultOpen className="space-y-2">
         <div className="flex items-center justify-between space-x-4">
           <h4 className="text-sm font-semibold">
             @barefootjs/dom has 3 repositories
           </h4>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="w-9 p-0">
-              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <ChevronDownIcon size="sm" className="transition-transform duration-normal" />
               <span className="sr-only">Toggle</span>
             </Button>
           </CollapsibleTrigger>
@@ -37,7 +37,7 @@ export function CollapsibleBasicDemo() {
         <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
           @barefootjs/dom
         </div>
-        <CollapsibleContent class="space-y-2">
+        <CollapsibleContent className="space-y-2">
           <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
             @barefootjs/jsx
           </div>
@@ -59,14 +59,14 @@ export function CollapsibleControlledDemo() {
 
   return (
     <div className="w-full max-w-sm space-y-4">
-      <Collapsible open={open()} onOpenChange={setOpen} class="space-y-2">
+      <Collapsible open={open()} onOpenChange={setOpen} className="space-y-2">
         <div className="flex items-center justify-between space-x-4">
           <h4 className="text-sm font-semibold">
             Starred Repositories
           </h4>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="w-9 p-0">
-              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <ChevronDownIcon size="sm" className="transition-transform duration-normal" />
               <span className="sr-only">Toggle</span>
             </Button>
           </CollapsibleTrigger>
@@ -74,7 +74,7 @@ export function CollapsibleControlledDemo() {
         <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
           solidjs/solid
         </div>
-        <CollapsibleContent class="space-y-2">
+        <CollapsibleContent className="space-y-2">
           <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
             honojs/hono
           </div>
@@ -96,14 +96,14 @@ export function CollapsibleControlledDemo() {
 export function CollapsibleDisabledDemo() {
   return (
     <div className="w-full max-w-sm">
-      <Collapsible disabled class="space-y-2">
+      <Collapsible disabled className="space-y-2">
         <div className="flex items-center justify-between space-x-4">
           <h4 className="text-sm font-semibold text-muted-foreground">
             Archived Repositories (disabled)
           </h4>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="w-9 p-0" disabled>
-              <ChevronDownIcon size="sm" class="transition-transform duration-normal" />
+              <ChevronDownIcon size="sm" className="transition-transform duration-normal" />
               <span className="sr-only">Toggle</span>
             </Button>
           </CollapsibleTrigger>
@@ -111,7 +111,7 @@ export function CollapsibleDisabledDemo() {
         <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs opacity-50">
           @barefootjs/legacy
         </div>
-        <CollapsibleContent class="space-y-2">
+        <CollapsibleContent className="space-y-2">
           <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
             @barefootjs/old-adapter
           </div>

--- a/site/ui/components/command-demo.tsx
+++ b/site/ui/components/command-demo.tsx
@@ -24,7 +24,7 @@ import {
  */
 export function CommandPreviewDemo() {
   return (
-    <Command class="rounded-lg border shadow-md md:min-w-[450px]">
+    <Command className="rounded-lg border shadow-md md:min-w-[450px]">
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
@@ -153,7 +153,7 @@ export function CommandFilterDemo() {
   }
 
   return (
-    <Command filter={prefixFilter} class="rounded-lg border shadow-md md:min-w-[450px]">
+    <Command filter={prefixFilter} className="rounded-lg border shadow-md md:min-w-[450px]">
       <CommandInput placeholder="Try prefix matching..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>

--- a/site/ui/components/dialog-demo.tsx
+++ b/site/ui/components/dialog-demo.tsx
@@ -205,9 +205,9 @@ export function DialogLongContentDemo() {
         <DialogContent
           ariaLabelledby="long-dialog-title"
           ariaDescribedby="long-dialog-description"
-          class="max-h-[66vh]"
+          className="max-h-[66vh]"
         >
-          <DialogHeader class="flex-shrink-0">
+          <DialogHeader className="flex-shrink-0">
             <DialogTitle id="long-dialog-title">Terms of Service</DialogTitle>
             <DialogDescription id="long-dialog-description">
               Please read the following terms carefully.
@@ -239,7 +239,7 @@ export function DialogLongContentDemo() {
               At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident.
             </p>
           </div>
-          <DialogFooter class="flex-shrink-0">
+          <DialogFooter className="flex-shrink-0">
             <DialogClose>Decline</DialogClose>
             <DialogClose>Accept</DialogClose>
           </DialogFooter>

--- a/site/ui/components/drawer-demo.tsx
+++ b/site/ui/components/drawer-demo.tsx
@@ -202,7 +202,7 @@ export function DrawerFormDemo() {
             </div>
           </div>
           <DrawerFooter>
-            <DrawerClose class="bg-primary text-primary-foreground hover:bg-primary/90 border-0 w-full">Submit</DrawerClose>
+            <DrawerClose className="bg-primary text-primary-foreground hover:bg-primary/90 border-0 w-full">Submit</DrawerClose>
             <DrawerClose>Cancel</DrawerClose>
           </DrawerFooter>
         </DrawerContent>

--- a/site/ui/components/dropdown-menu-demo.tsx
+++ b/site/ui/components/dropdown-menu-demo.tsx
@@ -105,7 +105,7 @@ export function DropdownMenuProfileDemo() {
 
   return (
     <DropdownMenu open={open()} onOpenChange={setOpen}>
-      <DropdownMenuTrigger class="rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+      <DropdownMenuTrigger className="rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
         <span
           className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-medium"
           aria-label="Profile menu"

--- a/site/ui/components/hover-card-demo.tsx
+++ b/site/ui/components/hover-card-demo.tsx
@@ -30,7 +30,7 @@ export function HoverCardPreviewDemo() {
           @barefootjs
         </a>
       </HoverCardTrigger>
-      <HoverCardContent align="start" class="w-80">
+      <HoverCardContent align="start" className="w-80">
         <div className="flex justify-between space-x-4">
           <div className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground text-lg font-bold shrink-0">
             B

--- a/site/ui/components/popover-demo.tsx
+++ b/site/ui/components/popover-demo.tsx
@@ -29,7 +29,7 @@ export function PopoverPreviewDemo() {
           Open popover
         </span>
       </PopoverTrigger>
-      <PopoverContent class="w-80">
+      <PopoverContent className="w-80">
         <div className="grid gap-4">
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Dimensions</h4>
@@ -125,7 +125,7 @@ export function PopoverFormDemo() {
           <span>Settings</span>
         </span>
       </PopoverTrigger>
-      <PopoverContent align="start" class="w-80">
+      <PopoverContent align="start" className="w-80">
         <div className="grid gap-4">
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Notifications</h4>
@@ -156,7 +156,7 @@ export function PopoverFormDemo() {
             </div>
           </div>
           <div className="flex justify-between">
-            <PopoverClose class="inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-1.5 text-sm hover:bg-accent">
+            <PopoverClose className="inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-1.5 text-sm hover:bg-accent">
               <span>Cancel</span>
             </PopoverClose>
             <button

--- a/site/ui/components/radio-group-demo.tsx
+++ b/site/ui/components/radio-group-demo.tsx
@@ -103,7 +103,7 @@ export function RadioGroupCardDemo() {
 
   return (
     <div className="space-y-4">
-      <RadioGroup defaultValue="startup" onValueChange={setPlan} class="grid-cols-1 sm:grid-cols-3">
+      <RadioGroup defaultValue="startup" onValueChange={setPlan} className="grid-cols-1 sm:grid-cols-3">
         <div className="relative">
           <label className="flex items-start space-x-3 rounded-lg border p-4 hover:bg-accent/50 cursor-pointer">
             <RadioGroupItem value="startup" />

--- a/site/ui/components/resizable-demo.tsx
+++ b/site/ui/components/resizable-demo.tsx
@@ -19,7 +19,7 @@ export function ResizableHorizontalDemo() {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      class="max-w-md rounded-lg border"
+      className="max-w-md rounded-lg border"
     >
       <ResizablePanel defaultSize={50}>
         <div className="flex h-[200px] items-center justify-center p-6">
@@ -43,7 +43,7 @@ export function ResizableVerticalDemo() {
   return (
     <ResizablePanelGroup
       direction="vertical"
-      class="min-h-[200px] max-w-md rounded-lg border"
+      className="min-h-[200px] max-w-md rounded-lg border"
     >
       <ResizablePanel defaultSize={25}>
         <div className="flex h-full items-center justify-center p-6">
@@ -67,7 +67,7 @@ export function ResizableWithHandleDemo() {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      class="min-h-[200px] max-w-md rounded-lg border"
+      className="min-h-[200px] max-w-md rounded-lg border"
     >
       <ResizablePanel defaultSize={25}>
         <div className="flex h-full items-center justify-center p-6">
@@ -91,7 +91,7 @@ export function ResizableThreePanelDemo() {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      class="min-h-[200px] rounded-lg border"
+      className="min-h-[200px] rounded-lg border"
     >
       <ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
         <div className="flex h-full items-center justify-center p-6">

--- a/site/ui/components/scroll-area-demo.tsx
+++ b/site/ui/components/scroll-area-demo.tsx
@@ -18,7 +18,7 @@ const tags = Array.from({ length: 50 }).map(
  */
 export function ScrollAreaTagsDemo() {
   return (
-    <ScrollArea class="h-72 w-48 rounded-md border">
+    <ScrollArea className="h-72 w-48 rounded-md border">
       <div className="p-4">
         <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
         {tags.map((tag) => (
@@ -47,7 +47,7 @@ export function ScrollAreaHorizontalDemo() {
   ]
 
   return (
-    <ScrollArea class="w-96 whitespace-nowrap rounded-md border">
+    <ScrollArea className="w-96 whitespace-nowrap rounded-md border">
       <div className="flex w-max space-x-4 p-4">
         {works.map((work) => (
           <figure className="shrink-0">
@@ -72,7 +72,7 @@ export function ScrollAreaHorizontalDemo() {
  */
 export function ScrollAreaBothAxesDemo() {
   return (
-    <ScrollArea class="h-64 w-80 rounded-md border">
+    <ScrollArea className="h-64 w-80 rounded-md border">
       <div className="p-4" style="width: 600px;">
         <h4 className="mb-4 text-sm font-medium leading-none">Changelog</h4>
         <div className="space-y-4">

--- a/site/ui/components/select-demo.tsx
+++ b/site/ui/components/select-demo.tsx
@@ -28,7 +28,7 @@ export function SelectBasicDemo() {
   return (
     <div className="space-y-3">
       <Select value={value()} onValueChange={setValue}>
-        <SelectTrigger class="w-[280px]">
+        <SelectTrigger className="w-[280px]">
           <SelectValue placeholder="Select a fruit..." />
         </SelectTrigger>
         <SelectContent>
@@ -127,7 +127,7 @@ export function SelectGroupedDemo() {
   return (
     <div className="space-y-3">
       <Select value={timezone()} onValueChange={setTimezone}>
-        <SelectTrigger class="w-[280px]">
+        <SelectTrigger className="w-[280px]">
           <SelectValue placeholder="Select timezone..." />
         </SelectTrigger>
         <SelectContent>

--- a/site/ui/components/switch-demo.tsx
+++ b/site/ui/components/switch-demo.tsx
@@ -103,7 +103,7 @@ export function SwitchConsentDemo() {
         <Switch
           checked={accepted()}
           onCheckedChange={setAccepted}
-          class="mt-px"
+          className="mt-px"
         />
         <div
           className="grid gap-1.5 leading-none cursor-pointer select-none"

--- a/ui/components/ui/accordion.tsx
+++ b/ui/components/ui/accordion.tsx
@@ -243,7 +243,7 @@ function AccordionTrigger(props: AccordionTriggerProps) {
         ref={handleMount}
       >
         {props.children}
-        <ChevronDownIcon size="sm" class={iconClasses} />
+        <ChevronDownIcon size="sm" className={iconClasses} />
       </button>
     </h3>
   )

--- a/ui/components/ui/badge.tsx
+++ b/ui/components/ui/badge.tsx
@@ -74,7 +74,7 @@ interface BadgeProps extends HTMLBaseAttributes {
  * @param props.asChild - Render child element instead of span
  */
 function Badge({
-  class: className = '',
+  className = '',
   variant = 'default',
   asChild = false,
   children,

--- a/ui/components/ui/icon.tsx
+++ b/ui/components/ui/icon.tsx
@@ -34,7 +34,6 @@ export type IconSize = 'sm' | 'md' | 'lg' | 'xl'
 
 export interface IconProps extends HTMLBaseAttributes {
   size?: IconSize
-  class?: string
 }
 
 // Map size to pixel values
@@ -72,7 +71,7 @@ export type IconName = keyof typeof strokePaths | 'github' | 'search' | 'setting
 // Icons that need butt linecap for proper visual centering
 const buttLinecapIcons = ['plus', 'minus'] as const
 
-export function CheckIcon({ size, class: className = '', ...props }: IconProps) {
+export function CheckIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -81,7 +80,7 @@ export function CheckIcon({ size, class: className = '', ...props }: IconProps) 
   )
 }
 
-export function ChevronDownIcon({ size, class: className = '', ...props }: IconProps) {
+export function ChevronDownIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -90,7 +89,7 @@ export function ChevronDownIcon({ size, class: className = '', ...props }: IconP
   )
 }
 
-export function ChevronUpIcon({ size, class: className = '', ...props }: IconProps) {
+export function ChevronUpIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -99,7 +98,7 @@ export function ChevronUpIcon({ size, class: className = '', ...props }: IconPro
   )
 }
 
-export function ChevronLeftIcon({ size, class: className = '', ...props }: IconProps) {
+export function ChevronLeftIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -108,7 +107,7 @@ export function ChevronLeftIcon({ size, class: className = '', ...props }: IconP
   )
 }
 
-export function ChevronRightIcon({ size, class: className = '', ...props }: IconProps) {
+export function ChevronRightIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -117,7 +116,7 @@ export function ChevronRightIcon({ size, class: className = '', ...props }: Icon
   )
 }
 
-export function XIcon({ size, class: className = '', ...props }: IconProps) {
+export function XIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -126,7 +125,7 @@ export function XIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function PlusIcon({ size, class: className = '', ...props }: IconProps) {
+export function PlusIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -135,7 +134,7 @@ export function PlusIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function MinusIcon({ size, class: className = '', ...props }: IconProps) {
+export function MinusIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="butt" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -144,7 +143,7 @@ export function MinusIcon({ size, class: className = '', ...props }: IconProps) 
   )
 }
 
-export function SunIcon({ size, class: className = '', ...props }: IconProps) {
+export function SunIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -153,7 +152,7 @@ export function SunIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function MoonIcon({ size, class: className = '', ...props }: IconProps) {
+export function MoonIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -162,7 +161,7 @@ export function MoonIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function MonitorIcon({ size, class: className = '', ...props }: IconProps) {
+export function MonitorIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -171,7 +170,7 @@ export function MonitorIcon({ size, class: className = '', ...props }: IconProps
   )
 }
 
-export function CopyIcon({ size, class: className = '', ...props }: IconProps) {
+export function CopyIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -180,7 +179,7 @@ export function CopyIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function ClipboardIcon({ size, class: className = '', ...props }: IconProps) {
+export function ClipboardIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -189,7 +188,7 @@ export function ClipboardIcon({ size, class: className = '', ...props }: IconPro
   )
 }
 
-export function ClipboardCheckIcon({ size, class: className = '', ...props }: IconProps) {
+export function ClipboardCheckIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -198,7 +197,7 @@ export function ClipboardCheckIcon({ size, class: className = '', ...props }: Ic
   )
 }
 
-export function MenuIcon({ size, class: className = '', ...props }: IconProps) {
+export function MenuIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -207,7 +206,7 @@ export function MenuIcon({ size, class: className = '', ...props }: IconProps) {
   )
 }
 
-export function ArrowLeftIcon({ size, class: className = '', ...props }: IconProps) {
+export function ArrowLeftIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -216,7 +215,7 @@ export function ArrowLeftIcon({ size, class: className = '', ...props }: IconPro
   )
 }
 
-export function ArrowRightIcon({ size, class: className = '', ...props }: IconProps) {
+export function ArrowRightIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -225,7 +224,7 @@ export function ArrowRightIcon({ size, class: className = '', ...props }: IconPr
   )
 }
 
-export function EllipsisIcon({ size, class: className = '', ...props }: IconProps) {
+export function EllipsisIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -236,7 +235,7 @@ export function EllipsisIcon({ size, class: className = '', ...props }: IconProp
   )
 }
 
-export function GitHubIcon({ size, class: className = '', ...props }: IconProps) {
+export function GitHubIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="currentColor" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -245,7 +244,7 @@ export function GitHubIcon({ size, class: className = '', ...props }: IconProps)
   )
 }
 
-export function SettingsIcon({ size, class: className = '', ...props }: IconProps) {
+export function SettingsIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -255,7 +254,7 @@ export function SettingsIcon({ size, class: className = '', ...props }: IconProp
   )
 }
 
-export function GlobeIcon({ size, class: className = '', ...props }: IconProps) {
+export function GlobeIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -266,7 +265,7 @@ export function GlobeIcon({ size, class: className = '', ...props }: IconProps) 
   )
 }
 
-export function LogOutIcon({ size, class: className = '', ...props }: IconProps) {
+export function LogOutIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -277,7 +276,7 @@ export function LogOutIcon({ size, class: className = '', ...props }: IconProps)
   )
 }
 
-export function CircleHelpIcon({ size, class: className = '', ...props }: IconProps) {
+export function CircleHelpIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -288,7 +287,7 @@ export function CircleHelpIcon({ size, class: className = '', ...props }: IconPr
   )
 }
 
-export function SearchIcon({ size, class: className = '', ...props }: IconProps) {
+export function SearchIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -298,7 +297,7 @@ export function SearchIcon({ size, class: className = '', ...props }: IconProps)
   )
 }
 
-export function CircleCheckIcon({ size, class: className = '', ...props }: IconProps) {
+export function CircleCheckIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -308,7 +307,7 @@ export function CircleCheckIcon({ size, class: className = '', ...props }: IconP
   )
 }
 
-export function CircleXIcon({ size, class: className = '', ...props }: IconProps) {
+export function CircleXIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -319,7 +318,7 @@ export function CircleXIcon({ size, class: className = '', ...props }: IconProps
   )
 }
 
-export function TriangleAlertIcon({ size, class: className = '', ...props }: IconProps) {
+export function TriangleAlertIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -330,7 +329,7 @@ export function TriangleAlertIcon({ size, class: className = '', ...props }: Ico
   )
 }
 
-export function InfoIcon({ size, class: className = '', ...props }: IconProps) {
+export function InfoIcon({ size, className = '', ...props }: IconProps) {
   const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}
   return (
     <svg xmlns="http://www.w3.org/2000/svg" {...sizeAttrs} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className={`shrink-0 ${className}`} aria-hidden="true" {...props}>
@@ -342,31 +341,31 @@ export function InfoIcon({ size, class: className = '', ...props }: IconProps) {
 }
 
 // Generic Icon component for dynamic icon selection
-export function Icon({ name, size = 'md', class: className = '', ...props }: { name: IconName } & IconProps) {
+export function Icon({ name, size = 'md', className = '', ...props }: { name: IconName } & IconProps) {
   const s = sizeMap[size]
 
   if (name === 'github') {
-    return <GitHubIcon size={size} class={className} {...props} />
+    return <GitHubIcon size={size} className={className} {...props} />
   }
 
   if (name === 'search') {
-    return <SearchIcon size={size} class={className} {...props} />
+    return <SearchIcon size={size} className={className} {...props} />
   }
 
   if (name === 'settings') {
-    return <SettingsIcon size={size} class={className} {...props} />
+    return <SettingsIcon size={size} className={className} {...props} />
   }
 
   if (name === 'globe') {
-    return <GlobeIcon size={size} class={className} {...props} />
+    return <GlobeIcon size={size} className={className} {...props} />
   }
 
   if (name === 'log-out') {
-    return <LogOutIcon size={size} class={className} {...props} />
+    return <LogOutIcon size={size} className={className} {...props} />
   }
 
   if (name === 'circle-help') {
-    return <CircleHelpIcon size={size} class={className} {...props} />
+    return <CircleHelpIcon size={size} className={className} {...props} />
   }
 
   const path = strokePaths[name as keyof typeof strokePaths]

--- a/ui/components/ui/scroll-area.tsx
+++ b/ui/components/ui/scroll-area.tsx
@@ -11,7 +11,7 @@ import { createSignal, onCleanup } from '@barefootjs/dom'
  *
  * @example
  * ```tsx
- * <ScrollArea class="h-72 w-48 rounded-md border">
+ * <ScrollArea className="h-72 w-48 rounded-md border">
  *   <div className="p-4">{content}</div>
  * </ScrollArea>
  * ```

--- a/ui/components/ui/slot.tsx
+++ b/ui/components/ui/slot.tsx
@@ -48,7 +48,7 @@ interface SlotProps {
   /** Child element to merge props with */
   children?: Child
   /** CSS class to merge with child's class */
-  class?: string
+  className?: string
   /** Additional props to merge with child element */
   [key: string]: unknown
 }
@@ -65,13 +65,13 @@ function isValidElement(element: unknown): element is { tag: unknown; props: Rec
  * Slot component that renders its child with merged props.
  *
  * @param props.children - Child element to merge props with
- * @param props.class - CSS class to merge with child's class
+ * @param props.className - CSS class to merge with child's class
  */
-function Slot({ children, class: className, ...props }: SlotProps) {
+function Slot({ children, className, ...props }: SlotProps) {
   if (children && isValidElement(children)) {
     const Tag = children.tag as any
     const childProps = children.props || {}
-    const childClass = (childProps.class as string) || ''
+    const childClass = (childProps.className as string) || ''
     const childChildren = childProps.children
 
     // Use JSX syntax - compiler will call jsx() from jsxImportSource

--- a/ui/components/ui/toast.tsx
+++ b/ui/components/ui/toast.tsx
@@ -374,7 +374,7 @@ function ToastClose(props: ToastCloseProps) {
       className={`${toastCloseClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
-      <XIcon size="sm" class="pointer-events-none" />
+      <XIcon size="sm" className="pointer-events-none" />
     </button>
   )
 }


### PR DESCRIPTION
## Summary

- Remove `class?: string` from `IconProps` and `SlotProps` (redundant — `className` already provided by `HTMLBaseAttributes`)
- Update all 30 icon function signatures from `class: className = ''` to `className = ''`
- Fix 6 internal `class={className}` calls in `Icon()` body
- Fix `badge.tsx`, `accordion.tsx`, `toast.tsx` call sites
- Update JSDoc example in `scroll-area.tsx`
- Fix all `site/ui` demo files: collapsible, command, dialog, drawer, dropdown-menu, hover-card, popover, radio-group, resizable, scroll-area, select, switch, alert-dialog

Note: `portal-demo.tsx` uses `class=` inside raw HTML template strings passed to `createPortal()` — these are correct HTML and were intentionally left unchanged.

## Test plan

- [x] `bun test packages/jsx/` — 47 pass, same as before (5 pre-existing failures due to missing `typescript` package)
- [x] `bunx tsc --noEmit --project ui/tsconfig.json` — no `class`-related errors
- [ ] E2E: accordion, toast, collapsible, badge, scroll-area (requires Playwright setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)