### PR TITLE
Formalize token system: JSON source of truth with CSS generation

### DIFF
--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -1,0 +1,88 @@
+// barefoot tokens — list design tokens by category.
+
+import { resolve } from 'node:path'
+import type { CliContext } from '../context'
+import type { TokenSet, Token, ColorToken } from '../../../../site/shared/tokens/schema'
+
+type CategoryName = 'typography' | 'spacing' | 'borderRadius' | 'transitions' | 'layout' | 'colors' | 'shadows'
+
+const CATEGORY_NAMES: CategoryName[] = [
+  'typography', 'spacing', 'borderRadius', 'transitions', 'layout', 'colors', 'shadows',
+]
+
+async function loadTokenSet(ctx: CliContext): Promise<TokenSet> {
+  const { loadTokens, mergeTokenSets } = await import(
+    resolve(ctx.root, 'site/shared/tokens/index')
+  )
+  const base = await loadTokens(resolve(ctx.root, 'site/shared/tokens/tokens.json'))
+  const uiJsonPath = resolve(ctx.root, 'site/ui/tokens.json')
+  const uiFile = Bun.file(uiJsonPath)
+  if (await uiFile.exists()) {
+    const ext = await loadTokens(uiJsonPath)
+    return mergeTokenSets(base, ext)
+  }
+  return base
+}
+
+function flattenTokens(tokenSet: TokenSet, category?: CategoryName): Token[] {
+  const result: Token[] = []
+
+  function add(cat: CategoryName, tokens: Token[]) {
+    if (category && category !== cat) return
+    result.push(...tokens)
+  }
+
+  add('typography', [...tokenSet.typography.fontFamily, ...tokenSet.typography.letterSpacing])
+  add('spacing', tokenSet.spacing)
+  add('borderRadius', tokenSet.borderRadius)
+  add('transitions', [...tokenSet.transitions.duration, ...tokenSet.transitions.easing])
+  add('layout', tokenSet.layout)
+  add('colors', tokenSet.colors)
+  add('shadows', tokenSet.shadows)
+
+  return result
+}
+
+function printTokens(tokens: Token[], jsonFlag: boolean) {
+  if (jsonFlag) {
+    console.log(JSON.stringify(tokens, null, 2))
+    return
+  }
+
+  if (tokens.length === 0) {
+    console.log('No tokens found.')
+    return
+  }
+
+  const nameWidth = Math.max(25, ...tokens.map(t => t.name.length + 4))
+  const header = `${'NAME'.padEnd(nameWidth)}VALUE`
+  console.log(header)
+  console.log('-'.repeat(header.length + 20))
+
+  for (const t of tokens) {
+    const name = `--${t.name}`
+    const dark = (t as ColorToken).dark
+    const darkSuffix = dark ? `  (dark: ${dark})` : ''
+    console.log(`${name.padEnd(nameWidth)}${t.value}${darkSuffix}`)
+  }
+  console.log(`\n${tokens.length} token(s)`)
+}
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  // Parse --category flag
+  let category: CategoryName | undefined
+  const catIdx = args.indexOf('--category')
+  if (catIdx >= 0 && args[catIdx + 1]) {
+    const val = args[catIdx + 1] as CategoryName
+    if (!CATEGORY_NAMES.includes(val)) {
+      console.error(`Unknown category: ${val}`)
+      console.error(`Available: ${CATEGORY_NAMES.join(', ')}`)
+      process.exit(1)
+    }
+    category = val
+  }
+
+  const tokenSet = await loadTokenSet(ctx)
+  const tokens = flattenTokens(tokenSet, category)
+  printTokens(tokens, ctx.jsonFlag)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ Commands:
   test [component]            Find and show test commands
   test:template <name>        Generate IR test from existing source
   preview <component>         Start preview dev server for visual check
