### PR TITLE
Use kfly8 avatar in Avatar demos

### DIFF
--- a/site/ui/components/avatar-demo.tsx
+++ b/site/ui/components/avatar-demo.tsx
@@ -14,8 +14,8 @@ import { Avatar, AvatarImage, AvatarFallback } from '@ui/components/ui/avatar'
 export function AvatarDemo() {
   return (
     <Avatar>
-      <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-      <AvatarFallback>CN</AvatarFallback>
+      <AvatarImage src="https://github.com/kfly8.png" alt="@kfly8" />
+      <AvatarFallback>KF</AvatarFallback>
     </Avatar>
   )
 }
@@ -38,8 +38,8 @@ export function AvatarGroupDemo() {
   return (
     <div className="flex -space-x-3">
       <Avatar className="border-2 border-background">
-        <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-        <AvatarFallback>CN</AvatarFallback>
+        <AvatarImage src="https://github.com/kfly8.png" alt="@kfly8" />
+        <AvatarFallback>KF</AvatarFallback>
       </Avatar>
       <Avatar className="border-2 border-background">
         <AvatarFallback>AB</AvatarFallback>

--- a/site/ui/pages/avatar.tsx
+++ b/site/ui/pages/avatar.tsx
@@ -32,8 +32,8 @@ const previewCode = `import { Avatar, AvatarImage, AvatarFallback } from '@/comp
 function AvatarDemo() {
   return (
     <Avatar>
-      <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-      <AvatarFallback>CN</AvatarFallback>
+      <AvatarImage src="https://github.com/kfly8.png" alt="@kfly8" />
+      <AvatarFallback>KF</AvatarFallback>
     </Avatar>
   )
 }`
@@ -43,8 +43,8 @@ const basicCode = `import { Avatar, AvatarImage, AvatarFallback } from '@/compon
 function AvatarBasic() {
   return (
     <Avatar>
-      <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-      <AvatarFallback>CN</AvatarFallback>
+      <AvatarImage src="https://github.com/kfly8.png" alt="@kfly8" />
+      <AvatarFallback>KF</AvatarFallback>
     </Avatar>
   )
 }`
@@ -65,8 +65,8 @@ function AvatarGroup() {
   return (
     <div className="flex -space-x-3">
       <Avatar className="border-2 border-background">
-        <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-        <AvatarFallback>CN</AvatarFallback>
+        <AvatarImage src="https://github.com/kfly8.png" alt="@kfly8" />
+        <AvatarFallback>KF</AvatarFallback>
       </Avatar>
       <Avatar className="border-2 border-background">
         <AvatarFallback>AB</AvatarFallback>


### PR DESCRIPTION
## Summary
- Replace shadcn placeholder avatar image with project author's GitHub avatar (`kfly8`)
- Update fallback initials from `CN` to `KF` to match

## Test plan
- [ ] Verify avatar image loads at `/docs/components/avatar`
- [ ] Verify code examples show updated URL and initials

🤖 Generated with [Claude Code](https://claude.com/claude-code)