### PR TITLE
Fix Table column width and hover styling

### DIFF
--- a/site/ui/components/shared/docs.tsx
+++ b/site/ui/components/shared/docs.tsx
@@ -234,7 +234,7 @@ export function Example({
         {/* Preview section */}
         <div className="flex flex-wrap items-center justify-center gap-4 px-8 py-32 bg-card relative overflow-hidden">
           <div className="absolute inset-0 bg-[radial-gradient(circle,hsl(var(--muted)/0.5)_1px,transparent_1px)] bg-[length:16px_16px] pointer-events-none" />
-          <div className="relative z-10 flex flex-wrap items-center justify-center gap-4">
+          <div className="relative z-10 w-full flex flex-wrap items-center justify-center gap-4">
             {children}
           </div>
         </div>

--- a/ui/components/ui/table.tsx
+++ b/ui/components/ui/table.tsx
@@ -70,10 +70,10 @@ const tableFooterClasses = 'bg-muted/50 border-t font-medium [&>tr]:last:border-
 const tableRowClasses = 'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors'
 
 // TableHead classes
-const tableHeadClasses = 'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
+const tableHeadClasses = 'text-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
 
 // TableCell classes
-const tableCellClasses = 'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
+const tableCellClasses = 'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
 
 // TableCaption classes
 const tableCaptionClasses = 'text-muted-foreground mt-4 text-sm'

--- a/ui/components/ui/table.tsx
+++ b/ui/components/ui/table.tsx
@@ -55,7 +55,7 @@ import type { Child } from '../../types'
 const tableContainerClasses = 'relative w-full overflow-x-auto'
 
 // Table classes
-const tableClasses = 'w-full caption-bottom text-sm'
+const tableClasses = 'w-full caption-bottom border-collapse text-sm'
 
 // TableHeader classes
 const tableHeaderClasses = '[&_tr]:border-b'


### PR DESCRIPTION
## Summary
- Add `w-full` to `Example` preview inner wrapper (`docs.tsx`) so full-width components naturally expand instead of shrinking to content width inside flex container
- Remove `whitespace-nowrap` from `TableHead`/`TableCell` for proper column width distribution in UnoCSS environment
- Add `border-collapse` to table classes (UnoCSS lacks Tailwind's preflight table reset, causing visible cell gaps on hover)

## Root cause
The `Example` component's preview area uses nested `flex justify-center` divs. The inner wrapper had no explicit width, so it shrank to content size. Table's `w-full` resolved to this content width rather than the full container width. Adding `w-full` to the inner wrapper fixes this for all full-width components while preserving center alignment for small components (Button, Badge, etc.).

## Test plan
- [x] IR tests pass (25/25)
- [x] E2E tests pass: table (8), badge (8), card (6), separator (5) — all 27 pass
- [ ] Verify table columns distribute width like shadcn/ui at `/docs/components/table`
- [ ] Verify small components (Button, Badge) remain centered in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)