### PR TITLE
Support DOM children in reconcileList createComponent

### DIFF
--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1103,6 +1103,7 @@ function transformMapCall(
           isLiteral: p.isLiteral,
           isEventHandler: p.name.startsWith('on') && p.name.length > 2,
         })),
+      children: comp.children,
     }
   }
 
@@ -1161,6 +1162,7 @@ function collectNestedComponents(nodes: IRNode[]): IRLoopChildComponent[] {
             isLiteral: p.isLiteral,
             isEventHandler: p.name.startsWith('on') && p.name.length > 2,
           })),
+        children: node.children,
       })
     }
     if (node.type === 'element' && node.children) {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -140,6 +140,7 @@ export interface IRLoopChildComponent {
     isLiteral: boolean // true if value came from a string literal attribute
     isEventHandler: boolean
   }>
+  children: IRNode[] // Child nodes for nested component rendering
 }
 
 export interface IRLoop {


### PR DESCRIPTION
## Summary

- Extend `IRLoopChildComponent` with a `children` field so nested JSX children are preserved through the IR pipeline
- Add `irChildrenToJsExpr()` helper to convert IR children into nested `createComponent()` calls with `get children()` getters
- Recursively collect component names from children for correct import generation
- Handle DOM element children in runtime `createComponent()` via `appendChild`

Closes #481

## Test plan

- [x] Compiler: component with component children in `.map()` emits nested `createComponent` with `get children()`
- [x] Compiler: mixed children (text + components) handled correctly
- [x] Compiler: component without children does NOT emit `children` getter (no regression)
- [x] Compiler: deeply nested A > B > C pattern works recursively with correct imports
- [x] All existing tests pass (294 jsx, 122 dom, 5 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)