### PR TITLE
Refactor E2E tests and add IR tests for all UI components

### DIFF
--- a/site/ui/e2e/accordion.spec.ts
+++ b/site/ui/e2e/accordion.spec.ts
@@ -5,40 +5,7 @@ test.describe('Accordion Documentation Page', () => {
     await page.goto('/docs/components/accordion')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Accordion')
-    await expect(page.locator('text=A vertically stacked set of interactive headings')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test.describe('Accordion Rendering', () => {
-    test('displays accordion items', async ({ page }) => {
-      const accordionItems = page.locator('[data-state]')
-      expect(await accordionItems.count()).toBeGreaterThan(0)
-    })
-
-    test('displays accordion triggers', async ({ page }) => {
-      const triggers = page.locator('button[aria-expanded]')
-      expect(await triggers.count()).toBeGreaterThan(0)
-    })
-  })
-
   test.describe('Single Open Accordion', () => {
-    test('displays single open accordion example', async ({ page }) => {
-      const accordion = page.locator('[bf-s^="AccordionSingleOpenDemo_"]').first()
-      await expect(accordion).toBeVisible()
-    })
-
-    test('first item is open by default', async ({ page }) => {
-      const accordion = page.locator('[bf-s^="AccordionSingleOpenDemo_"]').first()
-      await expect(accordion.locator('text=Yes. It adheres to the WAI-ARIA design pattern.')).toBeVisible()
-    })
-
     test('clicking another item closes the first', async ({ page }) => {
       const accordion = page.locator('[bf-s^="AccordionSingleOpenDemo_"]').first()
       const secondTrigger = accordion.locator('button:has-text("Is it styled?")')
@@ -66,16 +33,6 @@ test.describe('Accordion Documentation Page', () => {
   })
 
   test.describe('Multiple Open Accordion', () => {
-    test('displays multiple open accordion example', async ({ page }) => {
-      const accordion = page.locator('[bf-s^="AccordionMultipleOpenDemo_"]').first()
-      await expect(accordion).toBeVisible()
-    })
-
-    test('first item is open by default', async ({ page }) => {
-      const accordion = page.locator('[bf-s^="AccordionMultipleOpenDemo_"]').first()
-      await expect(accordion.locator('text=This accordion allows multiple items to be open')).toBeVisible()
-    })
-
     test('can open multiple items simultaneously', async ({ page }) => {
       const accordion = page.locator('[bf-s^="AccordionMultipleOpenDemo_"]').first()
       const secondTrigger = accordion.locator('button:has-text("Second Item")')
@@ -86,24 +43,6 @@ test.describe('Accordion Documentation Page', () => {
       // Both items should be visible
       await expect(accordion.locator('text=This accordion allows multiple items to be open')).toBeVisible()
       await expect(accordion.locator('text=Each item manages its own open/close state')).toBeVisible()
-    })
-  })
-
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays AccordionItem props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AccordionItem")')).toBeVisible()
-    })
-
-    test('displays AccordionTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AccordionTrigger")')).toBeVisible()
-    })
-
-    test('displays AccordionContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AccordionContent")')).toBeVisible()
     })
   })
 
@@ -213,15 +152,6 @@ test.describe('Accordion asChild', () => {
     await page.goto('/docs/components/accordion')
   })
 
-  test('renders child element as trigger', async ({ page }) => {
-    const trigger = page.locator('[data-testid="accordion-aschild-trigger"]')
-    await expect(trigger).toBeVisible()
-
-    // Should be a <button> tag (the custom child), not the default accordion button
-    const tagName = await trigger.evaluate((el) => el.tagName.toLowerCase())
-    expect(tagName).toBe('button')
-  })
-
   test('toggles content on click with reactive state', async ({ page }) => {
     const trigger = page.locator('[data-testid="accordion-aschild-trigger"]')
     const stateEl = page.locator('[data-testid="accordion-aschild-state"]')
@@ -271,20 +201,6 @@ test.describe('Accordion asChild', () => {
     // ArrowUp should wrap to standard trigger
     await page.keyboard.press('ArrowUp')
     await expect(standardTrigger).toBeFocused()
-  })
-})
-
-test.describe('Home Page - Accordion Link', () => {
-  test('displays Accordion preview card', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('#components a[href="/docs/components/accordion"]')).toBeVisible()
-  })
-
-  test('navigates to Accordion page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#components a[href="/docs/components/accordion"]').click()
-    await expect(page).toHaveURL('/docs/components/accordion')
-    await expect(page.locator('h1')).toContainText('Accordion')
   })
 })
 

