### PR TITLE
Fix string literal type annotations not stripped from client JS

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -2551,6 +2551,10 @@ describe('Compiler', () => {
             ))
           }
 
+          const handleSort = (key: 'amount' | 'status') => {
+            setSelected(key)
+          }
+
           onCleanup(() => {
             if (timer) clearTimeout(timer)
           })
@@ -2582,6 +2586,10 @@ describe('Compiler', () => {
       expect(js).not.toContain('item: ItemType')
       expect(js).not.toContain('i: number')
       expect(js).not.toContain('id: string')
+
+      // --- String literal union type annotations (#496) ---
+      expect(js).not.toContain("key: 'amount'")
+      expect(js).not.toContain("'amount' | 'status'")
 
       // --- Type assertions ---
       expect(js).not.toContain('as HTMLElement')

--- a/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
+++ b/packages/jsx/src/__tests__/strip-typescript-syntax.test.ts
@@ -74,6 +74,24 @@ describe('stripTypeScriptSyntax', () => {
         stripTypeScriptSyntax('(id: number | undefined) => { use(id) }')
       ).toBe('(id) => { use(id) }')
     })
+
+    test('strips string literal union type annotation (#496)', () => {
+      expect(
+        stripTypeScriptSyntax("(key: 'amount' | 'status') => { use(key) }")
+      ).toBe('(key) => { use(key) }')
+    })
+
+    test('strips double-quoted string literal union type annotation (#496)', () => {
+      expect(
+        stripTypeScriptSyntax('(dir: "horizontal" | "vertical") => { use(dir) }')
+      ).toBe('(dir) => { use(dir) }')
+    })
+
+    test('strips mixed keyword and string literal union type annotation (#496)', () => {
+      expect(
+        stripTypeScriptSyntax("(value: string | 'auto') => { use(value) }")
+      ).toBe('(value) => { use(value) }')
+    })
   })
 
   describe('object properties are not stripped', () => {

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -157,9 +157,10 @@ export function stripTypeScriptSyntax(code: string): string {
   result = result.replace(new RegExp(`\\s+as\\s+${tsTypeAtom}(?:\\s*\\|\\s*${tsTypeAtom})*`, 'g'), '')
 
   // Parameter type annotations: (param: Type) or (param: Type | Type2) => (param)
-  // Only match TypeScript types (uppercase initial or type keyword) to avoid matching object properties
+  // Only match TypeScript types (uppercase initial, type keyword, or string literals) to avoid matching object properties
+  const paramTypeAtom = `(?:[A-Z][A-Za-z0-9_]*|number|string|boolean|void|null|undefined|any|unknown|never|'[^']*'|"[^"]*")`
   result = result.replace(
-    /([(,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*((?:[A-Z][A-Za-z0-9_]*|number|string|boolean|void|null|undefined|any|unknown|never)(?:<[^>]*>)?(?:\[\])?(?:\s*\|\s*(?:[A-Z][A-Za-z0-9_]*|number|string|boolean|void|null|undefined|any|unknown|never)(?:<[^>]*>)?(?:\[\])?)*)(?=\s*[,)])/g,
+    new RegExp(`([(,]\\s*)([a-zA-Z_][a-zA-Z0-9_]*)\\s*:\\s*(${paramTypeAtom}(?:<[^>]*>)?(?:\\[\\])?(?:\\s*\\|\\s*${paramTypeAtom}(?:<[^>]*>)?(?:\\[\\])?)*)(?=\\s*[,)])`, 'g'),
     '$1$2'
   )
 


### PR DESCRIPTION
## Summary

- Fix `stripTypeScriptSyntax()` to handle string literal types (`'...'` and `"..."`) in parameter type annotations
- Previously, arrow function parameters with string literal union types like `(key: 'amount' | 'status') => { ... }` were not stripped, causing `Unexpected token ':'` syntax errors in the browser

Closes #496

## Changes

- **`packages/jsx/src/ir-to-client-js/utils.ts`**: Add `'[^']*'` and `"[^"]*"` to the parameter type annotation regex, extracted as `paramTypeAtom` for readability
- **`packages/jsx/src/__tests__/strip-typescript-syntax.test.ts`**: Add 3 unit tests for single-quoted, double-quoted, and mixed keyword+literal union types
- **`packages/jsx/src/__tests__/compiler.test.ts`**: Extend TypeScript syntax guard integration test with a string literal union type parameter

## Test plan

- [x] Unit tests pass: `bun test packages/jsx/src/__tests__/strip-typescript-syntax.test.ts` (21 tests)
- [x] Integration tests pass: `bun test packages/jsx/src/__tests__/compiler.test.ts` (122 tests)
- [x] Full suite passes: `cd packages/jsx && bun test` (299 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)