### PR TITLE
Remove span tag from counter template

### DIFF
--- a/packages/adapter-tests/fixtures/child-component.ts
+++ b/packages/adapter-tests/fixtures/child-component.ts
@@ -19,8 +19,8 @@ export function Badge({ label }: { label: string }) {
   props: { title: 'Hello' },
   expectedHtml: `
     <div bf-s="test">
-      <h2 bf="s1"><span bf="s0">Hello</span></h2>
-      <span bf-s="test_s2" bf="s1"><span bf="s0">New</span></span>
+      <h2 bf="s1"><!--bf:s0-->Hello<!--/bf:s0--></h2>
+      <span bf-s="test_s2" bf="s1"><!--bf:s0-->New<!--/bf:s0--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/controlled-signal.ts
+++ b/packages/adapter-tests/fixtures/controlled-signal.ts
@@ -13,6 +13,6 @@ export function ControlledSignal(props: { value: number }) {
 `,
   props: { value: 42 },
   expectedHtml: `
-    <span bf-s="test" bf="s1"><span bf="s0">42</span></span>
+    <span bf-s="test" bf="s1"><!--bf:s0-->42<!--/bf:s0--></span>
   `,
 })

--- a/packages/adapter-tests/fixtures/counter.ts
+++ b/packages/adapter-tests/fixtures/counter.ts
@@ -12,6 +12,6 @@ export function Counter() {
 }
 `,
   expectedHtml: `
-    <button bf-s="test" bf="s1">Count: <span bf="s0">0</span></button>
+    <button bf-s="test" bf="s1">Count: <!--bf:s0-->0<!--/bf:s0--></button>
   `,
 })

--- a/packages/adapter-tests/fixtures/default-props.ts
+++ b/packages/adapter-tests/fixtures/default-props.ts
@@ -15,8 +15,8 @@ export function DefaultProps(props: { label?: string; size?: number }) {
   props: { label: 'Custom', size: 5 },
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0">Custom</span></span>
-      <span bf="s3"><span bf="s2">5</span></span>
+      <span bf="s1"><!--bf:s0-->Custom<!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->5<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/effect.ts
+++ b/packages/adapter-tests/fixtures/effect.ts
@@ -13,6 +13,6 @@ export function EffectDemo() {
 }
 `,
   expectedHtml: `
-    <div bf-s="test" bf="s1"><span bf="s0">0</span></div>
+    <div bf-s="test" bf="s1"><!--bf:s0-->0<!--/bf:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/event-handlers.ts
+++ b/packages/adapter-tests/fixtures/event-handlers.ts
@@ -23,8 +23,8 @@ export function EventHandlers() {
     <div bf-s="test">
       <input type="text" bf="s0">
       <button bf="s1">Click</button>
-      <span bf="s3"><span bf="s2"></span></span>
-      <span bf="s5"><span bf="s4">0</span></span>
+      <span bf="s3"><!--bf:s2--><!--/bf:s2--></span>
+      <span bf="s5"><!--bf:s4-->0<!--/bf:s4--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/fragment.ts
+++ b/packages/adapter-tests/fixtures/fragment.ts
@@ -14,6 +14,6 @@ export function FragmentDemo() {
   expectedHtml: `
     <!--bf-scope:test-->
     <span>A</span>
-    <span bf="s1"><span bf="s0">0</span></span>
+    <span bf="s1"><!--bf:s0-->0<!--/bf:s0--></span>
   `,
 })

--- a/packages/adapter-tests/fixtures/memo.ts
+++ b/packages/adapter-tests/fixtures/memo.ts
@@ -14,8 +14,8 @@ export function MemoDemo() {
 `,
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0">0</span></span>
-      <span bf="s3"><span bf="s2">0</span></span>
+      <span bf="s1"><!--bf:s0-->0<!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->0<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/multiple-instances.ts
+++ b/packages/adapter-tests/fixtures/multiple-instances.ts
@@ -18,9 +18,9 @@ export function Tag({ label }: { label: string }) {
   },
   expectedHtml: `
     <div bf-s="test">
-      <span bf-s="test_s0" bf="s1"><span bf="s0">Alpha</span></span>
-      <span bf-s="test_s1" bf="s1"><span bf="s0">Beta</span></span>
-      <span bf-s="test_s2" bf="s1"><span bf="s0">Gamma</span></span>
+      <span bf-s="test_s0" bf="s1"><!--bf:s0-->Alpha<!--/bf:s0--></span>
+      <span bf-s="test_s1" bf="s1"><!--bf:s0-->Beta<!--/bf:s0--></span>
+      <span bf-s="test_s2" bf="s1"><!--bf:s0-->Gamma<!--/bf:s0--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/multiple-signals.ts
+++ b/packages/adapter-tests/fixtures/multiple-signals.ts
@@ -14,8 +14,8 @@ export function MultipleSignals() {
 `,
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0"></span></span>
-      <span bf="s3"><span bf="s2">0</span></span>
+      <span bf="s1"><!--bf:s0--><!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->0<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/nested-elements.ts
+++ b/packages/adapter-tests/fixtures/nested-elements.ts
@@ -20,6 +20,6 @@ export function NestedElements() {
 }
 `,
   expectedHtml: `
