### PR TITLE
Fix compiler dropping let variable declarations

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -347,6 +347,11 @@ export class HonoAdapter implements TemplateAdapter {
 
     // Include local constants
     for (const constant of ir.metadata.localConstants) {
+      const keyword = constant.declarationKind ?? 'const'
+      if (!constant.value) {
+        lines.push(`  ${keyword} ${constant.name}`)
+        continue
+      }
       const value = constant.value.trim()
       // Skip client-only constructs in SSR:
       // - createContext() — only used client-side via provideContext/useContext
@@ -365,10 +370,10 @@ export class HonoAdapter implements TemplateAdapter {
         // Generate a stub function for SSR (these may be referenced as props)
         // Extract parameters if possible
         const params = this.extractFunctionParams(value)
-        lines.push(`  const ${constant.name} = (${params}) => {}`)
+        lines.push(`  ${keyword} ${constant.name} = (${params}) => {}`)
       } else {
         // Output non-function constants directly
-        lines.push(`  const ${constant.name} = ${constant.value}`)
+        lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
       }
     }
 

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -3073,4 +3073,122 @@ describe('Compiler', () => {
       expect(content).not.toContain("findScope('SingleRoot', __instanceIndex, __parentScope, true)")
     })
   })
+
+  describe('let variable declarations (#482)', () => {
+    test('let without initializer is captured by analyzer', () => {
+      const source = `
+        'use client'
+        import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
+
+        type ApiType = { scrollPrev: () => void }
+
+        export function Carousel() {
+          let emblaApi: ApiType | undefined
+          const [canScrollPrev, setCanScrollPrev] = createSignal(false)
+
+          createEffect(() => {
+            if (emblaApi) {
+              setCanScrollPrev(true)
+            }
+          })
+
+          return <div>{canScrollPrev() ? 'yes' : 'no'}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'Carousel.tsx')
+      const letConstant = ctx.localConstants.find(c => c.name === 'emblaApi')
+      expect(letConstant).toBeDefined()
+      expect(letConstant!.declarationKind).toBe('let')
+      expect(letConstant!.value).toBeUndefined()
+    })
+
+    test('let without initializer is emitted in client JS', () => {
+      const source = `
+        'use client'
+        import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
+
+        type ApiType = { scrollPrev: () => void }
+
+        export function Carousel() {
+          let emblaApi: ApiType | undefined
+          const [canScrollPrev, setCanScrollPrev] = createSignal(false)
+
+          const scrollPrev = () => {
+            if (emblaApi) emblaApi.scrollPrev()
+          }
+
+          createEffect(() => {
+            if (emblaApi) {
+              setCanScrollPrev(true)
+            }
+          })
+
+          return <div onClick={scrollPrev}>{canScrollPrev() ? 'yes' : 'no'}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'Carousel.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('let emblaApi')
+      // Must not contain type annotation in output
+      expect(clientJs!.content).not.toContain('ApiType')
+    })
+
+    test('let with initializer is emitted as let, not const', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          let count = 0
+          const [value, setValue] = createSignal(count)
+          return <div>{value()}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'Counter.tsx')
+      const letConstant = ctx.localConstants.find(c => c.name === 'count')
+      expect(letConstant).toBeDefined()
+      expect(letConstant!.declarationKind).toBe('let')
+      expect(letConstant!.value).toBe('0')
+
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('let count = 0')
+      expect(clientJs!.content).not.toContain('const count')
+    })
+
+    test('const declarations still emitted as const (regression)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const prefix = 'count'
+          const [value, setValue] = createSignal(0)
+          return <div>{value() + prefix}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'Counter.tsx')
+      const constConstant = ctx.localConstants.find(c => c.name === 'prefix')
+      expect(constConstant).toBeDefined()
+      expect(constConstant!.declarationKind).toBe('const')
+
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain("const prefix = 'count'")
+      expect(clientJs!.content).not.toContain('let prefix')
+    })
+  })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -176,6 +176,11 @@ export class TestAdapter extends BaseAdapter {
     }
 
     for (const constant of ir.metadata.localConstants) {
+      const keyword = constant.declarationKind ?? 'const'
+      if (!constant.value) {
+        lines.push(`  ${keyword} ${constant.name}`)
+        continue
+      }
       const value = constant.value.trim()
       const isArrowFunc =
         value.startsWith('async (') ||
@@ -184,9 +189,9 @@ export class TestAdapter extends BaseAdapter {
         /^\([^)]*\)\s*=>/.test(value)
 
       if (isArrowFunc) {
-        lines.push(`  const ${constant.name} = () => {}`)
+        lines.push(`  ${keyword} ${constant.name} = () => {}`)
       } else {
-        lines.push(`  const ${constant.name} = ${constant.value}`)
+        lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
       }
     }
 

