### PR TITLE
Add pre-generated expectedHtml for fixture-based conformance testing

### DIFF
--- a/packages/adapter-tests/fixtures/child-component.ts
+++ b/packages/adapter-tests/fixtures/child-component.ts
@@ -17,4 +17,5 @@ export function Badge({ label }: { label: string }) {
 `,
   },
   props: { title: 'Hello' },
+  expectedHtml: `<div bf-s="test"><h2 bf="s1"><span bf="s0">Hello</span></h2><span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/class-vs-classname.ts
+++ b/packages/adapter-tests/fixtures/class-vs-classname.ts
@@ -8,4 +8,5 @@ export function ClassVsClassname() {
   return <div className="container"><span className="label">Text</span></div>
 }
 `,
+  expectedHtml: `<div class="container" bf-s="test"><span class="label">Text</span></div>`,
 })

--- a/packages/adapter-tests/fixtures/client-only.ts
+++ b/packages/adapter-tests/fixtures/client-only.ts
@@ -18,4 +18,5 @@ export function ClientOnly() {
   )
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/conditional-class.ts
+++ b/packages/adapter-tests/fixtures/conditional-class.ts
@@ -11,4 +11,5 @@ export function ConditionalClass() {
   return <div className={active() ? 'on' : 'off'}>Toggle</div>
 }
 `,
+  expectedHtml: `<div class="off" bf-s="test" bf="s0">Toggle</div>`,
 })

--- a/packages/adapter-tests/fixtures/controlled-signal.ts
+++ b/packages/adapter-tests/fixtures/controlled-signal.ts
@@ -12,4 +12,5 @@ export function ControlledSignal(props: { value: number }) {
 }
 `,
   props: { value: 42 },
+  expectedHtml: `<span bf-s="test" bf="s1"><span bf="s0">42</span></span>`,
 })

--- a/packages/adapter-tests/fixtures/counter.ts
+++ b/packages/adapter-tests/fixtures/counter.ts
@@ -11,4 +11,5 @@ export function Counter() {
   return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
 }
 `,
+  expectedHtml: `<button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>`,
 })

--- a/packages/adapter-tests/fixtures/default-props.ts
+++ b/packages/adapter-tests/fixtures/default-props.ts
@@ -13,4 +13,5 @@ export function DefaultProps(props: { label?: string; size?: number }) {
 }
 `,
   props: { label: 'Custom', size: 5 },
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Custom</span></span><span bf="s3"><span bf="s2">5</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/dynamic-attributes.ts
+++ b/packages/adapter-tests/fixtures/dynamic-attributes.ts
@@ -12,4 +12,5 @@ export function DynamicAttributes() {
   return <div data-state={state()} data-count={count()}>Content</div>
 }
 `,
+  expectedHtml: `<div data-state="closed" data-count="0" bf-s="test" bf="s0">Content</div>`,
 })

--- a/packages/adapter-tests/fixtures/effect.ts
+++ b/packages/adapter-tests/fixtures/effect.ts
@@ -12,4 +12,5 @@ export function EffectDemo() {
   return <div>{count()}</div>
 }
 `,
+  expectedHtml: `<div bf-s="test" bf="s1"><span bf="s0">0</span></div>`,
 })

--- a/packages/adapter-tests/fixtures/event-handlers.ts
+++ b/packages/adapter-tests/fixtures/event-handlers.ts
@@ -19,4 +19,5 @@ export function EventHandlers() {
   )
 }
 `,
+  expectedHtml: `<div bf-s="test"><input type="text" bf="s0"><button bf="s1">Click</button><span bf="s3"><span bf="s2"></span></span><span bf="s5"><span bf="s4">0</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/filter-simple.ts
+++ b/packages/adapter-tests/fixtures/filter-simple.ts
@@ -12,4 +12,5 @@ export function FilterSimple() {
   return <ul>{todos().filter(t => t.done).map(t => <li>{t.text}</li>)}</ul>
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/filter-sort-chain.ts
+++ b/packages/adapter-tests/fixtures/filter-sort-chain.ts
@@ -12,4 +12,5 @@ export function FilterSortChain() {
   return <ul>{products().filter(p => p.active).sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/fragment.ts
+++ b/packages/adapter-tests/fixtures/fragment.ts
@@ -11,4 +11,5 @@ export function FragmentDemo() {
   return <><span>A</span><span>{count()}</span></>
 }
 `,
