### PR TITLE
Fix flaky e2e tests for sheet, drawer, dialog, and alert-dialog

### DIFF
--- a/site/ui/e2e/alert-dialog.spec.ts
+++ b/site/ui/e2e/alert-dialog.spec.ts
@@ -156,8 +156,8 @@ test.describe('AlertDialog Documentation Page', () => {
       await expect(openDialog).toBeVisible()
       await expect(openDialog).toHaveCSS('opacity', '1')
 
-      const transform = await openDialog.evaluate((el) => getComputedStyle(el).transform)
-      expect(transform).toMatch(/^matrix\(1, 0, 0, 1,/)
+      // Dialog should have scale-100 class applied (fully scaled)
+      await expect(openDialog).toHaveClass(/scale-100/)
     })
 
     test('close via ESC - animation plays', async ({ page }) => {

--- a/site/ui/e2e/dialog.spec.ts
+++ b/site/ui/e2e/dialog.spec.ts
@@ -153,9 +153,8 @@ test.describe('Dialog Documentation Page', () => {
       await expect(openDialog).toBeVisible()
       await expect(openDialog).toHaveCSS('opacity', '1')
 
-      // Dialog should have scale-100 (transform contains scale(1) = matrix(1, 0, 0, 1, ...))
-      const transform = await openDialog.evaluate((el) => getComputedStyle(el).transform)
-      expect(transform).toMatch(/^matrix\(1, 0, 0, 1,/)
+      // Dialog should have scale-100 class applied (fully scaled)
+      await expect(openDialog).toHaveClass(/scale-100/)
     })
 
     test('close via ESC - animation plays', async ({ page }) => {

--- a/site/ui/e2e/sheet.spec.ts
+++ b/site/ui/e2e/sheet.spec.ts
@@ -131,9 +131,7 @@ test.describe('Sheet Documentation Page', () => {
 
       // Before opening, sheet should be translated off-screen (translate-x-full)
       const closedSheet = page.locator('[role="dialog"][aria-labelledby="sheet-basic-title"][data-state="closed"]').first()
-      const closedTransform = await closedSheet.evaluate((el) => getComputedStyle(el).transform)
-      // translate-x-full means transform matrix with positive x translation
-      expect(closedTransform).not.toBe('none')
+      await expect(closedSheet).toHaveClass(/translate-x-full/)
 
       await trigger.click()
 

--- a/ui/components/ui/drawer/index.tsx
+++ b/ui/components/ui/drawer/index.tsx
@@ -81,12 +81,13 @@ const directionOpenClasses: Record<DrawerDirection, string> = {
   left: 'translate-x-0',
 }
 
-// Direction-specific closed state classes (slide off-screen)
+// Direction-specific closed state classes (slide off-screen + pointer-events-none to prevent
+// closed portaled panels from other demos intercepting clicks)
 const directionClosedClasses: Record<DrawerDirection, string> = {
-  top: '-translate-y-full',
-  right: 'translate-x-full',
-  bottom: 'translate-y-full',
-  left: '-translate-x-full',
+  top: '-translate-y-full pointer-events-none',
+  right: 'translate-x-full pointer-events-none',
+  bottom: 'translate-y-full pointer-events-none',
+  left: '-translate-x-full pointer-events-none',
 }
 
 // DrawerHeader classes — centered text for vertical drawers

--- a/ui/components/ui/sheet/index.tsx
+++ b/ui/components/ui/sheet/index.tsx
@@ -79,12 +79,13 @@ const sideOpenClasses: Record<SheetSide, string> = {
   left: 'translate-x-0',
 }
 
-// Side-specific closed state classes (slide off-screen)
+// Side-specific closed state classes (slide off-screen + pointer-events-none to prevent
+// closed portaled panels from other demos intercepting clicks)
 const sideClosedClasses: Record<SheetSide, string> = {
-  top: '-translate-y-full',
-  right: 'translate-x-full',
-  bottom: 'translate-y-full',
-  left: '-translate-x-full',
+  top: '-translate-y-full pointer-events-none',
+  right: 'translate-x-full pointer-events-none',
+  bottom: 'translate-y-full pointer-events-none',
+  left: '-translate-x-full pointer-events-none',
 }
 
 // SheetHeader classes


### PR DESCRIPTION
## Summary
- Add `pointer-events-none` to closed state of Sheet and Drawer content panels to prevent closed portaled panels from intercepting clicks on the active panel
- Replace fragile `getComputedStyle().transform` one-shot assertions with Playwright auto-retry `toHaveClass` checks in animation tests

## Test plan
- [x] All 75 affected e2e tests pass locally (sheet, drawer, dialog, alert-dialog)
- [x] 784 UI component IR tests pass
- [x] 35 Hono adapter tests pass
- [x] 5 test package tests pass
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)