+  tokens [--category <cat>]   List design tokens (categories: typography, spacing, etc.)
   meta:extract                Extract metadata from ui/components/ui/*.tsx
 
 Options:
@@ -69,6 +70,12 @@ switch (command) {
 
   case 'preview': {
     const { run } = await import('./commands/preview')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'tokens': {
+    const { run } = await import('./commands/tokens')
     await run(commandArgs, ctx)
     break
   }

--- a/packages/preview/src/compile.ts
+++ b/packages/preview/src/compile.ts
@@ -130,8 +130,14 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
   await Bun.write(resolve(DIST_DIR, 'barefoot.js'), Bun.file(domDistFile))
   console.log('Generated: .preview-dist/barefoot.js')
 
-  // 2. Copy CSS
-  const tokensCSS = await Bun.file(resolve(ROOT_DIR, 'site/shared/styles/tokens.css')).text()
+  // 2. Generate CSS from token JSON
+  const { loadTokens, mergeTokenSets, generateCSS } = await import(
+    resolve(ROOT_DIR, 'site/shared/tokens/index')
+  )
+  const baseTokens = await loadTokens(resolve(ROOT_DIR, 'site/shared/tokens/tokens.json'))
+  const uiTokens = await loadTokens(resolve(ROOT_DIR, 'site/ui/tokens.json'))
+  const mergedTokens = mergeTokenSets(baseTokens, uiTokens)
+  const tokensCSS = generateCSS(mergedTokens)
   const globalsCSS = await Bun.file(resolve(ROOT_DIR, 'site/ui/styles/globals.css')).text()
   await Bun.write(resolve(DIST_DIR, 'globals.css'), tokensCSS + '\n' + globalsCSS)
   console.log('Generated: .preview-dist/globals.css')

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -268,8 +268,10 @@ if (componentExports.length > 0) {
   console.log('Generated: dist/components/index.ts')
 }
 
-// ── 4. CSS: Concatenate tokens.css + globals.css + landing.css ─
-const tokensCSS = await Bun.file(resolve(SHARED_DIR, 'styles/tokens.css')).text()
+// ── 4. CSS: Generate tokens from JSON + globals.css + landing.css ─
+const { loadTokens, generateCSS } = await import('../shared/tokens/index')
+const baseTokens = await loadTokens(resolve(SHARED_DIR, 'tokens/tokens.json'))
+const tokensCSS = generateCSS(baseTokens)
 const globalsCSS = await Bun.file(resolve(ROOT_DIR, 'styles/globals.css')).text()
 const landingCSS = await Bun.file(resolve(ROOT_DIR, 'styles/landing.css')).text()
 const combinedCSS = tokensCSS + '\n' + globalsCSS + '\n' + landingCSS

--- a/site/shared/package.json
+++ b/site/shared/package.json
@@ -2,11 +2,15 @@
   "name": "@barefootjs/site-shared",
   "version": "0.0.1",
   "private": true,
+  "scripts": {
+    "generate:tokens": "bun run tokens/generate-tokens.ts"
+  },
   "exports": {
     "./styles/*": "./styles/*",
     "./components/*": "./components/*",
     "./lib/*": "./lib/*",
-    "./lib/theme-init": "./lib/theme-init.ts"
+    "./lib/theme-init": "./lib/theme-init.ts",
+    "./tokens": "./tokens/index.ts"
   },
   "dependencies": {
     "@barefootjs/hono": "workspace:*",

--- a/site/shared/styles/tokens.css
+++ b/site/shared/styles/tokens.css
@@ -1,11 +1,8 @@
 /**
+ * AUTO-GENERATED — Do not edit manually.
+ * Generated from tokens.json by generate-css.ts.
+ *
  * BarefootJS Design Tokens
- *
- * Shared CSS variables for all BarefootJS sites (docs, ui, lp).
- * Each site can override these values in its own globals.css.
- *
- * Color values use the OKLCH color space with the neutral theme
- * from site/ui as the canonical defaults.
  */
 
 :root {
@@ -43,32 +40,24 @@
   /* ── Layout ──────────────────────────────────────────── */
   --header-height: 52px;
 
-  /* ── Colors (OKLCH, neutral theme) ───────────────────── */
+  /* ── Colors (OKLCH, neutral theme) ─────────────── */
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
-
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);
-
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
-
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
-
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
-
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-
   --gradient-start: oklch(0.65 0.18 145);
   --gradient-end: oklch(0.55 0.15 165);
 
@@ -84,29 +73,21 @@
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
-
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
-
   --primary: oklch(0.35 0 0);
   --primary-foreground: oklch(0.985 0 0);
-
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
-
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
-
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-
   --gradient-start: oklch(0.70 0.18 145);
   --gradient-end: oklch(0.60 0.15 165);
 }

