### PR TITLE
Improve fixture readability with indented expectedHtml

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -1,0 +1,64 @@
+name: Update Fixtures
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/jsx/**'
+      - 'packages/hono/**'
+      - 'packages/dom/**'
+      - 'packages/adapter-tests/src/**'
+      - 'packages/adapter-tests/scripts/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-fixtures-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-expected-html:
+    runs-on: ubuntu-latest
+    # Skip fork PRs (no write permission)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          cd packages/dom && bun run build
+          cd ../jsx && bun run build
+          cd ../hono && bun run build
+
+      - name: Generate expectedHtml
+        run: bun run packages/adapter-tests/scripts/generate-expected-html.ts
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet packages/adapter-tests/fixtures/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/adapter-tests/fixtures/
+          git commit -m "Update fixture expectedHtml (auto-generated)"
+          git push

--- a/packages/adapter-tests/fixtures/child-component.ts
+++ b/packages/adapter-tests/fixtures/child-component.ts
@@ -17,5 +17,10 @@ export function Badge({ label }: { label: string }) {
 `,
   },
   props: { title: 'Hello' },
-  expectedHtml: `<div bf-s="test"><h2 bf="s1"><span bf="s0">Hello</span></h2><span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <h2 bf="s1"><span bf="s0">Hello</span></h2>
+      <span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/class-vs-classname.ts
+++ b/packages/adapter-tests/fixtures/class-vs-classname.ts
@@ -8,5 +8,7 @@ export function ClassVsClassname() {
   return <div className="container"><span className="label">Text</span></div>
 }
 `,
-  expectedHtml: `<div class="container" bf-s="test"><span class="label">Text</span></div>`,
+  expectedHtml: `
+    <div class="container" bf-s="test"><span class="label">Text</span></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/client-only.ts
+++ b/packages/adapter-tests/fixtures/client-only.ts
@@ -18,5 +18,7 @@ export function ClientOnly() {
   )
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/conditional-class.ts
+++ b/packages/adapter-tests/fixtures/conditional-class.ts
@@ -11,5 +11,7 @@ export function ConditionalClass() {
   return <div className={active() ? 'on' : 'off'}>Toggle</div>
 }
 `,
-  expectedHtml: `<div class="off" bf-s="test" bf="s0">Toggle</div>`,
+  expectedHtml: `
+    <div class="off" bf-s="test" bf="s0">Toggle</div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/controlled-signal.ts
+++ b/packages/adapter-tests/fixtures/controlled-signal.ts
@@ -12,5 +12,7 @@ export function ControlledSignal(props: { value: number }) {
 }
 `,
   props: { value: 42 },
-  expectedHtml: `<span bf-s="test" bf="s1"><span bf="s0">42</span></span>`,
+  expectedHtml: `
+    <span bf-s="test" bf="s1"><span bf="s0">42</span></span>
+  `,
 })

--- a/packages/adapter-tests/fixtures/counter.ts
+++ b/packages/adapter-tests/fixtures/counter.ts
@@ -11,5 +11,7 @@ export function Counter() {
   return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
 }
 `,
-  expectedHtml: `<button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>`,
+  expectedHtml: `
+    <button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>
+  `,
 })

--- a/packages/adapter-tests/fixtures/default-props.ts
+++ b/packages/adapter-tests/fixtures/default-props.ts
@@ -13,5 +13,10 @@ export function DefaultProps(props: { label?: string; size?: number }) {
 }
 `,
   props: { label: 'Custom', size: 5 },
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Custom</span></span><span bf="s3"><span bf="s2">5</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0">Custom</span></span>
+      <span bf="s3"><span bf="s2">5</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/dynamic-attributes.ts
+++ b/packages/adapter-tests/fixtures/dynamic-attributes.ts
@@ -12,5 +12,7 @@ export function DynamicAttributes() {
   return <div data-state={state()} data-count={count()}>Content</div>
 }
 `,
-  expectedHtml: `<div data-state="closed" data-count="0" bf-s="test" bf="s0">Content</div>`,
+  expectedHtml: `
+    <div data-state="closed" data-count="0" bf-s="test" bf="s0">Content</div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/effect.ts
+++ b/packages/adapter-tests/fixtures/effect.ts
@@ -12,5 +12,7 @@ export function EffectDemo() {
   return <div>{count()}</div>
 }
 `,
-  expectedHtml: `<div bf-s="test" bf="s1"><span bf="s0">0</span></div>`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><span bf="s0">0</span></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/event-handlers.ts
+++ b/packages/adapter-tests/fixtures/event-handlers.ts
@@ -19,5 +19,12 @@ export function EventHandlers() {
   )
 }
 `,
-  expectedHtml: `<div bf-s="test"><input type="text" bf="s0"><button bf="s1">Click</button><span bf="s3"><span bf="s2"></span></span><span bf="s5"><span bf="s4">0</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <input type="text" bf="s0">
+      <button bf="s1">Click</button>
+      <span bf="s3"><span bf="s2"></span></span>
+      <span bf="s5"><span bf="s4">0</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/filter-simple.ts
+++ b/packages/adapter-tests/fixtures/filter-simple.ts
@@ -12,5 +12,7 @@ export function FilterSimple() {
   return <ul>{todos().filter(t => t.done).map(t => <li>{t.text}</li>)}</ul>
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/filter-sort-chain.ts
+++ b/packages/adapter-tests/fixtures/filter-sort-chain.ts
@@ -12,5 +12,7 @@ export function FilterSortChain() {
   return <ul>{products().filter(p => p.active).sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/fragment.ts
+++ b/packages/adapter-tests/fixtures/fragment.ts
@@ -11,5 +11,9 @@ export function FragmentDemo() {
   return <><span>A</span><span>{count()}</span></>
 }
 `,
-  expectedHtml: `<!--bf-scope:test--><span>A</span><span bf="s1"><span bf="s0">0</span></span>`,
+  expectedHtml: `
+    <!--bf-scope:test-->
+    <span>A</span>
+    <span bf="s1"><span bf="s0">0</span></span>
+  `,
 })

--- a/packages/adapter-tests/fixtures/logical-and.ts
+++ b/packages/adapter-tests/fixtures/logical-and.ts
@@ -11,5 +11,7 @@ export function LogicalAndDemo() {
   return <div>{show() && <span>Shown</span>}</div>
 }
 `,
-  expectedHtml: `<div bf-s="test" bf="s1"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/map-basic.ts
+++ b/packages/adapter-tests/fixtures/map-basic.ts
@@ -12,5 +12,7 @@ export function MapBasic() {
   return <ul>{items().map(item => <li>{item.name}</li>)}</ul>
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/map-with-index.ts
+++ b/packages/adapter-tests/fixtures/map-with-index.ts
@@ -12,5 +12,7 @@ export function MapWithIndex() {
   return <ul>{entries().map((entry, i) => <li>{i}: {entry.label}</li>)}</ul>
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/memo.ts
+++ b/packages/adapter-tests/fixtures/memo.ts
@@ -12,5 +12,10 @@ export function MemoDemo() {
   return <div><span>{count()}</span><span>{doubled()}</span></div>
 }
 `,
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">0</span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0">0</span></span>
+      <span bf="s3"><span bf="s2">0</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/multiple-instances.ts
+++ b/packages/adapter-tests/fixtures/multiple-instances.ts
@@ -16,5 +16,11 @@ export function Tag({ label }: { label: string }) {
 }
 `,
   },
-  expectedHtml: `<div bf-s="test"><span bf-s="test_s0" bf="s1"><span bf="s0">Alpha</span></span><span bf-s="test_s1" bf="s1"><span bf="s0">Beta</span></span><span bf-s="test_s2" bf="s1"><span bf="s0">Gamma</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf-s="test_s0" bf="s1"><span bf="s0">Alpha</span></span>
+      <span bf-s="test_s1" bf="s1"><span bf="s0">Beta</span></span>
+      <span bf-s="test_s2" bf="s1"><span bf="s0">Gamma</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/multiple-signals.ts
+++ b/packages/adapter-tests/fixtures/multiple-signals.ts
@@ -12,5 +12,10 @@ export function MultipleSignals() {
   return <div><span>{name()}</span><span>{age()}</span></div>
 }
 `,
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0"></span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0"></span></span>
+      <span bf="s3"><span bf="s2">0</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/nested-elements.ts
+++ b/packages/adapter-tests/fixtures/nested-elements.ts
@@ -19,5 +19,7 @@ export function NestedElements() {
   )
 }
 `,
-  expectedHtml: `<div bf-s="test"><section><article><p bf="s1"><span bf="s0">hello</span></p></article></section></div>`,
+  expectedHtml: `
+    <div bf-s="test"><section><article><p bf="s1"><span bf="s0">hello</span></p></article></section></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
@@ -12,5 +12,10 @@ export function NullishCoalescingText(props: { label?: string; size?: number }) 
 }
 `,
   props: { label: 'Custom', size: 5 },
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Custom</span></span><span bf="s3"><span bf="s2">5</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0">Custom</span></span>
+      <span bf="s3"><span bf="s2">5</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/props-reactive.ts
+++ b/packages/adapter-tests/fixtures/props-reactive.ts
@@ -12,5 +12,10 @@ export function PropsReactive(props: { label: string }) {
 }
 `,
   props: { label: 'Hello' },
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Hello</span></span><span bf="s3"><span bf="s2">0</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0">Hello</span></span>
+      <span bf="s3"><span bf="s2">0</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/props-static.ts
+++ b/packages/adapter-tests/fixtures/props-static.ts
@@ -9,5 +9,10 @@ export function PropsStatic({ label, count }: { label: string; count: number }) 
 }
 `,
   props: { label: 'Items', count: 10 },
-  expectedHtml: `<div bf-s="test"><span bf="s1"><span bf="s0">Items</span></span><span bf="s3"><span bf="s2">10</span></span></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><span bf="s0">Items</span></span>
+      <span bf="s3"><span bf="s2">10</span></span>
+    </div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/signal-prop-same-name.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name.ts
@@ -12,5 +12,7 @@ export function SignalPropSameName(props: { label?: string }) {
 }
 `,
   props: { label: 'Hello' },
-  expectedHtml: `<span bf-s="test" bf="s1"><span bf="s0">Hello</span></span>`,
+  expectedHtml: `
+    <span bf-s="test" bf="s1"><span bf="s0">Hello</span></span>
+  `,
 })

--- a/packages/adapter-tests/fixtures/signal-with-fallback.ts
+++ b/packages/adapter-tests/fixtures/signal-with-fallback.ts
@@ -12,5 +12,7 @@ export function SignalWithFallback(props: { initial?: number }) {
 }
 `,
   props: { initial: 5 },
-  expectedHtml: `<div bf-s="test" bf="s1"><span bf="s0">5</span></div>`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><span bf="s0">5</span></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/sort-simple.ts
+++ b/packages/adapter-tests/fixtures/sort-simple.ts
@@ -12,5 +12,7 @@ export function SortSimple() {
   return <ul>{products().sort((a, b) => a.price - b.price).map(p => <li>{p.name}</li>)}</ul>
 }
 `,
-  expectedHtml: `<ul bf-s="test" bf="s0"></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s0"></ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/static-array-children.ts
+++ b/packages/adapter-tests/fixtures/static-array-children.ts
@@ -23,5 +23,10 @@ export function ListItem({ label, className }: { label: string; className?: stri
 }
 `,
   },
-  expectedHtml: `<ul bf-s="test" bf="s1"><li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Alpha</span></li><li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Beta</span></li></ul>`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Alpha</span></li>
+      <li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Beta</span></li>
+    </ul>
+  `,
 })

--- a/packages/adapter-tests/fixtures/style-attribute.ts
+++ b/packages/adapter-tests/fixtures/style-attribute.ts
@@ -8,5 +8,7 @@ export function StyleAttribute() {
   return <div style="color: red; font-size: 16px">Styled</div>
 }
 `,
-  expectedHtml: `<div style="color: red; font-size: 16px" bf-s="test">Styled</div>`,
+  expectedHtml: `
+    <div style="color: red; font-size: 16px" bf-s="test">Styled</div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/ternary.ts
+++ b/packages/adapter-tests/fixtures/ternary.ts
@@ -11,5 +11,7 @@ export function TernaryDemo() {
   return <div>{show() ? <span>Visible</span> : <span>Hidden</span>}</div>
 }
 `,
-  expectedHtml: `<div bf-s="test" bf="s1"><span bf-c="s0">Hidden</span></div>`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><span bf-c="s0">Hidden</span></div>
+  `,
 })

--- a/packages/adapter-tests/fixtures/void-elements.ts
+++ b/packages/adapter-tests/fixtures/void-elements.ts
@@ -15,5 +15,12 @@ export function VoidElements() {
   )
 }
 `,
-  expectedHtml: `<div bf-s="test"><br><hr><img src="test.png" alt="test"><input type="text"></div>`,
+  expectedHtml: `
+    <div bf-s="test">
+      <br>
+      <hr>
+      <img src="test.png" alt="test">
+      <input type="text">
+    </div>
+  `,
 })

--- a/packages/adapter-tests/src/__tests__/indent-html.test.ts
+++ b/packages/adapter-tests/src/__tests__/indent-html.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test'
+import { indentHTML } from '../indent-html'
+import { normalizeExpectedHtml } from '../types'
+import { jsxFixtures } from '../../fixtures'
+
+describe('indentHTML', () => {
+  test('single leaf element stays on one line', () => {
+    const html = '<button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>'
+    const result = indentHTML(html)
+    const contentLines = result.trim().split('\n').filter(l => l.trim())
+    expect(contentLines.length).toBe(1)
+    expect(contentLines[0].trim()).toBe(html)
+  })
+
+  test('element with 2+ child elements is expanded', () => {
+    const html = '<div bf-s="test"><h2 bf="s1"><span bf="s0">Hello</span></h2><span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span></div>'
+    const result = indentHTML(html)
+    const lines = result.trim().split('\n')
+    expect(lines.length).toBe(4)
+    expect(lines[0].trim()).toBe('<div bf-s="test">')
+    expect(lines[1].trim()).toBe('<h2 bf="s1"><span bf="s0">Hello</span></h2>')
+    expect(lines[2].trim()).toBe('<span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span>')
+    expect(lines[3].trim()).toBe('</div>')
+  })
+
+  test('void elements cause parent expansion', () => {
+    const html = '<div bf-s="test"><br><hr><img src="test.png" alt="test"><input type="text"></div>'
+    const result = indentHTML(html)
+    const lines = result.trim().split('\n')
+    expect(lines.length).toBe(6) // open + 4 voids + close
+    expect(lines[0].trim()).toBe('<div bf-s="test">')
+    expect(lines[1].trim()).toBe('<br>')
+    expect(lines[2].trim()).toBe('<hr>')
+    expect(lines[5].trim()).toBe('</div>')
+  })
+
+  test('HTML comments (fragments)', () => {
+    const html = '<!--bf-scope:test--><span>A</span><span bf="s1"><span bf="s0">0</span></span>'
+    const result = indentHTML(html)
+    expect(result).toContain('<!--bf-scope:test-->')
+    expect(result).toContain('<span>A</span>')
+    expect(result).toContain('<span bf="s1"><span bf="s0">0</span></span>')
+  })
+
+  test('nested single-child chain stays on one line', () => {
+    const html = '<span bf="s1"><span bf="s0">Hello</span></span>'
+    const result = indentHTML(html)
+    const contentLines = result.trim().split('\n').filter(l => l.trim())
+    expect(contentLines.length).toBe(1)
+  })
+
+  test('deeply nested with siblings expands correctly', () => {
+    const html = '<div bf-s="test"><span bf="s3"><span bf="s2"></span></span><span bf="s5"><span bf="s4">0</span></span></div>'
+    const result = indentHTML(html)
+    const lines = result.trim().split('\n')
+    expect(lines.length).toBe(4)
+    expect(lines[0].trim()).toBe('<div bf-s="test">')
+    expect(lines[1].trim()).toBe('<span bf="s3"><span bf="s2"></span></span>')
+    expect(lines[2].trim()).toBe('<span bf="s5"><span bf="s4">0</span></span>')
+    expect(lines[3].trim()).toBe('</div>')
+  })
+})
+
+describe('normalizeExpectedHtml', () => {
+  test('collapses inter-tag whitespace', () => {
+    const indented = `
+    <div bf-s="test">
+      <span bf="s0">Hello</span>
+    </div>
+  `
+    expect(normalizeExpectedHtml(indented)).toBe(
+      '<div bf-s="test"><span bf="s0">Hello</span></div>'
+    )
+  })
+
+  test('collapses multiple spaces', () => {
+    expect(normalizeExpectedHtml('  <div>   text  </div>  ')).toBe('<div> text </div>')
+  })
+
+  test('already flat HTML passes through', () => {
+    const flat = '<button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>'
+    expect(normalizeExpectedHtml(flat)).toBe(flat)
+  })
+})
+
+describe('round-trip: normalizeExpectedHtml(indentHTML(html)) === html', () => {
+  for (const fixture of jsxFixtures) {
+    if (!fixture.expectedHtml) continue
+    test(`[${fixture.id}] round-trip preserves normalized HTML`, () => {
+      const indented = indentHTML(fixture.expectedHtml!)
+      const normalized = normalizeExpectedHtml(indented)
+      expect(normalized).toBe(fixture.expectedHtml)
+    })
+  }
+})

--- a/packages/adapter-tests/src/indent-html.ts
+++ b/packages/adapter-tests/src/indent-html.ts
@@ -1,0 +1,154 @@
+/**
+ * HTML indentation utility for fixture readability.
+ *
+ * Converts flat single-line HTML into indented multi-line form.
+ * An element is expanded (multi-line) only if it has 2+ direct child elements.
+ * Otherwise it stays on one line (inline/leaf).
+ */
+
+/** HTML void elements that never have a closing tag */
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+  'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+interface Token {
+  type: 'open' | 'close' | 'void' | 'text' | 'comment'
+  raw: string
+  tagName?: string
+}
+
+/**
+ * Tokenize HTML string into tags, text, and comments.
+ */
+function tokenize(html: string): Token[] {
+  const tokens: Token[] = []
+  const re = /<!--[\s\S]*?-->|<\/([a-zA-Z][a-zA-Z0-9]*)>|<([a-zA-Z][a-zA-Z0-9]*)(\s[^>]*)?>|[^<]+/g
+  let match: RegExpExecArray | null
+
+  while ((match = re.exec(html)) !== null) {
+    const raw = match[0]
+
+    if (raw.startsWith('<!--')) {
+      tokens.push({ type: 'comment', raw })
+    } else if (match[1]) {
+      tokens.push({ type: 'close', raw, tagName: match[1] })
+    } else if (match[2]) {
+      const tagName = match[2]
+      if (VOID_ELEMENTS.has(tagName)) {
+        tokens.push({ type: 'void', raw, tagName })
+      } else {
+        tokens.push({ type: 'open', raw, tagName })
+      }
+    } else {
+      tokens.push({ type: 'text', raw })
+    }
+  }
+
+  return tokens
+}
+
+/**
+ * Find the index of the matching close tag for an open tag at `start`.
+ */
+function findMatchingClose(tokens: Token[], start: number): number {
+  let depth = 0
+  for (let i = start; i < tokens.length; i++) {
+    if (tokens[i].type === 'open') depth++
+    else if (tokens[i].type === 'close') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Count direct child elements (open tags + void tags at depth 1) of an open tag.
+ */
+function countDirectChildElements(tokens: Token[], openIndex: number): number {
+  let count = 0
+  let depth = 0
+  for (let i = openIndex; i < tokens.length; i++) {
+    if (tokens[i].type === 'open') {
+      depth++
+      if (depth === 2) count++
+    } else if (tokens[i].type === 'close') {
+      depth--
+      if (depth === 0) break
+    } else if (tokens[i].type === 'void' && depth === 1) {
+      count++
+    }
+  }
+  return count
+}
+
+/**
+ * Concatenate all token raws from start to end (inclusive).
+ */
+function concatTokens(tokens: Token[], start: number, end: number): string {
+  let result = ''
+  for (let i = start; i <= end; i++) {
+    result += tokens[i].raw
+  }
+  return result
+}
+
+/**
+ * Format flat HTML into indented multi-line form.
+ *
+ * @param html - Flat, single-line HTML string
+ * @param baseIndent - Number of spaces for the base indentation level (default: 4)
+ * @param indentSize - Number of spaces per indentation level (default: 2)
+ * @returns Indented HTML string (starts with newline, ends with newline + base indent minus one level)
+ */
+export function indentHTML(html: string, baseIndent = 4, indentSize = 2): string {
+  const tokens = tokenize(html)
+  if (tokens.length === 0) return html
+
+  const lines: string[] = []
+  let depth = 0
+  let i = 0
+
+  while (i < tokens.length) {
+    const token = tokens[i]
+    const indent = ' '.repeat(baseIndent + depth * indentSize)
+
+    if (token.type === 'open') {
+      const closeIndex = findMatchingClose(tokens, i)
+      if (closeIndex === -1) {
+        // Malformed HTML: just output as-is
+        lines.push(`${indent}${token.raw}`)
+        i++
+        continue
+      }
+
+      const childCount = countDirectChildElements(tokens, i)
+      if (childCount < 2) {
+        // Inline/leaf: keep everything on one line
+        lines.push(`${indent}${concatTokens(tokens, i, closeIndex)}`)
+        i = closeIndex + 1
+        continue
+      }
+
+      // Expanded: open tag on its own line
+      lines.push(`${indent}${token.raw}`)
+      depth++
+    } else if (token.type === 'close') {
+      depth--
+      const closeIndent = ' '.repeat(baseIndent + depth * indentSize)
+      lines.push(`${closeIndent}${token.raw}`)
+    } else if (token.type === 'void') {
+      lines.push(`${indent}${token.raw}`)
+    } else if (token.type === 'comment') {
+      lines.push(`${indent}${token.raw}`)
+    } else if (token.type === 'text') {
+      lines.push(`${indent}${token.raw}`)
+    }
+
+    i++
+  }
+
+  const closingIndent = ' '.repeat(baseIndent - indentSize)
+  return '\n' + lines.join('\n') + '\n' + closingIndent
+}

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { runJSXConformanceTests, normalizeHTML } from './jsx-runner'
-export { createFixture } from './types'
+export { createFixture, normalizeExpectedHtml } from './types'
 export type { JSXFixture } from './types'
+export { indentHTML } from './indent-html'
 export type { RunJSXConformanceOptions, RenderOptions } from './jsx-runner'

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -22,9 +22,19 @@ export interface JSXFixture {
 }
 
 /**
+ * Normalize expectedHtml by collapsing whitespace for comparison.
+ * Allows expectedHtml to be written with indentation in fixtures
+ * while still matching flat HTML output from adapters.
+ */
+export function normalizeExpectedHtml(html: string): string {
+  return html.replace(/>\s+</g, '><').replace(/\s+/g, ' ').trim()
+}
+
+/**
  * Create a JSXFixture with automatic source trimming.
  * Strips leading newline from template literals so source
  * can be written with a natural indentation style.
+ * Normalizes expectedHtml by collapsing whitespace.
  */
 export function createFixture(input: {
   id: string
@@ -39,5 +49,13 @@ export function createFixture(input: {
         Object.entries(input.components).map(([k, v]) => [k, v.trimStart()]),
       )
     : undefined
-  return { ...input, source: input.source.trimStart(), components: trimmedComponents }
+  const normalizedExpectedHtml = input.expectedHtml
+    ? normalizeExpectedHtml(input.expectedHtml)
+    : undefined
+  return {
+    ...input,
+    source: input.source.trimStart(),
+    components: trimmedComponents,
+    expectedHtml: normalizedExpectedHtml,
+  }
 }


### PR DESCRIPTION
## Summary

- Format `expectedHtml` in fixture files as indented multi-line HTML for better readability
- Add `normalizeExpectedHtml()` to collapse whitespace at load time so test comparison is unchanged
- Add `indentHTML()` utility that expands elements with 2+ child elements while keeping leaf elements on one line
- Update `generate-expected-html.ts` script to output indented HTML
- Add GitHub Action (`update-fixtures.yml`) to auto-update fixture `expectedHtml` on PRs

## Test plan

- [x] Unit tests for `indentHTML` and `normalizeExpectedHtml` (39 tests pass)
- [x] Round-trip verification: `normalizeExpectedHtml(indentHTML(html)) === html` for all 30 fixtures
- [x] Existing Hono adapter tests pass (35 tests)
- [x] Existing Go template adapter tests pass (43 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)