### PR TITLE
Add multi-file JSX fixtures for child component composition

### DIFF
--- a/packages/adapter-tests/fixtures/child-component.ts
+++ b/packages/adapter-tests/fixtures/child-component.ts
@@ -1,0 +1,20 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'child-component',
+  description: 'Parent renders a child component from a separate file',
+  source: `
+import { Badge } from './badge'
+export function ParentCard({ title }: { title: string }) {
+  return <div><h2>{title}</h2><Badge label="New" /></div>
+}
+`,
+  components: {
+    './badge.tsx': `
+export function Badge({ label }: { label: string }) {
+  return <span>{label}</span>
+}
+`,
+  },
+  props: { title: 'Hello' },
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -29,6 +29,9 @@ import { fixture as fragment } from './fragment'
 import { fixture as clientOnly } from './client-only'
 import { fixture as eventHandlers } from './event-handlers'
 import { fixture as defaultProps } from './default-props'
+// Priority 7: Multi-file composition
+import { fixture as childComponent } from './child-component'
+import { fixture as multipleInstances } from './multiple-instances'
 
 import type { JSXFixture } from '../src/types'
 
@@ -64,4 +67,7 @@ export const jsxFixtures: JSXFixture[] = [
   clientOnly,
   eventHandlers,
   defaultProps,
+  // Priority 7: Multi-file composition
+  childComponent,
+  multipleInstances,
 ]

--- a/packages/adapter-tests/fixtures/multiple-instances.ts
+++ b/packages/adapter-tests/fixtures/multiple-instances.ts
@@ -1,0 +1,19 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'multiple-instances',
+  description: 'Same component rendered multiple times with different props',
+  source: `
+import { Tag } from './tag'
+export function TagList() {
+  return <div><Tag label="Alpha" /><Tag label="Beta" /><Tag label="Gamma" /></div>
+}
+`,
+  components: {
+    './tag.tsx': `
+export function Tag({ label }: { label: string }) {
+  return <span>{label}</span>
+}
+`,
+  },
+})

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -13,6 +13,8 @@ export interface JSXFixture {
   description: string
   /** JSX source code (complete component file) */
   source: string
+  /** Additional component files available for import (filename → source) */
+  components?: Record<string, string>
   /** Props to pass when rendering (optional) */
   props?: Record<string, unknown>
 }
@@ -26,7 +28,13 @@ export function createFixture(input: {
   id: string
   description: string
   source: string
+  components?: Record<string, string>
   props?: Record<string, unknown>
 }): JSXFixture {
-  return { ...input, source: input.source.trimStart() }
+  const trimmedComponents = input.components
+    ? Object.fromEntries(
+        Object.entries(input.components).map(([k, v]) => [k, v.trimStart()]),
+      )
+    : undefined
+  return { ...input, source: input.source.trimStart(), components: trimmedComponents }
 }


### PR DESCRIPTION
## Summary

- Extend the adapter conformance test suite to support multi-file JSX compilation via a new `components` field on `JSXFixture`
- Update both Hono and Go Template test renderers to compile child components and combine them with the parent
- Add two new fixtures: `child-component` (parent renders a Badge from a separate file) and `multiple-instances` (same Tag component rendered 3 times with different props)
- Improve `normalizeHTML` to handle cross-adapter differences in child scope ID prefixes and inter-tag whitespace

## Test plan

- [x] `bun test packages/hono/` — 27 tests pass (including 2 new multi-file fixtures)
- [x] `bun test packages/go-template/` — 40 tests pass (including 2 new multi-file fixtures with cross-adapter comparison)
- [x] `bun test packages/` — all 534 tests pass

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)