--- a/site/shared/tokens/__tests__/generate-css.test.ts
+++ b/site/shared/tokens/__tests__/generate-css.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from 'bun:test'
+import { resolve, dirname } from 'node:path'
+import { loadTokens, generateCSS, mergeTokenSets } from '../index'
+import type { TokenSet, ColorToken } from '../schema'
+
+const TOKENS_DIR = dirname(import.meta.dir)
+const BASE_JSON = resolve(TOKENS_DIR, 'tokens.json')
+const UI_JSON = resolve(dirname(dirname(TOKENS_DIR)), 'ui/tokens.json')
+
+describe('generateCSS roundtrip', () => {
+  test('all token names appear in generated CSS', async () => {
+    const tokens = await loadTokens(BASE_JSON)
+    const css = generateCSS(tokens)
+
+    const allTokens = [
+      ...tokens.typography.fontFamily,
+      ...tokens.typography.letterSpacing,
+      ...tokens.spacing,
+      ...tokens.borderRadius,
+      ...tokens.transitions.duration,
+      ...tokens.transitions.easing,
+      ...tokens.layout,
+      ...tokens.colors,
+      ...tokens.shadows,
+    ]
+
+    for (const t of allTokens) {
+      expect(css).toContain(`--${t.name}:`)
+    }
+  })
+
+  test('color dark values appear in .dark block', async () => {
+    const tokens = await loadTokens(BASE_JSON)
+    const css = generateCSS(tokens)
+
+    // Split at .dark to isolate the dark block
+    const darkBlockMatch = css.match(/\.dark\s*\{([^}]+)\}/)
+    expect(darkBlockMatch).not.toBeNull()
+    const darkBlock = darkBlockMatch![1]
+
+    const darkColors = tokens.colors.filter((c: ColorToken) => c.dark)
+    for (const c of darkColors) {
+      expect(darkBlock).toContain(`--${c.name}: ${c.dark}`)
+    }
+  })
+
+  test('CSS contains :root and .dark selectors', async () => {
+    const tokens = await loadTokens(BASE_JSON)
+    const css = generateCSS(tokens)
+
+    expect(css).toContain(':root {')
+    expect(css).toContain('.dark {')
+  })
+
+  test('CSS contains AUTO-GENERATED header', async () => {
+    const tokens = await loadTokens(BASE_JSON)
+    const css = generateCSS(tokens)
+
+    expect(css).toContain('AUTO-GENERATED')
+  })
+})
+
+describe('mergeTokenSets', () => {
+  test('extension tokens are added to base', async () => {
+    const base = await loadTokens(BASE_JSON)
+    const ext = await loadTokens(UI_JSON)
+    const merged = mergeTokenSets(base, ext)
+
+    // Extension adds popover color
+    expect(merged.colors.find(c => c.name === 'popover')).toBeTruthy()
+    // Base colors still present
+    expect(merged.colors.find(c => c.name === 'background')).toBeTruthy()
+  })
+
+  test('extension overrides base token with same name', () => {
+    const base: TokenSet = {
+      $schema: '', version: 1,
+      typography: { fontFamily: [], letterSpacing: [] },
+      spacing: [{ name: 'space-1', value: '4px' }],
+      borderRadius: [], transitions: { duration: [], easing: [] },
+      layout: [], colors: [], shadows: [],
+    }
+    const ext: TokenSet = {
+      $schema: '', version: 1,
+      typography: { fontFamily: [], letterSpacing: [] },
+      spacing: [{ name: 'space-1', value: '8px' }],
+      borderRadius: [], transitions: { duration: [], easing: [] },
+      layout: [], colors: [], shadows: [],
+    }
+
+    const merged = mergeTokenSets(base, ext)
+    expect(merged.spacing).toHaveLength(1)
+    expect(merged.spacing[0].value).toBe('8px')
+  })
+
+  test('merged tokens produce valid CSS with all tokens', async () => {
+    const base = await loadTokens(BASE_JSON)
+    const ext = await loadTokens(UI_JSON)
+    const merged = mergeTokenSets(base, ext)
+    const css = generateCSS(merged)
+
+    // Check extension-only tokens appear
+    expect(css).toContain('--popover:')
+    expect(css).toContain('--success:')
+    expect(css).toContain('--duration-slow:')
+    expect(css).toContain('--ease-default:')
+
+    // Check base tokens still present
+    expect(css).toContain('--font-sans:')
+    expect(css).toContain('--background:')
+  })
+})