--- a/packages/jsx/src/css-layer-prefixer.ts
+++ b/packages/jsx/src/css-layer-prefixer.ts
@@ -122,7 +122,7 @@ export function applyCssLayerPrefix(ir: ComponentIR, layerName: string): void {
     changed = false
     for (const constName of [...referencedConstants]) {
       const constant = ir.metadata.localConstants.find(c => c.name === constName)
-      if (!constant) continue
+      if (!constant || !constant.value) continue
       for (const id of extractIdentifiers(constant.value)) {
         if (constantNames.has(id) && !referencedConstants.has(id)) {
           referencedConstants.add(id)
@@ -134,7 +134,7 @@ export function applyCssLayerPrefix(ir: ComponentIR, layerName: string): void {
 
   // Apply prefixing to referenced constants
   for (const constant of ir.metadata.localConstants) {
-    if (referencedConstants.has(constant.name)) {
+    if (referencedConstants.has(constant.name) && constant.value) {
       constant.value = prefixConstantValue(constant.value, layerName)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -85,8 +85,13 @@ export function emitPropsExtraction(
 /** Emit constants that have no signal/memo dependencies (before signal declarations). */
 export function emitEarlyConstants(lines: string[], earlyConstants: ConstantInfo[]): void {
   for (const constant of earlyConstants) {
-    const jsValue = stripTypeScriptSyntax(constant.value)
-    lines.push(`  const ${constant.name} = ${jsValue}`)
+    const keyword = constant.declarationKind ?? 'const'
+    if (constant.value !== undefined) {
+      const jsValue = stripTypeScriptSyntax(constant.value)
+      lines.push(`  ${keyword} ${constant.name} = ${jsValue}`)
+    } else {
+      lines.push(`  ${keyword} ${constant.name}`)
+    }
   }
   if (earlyConstants.length > 0) {
     lines.push('')
@@ -153,8 +158,13 @@ export function emitSignalsAndMemos(
   }
 
   for (const constant of lateConstants) {
-    const jsValue = stripTypeScriptSyntax(constant.value)
-    lines.push(`  const ${constant.name} = ${jsValue}`)
+    const keyword = constant.declarationKind ?? 'const'
+    if (constant.value !== undefined) {
+      const jsValue = stripTypeScriptSyntax(constant.value)
+      lines.push(`  ${keyword} ${constant.name} = ${jsValue}`)
+    } else {
+      lines.push(`  ${keyword} ${constant.name}`)
+    }
   }
 
   if (ctx.signals.length > 0 || ctx.memos.length > 0 || lateConstants.length > 0) {
@@ -182,11 +192,13 @@ export function emitFunctionsAndHandlers(
 
   for (const constant of ctx.localConstants) {
     if (outputConstants.has(constant.name)) continue
+    if (!constant.value) continue
     if (usedIdentifiers.has(constant.name)) {
       const value = constant.value.trim()
       if (value.includes('=>')) {
+        const keyword = constant.declarationKind ?? 'const'
         const jsValue = stripTypeScriptSyntax(value)
-        lines.push(`  const ${constant.name} = ${jsValue}`)
+        lines.push(`  ${keyword} ${constant.name} = ${jsValue}`)
         lines.push('')
       }
     }
@@ -834,6 +846,11 @@ export function emitRegistrationAndHydration(
   }
 
   for (const constant of ctx.localConstants) {
+    if (!constant.value) {
+      // `let x` with no initializer — not safe for template inlining
+      unsafeLocalNames.add(constant.name)
+      continue
+    }
     const trimmedValue = constant.value.trim()
 
     // Arrow functions cannot be inlined into templates

--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -152,7 +152,7 @@ export function collectUsedIdentifiers(ctx: ClientJsContext): Set<string> {
   }
 
   for (const constant of ctx.localConstants) {
-    extractIdentifiers(constant.value, used)
+    if (constant.value) extractIdentifiers(constant.value, used)
   }
 
   for (const child of ctx.childInits) {

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -48,6 +48,7 @@ export function analyzeClientNeeds(ir: ComponentIR): { needsInit: boolean; usedP
   // Transitive props via constants
   for (const constant of ctx.localConstants) {
     if (usedIdentifiers.has(constant.name)) {
+      if (!constant.value) continue
       const trimmedValue = constant.value.trim()
       if (/^createContext\b/.test(trimmedValue) || /^new WeakMap\b/.test(trimmedValue)) continue
       if (!trimmedValue.includes('=>') && constant.name !== 'props') {

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -16,7 +16,7 @@ export function expandDynamicPropValue(value: string, ctx: ClientJsContext): str
   const trimmedValue = value.trim()
 
   const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
-  if (constant) {
+  if (constant && constant.value) {
     return constant.value
   }
 
@@ -135,7 +135,7 @@ export function detectPropsWithPropertyAccess(
     sources.push(elem.expression)
   }
   for (const constant of neededConstants) {
-    sources.push(constant.value)
+    if (constant.value) sources.push(constant.value)
   }
 
   for (const prop of ctx.propsParams) {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1600,7 +1600,7 @@ function isReactiveExpression(expr: string, ctx: TransformContext): boolean {
     const constPattern = new RegExp(`\\b${constant.name}\\b`)
     if (constPattern.test(expr)) {
       // Check if the constant's value contains reactive references
-      if (isReactiveValue(constant.value, ctx)) {
+      if (constant.value && isReactiveValue(constant.value, ctx)) {
         return true
       }
     }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -368,7 +368,8 @@ export interface FunctionInfo {
 
 export interface ConstantInfo {
   name: string
-  value: string
+  value?: string
+  declarationKind: 'const' | 'let'
   type: TypeInfo | null
   loc: SourceLocation
 }

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -11,10 +11,11 @@
  * Only resolves string literals, template literals, and array.join() patterns.
  * Record lookups, function expressions, and other complex values are skipped.
  */
-export function resolveConstants(constants: Array<{ name: string; value: string }>): Map<string, string> {
+export function resolveConstants(constants: Array<{ name: string; value?: string }>): Map<string, string> {
   const resolved = new Map<string, string>()
 
   for (const c of constants) {
+    if (!c.value) continue
     const value = tryResolve(c.value, resolved)
     if (value !== null) {
       resolved.set(c.name, value)


### PR DESCRIPTION
## Summary

Closes #482

- The analyzer's `visitComponentBody()` only collected variable declarations with initializers, silently dropping `let x: Type` declarations (e.g., `let emblaApi: ApiType | undefined`). This caused the compiled client JS to reference undefined variables, breaking closures like `scrollPrev()`/`scrollNext()` in the Carousel component.
- All collected declarations were emitted as `const` regardless of the original keyword, which would break reassignment for `let` variables.
- Added `declarationKind: 'const' | 'let'` to `ConstantInfo` and made `value` optional to support declarations without initializers.
- Guarded all `constant.value` access points across 13 files (analyzer, emitters, adapters, CSS prefixer, test utilities).

## Test plan

- [x] Added 4 compiler unit tests: `let` without initializer (analyzer + emission), `let` with initializer emitted as `let`, `const` regression test
- [x] `bun test packages/jsx/` — 113 pass, 0 fail
- [x] `bun test packages/jsx/ packages/test/ packages/dom/` — 414 pass, 0 fail
- [x] Full test suite — no new failures (existing Playwright version conflict failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)