--- a/site/ui/e2e/alert-dialog.spec.ts
+++ b/site/ui/e2e/alert-dialog.spec.ts
@@ -15,23 +15,6 @@ test.describe('AlertDialog Documentation Page', () => {
     await page.goto('/docs/components/alert-dialog')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Alert Dialog')
-    await expect(page.locator('text=A modal dialog that interrupts the user')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("ESC key to close")')).toBeVisible()
-    await expect(page.locator('strong:has-text("No outside click dismiss")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Scroll lock")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Focus trap")')).toBeVisible()
-  })
-
   test.describe('Basic AlertDialog', () => {
     test('opens alert dialog when trigger is clicked', async ({ page }) => {
       const trigger = page.locator(BASIC_TRIGGER).first()
@@ -256,35 +239,6 @@ test.describe('AlertDialog Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays AlertDialogTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogTrigger")')).toBeVisible()
-    })
-
-    test('displays AlertDialogContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogContent")')).toBeVisible()
-    })
-
-    test('displays AlertDialogTitle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogTitle")')).toBeVisible()
-    })
-
-    test('displays AlertDialogDescription props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogDescription")')).toBeVisible()
-    })
-
-    test('displays AlertDialogCancel props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogCancel")')).toBeVisible()
-    })
-
-    test('displays AlertDialogAction props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("AlertDialogAction")')).toBeVisible()
-    })
-  })
 })
 
 test.describe('AlertDialogTrigger asChild', () => {

--- a/site/ui/e2e/badge.spec.ts
+++ b/site/ui/e2e/badge.spec.ts
@@ -5,23 +5,6 @@ test.describe('Badge Documentation Page', () => {
     await page.goto('/docs/components/badge')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Badge')
-    // Use getByRole('main') to target description in main content (not sidebar)
-    await expect(page.getByRole('main').getByText('Displays a badge or a component')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    // Check that the installation section contains the package manager tabs
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Badge Variants', () => {
     // Use data-slot selector to target actual Badge components (not syntax-highlighted code spans)
     const badgeSelector = '[data-slot="badge"]'
@@ -96,22 +79,4 @@ test.describe('Badge Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^children$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/breadcrumb.spec.ts
+++ b/site/ui/e2e/breadcrumb.spec.ts
@@ -5,21 +5,6 @@ test.describe('Breadcrumb Documentation Page', () => {
     await page.goto('/docs/components/breadcrumb')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Breadcrumb')
-    await expect(page.getByRole('main').getByText('Displays the path to the current resource')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Breadcrumb Structure', () => {
     test('renders breadcrumb navigation with correct ARIA attributes', async ({ page }) => {
       const breadcrumb = page.locator('[data-slot="breadcrumb"]').first()
@@ -97,24 +82,4 @@ test.describe('Breadcrumb Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Description")').first()).toBeVisible()
-    })
-
-    test('displays sub-component sections', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Breadcrumb")').first()).toBeVisible()
-      await expect(page.locator('h3:has-text("BreadcrumbList")')).toBeVisible()
-      await expect(page.locator('h3:has-text("BreadcrumbItem")')).toBeVisible()
-      await expect(page.locator('h3:has-text("BreadcrumbLink")')).toBeVisible()
-      await expect(page.locator('h3:has-text("BreadcrumbPage")')).toBeVisible()
-      await expect(page.locator('h3:has-text("BreadcrumbSeparator")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/button.spec.ts
+++ b/site/ui/e2e/button.spec.ts
@@ -5,62 +5,7 @@ test.describe('Button Documentation Page', () => {
     await page.goto('/docs/components/button')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Button')
-    // Use first() to avoid strict mode violation when text appears in multiple places
-    await expect(page.locator('text=Displays a button or a component').first()).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    // Default tab is 'bun', command includes --bun flag
-    // Check that the installation section contains the package manager tabs
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
-  test.describe('Button Variants', () => {
-    test('displays all variant buttons', async ({ page }) => {
-      // Use first() for buttons that might appear multiple times
-      await expect(page.locator('button:has-text("Default")').first()).toBeVisible()
-      await expect(page.locator('button:has-text("Secondary")')).toBeVisible()
-      await expect(page.locator('button:has-text("Destructive")')).toBeVisible()
-      await expect(page.locator('button:has-text("Outline")').first()).toBeVisible()
-      await expect(page.locator('button:has-text("Ghost")')).toBeVisible()
-      await expect(page.locator('button:has-text("Link")')).toBeVisible()
-    })
-  })
-
-  test.describe('Button Sizes', () => {
-    test('displays all size buttons', async ({ page }) => {
-      await expect(page.locator('button:has-text("Small")')).toBeVisible()
-      await expect(page.locator('button:has-text("Large")')).toBeVisible()
-    })
-
-    test('displays icon button', async ({ page }) => {
-      // Icon button is in the Sizes section, it's a button with only an SVG icon (no text)
-      // Find buttons with SVG that have icon size classes
-      const iconButton = page.locator('button:has(svg)').filter({ hasText: '' }).first()
-      await expect(iconButton).toBeVisible()
-    })
-  })
-
-  test.describe('Disabled State', () => {
-    test('displays disabled buttons', async ({ page }) => {
-      const disabledButtons = page.locator('button:has-text("Disabled")')
-      await expect(disabledButtons).toHaveCount(2)
-    })
-  })
-
   test.describe('Interactive Counter', () => {
-    test('displays counter button', async ({ page }) => {
-      await expect(page.locator('button:has-text("Clicked")')).toBeVisible()
-    })
-
     test('increments count on click', async ({ page }) => {
       const counterButton = page.locator('button:has-text("Clicked")')
 
@@ -123,24 +68,4 @@ test.describe('Button Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      // Check prop names exist in table (use first() for exact match)
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^size$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^asChild$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/card.spec.ts
+++ b/site/ui/e2e/card.spec.ts
@@ -6,23 +6,6 @@ test.describe('Card Documentation Page', () => {
     await page.goto('/docs/components/card', { waitUntil: 'domcontentloaded' })
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Card')
-    // Use first() to avoid strict mode violation when text appears in multiple places
-    await expect(page.locator('text=Displays a card with header, content, and footer').first()).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    // Check that the installation section contains the package manager tabs
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Card Preview', () => {
     test('displays preview card (Swiss Alps Adventure)', async ({ page }) => {
       // Check that preview card has the travel card example
@@ -70,24 +53,4 @@ test.describe('Card Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays all sub-component sections', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Card")').first()).toBeVisible()
-      await expect(page.locator('h3:has-text("CardHeader")')).toBeVisible()
-      await expect(page.locator('h3:has-text("CardTitle")')).toBeVisible()
-      await expect(page.locator('h3:has-text("CardDescription")')).toBeVisible()
-      await expect(page.locator('h3:has-text("CardContent")')).toBeVisible()
-      await expect(page.locator('h3:has-text("CardFooter")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Description")').first()).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/checkbox.spec.ts
+++ b/site/ui/e2e/checkbox.spec.ts
@@ -5,40 +5,7 @@ test.describe('Checkbox Documentation Page', () => {
     await page.goto('/docs/components/checkbox')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Checkbox')
-    await expect(page.locator('text=A control that allows the user to toggle')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test.describe('Checkbox Rendering', () => {
-    test('displays checkbox elements', async ({ page }) => {
-      // The Checkbox component uses button with role="checkbox"
-      const checkboxes = page.locator('button[role="checkbox"]')
-      await expect(checkboxes.first()).toBeVisible()
-    })
-
-    test('has multiple checkbox examples', async ({ page }) => {
-      const checkboxes = page.locator('button[role="checkbox"]')
-      // Should have checkboxes on the page (preview + examples)
-      expect(await checkboxes.count()).toBeGreaterThan(3)
-    })
-  })
-
   test.describe('Preview (Terms Demo)', () => {
-    test('displays preview with checkbox and button', async ({ page }) => {
-      // Use first() to avoid strict mode error (parent and child both have matching scope)
-      const section = page.locator('[bf-s^="CheckboxTermsDemo_"]:not([data-slot])').first()
-      await expect(section).toBeVisible()
-      await expect(section.locator('button[role="checkbox"]')).toBeVisible()
-      await expect(section.locator('button:has-text("Continue")')).toBeVisible()
-    })
-
     test('button is disabled when unchecked', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxTermsDemo_"]:not([data-slot])').first()
       const button = section.locator('button:has-text("Continue")')
@@ -75,36 +42,6 @@ test.describe('Checkbox Documentation Page', () => {
   })
 
   test.describe('Basic', () => {
-    test('displays basic example', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
-      const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
-      await expect(section).toBeVisible()
-    })
-
-    test('has three checkboxes', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-      await expect(checkboxes).toHaveCount(3)
-    })
-
-    test('first checkbox starts unchecked', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-      await expect(checkboxes.first()).toHaveAttribute('aria-checked', 'false')
-    })
-
-    test('second checkbox starts checked (defaultChecked)', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-      await expect(checkboxes.nth(1)).toHaveAttribute('aria-checked', 'true')
-    })
-
-    test('third checkbox is disabled', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-      await expect(checkboxes.nth(2)).toBeDisabled()
-    })
-
     test('clicking toggles checkbox state', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxBasicDemo_"]:not([data-slot])').first()
       const checkbox = section.locator('button[role="checkbox"]').first()
@@ -123,38 +60,6 @@ test.describe('Checkbox Documentation Page', () => {
   })
 
   test.describe('Form', () => {
-    test('displays form example with multiple checkboxes', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Form")')).toBeVisible()
-      const section = page.locator('[bf-s^="CheckboxFormDemo_"]:not([data-slot])').first()
-      await expect(section).toBeVisible()
-
-      // Should have 3 checkboxes (Mobile, Desktop, Email)
-      const checkboxes = section.locator('button[role="checkbox"]')
-      await expect(checkboxes).toHaveCount(3)
-    })
-
-    test('shows sidebar heading and description', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxFormDemo_"]:not([data-slot])').first()
-      await expect(section.locator('h4:has-text("Sidebar")')).toBeVisible()
-      await expect(section.locator('text=Select the items you want')).toBeVisible()
-    })
-
-    test('Desktop is checked by default', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxFormDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-
-      // Desktop is the second checkbox
-      const desktopCheckbox = checkboxes.nth(1)
-      await expect(desktopCheckbox).toHaveAttribute('aria-checked', 'true')
-    })
-
-    test('shows selected items', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxFormDemo_"]:not([data-slot])').first()
-      await expect(section.locator('text=Selected:')).toBeVisible()
-      // Use first() since "Desktop" appears twice (label and selected text)
-      await expect(section.locator('text=Desktop').first()).toBeVisible()
-    })
-
     test('updates selection when checkboxes are toggled', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxFormDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
@@ -168,18 +73,6 @@ test.describe('Checkbox Documentation Page', () => {
   })
 
   test.describe('Email List', () => {
-    test('displays email list example', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Email List")')).toBeVisible()
-      const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
-      await expect(section).toBeVisible()
-    })
-
-    test('shows select all checkbox and items', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
-      await expect(section.locator('text=Select all')).toBeVisible()
-      await expect(section.locator('text=Meeting tomorrow')).toBeVisible()
-    })
-
     test('can select individual emails', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
@@ -215,19 +108,6 @@ test.describe('Checkbox Documentation Page', () => {
   })
 
   test.describe('Email List Detailed Behavior', () => {
-    test('initial state: all unchecked, shows "Select all"', async ({ page }) => {
-      const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
-      const checkboxes = section.locator('button[role="checkbox"]')
-
-      // All 4 checkboxes unchecked
-      for (let i = 0; i < 4; i++) {
-        await expect(checkboxes.nth(i)).toHaveAttribute('aria-checked', 'false')
-      }
-      // Shows "Select all"
-      await expect(section.locator('text=Select all')).toBeVisible()
-      await expect(section.locator('text=selected')).not.toBeVisible()
-    })
-
     test('selecting 1 email shows "1 selected"', async ({ page }) => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
@@ -319,23 +199,4 @@ test.describe('Checkbox Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^checked$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onCheckedChange$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/collapsible.spec.ts
+++ b/site/ui/e2e/collapsible.spec.ts
@@ -5,17 +5,6 @@ test.describe('Collapsible Documentation Page', () => {
     await page.goto('/docs/components/collapsible')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Collapsible')
-    await expect(page.locator('text=An interactive component which expands/collapses a panel')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Basic Demo', () => {
     test('displays basic example', async ({ page }) => {
       await expect(page.locator('h3:has-text("Basic")')).toBeVisible()
@@ -126,25 +115,4 @@ test.describe('Collapsible Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays Collapsible props', async ({ page }) => {
-      await expect(page.locator('h3').filter({ hasText: /^Collapsible$/ })).toBeVisible()
-      const tables = page.locator('table')
-      await expect(tables.first().locator('td').filter({ hasText: /^open$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^defaultOpen$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-    })
-
-    test('displays CollapsibleTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("CollapsibleTrigger")')).toBeVisible()
-    })
-
-    test('displays CollapsibleContent section', async ({ page }) => {
-      await expect(page.locator('h3:has-text("CollapsibleContent")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/command.spec.ts
+++ b/site/ui/e2e/command.spec.ts
@@ -5,41 +5,7 @@ test.describe('Command Documentation Page', () => {
     await page.goto('/docs/components/command')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Command')
-    await expect(page.locator('text=A command menu with search')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Preview Demo', () => {
-    test('displays command input', async ({ page }) => {
-      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
-      await expect(section).toBeVisible()
-      const input = section.locator('input[data-slot="command-input"]')
-      await expect(input).toBeVisible()
-    })
-
-    test('displays groups with headings', async ({ page }) => {
-      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
-      await expect(section.locator('[data-slot="command-group-heading"]').first()).toBeVisible()
-      await expect(section.locator('[data-slot="command-group-heading"]')).toHaveCount(2)
-    })
-
-    test('displays command items', async ({ page }) => {
-      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
-      await expect(section.locator('[data-slot="command-item"]')).toHaveCount(6)
-    })
-
-    test('displays keyboard shortcuts', async ({ page }) => {
-      const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
-      await expect(section.locator('[data-slot="command-shortcut"]')).toHaveCount(3)
-    })
-
     test('filtering hides non-matching items', async ({ page }) => {
       const section = page.locator('[bf-s^="CommandPreviewDemo_"]').first()
       const input = section.locator('input[data-slot="command-input"]')
@@ -85,10 +51,6 @@ test.describe('Command Documentation Page', () => {
   })
 
   test.describe('Dialog Demo', () => {
-    test('displays dialog trigger button', async ({ page }) => {
-      await expect(page.locator('[data-command-dialog-trigger]')).toBeVisible()
-    })
-
     test('opens dialog on button click', async ({ page }) => {
       await page.locator('[data-command-dialog-trigger]').click()
       await page.waitForTimeout(200)
@@ -113,30 +75,4 @@ test.describe('Command Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays Command props table', async ({ page }) => {
-      await expect(page.locator('h3').filter({ hasText: /^Command$/ })).toBeVisible()
-    })
-
-    test('displays CommandInput props table', async ({ page }) => {
-      await expect(page.locator('h3:has-text("CommandInput")')).toBeVisible()
-    })
-
-    test('displays CommandItem props table', async ({ page }) => {
-      await expect(page.locator('h3:has-text("CommandItem")')).toBeVisible()
-    })
-  })
-})
-
-test.describe('Home Page', () => {
-  test('displays Command card', async ({ page }) => {
-    await page.goto('/')
-    const card = page.locator('#components a[href="/docs/components/command"]')
-    await expect(card).toBeVisible()
-    await expect(card.locator('h3')).toContainText('Command')
-  })
 })

--- a/site/ui/e2e/context-menu.spec.ts
+++ b/site/ui/e2e/context-menu.spec.ts
@@ -5,24 +5,6 @@ test.describe('ContextMenu Documentation Page', () => {
     await page.goto('/docs/components/context-menu')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Context Menu')
-    await expect(page.locator('text=A menu triggered by right-click')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add context-menu').first()).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Right-click trigger")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Cursor positioning")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Submenu")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Checkbox items")')).toBeVisible()
-  })
-
   test.describe('Basic Demo', () => {
     test('opens menu on right-click and shows items', async ({ page }) => {
       const demo = page.locator('[bf-s^="ContextMenuBasicDemo_"]').first()
@@ -156,30 +138,6 @@ test.describe('ContextMenu Documentation Page', () => {
       await expect(content.locator('text=Back')).toBeVisible()
       await expect(content.locator('text=Forward')).toBeVisible()
       await expect(content.locator('text=Reload')).toBeVisible()
-    })
-
-    test('has correct ARIA roles', async ({ page }) => {
-      const demo = page.locator('[bf-s^="ContextMenuFullDemo_"]').first()
-      const trigger = demo.locator('[data-slot="context-menu-trigger"]')
-
-      await trigger.click({ button: 'right' })
-
-      const content = page.locator('[data-slot="context-menu-content"][data-state="open"]')
-      await expect(content).toHaveAttribute('role', 'menu')
-
-      const items = content.locator('[role="menuitem"]')
-      expect(await items.count()).toBeGreaterThan(0)
-    })
-
-    test('displays separators', async ({ page }) => {
-      const demo = page.locator('[bf-s^="ContextMenuFullDemo_"]').first()
-      const trigger = demo.locator('[data-slot="context-menu-trigger"]')
-
-      await trigger.click({ button: 'right' })
-
-      const content = page.locator('[data-slot="context-menu-content"][data-state="open"]')
-      const separators = content.locator('[data-slot="context-menu-separator"]')
-      expect(await separators.count()).toBeGreaterThanOrEqual(2)
     })
 
     test('keyboard navigation with arrow keys', async ({ page }) => {
@@ -419,15 +377,4 @@ test.describe('ContextMenu Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-      await expect(page.locator('h3:text-is("ContextMenu")')).toBeVisible()
-      await expect(page.locator('h3:has-text("ContextMenuTrigger")')).toBeVisible()
-      await expect(page.locator('h3:has-text("ContextMenuContent")')).toBeVisible()
-      await expect(page.locator('h3:has-text("ContextMenuItem")')).toBeVisible()
-      await expect(page.locator('h3:has-text("ContextMenuLabel")')).toBeVisible()
-      await expect(page.locator('h3:has-text("ContextMenuShortcut")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/controlled-input.spec.ts
+++ b/site/ui/e2e/controlled-input.spec.ts
@@ -5,23 +5,6 @@ test.describe('Controlled Input Documentation Page', () => {
     await page.goto('/docs/forms/controlled-input')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Controlled Input')
-    await expect(page.locator('text=Signal ↔ input value synchronization')).toBeVisible()
-  })
-
-  test('displays pattern overview section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Pattern Overview")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
-  test('displays key points section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Key Points")')).toBeVisible()
-  })
-
   test.describe('Basic Two-Way Binding', () => {
     test('displays basic controlled demo', async ({ page }) => {
       await expect(page.locator('[bf-s^="BasicControlledDemo_"]')).toBeVisible()
@@ -162,26 +145,5 @@ test.describe('Controlled Input Documentation Page', () => {
       await expect(inputA).toHaveValue('World')
       await expect(sharedValue).toHaveText('World')
     })
-  })
-})
-
-test.describe('Home Page - Controlled Input Link', () => {
-  test('displays Form Patterns section', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
-  })
-
-  test('displays Controlled Input link', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#form-patterns a[href="/docs/forms/controlled-input"]')
-    await expect(link).toBeVisible()
-    await expect(link).toContainText('Controlled Input')
-  })
-
-  test('navigates to Controlled Input page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#form-patterns a[href="/docs/forms/controlled-input"]').click()
-    await expect(page).toHaveURL('/docs/forms/controlled-input')
-    await expect(page.locator('h1')).toContainText('Controlled Input')
   })
 })

--- a/site/ui/e2e/dialog.spec.ts
+++ b/site/ui/e2e/dialog.spec.ts
@@ -10,23 +10,6 @@ test.describe('Dialog Documentation Page', () => {
     await page.goto('/docs/components/dialog')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Dialog')
-    await expect(page.locator('text=A modal dialog that displays content')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("ESC key to close")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Click outside to close")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Scroll lock")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Focus trap")')).toBeVisible()
-  })
-
   test.describe('Basic Dialog', () => {
     test('opens dialog when trigger is clicked', async ({ page }) => {
       const basicDemo = page.locator('[bf-s^="DialogBasicDemo_"]').first()
@@ -383,31 +366,6 @@ test.describe('Dialog Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays DialogTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DialogTrigger")')).toBeVisible()
-    })
-
-    test('displays DialogContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DialogContent")')).toBeVisible()
-    })
-
-    test('displays DialogTitle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DialogTitle")')).toBeVisible()
-    })
-
-    test('displays DialogDescription props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DialogDescription")')).toBeVisible()
-    })
-
-    test('displays DialogClose props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DialogClose")')).toBeVisible()
-    })
-  })
 })
 
 test.describe('DialogTrigger asChild', () => {
@@ -462,19 +420,5 @@ test.describe('DialogTrigger asChild', () => {
     await trigger.click()
     await expect(dialog).toBeVisible()
     await expect(dialog).toHaveCSS('opacity', '1')
-  })
-})
-
-test.describe('Home Page - Dialog Link', () => {
-  test('displays Dialog preview card', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('#components a[href="/docs/components/dialog"]')).toBeVisible()
-  })
-
-  test('navigates to Dialog page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#components a[href="/docs/components/dialog"]').click()
-    await expect(page).toHaveURL('/docs/components/dialog')
-    await expect(page.locator('h1')).toContainText('Dialog')
   })
 })

--- a/site/ui/e2e/drawer.spec.ts
+++ b/site/ui/e2e/drawer.spec.ts
@@ -9,15 +9,6 @@ test.describe('Drawer Documentation Page', () => {
     await page.goto('/docs/components/drawer')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Drawer')
-    await expect(page.locator('text=A panel that slides in from the edge')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
   test.describe('Basic Drawer', () => {
     test('opens drawer when trigger is clicked', async ({ page }) => {
       const basicDemo = page.locator('[bf-s^="DrawerBasicDemo_"]').first()
@@ -281,33 +272,4 @@ test.describe('Drawer Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays DrawerTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerTrigger")')).toBeVisible()
-    })
-
-    test('displays DrawerContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerContent")')).toBeVisible()
-    })
-
-    test('displays DrawerHandle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerHandle")')).toBeVisible()
-    })
-
-    test('displays DrawerTitle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerTitle")')).toBeVisible()
-    })
-
-    test('displays DrawerDescription props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerDescription")')).toBeVisible()
-    })
-
-    test('displays DrawerClose props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("DrawerClose")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/dropdown-menu.spec.ts
+++ b/site/ui/e2e/dropdown-menu.spec.ts
@@ -5,25 +5,6 @@ test.describe('DropdownMenu Documentation Page', () => {
     await page.goto('/docs/components/dropdown-menu')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Dropdown Menu')
-    await expect(page.locator('text=A menu of actions triggered by a button')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add dropdown-menu').first()).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Props-based state")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Flexible trigger")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Submenu")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Checkbox items")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Destructive variant")')).toBeVisible()
-  })
-
   test.describe('Basic Demo', () => {
     test('opens menu and shows items', async ({ page }) => {
       const demo = page.locator('[bf-s^="DropdownMenuBasicDemo_"]').first()
@@ -557,15 +538,4 @@ test.describe('DropdownMenu Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-      await expect(page.locator('h3:text-is("DropdownMenu")')).toBeVisible()
-      await expect(page.locator('h3:has-text("DropdownMenuTrigger")')).toBeVisible()
-      await expect(page.locator('h3:has-text("DropdownMenuContent")')).toBeVisible()
-      await expect(page.locator('h3:has-text("DropdownMenuItem")')).toBeVisible()
-      await expect(page.locator('h3:has-text("DropdownMenuLabel")')).toBeVisible()
-      await expect(page.locator('h3:has-text("DropdownMenuShortcut")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/field-arrays.spec.ts
+++ b/site/ui/e2e/field-arrays.spec.ts
@@ -14,23 +14,6 @@ test.describe('Field Arrays Documentation Page', () => {
     await page.goto('/docs/forms/field-arrays')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Field Arrays')
-    await expect(page.locator('p.text-muted-foreground.text-lg')).toContainText('dynamic list of form inputs')
-  })
-
-  test('displays pattern overview section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Pattern Overview")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
-  test('displays key points section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Key Points")')).toBeVisible()
-  })
-
   test.describe('Basic Field Array Demo', () => {
     test('displays basic field array demo', async ({ page }) => {
       await expect(page.locator('[bf-s^="BasicFieldArrayDemo_"]')).toBeVisible()
@@ -283,26 +266,5 @@ test.describe('Field Arrays Documentation Page', () => {
       await removeButtons.first().click()
       await expect(inputs).toHaveCount(1)
     })
-  })
-})
-
-test.describe('Home Page - Field Arrays Link', () => {
-  test('displays Form Patterns section', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
-  })
-
-  test('displays Field Arrays link', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#form-patterns a[href="/docs/forms/field-arrays"]')
-    await expect(link).toBeVisible()
-    await expect(link).toContainText('Field Arrays')
-  })
-
-  test('navigates to Field Arrays page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#form-patterns a[href="/docs/forms/field-arrays"]').click()
-    await expect(page).toHaveURL('/docs/forms/field-arrays')
-    await expect(page.locator('h1')).toContainText('Field Arrays')
   })
 })

--- a/site/ui/e2e/home.spec.ts
+++ b/site/ui/e2e/home.spec.ts
@@ -18,9 +18,23 @@ test.describe('Home Page', () => {
   })
 
   test('displays component preview cards', async ({ page }) => {
+    await expect(page.locator('#components a[href="/docs/components/accordion"]')).toBeVisible()
     await expect(page.locator('#components a[href="/docs/components/button"]')).toBeVisible()
     await expect(page.locator('#components a[href="/docs/components/card"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/docs/components/command"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/docs/components/dialog"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/docs/components/select"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/docs/components/slider"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/docs/components/switch"]')).toBeVisible()
     await expect(page.locator('#components a[href="/docs/components/tabs"]')).toBeVisible()
+  })
+
+  test('displays form patterns section', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
+    await expect(page.locator('#form-patterns a[href="/docs/forms/controlled-input"]')).toBeVisible()
+    await expect(page.locator('#form-patterns a[href="/docs/forms/field-arrays"]')).toBeVisible()
+    await expect(page.locator('#form-patterns a[href="/docs/forms/submit"]')).toBeVisible()
+    await expect(page.locator('#form-patterns a[href="/docs/forms/validation"]')).toBeVisible()
   })
 
   test('navigates to Button page on click', async ({ page }) => {

--- a/site/ui/e2e/hover-card.spec.ts
+++ b/site/ui/e2e/hover-card.spec.ts
@@ -5,16 +5,6 @@ test.describe('Hover Card Documentation Page', () => {
     await page.goto('/docs/components/hover-card')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Hover Card')
-    await expect(page.locator('text=A floating card that appears on hover to display rich content')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add hover-card').first()).toBeVisible()
-  })
-
   test.describe('Preview Demo', () => {
     test('opens hover card on trigger hover', async ({ page }) => {
       const demo = page.locator('[bf-s^="HoverCardPreviewDemo_"]').first()
@@ -118,12 +108,4 @@ test.describe('Hover Card Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-      await expect(page.locator('h3:text-is("HoverCard")')).toBeVisible()
-      await expect(page.locator('h3:text-is("HoverCardTrigger")')).toBeVisible()
-      await expect(page.locator('h3:text-is("HoverCardContent")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/input.spec.ts
+++ b/site/ui/e2e/input.spec.ts
@@ -5,17 +5,6 @@ test.describe('Input Documentation Page', () => {
     await page.goto('/docs/components/input')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Input')
-    await expect(page.locator('text=Displays an input field')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Input Rendering', () => {
     test('displays input elements', async ({ page }) => {
       const inputs = page.locator('input[data-slot="input"]')
@@ -100,26 +89,5 @@ test.describe('Input Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^type$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^placeholder$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^value$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onInput$/ })).toBeVisible()
-    })
-  })
 })
 

--- a/site/ui/e2e/label.spec.ts
+++ b/site/ui/e2e/label.spec.ts
@@ -5,17 +5,6 @@ test.describe('Label Documentation Page', () => {
     await page.goto('/docs/components/label')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Label')
-    await expect(page.locator('text=Renders an accessible label associated with controls')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Preview', () => {
     test('displays label with data-slot', async ({ page }) => {
       const label = page.locator('label[data-slot="label"]').first()
@@ -65,23 +54,4 @@ test.describe('Label Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^for$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^className$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^children$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/menubar.spec.ts
+++ b/site/ui/e2e/menubar.spec.ts
@@ -5,40 +5,7 @@ test.describe('Menubar Documentation Page', () => {
     await page.goto('/docs/components/menubar')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Menubar')
-    await expect(page.locator('text=A visually persistent menu common in desktop applications')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add menubar').first()).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Roving hover")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Keyboard navigation")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Submenu support")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Checkbox items")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Radio items")')).toBeVisible()
-  })
-
   test.describe('Basic Demo', () => {
-    // BasicDemo is the 2nd menubar on the page (after preview ApplicationDemo, then Basic, then Application)
-    // Use bf-s^="MenubarBasicDemo_" which IS the menubar element itself
-    test('renders menubar with triggers', async ({ page }) => {
-      const menubar = page.locator('[bf-s^="MenubarBasicDemo_"]').first()
-
-      await expect(menubar).toBeVisible()
-      await expect(menubar).toHaveAttribute('role', 'menubar')
-
-      const triggers = menubar.locator('[data-slot="menubar-trigger"]')
-      expect(await triggers.count()).toBe(2)
-      await expect(triggers.nth(0)).toContainText('File')
-      await expect(triggers.nth(1)).toContainText('Edit')
-    })
-
     test('opens menu on trigger click', async ({ page }) => {
       const menubar = page.locator('[bf-s^="MenubarBasicDemo_"]').first()
       const fileTrigger = menubar.locator('[data-slot="menubar-trigger"]').filter({ hasText: 'File' })
@@ -452,17 +419,4 @@ test.describe('Menubar Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-      await expect(page.locator('h3:text-is("Menubar")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarMenu")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarTrigger")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarContent")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarItem")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarCheckboxItem")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarRadioGroup")')).toBeVisible()
-      await expect(page.locator('h3:has-text("MenubarShortcut")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/pagination.spec.ts
+++ b/site/ui/e2e/pagination.spec.ts
@@ -5,21 +5,6 @@ test.describe('Pagination Documentation Page', () => {
     await page.goto('/docs/components/pagination')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Pagination')
-    await expect(page.locator('text=Pagination with page navigation')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Preview', () => {
     test('displays pagination nav element', async ({ page }) => {
       const nav = page.locator('nav[aria-label="pagination"]').first()
@@ -136,23 +121,4 @@ test.describe('Pagination Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays key props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^isActive$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^size$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^href$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/popover.spec.ts
+++ b/site/ui/e2e/popover.spec.ts
@@ -5,16 +5,6 @@ test.describe('Popover Documentation Page', () => {
     await page.goto('/docs/components/popover')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Popover')
-    await expect(page.locator('text=A floating panel that appears relative to a trigger element')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add popover').first()).toBeVisible()
-  })
-
   test.describe('Preview Demo', () => {
     test('opens popover on trigger click', async ({ page }) => {
       const demo = page.locator('[bf-s^="PopoverPreviewDemo_"]').first()
@@ -138,13 +128,4 @@ test.describe('Popover Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-      await expect(page.locator('h3:text-is("Popover")')).toBeVisible()
-      await expect(page.locator('h3:has-text("PopoverTrigger")')).toBeVisible()
-      await expect(page.locator('h3:has-text("PopoverContent")')).toBeVisible()
-      await expect(page.locator('h3:has-text("PopoverClose")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/portal.spec.ts
+++ b/site/ui/e2e/portal.spec.ts
@@ -5,23 +5,6 @@ test.describe('Portal Documentation Page', () => {
     await page.goto('/docs/components/portal')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Portal')
-    await expect(page.locator('text=Renders children into a different part')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("DOM escape")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Custom container")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Flexible input")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Cleanup")')).toBeVisible()
-  })
-
   test.describe('Basic Portal', () => {
     test('shows portal content when button clicked', async ({ page }) => {
       const basicDemo = page.locator('[bf-s^="PortalBasicDemo_"]').first()
@@ -130,25 +113,4 @@ test.describe('Portal Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays createPortal function heading', async ({ page }) => {
-      await expect(page.locator('h3:has-text("createPortal")')).toBeVisible()
-    })
-
-    test('displays parameters table', async ({ page }) => {
-      await expect(page.locator('h4:has-text("Parameters")')).toBeVisible()
-      // Check for the first cell in parameters table
-      await expect(page.locator('td:has-text("children")').first()).toBeVisible()
-    })
-
-    test('displays return value table', async ({ page }) => {
-      await expect(page.locator('h4:has-text("Return Value")')).toBeVisible()
-      // Check for table cells in return value table
-      await expect(page.locator('td:has-text("unmount")').first()).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/radio-group.spec.ts
+++ b/site/ui/e2e/radio-group.spec.ts
@@ -5,17 +5,6 @@ test.describe('RadioGroup Documentation Page', () => {
     await page.goto('/docs/components/radio-group')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Radio Group')
-    await expect(page.locator('text=A set of checkable buttons where only one can be checked')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('RadioGroup Rendering', () => {
     test('displays radio elements', async ({ page }) => {
       const radios = page.locator('button[role="radio"]')
@@ -204,26 +193,4 @@ test.describe('RadioGroup Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays RadioGroup and RadioGroupItem props tables', async ({ page }) => {
-      await expect(page.locator('h3').filter({ hasText: /^RadioGroup$/ })).toBeVisible()
-      await expect(page.locator('h3').filter({ hasText: /^RadioGroupItem$/ })).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
-    })
-
-    test('displays key props', async ({ page }) => {
-      const tables = page.locator('table')
-      await expect(tables.first().locator('td').filter({ hasText: /^defaultValue$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
-      await expect(tables.nth(1).locator('td').filter({ hasText: /^value$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/resizable.spec.ts
+++ b/site/ui/e2e/resizable.spec.ts
@@ -5,17 +5,6 @@ test.describe('Resizable Documentation Page', () => {
     await page.goto('/docs/components/resizable')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Resizable')
-    await expect(page.locator('text=Accessible resizable panel groups')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Resizable Rendering', () => {
     test('displays resizable panel groups', async ({ page }) => {
       const groups = page.locator('[data-slot="resizable-panel-group"]')
@@ -127,15 +116,4 @@ test.describe('Resizable Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays all three component props tables', async ({ page }) => {
-      await expect(page.getByRole('heading', { name: 'ResizablePanelGroup', exact: true })).toBeVisible()
-      await expect(page.getByRole('heading', { name: 'ResizablePanel', exact: true })).toBeVisible()
-      await expect(page.getByRole('heading', { name: 'ResizableHandle', exact: true })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/scroll-area.spec.ts
+++ b/site/ui/e2e/scroll-area.spec.ts
@@ -5,17 +5,6 @@ test.describe('Scroll Area Documentation Page', () => {
     await page.goto('/docs/components/scroll-area')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Scroll Area')
-    await expect(page.locator('text=Augments native scroll functionality')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('ScrollArea Rendering', () => {
     test('displays scroll area elements', async ({ page }) => {
       const scrollAreas = page.locator('[data-slot="scroll-area"]')
@@ -82,22 +71,4 @@ test.describe('Scroll Area Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays scroll area props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^class$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^type$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/select.spec.ts
+++ b/site/ui/e2e/select.spec.ts
@@ -5,17 +5,6 @@ test.describe('Select Documentation Page', () => {
     await page.goto('/docs/components/select')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Select')
-    await expect(page.locator('text=Displays a list of options for the user to pick from')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Basic Demo', () => {
     test('renders trigger with placeholder', async ({ page }) => {
       const section = page.locator('[bf-s^="SelectBasicDemo_"]:not([data-slot])').first()
@@ -277,40 +266,4 @@ test.describe('Select Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props tables', async ({ page }) => {
-      await expect(page.locator('h3:text-is("Select")')).toBeVisible()
-      await expect(page.locator('h3:has-text("SelectItem")')).toBeVisible()
-      const tables = page.locator('table')
-      expect(await tables.count()).toBeGreaterThanOrEqual(2)
-    })
-
-    test('displays Select props', async ({ page }) => {
-      const tables = page.locator('table')
-      await expect(tables.first().locator('td').filter({ hasText: /^value$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-    })
-  })
-})
-
-test.describe('Home Page - Select Link', () => {
-  test('displays Select component link', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#components a[href="/docs/components/select"]')
-    await expect(link).toBeVisible()
-    await expect(link).toContainText('Select')
-  })
-
-  test('navigates to Select page on click', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#components a[href="/docs/components/select"]')
-    await link.click()
-    await expect(page).toHaveURL('/docs/components/select')
-    await expect(page.locator('h1')).toContainText('Select')
-  })
 })

--- a/site/ui/e2e/separator.spec.ts
+++ b/site/ui/e2e/separator.spec.ts
@@ -5,21 +5,6 @@ test.describe('Separator Documentation Page', () => {
     await page.goto('/docs/components/separator')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Separator')
-    await expect(page.getByRole('main').getByText('Visually or semantically separates content')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Separator Rendering', () => {
     const separatorSelector = '[data-slot="separator"]'
 
@@ -53,23 +38,4 @@ test.describe('Separator Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^orientation$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^decorative$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^className$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/sheet.spec.ts
+++ b/site/ui/e2e/sheet.spec.ts
@@ -9,15 +9,6 @@ test.describe('Sheet Documentation Page', () => {
     await page.goto('/docs/components/sheet')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Sheet')
-    await expect(page.locator('text=A panel that slides in from the edge')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
   test.describe('Basic Sheet', () => {
     test('opens sheet when trigger is clicked', async ({ page }) => {
       const basicDemo = page.locator('[bf-s^="SheetBasicDemo_"]').first()
@@ -279,29 +270,4 @@ test.describe('Sheet Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays SheetTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("SheetTrigger")')).toBeVisible()
-    })
-
-    test('displays SheetContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("SheetContent")')).toBeVisible()
-    })
-
-    test('displays SheetTitle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("SheetTitle")')).toBeVisible()
-    })
-
-    test('displays SheetDescription props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("SheetDescription")')).toBeVisible()
-    })
-
-    test('displays SheetClose props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("SheetClose")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/slider.spec.ts
+++ b/site/ui/e2e/slider.spec.ts
@@ -5,17 +5,6 @@ test.describe('Slider Documentation Page', () => {
     await page.goto('/docs/components/slider')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Slider')
-    await expect(page.locator('text=An input where the user selects a value')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Slider Rendering', () => {
     test('displays slider elements', async ({ page }) => {
       const sliders = page.locator('[role="slider"]')
@@ -223,41 +212,4 @@ test.describe('Slider Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^defaultValue$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^value$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^min$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^max$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^step$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
-    })
-  })
-})
-
-test.describe('Home Page - Slider Link', () => {
-  test('displays Slider preview card', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('#components a[href="/docs/components/slider"]')).toBeVisible()
-  })
-
-  test('navigates to Slider page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#components a[href="/docs/components/slider"]').click()
-    await expect(page).toHaveURL('/docs/components/slider')
-    await expect(page.locator('h1')).toContainText('Slider')
-  })
 })

--- a/site/ui/e2e/submit.spec.ts
+++ b/site/ui/e2e/submit.spec.ts
@@ -5,23 +5,6 @@ test.describe('Form Submit Documentation Page', () => {
     await page.goto('/docs/forms/submit')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Form Submit')
-    await expect(page.locator('p.text-muted-foreground.text-lg')).toContainText('async submit handling')
-  })
-
-  test('displays pattern overview section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Pattern Overview")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
-  test('displays key points section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Key Points")')).toBeVisible()
-  })
-
   test.describe('Basic Submit Demo', () => {
     test('displays basic submit demo', async ({ page }) => {
       await expect(page.locator('[bf-s^="BasicSubmitDemo_"]')).toBeVisible()
@@ -202,26 +185,5 @@ test.describe('Form Submit Documentation Page', () => {
       const successToast = page.locator('[data-slot="toast"][bf-s*="ServerValidationDemo"]')
       await expect(successToast).toBeVisible({ timeout: 5000 })
     })
-  })
-})
-
-test.describe('Home Page - Form Submit Link', () => {
-  test('displays Form Patterns section', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
-  })
-
-  test('displays Form Submit link', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#form-patterns a[href="/docs/forms/submit"]')
-    await expect(link).toBeVisible()
-    await expect(link).toContainText('Form Submit')
-  })
-
-  test('navigates to Form Submit page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#form-patterns a[href="/docs/forms/submit"]').click()
-    await expect(page).toHaveURL('/docs/forms/submit')
-    await expect(page.locator('h1')).toContainText('Form Submit')
   })
 })

--- a/site/ui/e2e/switch.spec.ts
+++ b/site/ui/e2e/switch.spec.ts
@@ -5,17 +5,6 @@ test.describe('Switch Documentation Page', () => {
     await page.goto('/docs/components/switch')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Switch')
-    await expect(page.locator('text=A control that allows the user to toggle')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Switch Rendering', () => {
     test('displays switch elements', async ({ page }) => {
       const switches = page.locator('button[role="switch"]')
@@ -290,38 +279,4 @@ test.describe('Switch Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^defaultChecked$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^checked$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onCheckedChange$/ })).toBeVisible()
-    })
-  })
-})
-
-test.describe('Home Page - Switch Link', () => {
-  test('displays Switch preview card', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('#components a[href="/docs/components/switch"]')).toBeVisible()
-  })
-
-  test('navigates to Switch page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#components a[href="/docs/components/switch"]').click()
-    await expect(page).toHaveURL('/docs/components/switch')
-    await expect(page.locator('h1')).toContainText('Switch')
-  })
 })

--- a/site/ui/e2e/tabs.spec.ts
+++ b/site/ui/e2e/tabs.spec.ts
@@ -33,20 +33,6 @@ test.describe('Tabs Documentation Page', () => {
     await page.goto('/docs/components/tabs')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Tabs')
-    await expect(page.locator('text=A set of layered sections of content')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('text=bunx --bun barefoot add tabs')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
   test.describe('Tabs Rendering', () => {
     test('displays tab list', async ({ page }) => {
       const tablist = page.locator('[role="tablist"]')
@@ -169,40 +155,7 @@ test.describe('Tabs Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays Tabs props', async ({ page }) => {
-      await expect(page.locator('h3').filter({ hasText: /^Tabs$/ })).toBeVisible()
-    })
-
-    test('displays TabsTrigger props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("TabsTrigger")')).toBeVisible()
-    })
-
-    test('displays TabsContent props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("TabsContent")')).toBeVisible()
-    })
-  })
 })
-
-// Skip: Focus on Button during issue #126 design phase
-test.describe('Home Page - Tabs Link', () => {
-  test('displays Tabs preview card', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('#components a[href="/docs/components/tabs"]')).toBeVisible()
-  })
-
-  test('navigates to Tabs page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#components a[href="/docs/components/tabs"]').click()
-    await expect(page).toHaveURL('/docs/components/tabs')
-    await expect(page.locator('h1')).toContainText('Tabs')
-  })
-})
-
 test.describe('Tabs Keyboard Navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/docs/components/tabs')

--- a/site/ui/e2e/textarea.spec.ts
+++ b/site/ui/e2e/textarea.spec.ts
@@ -5,17 +5,6 @@ test.describe('Textarea Documentation Page', () => {
     await page.goto('/docs/components/textarea')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Textarea')
-    await expect(page.locator('text=Displays a multi-line text input field.')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Textarea Rendering', () => {
     test('displays textarea elements', async ({ page }) => {
       const textareas = page.locator('textarea[data-slot="textarea"]')
@@ -73,24 +62,4 @@ test.describe('Textarea Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^placeholder$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^rows$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onInput$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/toast.spec.ts
+++ b/site/ui/e2e/toast.spec.ts
@@ -5,23 +5,6 @@ test.describe('Toast Documentation Page', () => {
     await page.goto('/docs/components/toast')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Toast')
-    await expect(page.locator('text=A non-blocking notification')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-  })
-
-  test('displays features section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Features")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Auto-dismiss")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Manual dismiss")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Variants")')).toBeVisible()
-    await expect(page.locator('strong:has-text("Portal rendering")')).toBeVisible()
-  })
-
   test.describe('Default Toast', () => {
     test('opens toast when button is clicked', async ({ page }) => {
       const demo = page.locator('[bf-s^="ToastDefaultDemo_"]').first()
@@ -227,33 +210,4 @@ test.describe('Toast Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays ToastProvider props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToastProvider")')).toBeVisible()
-    })
-
-    test('displays Toast props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("Toast")').first()).toBeVisible()
-    })
-
-    test('displays ToastTitle props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToastTitle")')).toBeVisible()
-    })
-
-    test('displays ToastDescription props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToastDescription")')).toBeVisible()
-    })
-
-    test('displays ToastClose props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToastClose")')).toBeVisible()
-    })
-
-    test('displays ToastAction props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToastAction")')).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/toggle-group.spec.ts
+++ b/site/ui/e2e/toggle-group.spec.ts
@@ -5,17 +5,6 @@ test.describe('Toggle Group Documentation Page', () => {
     await page.goto('/docs/components/toggle-group')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Toggle Group')
-    await expect(page.locator('text=A set of two-state buttons that can be toggled on or off.')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Toggle Group Rendering', () => {
     test('displays toggle-group elements with data-slot', async ({ page }) => {
       const groups = page.locator('[data-slot="toggle-group"]')
@@ -214,33 +203,4 @@ test.describe('Toggle Group Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Type")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Default")').first()).toBeVisible()
-      await expect(page.locator('th:has-text("Description")').first()).toBeVisible()
-    })
-
-    test('displays ToggleGroup props', async ({ page }) => {
-      await expect(page.getByRole('heading', { name: 'ToggleGroup', exact: true })).toBeVisible()
-      const tables = page.locator('table')
-      await expect(tables.first().locator('td').filter({ hasText: /^type$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^size$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(tables.first().locator('td').filter({ hasText: /^onValueChange$/ })).toBeVisible()
-    })
-
-    test('displays ToggleGroupItem props', async ({ page }) => {
-      await expect(page.locator('h3:has-text("ToggleGroupItem")')).toBeVisible()
-      const tables = page.locator('table')
-      await expect(tables.nth(1).locator('td').filter({ hasText: /^value$/ })).toBeVisible()
-      await expect(tables.nth(1).locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/toggle.spec.ts
+++ b/site/ui/e2e/toggle.spec.ts
@@ -5,17 +5,6 @@ test.describe('Toggle Documentation Page', () => {
     await page.goto('/docs/components/toggle')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Toggle')
-    await expect(page.locator('text=A two-state button that can be either on or off.')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Toggle Rendering', () => {
     test('displays toggle elements with data-slot', async ({ page }) => {
       const toggles = page.locator('[data-slot="toggle"]')
@@ -128,25 +117,4 @@ test.describe('Toggle Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^pressed$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^disabled$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^variant$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^size$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^onPressedChange$/ })).toBeVisible()
-    })
-  })
 })

--- a/site/ui/e2e/tooltip.spec.ts
+++ b/site/ui/e2e/tooltip.spec.ts
@@ -5,17 +5,6 @@ test.describe('Tooltip Documentation Page', () => {
     await page.goto('/docs/components/tooltip')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Tooltip')
-    await expect(page.locator('text=A popup that displays contextual information')).toBeVisible()
-  })
-
-  test('displays installation section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Installation")')).toBeVisible()
-    await expect(page.locator('[role="tablist"]').first()).toBeVisible()
-    await expect(page.locator('button:has-text("bun")')).toBeVisible()
-  })
-
   test.describe('Basic Tooltip', () => {
     test('shows tooltip on hover', async ({ page }) => {
       const demo = page.locator('[bf-s^="TooltipBasicDemo_"]:not([data-slot])').first()
@@ -190,39 +179,4 @@ test.describe('Tooltip Documentation Page', () => {
     })
   })
 
-  test.describe('API Reference', () => {
-    test('displays API Reference section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("API Reference")')).toBeVisible()
-    })
-
-    test('displays props table headers', async ({ page }) => {
-      await expect(page.locator('th:has-text("Prop")')).toBeVisible()
-      await expect(page.locator('th:has-text("Type")')).toBeVisible()
-      await expect(page.locator('th:has-text("Default")')).toBeVisible()
-      await expect(page.locator('th:has-text("Description")')).toBeVisible()
-    })
-
-    test('displays all props', async ({ page }) => {
-      const propsTable = page.locator('table')
-      await expect(propsTable.locator('td').filter({ hasText: /^content$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^placement$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^delayDuration$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^closeDelay$/ })).toBeVisible()
-      await expect(propsTable.locator('td').filter({ hasText: /^id$/ })).toBeVisible()
-    })
-  })
-})
-
-test.describe('Navigation - Tooltip Link', () => {
-  test('displays Tooltip link in sidebar navigation', async ({ page }) => {
-    await page.goto('/docs/components/tooltip')
-    await expect(page.locator('nav a[href="/docs/components/tooltip"]').last()).toBeVisible()
-  })
-
-  test('navigates to Tooltip page from sidebar', async ({ page }) => {
-    await page.goto('/docs/components/switch')
-    await page.locator('nav a[href="/docs/components/tooltip"]').last().click()
-    await expect(page).toHaveURL('/docs/components/tooltip')
-    await expect(page.locator('h1')).toContainText('Tooltip')
-  })
 })

--- a/site/ui/e2e/validation.spec.ts
+++ b/site/ui/e2e/validation.spec.ts
@@ -5,23 +5,6 @@ test.describe('Form Validation Documentation Page', () => {
     await page.goto('/docs/forms/validation')
   })
 
-  test('displays page header', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Form Validation')
-    await expect(page.locator('p.text-muted-foreground.text-lg')).toContainText('error state management')
-  })
-
-  test('displays pattern overview section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Pattern Overview")')).toBeVisible()
-  })
-
-  test('displays examples section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Examples")')).toBeVisible()
-  })
-
-  test('displays key points section', async ({ page }) => {
-    await expect(page.locator('h2:has-text("Key Points")')).toBeVisible()
-  })
-
   test.describe('Required Field Demo', () => {
     test('displays required field demo', async ({ page }) => {
       await expect(page.locator('[bf-s^="RequiredFieldDemo_"]')).toBeVisible()
@@ -222,26 +205,5 @@ test.describe('Form Validation Documentation Page', () => {
       await expect(nameError).toHaveText('')
       await expect(emailError).toHaveText('')
     })
-  })
-})
-
-test.describe('Home Page - Form Validation Link', () => {
-  test('displays Form Patterns section', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.locator('h2:has-text("Form Patterns")')).toBeVisible()
-  })
-
-  test('displays Form Validation link', async ({ page }) => {
-    await page.goto('/')
-    const link = page.locator('#form-patterns a[href="/docs/forms/validation"]')
-    await expect(link).toBeVisible()
-    await expect(link).toContainText('Form Validation')
-  })
-
-  test('navigates to Form Validation page on click', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('#form-patterns a[href="/docs/forms/validation"]').click()
-    await expect(page).toHaveURL('/docs/forms/validation')
-    await expect(page.locator('h1')).toContainText('Form Validation')
   })
 })

--- a/ui/components/ui/__tests__/alert-dialog.test.ts
+++ b/ui/components/ui/__tests__/alert-dialog.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../alert-dialog.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// AlertDialog (context provider — no DOM root, wraps children with Provider)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialog', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialog')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialog', () => {
+    expect(result.componentName).toBe('AlertDialog')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogTrigger (conditional: asChild=span or button, click event)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogTrigger', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogTrigger', () => {
+    expect(result.componentName).toBe('AlertDialogTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a button with data-slot=alert-dialog-trigger', () => {
+    const button = result.find({ tag: 'button', props: { 'data-slot': 'alert-dialog-trigger' } })
+    expect(button).not.toBeNull()
+  })
+
+
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogOverlay (portaled overlay, no click-to-close, data-state=closed)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogOverlay', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogOverlay')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogOverlay', () => {
+    expect(result.componentName).toBe('AlertDialogOverlay')
+  })
+
+  test('root is a div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=alert-dialog-overlay', () => {
+    expect(result.root.props['data-slot']).toBe('alert-dialog-overlay')
+  })
+
+  test('root has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogContent (portaled modal, role=alertdialog, aria-modal=true, data-state=closed)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogContent', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogContent', () => {
+    expect(result.componentName).toBe('AlertDialogContent')
+  })
+
+  test('root is a div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has role=alertdialog', () => {
+    expect(result.root.role).toBe('alertdialog')
+  })
+
+  test('root has aria-modal=true', () => {
+    expect(result.root.aria['modal']).toBe('true')
+  })
+
+  test('root has data-slot=alert-dialog-content', () => {
+    expect(result.root.props['data-slot']).toBe('alert-dialog-content')
+  })
+
+  test('root has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogHeader (layout container)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogHeader', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogHeader', () => {
+    expect(result.componentName).toBe('AlertDialogHeader')
+  })
+
+  test('root is div with data-slot=alert-dialog-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-header')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogTitle (heading element)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogTitle', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogTitle', () => {
+    expect(result.componentName).toBe('AlertDialogTitle')
+  })
+
+  test('root is h2 with data-slot=alert-dialog-title', () => {
+    expect(result.root.tag).toBe('h2')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-title')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogDescription (description text)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogDescription', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogDescription', () => {
+    expect(result.componentName).toBe('AlertDialogDescription')
+  })
+
+  test('root is p with data-slot=alert-dialog-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-description')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogFooter (layout container for action buttons)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogFooter', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogFooter', () => {
+    expect(result.componentName).toBe('AlertDialogFooter')
+  })
+
+  test('root is div with data-slot=alert-dialog-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-footer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogCancel (cancel button, closes dialog, click event)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogCancel', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogCancel')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogCancel', () => {
+    expect(result.componentName).toBe('AlertDialogCancel')
+  })
+
+  test('root is button with data-slot=alert-dialog-cancel', () => {
+    expect(result.root.tag).toBe('button')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-cancel')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AlertDialogAction (confirm button, triggers action, click event)
+// ---------------------------------------------------------------------------
+
+describe('AlertDialogAction', () => {
+  const result = renderToTest(source, 'alert-dialog.tsx', 'AlertDialogAction')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is AlertDialogAction', () => {
+    expect(result.componentName).toBe('AlertDialogAction')
+  })
+
+  test('root is button with data-slot=alert-dialog-action', () => {
+    expect(result.root.tag).toBe('button')
+    expect(result.root.props['data-slot']).toBe('alert-dialog-action')
+  })
+})

--- a/ui/components/ui/__tests__/badge.test.ts
+++ b/ui/components/ui/__tests__/badge.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const badgeSource = readFileSync(resolve(__dirname, '../badge.tsx'), 'utf-8')
+
+describe('Badge', () => {
+  const result = renderToTest(badgeSource, 'badge.tsx', 'Badge')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Badge', () => {
+    expect(result.componentName).toBe('Badge')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a span with data-slot=badge', () => {
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.props['data-slot']).toBe('badge')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const span = result.find({ tag: 'span' })!
+    expect(span.classes).toContain('inline-flex')
+    expect(span.classes).toContain('items-center')
+    expect(span.classes).toContain('rounded-full')
+  })
+
+  test('contains Slot component for asChild', () => {
+    const slot = result.find({ componentName: 'Slot' })
+    expect(slot).not.toBeNull()
+  })
+})

--- a/ui/components/ui/__tests__/breadcrumb.test.ts
+++ b/ui/components/ui/__tests__/breadcrumb.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const breadcrumbSource = readFileSync(resolve(__dirname, '../breadcrumb.tsx'), 'utf-8')
+
+describe('Breadcrumb', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'Breadcrumb')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Breadcrumb', () => {
+    expect(result.componentName).toBe('Breadcrumb')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as nav with aria-label=breadcrumb', () => {
+    expect(result.root.tag).toBe('nav')
+    expect(result.root.aria['label']).toBe('breadcrumb')
+  })
+
+  test('has data-slot=breadcrumb', () => {
+    expect(result.root.props['data-slot']).toBe('breadcrumb')
+  })
+})
+
+describe('BreadcrumbList', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbList')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbList', () => {
+    expect(result.componentName).toBe('BreadcrumbList')
+  })
+
+  test('renders as ol with data-slot=breadcrumb-list', () => {
+    expect(result.root.tag).toBe('ol')
+    expect(result.root.props['data-slot']).toBe('breadcrumb-list')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-wrap')
+  })
+})
+
+describe('BreadcrumbItem', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbItem', () => {
+    expect(result.componentName).toBe('BreadcrumbItem')
+  })
+
+  test('renders as li with data-slot=breadcrumb-item', () => {
+    expect(result.root.tag).toBe('li')
+    expect(result.root.props['data-slot']).toBe('breadcrumb-item')
+  })
+})
+
+describe('BreadcrumbLink', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbLink')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbLink', () => {
+    expect(result.componentName).toBe('BreadcrumbLink')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains an anchor with data-slot=breadcrumb-link', () => {
+    const link = result.find({ tag: 'a' })
+    expect(link).not.toBeNull()
+    expect(link!.props['data-slot']).toBe('breadcrumb-link')
+  })
+})
+
+describe('BreadcrumbPage', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbPage')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbPage', () => {
+    expect(result.componentName).toBe('BreadcrumbPage')
+  })
+
+  test('renders as span with aria-current=page', () => {
+    expect(result.root.tag).toBe('span')
+    expect(result.root.aria['current']).toBe('page')
+  })
+
+  test('has data-slot=breadcrumb-page', () => {
+    expect(result.root.props['data-slot']).toBe('breadcrumb-page')
+  })
+})
+
+describe('BreadcrumbSeparator', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbSeparator')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbSeparator', () => {
+    expect(result.componentName).toBe('BreadcrumbSeparator')
+  })
+
+  test('renders as li with role=presentation', () => {
+    expect(result.root.tag).toBe('li')
+    expect(result.root.role).toBe('presentation')
+  })
+
+  test('has aria-hidden=true', () => {
+    expect(result.root.aria['hidden']).toBe('true')
+  })
+})
+
+describe('BreadcrumbEllipsis', () => {
+  const result = renderToTest(breadcrumbSource, 'breadcrumb.tsx', 'BreadcrumbEllipsis')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is BreadcrumbEllipsis', () => {
+    expect(result.componentName).toBe('BreadcrumbEllipsis')
+  })
+
+  test('renders as span with role=presentation', () => {
+    expect(result.root.tag).toBe('span')
+    expect(result.root.role).toBe('presentation')
+  })
+
+  test('has data-slot=breadcrumb-ellipsis', () => {
+    expect(result.root.props['data-slot']).toBe('breadcrumb-ellipsis')
+  })
+})

--- a/ui/components/ui/__tests__/card.test.ts
+++ b/ui/components/ui/__tests__/card.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const cardSource = readFileSync(resolve(__dirname, '../card.tsx'), 'utf-8')
+
+describe('Card', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'Card')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Card', () => {
+    expect(result.componentName).toBe('Card')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div with data-slot=card', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('card')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-col')
+    expect(result.root.classes).toContain('rounded-xl')
+  })
+})
+
+describe('CardHeader', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=card-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('card-header')
+  })
+})
+
+describe('CardTitle', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as h3 with data-slot=card-title', () => {
+    expect(result.root.tag).toBe('h3')
+    expect(result.root.props['data-slot']).toBe('card-title')
+  })
+})
+
+describe('CardDescription', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as p with data-slot=card-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('card-description')
+  })
+})
+
+describe('CardContent', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=card-content', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('card-content')
+  })
+})
+
+describe('CardImage', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardImage')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as img with data-slot=card-image', () => {
+    expect(result.root.tag).toBe('img')
+    expect(result.root.props['data-slot']).toBe('card-image')
+  })
+})
+
+describe('CardAction', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardAction')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=card-action', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('card-action')
+  })
+})
+
+describe('CardFooter', () => {
+  const result = renderToTest(cardSource, 'card.tsx', 'CardFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=card-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('card-footer')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})

--- a/ui/components/ui/__tests__/checkbox.test.ts
+++ b/ui/components/ui/__tests__/checkbox.test.ts
@@ -21,9 +21,15 @@ describe('Checkbox', () => {
     expect(result.componentName).toBe('Checkbox')
   })
 
-  test('has signals: internalChecked, controlledChecked', () => {
+  test('has signals: internalChecked, controlledChecked (createSignal)', () => {
     expect(result.signals).toContain('internalChecked')
     expect(result.signals).toContain('controlledChecked')
+  })
+
+  test('isControlled and isChecked are memos, not in signals', () => {
+    // isControlled and isChecked are created via createMemo, not createSignal
+    expect(result.signals).not.toContain('isControlled')
+    expect(result.signals).not.toContain('isChecked')
   })
 
   test('renders as <button>', () => {

--- a/ui/components/ui/__tests__/collapsible.test.ts
+++ b/ui/components/ui/__tests__/collapsible.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const collapsibleSource = readFileSync(resolve(__dirname, '../collapsible.tsx'), 'utf-8')
+
+describe('Collapsible', () => {
+  const result = renderToTest(collapsibleSource, 'collapsible.tsx', 'Collapsible')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Collapsible', () => {
+    expect(result.componentName).toBe('Collapsible')
+  })
+
+  test('has signal: internalOpen (createSignal)', () => {
+    expect(result.signals).toContain('internalOpen')
+  })
+
+  test('renders a div with data-slot=collapsible', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('collapsible')
+  })
+
+  test('has data-state attribute', () => {
+    const div = result.find({ tag: 'div' })!
+    expect(div.dataState).not.toBeNull()
+  })
+})
+
+describe('CollapsibleTrigger', () => {
+  const result = renderToTest(collapsibleSource, 'collapsible.tsx', 'CollapsibleTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CollapsibleTrigger', () => {
+    expect(result.componentName).toBe('CollapsibleTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('has button with aria-expanded', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.aria).toHaveProperty('expanded')
+  })
+
+
+})
+
+describe('CollapsibleContent', () => {
+  const result = renderToTest(collapsibleSource, 'collapsible.tsx', 'CollapsibleContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is CollapsibleContent', () => {
+    expect(result.componentName).toBe('CollapsibleContent')
+  })
+
+  test('has role=region', () => {
+    const region = result.find({ role: 'region' })
+    expect(region).not.toBeNull()
+  })
+
+  test('has data-state attribute', () => {
+    const region = result.find({ role: 'region' })!
+    expect(region.dataState).not.toBeNull()
+  })
+})

--- a/ui/components/ui/__tests__/dialog.test.ts
+++ b/ui/components/ui/__tests__/dialog.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../dialog.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Dialog (context provider — no DOM root, wraps children with Provider)
+// ---------------------------------------------------------------------------
+
+describe('Dialog', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'Dialog')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Dialog', () => {
+    expect(result.componentName).toBe('Dialog')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogTrigger (conditional: asChild=span or button, click event)
+// ---------------------------------------------------------------------------
+
+describe('DialogTrigger', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogTrigger', () => {
+    expect(result.componentName).toBe('DialogTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a button with data-slot=dialog-trigger', () => {
+    const button = result.find({ tag: 'button', props: { 'data-slot': 'dialog-trigger' } })
+    expect(button).not.toBeNull()
+  })
+
+
+})
+
+// ---------------------------------------------------------------------------
+// DialogOverlay (portaled overlay, data-state=closed)
+// ---------------------------------------------------------------------------
+
+describe('DialogOverlay', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogOverlay')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogOverlay', () => {
+    expect(result.componentName).toBe('DialogOverlay')
+  })
+
+  test('root is a div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=dialog-overlay', () => {
+    expect(result.root.props['data-slot']).toBe('dialog-overlay')
+  })
+
+  test('root has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogContent (portaled modal, role=dialog, aria-modal=true, data-state=closed)
+// ---------------------------------------------------------------------------
+
+describe('DialogContent', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogContent', () => {
+    expect(result.componentName).toBe('DialogContent')
+  })
+
+  test('root is a div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has role=dialog', () => {
+    expect(result.root.role).toBe('dialog')
+  })
+
+  test('root has aria-modal=true', () => {
+    expect(result.root.aria['modal']).toBe('true')
+  })
+
+  test('root has data-slot=dialog-content', () => {
+    expect(result.root.props['data-slot']).toBe('dialog-content')
+  })
+
+  test('root has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogHeader (layout container)
+// ---------------------------------------------------------------------------
+
+describe('DialogHeader', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogHeader', () => {
+    expect(result.componentName).toBe('DialogHeader')
+  })
+
+  test('root is a div with data-slot=dialog-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('dialog-header')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogTitle (heading element)
+// ---------------------------------------------------------------------------
+
+describe('DialogTitle', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogTitle', () => {
+    expect(result.componentName).toBe('DialogTitle')
+  })
+
+  test('root is h2 with data-slot=dialog-title', () => {
+    expect(result.root.tag).toBe('h2')
+    expect(result.root.props['data-slot']).toBe('dialog-title')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogDescription (description text)
+// ---------------------------------------------------------------------------
+
+describe('DialogDescription', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogDescription', () => {
+    expect(result.componentName).toBe('DialogDescription')
+  })
+
+  test('root is p with data-slot=dialog-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('dialog-description')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogFooter (layout container for action buttons)
+// ---------------------------------------------------------------------------
+
+describe('DialogFooter', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogFooter', () => {
+    expect(result.componentName).toBe('DialogFooter')
+  })
+
+  test('root is div with data-slot=dialog-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('dialog-footer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DialogClose (close button, click event)
+// ---------------------------------------------------------------------------
+
+describe('DialogClose', () => {
+  const result = renderToTest(source, 'dialog.tsx', 'DialogClose')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DialogClose', () => {
+    expect(result.componentName).toBe('DialogClose')
+  })
+
+  test('root is button with data-slot=dialog-close', () => {
+    expect(result.root.tag).toBe('button')
+    expect(result.root.props['data-slot']).toBe('dialog-close')
+  })
+})

--- a/ui/components/ui/__tests__/drawer.test.ts
+++ b/ui/components/ui/__tests__/drawer.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const drawerSource = readFileSync(resolve(__dirname, '../drawer.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Drawer (Provider-only root — no DOM root, children manage own elements)
+// ---------------------------------------------------------------------------
+
+describe('Drawer', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'Drawer')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Drawer', () => {
+    expect(result.componentName).toBe('Drawer')
+  })
+
+  test('no signals (open state comes from props)', () => {
+    expect(result.signals).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerTrigger (conditional asChild — button or span wrapper)
+// ---------------------------------------------------------------------------
+
+describe('DrawerTrigger', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DrawerTrigger', () => {
+    expect(result.componentName).toBe('DrawerTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a <button> with data-slot=drawer-trigger', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.props['data-slot']).toBe('drawer-trigger')
+  })
+
+  test('asChild branch uses span with display:contents', () => {
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.props['style']).toBe('display:contents')
+    expect(span!.props['data-slot']).toBe('drawer-trigger')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerOverlay (portaled overlay, data-state=closed initially)
+// ---------------------------------------------------------------------------
+
+describe('DrawerOverlay', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerOverlay')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DrawerOverlay', () => {
+    expect(result.componentName).toBe('DrawerOverlay')
+  })
+
+  test('renders as div with data-slot=drawer-overlay', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('drawer-overlay')
+  })
+
+  test('has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('fixed')
+    expect(result.root.classes).toContain('inset-0')
+    expect(result.root.classes).toContain('z-50')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerContent (portaled dialog panel, role=dialog, aria-modal, data-state)
+// ---------------------------------------------------------------------------
+
+describe('DrawerContent', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DrawerContent', () => {
+    expect(result.componentName).toBe('DrawerContent')
+  })
+
+  test('renders as div with role=dialog', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.role).toBe('dialog')
+  })
+
+  test('has aria-modal=true', () => {
+    expect(result.root.aria['modal']).toBe('true')
+  })
+
+  test('has data-slot=drawer-content', () => {
+    expect(result.root.props['data-slot']).toBe('drawer-content')
+  })
+
+  test('has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+
+  test('has base classes (non-direction-specific)', () => {
+    // Direction-specific classes (fixed, inset-x-0, bottom-0, etc.) come from a dynamic lookup
+    // and are not statically resolvable in IR tests
+    expect(result.root.classes).toContain('z-50')
+    expect(result.root.classes).toContain('flex-col')
+    expect(result.root.classes).toContain('bg-background')
+    expect(result.root.classes).toContain('shadow-lg')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerHandle (decorative bar indicator)
+// ---------------------------------------------------------------------------
+
+describe('DrawerHandle', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerHandle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DrawerHandle', () => {
+    expect(result.componentName).toBe('DrawerHandle')
+  })
+
+  test('renders as div with data-slot=drawer-handle', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('drawer-handle')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('rounded-full')
+    expect(result.root.classes).toContain('bg-muted')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerHeader / DrawerFooter / DrawerTitle / DrawerDescription (stateless)
+// ---------------------------------------------------------------------------
+
+describe('DrawerHeader', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=drawer-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('drawer-header')
+  })
+})
+
+describe('DrawerTitle', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as h2 with data-slot=drawer-title', () => {
+    expect(result.root.tag).toBe('h2')
+    expect(result.root.props['data-slot']).toBe('drawer-title')
+  })
+})
+
+describe('DrawerDescription', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as p with data-slot=drawer-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('drawer-description')
+  })
+})
+
+describe('DrawerFooter', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=drawer-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('drawer-footer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DrawerClose (close button, reads context on mount)
+// ---------------------------------------------------------------------------
+
+describe('DrawerClose', () => {
+  const result = renderToTest(drawerSource, 'drawer.tsx', 'DrawerClose')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DrawerClose', () => {
+    expect(result.componentName).toBe('DrawerClose')
+  })
+
+  test('renders as button with data-slot=drawer-close', () => {
+    expect(result.root.tag).toBe('button')
+    expect(result.root.props['data-slot']).toBe('drawer-close')
+  })
+
+  test('has type=button', () => {
+    expect(result.root.props['type']).toBe('button')
+  })
+})

--- a/ui/components/ui/__tests__/dropdown-menu.test.ts
+++ b/ui/components/ui/__tests__/dropdown-menu.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const dropdownMenuSource = readFileSync(resolve(__dirname, '../dropdown-menu.tsx'), 'utf-8')
+
+describe('DropdownMenu', () => {
+  const result = renderToTest(dropdownMenuSource, 'dropdown-menu.tsx', 'DropdownMenu')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is DropdownMenu', () => {
+    expect(result.componentName).toBe('DropdownMenu')
+  })
+
+  test('no signals (open state from props via context)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders a div with data-slot=dropdown-menu', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('dropdown-menu')
+  })
+})
+
+describe('DropdownMenuTrigger', () => {
+  const result = renderToTest(dropdownMenuSource, 'dropdown-menu.tsx', 'DropdownMenuTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DropdownMenuTrigger', () => {
+    expect(result.componentName).toBe('DropdownMenuTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('button has aria-expanded and aria-haspopup', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.aria).toHaveProperty('expanded')
+    expect(button!.aria).toHaveProperty('haspopup')
+  })
+})
+
+describe('DropdownMenuContent', () => {
+  const result = renderToTest(dropdownMenuSource, 'dropdown-menu.tsx', 'DropdownMenuContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DropdownMenuContent', () => {
+    expect(result.componentName).toBe('DropdownMenuContent')
+  })
+
+  test('has role=menu', () => {
+    const menu = result.find({ role: 'menu' })
+    expect(menu).not.toBeNull()
+    expect(menu!.props['data-slot']).toBe('dropdown-menu-content')
+  })
+
+  test('has data-state attribute', () => {
+    const menu = result.find({ role: 'menu' })!
+    expect(menu.dataState).not.toBeNull()
+  })
+})
+
+describe('DropdownMenuItem', () => {
+  const result = renderToTest(dropdownMenuSource, 'dropdown-menu.tsx', 'DropdownMenuItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DropdownMenuItem', () => {
+    expect(result.componentName).toBe('DropdownMenuItem')
+  })
+
+  test('has role=menuitem', () => {
+    const item = result.find({ role: 'menuitem' })
+    expect(item).not.toBeNull()
+    expect(item!.props['data-slot']).toBe('dropdown-menu-item')
+  })
+
+})
+
+describe('DropdownMenuSub', () => {
+  const result = renderToTest(dropdownMenuSource, 'dropdown-menu.tsx', 'DropdownMenuSub')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is DropdownMenuSub', () => {
+    expect(result.componentName).toBe('DropdownMenuSub')
+  })
+
+  test('has signal: subOpen (createSignal)', () => {
+    expect(result.signals).toContain('subOpen')
+  })
+
+  test('renders a div with data-slot=dropdown-menu-sub', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('dropdown-menu-sub')
+  })
+})

