### PR TITLE
Fix Go template adapter duplicate struct field when signal name matches prop name

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -2,6 +2,7 @@ import { fixture as counter } from './counter'
 // Priority 1: Core reactivity
 import { fixture as signalWithFallback } from './signal-with-fallback'
 import { fixture as controlledSignal } from './controlled-signal'
+import { fixture as signalPropSameName } from './signal-prop-same-name'
 import { fixture as memo } from './memo'
 import { fixture as effect } from './effect'
 import { fixture as multipleSignals } from './multiple-signals'
@@ -40,6 +41,7 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 1: Core reactivity
   signalWithFallback,
   controlledSignal,
+  signalPropSameName,
   memo,
   effect,
   multipleSignals,

--- a/packages/adapter-tests/fixtures/signal-prop-same-name.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'signal-prop-same-name',
+  description: 'Signal initialized from prop with identical name',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function SignalPropSameName(props: { label?: string }) {
+  const [label, setLabel] = createSignal(props.label ?? 'Default')
+  return <span>{label()}</span>
+}
+`,
+  props: { label: 'Hello' },
+})


### PR DESCRIPTION
## Summary

- Fix duplicate Go struct fields when a signal is initialized from a prop with the same name (e.g., `const [label, setLabel] = createSignal(props.label ?? 'Default')` produced two `Label` fields)
- Track emitted prop field names in `generatePropsStruct()` and `generateNewPropsFunction()` to skip duplicate signal fields
- Add unit test and conformance fixture (`signal-prop-same-name`)

Closes #461

## Test plan

- [x] `cd packages/go-template && bun test` — 42 tests pass, including new deduplication test
- [x] `cd packages/jsx && bun test` — 270 tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)