### PR TITLE
Add Table component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -35,6 +35,7 @@ export const componentOrder = [
   { slug: 'sheet', title: 'Sheet' },
   { slug: 'slider', title: 'Slider' },
   { slug: 'switch', title: 'Switch' },
+  { slug: 'table', title: 'Table' },
   { slug: 'tabs', title: 'Tabs' },
   { slug: 'textarea', title: 'Textarea' },
   { slug: 'toast', title: 'Toast' },

--- a/site/ui/components/table-demo.tsx
+++ b/site/ui/components/table-demo.tsx
@@ -1,0 +1,125 @@
+/**
+ * Table Demo Components
+ *
+ * Static demos for the Table documentation page.
+ */
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+/** Invoice data for demos */
+const invoices = [
+  { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
+  { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+  { invoice: 'INV003', status: 'Unpaid', method: 'Bank Transfer', amount: '$350.00' },
+  { invoice: 'INV004', status: 'Paid', method: 'Credit Card', amount: '$450.00' },
+  { invoice: 'INV005', status: 'Paid', method: 'PayPal', amount: '$550.00' },
+  { invoice: 'INV006', status: 'Pending', method: 'Bank Transfer', amount: '$200.00' },
+  { invoice: 'INV007', status: 'Unpaid', method: 'Credit Card', amount: '$300.00' },
+]
+
+/**
+ * Preview demo — Invoice table with caption and footer.
+ */
+export function TablePreviewDemo() {
+  return (
+    <Table>
+      <TableCaption>A list of your recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">$2,500.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}
+
+/**
+ * Basic demo — Simple invoice table.
+ */
+export function TableBasicDemo() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 4).map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+/**
+ * With Footer demo — Table with totals row.
+ */
+export function TableWithFooterDemo() {
+  return (
+    <Table>
+      <TableCaption>A list of your recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">$2,500.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}

--- a/site/ui/e2e/table.spec.ts
+++ b/site/ui/e2e/table.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Table Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/table')
+  })
+
+  test.describe('Table Structure', () => {
+    const tableSelector = '[data-slot="table"]'
+
+    test('renders table element', async ({ page }) => {
+      const table = page.locator(tableSelector).first()
+      await expect(table).toBeVisible()
+    })
+
+    test('table is wrapped in scrollable container', async ({ page }) => {
+      const container = page.locator('[data-slot="table-container"]').first()
+      await expect(container).toBeVisible()
+      await expect(container).toHaveClass(/overflow-x-auto/)
+    })
+
+    test('renders table header', async ({ page }) => {
+      const header = page.locator('[data-slot="table-header"]').first()
+      await expect(header).toBeVisible()
+    })
+
+    test('renders table body with rows', async ({ page }) => {
+      const body = page.locator('[data-slot="table-body"]').first()
+      await expect(body).toBeVisible()
+
+      const rows = body.locator('[data-slot="table-row"]')
+      await expect(rows.first()).toBeVisible()
+    })
+
+    test('renders table head cells', async ({ page }) => {
+      const heads = page.locator('[data-slot="table-head"]').first()
+      await expect(heads).toBeVisible()
+
+      const tagName = await heads.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('th')
+    })
+
+    test('renders table data cells', async ({ page }) => {
+      const cells = page.locator('[data-slot="table-cell"]').first()
+      await expect(cells).toBeVisible()
+
+      const tagName = await cells.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('td')
+    })
+  })
+
+  test.describe('Table with Footer', () => {
+    test('renders table footer', async ({ page }) => {
+      const footer = page.locator('[data-slot="table-footer"]')
+      await expect(footer.first()).toBeVisible()
+    })
+
+    test('renders table caption', async ({ page }) => {
+      const caption = page.locator('[data-slot="table-caption"]')
+      await expect(caption.first()).toBeVisible()
+      await expect(caption.first()).toContainText('A list of your recent invoices')
+    })
+  })
+})

--- a/site/ui/pages/table.tsx
+++ b/site/ui/pages/table.tsx
@@ -1,0 +1,214 @@
+/**
+ * Table Documentation Page
+ */
+
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+import { TablePreviewDemo, TableBasicDemo, TableWithFooterDemo } from '../components/table-demo'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'with-footer', title: 'With Footer', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const previewCode = `import {
+  Table, TableBody, TableCaption, TableCell,
+  TableFooter, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+
+const invoices = [
+  { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
+  { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+  { invoice: 'INV003', status: 'Unpaid', method: 'Bank Transfer', amount: '$350.00' },
+  { invoice: 'INV004', status: 'Paid', method: 'Credit Card', amount: '$450.00' },
+  { invoice: 'INV005', status: 'Paid', method: 'PayPal', amount: '$550.00' },
+  { invoice: 'INV006', status: 'Pending', method: 'Bank Transfer', amount: '$200.00' },
+  { invoice: 'INV007', status: 'Unpaid', method: 'Credit Card', amount: '$300.00' },
+]
+
+function TableDemo() {
+  return (
+    <Table>
+      <TableCaption>A list of your recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">$2,500.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}`
+
+const basicCode = `import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+
+const invoices = [
+  { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
+  { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+  { invoice: 'INV003', status: 'Unpaid', method: 'Bank Transfer', amount: '$350.00' },
+  { invoice: 'INV004', status: 'Paid', method: 'Credit Card', amount: '$450.00' },
+]
+
+function TableBasic() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}`
+
+const withFooterCode = `import {
+  Table, TableBody, TableCaption, TableCell,
+  TableFooter, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table'
+
+const invoices = [
+  { invoice: 'INV001', status: 'Paid', method: 'Credit Card', amount: '$250.00' },
+  { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+  { invoice: 'INV003', status: 'Unpaid', method: 'Bank Transfer', amount: '$350.00' },
+  { invoice: 'INV004', status: 'Paid', method: 'Credit Card', amount: '$450.00' },
+  { invoice: 'INV005', status: 'Paid', method: 'PayPal', amount: '$550.00' },
+  { invoice: 'INV006', status: 'Pending', method: 'Bank Transfer', amount: '$200.00' },
+  { invoice: 'INV007', status: 'Unpaid', method: 'Credit Card', amount: '$300.00' },
+]
+
+function TableWithFooter() {
+  return (
+    <Table>
+      <TableCaption>A list of your recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((inv) => (
+          <TableRow>
+            <TableCell className="font-medium">{inv.invoice}</TableCell>
+            <TableCell>{inv.status}</TableCell>
+            <TableCell>{inv.method}</TableCell>
+            <TableCell className="text-right">{inv.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">$2,500.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}`
+
+// Props definitions
+const tableProps: PropDefinition[] = [
+  {
+    name: 'className',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes applied to the table element.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    defaultValue: '-',
+    description: 'Table sub-components (TableHeader, TableBody, TableFooter, TableCaption).',
+  },
+]
+
+export function TablePage() {
+  return (
+    <DocPage slug="table" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Table"
+          description="A responsive table component for displaying structured data."
+          {...getNavLinks('table')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <TablePreviewDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add table" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <TableBasicDemo />
+            </Example>
+
+            <Example title="With Footer" code={withFooterCode}>
+              <TableWithFooterDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={tableProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -99,6 +99,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Switch', href: '/docs/components/switch' },
+      { title: 'Table', href: '/docs/components/table' },
       { title: 'Tabs', href: '/docs/components/tabs' },
       { title: 'Textarea', href: '/docs/components/textarea' },
       { title: 'Toast', href: '/docs/components/toast' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -43,6 +43,7 @@ import { DrawerPage } from './pages/drawer'
 import { SheetPage } from './pages/sheet'
 import { HoverCardPage } from './pages/hover-card'
 import { MenubarPage } from './pages/menubar'
+import { TablePage } from './pages/table'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -186,6 +187,10 @@ export function createApp() {
             <a href="/docs/components/switch" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Switch</h3>
               <p className="text-xs text-muted-foreground">On/off toggle control</p>
+            </a>
+            <a href="/docs/components/table" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Table</h3>
+              <p className="text-xs text-muted-foreground">Responsive data table</p>
             </a>
             <a href="/docs/components/tabs" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Tabs</h3>
@@ -427,6 +432,11 @@ export function createApp() {
   // Sheet documentation
   app.get('/docs/components/sheet', (c) => {
     return c.render(<SheetPage />)
+  })
+
+  // Table documentation
+  app.get('/docs/components/table', (c) => {
+    return c.render(<TablePage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/__tests__/table.test.ts
+++ b/ui/components/ui/__tests__/table.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const tableSource = readFileSync(resolve(__dirname, '../table.tsx'), 'utf-8')
+
+describe('Table', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'Table')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Table', () => {
+    expect(result.componentName).toBe('Table')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div container with data-slot=table-container', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('table-container')
+  })
+
+  test('has overflow-x-auto class on container', () => {
+    expect(result.root.classes).toContain('overflow-x-auto')
+  })
+
+  test('contains table element with data-slot=table', () => {
+    const table = result.find({ tag: 'table' })
+    expect(table).not.toBeNull()
+    expect(table!.props['data-slot']).toBe('table')
+  })
+})
+
+describe('TableHeader', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableHeader')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as thead with data-slot=table-header', () => {
+    expect(result.root.tag).toBe('thead')
+    expect(result.root.props['data-slot']).toBe('table-header')
+  })
+})
+
+describe('TableBody', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableBody')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as tbody with data-slot=table-body', () => {
+    expect(result.root.tag).toBe('tbody')
+    expect(result.root.props['data-slot']).toBe('table-body')
+  })
+})
+
+describe('TableFooter', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableFooter')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as tfoot with data-slot=table-footer', () => {
+    expect(result.root.tag).toBe('tfoot')
+    expect(result.root.props['data-slot']).toBe('table-footer')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('border-t')
+    expect(result.root.classes).toContain('font-medium')
+  })
+})
+
+describe('TableRow', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableRow')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as tr with data-slot=table-row', () => {
+    expect(result.root.tag).toBe('tr')
+    expect(result.root.props['data-slot']).toBe('table-row')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('border-b')
+    expect(result.root.classes).toContain('transition-colors')
+  })
+})
+
+describe('TableHead', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableHead')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as th with data-slot=table-head', () => {
+    expect(result.root.tag).toBe('th')
+    expect(result.root.props['data-slot']).toBe('table-head')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('font-medium')
+    expect(result.root.classes).toContain('text-left')
+  })
+})
+
+describe('TableCell', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableCell')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as td with data-slot=table-cell', () => {
+    expect(result.root.tag).toBe('td')
+    expect(result.root.props['data-slot']).toBe('table-cell')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('p-2')
+    expect(result.root.classes).toContain('align-middle')
+  })
+})
+
+describe('TableCaption', () => {
+  const result = renderToTest(tableSource, 'table.tsx', 'TableCaption')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('renders as caption with data-slot=table-caption', () => {
+    expect(result.root.tag).toBe('caption')
+    expect(result.root.props['data-slot']).toBe('table-caption')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+  })
+})