-    <div bf-s="test"><section><article><p bf="s1"><span bf="s0">hello</span></p></article></section></div>
+    <div bf-s="test"><section><article><p bf="s1"><!--bf:s0-->hello<!--/bf:s0--></p></article></section></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
@@ -14,8 +14,8 @@ export function NullishCoalescingText(props: { label?: string; size?: number }) 
   props: { label: 'Custom', size: 5 },
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0">Custom</span></span>
-      <span bf="s3"><span bf="s2">5</span></span>
+      <span bf="s1"><!--bf:s0-->Custom<!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->5<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/props-reactive.ts
+++ b/packages/adapter-tests/fixtures/props-reactive.ts
@@ -14,8 +14,8 @@ export function PropsReactive(props: { label: string }) {
   props: { label: 'Hello' },
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0">Hello</span></span>
-      <span bf="s3"><span bf="s2">0</span></span>
+      <span bf="s1"><!--bf:s0-->Hello<!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->0<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/props-static.ts
+++ b/packages/adapter-tests/fixtures/props-static.ts
@@ -11,8 +11,8 @@ export function PropsStatic({ label, count }: { label: string; count: number }) 
   props: { label: 'Items', count: 10 },
   expectedHtml: `
     <div bf-s="test">
-      <span bf="s1"><span bf="s0">Items</span></span>
-      <span bf="s3"><span bf="s2">10</span></span>
+      <span bf="s1"><!--bf:s0-->Items<!--/bf:s0--></span>
+      <span bf="s3"><!--bf:s2-->10<!--/bf:s2--></span>
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/signal-prop-same-name.ts
+++ b/packages/adapter-tests/fixtures/signal-prop-same-name.ts
@@ -13,6 +13,6 @@ export function SignalPropSameName(props: { label?: string }) {
 `,
   props: { label: 'Hello' },
   expectedHtml: `
-    <span bf-s="test" bf="s1"><span bf="s0">Hello</span></span>
+    <span bf-s="test" bf="s1"><!--bf:s0-->Hello<!--/bf:s0--></span>
   `,
 })

