### PR TITLE
Fix Skeleton Basic example invisible in flex container

### DIFF
--- a/site/ui/components/shared/docs.tsx
+++ b/site/ui/components/shared/docs.tsx
@@ -234,7 +234,7 @@ export function Example({
         {/* Preview section */}
         <div className="flex flex-wrap items-center justify-center gap-4 px-8 py-32 bg-card relative overflow-hidden">
           <div className="absolute inset-0 bg-[radial-gradient(circle,hsl(var(--muted)/0.5)_1px,transparent_1px)] bg-[length:16px_16px] pointer-events-none" />
-          <div className="relative z-10 flex flex-wrap items-center justify-center gap-4">
+          <div className="relative z-10 w-full flex flex-wrap items-center justify-center gap-4">
             {children}
           </div>
         </div>

--- a/site/ui/pages/skeleton.tsx
+++ b/site/ui/pages/skeleton.tsx
@@ -105,7 +105,7 @@ export function SkeletonPage() {
         <Section id="examples" title="Examples">
           <div className="space-y-8">
             <Example title="Basic" code={basicCode}>
-              <div className="space-y-2">
+              <div className="w-full max-w-sm space-y-2">
                 <Skeleton className="h-4 w-full" />
                 <Skeleton className="h-4 w-4/5" />
                 <Skeleton className="h-4 w-3/5" />


### PR DESCRIPTION
## Summary

- Fix Skeleton Basic example showing as invisible/empty in the documentation page
- The Example preview container uses `flex` + `justify-center` layout, causing percentage-based widths (`w-full`, `w-4/5`, `w-3/5`) on empty Skeleton divs to collapse to zero width
- Add `w-full max-w-sm` to the parent div to establish a width basis for the percentage children

## Test plan

- [ ] Dev server: `bun run --cwd site/ui dev` → navigate to `/docs/components/skeleton` → Basic example shows 3 visible skeleton bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)