--- a/ui/components/ui/__tests__/hover-card.test.ts
+++ b/ui/components/ui/__tests__/hover-card.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../hover-card.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// HoverCard (context-only root — Provider + div wrapper)
+// ---------------------------------------------------------------------------
+
+describe('HoverCard', () => {
+  const result = renderToTest(source, 'hover-card.tsx', 'HoverCard')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is HoverCard', () => {
+    expect(result.componentName).toBe('HoverCard')
+  })
+
+  test('contains div with data-slot=hover-card', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('hover-card')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HoverCardTrigger (asChild conditional, span with aria-expanded)
+// ---------------------------------------------------------------------------
+
+describe('HoverCardTrigger', () => {
+  const result = renderToTest(source, 'hover-card.tsx', 'HoverCardTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is HoverCardTrigger', () => {
+    expect(result.componentName).toBe('HoverCardTrigger')
+  })
+
+  test('root type is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains span with aria-expanded', () => {
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.aria).toHaveProperty('expanded')
+  })
+
+  test('that span has data-slot=hover-card-trigger', () => {
+    const span = result.find({ tag: 'span' })!
+    expect(span.props['data-slot']).toBe('hover-card-trigger')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HoverCardContent (portaled content, data-state=closed initially)
+// ---------------------------------------------------------------------------
+
+describe('HoverCardContent', () => {
+  const result = renderToTest(source, 'hover-card.tsx', 'HoverCardContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is HoverCardContent', () => {
+    expect(result.componentName).toBe('HoverCardContent')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=hover-card-content', () => {
+    expect(result.root.props['data-slot']).toBe('hover-card-content')
+  })
+
+  test('root has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+})

--- a/ui/components/ui/__tests__/input.test.ts
+++ b/ui/components/ui/__tests__/input.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const inputSource = readFileSync(resolve(__dirname, '../input.tsx'), 'utf-8')
+
+describe('Input', () => {
+  const result = renderToTest(inputSource, 'input.tsx', 'Input')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Input', () => {
+    expect(result.componentName).toBe('Input')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <input>', () => {
+    const input = result.find({ tag: 'input' })
+    expect(input).not.toBeNull()
+  })
+
+  test('has data-slot=input', () => {
+    const input = result.find({ tag: 'input' })
+    expect(input!.props['data-slot']).toBe('input')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const input = result.find({ tag: 'input' })!
+    expect(input.classes).toContain('h-9')
+    expect(input.classes).toContain('w-full')
+    expect(input.classes).toContain('rounded-md')
+    expect(input.classes).toContain('border')
+  })
+})

--- a/ui/components/ui/__tests__/label.test.ts
+++ b/ui/components/ui/__tests__/label.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const labelSource = readFileSync(resolve(__dirname, '../label.tsx'), 'utf-8')
+
+describe('Label', () => {
+  const result = renderToTest(labelSource, 'label.tsx', 'Label')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Label', () => {
+    expect(result.componentName).toBe('Label')
+  })
+
+  test('isClient is false (no "use client" directive)', () => {
+    expect(result.isClient).toBe(false)
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <label>', () => {
+    const label = result.find({ tag: 'label' })
+    expect(label).not.toBeNull()
+  })
+
+  test('has data-slot=label', () => {
+    const label = result.find({ tag: 'label' })
+    expect(label!.props['data-slot']).toBe('label')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const label = result.find({ tag: 'label' })!
+    expect(label.classes).toContain('flex')
+    expect(label.classes).toContain('items-center')
+    expect(label.classes).toContain('text-sm')
+  })
+})

--- a/ui/components/ui/__tests__/pagination.test.ts
+++ b/ui/components/ui/__tests__/pagination.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../pagination.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Pagination (nav wrapper with role=navigation)
+// ---------------------------------------------------------------------------
+
+describe('Pagination', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'Pagination')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Pagination', () => {
+    expect(result.componentName).toBe('Pagination')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as nav', () => {
+    expect(result.root.tag).toBe('nav')
+  })
+
+  test('has role=navigation', () => {
+    expect(result.root.role).toBe('navigation')
+  })
+
+  test('has aria-label=pagination', () => {
+    expect(result.root.aria['label']).toBe('pagination')
+  })
+
+  test('has data-slot=pagination', () => {
+    expect(result.root.props['data-slot']).toBe('pagination')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationContent (ul wrapper with flex layout)
+// ---------------------------------------------------------------------------
+
+describe('PaginationContent', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationContent', () => {
+    expect(result.componentName).toBe('PaginationContent')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as ul', () => {
+    expect(result.root.tag).toBe('ul')
+  })
+
+  test('has data-slot=pagination-content', () => {
+    expect(result.root.props['data-slot']).toBe('pagination-content')
+  })
+
+  test('has flex layout classes', () => {
+    expect(result.root.classes).toContain('flex')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationItem (li wrapper)
+// ---------------------------------------------------------------------------
+
+describe('PaginationItem', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationItem', () => {
+    expect(result.componentName).toBe('PaginationItem')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as li', () => {
+    expect(result.root.tag).toBe('li')
+  })
+
+  test('has data-slot=pagination-item', () => {
+    expect(result.root.props['data-slot']).toBe('pagination-item')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationLink (anchor link with data-slot)
+// ---------------------------------------------------------------------------
+
+describe('PaginationLink', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationLink')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationLink', () => {
+    expect(result.componentName).toBe('PaginationLink')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('contains an <a> element with data-slot=pagination-link', () => {
+    const link = result.find({ tag: 'a' })
+    expect(link).not.toBeNull()
+    expect(link!.props['data-slot']).toBe('pagination-link')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationPrevious (anchor with "Go to previous page" label)
+// ---------------------------------------------------------------------------
+
+describe('PaginationPrevious', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationPrevious')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationPrevious', () => {
+    expect(result.componentName).toBe('PaginationPrevious')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as a', () => {
+    expect(result.root.tag).toBe('a')
+  })
+
+  test('has aria-label "Go to previous page"', () => {
+    expect(result.root.aria['label']).toBe('Go to previous page')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationNext (anchor with "Go to next page" label)
+// ---------------------------------------------------------------------------
+
+describe('PaginationNext', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationNext')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationNext', () => {
+    expect(result.componentName).toBe('PaginationNext')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as a', () => {
+    expect(result.root.tag).toBe('a')
+  })
+
+  test('has aria-label "Go to next page"', () => {
+    expect(result.root.aria['label']).toBe('Go to next page')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PaginationEllipsis (span with aria-hidden)
+// ---------------------------------------------------------------------------
+
+describe('PaginationEllipsis', () => {
+  const result = renderToTest(source, 'pagination.tsx', 'PaginationEllipsis')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PaginationEllipsis', () => {
+    expect(result.componentName).toBe('PaginationEllipsis')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as span', () => {
+    expect(result.root.tag).toBe('span')
+  })
+
+  test('has data-slot=pagination-ellipsis', () => {
+    expect(result.root.props['data-slot']).toBe('pagination-ellipsis')
+  })
+})

--- a/ui/components/ui/__tests__/popover.test.ts
+++ b/ui/components/ui/__tests__/popover.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const popoverSource = readFileSync(resolve(__dirname, '../popover.tsx'), 'utf-8')
+
+describe('Popover', () => {
+  const result = renderToTest(popoverSource, 'popover.tsx', 'Popover')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Popover', () => {
+    expect(result.componentName).toBe('Popover')
+  })
+
+  test('no signals (open state from props via context)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders a div with data-slot=popover', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('popover')
+  })
+})
+
+describe('PopoverTrigger', () => {
+  const result = renderToTest(popoverSource, 'popover.tsx', 'PopoverTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PopoverTrigger', () => {
+    expect(result.componentName).toBe('PopoverTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('has aria-expanded attribute', () => {
+    const trigger = result.find({ tag: 'button' })
+    expect(trigger).not.toBeNull()
+    expect(trigger!.aria).toHaveProperty('expanded')
+  })
+
+})
+
+describe('PopoverContent', () => {
+  const result = renderToTest(popoverSource, 'popover.tsx', 'PopoverContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PopoverContent', () => {
+    expect(result.componentName).toBe('PopoverContent')
+  })
+
+  test('has data-slot=popover-content', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['data-slot']).toBe('popover-content')
+  })
+
+  test('has data-state attribute', () => {
+    const div = result.find({ tag: 'div' })!
+    expect(div.dataState).not.toBeNull()
+  })
+})
+
+describe('PopoverClose', () => {
+  const result = renderToTest(popoverSource, 'popover.tsx', 'PopoverClose')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is PopoverClose', () => {
+    expect(result.componentName).toBe('PopoverClose')
+  })
+
+  test('renders as <button>', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.props['data-slot']).toBe('popover-close')
+  })
+
+})

--- a/ui/components/ui/__tests__/portal.test.ts
+++ b/ui/components/ui/__tests__/portal.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const portalSource = readFileSync(resolve(__dirname, '../portal.tsx'), 'utf-8')
+
+describe('Portal', () => {
+  const result = renderToTest(portalSource, 'portal.tsx', 'Portal')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Portal', () => {
+    expect(result.componentName).toBe('Portal')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders a div with data-slot=portal', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('portal')
+  })
+
+  test('has data-portal=true', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['data-portal']).toBe('true')
+  })
+})

