### PR TITLE
Add Spinner component

### DIFF
--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -37,6 +37,7 @@ export const componentOrder = [
   { slug: 'skeleton', title: 'Skeleton' },
   { slug: 'sheet', title: 'Sheet' },
   { slug: 'slider', title: 'Slider' },
+  { slug: 'spinner', title: 'Spinner' },
   { slug: 'switch', title: 'Switch' },
   { slug: 'table', title: 'Table' },
   { slug: 'tabs', title: 'Tabs' },

--- a/site/ui/components/spinner-demo.tsx
+++ b/site/ui/components/spinner-demo.tsx
@@ -35,7 +35,8 @@ export function SpinnerSizesDemo() {
 
 /**
  * Button with loading state.
- * Demonstrates realistic async operation with spinner feedback.
+ * Uses visibility toggling (not conditional rendering) so the Spinner SVG
+ * is always in the DOM and the client JS only toggles classes.
  */
 export function SpinnerButtonDemo() {
   const [loading, setLoading] = createSignal(false)
@@ -53,14 +54,10 @@ export function SpinnerButtonDemo() {
       disabled={loading()}
       onClick={handleClick}
     >
-      {loading() ? (
-        <span className="inline-flex items-center gap-2">
-          <Spinner className="size-4" />
-          Processing...
-        </span>
-      ) : (
-        'Submit'
-      )}
+      <Spinner className={`size-4 ${loading() ? '' : 'hidden'}`} />
+      <span data-testid="spinner-button-label">
+        {loading() ? 'Processing...' : 'Submit'}
+      </span>
     </Button>
   )
 }

--- a/site/ui/components/spinner-demo.tsx
+++ b/site/ui/components/spinner-demo.tsx
@@ -1,0 +1,66 @@
+"use client"
+/**
+ * SpinnerDemo Components
+ *
+ * Interactive demos for the Spinner component:
+ * - SpinnerPreviewDemo: Default spinner display
+ * - SpinnerSizesDemo: Multiple size variations
+ * - SpinnerButtonDemo: Button with loading state
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Spinner } from '@ui/components/ui/spinner'
+import { Button } from '@ui/components/ui/button'
+
+/**
+ * Preview: Default spinner.
+ */
+export function SpinnerPreviewDemo() {
+  return <Spinner />
+}
+
+/**
+ * Sizes: Multiple spinner sizes.
+ */
+export function SpinnerSizesDemo() {
+  return (
+    <div className="flex items-center gap-4">
+      <Spinner className="size-4" />
+      <Spinner className="size-6" />
+      <Spinner />
+      <Spinner className="size-12" />
+    </div>
+  )
+}
+
+/**
+ * Button with loading state.
+ * Demonstrates realistic async operation with spinner feedback.
+ */
+export function SpinnerButtonDemo() {
+  const [loading, setLoading] = createSignal(false)
+
+  const handleClick = (e: Event) => {
+    e.preventDefault()
+    if (loading()) return
+    setLoading(true)
+    setTimeout(() => setLoading(false), 2000)
+  }
+
+  return (
+    <Button
+      data-testid="spinner-button"
+      disabled={loading()}
+      onClick={handleClick}
+    >
+      {loading() ? (
+        <span className="inline-flex items-center gap-2">
+          <Spinner className="size-4" />
+          Processing...
+        </span>
+      ) : (
+        'Submit'
+      )}
+    </Button>
+  )
+}

--- a/site/ui/components/spinner-demo.tsx
+++ b/site/ui/components/spinner-demo.tsx
@@ -27,7 +27,7 @@ export function SpinnerSizesDemo() {
     <div className="flex items-center gap-4">
       <Spinner className="size-4" />
       <Spinner className="size-6" />
-      <Spinner />
+      <Spinner className="size-8" />
       <Spinner className="size-12" />
     </div>
   )

--- a/site/ui/e2e/spinner.spec.ts
+++ b/site/ui/e2e/spinner.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Spinner Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/spinner')
+  })
+
+  test.describe('Spinner Display', () => {
+    const spinnerSelector = '[data-slot="spinner"]'
+
+    test('displays spinner with correct SVG element', async ({ page }) => {
+      const spinner = page.locator(spinnerSelector).first()
+      await expect(spinner).toBeVisible()
+
+      const tagName = await spinner.evaluate((el) => el.tagName.toLowerCase())
+      expect(tagName).toBe('svg')
+    })
+
+    test('has animate-spin class', async ({ page }) => {
+      const spinner = page.locator(spinnerSelector).first()
+      await expect(spinner).toHaveClass(/animate-spin/)
+    })
+
+    test('has role=status for accessibility', async ({ page }) => {
+      const spinner = page.locator(spinnerSelector).first()
+      await expect(spinner).toHaveAttribute('role', 'status')
+    })
+
+    test('has aria-label for accessibility', async ({ page }) => {
+      const spinner = page.locator(spinnerSelector).first()
+      await expect(spinner).toHaveAttribute('aria-label', 'Loading')
+    })
+  })
+
+  test.describe('Sizes Demo', () => {
+    test('displays multiple spinners with different sizes', async ({ page }) => {
+      const spinners = page.locator('[data-slot="spinner"]')
+      const count = await spinners.count()
+      expect(count).toBeGreaterThanOrEqual(4)
+    })
+  })
+
+  test.describe('Button Loading Demo', () => {
+    test('shows spinner on button click', async ({ page }) => {
+      const button = page.locator('[data-testid="spinner-button"]')
+      await expect(button).toBeVisible()
+      await expect(button).toContainText('Submit')
+
+      // Click the button to trigger loading state
+      await button.click()
+
+      // Spinner should appear inside the button
+      const spinnerInButton = button.locator('[data-slot="spinner"]')
+      await expect(spinnerInButton).toBeVisible()
+      await expect(button).toContainText('Processing...')
+    })
+  })
+})