+  expectedHtml: `<!--bf-scope:test--><span>A</span><span bf="s1"><span bf="s0">0</span></span>`,
 })

--- a/packages/adapter-tests/fixtures/logical-and.ts
+++ b/packages/adapter-tests/fixtures/logical-and.ts
@@ -11,4 +11,5 @@ export function LogicalAndDemo() {
   return <div>{show() && <span>Shown</span>}</div>
 }
 `,
+  expectedHtml: `<div bf-s="test" bf="s1"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>`,
 })

--- a/packages/adapter-tests/fixtures/map-basic.ts
+++ b/packages/adapter-tests/fixtures/map-basic.ts
@@ -12,4 +12,5 @@ export function MapBasic() {
   return <ul>{items().map(item => <li>{item.name}</li>)}</ul>
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/map-with-index.ts
+++ b/packages/adapter-tests/fixtures/map-with-index.ts
@@ -12,4 +12,5 @@ export function MapWithIndex() {
   return <ul>{entries().map((entry, i) => <li>{i}: {entry.label}</li>)}</ul>
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/memo.ts
+++ b/packages/adapter-tests/fixtures/memo.ts
@@ -12,4 +12,5 @@ export function MemoDemo() {
   return <div><span>{count()}</span><span>{doubled()}</span></div>
 }
 `,
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">0</span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/multiple-instances.ts
+++ b/packages/adapter-tests/fixtures/multiple-instances.ts
@@ -16,4 +16,5 @@ export function Tag({ label }: { label: string }) {
 }
 `,
   },
+  expectedHtml: `<div bf-s="test"><span bf-s="test_s0" bf="s1"><span bf="s0">Alpha</span></span><span bf-s="test_s1" bf="s1"><span bf="s0">Beta</span></span><span bf-s="test_s2" bf="s1"><span bf="s0">Gamma</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/multiple-signals.ts
+++ b/packages/adapter-tests/fixtures/multiple-signals.ts
@@ -12,4 +12,5 @@ export function MultipleSignals() {
   return <div><span>{name()}</span><span>{age()}</span></div>
 }
 `,
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0"></span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/nested-elements.ts
+++ b/packages/adapter-tests/fixtures/nested-elements.ts
@@ -19,4 +19,5 @@ export function NestedElements() {
   )
 }
 `,
+  expectedHtml: `<div bf-s="test"><section><article><p bf="s1"><span bf="s0">hello</span></p></article></section></div>`,
 })

--- a/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
@@ -12,4 +12,5 @@ export function NullishCoalescingText(props: { label?: string; size?: number }) 
 }
 `,
   props: { label: 'Custom', size: 5 },
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Custom</span></span><span bf="s3"><span bf="s2">5</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/props-reactive.ts
+++ b/packages/adapter-tests/fixtures/props-reactive.ts
@@ -12,4 +12,5 @@ export function PropsReactive(props: { label: string }) {
 }
 `,
   props: { label: 'Hello' },
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Hello</span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/props-static.ts
+++ b/packages/adapter-tests/fixtures/props-static.ts
@@ -9,4 +9,5 @@ export function PropsStatic({ label, count }: { label: string; count: number }) 
 }
 `,
   props: { label: 'Items', count: 10 },
+  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Items</span></span><span bf="s3"><span bf="s2">10</span></span></div>`,
 })

--- a/packages/adapter-tests/fixtures/signal-prop-same-name.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name.ts
@@ -12,4 +12,5 @@ export function SignalPropSameName(props: { label?: string }) {
 }
 `,
   props: { label: 'Hello' },
+  expectedHtml: `<span bf-s="test" bf="s1"><span bf="s0">Hello</span></span>`,
 })

--- a/packages/adapter-tests/fixtures/signal-with-fallback.ts
+++ b/packages/adapter-tests/fixtures/signal-with-fallback.ts
@@ -12,4 +12,5 @@ export function SignalWithFallback(props: { initial?: number }) {
 }
 `,
   props: { initial: 5 },