--- a/ui/components/ui/__tests__/radio-group.test.ts
+++ b/ui/components/ui/__tests__/radio-group.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const radioGroupSource = readFileSync(resolve(__dirname, '../radio-group.tsx'), 'utf-8')
+
+describe('RadioGroup', () => {
+  const result = renderToTest(radioGroupSource, 'radio-group.tsx', 'RadioGroup')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is RadioGroup', () => {
+    expect(result.componentName).toBe('RadioGroup')
+  })
+
+  test('has signals: internalValue, controlledValue (createSignal)', () => {
+    expect(result.signals).toContain('internalValue')
+    expect(result.signals).toContain('controlledValue')
+  })
+
+  test('isControlled and currentValue are memos, not in signals', () => {
+    expect(result.signals).not.toContain('isControlled')
+    expect(result.signals).not.toContain('currentValue')
+  })
+
+  test('has role=radiogroup', () => {
+    const group = result.find({ role: 'radiogroup' })
+    expect(group).not.toBeNull()
+  })
+
+  test('root div has data-slot=radio-group', () => {
+    const group = result.find({ role: 'radiogroup' })!
+    expect(group.props['data-slot']).toBe('radio-group')
+  })
+})
+
+describe('RadioGroupItem', () => {
+  const result = renderToTest(radioGroupSource, 'radio-group.tsx', 'RadioGroupItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is RadioGroupItem', () => {
+    expect(result.componentName).toBe('RadioGroupItem')
+  })
+
+  test('has role=radio', () => {
+    const radio = result.find({ role: 'radio' })
+    expect(radio).not.toBeNull()
+    expect(radio!.tag).toBe('button')
+  })
+
+  test('has aria-checked attribute', () => {
+    const radio = result.find({ role: 'radio' })!
+    expect(radio.aria).toHaveProperty('checked')
+  })
+
+  test('has data-state attribute', () => {
+    const radio = result.find({ role: 'radio' })!
+    expect(radio.dataState).not.toBeNull()
+  })
+
+})

