### PR TITLE
Fix controlled prop detection for props.xxx ?? default pattern

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -2698,5 +2698,34 @@ describe('Compiler', () => {
       // Should not contain double ?? like "props.initial ?? 0 ?? 0"
       expect(clientJs?.content).not.toMatch(/\?\?.*\?\?/)
     })
+
+    test('custom props parameter name (e.g., p) generates sync effect', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        interface SliderProps {
+          initial?: number
+        }
+
+        export function Slider(p: SliderProps) {
+          const [value, setValue] = createSignal(p.initial ?? 0)
+          return <input type="range" value={value()} />
+        }
+      `
+
+      const result = compileJSXSync(source, 'Slider.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Sync effect should be generated
+      expect(clientJs?.content).toContain("AUTO-GENERATED: Sync controlled prop 'initial'")
+      // Output should use 'props.initial' (not 'p.initial')
+      expect(clientJs?.content).toContain('props.initial')
+      expect(clientJs?.content).not.toContain('p.initial')
+      // No double ??
+      expect(clientJs?.content).not.toMatch(/\?\?.*\?\?/)
+    })
   })
 })

--- a/packages/jsx/src/__tests__/prop-handling.test.ts
+++ b/packages/jsx/src/__tests__/prop-handling.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for getControlledPropName() — controlled prop detection.
+ *
+ * Verifies that createSignal initializers referencing props are correctly
+ * identified so the compiler generates sync effects for controlled components.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { getControlledPropName } from '../ir-to-client-js/prop-handling'
+import type { ParamInfo, SignalInfo, TypeInfo } from '../types'
+
+const boolType: TypeInfo = { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
+const strType: TypeInfo = { kind: 'primitive', raw: 'string', primitive: 'string' }
+const numType: TypeInfo = { kind: 'primitive', raw: 'number', primitive: 'number' }
+const loc = { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
+
+function makeSignal(initialValue: string): SignalInfo {
+  return {
+    getter: 'value',
+    setter: 'setValue',
+    initialValue,
+    type: strType,
+    loc,
+  }
+}
+
+const propsParams: ParamInfo[] = [
+  { name: 'checked', type: boolType, optional: true },
+  { name: 'value', type: strType, optional: true },
+  { name: 'initial', type: numType, optional: true },
+  { name: 'defaultChecked', type: boolType, optional: true },
+  { name: 'defaultValue', type: strType, optional: true },
+]
+
+describe('getControlledPropName', () => {
+  test('direct props.xxx reference', () => {
+    expect(getControlledPropName(makeSignal('props.checked'), propsParams)).toBe('checked')
+  })
+
+  test('props.xxx ?? default (bug fix: #434)', () => {
+    expect(getControlledPropName(makeSignal('props.initial ?? 0'), propsParams)).toBe('initial')
+  })
+
+  test('props.xxx ?? string default (bug fix: #434)', () => {
+    expect(getControlledPropName(makeSignal("props.value ?? ''"), propsParams)).toBe('value')
+  })
+
+  test('props.xxx || fallback', () => {
+    expect(getControlledPropName(makeSignal("props.value || ''"), propsParams)).toBe('value')
+  })
+
+  test('default-prefixed prop is excluded', () => {
+    expect(getControlledPropName(makeSignal('props.defaultChecked'), propsParams)).toBeNull()
+  })
+
+  test('default-prefixed prop with ?? is excluded', () => {
+    expect(getControlledPropName(makeSignal('props.defaultChecked ?? false'), propsParams)).toBeNull()
+  })
+
+  test('destructured prop name', () => {
+    expect(getControlledPropName(makeSignal('checked'), propsParams)).toBe('checked')
+  })
+
+  test('destructured prop with ?? fallback', () => {
+    expect(getControlledPropName(makeSignal('checked ?? false'), propsParams)).toBe('checked')
+  })
+
+  test('destructured default-prefixed prop is excluded', () => {
+    expect(getControlledPropName(makeSignal("defaultValue ?? ''"), propsParams)).toBeNull()
+  })
+
+  test('complex expression returns null', () => {
+    expect(getControlledPropName(makeSignal('someFunction(props.value)'), propsParams)).toBeNull()
+  })
+
+  test('unknown prop name returns null', () => {
+    expect(getControlledPropName(makeSignal('props.unknown'), propsParams)).toBeNull()
+  })
+})

--- a/packages/jsx/src/__tests__/prop-handling.test.ts
+++ b/packages/jsx/src/__tests__/prop-handling.test.ts
@@ -76,4 +76,26 @@ describe('getControlledPropName', () => {
   test('unknown prop name returns null', () => {
     expect(getControlledPropName(makeSignal('props.unknown'), propsParams)).toBeNull()
   })
+
+  describe('custom props parameter name', () => {
+    test('p.checked with propsObjectName="p"', () => {
+      expect(getControlledPropName(makeSignal('p.checked'), propsParams, 'p')).toBe('checked')
+    })
+
+    test('p.initial ?? 0 with propsObjectName="p"', () => {
+      expect(getControlledPropName(makeSignal('p.initial ?? 0'), propsParams, 'p')).toBe('initial')
+    })
+
+    test('p.defaultChecked ?? false is excluded', () => {
+      expect(getControlledPropName(makeSignal('p.defaultChecked ?? false'), propsParams, 'p')).toBeNull()
+    })
+
+    test('prop.value || "" with propsObjectName="prop"', () => {
+      expect(getControlledPropName(makeSignal("prop.value || ''"), propsParams, 'prop')).toBe('value')
+    })
+
+    test('props.checked is not matched when propsObjectName="p"', () => {
+      expect(getControlledPropName(makeSignal('props.checked'), propsParams, 'p')).toBeNull()
+    })
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -102,7 +102,7 @@ export function emitSignalsAndMemos(
 ): void {
   for (const signal of ctx.signals) {
     let initialValue: string
-    if (signal.initialValue.startsWith('props.')) {
+    if (signal.initialValue.startsWith('props.') && !signal.initialValue.includes('??')) {
       initialValue = `${signal.initialValue} ?? ${inferDefaultValue(signal.type)}`
     } else {
       const controlled = controlledSignals.find(c => c.signal === signal)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -175,7 +175,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 
   const controlledSignals: Array<{ signal: typeof ctx.signals[0]; propName: string }> = []
   for (const signal of ctx.signals) {
-    const controlledPropName = getControlledPropName(signal, ctx.propsParams)
+    const controlledPropName = getControlledPropName(signal, ctx.propsParams, ctx.propsObjectName)
     if (controlledPropName) {
       controlledSignals.push({ signal, propName: controlledPropName })
     }

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -80,8 +80,9 @@ export function getControlledPropName(
   const initialValue = signal.initialValue.trim()
   const isDefaultProp = (propName: string) => propName.startsWith('default')
 
-  // Direct props.X reference (e.g., props.checked)
-  const propsMatch = initialValue.match(/^props\.(\w+)$/)
+  // Direct props.X reference, optionally with ?? or || fallback
+  // e.g., props.checked, props.value ?? 0, props.initial || ''
+  const propsMatch = initialValue.match(/^props\.(\w+)(?:\s*(?:\?\?|\|\|)\s*.+)?$/)
   if (propsMatch) {
     const propName = propsMatch[1]
     if (propsParams.some((p) => p.name === propName) && !isDefaultProp(propName)) {
@@ -96,10 +97,11 @@ export function getControlledPropName(
     }
   }
 
-  // Prop with nullish coalescing (e.g., checked ?? false)
-  const nullishMatch = initialValue.match(/^(\w+)\s*\?\?\s*.+$/)
-  if (nullishMatch) {
-    const propName = nullishMatch[1]
+  // Prop with nullish coalescing or logical OR fallback
+  // e.g., checked ?? false, props.checked ?? false, value || ''
+  const fallbackMatch = initialValue.match(/^(?:props\.)?(\w+)\s*(?:\?\?|\|\|)\s*.+$/)
+  if (fallbackMatch) {
+    const propName = fallbackMatch[1]
     if (propsParams.some((p) => p.name === propName) && !isDefaultProp(propName)) {
       return propName
     }

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -75,14 +75,17 @@ export function valueReferencesReactiveData(
  */
 export function getControlledPropName(
   signal: SignalInfo,
-  propsParams: ParamInfo[]
+  propsParams: ParamInfo[],
+  propsObjectName: string | null = null
 ): string | null {
   const initialValue = signal.initialValue.trim()
   const isDefaultProp = (propName: string) => propName.startsWith('default')
+  const propsName = propsObjectName ?? 'props'
 
-  // Direct props.X reference, optionally with ?? or || fallback
-  // e.g., props.checked, props.value ?? 0, props.initial || ''
-  const propsMatch = initialValue.match(/^props\.(\w+)(?:\s*(?:\?\?|\|\|)\s*.+)?$/)
+  // Direct <propsName>.X reference, optionally with ?? or || fallback
+  // e.g., props.checked, p.value ?? 0, props.initial || ''
+  const propsPattern = new RegExp(`^${propsName}\\.(\\w+)(?:\\s*(?:\\?\\?|\\|\\|)\\s*.+)?$`)
+  const propsMatch = initialValue.match(propsPattern)
   if (propsMatch) {
     const propName = propsMatch[1]
     if (propsParams.some((p) => p.name === propName) && !isDefaultProp(propName)) {
@@ -98,8 +101,9 @@ export function getControlledPropName(
   }
 
   // Prop with nullish coalescing or logical OR fallback
-  // e.g., checked ?? false, props.checked ?? false, value || ''
-  const fallbackMatch = initialValue.match(/^(?:props\.)?(\w+)\s*(?:\?\?|\|\|)\s*.+$/)
+  // e.g., checked ?? false, props.checked ?? false, p.value || ''
+  const fallbackPattern = new RegExp(`^(?:${propsName}\\.)?(\\w+)\\s*(?:\\?\\?|\\|\\|)\\s*.+$`)
+  const fallbackMatch = initialValue.match(fallbackPattern)
   if (fallbackMatch) {
     const propName = fallbackMatch[1]
     if (propsParams.some((p) => p.name === propName) && !isDefaultProp(propName)) {


### PR DESCRIPTION
## Summary

- Fixed `getControlledPropName()` regex patterns to recognize `props.xxx ?? default` and `props.xxx || default` as controlled props, enabling sync effect generation
- Added guard in `emitSignalsAndMemos()` to prevent redundant double-`??` when `initialValue` already contains a nullish coalescing operator
- Support custom props parameter names (e.g., `function Slider(p: SliderProps)`) in controlled prop detection and emission — `propsObjectName` is now used to build dynamic regex in `getControlledPropName()` and to rewrite prefixes to `props.` in `emitSignalsAndMemos()`
- Added unit tests and integration tests for both standard and custom parameter name cases

Fixes #434

## Test plan

- [x] `bun test` in `packages/jsx/` — all 111 tests pass across prop-handling and compiler test files
- [x] Verify `createSignal(props.value ?? 0)` generates `AUTO-GENERATED: Sync controlled prop` in client JS output
- [x] Verify `props.defaultChecked ?? false` does NOT generate a sync effect
- [x] Verify `function Slider(p: SliderProps)` with `createSignal(p.initial ?? 0)` generates sync effect and outputs `props.initial` (not `p.initial`)
- [x] No double `??` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)