--- a/site/shared/tokens/generate-css.ts
+++ b/site/shared/tokens/generate-css.ts
@@ -1,0 +1,104 @@
+// Generate CSS custom properties from TokenSet JSON.
+
+import type { TokenSet, Token, ColorToken } from './schema'
+
+/**
+ * Merge multiple TokenSets. Later sets override earlier ones (by token name).
+ */
+export function mergeTokenSets(...sets: TokenSet[]): TokenSet {
+  if (sets.length === 0) throw new Error('mergeTokenSets requires at least one TokenSet')
+  if (sets.length === 1) return sets[0]
+
+  const base = structuredClone(sets[0])
+
+  for (let i = 1; i < sets.length; i++) {
+    const ext = sets[i]
+    mergeTokenArray(base.typography.fontFamily, ext.typography.fontFamily)
+    mergeTokenArray(base.typography.letterSpacing, ext.typography.letterSpacing)
+    mergeTokenArray(base.spacing, ext.spacing)
+    mergeTokenArray(base.borderRadius, ext.borderRadius)
+    mergeTokenArray(base.transitions.duration, ext.transitions.duration)
+    mergeTokenArray(base.transitions.easing, ext.transitions.easing)
+    mergeTokenArray(base.layout, ext.layout)
+    mergeTokenArray(base.colors, ext.colors)
+    mergeTokenArray(base.shadows, ext.shadows)
+  }
+
+  return base
+}
+
+function mergeTokenArray<T extends Token>(base: T[], ext: T[]): void {
+  for (const token of ext) {
+    const idx = base.findIndex(t => t.name === token.name)
+    if (idx >= 0) {
+      base[idx] = token
+    } else {
+      base.push(token)
+    }
+  }
+}
+
+/**
+ * Generate CSS string from a TokenSet.
+ * Produces :root { ... } and .dark { ... } blocks.
+ */
+export function generateCSS(tokenSet: TokenSet): string {
+  const rootLines: string[] = []
+  const darkLines: string[] = []
+
+  // Helper to add a section with comment header
+  function addSection(label: string, tokens: Token[]) {
+    if (tokens.length === 0) return
+    rootLines.push(`  /* ── ${label} ${'─'.repeat(Math.max(1, 50 - label.length))} */`)
+    for (const t of tokens) {
+      rootLines.push(`  --${t.name}: ${t.value};`)
+    }
+    rootLines.push('')
+  }
+
+  function addColorSection(tokens: ColorToken[]) {
+    if (tokens.length === 0) return
+    rootLines.push(`  /* ── Colors (OKLCH, neutral theme) ${'─'.repeat(15)} */`)
+    for (const t of tokens) {
+      rootLines.push(`  --${t.name}: ${t.value};`)
+    }
+    rootLines.push('')
+
+    // Dark overrides
+    const darkTokens = tokens.filter(t => t.dark)
+    if (darkTokens.length > 0) {
+      for (const t of darkTokens) {
+        darkLines.push(`  --${t.name}: ${t.dark};`)
+      }
+    }
+  }
+
+  addSection('Typography', [
+    ...tokenSet.typography.fontFamily,
+    ...tokenSet.typography.letterSpacing,
+  ])
+  addSection('Spacing scale', tokenSet.spacing)
+  addSection('Border radius', tokenSet.borderRadius)
+  addSection('Transitions', [
+    ...tokenSet.transitions.duration,
+    ...tokenSet.transitions.easing,
+  ])
+  addSection('Layout', tokenSet.layout)
+  addColorSection(tokenSet.colors)
+  addSection('Shadows', tokenSet.shadows)
+
+  const header = `/**
+ * AUTO-GENERATED — Do not edit manually.
+ * Generated from tokens.json by generate-css.ts.
+ *
+ * BarefootJS Design Tokens
+ */`
+
+  let css = `${header}\n\n:root {\n${rootLines.join('\n')}}\n`
+
+  if (darkLines.length > 0) {
+    css += `\n.dark {\n${darkLines.join('\n')}\n}\n`
+  }
+
+  return css
+}

