### PR TITLE
Add --dir and --registry flags to barefoot search

### DIFF
--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -1,17 +1,21 @@
-import { describe, test, expect, spyOn } from 'bun:test'
+import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test'
 import { search } from '../commands/search'
+import { loadIndex, fetchIndex } from '../lib/meta-loader'
+import type { MetaIndex } from '../lib/types'
 import path from 'path'
 
 const metaDir = path.resolve(import.meta.dir, '../../../../ui/meta')
 
 describe('search', () => {
+  const index = loadIndex(metaDir)
+
   test('finds component by name', () => {
-    const results = search('button', metaDir)
+    const results = search('button', index)
     expect(results.some(r => r.name === 'button')).toBe(true)
   })
 
   test('finds component by category', () => {
-    const results = search('input', metaDir)
+    const results = search('input', index)
     expect(results.length).toBeGreaterThan(0)
     expect(results.every(r =>
       r.name.includes('input') ||
@@ -22,7 +26,7 @@ describe('search', () => {
   })
 
   test('finds component by tag', () => {
-    const results = search('button', metaDir)
+    const results = search('button', index)
     // All results should match "button" in name, category, description, or tags
     expect(results.every(r =>
       r.name.includes('button') ||
@@ -33,19 +37,19 @@ describe('search', () => {
   })
 
   test('expands category aliases (form → input)', () => {
-    const results = search('form', metaDir)
+    const results = search('form', index)
     const hasInputCategory = results.some(r => r.category === 'input')
     expect(hasInputCategory).toBe(true)
   })
 
   test('returns empty array for no match', () => {
-    const results = search('zzz_nonexistent_zzz', metaDir)
+    const results = search('zzz_nonexistent_zzz', index)
     expect(results).toEqual([])
   })
 
   test('--dir override: searches in arbitrary directory', () => {
-    // search() accepts any metaDir, verifying --dir plumbing works
-    const results = search('button', metaDir)
+    // search() accepts any MetaIndex, verifying --dir plumbing works
+    const results = search('button', index)
     expect(results.some(r => r.name === 'button')).toBe(true)
   })
 
@@ -53,12 +57,75 @@ describe('search', () => {
     const exitSpy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
     const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
     try {
-      expect(() => search('button', '/nonexistent/path')).toThrow('exit')
+      expect(() => loadIndex('/nonexistent/path')).toThrow('exit')
       expect(exitSpy).toHaveBeenCalledWith(1)
       expect(errorSpy).toHaveBeenCalled()
     } finally {
       exitSpy.mockRestore()
       errorSpy.mockRestore()
     }
+  })
+})
+
+describe('fetchIndex', () => {
+  let exitSpy: ReturnType<typeof spyOn>
+  let errorSpy: ReturnType<typeof spyOn>
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    exitSpy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  const fakeIndex: MetaIndex = {
+    version: 1,
+    generatedAt: '2026-01-01',
+    components: [{ name: 'button', title: 'Button', category: 'input', description: 'A button', tags: ['button'], stateful: false }],
+  }
+
+  test('fetches and parses remote index.json', async () => {
+    globalThis.fetch = async (url: any) => {
+      expect(String(url)).toBe('https://example.com/r/index.json')
+      return new Response(JSON.stringify(fakeIndex), { status: 200 })
+    }
+    const result = await fetchIndex('https://example.com/r/')
+    expect(result).toEqual(fakeIndex)
+  })
+
+  test('appends /index.json when URL has no trailing slash', async () => {
+    globalThis.fetch = async (url: any) => {
+      expect(String(url)).toBe('https://example.com/r/index.json')
+      return new Response(JSON.stringify(fakeIndex), { status: 200 })
+    }
+    const result = await fetchIndex('https://example.com/r')
+    expect(result).toEqual(fakeIndex)
+  })
+
+  test('exits on non-200 response', async () => {
+    globalThis.fetch = async () => new Response('Not Found', { status: 404 })
+    await expect(fetchIndex('https://example.com/r/')).rejects.toThrow('exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('HTTP 404'))
+  })
+
+  test('exits on network error', async () => {
+    globalThis.fetch = async () => { throw new Error('Network failure') }
+    await expect(fetchIndex('https://example.com/r/')).rejects.toThrow('exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Network failure'))
+  })
+
+  test('exits on invalid JSON', async () => {
+    globalThis.fetch = async () => new Response('not json{{{', { status: 200 })
+    await expect(fetchIndex('https://example.com/r/')).rejects.toThrow('exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid JSON'))
   })
 })

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -2,8 +2,8 @@
 
 import path from 'path'
 import type { CliContext } from '../context'
-import type { MetaIndexEntry } from '../lib/types'
-import { loadIndex } from '../lib/meta-loader'
+import type { MetaIndex, MetaIndexEntry } from '../lib/types'
+import { loadIndex, fetchIndex } from '../lib/meta-loader'
 
 // Category aliases for better search (e.g., "form" → "input" components)
 const categoryAliases: Record<string, string[]> = {
@@ -13,8 +13,7 @@ const categoryAliases: Record<string, string[]> = {
   'menu': ['navigation', 'overlay'],
 }
 
-export function search(query: string, metaDir: string): MetaIndexEntry[] {
-  const index = loadIndex(metaDir)
+export function search(query: string, index: MetaIndex): MetaIndexEntry[] {
   const q = query.toLowerCase()
 
   // Expand query to include category aliases
@@ -53,7 +52,7 @@ function printSearchResults(results: MetaIndexEntry[], jsonFlag: boolean) {
   console.log(`\n${results.length} component(s) found. (* = stateful)`)
 }
 
-export function run(args: string[], ctx: CliContext): void {
+export async function run(args: string[], ctx: CliContext): Promise<void> {
   // Parse --dir flag
   let metaDir = ctx.metaDir
   const dirIdx = args.indexOf('--dir')
@@ -67,12 +66,34 @@ export function run(args: string[], ctx: CliContext): void {
     args = [...args.slice(0, dirIdx), ...args.slice(dirIdx + 2)]
   }
 
+  // Parse --registry flag
+  let registryUrl: string | undefined
+  const regIdx = args.indexOf('--registry')
+  if (regIdx !== -1) {
+    const regValue = args[regIdx + 1]
+    if (!regValue || regValue.startsWith('-')) {
+      console.error('Error: --registry requires a URL argument.')
+      process.exit(1)
+    }
+    registryUrl = regValue
+    args = [...args.slice(0, regIdx), ...args.slice(regIdx + 2)]
+  }
+
+  // Mutual exclusion
+  if (dirIdx !== -1 && registryUrl) {
+    console.error('Error: --dir and --registry cannot be used together.')
+    process.exit(1)
+  }
+
+  // Load index from local or remote source
+  const index = registryUrl
+    ? await fetchIndex(registryUrl)
+    : loadIndex(metaDir)
+
   const query = args.join(' ')
   if (!query) {
-    // List all components
-    const index = loadIndex(metaDir)
     printSearchResults(index.components, ctx.jsonFlag)
   } else {
-    printSearchResults(search(query, metaDir), ctx.jsonFlag)
+    printSearchResults(search(query, index), ctx.jsonFlag)
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ function printUsage() {
 Commands:
   init [--name <name>]        Initialize a new BarefootJS project
   add <component...> [--force] Add components to your project
-  search <query> [--dir <path>] Search components by name/category/tags
+  search <query> [--dir <path>] [--registry <url>] Search components by name/category/tags
   docs <component>            Show component documentation (props, examples, a11y)
   scaffold <name> <comp...>   Generate component skeleton + IR test
   test [component]            Find and show test commands
@@ -53,7 +53,7 @@ switch (command) {
 
   case 'search': {
     const { run } = await import('./commands/search')
-    run(commandArgs, ctx)
+    await run(commandArgs, ctx)
     break
   }
 


### PR DESCRIPTION
## Summary

- Add `--dir <path>` flag to search components in an arbitrary local directory (Level 1)
- Add `--registry <url>` flag to fetch remote `index.json` via HTTP for cross-project component discovery (Level 2)
- `--dir` and `--registry` are mutually exclusive
- Refactor `search()` to accept `MetaIndex` directly, making it a pure filter function
- Remote fetch uses `AbortSignal.timeout(10_000)` for a 10s timeout

## Test plan

- [x] Unit tests pass (75 tests across 5 files)
- [x] `fetchIndex` tests cover: successful fetch, trailing slash handling, non-200 response, network error, invalid JSON
- [x] Smoke tested: `barefoot search button`, `--dir`, `--registry` missing arg error, `--dir` + `--registry` mutual exclusion error

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)