+  expectedHtml: `<div bf-s="test" bf="s1"><span bf="s0">5</span></div>`,
 })

--- a/packages/adapter-tests/fixtures/sort-simple.ts
+++ b/packages/adapter-tests/fixtures/sort-simple.ts
@@ -12,4 +12,5 @@ export function SortSimple() {
   return <ul>{products().sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
 }
 `,
+  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
 })

--- a/packages/adapter-tests/fixtures/static-array-children.ts
+++ b/packages/adapter-tests/fixtures/static-array-children.ts
@@ -23,4 +23,5 @@ export function ListItem({ label, className }: { label: string; className?: stri
 }
 `,
   },
+  expectedHtml: `<ul bf-s="test" bf="s1"><li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Alpha</span></li><li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Beta</span></li></ul>`,
 })

--- a/packages/adapter-tests/fixtures/style-attribute.ts
+++ b/packages/adapter-tests/fixtures/style-attribute.ts
@@ -8,4 +8,5 @@ export function StyleAttribute() {
   return <div style="color: red; font-size: 16px">Styled</div>
 }
 `,
+  expectedHtml: `<div style="color: red; font-size: 16px" bf-s="test">Styled</div>`,
 })

--- a/packages/adapter-tests/fixtures/ternary.ts
+++ b/packages/adapter-tests/fixtures/ternary.ts
@@ -11,4 +11,5 @@ export function TernaryDemo() {
   return <div>{show() ? <span>Visible</span> : <span>Hidden</span>}</div>
 }
 `,
+  expectedHtml: `<div bf-s="test" bf="s1"><span bf-c="s0">Hidden</span></div>`,
 })

--- a/packages/adapter-tests/fixtures/void-elements.ts
+++ b/packages/adapter-tests/fixtures/void-elements.ts
@@ -15,4 +15,5 @@ export function VoidElements() {
   )
 }
 `,
+  expectedHtml: `<div bf-s="test"><br><hr><img src="test.png" alt="test"><input type="text"></div>`,
 })

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -1,0 +1,67 @@
+/**
+ * Generate expectedHtml for all fixtures using the Hono adapter as reference.
+ *
+ * Usage: bun run packages/adapter-tests/scripts/generate-expected-html.ts
+ *
+ * This compiles each fixture with HonoAdapter, renders to HTML, normalizes it,
+ * and writes the expectedHtml back into the fixture files.
+ */
+
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { renderHonoComponent } from '@barefootjs/hono/test-render'
+import { normalizeHTML } from '../src/jsx-runner'
+import { jsxFixtures } from '../fixtures'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const FIXTURES_DIR = resolve(import.meta.dir, '../fixtures')
+
+async function main() {
+  let updated = 0
+  let failed = 0
+
+  for (const fixture of jsxFixtures) {
+    try {
+      const adapter = new HonoAdapter()
+      const html = await renderHonoComponent({
+        source: fixture.source,
+        adapter,
+        props: fixture.props,
+        components: fixture.components,
+      })
+
+      const expectedHtml = normalizeHTML(html)
+      const expectedHtmlLine = `  expectedHtml: \`${expectedHtml}\`,`
+
+      // Read the fixture file and update it
+      const filePath = resolve(FIXTURES_DIR, `${fixture.id}.ts`)
+      let content = readFileSync(filePath, 'utf-8')
+
+      if (content.includes('expectedHtml:')) {
+        // Replace existing expectedHtml line
+        content = content.replace(
+          /^  expectedHtml:.*$/m,
+          expectedHtmlLine,
+        )
+      } else {
+        // Insert expectedHtml before the closing `})`
+        content = content.replace(
+          /\}\)\s*$/,
+          `${expectedHtmlLine}\n})\n`,
+        )
+      }
+
+      writeFileSync(filePath, content)
+      console.log(`✓ ${fixture.id}`)
+      updated++
+    } catch (err) {
+      console.error(`✗ ${fixture.id}: ${(err as Error).message}`)
+      failed++
+    }
+  }
+
+  console.log(`\nDone: ${updated} updated, ${failed} failed`)
+  if (failed > 0) process.exit(1)
+}
+
+main()

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -4,7 +4,7 @@
  * Provides a conformance test suite for TemplateAdapter implementations.
  */
 
