### PR TITLE
Fix Go template adapter nullish coalescing (??) in text content

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -29,6 +29,7 @@ import { fixture as fragment } from './fragment'
 import { fixture as clientOnly } from './client-only'
 import { fixture as eventHandlers } from './event-handlers'
 import { fixture as defaultProps } from './default-props'
+import { fixture as nullishCoalescingText } from './nullish-coalescing-text'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
 import { fixture as multipleInstances } from './multiple-instances'
@@ -67,6 +68,7 @@ export const jsxFixtures: JSXFixture[] = [
   clientOnly,
   eventHandlers,
   defaultProps,
+  nullishCoalescingText,
   // Priority 7: Multi-file composition
   childComponent,
   multipleInstances,

--- a/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
@@ -1,0 +1,15 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'nullish-coalescing-text',
+  description: 'Nullish coalescing (??) in text content renders correctly',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function NullishCoalescingText(props: { label?: string; size?: number }) {
+  const [count, setCount] = createSignal(props.size ?? 1)
+  return <div><span>{props.label ?? 'Default'}</span><span>{count()}</span></div>
+}
+`,
+  props: { label: 'Custom', size: 5 },
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -134,6 +134,26 @@ describe('expression-parser', () => {
       }
     })
 
+    test('parses nullish coalescing operator', () => {
+      const result = parseExpression('a ?? b')
+      expect(result.kind).toBe('logical')
+      if (result.kind === 'logical') {
+        expect(result.op).toBe('??')
+        expect(result.left.kind).toBe('identifier')
+        expect(result.right.kind).toBe('identifier')
+      }
+    })
+
+    test('parses nullish coalescing with member access and literal', () => {
+      const result = parseExpression("props.label ?? 'Default'")
+      expect(result.kind).toBe('logical')
+      if (result.kind === 'logical') {
+        expect(result.op).toBe('??')
+        expect(result.left.kind).toBe('member')
+        expect(result.right.kind).toBe('literal')
+      }
+    })
+
     test('parses unary negation', () => {
       const result = parseExpression('!isLoading')
       expect(result.kind).toBe('unary')
@@ -284,6 +304,13 @@ describe('expression-parser', () => {
       expect(result.level).toBe('L4')
     })
 
+    test('L4: nullish coalescing is supported', () => {
+      const expr = parseExpression("props.label ?? 'Default'")
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L4')
+    })
+
     test('L4: negation is supported', () => {
       const expr = parseExpression('!isLoading()')
       const result = isSupported(expr)
@@ -393,6 +420,11 @@ describe('expression-parser', () => {
     test('converts member access to string', () => {
       const expr = parseExpression('user.name')
       expect(exprToString(expr)).toBe('user.name')
+    })
+
+    test('converts nullish coalescing to string', () => {
+      const expr = parseExpression("a ?? 'fallback'")
+      expect(exprToString(expr)).toBe('a ?? "fallback"')
     })
 
     test('converts arrow function to string', () => {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -20,7 +20,7 @@ export type ParsedExpr =
   | { kind: 'binary'; op: string; left: ParsedExpr; right: ParsedExpr }
   | { kind: 'unary'; op: string; argument: ParsedExpr }
   | { kind: 'conditional'; test: ParsedExpr; consequent: ParsedExpr; alternate: ParsedExpr }
-  | { kind: 'logical'; op: '&&' | '||'; left: ParsedExpr; right: ParsedExpr }
+  | { kind: 'logical'; op: '&&' | '||' | '??'; left: ParsedExpr; right: ParsedExpr }
   | { kind: 'template-literal'; parts: TemplatePart[] }
   | { kind: 'arrow-fn'; param: string; body: ParsedExpr }
   | { kind: 'higher-order'; method: 'filter' | 'every' | 'some' | 'find' | 'findIndex'; object: ParsedExpr; param: string; predicate: ParsedExpr }
@@ -193,6 +193,9 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     }
     if (opToken.kind === ts.SyntaxKind.BarBarToken) {
       return { kind: 'logical', op: '||', left, right }
+    }
+    if (opToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+      return { kind: 'logical', op: '??', left, right }
     }
 
     // Convert operator token to string


### PR DESCRIPTION
## Summary

- Add `??` (nullish coalescing) as a `logical` operator in the expression parser alongside `&&` and `||`
- The Go template adapter already maps non-`&&` logical ops to Go's `or` function, so **zero adapter changes** needed
- Add conformance fixture verifying `props.label ?? 'Default'` renders correctly in text content

Closes #462

## Root Cause

The expression parser (`expression-parser.ts`) didn't recognize TypeScript's `QuestionQuestionToken`. It fell through to `getOperatorString()` which returned `'unknown'`, causing `isSupported()` to reject the expression and `convertExpressionToGo()` to emit BF101 and return `""`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/expression-parser.test.ts` — 62 tests pass (4 new)
- [x] `bun test packages/go-template/src/__tests__/go-template-adapter.test.ts` — 41 tests pass
- [x] `bun test --cwd . packages/` — all 552 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)