--- a/site/ui/e2e/spinner.spec.ts
+++ b/site/ui/e2e/spinner.spec.ts
@@ -44,15 +44,19 @@ test.describe('Spinner Documentation Page', () => {
     test('shows spinner on button click', async ({ page }) => {
       const button = page.locator('[data-testid="spinner-button"]')
       await expect(button).toBeVisible()
-      await expect(button).toContainText('Submit')
+
+      // Initially shows "Submit" and spinner is hidden
+      const label = page.locator('[data-testid="spinner-button-label"]')
+      await expect(label).toContainText('Submit')
+      const spinnerInButton = button.locator('[data-slot="spinner"]')
+      await expect(spinnerInButton).toHaveClass(/hidden/)
 
       // Click the button to trigger loading state
       await button.click()
 
-      // Spinner should appear inside the button
-      const spinnerInButton = button.locator('[data-slot="spinner"]')
-      await expect(spinnerInButton).toBeVisible()
-      await expect(button).toContainText('Processing...')
+      // Spinner becomes visible and text changes
+      await expect(spinnerInButton).not.toHaveClass(/hidden/)
+      await expect(label).toContainText('Processing...')
     })
   })
 })

--- a/site/ui/pages/spinner.tsx
+++ b/site/ui/pages/spinner.tsx
@@ -1,0 +1,139 @@
+/**
+ * Spinner Documentation Page
+ */
+
+import { Spinner } from '@ui/components/ui/spinner'
+import { SpinnerSizesDemo, SpinnerButtonDemo } from '@/components/spinner-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'default', title: 'Default', branch: 'start' },
+  { id: 'sizes', title: 'Sizes', branch: 'child' },
+  { id: 'button-loading', title: 'Button Loading', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const defaultCode = `import { Spinner } from '@/components/ui/spinner'
+
+function SpinnerDefault() {
+  return <Spinner />
+}`
+
+const sizesCode = `import { Spinner } from '@/components/ui/spinner'
+
+function SpinnerSizes() {
+  return (
+    <div className="flex items-center gap-4">
+      <Spinner className="size-4" />
+      <Spinner className="size-6" />
+      <Spinner />
+      <Spinner className="size-12" />
+    </div>
+  )
+}`
+
+const buttonLoadingCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import { Spinner } from '@/components/ui/spinner'
+import { Button } from '@/components/ui/button'
+
+function SpinnerButton() {
+  const [loading, setLoading] = createSignal(false)
+
+  const handleClick = (e: Event) => {
+    e.preventDefault()
+    if (loading()) return
+    setLoading(true)
+    setTimeout(() => setLoading(false), 2000)
+  }
+
+  return (
+    <Button disabled={loading()} onClick={handleClick}>
+      {loading() ? (
+        <span className="inline-flex items-center gap-2">
+          <Spinner className="size-4" />
+          Processing...
+        </span>
+      ) : (
+        'Submit'
+      )}
+    </Button>
+  )
+}`
+
+// Props definition
+const spinnerProps: PropDefinition[] = [
+  {
+    name: 'className',
+    type: 'string',
+    defaultValue: "''",
+    description: 'Additional CSS classes. Use size utilities like "size-4" or "size-6" to change the spinner size.',
+  },
+  {
+    name: 'aria-label',
+    type: 'string',
+    defaultValue: "'Loading'",
+    description: 'Accessible label for the spinner.',
+  },
+]
+
+export function SpinnerPage() {
+  return (
+    <DocPage slug="spinner" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Spinner"
+          description="An animated loading indicator for async operations."
+          {...getNavLinks('spinner')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<Spinner />`}>
+          <Spinner />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add spinner" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Default" code={defaultCode}>
+              <Spinner />
+            </Example>
+
+            <Example title="Sizes" code={sizesCode}>
+              <SpinnerSizesDemo />
+            </Example>
+
+            <Example title="Button Loading" code={buttonLoadingCode}>
+              <SpinnerButtonDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={spinnerProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/spinner.tsx
+++ b/site/ui/pages/spinner.tsx
@@ -2,7 +2,7 @@
  * Spinner Documentation Page
  */
 
-import { Spinner } from '@ui/components/ui/spinner'
+import { Spinner } from '@/components/ui/spinner'
 import { SpinnerSizesDemo, SpinnerButtonDemo } from '@/components/spinner-demo'
 import {
   DocPage,
@@ -64,14 +64,8 @@ function SpinnerButton() {
 
   return (
     <Button disabled={loading()} onClick={handleClick}>
-      {loading() ? (
-        <span className="inline-flex items-center gap-2">
-          <Spinner className="size-4" />
-          Processing...
-        </span>
-      ) : (
-        'Submit'
-      )}
+      <Spinner className={\`size-4 \${loading() ? '' : 'hidden'}\`} />
+      <span>{loading() ? 'Processing...' : 'Submit'}</span>
     </Button>
   )
 }`

--- a/site/ui/pages/spinner.tsx
+++ b/site/ui/pages/spinner.tsx
@@ -40,7 +40,7 @@ function SpinnerSizes() {
     <div className="flex items-center gap-4">
       <Spinner className="size-4" />
       <Spinner className="size-6" />
-      <Spinner />
+      <Spinner className="size-8" />
       <Spinner className="size-12" />
     </div>
   )

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -101,6 +101,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Skeleton', href: '/docs/components/skeleton' },
       { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/docs/components/slider' },
+      { title: 'Spinner', href: '/docs/components/spinner' },
       { title: 'Switch', href: '/docs/components/switch' },
       { title: 'Table', href: '/docs/components/table' },
       { title: 'Tabs', href: '/docs/components/tabs' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -47,6 +47,7 @@ import { SheetPage } from './pages/sheet'
 import { HoverCardPage } from './pages/hover-card'
 import { MenubarPage } from './pages/menubar'
 import { TablePage } from './pages/table'
+import { SpinnerPage } from './pages/spinner'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -199,6 +200,10 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Slider</h3>
               <p className="text-xs text-muted-foreground">Range value selector</p>
             </a>
+            <a href="/docs/components/spinner" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Spinner</h3>
+              <p className="text-xs text-muted-foreground">Animated loading indicator</p>
+            </a>
             <a href="/docs/components/switch" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Switch</h3>
               <p className="text-xs text-muted-foreground">On/off toggle control</p>
@@ -342,6 +347,11 @@ export function createApp() {
   // Slider documentation
   app.get('/docs/components/slider', (c) => {
     return c.render(<SliderPage />)
+  })
+
+  // Spinner documentation
+  app.get('/docs/components/spinner', (c) => {
+    return c.render(<SpinnerPage />)
   })
 
   // Switch documentation

--- a/ui/components/ui/__tests__/spinner.test.ts
+++ b/ui/components/ui/__tests__/spinner.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const spinnerSource = readFileSync(resolve(__dirname, '../spinner.tsx'), 'utf-8')
+
+describe('Spinner', () => {
+  const result = renderToTest(spinnerSource, 'spinner.tsx', 'Spinner')
+
+  test('has no compiler errors', () => {
+    const realErrors = result.errors.filter(e => e.code !== 'BF043')
+    expect(realErrors).toEqual([])
+  })
+
+  test('componentName is Spinner', () => {
+    expect(result.componentName).toBe('Spinner')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('root is an SVG element with data-slot=spinner', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+    expect(svg!.props['data-slot']).toBe('spinner')
+  })
+
+  test('has role=status for accessibility', () => {
+    const svg = result.find({ tag: 'svg' }) as any
+    expect(svg.role).toBe('status')
+  })
+
+  test('has aria-label for accessibility', () => {
+    const svg = result.find({ tag: 'svg' }) as any
+    expect(svg.aria).toEqual({ label: 'Loading' })
+  })
+
+  test('has animate-spin in class template', () => {
+    const svg = result.find({ tag: 'svg' })!
+    const classStr = svg.classes.join(' ')
+    expect(classStr).toContain('animate-spin')
+  })
+})

--- a/ui/components/ui/spinner.tsx
+++ b/ui/components/ui/spinner.tsx
@@ -1,0 +1,58 @@
+/**
+ * Spinner Component
+ *
+ * An animated loading indicator using the LoaderCircle SVG icon.
+ * Provides visual feedback during async operations with proper
+ * ARIA accessibility attributes.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Spinner />
+ * ```
+ *
+ * @example Custom size
+ * ```tsx
+ * <Spinner className="size-6" />
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+
+interface SpinnerProps extends HTMLBaseAttributes {
+  /** Additional CSS classes to apply. */
+  className?: string
+}
+
+/**
+ * Spinner component — animated loading indicator.
+ *
+ * Renders a spinning SVG arc (LoaderCircle icon from Lucide).
+ * Uses `animate-spin` CSS animation for rotation.
+ *
+ * @param props.className - Additional CSS classes (e.g., `"size-6"` for custom sizing)
+ */
+function Spinner({ className = '', ...props }: SpinnerProps) {
+  return (
+    <svg
+      data-slot="spinner"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      role="status"
+      aria-label="Loading"
+      className={`animate-spin ${className}`}
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  )
+}
+
+export { Spinner }
+export type { SpinnerProps }

--- a/ui/components/ui/spinner.tsx
+++ b/ui/components/ui/spinner.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 /**
  * Spinner Component
  *

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -140,6 +140,12 @@
       "type": "registry:ui",
       "title": "Table",
       "description": "A responsive table component for displaying structured data"
+    },
+    {
+      "name": "spinner",
+      "type": "registry:ui",
+      "title": "Spinner",
+      "description": "An animated loading indicator for async operations"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Spinner UI component ported from shadcn/ui — stateless SVG with `animate-spin` CSS animation, `role="status"` and `aria-label` for accessibility
- Include demos (default, sizes, button loading state), documentation page, IR test (7 tests passing), and E2E test
- Register in sidebar navigation, home page grid, page navigation, and component registry

## Test plan
- [x] IR test passes: `bun test ui/components/ui/__tests__/spinner.test.ts` (7/7)
- [ ] Dev server renders spinner page at `/docs/components/spinner`
- [ ] E2E test passes: `bunx playwright test site/ui/e2e/spinner.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)