--- a/packages/adapter-tests/fixtures/signal-with-fallback.ts
+++ b/packages/adapter-tests/fixtures/signal-with-fallback.ts
@@ -13,6 +13,6 @@ export function SignalWithFallback(props: { initial?: number }) {
 `,
   props: { initial: 5 },
   expectedHtml: `
-    <div bf-s="test" bf="s1"><span bf="s0">5</span></div>
+    <div bf-s="test" bf="s1"><!--bf:s0-->5<!--/bf:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/static-array-children.ts
+++ b/packages/adapter-tests/fixtures/static-array-children.ts
@@ -25,8 +25,8 @@ export function ListItem({ label, className }: { label: string; className?: stri
   },
   expectedHtml: `
     <ul bf-s="test" bf="s1">
-      <li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Alpha</span></li>
-      <li class="text-sm" bf-s="ListItem_*" bf="s1"><span bf="s0">Beta</span></li>
+      <li class="text-sm" bf-s="ListItem_*" bf="s1"><!--bf:s0-->Alpha<!--/bf:s0--></li>
+      <li class="text-sm" bf-s="ListItem_*" bf="s1"><!--bf:s0-->Beta<!--/bf:s0--></li>
     </ul>
   `,
 })

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -67,6 +67,7 @@ export {
   mount,
   $ as $,
   $c,
+  $t,
   type ComponentInitFn,
   type MountOptions,
   type BranchConfig,

--- a/packages/go-template/runtime/bf.go
+++ b/packages/go-template/runtime/bf.go
@@ -49,7 +49,9 @@ func FuncMap() template.FuncMap {
 		"bf_sort":       Sort,
 
 		// Comment marker (for hydration)
-		"bfComment": Comment,
+		"bfComment":    Comment,
+		"bfTextStart":  TextStart,
+		"bfTextEnd":    TextEnd,
 
 		// Script collection
 		"bfScripts": BfScripts,
@@ -524,6 +526,18 @@ func capitalize(s string) string {
 // The "bf-" prefix is automatically added.
 func Comment(content string) template.HTML {
 	return template.HTML("<!--bf-" + content + "-->")
+}
+
+// TextStart returns an HTML comment start marker for reactive text expressions.
+// Format: <!--bf:slotId-->
+func TextStart(slotId string) template.HTML {
+	return template.HTML("<!--bf:" + slotId + "-->")
+}
+
+// TextEnd returns an HTML comment end marker for reactive text expressions.
+// Format: <!--/bf:slotId-->
+func TextEnd(slotId string) template.HTML {
+	return template.HTML("<!--/bf:" + slotId + "-->")
 }
 
 // ScopeComment outputs a comment-based scope marker for fragment root components.

--- a/packages/go-template/runtime/bf_test.go
+++ b/packages/go-template/runtime/bf_test.go
@@ -319,6 +319,20 @@ func TestComment(t *testing.T) {
 	}
 }
 
+func TestTextMarkers(t *testing.T) {
+	gotStart := TextStart("s0")
+	wantStart := "<!--bf:s0-->"
+	if string(gotStart) != wantStart {
+		t.Errorf("TextStart(s0) = %v, want %v", gotStart, wantStart)
+	}
+
+	gotEnd := TextEnd("s0")
+	wantEnd := "<!--/bf:s0-->"
+	if string(gotEnd) != wantEnd {
+		t.Errorf("TextEnd(s0) = %v, want %v", gotEnd, wantEnd)
+	}
+}
+
 func TestFuncMap(t *testing.T) {
 	fm := FuncMap()
 
@@ -328,7 +342,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_lower", "bf_upper", "bf_trim", "bf_contains", "bf_join",
 		"bf_len", "bf_at", "bf_includes", "bf_first", "bf_last",
 		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
-		"bfComment", "bfPortalHTML",
+		"bfComment", "bfTextStart", "bfTextEnd", "bfPortalHTML",
 	}
 
 	for _, name := range expectedFuncs {

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -1047,13 +1047,14 @@ export class GoTemplateAdapter extends BaseAdapter {
     // Use comment markers instead of <span> to avoid changing DOM structure.
     if (goExpr.startsWith('{{')) {
       if (expr.reactive && expr.slotId) {
-        return `{{bfComment "expr-start:${expr.slotId}"}}${goExpr}{{bfComment "expr-end:${expr.slotId}"}}`
+        return `{{bfTextStart "${expr.slotId}"}}${goExpr}{{bfTextEnd "${expr.slotId}"}}`
       }
       return goExpr
     }
 
+    // Mark reactive expressions with comment nodes for client JS to find
     if (expr.reactive && expr.slotId) {
-      return `<span ${this.renderSlotMarker(expr.slotId)}>{{${goExpr}}}</span>`
+      return `{{bfTextStart "${expr.slotId}"}}{{${goExpr}}}{{bfTextEnd "${expr.slotId}"}}`
     }
 
     return `{{${goExpr}}}`

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -90,8 +90,8 @@ export class HonoAdapter implements TemplateAdapter {
   private generateImports(ir: ComponentIR): string {
     const lines: string[] = []
 
-    // Add bfComment for conditional reconciliation markers
-    lines.push("import { bfComment } from '@barefootjs/hono/utils'")
+    // Add bfComment/bfText for hydration markers
+    lines.push("import { bfComment, bfText } from '@barefootjs/hono/utils'")
 
     // Re-export original imports (excluding @barefootjs/dom)
     for (const imp of ir.metadata.imports) {
@@ -491,9 +491,9 @@ export class HonoAdapter implements TemplateAdapter {
     if (expr.clientOnly && expr.slotId) {
       return `{bfComment("client:${expr.slotId}")}`
     }
-    // Wrap reactive expressions in a span with slot marker for client JS to find
+    // Mark reactive expressions with comment nodes for client JS to find
     if (expr.reactive && expr.slotId) {
-      return `<span bf="${expr.slotId}">{${expr.expr}}</span>`
+      return `{bfText("${expr.slotId}")}{${expr.expr}}{bfText("${expr.slotId}", true)}`
     }
     return `{${expr.expr}}`
   }

--- a/packages/hono/src/utils.ts
+++ b/packages/hono/src/utils.ts
@@ -7,3 +7,12 @@ import { raw } from 'hono/html'
 export function bfComment(key: string) {
   return raw(`<!--bf-${key}-->`)
 }
+
+/**
+ * Output comment markers for reactive text expressions.
+ * Renders <!--bf:slotId--> (start) or <!--/bf:slotId--> (end).
+ */
+export function bfText(slotId: string, end?: boolean) {
+  return raw(end ? `<!--/bf:${slotId}-->` : `<!--bf:${slotId}-->`)
+}
+

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -715,9 +715,9 @@ describe('Compiler', () => {
       const content = clientJs!.content
 
       // The expression should be inlined inside the element check, not evaluated before it.
-      // Pattern: if (__el_XX) __el_XX.textContent = String(prev.title)
+      // Pattern: if (__el_XX) __el_XX.nodeValue = String(prev.title)
       // NOT:     const __val = prev.title  (which would throw when prev is undefined)
-      expect(content).toMatch(/if \(__el_\w+\) __el_\w+\.textContent = String\(prev\.title\)/)
+      expect(content).toMatch(/if \(__el_\w+\) __el_\w+\.nodeValue = String\(prev\.title\)/)
       expect(content).not.toMatch(/const __val = prev\.title/)
     })
 

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -246,7 +246,9 @@ export class TestAdapter extends BaseAdapter {
       return 'null'
     }
     if (expr.reactive && expr.slotId) {
-      return `<span bf="${expr.slotId}">{${expr.expr}}</span>`
+      // Use comment markers instead of span to avoid altering DOM structure.
+      // In JSX, this is rendered via bfText() at runtime.
+      return `{bfText("${expr.slotId}")}{${expr.expr}}{bfText("${expr.slotId}", true)}`
     }
     return `{${expr.expr}}`
   }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -224,7 +224,7 @@ export function emitFunctionsAndHandlers(
   }
 }
 
-/** Emit createEffect blocks that update textContent for reactive expressions. */
+/** Emit createEffect blocks that update text nodes for reactive expressions. */
 export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): void {
   // Group elements by expression to consolidate effects with same dependencies
   const byExpression = new Map<string, typeof ctx.dynamicElements>()
@@ -248,12 +248,12 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
         lines.push(`    const __val = ${expr}`)
         for (const elem of normalElems) {
           const v = varSlotId(elem.slotId)
-          lines.push(`    if (_${v}) _${v}.textContent = String(__val)`)
+          lines.push(`    if (_${v}) _${v}.nodeValue = String(__val)`)
         }
         for (const elem of conditionalElems) {
           const v = varSlotId(elem.slotId)
-          lines.push(`    const __el_${v} = $(__scope, '${elem.slotId}')`)
-          lines.push(`    if (__el_${v}) __el_${v}.textContent = String(__val)`)
+          lines.push(`    const __el_${v} = $t(__scope, '${elem.slotId}')`)
+          lines.push(`    if (__el_${v}) __el_${v}.nodeValue = String(__val)`)
         }
       } else {
         // Only conditional elements — defer expression evaluation until
@@ -261,8 +261,8 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
         // parent prop is undefined (e.g. prev?.title when prev is undefined).
         for (const elem of conditionalElems) {
           const v = varSlotId(elem.slotId)
-          lines.push(`    const __el_${v} = $(__scope, '${elem.slotId}')`)
-          lines.push(`    if (__el_${v}) __el_${v}.textContent = String(${expr})`)
+          lines.push(`    const __el_${v} = $t(__scope, '${elem.slotId}')`)
+          lines.push(`    if (__el_${v}) __el_${v}.nodeValue = String(${expr})`)
         }
       }
       lines.push(`  })`)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -257,6 +257,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
  */
 export function generateElementRefs(ctx: ClientJsContext): string {
   const regularSlots = new Set<string>()
+  const textSlots = new Set<string>()
   const componentSlots = new Set<string>()
   const conditionalSlotIds = collectConditionalSlotIds(ctx)
 
@@ -269,9 +270,10 @@ export function generateElementRefs(ctx: ClientJsContext): string {
       }
     }
   }
+  // Dynamic text expressions use comment markers found via $t()
   for (const elem of ctx.dynamicElements) {
     if (!elem.insideConditional) {
-      regularSlots.add(elem.slotId)
+      textSlots.add(elem.slotId)
     }
   }
   for (const elem of ctx.conditionalElements) {
@@ -308,13 +310,18 @@ export function generateElementRefs(ctx: ClientJsContext): string {
     regularSlots.delete(slotId)
   }
 
-  if (regularSlots.size === 0 && componentSlots.size === 0) return ''
+  if (regularSlots.size === 0 && textSlots.size === 0 && componentSlots.size === 0) return ''
 
   const refLines: string[] = []
 
   // Regular element slots use $() shorthand for find(scope, '[bf="id"]')
   for (const slotId of regularSlots) {
     refLines.push(`  const _${varSlotId(slotId)} = $(__scope, '${slotId}')`)
+  }
+
+  // Text slots use $t() to find Text nodes via comment markers <!--bf:id-->
+  for (const slotId of textSlots) {
+    refLines.push(`  const _${varSlotId(slotId)} = $t(__scope, '${slotId}')`)
   }
 
   // Component slots use $c() shorthand for find(scope, '[bf-s$="_id"]')

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -52,7 +52,7 @@ export function irToHtmlTemplate(node: IRNode): string {
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
       if (node.slotId) {
-        return `<span bf="${node.slotId}">\${${node.expr}}</span>`
+        return `<!--bf:${node.slotId}-->\${${node.expr}}<!--/bf:${node.slotId}-->`
       }
       return `\${${node.expr}}`
 
@@ -261,7 +261,7 @@ export function irToComponentTemplate(
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
       if (node.slotId) {
-        return `<span bf="${node.slotId}">\${${transformExpr(node.expr)}}</span>`
+        return `<!--bf:${node.slotId}-->\${${transformExpr(node.expr)}}<!--/bf:${node.slotId}-->`
       }
       return `\${${transformExpr(node.expr)}}`
 

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -33,7 +33,11 @@ export function detectUsedImports(code: string): Set<string> {
   if (/\$c\s*\(/.test(code)) {
     used.add('$c')
   }
-  // Match $( but not $c( - use negative lookahead
+  // Match $t( for text node finders
+  if (/\$t\s*\(/.test(code)) {
+    used.add('$t')
+  }
+  // Match $( but not $c( or $t( - use negative lookahead
   if (/\$\s*\(/.test(code)) {
     used.add('$')
   }


### PR DESCRIPTION

## Summary

Replace `<span bf="sN">` wrappers with HTML comment markers `<!--bf:sN-->...<!--/bf:sN-->` for reactive text expressions (e.g., `{count()}`).

**Before:**
```html
<button>Clicked <span bf="s0">0</span> times</button>
```

**After:**
```html
<button>Clicked <!--bf:s0-->0<!--/bf:s0--> times</button>
```

## Motivation

`<span>` wrappers alter the DOM structure, potentially affecting CSS selectors (e.g., `button > span`), layout, and accessibility. Comment nodes are visually and layoutwise transparent — they don't pollute the DOM.

## Changes

### Runtime (`packages/dom/`)
- Add `$t()` function: walks the DOM with `TreeWalker(SHOW_COMMENT)` to find `<!--bf:sN-->` markers and returns the adjacent Text node
- Add `commentBelongsToScope()`: scope boundary check preventing non-parent-owned slots from crossing into nested child component scopes
- Preserve `^` prefix for parent-owned slots: HTML outputs `<!--bf:^s0-->`, so the marker string must include `^` to match

### Compiler (`packages/jsx/`)
- `html-template.ts`: `<span bf="sN">` → `<!--bf:sN-->...<!--/bf:sN-->`
- `generate-init.ts`: use `$t()` for text slots instead of `$()`
- `emit-init-sections.ts`: `.textContent` → `.nodeValue`
- `imports.ts`: detect `$t` import usage

### Adapters
- **Hono**: add `bfText()` helper, emit comment markers in `renderExpression()`
- **Go Template**: add `TextStart()`/`TextEnd()` helpers, register `bfTextStart`/`bfTextEnd` in FuncMap
- **Test Adapter**: update from `<span>` to `bfText()` comment marker format

### Fixtures
- Update `expectedHtml` in 17 adapter-test fixtures

## Test plan

- [x] `packages/dom` — 122 tests pass
- [x] `packages/jsx` — compiler tests pass
- [x] `packages/adapter-tests` — 39 fixture tests pass
- [x] `packages/hono` — 35 tests pass
- [x] `packages/go-template` — 43 tests pass (TS) + Go tests pass
- [x] CI e2e-site-ui
