### PR TITLE
Add 24 JSX fixtures for adapter conformance testing

### DIFF
--- a/packages/adapter-tests/fixtures/class-vs-classname.ts
+++ b/packages/adapter-tests/fixtures/class-vs-classname.ts
@@ -1,0 +1,11 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'class-vs-classname',
+  description: 'className prop converts to class attribute',
+  source: `
+export function ClassVsClassname() {
+  return <div className="container"><span className="label">Text</span></div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/client-only.ts
+++ b/packages/adapter-tests/fixtures/client-only.ts
@@ -1,0 +1,21 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'client-only',
+  description: 'Client-only directive suppresses SSR for expression',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Item = { name: string; tags: string[] }
+export function ClientOnly() {
+  const [items, setItems] = createSignal<Item[]>([])
+  return (
+    <ul>
+      {/* @client */ items().filter(item => item.tags.includes('featured')).map(item => (
+        <li>{item.name}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/conditional-class.ts
+++ b/packages/adapter-tests/fixtures/conditional-class.ts
@@ -1,0 +1,14 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'conditional-class',
+  description: 'Conditional className via ternary expression',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function ConditionalClass() {
+  const [active, setActive] = createSignal(false)
+  return <div className={active() ? 'on' : 'off'}>Toggle</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/controlled-signal.ts
+++ b/packages/adapter-tests/fixtures/controlled-signal.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'controlled-signal',
+  description: 'Signal initialized directly from props value',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function ControlledSignal(props: { value: number }) {
+  const [val, setVal] = createSignal(props.value)
+  return <span>{val()}</span>
+}
+`,
+  props: { value: 42 },
+})

