### PR TITLE
Auto-generate default previews from component meta (#441)

### DIFF
--- a/packages/cli/src/__tests__/preview-generate.test.ts
+++ b/packages/cli/src/__tests__/preview-generate.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect } from 'bun:test'
+import { readdirSync } from 'fs'
+import path from 'path'
+import { loadComponent } from '../lib/meta-loader'
+import { generatePreview, type PreviewGenerateResult } from '../lib/preview-generate'
+
+const metaDir = path.resolve(import.meta.dir, '../../../../ui/meta')
+
+// Load all component names (exclude index.json)
+const allComponents = readdirSync(metaDir)
+  .filter(f => f.endsWith('.json') && f !== 'index.json')
+  .map(f => f.replace('.json', ''))
+
+describe('generatePreview', () => {
+  describe('all components produce valid output', () => {
+    for (const name of allComponents) {
+      test(`${name}: no crash, ≥1 preview`, () => {
+        const meta = loadComponent(metaDir, name)
+        const result = generatePreview(meta)
+
+        expect(result.code).toBeTruthy()
+        expect(result.previewNames.length).toBeGreaterThanOrEqual(1)
+        expect(result.filePath).toBe(`ui/components/ui/${name}/index.preview.tsx`)
+      })
+    }
+  })
+
+  describe('determinism', () => {
+    test('same meta produces identical output', () => {
+      const meta = loadComponent(metaDir, 'button')
+      const a = generatePreview(meta)
+      const b = generatePreview(meta)
+      expect(a.code).toBe(b.code)
+      expect(a.previewNames).toEqual(b.previewNames)
+    })
+  })
+
+  describe('"use client" correctness', () => {
+    test('stateful component has "use client"', () => {
+      const meta = loadComponent(metaDir, 'checkbox')
+      const result = generatePreview(meta)
+      expect(result.code).toContain('"use client"')
+    })
+
+    test('stateless component does not have "use client"', () => {
+      const meta = loadComponent(metaDir, 'button')
+      const result = generatePreview(meta)
+      expect(result.code).not.toContain('"use client"')
+    })
+
+    test('multi-component with stateful tag has "use client"', () => {
+      const meta = loadComponent(metaDir, 'accordion')
+      const result = generatePreview(meta)
+      expect(result.code).toContain('"use client"')
+    })
+
+    test('multi-component without stateful tag has no "use client"', () => {
+      const meta = loadComponent(metaDir, 'card')
+      const result = generatePreview(meta)
+      expect(result.code).not.toContain('"use client"')
+    })
+  })
+
+  describe('stateless + variants (button)', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'button')
+      result = generatePreview(meta)
+    })
+
+    test('has Default preview', () => {
+      expect(result.previewNames).toContain('Default')
+      expect(result.code).toContain('export function Default()')
+    })
+
+    test('has Variants preview with all 6 variants', () => {
+      expect(result.previewNames).toContain('Variants')
+      expect(result.code).toContain('variant="default"')
+      expect(result.code).toContain('variant="destructive"')
+      expect(result.code).toContain('variant="outline"')
+      expect(result.code).toContain('variant="secondary"')
+      expect(result.code).toContain('variant="ghost"')
+      expect(result.code).toContain('variant="link"')
+    })
+
+    test('has Sizes preview', () => {
+      expect(result.previewNames).toContain('Sizes')
+      expect(result.code).toContain('size="default"')
+      expect(result.code).toContain('size="sm"')
+      expect(result.code).toContain('size="lg"')
+    })
+
+    test('imports from correct path', () => {
+      expect(result.code).toContain("from '../button'")
+    })
+  })
+
+  describe('stateless simple (input)', () => {
+    test('renders with first simple example', () => {
+      const meta = loadComponent(metaDir, 'input')
+      const result = generatePreview(meta)
+      expect(result.previewNames).toContain('Default')
+      expect(result.code).toContain('<Input')
+    })
+  })
+
+  describe('stateful simple (checkbox)', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'checkbox')
+      result = generatePreview(meta)
+    })
+
+    test('has Default preview with state variations', () => {
+      expect(result.previewNames).toContain('Default')
+      expect(result.code).toContain('<Checkbox />')
+      expect(result.code).toContain('<Checkbox defaultChecked />')
+    })
+
+    test('does not import createSignal (not used in generated code)', () => {
+      expect(result.code).not.toContain("import { createSignal }")
+    })
+  })
+
+  describe('stateful + variants (toggle)', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'toggle')
+      result = generatePreview(meta)
+    })
+
+    test('has Default and variant previews', () => {
+      expect(result.previewNames).toContain('Default')
+      expect(result.previewNames).toContain('Variants')
+    })
+
+    test('has "use client"', () => {
+      expect(result.code).toContain('"use client"')
+    })
+  })
+
+  describe('multi-component (accordion)', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'accordion')
+      result = generatePreview(meta)
+    })
+
+    test('uses example code', () => {
+      expect(result.code).toContain('AccordionTrigger')
+      expect(result.code).toContain('AccordionContent')
+    })
+
+    test('imports createSignal when example uses it', () => {
+      expect(result.code).toContain("import { createSignal }")
+    })
+
+    test('imports sub-components', () => {
+      expect(result.code).toContain('AccordionItem')
+    })
+  })
+
+  describe('multi-component (card) — stateless', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'card')
+      result = generatePreview(meta)
+    })
+
+    test('uses example code', () => {
+      expect(result.code).toContain('CardHeader')
+      expect(result.code).toContain('CardTitle')
+      expect(result.code).toContain('CardContent')
+    })
+
+    test('does not have "use client"', () => {
+      expect(result.code).not.toContain('"use client"')
+    })
+  })
+
+  describe('multi-component with external refs (dialog)', () => {
+    let result: PreviewGenerateResult
+
+    test('setup', () => {
+      const meta = loadComponent(metaDir, 'dialog')
+      result = generatePreview(meta)
+    })
+
+    test('imports external component tags', () => {
+      expect(result.code).toContain("from '../button'")
+    })
+
+    test('injects no-op for undefined handlers', () => {
+      expect(result.code).toContain('const handleAction = () => {}')
+    })
+  })
+
+  describe('header comment', () => {
+    test('all generated previews start with auto-generated comment', () => {
+      const meta = loadComponent(metaDir, 'button')
+      const result = generatePreview(meta)
+      expect(result.code.startsWith('// Auto-generated preview.')).toBe(true)
+    })
+  })
+})