--- a/ui/components/ui/__tests__/resizable.test.ts
+++ b/ui/components/ui/__tests__/resizable.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const resizableSource = readFileSync(resolve(__dirname, '../resizable.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// ResizablePanelGroup (no signals — imperative DOM via ref)
+// ---------------------------------------------------------------------------
+
+describe('ResizablePanelGroup', () => {
+  const result = renderToTest(resizableSource, 'resizable.tsx', 'ResizablePanelGroup')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ResizablePanelGroup', () => {
+    expect(result.componentName).toBe('ResizablePanelGroup')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=resizable-panel-group', () => {
+    expect(result.root.props['data-slot']).toBe('resizable-panel-group')
+  })
+
+  test('root classes are present (direction-specific classes from dynamic lookup)', () => {
+    // Classes like flex and h-full are inside a template literal with groupBaseClasses and direction check
+    // The IR test doesn't resolve these complex expressions; just verify classes array is not empty
+    expect(result.root.classes.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ResizablePanel (stateless — overflow-hidden container)
+// ---------------------------------------------------------------------------
+
+describe('ResizablePanel', () => {
+  const result = renderToTest(resizableSource, 'resizable.tsx', 'ResizablePanel')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ResizablePanel', () => {
+    expect(result.componentName).toBe('ResizablePanel')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=resizable-panel', () => {
+    expect(result.root.props['data-slot']).toBe('resizable-panel')
+  })
+
+  test('root classes contain overflow-hidden', () => {
+    expect(result.root.classes).toContain('overflow-hidden')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ResizableHandle (drag handle with role=separator and inactive state)
+// ---------------------------------------------------------------------------
+
+describe('ResizableHandle', () => {
+  const result = renderToTest(resizableSource, 'resizable.tsx', 'ResizableHandle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ResizableHandle', () => {
+    expect(result.componentName).toBe('ResizableHandle')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root role is separator', () => {
+    expect(result.root.role).toBe('separator')
+  })
+
+  test('root has data-slot=resizable-handle', () => {
+    expect(result.root.props['data-slot']).toBe('resizable-handle')
+  })
+
+  test('root has data-resize-handle-state=inactive', () => {
+    expect(result.root.props['data-resize-handle-state']).toBe('inactive')
+  })
+})

--- a/ui/components/ui/__tests__/scroll-area.test.ts
+++ b/ui/components/ui/__tests__/scroll-area.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const scrollAreaSource = readFileSync(resolve(__dirname, '../scroll-area.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// ScrollArea (stateful — manages hover, scroll, thumb position signals)
+// ---------------------------------------------------------------------------
+
+describe('ScrollArea', () => {
+  const result = renderToTest(scrollAreaSource, 'scroll-area.tsx', 'ScrollArea')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is ScrollArea', () => {
+    expect(result.componentName).toBe('ScrollArea')
+  })
+
+  test('has signals: hovered, scrolling, thumbVSize', () => {
+    expect(result.signals).toContain('hovered')
+    expect(result.signals).toContain('scrolling')
+    expect(result.signals).toContain('thumbVSize')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=scroll-area', () => {
+    expect(result.root.props['data-slot']).toBe('scroll-area')
+  })
+
+  test('root has mouseenter event handler', () => {
+    expect(result.root.events).toContain('mouseenter')
+  })
+
+  test('contains viewport div with data-slot=scroll-area-viewport', () => {
+    const viewport = result.find({ tag: 'div' })
+    expect(viewport).not.toBeNull()
+    // Find the viewport specifically
+    const allDivs = result.findAll({ tag: 'div' })
+    const viewportDiv = allDivs.find(d => d.props['data-slot'] === 'scroll-area-viewport')
+    expect(viewportDiv).not.toBeNull()
+    expect(viewportDiv!.props['data-slot']).toBe('scroll-area-viewport')
+  })
+
+  test('contains two scrollbar divs with data-slot=scroll-area-scrollbar', () => {
+    const allDivs = result.findAll({ tag: 'div' })
+    const scrollbars = allDivs.filter(d => d.props['data-slot'] === 'scroll-area-scrollbar')
+    expect(scrollbars.length).toBe(2)
+  })
+
+  test('scrollbars have vertical and horizontal orientations', () => {
+    const allDivs = result.findAll({ tag: 'div' })
+    const scrollbars = allDivs.filter(d => d.props['data-slot'] === 'scroll-area-scrollbar')
+    const orientations = scrollbars.map(s => s.props['data-orientation'])
+    expect(orientations).toContain('vertical')
+    expect(orientations).toContain('horizontal')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ScrollBar (stateless standalone scrollbar — default orientation=vertical)
+// ---------------------------------------------------------------------------
+
+describe('ScrollBar', () => {
+  const result = renderToTest(scrollAreaSource, 'scroll-area.tsx', 'ScrollBar')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ScrollBar', () => {
+    expect(result.componentName).toBe('ScrollBar')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('root has data-slot=scroll-area-scrollbar', () => {
+    expect(result.root.props['data-slot']).toBe('scroll-area-scrollbar')
+  })
+
+  test('has data-orientation attribute', () => {
+    // data-orientation is dynamic (resolved from orientation variable), just check it exists
+    expect(result.root.props['data-orientation']).not.toBeUndefined()
+  })
+})

--- a/ui/components/ui/__tests__/select.test.ts
+++ b/ui/components/ui/__tests__/select.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const selectSource = readFileSync(resolve(__dirname, '../select.tsx'), 'utf-8')
+
+describe('Select', () => {
+  const result = renderToTest(selectSource, 'select.tsx', 'Select')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Select', () => {
+    expect(result.componentName).toBe('Select')
+  })
+
+  test('has signal: open (createSignal)', () => {
+    expect(result.signals).toContain('open')
+  })
+
+  test('renders a div with data-slot=select', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('select')
+  })
+})
+
+describe('SelectTrigger', () => {
+  const result = renderToTest(selectSource, 'select.tsx', 'SelectTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SelectTrigger', () => {
+    expect(result.componentName).toBe('SelectTrigger')
+  })
+
+  test('has role=combobox', () => {
+    const trigger = result.find({ role: 'combobox' })
+    expect(trigger).not.toBeNull()
+    expect(trigger!.tag).toBe('button')
+  })
+
+  test('has aria-expanded attribute', () => {
+    const trigger = result.find({ role: 'combobox' })!
+    expect(trigger.aria).toHaveProperty('expanded')
+  })
+
+  test('has aria-haspopup attribute', () => {
+    const trigger = result.find({ role: 'combobox' })!
+    expect(trigger.aria).toHaveProperty('haspopup')
+  })
+
+
+})
+
+describe('SelectContent', () => {
+  const result = renderToTest(selectSource, 'select.tsx', 'SelectContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SelectContent', () => {
+    expect(result.componentName).toBe('SelectContent')
+  })
+
+  test('has role=listbox', () => {
+    const listbox = result.find({ role: 'listbox' })
+    expect(listbox).not.toBeNull()
+    expect(listbox!.props['data-slot']).toBe('select-content')
+  })
+
+  test('has data-state attribute', () => {
+    const listbox = result.find({ role: 'listbox' })!
+    expect(listbox.dataState).not.toBeNull()
+  })
+})
+
+describe('SelectItem', () => {
+  const result = renderToTest(selectSource, 'select.tsx', 'SelectItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SelectItem', () => {
+    expect(result.componentName).toBe('SelectItem')
+  })
+
+  test('has role=option', () => {
+    const option = result.find({ role: 'option' })
+    expect(option).not.toBeNull()
+    expect(option!.props['data-slot']).toBe('select-item')
+  })
+
+  test('has aria-selected attribute', () => {
+    const option = result.find({ role: 'option' })!
+    expect(option.aria).toHaveProperty('selected')
+  })
+
+})

--- a/ui/components/ui/__tests__/separator.test.ts
+++ b/ui/components/ui/__tests__/separator.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../separator.tsx'), 'utf-8')
+
+describe('Separator', () => {
+  const result = renderToTest(source, 'separator.tsx', 'Separator')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Separator', () => {
+    expect(result.componentName).toBe('Separator')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=separator', () => {
+    expect(result.root.props['data-slot']).toBe('separator')
+  })
+
+  test('has data-orientation attribute', () => {
+    // data-orientation is dynamic (resolved from orientation variable), just check it exists
+    expect(result.root.props['data-orientation']).not.toBeUndefined()
+  })
+
+  test('has resolved CSS classes: bg-border and shrink-0', () => {
+    expect(result.root.classes).toContain('bg-border')
+    expect(result.root.classes).toContain('shrink-0')
+  })
+})

--- a/ui/components/ui/__tests__/sheet.test.ts
+++ b/ui/components/ui/__tests__/sheet.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const sheetSource = readFileSync(resolve(__dirname, '../sheet.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Sheet (Provider-only root — no DOM root, children manage own elements)
+// ---------------------------------------------------------------------------
+
+describe('Sheet', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'Sheet')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Sheet', () => {
+    expect(result.componentName).toBe('Sheet')
+  })
+
+  test('no signals (open state comes from props)', () => {
+    expect(result.signals).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SheetTrigger (conditional asChild — button or span wrapper)
+// ---------------------------------------------------------------------------
+
+describe('SheetTrigger', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetTrigger')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SheetTrigger', () => {
+    expect(result.componentName).toBe('SheetTrigger')
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a <button> with data-slot=sheet-trigger', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.props['data-slot']).toBe('sheet-trigger')
+  })
+
+  test('asChild branch uses span with display:contents', () => {
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.props['style']).toBe('display:contents')
+    expect(span!.props['data-slot']).toBe('sheet-trigger')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SheetOverlay (portaled overlay, data-state=closed initially)
+// ---------------------------------------------------------------------------
+
+describe('SheetOverlay', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetOverlay')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SheetOverlay', () => {
+    expect(result.componentName).toBe('SheetOverlay')
+  })
+
+  test('renders as div with data-slot=sheet-overlay', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('sheet-overlay')
+  })
+
+  test('has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('fixed')
+    expect(result.root.classes).toContain('inset-0')
+    expect(result.root.classes).toContain('z-50')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SheetContent (portaled dialog panel, role=dialog, aria-modal, built-in close button)
+// ---------------------------------------------------------------------------
+
+describe('SheetContent', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetContent')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SheetContent', () => {
+    expect(result.componentName).toBe('SheetContent')
+  })
+
+  test('renders as div with role=dialog', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.role).toBe('dialog')
+  })
+
+  test('has aria-modal=true', () => {
+    expect(result.root.aria['modal']).toBe('true')
+  })
+
+  test('has data-slot=sheet-content', () => {
+    expect(result.root.props['data-slot']).toBe('sheet-content')
+  })
+
+  test('has data-state=closed (initial state)', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+
+  test('has base classes (non-side-specific)', () => {
+    // Side-specific classes (fixed, inset-y-0, right-0, etc.) come from a dynamic lookup
+    // and are not statically resolvable in IR tests
+    expect(result.root.classes).toContain('z-50')
+    expect(result.root.classes).toContain('flex-col')
+    expect(result.root.classes).toContain('bg-background')
+    expect(result.root.classes).toContain('shadow-lg')
+  })
+
+  test('contains built-in close button (X)', () => {
+    const closeButton = result.find({ tag: 'button' })
+    expect(closeButton).not.toBeNull()
+    expect(closeButton!.props['data-slot']).toBe('sheet-close-button')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SheetHeader / SheetFooter / SheetTitle / SheetDescription (stateless)
+// ---------------------------------------------------------------------------
+
+describe('SheetHeader', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=sheet-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('sheet-header')
+  })
+})
+
+describe('SheetTitle', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as h2 with data-slot=sheet-title', () => {
+    expect(result.root.tag).toBe('h2')
+    expect(result.root.props['data-slot']).toBe('sheet-title')
+  })
+})
+
+describe('SheetDescription', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as p with data-slot=sheet-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('sheet-description')
+  })
+})
+
+describe('SheetFooter', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=sheet-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('sheet-footer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SheetClose (close button, reads context on mount)
+// ---------------------------------------------------------------------------
+
+describe('SheetClose', () => {
+  const result = renderToTest(sheetSource, 'sheet.tsx', 'SheetClose')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is SheetClose', () => {
+    expect(result.componentName).toBe('SheetClose')
+  })
+
+  test('renders as button with data-slot=sheet-close', () => {
+    expect(result.root.tag).toBe('button')
+    expect(result.root.props['data-slot']).toBe('sheet-close')
+  })
+
+  test('has type=button', () => {
+    expect(result.root.props['type']).toBe('button')
+  })
+})

--- a/ui/components/ui/__tests__/slider.test.ts
+++ b/ui/components/ui/__tests__/slider.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../slider.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Slider (stateful — internalValue, controlledValue, percentage signals)
+// ---------------------------------------------------------------------------
+
+describe('Slider', () => {
+  const result = renderToTest(source, 'slider.tsx', 'Slider')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Slider', () => {
+    expect(result.componentName).toBe('Slider')
+  })
+
+  test('has signals: internalValue, controlledValue (createSignal)', () => {
+    expect(result.signals).toContain('internalValue')
+    expect(result.signals).toContain('controlledValue')
+  })
+
+  test('isControlled, currentValue, percentage are memos, not in signals', () => {
+    // isControlled, currentValue, percentage are created via createMemo, not createSignal
+    expect(result.signals).not.toContain('isControlled')
+    expect(result.signals).not.toContain('currentValue')
+    expect(result.signals).not.toContain('percentage')
+  })
+
+  test('root tag is div with data-slot=slider', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('slider')
+  })
+
+  test('root has pointerdown event handler', () => {
+    expect(result.root.events).toContain('pointerdown')
+  })
+
+  test('contains span with role=slider', () => {
+    const thumb = result.find({ role: 'slider' })
+    expect(thumb).not.toBeNull()
+  })
+
+  test('slider thumb has data-slot=slider-thumb', () => {
+    const thumb = result.find({ role: 'slider' })!
+    expect(thumb.props['data-slot']).toBe('slider-thumb')
+  })
+
+  test('slider thumb has aria-valuemin', () => {
+    const thumb = result.find({ role: 'slider' })!
+    expect(thumb.aria).toHaveProperty('valuemin')
+  })
+
+  test('contains div with data-slot=slider-track', () => {
+    const track = result.find({ tag: 'div' })
+    expect(track).not.toBeNull()
+    const sliderTrack = result.findAll({ tag: 'div' }).find(d => d.props['data-slot'] === 'slider-track')
+    expect(sliderTrack).not.toBeNull()
+  })
+
+  test('contains div with data-slot=slider-range', () => {
+    const sliderRange = result.findAll({ tag: 'div' }).find(d => d.props['data-slot'] === 'slider-range')
+    expect(sliderRange).not.toBeNull()
+  })
+
+  test('toStructure() contains slider and aria-valuenow', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('slider')
+    expect(structure).toContain('aria-valuenow')
+  })
+})

