### PR TITLE
Simplify BfPreload and add modulepreload across all renderers

### DIFF
--- a/examples/hono/renderer.tsx
+++ b/examples/hono/renderer.tsx
@@ -7,6 +7,10 @@
 
 import { jsxRenderer } from 'hono/jsx-renderer'
 import { BfScripts } from '../../packages/hono/src/scripts'
+import { BfPreload, type Manifest } from '../../packages/hono/src/preload'
+
+// Import manifest for modulepreload of all client JS entries
+import manifest from './dist/components/manifest.json'
 
 // Import map for resolving @barefootjs/dom in client JS
 const importMapScript = JSON.stringify({
@@ -24,6 +28,7 @@ export const renderer = jsxRenderer(
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>BarefootJS + Hono/JSX</title>
           <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
+          <BfPreload manifest={manifest as Manifest} />
           <link rel="stylesheet" href="/shared/styles/components.css" />
           <link rel="stylesheet" href="/shared/styles/todo-app.css" />
           <style>{`

--- a/packages/preview/src/index.tsx
+++ b/packages/preview/src/index.tsx
@@ -56,6 +56,7 @@ export async function runPreview(componentName: string) {
       if (!Preview) return <div>Preview "{name}" not found</div>
       return <Preview />
     },
+    manifest: result.manifest,
     port: DEFAULT_PORT,
   })
 

--- a/packages/preview/src/server.tsx
+++ b/packages/preview/src/server.tsx
@@ -14,6 +14,7 @@ import { jsxRenderer, useRequestContext } from 'hono/jsx-renderer'
 import { serveStatic } from 'hono/bun'
 import { BfScripts } from '@barefootjs/hono/scripts'
 import { BfPortals } from '@barefootjs/hono/portals'
+import { BfPreload, type Manifest } from '@barefootjs/hono/preload'
 
 declare module 'hono' {
   interface ContextRenderer {
@@ -58,6 +59,8 @@ export interface ServerOptions {
   componentName: string
   /** Render function: given preview name, returns JSX */
   renderPreview: (name: string) => any
+  /** Component manifest for modulepreload */
+  manifest?: Manifest
   /** Port number */
   port?: number
 }
@@ -70,7 +73,7 @@ export function pascalToTitle(name: string): string {
 }
 
 export function createPreviewApp(options: ServerOptions) {
-  const { previews, componentName, renderPreview } = options
+  const { previews, componentName, renderPreview, manifest } = options
 
   const app = new Hono()
 
@@ -84,6 +87,7 @@ export function createPreviewApp(options: ServerOptions) {
             <html lang="en">
               <head>
                 <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
+                {manifest && <BfPreload manifest={manifest as Manifest} />}
                 <meta charset="UTF-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <title>{componentName} — Preview</title>

--- a/site/core/landing/renderer.tsx
+++ b/site/core/landing/renderer.tsx
@@ -10,6 +10,7 @@ import { Header } from '../../shared/components/header'
 import { SearchPlaceholder } from '../../shared/components/search-placeholder'
 import { ThemeSwitcher } from '@/components/theme-switcher'
 import { BfScripts } from '../../../packages/hono/src/scripts'
+import { BfPreload, type Manifest } from '../../../packages/hono/src/preload'
 import { themeInitScript } from '@barefootjs/site-shared/lib/theme-init'
 
 /**
@@ -29,6 +30,9 @@ function WithPredictableIds({ children }: { children: any }) {
   c.set('bfInstanceIdGenerator', createPredictableIdGenerator())
   return <>{children}</>
 }
+
+// Import manifest for modulepreload of all client JS entries
+import manifest from '../dist/components/manifest.json'
 
 // Import map for resolving @barefootjs/dom in client JS
 const importMapScript = JSON.stringify({
@@ -50,6 +54,7 @@ export const landingRenderer = jsxRenderer(
         <html lang="en">
           <head>
             <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
+            <BfPreload manifest={manifest as Manifest} />
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png" />

--- a/site/core/renderer.tsx
+++ b/site/core/renderer.tsx
@@ -12,6 +12,7 @@ import { SidebarNav, type SidebarEntry, type SidebarGroup, type SidebarLink } fr
 import { PageNav, type PageNavLink } from '../shared/components/page-nav'
 import { PageNavigation } from '../shared/components/page-navigation'
 import { BfScripts } from '../../packages/hono/src/scripts'
+import { BfPreload, type Manifest } from '../../packages/hono/src/preload'
 import { TableOfContents } from '@/components/table-of-contents'
 import type { TocItem } from '../shared/components/table-of-contents'
 
@@ -51,6 +52,9 @@ function WithPredictableIds({ children }: { children: any }) {
 }
 
 import { themeInitScript } from '@barefootjs/site-shared/lib/theme-init'
+
+// Import manifest for modulepreload of all client JS entries
+import manifest from './dist/components/manifest.json'
 
 // Import map for resolving @barefootjs/dom in client JS
 const importMapScript = JSON.stringify({
@@ -126,6 +130,7 @@ export const renderer = jsxRenderer(
         <html lang="en">
           <head>
             <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
+            <BfPreload manifest={manifest as Manifest} />
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png" />

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -30,9 +30,7 @@ import { SearchButton } from '@/components/search-button'
 import { ThemeSwitcher } from '@/components/theme-switcher'
 import { CommandPalette } from '@/components/command-palette'
 
-// Import manifest for dependency-aware preloading
-// This enables BfPreload to automatically preload the full dependency chain
-// Example: If Button depends on Slot, preloading Button will also preload Slot
+// Import manifest for modulepreload of all client JS entries
 import manifest from './dist/components/manifest.json'
 
 /**
@@ -156,10 +154,7 @@ export const renderer = jsxRenderer(
         <html lang="en">
           <head>
             <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
-            <BfPreload
-              manifest={manifest as Manifest}
-              components={['Button', 'CopyButton', 'Toggle', 'ThemeToggle']}
-            />
+            <BfPreload manifest={manifest as Manifest} />
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png" />


### PR DESCRIPTION
## Summary

- Simplify `BfPreload` to preload all `clientJs` entries from the manifest instead of requiring a hardcoded component list. Removes unused `resolveDependencyChain()` and `dependencies` field from `ManifestEntry`.
- Add `BfPreload` to all Hono renderers that were missing it: `examples/hono`, `packages/preview`, `site/core`, `site/core/landing`.
- Add equivalent `BfPreloadLinks()` function to the Go template runtime (`bf.go`) with `Preloads` field in `RenderContext`, so Go-based layouts can emit `<link rel="modulepreload">` in `<head>`.

## Test plan

- [x] `bun run build` succeeds for `site/ui/` and `site/core/`
- [x] Go runtime tests pass (`go test ./...`)
- [ ] Verify generated HTML contains `<link rel="modulepreload">` tags in `<head>` for all sites
- [ ] Verify pages load and hydrate correctly with `bun run dev`
- [ ] Check Network tab in DevTools: modulepreload resources appear as early requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)