### PR TITLE
Serve component meta/registry from ui.barefootjs.dev

### DIFF
--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -482,4 +482,13 @@ async function copyDir(src: string, dest: string) {
 await copyDir(DIST_COMPONENTS_DIR, resolve(DIST_STATIC_DIR, 'components'))
 console.log('Copied: dist/static/components/')
 
+// Generate _headers for Cloudflare Workers static assets (CORS + cache for registry)
+const headersContent = `/r/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, OPTIONS
+  Cache-Control: public, max-age=300
+`
+await Bun.write(resolve(DIST_DIR, '_headers'), headersContent)
+console.log('Generated: dist/_headers')
+
 console.log('\nBuild complete!')

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run build.ts",
-    "build:registry": "cd ../../ui && bun run build:registry && mkdir -p ../site/ui/dist/r && cp -r dist/r/* ../site/ui/dist/r/",
+    "build:registry": "cd ../../ui && bun run build:registry && mkdir -p ../site/ui/dist/r && cp -r dist/r/* ../site/ui/dist/r/ && cp meta/*.json ../site/ui/dist/r/",
     "build:worker": "bun run build && bun run build:registry",
     "dev": "bun run --watch server.tsx",
     "deploy": "bun run build:worker && wrangler deploy",

--- a/site/ui/server.tsx
+++ b/site/ui/server.tsx
@@ -21,6 +21,14 @@ app.use('/static/*', serveStatic({
   rewriteRequestPath: (path) => path.replace('/static', ''),
 }))
 
+// CORS + cache headers for registry (matches _headers for production)
+app.use('/r/*', async (c, next) => {
+  await next()
+  c.header('Access-Control-Allow-Origin', '*')
+  c.header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  c.header('Cache-Control', 'public, max-age=300')
+})
+
 // Registry routes - serve static JSON files
 app.use('/r/*', serveStatic({
   root: './dist',


### PR DESCRIPTION
## Summary

Closes #464

- Copy `ui/meta/*.json` into `dist/r/` during `build:registry` so `barefoot search --registry https://ui.barefootjs.dev/r/` can discover components remotely
- Generate `_headers` file for Cloudflare Workers static assets with CORS (`Access-Control-Allow-Origin: *`) and cache (`max-age=300`) headers on `/r/*`
- Add matching CORS + cache middleware in the Hono dev server for local development parity

## Test plan

- [x] `bun run build:worker` completes successfully in `site/ui/`
- [x] `dist/r/index.json` contains MetaIndex format (version, generatedAt, components)
- [x] `dist/r/registry.json` contains shadcn format ($schema, name, items)
- [x] `dist/_headers` contains CORS rules for `/r/*`
- [x] Dev server (`bun run dev`) returns `Access-Control-Allow-Origin: *` on `/r/index.json`
- [x] `barefoot search button --registry http://localhost:3002/r/` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)