-export { runJSXConformanceTests } from './jsx-runner'
+export { runJSXConformanceTests, normalizeHTML } from './jsx-runner'
 export { createFixture } from './types'
 export type { JSXFixture } from './types'
 export type { RunJSXConformanceOptions, RenderOptions } from './jsx-runner'

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -17,6 +17,8 @@ export interface JSXFixture {
   components?: Record<string, string>
   /** Props to pass when rendering (optional) */
   props?: Record<string, unknown>
+  /** Expected normalized HTML output (generated from reference Hono adapter) */
+  expectedHtml?: string
 }
 
 /**
@@ -30,6 +32,7 @@ export function createFixture(input: {
   source: string
   components?: Record<string, string>
   props?: Record<string, unknown>
+  expectedHtml?: string
 }): JSXFixture {
   const trimmedComponents = input.components
     ? Object.fromEntries(

--- a/packages/go-template/package.json
+++ b/packages/go-template/package.json
@@ -43,9 +43,7 @@
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
-    "@barefootjs/hono": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
-    "hono": "^4.6.0",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -7,8 +7,6 @@
 import { describe, test, expect } from 'bun:test'
 import { GoTemplateAdapter } from '../adapter/go-template-adapter'
 import { runJSXConformanceTests } from '@barefootjs/adapter-tests'
-import { HonoAdapter } from '@barefootjs/hono/adapter'
-import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { renderGoTemplateComponent, GoNotAvailableError } from '@barefootjs/go-template/test-render'
 import { compileJSXSync, type ComponentIR } from '@barefootjs/jsx'
 
@@ -19,8 +17,7 @@ import { compileJSXSync, type ComponentIR } from '@barefootjs/jsx'
 runJSXConformanceTests({
   createAdapter: () => new GoTemplateAdapter(),
   render: renderGoTemplateComponent,
-  referenceAdapter: () => new HonoAdapter(),
-  referenceRender: renderHonoComponent,
+  // Uses fixture.expectedHtml (pre-generated from Hono adapter) for comparison
   // Static array with child components from separate files is not yet supported
   // by the Go template renderer (child templates are not registered)
   skip: ['static-array-children'],


### PR DESCRIPTION
## Summary
This PR introduces a fixture-based reference system for JSX conformance tests, eliminating the need for live reference adapter rendering during test execution. Tests now compare against pre-generated `expectedHtml` values stored in fixture files.

## Key Changes

- **New script**: `generate-expected-html.ts` - Generates and updates `expectedHtml` for all fixtures using the Hono adapter as the reference implementation
- **Updated test runner**: Modified `jsx-runner.ts` to support both live reference rendering (for development) and pre-generated fixture expectations (for CI/production)
- **Fixture type enhancement**: Added optional `expectedHtml` field to `JSXFixture` interface for storing normalized HTML expectations
- **Exported utilities**: Made `normalizeHTML` function public in the adapter-tests package for use in the generation script
- **Updated all fixtures**: Added pre-generated `expectedHtml` values to all 30+ fixture files
- **Simplified go-template tests**: Removed direct Hono adapter dependency from go-template package, now uses fixture expectations instead

## Implementation Details

- The generation script compiles each fixture with HonoAdapter, renders to HTML, normalizes it, and writes the result back into fixture files
- Test logic now falls back to `fixture.expectedHtml` when no live reference adapter is provided
- This approach decouples adapter tests from the Hono implementation while maintaining conformance validation
- The pre-generated expectations serve as a stable reference that can be version-controlled and reviewed

https://claude.ai/code/session_01JdvgfLYfHDwbvyfrCXZ7Ge