### PR TITLE
Fix stateless components rendering as empty placeholders (#435)

### DIFF
--- a/packages/dom/src/component.ts
+++ b/packages/dom/src/component.ts
@@ -131,6 +131,38 @@ export function getPropsUpdateFn(element: HTMLElement): ((props: Record<string, 
 
 
 /**
+ * Render a child component's template to an HTML string.
+ * Used by compiler-generated template functions when a stateless component
+ * appears inside a conditional branch or loop template.
+ *
+ * If the component has a registered template, it renders the HTML and injects
+ * a bf-s scope attribute. Otherwise, falls back to an empty placeholder.
+ *
+ * @param name - Component name (e.g., 'Spinner')
+ * @param props - Props to pass to the template
+ * @param key - Optional key for list reconciliation
+ * @returns HTML string with scope marker
+ */
+export function renderChild(
+  name: string,
+  props: Record<string, unknown>,
+  key?: string | number
+): string {
+  const templateFn = getTemplate(name)
+  const id = Math.random().toString(36).slice(2, 8)
+  const keyAttr = key !== undefined ? ` data-key="${key}"` : ''
+
+  if (!templateFn) {
+    // Fallback: empty placeholder (for components without registered templates)
+    return `<div bf-s="${name}_${id}"${keyAttr}></div>`
+  }
+
+  const html = templateFn(props).trim()
+  // Inject bf-s scope attribute into the root element
+  return html.replace(/^(<\w+)/, `$1 bf-s="${name}_${id}"${keyAttr}`)
+}
+
+/**
  * Generate a random ID for scope identification
  */
 function generateId(): string {

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -43,7 +43,7 @@ export { createContext, useContext, provideContext, type Context } from './conte
 export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './template'
 
 // Component creation for dynamic rendering
-export { createComponent, getPropsUpdateFn, getComponentProps } from './component'
+export { createComponent, renderChild, getPropsUpdateFn, getComponentProps } from './component'
 
 // Props utilities
 export { splitProps } from './split-props'

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -2935,7 +2935,7 @@ describe('Compiler', () => {
       expect(analysis.needsInit).toBe(true)
     })
 
-    test('purely static component does not generate client JS', () => {
+    test('purely static component generates template-only mount (#435)', () => {
       const source = `
         export function StaticLabel() {
           return <span>Hello World</span>
@@ -2946,7 +2946,10 @@ describe('Compiler', () => {
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
-      expect(clientJs).toBeUndefined()
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain("mount('StaticLabel'")
+      expect(clientJs!.content).toContain('function initStaticLabel() {}')
+      expect(clientJs!.content).toContain('<span>Hello World</span>')
     })
 
     test('components with reactive primitives still require "use client"', () => {

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -8,7 +8,7 @@ import type { ComponentIR } from '../types'
 export const DOM_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
   'findScope', 'hydrate', 'cond', 'insert', 'reconcileList',
-  'createComponent', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker',
+  'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker',
   'mount',
   'createPortal',
   'provideContext', 'createContext', 'useContext',

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -10,6 +10,9 @@ import { collectElements } from './collect-elements'
 import { generateInitFunction } from './generate-init'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
 import { valueReferencesReactiveData } from './prop-handling'
+import { canGenerateStaticTemplate, irToComponentTemplate } from './html-template'
+import { buildInlinableConstants } from './emit-init-sections'
+import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
 
 /** Public entry point: IR → client JS string. Returns '' if no client JS is needed. */
 export function generateClientJs(ir: ComponentIR, siblingComponents?: string[]): string {
@@ -17,7 +20,8 @@ export function generateClientJs(ir: ComponentIR, siblingComponents?: string[]):
   collectElements(ir.root, ctx)
 
   if (!needsClientJs(ctx)) {
-    return ''
+    // Stateless components still need template registration so renderChild() can find them (#435)
+    return generateTemplateOnlyMount(ir, ctx)
   }
 
   return generateInitFunction(ir, ctx, siblingComponents)
@@ -117,4 +121,41 @@ function needsClientJs(ctx: ClientJsContext): boolean {
     ctx.clientOnlyConditionals.length > 0 ||
     ctx.providerSetups.length > 0
   )
+}
+
+/**
+ * Generate minimal client JS for stateless components that only need
+ * template registration. This allows renderChild() to find and render
+ * the component's template when it appears in conditional branches (#435).
+ *
+ * Returns '' if a static template cannot be generated.
+ */
+function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): string {
+  const propNamesForTemplate = new Set(ctx.propsParams.map((p) => p.name))
+  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
+
+  if (!canGenerateStaticTemplate(ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
+    return ''
+  }
+
+  const templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants)
+  if (!templateHtml) {
+    return ''
+  }
+
+  const name = ctx.componentName
+  const lines: string[] = []
+
+  lines.push(IMPORT_PLACEHOLDER)
+  lines.push('')
+  lines.push(`function init${name}() {}`)
+  lines.push('')
+  lines.push(`mount('${name}', init${name}, { template: (props) => \`${templateHtml}\` })`)
+
+  const generatedCode = lines.join('\n')
+  const usedImports = detectUsedImports(generatedCode)
+  const sortedImports = [...usedImports].sort()
+  const importLine = `import { ${sortedImports.join(', ')} } from '@barefootjs/dom'`
+
+  return generatedCode.replace(IMPORT_PLACEHOLDER, importLine)
 }

--- a/site/ui/components/spinner-demo.tsx
+++ b/site/ui/components/spinner-demo.tsx
@@ -35,8 +35,6 @@ export function SpinnerSizesDemo() {
 
 /**
  * Button with loading state.
- * Uses visibility toggling (not conditional rendering) so the Spinner SVG
- * is always in the DOM and the client JS only toggles classes.
  */
 export function SpinnerButtonDemo() {
   const [loading, setLoading] = createSignal(false)
@@ -54,7 +52,7 @@ export function SpinnerButtonDemo() {
       disabled={loading()}
       onClick={handleClick}
     >
-      <Spinner className={`size-4 ${loading() ? '' : 'hidden'}`} />
+      {loading() ? <Spinner className="size-4" /> : null}
       <span data-testid="spinner-button-label">
         {loading() ? 'Processing...' : 'Submit'}
       </span>

--- a/site/ui/e2e/spinner.spec.ts
+++ b/site/ui/e2e/spinner.spec.ts
@@ -45,17 +45,18 @@ test.describe('Spinner Documentation Page', () => {
       const button = page.locator('[data-testid="spinner-button"]')
       await expect(button).toBeVisible()
 
-      // Initially shows "Submit" and spinner is hidden
+      // Initially shows "Submit" and no spinner
       const label = page.locator('[data-testid="spinner-button-label"]')
       await expect(label).toContainText('Submit')
       const spinnerInButton = button.locator('[data-slot="spinner"]')
-      await expect(spinnerInButton).toHaveClass(/hidden/)
+      await expect(spinnerInButton).toHaveCount(0)
 
       // Click the button to trigger loading state
       await button.click()
 
-      // Spinner becomes visible and text changes
-      await expect(spinnerInButton).not.toHaveClass(/hidden/)
+      // Spinner appears and text changes
+      await expect(spinnerInButton).toHaveCount(1)
+      await expect(spinnerInButton).toBeVisible()
       await expect(label).toContainText('Processing...')
     })
   })


### PR DESCRIPTION
## Summary

- Add `renderChild()` runtime helper that looks up a component's registered template and renders inline HTML with scope markers
- Change compiler template generation to emit `renderChild()` calls instead of empty `<div>` placeholders for component nodes in conditional branches and loops
- Generate minimal template-only `mount()` code for stateless components so their templates are registered in the runtime
- Extract `buildInlinableConstants()` from `emitRegistrationAndHydration` for reuse

## Root cause

When a stateless component (no signals/effects) appeared inside a client-side conditional branch, two linked issues caused it to render as an empty placeholder:
1. `irToHtmlTemplate()` always generated empty `<div bf-s="Name_xxx"></div>` for component nodes
2. `generateClientJs()` returned `''` for stateless components — no template was registered, so nothing could render the content

## Changes

| File | Change |
|------|--------|
| `packages/dom/src/component.ts` | Add `renderChild()` helper |
| `packages/dom/src/index.ts` | Export `renderChild` |
| `packages/jsx/src/ir-to-client-js/html-template.ts` | Use `renderChild()` in both `irToHtmlTemplate` and `irToComponentTemplate`; allow component nodes in `canGenerateStaticTemplate` |
| `packages/jsx/src/ir-to-client-js/imports.ts` | Add `renderChild` to `DOM_IMPORT_CANDIDATES` |
| `packages/jsx/src/ir-to-client-js/index.ts` | Add `generateTemplateOnlyMount()` for stateless components |
| `packages/jsx/src/ir-to-client-js/emit-init-sections.ts` | Extract `buildInlinableConstants()` for reuse |

## Test plan

- [x] Compiler unit tests pass (281/281 in `packages/jsx/`)
- [x] DOM runtime tests pass (118/118 in `packages/dom/`)
- [x] Updated test: stateless component now generates template-only mount instead of no client JS
- [ ] E2E: Spinner demo — click button → Spinner SVG appears inside button, toggle back → disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)