--- a/packages/cli/src/commands/preview-generate.ts
+++ b/packages/cli/src/commands/preview-generate.ts
@@ -1,0 +1,35 @@
+// barefoot preview:generate — generate preview file from component metadata.
+
+import { existsSync, writeFileSync, mkdirSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+import { loadComponent } from '../lib/meta-loader'
+import { generatePreview } from '../lib/preview-generate'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const force = args.includes('--force')
+  const name = args.find(a => !a.startsWith('--'))
+
+  if (!name) {
+    console.error('Usage: barefoot preview:generate <component> [--force]')
+    process.exit(1)
+  }
+
+  const meta = loadComponent(ctx.metaDir, name)
+  const result = generatePreview(meta)
+  const absPath = path.join(ctx.root, result.filePath)
+
+  if (existsSync(absPath) && !force) {
+    console.error(`Error: ${result.filePath} already exists. Use --force to overwrite.`)
+    process.exit(1)
+  }
+
+  const dir = path.dirname(absPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  writeFileSync(absPath, result.code)
+  console.log(`Generated ${result.filePath}`)
+  console.log(`Previews: ${result.previewNames.join(', ')}`)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ Commands:
   test [component]            Find and show test commands
   test:template <name>        Generate IR test from existing source
   preview <component>         Start preview dev server for visual check
+  preview:generate <comp> [--force]  Generate preview file from component metadata
   tokens [--category <cat>]   List design tokens (categories: typography, spacing, etc.)
   meta:extract                Extract metadata from ui/components/ui/*.tsx
 
@@ -83,6 +84,12 @@ switch (command) {
 
   case 'preview': {
     const { run } = await import('./commands/preview')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'preview:generate': {
+    const { run } = await import('./commands/preview-generate')
     await run(commandArgs, ctx)
     break
   }

--- a/packages/cli/src/lib/preview-generate.ts
+++ b/packages/cli/src/lib/preview-generate.ts
@@ -1,0 +1,369 @@
+// Generate preview code from component metadata.
+
+import type { ComponentMeta, PropMeta } from './types'
+
+export interface PreviewGenerateResult {
+  code: string
+  previewNames: string[]
+  filePath: string
+}
+
+function toPascalCase(kebab: string): string {
+  return kebab.split('-').map(w => w[0].toUpperCase() + w.slice(1)).join('')
+}
+
+function toKebabCase(pascal: string): string {
+  return pascal
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * Find the prop name that matches a variant type name.
+ * e.g. ButtonVariant → variant, ButtonSize → size
+ */
+function inferVariantPropName(typeName: string, props: PropMeta[]): string | null {
+  const match = props.find(p => p.type === typeName)
+  return match ? match.name : null
+}
+
+/**
+ * Find PascalCase JSX tags that are not in the known component set.
+ */
+function findExternalTags(code: string, knownNames: Set<string>): string[] {
+  const external: string[] = []
+  for (const m of code.matchAll(/<([A-Z][a-zA-Z]*)/g)) {
+    if (!knownNames.has(m[1]) && !external.includes(m[1])) {
+      external.push(m[1])
+    }
+  }
+  return external
+}
+
+/**
+ * Split example code into statement lines (before JSX) and JSX body.
+ */
+function splitExampleCode(code: string): { statements: string[]; jsx: string } {
+  const lines = code.split('\n')
+  const firstJsxLine = lines.findIndex(l => l.trim().startsWith('<'))
+  if (firstJsxLine <= 0) {
+    return { statements: [], jsx: code }
+  }
+  return {
+    statements: lines.slice(0, firstJsxLine).filter(l => l.trim() !== ''),
+    jsx: lines.slice(firstJsxLine).join('\n'),
+  }
+}
+
+/**
+ * Check if an example code snippet is simple JSX (no signal usage).
+ */
+function isSimpleJsx(code: string): boolean {
+  const trimmed = code.trim()
+  return trimmed.startsWith('<') && !trimmed.includes('createSignal')
+}
+
+/**
+ * Generate preview code from component metadata.
+ */
+export function generatePreview(meta: ComponentMeta): PreviewGenerateResult {
+  const pascalName = toPascalCase(meta.name)
+  const hasVariants = meta.variants != null && Object.keys(meta.variants).length > 0
+  const hasSubComponents = meta.subComponents != null && meta.subComponents.length > 0
+
+  // Determine if preview needs "use client" directive
+  let needsClient = meta.stateful || meta.tags.includes('stateful')
+
+  // Multi-component examples may use createSignal even if root component is not stateful
+  const exampleCode = hasSubComponents && meta.examples.length > 0 ? meta.examples[0].code : ''
+  if (exampleCode.includes('createSignal')) {
+    needsClient = true
+  }
+
+  // Only import createSignal if generated code actually calls it
+  const needsCreateSignalImport = exampleCode.includes('createSignal')
+
+  const lines: string[] = []
+  const previewNames: string[] = []
+
+  // Header comment
+  lines.push('// Auto-generated preview. Customize by editing this file.')
+
+  // "use client" directive
+  if (needsClient) {
+    lines.push('"use client"')
+  }
+  lines.push('')
+
+  // Imports
+  if (needsCreateSignalImport) {
+    lines.push("import { createSignal } from '@barefootjs/dom'")
+  }
+
+  const componentImports = [pascalName]
+  const subNames: string[] = []
+  if (hasSubComponents) {
+    for (const sub of meta.subComponents!) {
+      componentImports.push(sub.name)
+      subNames.push(sub.name)
+    }
+  }
+  lines.push(`import { ${componentImports.join(', ')} } from '../${meta.name}'`)
+
+  // Add imports for external component tags found in example code
+  if (hasSubComponents && exampleCode) {
+    const knownNames = new Set([pascalName, ...subNames])
+    for (const tag of findExternalTags(exampleCode, knownNames)) {
+      lines.push(`import { ${tag} } from '../${toKebabCase(tag)}'`)
+    }
+  }
+
+  lines.push('')
+
+  // Generate preview functions based on component type
+  if (hasSubComponents) {
+    generateMultiComponent(lines, previewNames, meta, pascalName, subNames)
+  } else if (needsClient && hasVariants) {
+    generateStatefulWithVariants(lines, previewNames, meta, pascalName)
+  } else if (needsClient) {
+    generateStateful(lines, previewNames, meta, pascalName)
+  } else if (hasVariants) {
+    generateStatelessWithVariants(lines, previewNames, meta, pascalName)
+  } else {
+    generateStatelessSimple(lines, previewNames, meta, pascalName)
+  }
+
+  lines.push('')
+
+  return {
+    code: lines.join('\n'),
+    previewNames,
+    filePath: `ui/components/ui/${meta.name}/index.preview.tsx`,
+  }
+}
+
+// --- Strategy: Stateless + Variants (button, badge) ---
+
+function generateStatelessWithVariants(
+  lines: string[],
+  previewNames: string[],
+  meta: ComponentMeta,
+  pascalName: string,
+): void {
+  // Default preview
+  previewNames.push('Default')
+  lines.push('export function Default() {')
+  lines.push(`  return <${pascalName}>${meta.title}</${pascalName}>`)
+  lines.push('}')
+  lines.push('')
+
+  // One preview function per variant type
+  for (const [typeName, values] of Object.entries(meta.variants!)) {
+    const propName = inferVariantPropName(typeName, meta.props)
+    if (!propName) continue
+
+    const funcName = capitalize(propName) + 's'
+    previewNames.push(funcName)
+
+    lines.push(`export function ${funcName}() {`)
+    lines.push('  return (')
+    lines.push('    <div className="flex flex-wrap items-center gap-4">')
+    for (const value of values) {
+      lines.push(`      <${pascalName} ${propName}="${value}">${capitalize(value)}</${pascalName}>`)
+    }
+    lines.push('    </div>')
+    lines.push('  )')
+    lines.push('}')
+    lines.push('')
+  }
+}
+
+// --- Strategy: Stateless Simple (input, separator) ---
+
+function generateStatelessSimple(
+  lines: string[],
+  previewNames: string[],
+  meta: ComponentMeta,
+  pascalName: string,
+): void {
+  previewNames.push('Default')
+  lines.push('export function Default() {')
+
+  // Use first simple (static JSX) example if available
+  const simpleExample = meta.examples.find(e => isSimpleJsx(e.code))
+
+  if (simpleExample) {
+    const jsxLines = simpleExample.code.split('\n')
+    if (jsxLines.length === 1) {
+      lines.push(`  return ${simpleExample.code}`)
+    } else {
+      lines.push('  return (')
+      for (const l of jsxLines) {
+        lines.push(`    ${l}`)
+      }
+      lines.push('  )')
+    }
+  } else {
+    const hasChildren = meta.props.some(p => p.name === 'children')
+    if (hasChildren) {
+      lines.push(`  return <${pascalName}>${meta.title}</${pascalName}>`)
+    } else {
+      lines.push(`  return <${pascalName} />`)
+    }
+  }
+
+  lines.push('}')
+  lines.push('')
+}
+
+// --- Strategy: Stateful Simple (checkbox, switch) ---
+
+function generateStateful(
+  lines: string[],
+  previewNames: string[],
+  meta: ComponentMeta,
+  pascalName: string,
+): void {
+  previewNames.push('Default')
+  lines.push('export function Default() {')
+  lines.push('  return (')
+  lines.push('    <div className="flex gap-4">')
+
+  // Bare component
+  lines.push(`      <${pascalName} />`)
+
+  // With default state prop set (defaultChecked, defaultPressed, etc.)
+  const defaultStateProp = meta.props.find(p =>
+    p.name === 'defaultChecked' || p.name === 'defaultPressed' ||
+    p.name === 'defaultValue' || p.name === 'defaultOpen'
+  )
+  if (defaultStateProp) {
+    lines.push(`      <${pascalName} ${defaultStateProp.name} />`)
+  }
+
+  // Disabled state
+  if (meta.props.some(p => p.name === 'disabled')) {
+    lines.push(`      <${pascalName} disabled />`)
+  }
+
+  lines.push('    </div>')
+  lines.push('  )')
+  lines.push('}')
+  lines.push('')
+}
+
+// --- Strategy: Stateful + Variants (toggle) ---
+
+function generateStatefulWithVariants(
+  lines: string[],
+  previewNames: string[],
+  meta: ComponentMeta,
+  pascalName: string,
+): void {
+  // Default preview (reuse stateful simple logic)
+  generateStateful(lines, previewNames, meta, pascalName)
+
+  // Variant previews
+  const hasChildren = meta.props.some(p => p.name === 'children')
+  for (const [typeName, values] of Object.entries(meta.variants!)) {
+    const propName = inferVariantPropName(typeName, meta.props)
+    if (!propName) continue
+
+    const funcName = capitalize(propName) + 's'
+    previewNames.push(funcName)
+
+    lines.push(`export function ${funcName}() {`)
+    lines.push('  return (')
+    lines.push('    <div className="flex flex-wrap items-center gap-4">')
+    for (const value of values) {
+      if (hasChildren) {
+        lines.push(`      <${pascalName} ${propName}="${value}">${capitalize(value)}</${pascalName}>`)
+      } else {
+        lines.push(`      <${pascalName} ${propName}="${value}" />`)
+      }
+    }
+    lines.push('    </div>')
+    lines.push('  )')
+    lines.push('}')
+    lines.push('')
+  }
+}
+
+// --- Strategy: Multi-component (accordion, card, dialog) ---
+
+function generateMultiComponent(
+  lines: string[],
+  previewNames: string[],
+  meta: ComponentMeta,
+  pascalName: string,
+  _subNames: string[],
+): void {
+  previewNames.push('Default')
+
+  if (meta.examples.length > 0) {
+    const example = meta.examples[0]
+    const { statements, jsx } = splitExampleCode(example.code)
+
+    lines.push('export function Default() {')
+
+    // Emit statements from example
+    for (const stmt of statements) {
+      lines.push(`  ${stmt}`)
+    }
+
+    // Inject no-op handlers for undefined handleXxx references in JSX
+    const definedNames = new Set(
+      statements.flatMap(s => [...s.matchAll(/\b(?:const|let|var)\s+(?:\[([^\]]+)\]|(\w+))/g)])
+        .flatMap(m => (m[1] ? m[1].split(',').map(v => v.trim()) : [m[2]]))
+    )
+    const handlerRefs = [...new Set([...jsx.matchAll(/\b(handle[A-Z]\w*)\b/g)].map(m => m[1]))]
+    for (const h of handlerRefs) {
+      if (!definedNames.has(h)) {
+        lines.push(`  const ${h} = () => {}`)
+      }
+    }
+
+    if (statements.length > 0 || handlerRefs.length > 0) {
+      lines.push('')
+    }
+
+    const jsxLines = jsx.split('\n')
+    if (jsxLines.length === 1) {
+      lines.push(`  return ${jsx}`)
+    } else {
+      lines.push('  return (')
+      for (const l of jsxLines) {
+        lines.push(`    ${l}`)
+      }
+      lines.push('  )')
+    }
+
+    lines.push('}')
+  } else {
+    // No examples: generate basic composition from sub-component structure
+    lines.push('export function Default() {')
+    lines.push('  return (')
+    lines.push(`    <${pascalName}>`)
+
+    for (const sub of meta.subComponents!) {
+      const hasChildrenProp = sub.props.some(p => p.name === 'children')
+      const label = sub.name.replace(pascalName, '') || sub.name
+      if (hasChildrenProp) {
+        lines.push(`      <${sub.name}>${label}</${sub.name}>`)
+      } else {
+        lines.push(`      <${sub.name} />`)
+      }
+    }
+
+    lines.push(`    </${pascalName}>`)
+    lines.push('  )')
+    lines.push('}')
+  }
+
+  lines.push('')
+}


### PR DESCRIPTION
## Summary

- Add `barefoot preview:generate <component> [--force]` command that generates `index.preview.tsx` from component metadata (`ui/meta/*.json`)
- Add auto-fallback in `barefoot preview` — when no preview file exists, it auto-generates one from metadata before compiling and serving
- Supports 4 generation strategies based on component type: stateless+variants, stateless simple, stateful, and multi-component
- Handles external component imports and undefined handler injection for multi-component examples

## Details

Currently only 2 of 43+ components have manually written preview files. Component metadata already contains props, variants, examples, and dependency info — enough to generate useful default previews automatically.

### New files
- `packages/cli/src/lib/preview-generate.ts` — Core generation logic (`generatePreview(meta)`)
- `packages/cli/src/commands/preview-generate.ts` — CLI command wrapper
- `packages/cli/src/__tests__/preview-generate.test.ts` — 71 unit tests

### Modified files
- `packages/cli/src/index.ts` — Register `preview:generate` command
- `packages/preview/src/index.tsx` — Auto-fallback when preview file doesn't exist

## Test plan

- [x] `bun test packages/cli/src/__tests__/preview-generate.test.ts` — 71 tests pass (all 43 components generate valid output, determinism, "use client" correctness, variant generation, multi-component handling)
- [x] `bun test packages/cli/` — All 156 CLI tests pass
- [x] `bun run packages/cli/src/index.ts preview:generate button` — generates valid preview file
- [x] `bun run packages/cli/src/index.ts preview:generate checkbox` — generates stateful preview with "use client"
- [x] `bun run packages/preview/src/index.tsx badge` — auto-fallback generates and serves preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)