### PR TITLE
Add Alert component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -8,6 +8,7 @@
 // Component order for navigation (alphabetical)
 export const componentOrder = [
   { slug: 'accordion', title: 'Accordion' },
+  { slug: 'alert', title: 'Alert' },
   { slug: 'alert-dialog', title: 'Alert Dialog' },
   { slug: 'badge', title: 'Badge' },
   { slug: 'breadcrumb', title: 'Breadcrumb' },

--- a/site/ui/pages/alert.tsx
+++ b/site/ui/pages/alert.tsx
@@ -1,0 +1,163 @@
+/**
+ * Alert Documentation Page
+ */
+
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'default', title: 'Default', branch: 'start' },
+  { id: 'destructive', title: 'Destructive', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const previewCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+
+function AlertDemo() {
+  return (
+    <Alert>
+      <AlertTitle>Heads up!</AlertTitle>
+      <AlertDescription>
+        You can add components to your app using the CLI.
+      </AlertDescription>
+    </Alert>
+  )
+}`
+
+const defaultCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+
+function AlertDefault() {
+  return (
+    <Alert>
+      <AlertTitle>Heads up!</AlertTitle>
+      <AlertDescription>
+        You can add components to your app using the CLI.
+      </AlertDescription>
+    </Alert>
+  )
+}`
+
+const destructiveCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+
+function AlertDestructive() {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Error</AlertTitle>
+      <AlertDescription>
+        Your session has expired. Please log in again.
+      </AlertDescription>
+    </Alert>
+  )
+}`
+
+const alertProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: "'default' | 'destructive'",
+    defaultValue: "'default'",
+    description: 'The visual style of the alert.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The content of the alert (typically AlertTitle and AlertDescription).',
+  },
+]
+
+const alertTitleProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The title text of the alert.',
+  },
+]
+
+const alertDescriptionProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The description text of the alert.',
+  },
+]
+
+export function AlertPage() {
+  return (
+    <DocPage slug="alert" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Alert"
+          description="Displays a callout for important content."
+          {...getNavLinks('alert')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <Alert>
+            <AlertTitle>Heads up!</AlertTitle>
+            <AlertDescription>
+              You can add components to your app using the CLI.
+            </AlertDescription>
+          </Alert>
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add alert" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Default" code={defaultCode}>
+              <Alert>
+                <AlertTitle>Heads up!</AlertTitle>
+                <AlertDescription>
+                  You can add components to your app using the CLI.
+                </AlertDescription>
+              </Alert>
+            </Example>
+
+            <Example title="Destructive" code={destructiveCode}>
+              <Alert variant="destructive">
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>
+                  Your session has expired. Please log in again.
+                </AlertDescription>
+              </Alert>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-semibold mb-3">Alert</h3>
+              <PropsTable props={alertProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">AlertTitle</h3>
+              <PropsTable props={alertTitleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">AlertDescription</h3>
+              <PropsTable props={alertDescriptionProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -73,6 +73,7 @@ const menuEntries: SidebarEntry[] = [
     title: 'Components',
     links: [
       { title: 'Accordion', href: '/docs/components/accordion' },
+      { title: 'Alert', href: '/docs/components/alert' },
       { title: 'Alert Dialog', href: '/docs/components/alert-dialog' },
       { title: 'Badge', href: '/docs/components/badge' },
       { title: 'Breadcrumb', href: '/docs/components/breadcrumb' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -9,6 +9,7 @@ import { Hono } from 'hono'
 import { renderer } from './renderer'
 
 // Component pages
+import { AlertPage } from './pages/alert'
 import { AlertDialogPage } from './pages/alert-dialog'
 import { BadgePage } from './pages/badge'
 import { BreadcrumbPage } from './pages/breadcrumb'
@@ -82,6 +83,10 @@ export function createApp() {
             <a href="/docs/components/accordion" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Accordion</h3>
               <p className="text-xs text-muted-foreground">Vertically collapsing content sections</p>
+            </a>
+            <a href="/docs/components/alert" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Alert</h3>
+              <p className="text-xs text-muted-foreground">Callout for important content</p>
             </a>
             <a href="/docs/components/alert-dialog" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Alert Dialog</h3>
@@ -254,6 +259,11 @@ export function createApp() {
         </div>
       </div>
     )
+  })
+
+  // Alert documentation
+  app.get('/docs/components/alert', (c) => {
+    return c.render(<AlertPage />)
   })
 
   // Alert Dialog documentation

--- a/ui/components/ui/__tests__/alert.test.ts
+++ b/ui/components/ui/__tests__/alert.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const alertSource = readFileSync(resolve(__dirname, '../alert.tsx'), 'utf-8')
+
+describe('Alert', () => {
+  const result = renderToTest(alertSource, 'alert.tsx', 'Alert')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Alert', () => {
+    expect(result.componentName).toBe('Alert')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div with data-slot=alert', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('alert')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('rounded-lg')
+    expect(result.root.classes).toContain('border')
+    expect(result.root.classes).toContain('grid')
+  })
+})
+
+describe('AlertTitle', () => {
+  const result = renderToTest(alertSource, 'alert.tsx', 'AlertTitle')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as h5 with data-slot=alert-title', () => {
+    expect(result.root.tag).toBe('h5')
+    expect(result.root.props['data-slot']).toBe('alert-title')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('font-medium')
+    expect(result.root.classes).toContain('tracking-tight')
+  })
+})
+
+describe('AlertDescription', () => {
+  const result = renderToTest(alertSource, 'alert.tsx', 'AlertDescription')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as div with data-slot=alert-description', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('alert-description')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+  })
+})

--- a/ui/components/ui/alert.tsx
+++ b/ui/components/ui/alert.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+/**
+ * Alert Components
+ *
+ * Displays a callout for important content with variant support.
+ * Sub-components: Alert, AlertTitle, AlertDescription
+ *
+ * @see https://ui.shadcn.com/docs/components/alert
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../types'
+
+type AlertVariant = 'default' | 'destructive'
+
+const baseClasses = 'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current'
+
+const variantClasses: Record<AlertVariant, string> = {
+  default: 'bg-card text-card-foreground',
+  destructive: 'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+}
+
+const alertTitleClasses = 'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight'
+const alertDescriptionClasses = 'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed'
+
+interface AlertProps extends HTMLBaseAttributes {
+  variant?: AlertVariant
+  children?: Child
+}
+
+function Alert({ children, className = '', variant = 'default', ...props }: AlertProps) {
+  return <div data-slot="alert" role="alert" className={`${baseClasses} ${variantClasses[variant]} ${className}`} {...props}>{children}</div>
+}
+
+interface AlertTitleProps extends HTMLBaseAttributes { children?: Child }
+function AlertTitle({ children, className = '', ...props }: AlertTitleProps) {
+  return <h5 data-slot="alert-title" className={`${alertTitleClasses} ${className}`} {...props}>{children}</h5>
+}
+
+interface AlertDescriptionProps extends HTMLBaseAttributes { children?: Child }
+function AlertDescription({ children, className = '', ...props }: AlertDescriptionProps) {
+  return <div data-slot="alert-description" className={`${alertDescriptionClasses} ${className}`} {...props}>{children}</div>
+}
+
+export { Alert, AlertTitle, AlertDescription }
+export type { AlertVariant, AlertProps, AlertTitleProps, AlertDescriptionProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -4,6 +4,12 @@
   "homepage": "https://ui.barefootjs.dev",
   "items": [
     {
+      "name": "alert",
+      "type": "registry:ui",
+      "title": "Alert",
+      "description": "Displays a callout for important content"
+    },
+    {
       "name": "alert-dialog",
       "type": "registry:ui",
       "title": "Alert Dialog",


### PR DESCRIPTION
## Summary

- Port shadcn/ui Alert component (Alert, AlertTitle, AlertDescription) as stateless BarefootJS components
- Support `default` and `destructive` variants using `Record<AlertVariant, string>` pattern
- Add documentation page with examples at `/docs/components/alert`
- Register in site navigation, page navigation, routes, and component registry

## Test plan

- [x] IR tests pass (`bun test ui/components/ui/__tests__/alert.test.ts` — 11 tests)
- [ ] Verify documentation page renders at `/docs/components/alert`
- [ ] Verify sidebar navigation includes Alert between Accordion and Alert Dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)