### PR TITLE
Fix static array child components hydrated with empty props (#483)

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -34,6 +34,7 @@ import { fixture as nullishCoalescingText } from './nullish-coalescing-text'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
 import { fixture as multipleInstances } from './multiple-instances'
+import { fixture as staticArrayChildren } from './static-array-children'
 
 import type { JSXFixture } from '../src/types'
 
@@ -74,4 +75,5 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 7: Multi-file composition
   childComponent,
   multipleInstances,
+  staticArrayChildren,
 ]

--- a/packages/adapter-tests/fixtures/static-array-children.ts
+++ b/packages/adapter-tests/fixtures/static-array-children.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'static-array-children',
+  description: 'Static array with child components preserves className (#483)',
+  source: `
+import { ListItem } from './list-item'
+export function StaticList() {
+  const items = [{ label: 'Alpha' }, { label: 'Beta' }]
+  return (
+    <ul>
+      {items.map(item => (
+        <ListItem label={item.label} className="text-sm" />
+      ))}
+    </ul>
+  )
+}
+`,
+  components: {
+    './list-item.tsx': `
+export function ListItem({ label, className }: { label: string; className?: string }) {
+  return <li className={className}>{label}</li>
+}
+`,
+  },
+})

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -21,6 +21,9 @@ runJSXConformanceTests({
   render: renderGoTemplateComponent,
   referenceAdapter: () => new HonoAdapter(),
   referenceRender: renderHonoComponent,
+  // Static array with child components from separate files is not yet supported
+  // by the Go template renderer (child templates are not registered)
+  skip: ['static-array-children'],
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -50,6 +50,7 @@ export class HonoAdapter implements TemplateAdapter {
   private componentName: string = ''
   private options: HonoAdapterOptions
   private isClientComponent: boolean = false
+  private hasClientInteractivity: boolean = false
   private currentComponentHasProps: boolean = false
 
   constructor(options: HonoAdapterOptions = {}) {
@@ -193,6 +194,7 @@ export class HonoAdapter implements TemplateAdapter {
     // that need client JS wiring (detected by analyzeClientNeeds)
     const needsClientInit = ir.metadata.clientAnalysis?.needsInit ?? false
     const hasClientInteractivity = ir.metadata.isClientComponent || needsClientInit
+    this.hasClientInteractivity = hasClientInteractivity
 
     // Check if component uses props object pattern (SolidJS-style)
     const propsObjectName = ir.metadata.propsObjectName
@@ -637,8 +639,8 @@ export class HonoAdapter implements TemplateAdapter {
     // Determine how to pass scope to child component
     let scopeAttr: string
     // Mark child components with slotId for parent-first hydration
-    // Only add __bfChild when parent is a client component (will call initChild)
-    const bfChildAttr = (comp.slotId && this.isClientComponent) ? ' __bfChild={true}' : ''
+    // Add __bfChild when parent has client interactivity (will call initChild)
+    const bfChildAttr = (comp.slotId && this.hasClientInteractivity) ? ' __bfChild={true}' : ''
     if (ctx?.isRootOfClientComponent) {
       // Root component: if it has a slotId, include it so client JS can find it
       // with [bf-s$="_sX"] selector. Otherwise pass parent's scope directly.


### PR DESCRIPTION
## Summary

- Fix `__bfChild={true}` not being passed in SSR templates when the parent component lacks `"use client"` but still has client interactivity (static array with child components)
- Without `__bfChild`, child components hydrate with empty props before the parent's `initChild()` can pass the correct props (including `className`)
- The fix changes the condition from `isClientComponent` to `hasClientInteractivity`, which matches exactly when client JS with `initChild` calls will be generated

## Root Cause

In `hono-adapter.ts`, `bfChildAttr` was gated on `this.isClientComponent` (true only with `"use client"`). But a parent can generate client JS with `initChild` calls even without `"use client"` — this happens when it has static array children that need client initialization.

## Changes

| File | Change |
|------|--------|
| `packages/hono/src/adapter/hono-adapter.ts` | Add `hasClientInteractivity` field; update `bfChildAttr` condition |
| `packages/jsx/src/__tests__/compiler.test.ts` | Add 2 compiler tests for `__bfChild` in SSR template |
| `packages/adapter-tests/fixtures/static-array-children.ts` | Add conformance fixture |
| `packages/adapter-tests/fixtures/index.ts` | Register new fixture |
| `packages/go-template/src/__tests__/go-template-adapter.test.ts` | Skip fixture (Go renderer doesn't register child templates) |

## Go adapter

The Go adapter is **not affected** by this bug. Its runtime (`bf.go`) always sets `BfIsChild = true` on all child component props in the `Render()` function (lines 768/776), independent of the adapter's compile-time condition. The `ScopeAttr()` function then adds the `~` prefix based on this flag.

## Test plan

- [x] Compiler tests pass (`bun test packages/jsx/src/__tests__/compiler.test.ts`)
- [x] Hono adapter conformance tests pass (`bun test packages/hono/__tests__/`)
- [x] Go adapter conformance tests pass (`bun test packages/go-template/src/__tests__/`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)