--- a/ui/components/ui/__tests__/switch.test.ts
+++ b/ui/components/ui/__tests__/switch.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const switchSource = readFileSync(resolve(__dirname, '../switch.tsx'), 'utf-8')
+
+describe('Switch', () => {
+  const result = renderToTest(switchSource, 'switch.tsx', 'Switch')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Switch', () => {
+    expect(result.componentName).toBe('Switch')
+  })
+
+  test('has signals: internalChecked, controlledChecked', () => {
+    expect(result.signals).toContain('internalChecked')
+    expect(result.signals).toContain('controlledChecked')
+  })
+
+  test('has button with role=switch', () => {
+    const button = result.find({ role: 'switch' })
+    expect(button).not.toBeNull()
+    expect(button!.tag).toBe('button')
+  })
+
+  test('button has aria-checked attribute', () => {
+    const button = result.find({ role: 'switch' })!
+    expect(button.aria).toHaveProperty('checked')
+  })
+
+  test('button has data-state attribute', () => {
+    const button = result.find({ role: 'switch' })!
+    expect(button.dataState).not.toBeNull()
+  })
+
+  test('button has click event handler', () => {
+    const button = result.find({ role: 'switch' })!
+    expect(button.events).toContain('click')
+  })
+
+  test('has span with data-slot=switch-thumb', () => {
+    const thumb = result.find({ tag: 'span' })
+    expect(thumb).not.toBeNull()
+    expect(thumb!.props['data-slot']).toBe('switch-thumb')
+  })
+
+  test('toStructure() contains switch role and aria-checked', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('switch')
+    expect(structure).toContain('aria-checked')
+  })
+})