--- a/site/shared/tokens/generate-tokens.ts
+++ b/site/shared/tokens/generate-tokens.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+// Regenerate tokens.css from tokens.json.
+
+import { resolve, dirname } from 'node:path'
+import { loadTokens, generateCSS } from './index'
+
+const ROOT = dirname(import.meta.dir)
+const tokensPath = resolve(ROOT, 'tokens/tokens.json')
+const outputPath = resolve(ROOT, 'styles/tokens.css')
+
+const tokens = await loadTokens(tokensPath)
+const css = generateCSS(tokens)
+await Bun.write(outputPath, css)
+console.log(`Generated: ${outputPath}`)

--- a/site/shared/tokens/index.ts
+++ b/site/shared/tokens/index.ts
@@ -1,0 +1,15 @@
+// Public API for BarefootJS design tokens.
+
+import { readFile } from 'node:fs/promises'
+import type { TokenSet } from './schema'
+
+export type { Token, ColorToken, TokenSet } from './schema'
+export { generateCSS, mergeTokenSets } from './generate-css'
+
+/**
+ * Load a TokenSet from a JSON file path.
+ */
+export async function loadTokens(jsonPath: string): Promise<TokenSet> {
+  const content = await readFile(jsonPath, 'utf-8')
+  return JSON.parse(content) as TokenSet
+}

--- a/site/shared/tokens/schema.ts
+++ b/site/shared/tokens/schema.ts
@@ -1,0 +1,33 @@
+// Token schema types for BarefootJS design tokens.
+
+export interface Token {
+  /** CSS variable name without -- prefix, e.g. "font-sans" */
+  name: string
+  /** CSS value, e.g. "-apple-system, BlinkMacSystemFont, ..." */
+  value: string
+  /** Optional human-readable description */
+  description?: string
+}
+
+export interface ColorToken extends Token {
+  /** Value override for .dark theme (colors only) */
+  dark?: string
+}
+
+export interface TokenSet {
+  $schema: string
+  version: 1
+  typography: {
+    fontFamily: Token[]
+    letterSpacing: Token[]
+  }
+  spacing: Token[]
+  borderRadius: Token[]
+  transitions: {
+    duration: Token[]
+    easing: Token[]
+  }
+  layout: Token[]
+  colors: ColorToken[]
+  shadows: Token[]
+}

