### PR TITLE
Allow event callbacks on stateless components without "use client"

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -6,7 +6,9 @@ import { describe, test, expect } from 'bun:test'
 import { compileJSXSync, compileJSX } from '../compiler'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
+import { analyzeClientNeeds } from '../ir-to-client-js'
 import { TestAdapter } from '../adapters/test-adapter'
+import { HonoAdapter } from '../../../../packages/hono/src/adapter/hono-adapter'
 import { resolve, dirname } from 'node:path'
 import { isBooleanAttr, BOOLEAN_ATTRS } from '../html-constants'
 
@@ -2800,6 +2802,164 @@ describe('Compiler', () => {
       expect(clientJs?.content).not.toContain('p.initial')
       // No double ??
       expect(clientJs?.content).not.toMatch(/\?\?.*\?\?/)
+    })
+  })
+
+  describe('event callbacks on stateless components', () => {
+    test('stateless component with event-forwarding prop generates client JS', () => {
+      const source = `
+        interface SortHeaderProps {
+          label: string
+          onSort: () => void
+        }
+
+        export function SortHeader({ label, onSort }: SortHeaderProps) {
+          return <th onClick={onSort}>{label}</th>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SortHeader.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs?.content).toContain('click')
+    })
+
+    test('stateless component with local event handler generates client JS', () => {
+      const source = `
+        export function LogButton() {
+          return <button onClick={() => console.log('clicked')}>Log</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'LogButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs?.content).toContain('click')
+    })
+
+    test('analyzeClientNeeds returns needsInit: true for event-wiring components', () => {
+      const source = `
+        interface ClickableProps {
+          onClick: () => void
+        }
+
+        export function Clickable({ onClick }: ClickableProps) {
+          return <div onClick={onClick}>Click me</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'Clickable.tsx')
+      const ir = jsxToIR(ctx)
+      expect(ir).not.toBeNull()
+
+      const componentIR = {
+        version: '0.1' as const,
+        metadata: {
+          componentName: ctx.componentName || 'Clickable',
+          hasDefaultExport: ctx.hasDefaultExport,
+          isClientComponent: ctx.hasUseClientDirective,
+          typeDefinitions: ctx.typeDefinitions,
+          propsType: ctx.propsType,
+          propsParams: ctx.propsParams,
+          propsObjectName: ctx.propsObjectName,
+          restPropsName: ctx.restPropsName,
+          restPropsExpandedKeys: ctx.restPropsExpandedKeys,
+          signals: ctx.signals,
+          memos: ctx.memos,
+          effects: ctx.effects,
+          onMounts: ctx.onMounts,
+          imports: ctx.imports,
+          localFunctions: ctx.localFunctions,
+          localConstants: ctx.localConstants,
+        },
+        root: ir!,
+        errors: [],
+      }
+
+      const analysis = analyzeClientNeeds(componentIR)
+      expect(analysis.needsInit).toBe(true)
+    })
+
+    test('purely static component does not generate client JS', () => {
+      const source = `
+        export function StaticLabel() {
+          return <span>Hello World</span>
+        }
+      `
+
+      const result = compileJSXSync(source, 'StaticLabel.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeUndefined()
+    })
+
+    test('components with reactive primitives still require "use client"', () => {
+      const source = `
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+
+      // This should produce errors because signals require "use client"
+      // The compiler itself doesn't throw, but the adapter will
+      expect(() => {
+        compileJSXSync(source, 'Counter.tsx', { adapter })
+      }).not.toThrow()
+
+      // Verify the analyzer detects the issue
+      const ctx = analyzeComponent(source, 'Counter.tsx')
+      expect(ctx.signals.length).toBeGreaterThan(0)
+      expect(ctx.hasUseClientDirective).toBe(false)
+    })
+
+    test('HonoAdapter does not throw for stateless event-wiring components', () => {
+      const source = `
+        interface SortHeaderProps {
+          label: string
+          onSort: () => void
+        }
+
+        export function SortHeader({ label, onSort }: SortHeaderProps) {
+          return <th onClick={onSort}>{label}</th>
+        }
+      `
+
+      const honoAdapter = new HonoAdapter()
+      const result = compileJSXSync(source, 'SortHeader.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      // Should produce client JS
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // Should produce marked template with scope attributes
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      expect(template?.content).toContain('bf-s=')
+    })
+
+    test('HonoAdapter throws for signals without "use client"', () => {
+      const source = `
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+
+      const honoAdapter = new HonoAdapter()
+      expect(() => {
+        compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      }).toThrow(/reactive primitives/)
     })
   })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -99,7 +99,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           param: node.param,
           index: node.index,
           key: node.key,
-          template: node.childComponent ? '' : irToHtmlTemplate(node.children[0]),
+          template: node.childComponent ? '' : (node.children[0] ? irToHtmlTemplate(node.children[0]) : ''),
           childEventHandlers: childHandlers,
           childEvents,
           childComponent: node.childComponent,

--- a/packages/test/__tests__/event-callbacks.test.ts
+++ b/packages/test/__tests__/event-callbacks.test.ts
@@ -1,0 +1,81 @@
+/**
+ * IR tests for event callbacks on stateless components (Issue #467).
+ *
+ * Verifies that stateless child components can wire event callback props
+ * to DOM events without requiring "use client".
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { renderToTest } from '../src/index'
+
+describe('Event callbacks on stateless components', () => {
+  test('stateless component with event-forwarding prop has click event in IR', () => {
+    const source = `
+interface SortHeaderProps {
+  label: string
+  onSort: () => void
+}
+
+export function SortHeader({ label, onSort }: SortHeaderProps) {
+  return <th onClick={onSort}>{label}</th>
+}
+`
+    const result = renderToTest(source, 'SortHeader.tsx')
+    expect(result.errors).toHaveLength(0)
+    expect(result.componentName).toBe('SortHeader')
+    expect(result.isClient).toBe(false)
+
+    const th = result.find({ tag: 'th' })
+    expect(th).not.toBeNull()
+    expect(th!.events).toContain('click')
+  })
+
+  test('stateless component with inline event handler has click event in IR', () => {
+    const source = `
+export function LogButton() {
+  return <button onClick={() => console.log('clicked')}>Log</button>
+}
+`
+    const result = renderToTest(source, 'LogButton.tsx')
+    expect(result.errors).toHaveLength(0)
+    expect(result.isClient).toBe(false)
+
+    const btn = result.find({ tag: 'button' })
+    expect(btn).not.toBeNull()
+    expect(btn!.events).toContain('click')
+  })
+
+  test('stateless component without events has no events in IR', () => {
+    const source = `
+interface LabelProps {
+  text: string
+}
+
+export function Label({ text }: LabelProps) {
+  return <span>{text}</span>
+}
+`
+    const result = renderToTest(source, 'Label.tsx')
+    expect(result.errors).toHaveLength(0)
+
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.events).toHaveLength(0)
+  })
+
+  test('no BF001 error for stateless event-only component', () => {
+    const source = `
+interface ClickableProps {
+  onClick: () => void
+  children: any
+}
+
+export function Clickable({ onClick, children }: ClickableProps) {
+  return <div onClick={onClick}>{children}</div>
+}
+`
+    const result = renderToTest(source, 'Clickable.tsx')
+    const errorCodes = result.errors.map(e => e.code)
+    expect(errorCodes).not.toContain('BF001')
+  })
+})

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -178,12 +178,11 @@ const manifest: Record<string, { clientJs?: string; markedTemplate: string }> = 
 const adapter = new HonoAdapter()
 
 // Compile each component
+// Components with "use client" are always compiled. Other components are also compiled
+// to detect event handlers that need client JS wiring (stateless event callbacks).
 for (const entryPath of componentFiles) {
-  // Check if file has "use client" directive
   const sourceContent = await Bun.file(entryPath).text()
-  if (!hasUseClientDirective(sourceContent)) {
-    continue // Skip server-only components
-  }
+  const hasDirective = hasUseClientDirective(sourceContent)
 
   // Determine rootDir based on whether the file is from UI, docs, or shared components
   const isUiComponent = entryPath.startsWith(UI_COMPONENTS_DIR)
@@ -212,6 +211,13 @@ for (const entryPath of componentFiles) {
     for (const error of errors) {
       console.error(`  ${error.message}`)
     }
+    continue
+  }
+
+  // Skip non-"use client" components that didn't produce client JS
+  // These are pure server components — copyServerComponents() handles them
+  const hasClientJsFile = result.files.some(f => f.type === 'clientJs')
+  if (!hasDirective && !hasClientJsFile) {
     continue
   }
 

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -47,6 +47,12 @@ function hasUseClientDirective(content: string): boolean {
   return trimmed.startsWith('"use client"') || trimmed.startsWith("'use client'")
 }
 
+// Detect if source may contain event handler attributes (e.g., onClick={...})
+// Used as a lightweight pre-filter to avoid compiling purely static server components
+function mayHaveEventHandlers(content: string): boolean {
+  return /\bon[A-Z]\w*\s*[=({]/.test(content)
+}
+
 // Generate short hash from content
 function generateHash(content: string): string {
   const hash = Bun.hash(content)
@@ -178,11 +184,16 @@ const manifest: Record<string, { clientJs?: string; markedTemplate: string }> = 
 const adapter = new HonoAdapter()
 
 // Compile each component
-// Components with "use client" are always compiled. Other components are also compiled
-// to detect event handlers that need client JS wiring (stateless event callbacks).
+// Components with "use client" are always compiled. Components without the directive
+// are also compiled if they contain event handler patterns (stateless event callbacks).
 for (const entryPath of componentFiles) {
   const sourceContent = await Bun.file(entryPath).text()
   const hasDirective = hasUseClientDirective(sourceContent)
+
+  // Skip components that have neither "use client" nor event handler patterns
+  if (!hasDirective && !mayHaveEventHandlers(sourceContent)) {
+    continue
+  }
 
   // Determine rootDir based on whether the file is from UI, docs, or shared components
   const isUiComponent = entryPath.startsWith(UI_COMPONENTS_DIR)


### PR DESCRIPTION
## Summary

- Relax HonoAdapter validation to only require `"use client"` for reactive primitives (signals, memos, effects, onMounts), not for event handlers alone
- Enable stateless child components to wire event callback props (e.g., `onClick={onSort}`) to DOM events and generate minimal client JS without the directive
- Update `site/ui/build.ts` to include event-wiring components in client JS bundling by checking compilation output instead of only the `"use client"` directive

Closes #467

## Test plan

- [x] Compiler tests: stateless components with event-forwarding props generate client JS
- [x] Compiler tests: `analyzeClientNeeds()` returns `needsInit: true` for event-wiring components
- [x] Compiler tests: HonoAdapter does not throw for stateless event-wiring components
- [x] Compiler tests: HonoAdapter still throws for reactive primitives without `"use client"`
- [x] IR tests: stateless event callback components have correct event metadata
- [x] All existing tests pass (275 in `packages/jsx/`, 5 in `packages/test/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)