--- a/ui/components/ui/__tests__/textarea.test.ts
+++ b/ui/components/ui/__tests__/textarea.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const textareaSource = readFileSync(resolve(__dirname, '../textarea.tsx'), 'utf-8')
+
+describe('Textarea', () => {
+  const result = renderToTest(textareaSource, 'textarea.tsx', 'Textarea')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Textarea', () => {
+    expect(result.componentName).toBe('Textarea')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <textarea>', () => {
+    const textarea = result.find({ tag: 'textarea' })
+    expect(textarea).not.toBeNull()
+  })
+
+  test('has data-slot=textarea', () => {
+    const textarea = result.find({ tag: 'textarea' })
+    expect(textarea!.props['data-slot']).toBe('textarea')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const textarea = result.find({ tag: 'textarea' })!
+    expect(textarea.classes).toContain('w-full')
+    expect(textarea.classes).toContain('rounded-md')
+    expect(textarea.classes).toContain('border')
+  })
+})

--- a/ui/components/ui/__tests__/toast.test.ts
+++ b/ui/components/ui/__tests__/toast.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const toastSource = readFileSync(resolve(__dirname, '../toast.tsx'), 'utf-8')
+
+describe('ToastProvider', () => {
+  const result = renderToTest(toastSource, 'toast.tsx', 'ToastProvider')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ToastProvider', () => {
+    expect(result.componentName).toBe('ToastProvider')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders a div with data-slot=toast-provider', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('toast-provider')
+  })
+})
+
+describe('Toast', () => {
+  const result = renderToTest(toastSource, 'toast.tsx', 'Toast')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Toast', () => {
+    expect(result.componentName).toBe('Toast')
+  })
+
+  test('no signals (animations managed via createEffect in ref)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders div with data-slot=toast', () => {
+    // Provider is transparent; result.root is the toast div
+    // role is dynamic (ternary on variant), so find by data-slot
+    const toast = result.findAll({ tag: 'div' }).find(d => d.props['data-slot'] === 'toast')
+    expect(toast).not.toBeNull()
+  })
+
+  test('has aria-live attribute (dynamic based on variant)', () => {
+    const toast = result.findAll({ tag: 'div' }).find(d => d.props['data-slot'] === 'toast')!
+    expect(toast.aria).toHaveProperty('live')
+  })
+
+  test('has data-state=hidden (initial state)', () => {
+    const toast = result.findAll({ tag: 'div' }).find(d => d.props['data-slot'] === 'toast')!
+    expect(toast.dataState).toBe('hidden')
+  })
+})
+
+describe('ToastClose', () => {
+  const result = renderToTest(toastSource, 'toast.tsx', 'ToastClose')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ToastClose', () => {
+    expect(result.componentName).toBe('ToastClose')
+  })
+
+  test('renders a button with aria-label=Close', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.aria).toHaveProperty('label')
+  })
+
+  test('has data-slot=toast-close', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.props['data-slot']).toBe('toast-close')
+  })
+})
+
+describe('ToastAction', () => {
+  const result = renderToTest(toastSource, 'toast.tsx', 'ToastAction')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ToastAction', () => {
+    expect(result.componentName).toBe('ToastAction')
+  })
+
+  test('renders a button with data-slot=toast-action', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.props['data-slot']).toBe('toast-action')
+  })
+})