--- a/packages/adapter-tests/fixtures/default-props.ts
+++ b/packages/adapter-tests/fixtures/default-props.ts
@@ -1,0 +1,16 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'default-props',
+  description: 'Props with fallback defaults via ?? in signal initialization',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function DefaultProps(props: { label?: string; size?: number }) {
+  const [currentLabel, setCurrentLabel] = createSignal(props.label ?? 'Default')
+  const [count, setCount] = createSignal(props.size ?? 1)
+  return <div><span>{currentLabel()}</span><span>{count()}</span></div>
+}
+`,
+  props: { label: 'Custom', size: 5 },
+})

--- a/packages/adapter-tests/fixtures/dynamic-attributes.ts
+++ b/packages/adapter-tests/fixtures/dynamic-attributes.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'dynamic-attributes',
+  description: 'Dynamic data attributes bound to signals',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function DynamicAttributes() {
+  const [state, setState] = createSignal('closed')
+  const [count, setCount] = createSignal(0)
+  return <div data-state={state()} data-count={count()}>Content</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/effect.ts
+++ b/packages/adapter-tests/fixtures/effect.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'effect',
+  description: 'Component with createEffect (SSR renders initial state only)',
+  source: `
+'use client'
+import { createSignal, createEffect } from '@barefootjs/dom'
+export function EffectDemo() {
+  const [count, setCount] = createSignal(0)
+  createEffect(() => { console.log(count()) })
+  return <div>{count()}</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/event-handlers.ts
+++ b/packages/adapter-tests/fixtures/event-handlers.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'event-handlers',
+  description: 'Multiple event handler types (onClick, onInput)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function EventHandlers() {
+  const [text, setText] = createSignal('')
+  const [count, setCount] = createSignal(0)
+  return (
+    <div>
+      <input type="text" onInput={(e) => setText(e.currentTarget.value)} />
+      <button onClick={() => setCount(n => n + 1)}>Click</button>
+      <span>{text()}</span>
+      <span>{count()}</span>
+    </div>
+  )
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/filter-simple.ts
+++ b/packages/adapter-tests/fixtures/filter-simple.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'filter-simple',
+  description: 'Filter by boolean field then map',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Todo = { text: string; done: boolean }
+export function FilterSimple() {
+  const [todos, setTodos] = createSignal<Todo[]>([])
+  return <ul>{todos().filter(t => t.done).map(t => <li>{t.text}</li>)}</ul>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/filter-sort-chain.ts
+++ b/packages/adapter-tests/fixtures/filter-sort-chain.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'filter-sort-chain',
+  description: 'Chained filter and sort before map',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Product = { name: string; price: number; active: boolean }
+export function FilterSortChain() {
+  const [products, setProducts] = createSignal<Product[]>([])
+  return <ul>{products().filter(p => p.active).sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/fragment.ts
+++ b/packages/adapter-tests/fixtures/fragment.ts
@@ -1,0 +1,14 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'fragment',
+  description: 'Fragment as root element',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function FragmentDemo() {
+  const [count, setCount] = createSignal(0)
+  return <><span>A</span><span>{count()}</span></>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -1,6 +1,67 @@
 import { fixture as counter } from './counter'
+// Priority 1: Core reactivity
+import { fixture as signalWithFallback } from './signal-with-fallback'
+import { fixture as controlledSignal } from './controlled-signal'
+import { fixture as memo } from './memo'
+import { fixture as effect } from './effect'
+import { fixture as multipleSignals } from './multiple-signals'
+// Priority 2: Props and composition
+import { fixture as propsStatic } from './props-static'
+import { fixture as propsReactive } from './props-reactive'
+import { fixture as nestedElements } from './nested-elements'
+// Priority 3: Conditionals
+import { fixture as ternary } from './ternary'
+import { fixture as logicalAnd } from './logical-and'
+import { fixture as conditionalClass } from './conditional-class'
+// Priority 4: Loops
+import { fixture as mapBasic } from './map-basic'
+import { fixture as mapWithIndex } from './map-with-index'
+import { fixture as filterSimple } from './filter-simple'
+import { fixture as sortSimple } from './sort-simple'
+import { fixture as filterSortChain } from './filter-sort-chain'
+// Priority 5: Elements and attributes
+import { fixture as voidElements } from './void-elements'
+import { fixture as dynamicAttributes } from './dynamic-attributes'
+import { fixture as classVsClassname } from './class-vs-classname'
+import { fixture as styleAttribute } from './style-attribute'
+// Priority 6: Advanced patterns
+import { fixture as fragment } from './fragment'
+import { fixture as clientOnly } from './client-only'
+import { fixture as eventHandlers } from './event-handlers'
+import { fixture as defaultProps } from './default-props'
+
 import type { JSXFixture } from '../src/types'
 
 export const jsxFixtures: JSXFixture[] = [
   counter,
+  // Priority 1: Core reactivity
+  signalWithFallback,
+  controlledSignal,
+  memo,
+  effect,
+  multipleSignals,
+  // Priority 2: Props and composition
+  propsStatic,
+  propsReactive,
+  nestedElements,
+  // Priority 3: Conditionals
+  ternary,
+  logicalAnd,
+  conditionalClass,
+  // Priority 4: Loops
+  mapBasic,
+  mapWithIndex,
+  filterSimple,
+  sortSimple,
+  filterSortChain,
+  // Priority 5: Elements and attributes
+  voidElements,
+  dynamicAttributes,
+  classVsClassname,
+  styleAttribute,
+  // Priority 6: Advanced patterns
+  fragment,
+  clientOnly,
+  eventHandlers,
+  defaultProps,
 ]

--- a/packages/adapter-tests/fixtures/logical-and.ts
+++ b/packages/adapter-tests/fixtures/logical-and.ts
@@ -1,0 +1,14 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'logical-and',
+  description: 'Logical AND conditional rendering',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function LogicalAndDemo() {
+  const [show, setShow] = createSignal(false)
+  return <div>{show() && <span>Shown</span>}</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/map-basic.ts
+++ b/packages/adapter-tests/fixtures/map-basic.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'map-basic',
+  description: 'Basic array map rendering',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Item = { name: string }
+export function MapBasic() {
+  const [items, setItems] = createSignal<Item[]>([])
+  return <ul>{items().map(item => <li>{item.name}</li>)}</ul>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/map-with-index.ts
+++ b/packages/adapter-tests/fixtures/map-with-index.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'map-with-index',
+  description: 'Array map with index parameter',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Entry = { label: string }
+export function MapWithIndex() {
+  const [entries, setEntries] = createSignal<Entry[]>([])
+  return <ul>{entries().map((entry, i) => <li>{i}: {entry.label}</li>)}</ul>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/memo.ts
+++ b/packages/adapter-tests/fixtures/memo.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'memo',
+  description: 'Derived value with createMemo',
+  source: `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/dom'
+export function MemoDemo() {
+  const [count, setCount] = createSignal(0)
+  const doubled = createMemo(() => count() * 2)
+  return <div><span>{count()}</span><span>{doubled()}</span></div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/multiple-signals.ts
+++ b/packages/adapter-tests/fixtures/multiple-signals.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'multiple-signals',
+  description: 'Multiple signals of different types (string + number)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function MultipleSignals() {
+  const [name, setName] = createSignal('')
+  const [age, setAge] = createSignal(0)
+  return <div><span>{name()}</span><span>{age()}</span></div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/nested-elements.ts
+++ b/packages/adapter-tests/fixtures/nested-elements.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'nested-elements',
+  description: 'Deeply nested elements with dynamic content',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function NestedElements() {
+  const [text, setText] = createSignal('hello')
+  return (
+    <div>
+      <section>
+        <article>
+          <p>{text()}</p>
+        </article>
+      </section>
+    </div>
+  )
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/props-reactive.ts
+++ b/packages/adapter-tests/fixtures/props-reactive.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'props-reactive',
+  description: 'Stateful component accessing props via props.xxx',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function PropsReactive(props: { label: string }) {
+  const [count, setCount] = createSignal(0)
+  return <div><span>{props.label}</span><span>{count()}</span></div>
+}
+`,
+  props: { label: 'Hello' },
+})

--- a/packages/adapter-tests/fixtures/props-static.ts
+++ b/packages/adapter-tests/fixtures/props-static.ts
@@ -1,0 +1,12 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'props-static',
+  description: 'Stateless component with destructured props',
+  source: `
+export function PropsStatic({ label, count }: { label: string; count: number }) {
+  return <div><span>{label}</span><span>{count}</span></div>
+}
+`,
+  props: { label: 'Items', count: 10 },
+})

--- a/packages/adapter-tests/fixtures/signal-with-fallback.ts
+++ b/packages/adapter-tests/fixtures/signal-with-fallback.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'signal-with-fallback',
+  description: 'Signal initialized with props fallback via ??',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function SignalWithFallback(props: { initial?: number }) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
+  return <div>{count()}</div>
+}
+`,
+  props: { initial: 5 },
+})

--- a/packages/adapter-tests/fixtures/sort-simple.ts
+++ b/packages/adapter-tests/fixtures/sort-simple.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'sort-simple',
+  description: 'Simple subtraction sort then map',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+type Product = { name: string; price: number }
+export function SortSimple() {
+  const [products, setProducts] = createSignal<Product[]>([])
+  return <ul>{products().sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/style-attribute.ts
+++ b/packages/adapter-tests/fixtures/style-attribute.ts
@@ -1,0 +1,11 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'style-attribute',
+  description: 'Inline style string attribute',
+  source: `
+export function StyleAttribute() {
+  return <div style="color: red; font-size: 16px">Styled</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/ternary.ts
+++ b/packages/adapter-tests/fixtures/ternary.ts
@@ -1,0 +1,14 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'ternary',
+  description: 'Ternary conditional rendering',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function TernaryDemo() {
+  const [show, setShow] = createSignal(false)
+  return <div>{show() ? <span>Visible</span> : <span>Hidden</span>}</div>
+}
+`,
+})

--- a/packages/adapter-tests/fixtures/void-elements.ts
+++ b/packages/adapter-tests/fixtures/void-elements.ts
@@ -1,0 +1,18 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'void-elements',
+  description: 'Void HTML elements (br, hr, img, input)',
+  source: `
+export function VoidElements() {
+  return (
+    <div>
+      <br />
+      <hr />
+      <img src="test.png" alt="test" />
+      <input type="text" />
+    </div>
+  )
+}
+`,
+})


### PR DESCRIPTION
## Summary

- Add 24 JSX fixtures to `@barefootjs/adapter-tests` covering the full compiler feature set (reactivity, props, conditionals, loops, elements/attributes, advanced patterns)
- Improve `normalizeHTML` in the conformance test runner to handle known cross-adapter formatting differences (bf-p attribute, void element self-closing, trailing whitespace)
- Total fixtures: 1 → 25

Closes #456

## Fixtures added

| Priority | Fixtures | Coverage |
|----------|----------|----------|
| P1: Core reactivity | `signal-with-fallback`, `controlled-signal`, `memo`, `effect`, `multiple-signals` | Signals, memos, effects |
| P2: Props | `props-static`, `props-reactive`, `nested-elements` | Static/reactive props, nesting |
| P3: Conditionals | `ternary`, `logical-and`, `conditional-class` | Ternary, `&&`, conditional class |
| P4: Loops | `map-basic`, `map-with-index`, `filter-simple`, `sort-simple`, `filter-sort-chain` | map/filter/sort chains |
| P5: Elements | `void-elements`, `dynamic-attributes`, `class-vs-classname`, `style-attribute` | Void elements, dynamic attrs |
| P6: Advanced | `fragment`, `client-only`, `event-handlers`, `default-props` | Fragments, @client, events |

## Normalizer improvements

The `normalizeHTML` function now handles three known adapter output differences:
- **bf-p attribute**: Hono serializes props as JSON in `bf-p`; Go uses struct fields — stripped from comparison
- **Void element self-closing**: Hono outputs `<br/>`; Go outputs `<br>` — normalized to `<br>`
- **Trailing whitespace**: Go template's `bfPropsAttr()` leaves trailing space when empty — stripped

## Follow-up issues

- #460 — Multi-file fixtures (child-component, multiple-instances)
- #461 — Go adapter: duplicate struct field when signal name matches prop name
- #462 — Go adapter: `??` in text content renders empty for string props

## Test plan

- [x] `bun test packages/hono/__tests__/hono-adapter.test.ts` — 25 pass
- [x] `bun test packages/go-template/src/__tests__/go-template-adapter.test.ts` — 38 pass (25 conformance + 13 adapter-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)