### PR TITLE
Optimize findScopeByComment: skip comment scope fallback for single-root components (#381)

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -68,5 +68,6 @@ export {
   $ as $,
   $c,
   type ComponentInitFn,
+  type MountOptions,
   type BranchConfig,
 } from './runtime'

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -2,7 +2,7 @@
  * generateInitFunction orchestrator + generateElementRefs.
  */
 
-import type { ComponentIR, ConstantInfo } from '../types'
+import type { ComponentIR, ConstantInfo, IRFragment } from '../types'
 import type { ClientJsContext } from './types'
 import { stripTypeScriptSyntax, varSlotId } from './utils'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
@@ -60,8 +60,11 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   lines.push('')
   lines.push(MODULE_CONSTANTS_PLACEHOLDER)
 
+  const isCommentScope = _ir.root.type === 'fragment'
+    && (_ir.root as IRFragment).needsScopeComment
+
   lines.push(`export function init${name}(__instanceIndex, __parentScope, props = {}) {`)
-  lines.push(`  const __scope = findScope('${name}', __instanceIndex, __parentScope)`)
+  lines.push(`  const __scope = findScope('${name}', __instanceIndex, __parentScope${isCommentScope ? ', true' : ''})`)
   lines.push(`  if (!__scope) return`)
   lines.push('')
 


### PR DESCRIPTION
## Summary

- Skip unnecessary `hydrateCommentScopes()` TreeWalker traversal for single-root components by passing a `comment` flag from the compiler to the runtime
- `mount()` now accepts a `MountOptions` object (`{ template?, comment? }`) with backward compatibility for the legacy positional `templateFn` signature
- `findScope()` and `hydrate()` accept an optional `comment` parameter; without it, comment-based scope fallback is skipped entirely

## Context

`hydrate()` previously called `hydrateCommentScopes()` (TreeWalker over ALL comments in the document) for every component mount, even when the component uses attribute-based scopes (`bf-s`). Comment-based scopes are only needed for **fragment-root components** (`<>...</>`), which are a minority. The compiler already knows this via `IRFragment.needsScopeComment`, so we now pass this information to the runtime.

## Changed files

| File | Change |
|------|--------|
| `packages/dom/src/runtime.ts` | Add `comment` param to `findScope()`/`hydrate()`, `MountOptions` interface for `mount()` |
| `packages/dom/src/index.ts` | Export `MountOptions` type |
| `packages/jsx/src/ir-to-client-js/generate-init.ts` | Pass `true` to `findScope()` for fragment roots |
| `packages/jsx/src/ir-to-client-js/emit-init-sections.ts` | Generate `mount()` with options object including `comment: true` |

## Test plan

- [x] Runtime tests: `findScope` with/without `comment` flag, `hydrate` with/without `comment` flag (4 new tests)
- [x] Compiler tests: fragment-root generates `comment: true`, single-root does not (2 new tests)
- [x] All existing `packages/dom/` and `packages/jsx/` tests pass (398 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)