--- a/ui/components/ui/__tests__/toggle-group.test.ts
+++ b/ui/components/ui/__tests__/toggle-group.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const toggleGroupSource = readFileSync(resolve(__dirname, '../toggle-group.tsx'), 'utf-8')
+
+describe('ToggleGroup', () => {
+  const result = renderToTest(toggleGroupSource, 'toggle-group.tsx', 'ToggleGroup')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is ToggleGroup', () => {
+    expect(result.componentName).toBe('ToggleGroup')
+  })
+
+  test('has signals: internalValue, controlledValue (createSignal)', () => {
+    expect(result.signals).toContain('internalValue')
+    expect(result.signals).toContain('controlledValue')
+  })
+
+  test('isControlled and currentValue are memos, not in signals', () => {
+    expect(result.signals).not.toContain('isControlled')
+    expect(result.signals).not.toContain('currentValue')
+  })
+
+  test('has role=group', () => {
+    const group = result.find({ role: 'group' })
+    expect(group).not.toBeNull()
+  })
+
+  test('root div has data-slot=toggle-group', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['data-slot']).toBe('toggle-group')
+  })
+})
+
+describe('ToggleGroupItem', () => {
+  const result = renderToTest(toggleGroupSource, 'toggle-group.tsx', 'ToggleGroupItem')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is ToggleGroupItem', () => {
+    expect(result.componentName).toBe('ToggleGroupItem')
+  })
+
+  test('renders as <button>', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+  })
+
+  test('has aria-pressed attribute', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.aria).toHaveProperty('pressed')
+  })
+
+  test('has data-state attribute', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.dataState).not.toBeNull()
+  })
+
+})

--- a/ui/components/ui/__tests__/toggle.test.ts
+++ b/ui/components/ui/__tests__/toggle.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const toggleSource = readFileSync(resolve(__dirname, '../toggle.tsx'), 'utf-8')
+
+describe('Toggle', () => {
+  const result = renderToTest(toggleSource, 'toggle.tsx', 'Toggle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Toggle', () => {
+    expect(result.componentName).toBe('Toggle')
+  })
+
+  test('has signals: internalPressed, controlledPressed', () => {
+    expect(result.signals).toContain('internalPressed')
+    expect(result.signals).toContain('controlledPressed')
+  })
+
+  test('root tag is button', () => {
+    expect(result.root.tag).toBe('button')
+  })
+
+  test('root has data-slot=toggle', () => {
+    expect(result.root.props['data-slot']).toBe('toggle')
+  })
+
+  test('root has aria-pressed attribute', () => {
+    expect(result.root.aria).toHaveProperty('pressed')
+  })
+
+  test('root has data-state attribute', () => {
+    expect(result.root.dataState).not.toBeNull()
+  })
+
+  test('root has click event handler', () => {
+    expect(result.root.events).toContain('click')
+  })
+
+  test('root classes contain inline-flex', () => {
+    expect(result.root.classes).toContain('inline-flex')
+  })
+})

--- a/ui/components/ui/__tests__/tooltip.test.ts
+++ b/ui/components/ui/__tests__/tooltip.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../tooltip.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Tooltip (stateful — open signal, hover/focus events, role=tooltip)
+// ---------------------------------------------------------------------------
+
+describe('Tooltip', () => {
+  const result = renderToTest(source, 'tooltip.tsx', 'Tooltip')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Tooltip', () => {
+    expect(result.componentName).toBe('Tooltip')
+  })
+
+  test('has signal: open', () => {
+    expect(result.signals).toContain('open')
+  })
+
+  test('root tag is span', () => {
+    expect(result.root.tag).toBe('span')
+  })
+
+  test('root has data-slot=tooltip', () => {
+    expect(result.root.props['data-slot']).toBe('tooltip')
+  })
+
+  test('root has mouseenter event handler', () => {
+    expect(result.root.events).toContain('mouseenter')
+  })
+
+  test('contains div with role=tooltip', () => {
+    const tooltipDiv = result.find({ role: 'tooltip' })
+    expect(tooltipDiv).not.toBeNull()
+  })
+
+  test('tooltip content div has data-slot=tooltip-content', () => {
+    const tooltipDiv = result.find({ role: 'tooltip' })!
+    expect(tooltipDiv.props['data-slot']).toBe('tooltip-content')
+  })
+
+  test('tooltip content div has data-state attribute', () => {
+    // data-state is dynamic (ternary on open()), just check it exists
+    const tooltipDiv = result.find({ role: 'tooltip' })!
+    expect(tooltipDiv.dataState).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Remove template-based boilerplate from all 39 E2E spec files, keeping only interaction-specific tests
- Add IR tests (27 new files) covering all UI components for structure, ARIA, signals, classes, and data-state verification at compile time without a browser
- Update `checkbox.test.ts` to clarify `createSignal` vs `createMemo` distinction in signal assertions

## IR test coverage (708 tests, 0 failures)

All components now have IR tests:
`accordion`, `alert-dialog`, `badge`, `breadcrumb`, `button`, `card`, `checkbox`, `collapsible`, `command`, `context-menu`, `dialog`, `drawer`, `dropdown-menu`, `hover-card`, `input`, `label`, `menubar`, `pagination`, `popover`, `portal`, `radio-group`, `resizable`, `scroll-area`, `select`, `separator`, `sheet`, `slider`, `switch`, `textarea`, `toast`, `toggle`, `toggle-group`, `tooltip`

## Test plan

- [x] `bun test ui/components/ui/__tests__/` → 708 pass, 0 fail
- [x] E2E tests (Playwright) — interaction-specific tests remain in spec files

🤖 Generated with [Claude Code](https://claude.com/claude-code)