--- a/site/shared/tokens/tokens.json
+++ b/site/shared/tokens/tokens.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "./schema.ts",
+  "version": 1,
+  "typography": {
+    "fontFamily": [
+      { "name": "font-sans", "value": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Noto Sans\", Helvetica, Arial, sans-serif" },
+      { "name": "font-mono", "value": "ui-monospace, SFMono-Regular, \"SF Mono\", Menlo, Consolas, \"Liberation Mono\", monospace" }
+    ],
+    "letterSpacing": [
+      { "name": "tracking-tighter", "value": "-0.05em" },
+      { "name": "tracking-tight", "value": "-0.025em" },
+      { "name": "tracking-normal", "value": "0" },
+      { "name": "tracking-wide", "value": "0.025em" },
+      { "name": "tracking-wider", "value": "0.05em" }
+    ]
+  },
+  "spacing": [
+    { "name": "space-1", "value": "4px" },
+    { "name": "space-2", "value": "8px" },
+    { "name": "space-3", "value": "12px" },
+    { "name": "space-4", "value": "16px" },
+    { "name": "space-5", "value": "20px" },
+    { "name": "space-6", "value": "24px" },
+    { "name": "space-8", "value": "32px" },
+    { "name": "space-10", "value": "40px" },
+    { "name": "space-12", "value": "48px" }
+  ],
+  "borderRadius": [
+    { "name": "radius", "value": "0.625rem" },
+    { "name": "radius-sm", "value": "4px" },
+    { "name": "radius-md", "value": "6px" },
+    { "name": "radius-lg", "value": "8px" },
+    { "name": "radius-xl", "value": "12px" }
+  ],
+  "transitions": {
+    "duration": [
+      { "name": "duration-fast", "value": "0.15s" },
+      { "name": "duration-normal", "value": "0.25s" }
+    ],
+    "easing": []
+  },
+  "layout": [
+    { "name": "header-height", "value": "52px" }
+  ],
+  "colors": [
+    { "name": "background", "value": "oklch(1 0 0)", "dark": "oklch(0.145 0 0)" },
+    { "name": "foreground", "value": "oklch(0.145 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "card", "value": "oklch(1 0 0)", "dark": "oklch(0.205 0 0)" },
+    { "name": "card-foreground", "value": "oklch(0.145 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "primary", "value": "oklch(0.205 0 0)", "dark": "oklch(0.35 0 0)" },
+    { "name": "primary-foreground", "value": "oklch(0.985 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "secondary", "value": "oklch(0.97 0 0)", "dark": "oklch(0.269 0 0)" },
+    { "name": "secondary-foreground", "value": "oklch(0.205 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "muted", "value": "oklch(0.97 0 0)", "dark": "oklch(0.269 0 0)" },
+    { "name": "muted-foreground", "value": "oklch(0.556 0 0)", "dark": "oklch(0.708 0 0)" },
+    { "name": "accent", "value": "oklch(0.97 0 0)", "dark": "oklch(0.269 0 0)" },
+    { "name": "accent-foreground", "value": "oklch(0.205 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "destructive", "value": "oklch(0.577 0.245 27.325)", "dark": "oklch(0.704 0.191 22.216)" },
+    { "name": "destructive-foreground", "value": "oklch(0.985 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "border", "value": "oklch(0.922 0 0)", "dark": "oklch(1 0 0 / 10%)" },
+    { "name": "input", "value": "oklch(0.922 0 0)", "dark": "oklch(1 0 0 / 15%)" },
+    { "name": "ring", "value": "oklch(0.708 0 0)", "dark": "oklch(0.556 0 0)" },
+    { "name": "gradient-start", "value": "oklch(0.65 0.18 145)", "dark": "oklch(0.70 0.18 145)" },
+    { "name": "gradient-end", "value": "oklch(0.55 0.15 165)", "dark": "oklch(0.60 0.15 165)" }
+  ],
+  "shadows": [
+    { "name": "shadow-sm", "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)" },
+    { "name": "shadow", "value": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)" },
+    { "name": "shadow-md", "value": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)" },
+    { "name": "shadow-lg", "value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)" },
+    { "name": "shadow-xl", "value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)" },
+    { "name": "shadow-inner", "value": "inset 0 2px 4px 0 rgb(0 0 0 / 0.05)" }
+  ]
+}

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -339,10 +339,13 @@ if (componentExports.length > 0) {
   console.log('Generated: dist/components/index.ts')
 }
 
-// Concatenate tokens.css + globals.css to dist
+// Generate tokens CSS from JSON and concatenate with globals.css
+const { loadTokens, mergeTokenSets, generateCSS } = await import('../shared/tokens/index')
 const STYLES_DIR = resolve(ROOT_DIR, 'styles')
-const SHARED_STYLES_DIR = resolve(ROOT_DIR, '../shared/styles')
-const tokensCSS = await Bun.file(resolve(SHARED_STYLES_DIR, 'tokens.css')).text()
+const baseTokens = await loadTokens(resolve(ROOT_DIR, '../shared/tokens/tokens.json'))
+const uiTokens = await loadTokens(resolve(ROOT_DIR, 'tokens.json'))
+const mergedTokens = mergeTokenSets(baseTokens, uiTokens)
+const tokensCSS = generateCSS(mergedTokens)
 const siteGlobalsCSS = await Bun.file(resolve(STYLES_DIR, 'globals.css')).text()
 await Bun.write(resolve(DIST_DIR, 'globals.css'), tokensCSS + '\n' + siteGlobalsCSS)
 console.log('Generated: dist/globals.css (tokens + globals)')

--- a/site/ui/styles/globals.css
+++ b/site/ui/styles/globals.css
@@ -5,62 +5,6 @@
  * User override classes stay in @layer default, so they always win. */
 @layer preflights, base, shortcuts, components, default;
 
-/**
- * BarefootJS Design System - CSS Variables
- *
- * Based on shadcn/ui v4 color system (neutral theme).
- * Uses OKLCH values for CSS custom properties.
- */
-
-:root {
-  /* UI-specific tokens (not in shared tokens.css) */
-
-  /* Popover */
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-
-  /* Success */
-  --success: oklch(0.527 0.154 150.069);
-  --success-foreground: oklch(0.985 0 0);
-
-  /* Warning */
-  --warning: oklch(0.769 0.188 70.08);
-  --warning-foreground: oklch(0.145 0 0);
-
-  /* Info */
-  --info: oklch(0.623 0.214 259.815);
-  --info-foreground: oklch(0.985 0 0);
-
-  /* Animation Durations */
-  --duration-slow: 300ms;
-
-  /* Animation Easings */
-  --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-in: cubic-bezier(0.4, 0, 1, 1);
-  --ease-out: cubic-bezier(0, 0, 0.2, 1);
-  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.dark {
-  /* UI-specific dark overrides (not in shared tokens.css) */
-
-  /* Popover */
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-
-  /* Success */
-  --success: oklch(0.696 0.17 162.48);
-  --success-foreground: oklch(0.145 0 0);
-
-  /* Warning */
-  --warning: oklch(0.769 0.188 70.08);
-  --warning-foreground: oklch(0.145 0 0);
-
-  /* Info */
-  --info: oklch(0.623 0.214 259.815);
-  --info-foreground: oklch(0.985 0 0);
-}
-
 /* Theme transition - applied temporarily during theme switch */
 html.theme-transition,
 html.theme-transition *,

--- a/site/ui/tokens.json
+++ b/site/ui/tokens.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../site/shared/tokens/schema.ts",
+  "version": 1,
+  "typography": {
+    "fontFamily": [],
+    "letterSpacing": []
+  },
+  "spacing": [],
+  "borderRadius": [],
+  "transitions": {
+    "duration": [
+      { "name": "duration-slow", "value": "300ms" }
+    ],
+    "easing": [
+      { "name": "ease-default", "value": "cubic-bezier(0.4, 0, 0.2, 1)" },
+      { "name": "ease-in", "value": "cubic-bezier(0.4, 0, 1, 1)" },
+      { "name": "ease-out", "value": "cubic-bezier(0, 0, 0.2, 1)" },
+      { "name": "ease-in-out", "value": "cubic-bezier(0.4, 0, 0.2, 1)" }
+    ]
+  },
+  "layout": [],
+  "colors": [
+    { "name": "popover", "value": "oklch(1 0 0)", "dark": "oklch(0.205 0 0)" },
+    { "name": "popover-foreground", "value": "oklch(0.145 0 0)", "dark": "oklch(0.985 0 0)" },
+    { "name": "success", "value": "oklch(0.527 0.154 150.069)", "dark": "oklch(0.696 0.17 162.48)" },
+    { "name": "success-foreground", "value": "oklch(0.985 0 0)", "dark": "oklch(0.145 0 0)" },
+    { "name": "warning", "value": "oklch(0.769 0.188 70.08)", "dark": "oklch(0.769 0.188 70.08)" },
+    { "name": "warning-foreground", "value": "oklch(0.145 0 0)", "dark": "oklch(0.145 0 0)" },
+    { "name": "info", "value": "oklch(0.623 0.214 259.815)", "dark": "oklch(0.623 0.214 259.815)" },
+    { "name": "info-foreground", "value": "oklch(0.985 0 0)", "dark": "oklch(0.985 0 0)" }
+  ],
+  "shadows": []
+}


### PR DESCRIPTION
## Summary

- Replace hand-maintained `tokens.css` with a JSON-driven pipeline where `tokens.json` is the single source of truth
- Add `site/shared/tokens/` module: schema types, `generateCSS()`, `mergeTokenSets()`, `loadTokens()` public API
- Add `site/ui/tokens.json` for UI-specific extension tokens (popover, success, warning, info, easing)
- Update all three build pipelines (`site/ui`, `site/core`, `packages/preview`) to generate CSS from JSON at build time
- Add `barefoot tokens` CLI command with `--category` filter and `--json` output

## Test plan

- [x] Roundtrip tests pass (`bun test site/shared/tokens/` — 7 tests)
- [x] `site/ui` build succeeds with merged base + extension tokens in output
- [x] `site/core` build succeeds with base tokens only
- [x] `barefoot tokens`, `barefoot tokens --category colors`, `barefoot tokens --json` all work
- [x] Visual check: preview server renders components with correct token values

🤖 Generated with [Claude Code](https://claude.com/claude-code)