--- a/ui/components/ui/table.tsx
+++ b/ui/components/ui/table.tsx
@@ -1,0 +1,263 @@
+/**
+ * Table Components
+ *
+ * A composable set of table sub-components for displaying structured data.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic table
+ * ```tsx
+ * <Table>
+ *   <TableHeader>
+ *     <TableRow>
+ *       <TableHead>Name</TableHead>
+ *       <TableHead>Status</TableHead>
+ *     </TableRow>
+ *   </TableHeader>
+ *   <TableBody>
+ *     <TableRow>
+ *       <TableCell>Item 1</TableCell>
+ *       <TableCell>Active</TableCell>
+ *     </TableRow>
+ *   </TableBody>
+ * </Table>
+ * ```
+ *
+ * @example Table with caption and footer
+ * ```tsx
+ * <Table>
+ *   <TableCaption>A list of recent invoices.</TableCaption>
+ *   <TableHeader>
+ *     <TableRow>
+ *       <TableHead>Invoice</TableHead>
+ *       <TableHead className="text-right">Amount</TableHead>
+ *     </TableRow>
+ *   </TableHeader>
+ *   <TableBody>
+ *     <TableRow>
+ *       <TableCell>INV001</TableCell>
+ *       <TableCell className="text-right">$250.00</TableCell>
+ *     </TableRow>
+ *   </TableBody>
+ *   <TableFooter>
+ *     <TableRow>
+ *       <TableCell>Total</TableCell>
+ *       <TableCell className="text-right">$250.00</TableCell>
+ *     </TableRow>
+ *   </TableFooter>
+ * </Table>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../types'
+
+// Table container classes (scrollable wrapper)
+const tableContainerClasses = 'relative w-full overflow-x-auto'
+
+// Table classes
+const tableClasses = 'w-full caption-bottom text-sm'
+
+// TableHeader classes
+const tableHeaderClasses = '[&_tr]:border-b'
+
+// TableBody classes
+const tableBodyClasses = '[&_tr:last-child]:border-0'
+
+// TableFooter classes
+const tableFooterClasses = 'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0'
+
+// TableRow classes
+const tableRowClasses = 'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors'
+
+// TableHead classes
+const tableHeadClasses = 'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
+
+// TableCell classes
+const tableCellClasses = 'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
+
+// TableCaption classes
+const tableCaptionClasses = 'text-muted-foreground mt-4 text-sm'
+
+/**
+ * Props for Table component.
+ */
+interface TableProps extends HTMLBaseAttributes {
+  /** Table content (typically TableHeader, TableBody, TableFooter, TableCaption) */
+  children?: Child
+}
+
+/**
+ * Table container component with horizontal scroll support.
+ *
+ * @param props.children - Table sub-components
+ * @param props.className - Additional CSS classes
+ */
+function Table({ children, className = '', ...props }: TableProps) {
+  return (
+    <div data-slot="table-container" className={tableContainerClasses}>
+      <table data-slot="table" className={`${tableClasses} ${className}`} {...props}>
+        {children}
+      </table>
+    </div>
+  )
+}
+
+/**
+ * Props for TableHeader component.
+ */
+interface TableHeaderProps extends HTMLBaseAttributes {
+  /** Header rows */
+  children?: Child
+}
+
+/**
+ * Table header section.
+ *
+ * @param props.children - TableRow elements
+ */
+function TableHeader({ children, className = '', ...props }: TableHeaderProps) {
+  return (
+    <thead data-slot="table-header" className={`${tableHeaderClasses} ${className}`} {...props}>
+      {children}
+    </thead>
+  )
+}
+
+/**
+ * Props for TableBody component.
+ */
+interface TableBodyProps extends HTMLBaseAttributes {
+  /** Body rows */
+  children?: Child
+}
+
+/**
+ * Table body section.
+ *
+ * @param props.children - TableRow elements
+ */
+function TableBody({ children, className = '', ...props }: TableBodyProps) {
+  return (
+    <tbody data-slot="table-body" className={`${tableBodyClasses} ${className}`} {...props}>
+      {children}
+    </tbody>
+  )
+}
+
+/**
+ * Props for TableFooter component.
+ */
+interface TableFooterProps extends HTMLBaseAttributes {
+  /** Footer rows */
+  children?: Child
+}
+
+/**
+ * Table footer section.
+ *
+ * @param props.children - TableRow elements
+ */
+function TableFooter({ children, className = '', ...props }: TableFooterProps) {
+  return (
+    <tfoot data-slot="table-footer" className={`${tableFooterClasses} ${className}`} {...props}>
+      {children}
+    </tfoot>
+  )
+}
+
+/**
+ * Props for TableRow component.
+ */
+interface TableRowProps extends HTMLBaseAttributes {
+  /** Row cells */
+  children?: Child
+}
+
+/**
+ * Table row component.
+ *
+ * @param props.children - TableHead or TableCell elements
+ */
+function TableRow({ children, className = '', ...props }: TableRowProps) {
+  return (
+    <tr data-slot="table-row" className={`${tableRowClasses} ${className}`} {...props}>
+      {children}
+    </tr>
+  )
+}
+
+/**
+ * Props for TableHead component.
+ */
+interface TableHeadProps extends HTMLBaseAttributes {
+  /** Header cell content */
+  children?: Child
+  /** Number of columns a header cell should span */
+  colSpan?: number
+  /** Number of rows a header cell should span */
+  rowSpan?: number
+  /** Specifies a group of columns for alignment */
+  scope?: 'col' | 'colgroup' | 'row' | 'rowgroup'
+}
+
+/**
+ * Table header cell component.
+ *
+ * @param props.children - Header content
+ */
+function TableHead({ children, className = '', ...props }: TableHeadProps) {
+  return (
+    <th data-slot="table-head" className={`${tableHeadClasses} ${className}`} {...props}>
+      {children}
+    </th>
+  )
+}
+
+/**
+ * Props for TableCell component.
+ */
+interface TableCellProps extends HTMLBaseAttributes {
+  /** Cell content */
+  children?: Child
+  /** Number of columns a cell should span */
+  colSpan?: number
+  /** Number of rows a cell should span */
+  rowSpan?: number
+}
+
+/**
+ * Table data cell component.
+ *
+ * @param props.children - Cell content
+ */
+function TableCell({ children, className = '', ...props }: TableCellProps) {
+  return (
+    <td data-slot="table-cell" className={`${tableCellClasses} ${className}`} {...props}>
+      {children}
+    </td>
+  )
+}
+
+/**
+ * Props for TableCaption component.
+ */
+interface TableCaptionProps extends HTMLBaseAttributes {
+  /** Caption text */
+  children?: Child
+}
+
+/**
+ * Table caption component.
+ *
+ * @param props.children - Caption content
+ */
+function TableCaption({ children, className = '', ...props }: TableCaptionProps) {
+  return (
+    <caption data-slot="table-caption" className={`${tableCaptionClasses} ${className}`} {...props}>
+      {children}
+    </caption>
+  )
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption }
+export type { TableProps, TableHeaderProps, TableBodyProps, TableFooterProps, TableRowProps, TableHeadProps, TableCellProps, TableCaptionProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -116,6 +116,12 @@
       "type": "registry:ui",
       "title": "Scroll Area",
       "description": "Augments native scroll functionality for custom, cross-browser styling"
+    },
+    {
+      "name": "table",
+      "type": "registry:ui",
+      "title": "Table",
+      "description": "A responsive table component for displaying structured data"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Port shadcn/ui Table component to BarefootJS with 8 stateless composable sub-components (Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)
- Add documentation page with Preview, Basic, and With Footer examples
- Register in site navigation (sidebar, home grid, page navigation, registry)

## Test plan
- [x] IR tests: 25 tests pass (`bun test ui/components/ui/__tests__/table.test.ts`)
- [x] E2E tests: 8 tests pass (`bunx playwright test e2e/table.spec.ts`)
- [ ] Verify page renders at `/docs/components/table`
- [ ] Verify prev/next navigation links work (Switch ← Table → Tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)