### PR TITLE
Fix nested ternary JSX leaving uncompiled JSX in false branch

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -12,6 +12,7 @@ import { fixture as propsReactive } from './props-reactive'
 import { fixture as nestedElements } from './nested-elements'
 // Priority 3: Conditionals
 import { fixture as ternary } from './ternary'
+import { fixture as nestedTernary } from './nested-ternary'
 import { fixture as logicalAnd } from './logical-and'
 import { fixture as conditionalClass } from './conditional-class'
 // Priority 4: Loops
@@ -53,6 +54,7 @@ export const jsxFixtures: JSXFixture[] = [
   nestedElements,
   // Priority 3: Conditionals
   ternary,
+  nestedTernary,
   logicalAnd,
   conditionalClass,
   // Priority 4: Loops

--- a/packages/adapter-tests/fixtures/nested-ternary.ts
+++ b/packages/adapter-tests/fixtures/nested-ternary.ts
@@ -1,0 +1,17 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'nested-ternary',
+  description: 'Nested ternary conditional rendering',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function NestedTernaryDemo() {
+  const [status, setStatus] = createSignal('idle')
+  return <div>{status() === 'loading' ? <span>Loading...</span> : status() === 'error' ? <span>Error</span> : <span>Idle</span>}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2"><!--bf-cond-start:s0--><span bf-c="s1">Idle</span><!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -3483,4 +3483,86 @@ describe('Compiler', () => {
       expect(clientJs!.content).not.toContain('let prefix')
     })
   })
+
+  describe('nested ternary (#495)', () => {
+    test('compiles all branches of nested ternary', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        export function StatusBadge() {
+          const [status, setStatus] = createSignal('idle')
+          return <div>{status() === 'loading' ? <span>Loading</span> : status() === 'error' ? <span>Error</span> : <span>Idle</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'StatusBadge.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // No raw JSX should remain in the compiled output
+      expect(clientJs!.content).not.toContain('<span>Loading</span>')
+      expect(clientJs!.content).not.toContain('<span>Error</span>')
+      expect(clientJs!.content).not.toContain('<span>Idle</span>')
+    })
+
+    test('compiles deeply nested ternary (3+ levels)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        export function DeepTernary() {
+          const [v, setV] = createSignal(0)
+          return <div>{v() === 1 ? <span>One</span> : v() === 2 ? <span>Two</span> : v() === 3 ? <span>Three</span> : <span>Other</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'DeepTernary.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).not.toContain('<span>One</span>')
+      expect(clientJs!.content).not.toContain('<span>Two</span>')
+      expect(clientJs!.content).not.toContain('<span>Three</span>')
+      expect(clientJs!.content).not.toContain('<span>Other</span>')
+    })
+
+    test('compiles stateless nested ternary without errors', () => {
+      const source = `
+        export function StaticNested(props: { status: string }) {
+          return <div>{props.status === 'a' ? <span>A</span> : props.status === 'b' ? <span>B</span> : <span>C</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'StaticNested.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      // Stateless components produce JSX templates — verify template is generated
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      // The nested ternary should produce two conditional expressions in the template
+      expect(template!.content).toContain("props.status === 'a'")
+      expect(template!.content).toContain("props.status === 'b'")
+    })
+
+    test('compiles logical AND inside ternary branch', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        export function AndInBranch() {
+          const [a, setA] = createSignal(false)
+          const [b, setB] = createSignal(false)
+          return <div>{a() ? <span>A</span> : b() && <span>B</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'AndInBranch.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).not.toContain('<span>A</span>')
+      expect(clientJs!.content).not.toContain('<span>B</span>')
+    })
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -56,8 +56,13 @@ export function irToHtmlTemplate(node: IRNode): string {
       }
       return `\${${node.expr}}`
 
-    case 'conditional':
-      return `\${${node.condition} ? \`${irToHtmlTemplate(node.whenTrue)}\` : \`${irToHtmlTemplate(node.whenFalse)}\`}`
+    case 'conditional': {
+      const trueBranch = irToHtmlTemplate(node.whenTrue)
+      const falseBranch = irToHtmlTemplate(node.whenFalse)
+      const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
+      const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
+      return `\${${node.condition} ? \`${trueHtml}\` : \`${falseHtml}\`}`
+    }
 
     case 'fragment':
       return node.children.map(irToHtmlTemplate).join('')

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -689,6 +689,16 @@ function transformConditionalBranch(
     return transformConditionalBranch(node.expression, ctx)
   }
 
+  // Nested ternary: cond1 ? <A/> : cond2 ? <B/> : <C/>
+  if (ts.isConditionalExpression(node)) {
+    return transformConditional(node, ctx)
+  }
+
+  // Logical AND in branch: cond1 ? <A/> : (cond2 && <B/>)
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+    return transformLogicalAnd(node, ctx)
+  }
+
   // Regular expression (including null)
   const exprText = node.getText(ctx.sourceFile)
   return {


### PR DESCRIPTION
## Summary

- Fix `transformConditionalBranch()` in Phase 1 (`jsx-to-ir.ts`) to recognize nested ternary expressions (`ts.isConditionalExpression`) and logical AND (`ts.isBinaryExpression` with `&&`) in conditional branches, producing proper `IRConditional` nodes instead of raw text via `getText()`
- Fix `irToHtmlTemplate()` in Phase 2 (`html-template.ts`) to apply `addCondAttrToTemplate()` for nested conditionals, ensuring `bf-c` markers are included in branch templates for client-side `insert()` binding
- Add `nested-ternary` adapter test fixture and 4 compiler unit tests covering 2-level, 3+ level, stateless, and logical-AND-in-branch cases

Closes #495

## Test plan

- [x] `bun test packages/jsx/src/__tests__/compiler.test.ts` — 126 tests pass (4 new)
- [x] `bun test packages/` — 703 tests pass (including nested-ternary fixture for both adapters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)