### PR TITLE
Add Skeleton component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -32,6 +32,7 @@ export const componentOrder = [
   { slug: 'scroll-area', title: 'Scroll Area' },
   { slug: 'select', title: 'Select' },
   { slug: 'separator', title: 'Separator' },
+  { slug: 'skeleton', title: 'Skeleton' },
   { slug: 'sheet', title: 'Sheet' },
   { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },

--- a/site/ui/e2e/skeleton.spec.ts
+++ b/site/ui/e2e/skeleton.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Skeleton Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/skeleton')
+  })
+
+  test.describe('Skeleton Rendering', () => {
+    const skeletonSelector = '[data-slot="skeleton"]'
+
+    test('renders skeleton elements', async ({ page }) => {
+      const skeletons = page.locator(skeletonSelector)
+      await expect(skeletons.first()).toBeVisible()
+    })
+
+    test('skeleton has correct styling', async ({ page }) => {
+      const skeleton = page.locator(skeletonSelector).first()
+      await expect(skeleton).toHaveClass(/bg-muted/)
+      await expect(skeleton).toHaveClass(/animate-pulse/)
+      await expect(skeleton).toHaveClass(/rounded-md/)
+    })
+  })
+})

--- a/site/ui/pages/skeleton.tsx
+++ b/site/ui/pages/skeleton.tsx
@@ -1,0 +1,134 @@
+/**
+ * Skeleton Documentation Page
+ */
+
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'card', title: 'Card', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const previewCode = `import { Skeleton } from '@/components/ui/skeleton'
+
+function SkeletonPreview() {
+  return (
+    <div className="flex items-center space-x-4">
+      <Skeleton className="h-12 w-12 rounded-full" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[250px]" />
+        <Skeleton className="h-4 w-[200px]" />
+      </div>
+    </div>
+  )
+}`
+
+const basicCode = `import { Skeleton } from '@/components/ui/skeleton'
+
+function SkeletonBasic() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-4/5" />
+      <Skeleton className="h-4 w-3/5" />
+    </div>
+  )
+}`
+
+const cardCode = `import { Skeleton } from '@/components/ui/skeleton'
+
+function SkeletonCard() {
+  return (
+    <div className="flex flex-col space-y-3">
+      <Skeleton className="h-[125px] w-[250px] rounded-xl" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[250px]" />
+        <Skeleton className="h-4 w-[200px]" />
+      </div>
+    </div>
+  )
+}`
+
+// Props definition
+const skeletonProps: PropDefinition[] = [
+  {
+    name: 'className',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes to control size and shape.',
+  },
+]
+
+export function SkeletonPage() {
+  return (
+    <DocPage slug="skeleton" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Skeleton"
+          description="Use to show a placeholder while content is loading."
+          {...getNavLinks('skeleton')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <div className="flex items-center space-x-4">
+            <Skeleton className="h-12 w-12 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-[250px]" />
+              <Skeleton className="h-4 w-[200px]" />
+            </div>
+          </div>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add skeleton" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-4/5" />
+                <Skeleton className="h-4 w-3/5" />
+              </div>
+            </Example>
+
+            <Example title="Card" code={cardCode}>
+              <div className="flex flex-col space-y-3">
+                <Skeleton className="h-[125px] w-[250px] rounded-xl" />
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-[250px]" />
+                  <Skeleton className="h-4 w-[200px]" />
+                </div>
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={skeletonProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -96,6 +96,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Scroll Area', href: '/docs/components/scroll-area' },
       { title: 'Select', href: '/docs/components/select' },
       { title: 'Separator', href: '/docs/components/separator' },
+      { title: 'Skeleton', href: '/docs/components/skeleton' },
       { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -34,6 +34,7 @@ import { SelectPage } from './pages/select'
 import { ResizablePage } from './pages/resizable'
 import { ScrollAreaPage } from './pages/scroll-area'
 import { SeparatorPage } from './pages/separator'
+import { SkeletonPage } from './pages/skeleton'
 import { TextareaPage } from './pages/textarea'
 import { PortalPage } from './pages/portal'
 import { PaginationPage } from './pages/pagination'
@@ -174,6 +175,10 @@ export function createApp() {
             <a href="/docs/components/separator" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Separator</h3>
               <p className="text-xs text-muted-foreground">Visual divider between content</p>
+            </a>
+            <a href="/docs/components/skeleton" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Skeleton</h3>
+              <p className="text-xs text-muted-foreground">Placeholder loading indicator</p>
             </a>
             <a href="/docs/components/sheet" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Sheet</h3>
@@ -372,6 +377,11 @@ export function createApp() {
   // Separator documentation
   app.get('/docs/components/separator', (c) => {
     return c.render(<SeparatorPage />)
+  })
+
+  // Skeleton documentation
+  app.get('/docs/components/skeleton', (c) => {
+    return c.render(<SkeletonPage />)
   })
 
   // Textarea documentation

--- a/ui/components/ui/__tests__/skeleton.test.ts
+++ b/ui/components/ui/__tests__/skeleton.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, '../skeleton.tsx'), 'utf-8')
+
+describe('Skeleton', () => {
+  const result = renderToTest(source, 'skeleton.tsx', 'Skeleton')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Skeleton', () => {
+    expect(result.componentName).toBe('Skeleton')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=skeleton', () => {
+    expect(result.root.props['data-slot']).toBe('skeleton')
+  })
+
+  test('has resolved CSS classes: bg-muted, animate-pulse, rounded-md', () => {
+    expect(result.root.classes).toContain('bg-muted')
+    expect(result.root.classes).toContain('animate-pulse')
+    expect(result.root.classes).toContain('rounded-md')
+  })
+})

--- a/ui/components/ui/skeleton.tsx
+++ b/ui/components/ui/skeleton.tsx
@@ -1,0 +1,35 @@
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+
+const baseClasses = 'bg-muted animate-pulse rounded-md'
+
+/** Props for the Skeleton component. */
+interface SkeletonProps extends HTMLBaseAttributes {}
+
+/**
+ * Skeleton Component
+ *
+ * A placeholder loading indicator that mimics the shape of content
+ * with a pulsing animation.
+ *
+ * @example Basic rectangle
+ * ```tsx
+ * <Skeleton className="h-4 w-[250px]" />
+ * ```
+ *
+ * @example Circle avatar
+ * ```tsx
+ * <Skeleton className="h-12 w-12 rounded-full" />
+ * ```
+ */
+function Skeleton({ className = '', ...props }: SkeletonProps) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={`${baseClasses} ${className}`}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }
+export type { SkeletonProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -70,6 +70,12 @@
       "description": "A visual divider that separates content horizontally or vertically"
     },
     {
+      "name": "skeleton",
+      "type": "registry:ui",
+      "title": "Skeleton",
+      "description": "A placeholder loading indicator with pulse animation"
+    },
+    {
       "name": "drawer",
       "type": "registry:ui",
       "title": "Drawer",


### PR DESCRIPTION
## Summary

- Port Skeleton loading placeholder from shadcn/ui as a stateless component (`bg-muted animate-pulse rounded-md`)
- Add documentation page with Preview, Basic, and Card examples
- Add IR test (6 tests passing) and E2E test
- Register in site navigation (sidebar, home page grid, page nav, registry)

## Test plan

- [x] IR test passes: `bun test ui/components/ui/__tests__/skeleton.test.ts`
- [ ] Dev server: `bun run --cwd site/ui dev` → navigate to `/docs/components/skeleton`
- [ ] E2E test: `bunx playwright test site/ui/e2e/skeleton.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)