### PR TITLE
Add NavigationMenu component

### DIFF
--- a/site/ui/components/navigation-menu-demo.tsx
+++ b/site/ui/components/navigation-menu-demo.tsx
@@ -1,0 +1,154 @@
+"use client"
+/**
+ * NavigationMenuDemo Components
+ *
+ * Interactive demos for NavigationMenu component.
+ * Used in navigation-menu documentation page.
+ */
+
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+} from '@ui/components/ui/navigation-menu'
+
+/**
+ * Basic demo — two trigger menus with link grids
+ */
+export function NavigationMenuBasicDemo() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="getting-started">
+          <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[400px] md:w-[500px]">
+            <ul className="grid gap-3 p-4 md:grid-cols-2">
+              <li>
+                <NavigationMenuLink href="/docs">
+                  <div className="text-sm font-medium leading-none">Introduction</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Learn the basics of BarefootJS and get up and running.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/installation">
+                  <div className="text-sm font-medium leading-none">Installation</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    How to install and configure BarefootJS.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/primitives">
+                  <div className="text-sm font-medium leading-none">Primitives</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Signals, effects, memos, and other reactive primitives.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/styling">
+                  <div className="text-sm font-medium leading-none">Styling</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Using Tailwind CSS and UnoCSS with BarefootJS.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem value="components">
+          <NavigationMenuTrigger>Components</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[400px] md:w-[500px]">
+            <ul className="grid gap-3 p-4 md:grid-cols-2">
+              <li>
+                <NavigationMenuLink href="/docs/components/button">
+                  <div className="text-sm font-medium leading-none">Button</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Clickable actions with multiple variants and sizes.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/components/dialog">
+                  <div className="text-sm font-medium leading-none">Dialog</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Modal overlay with custom content and focus trap.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/components/tabs">
+                  <div className="text-sm font-medium leading-none">Tabs</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Tabbed content with keyboard navigation.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/components/accordion">
+                  <div className="text-sm font-medium leading-none">Accordion</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Vertically collapsing content sections.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}
+
+/**
+ * Demo with trigger menus and direct links mixed
+ */
+export function NavigationMenuWithLinksDemo() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="docs">
+          <NavigationMenuTrigger>Documentation</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[300px]">
+            <ul className="grid gap-3 p-4">
+              <li>
+                <NavigationMenuLink href="/docs/introduction">
+                  <div className="text-sm font-medium leading-none">Introduction</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Get started with BarefootJS.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/api" active={true}>
+                  <div className="text-sm font-medium leading-none">API Reference</div>
+                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                    Full API documentation.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/blog" className="h-9 px-4 py-2 inline-flex items-center justify-center text-sm font-medium">
+            Blog
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/about" className="h-9 px-4 py-2 inline-flex items-center justify-center text-sm font-medium">
+            About
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -29,6 +29,7 @@ export const componentOrder = [
   { slug: 'input', title: 'Input' },
   { slug: 'label', title: 'Label' },
   { slug: 'menubar', title: 'Menubar' },
+  { slug: 'navigation-menu', title: 'Navigation Menu' },
   { slug: 'pagination', title: 'Pagination' },
   { slug: 'popover', title: 'Popover' },
   { slug: 'portal', title: 'Portal' },

--- a/site/ui/e2e/navigation-menu.spec.ts
+++ b/site/ui/e2e/navigation-menu.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Navigation Menu Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/navigation-menu')
+  })
+
+  test.describe('Basic Demo', () => {
+    test('opens content on trigger click', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const gsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      await gsTrigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('text=Introduction')).toBeVisible()
+      await expect(content.locator('text=Installation')).toBeVisible()
+    })
+
+    test('has ARIA attributes on trigger', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').first()
+
+      await expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+      await trigger.click()
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    test('closes content on ESC', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.keyboard.press('Escape')
+      await expect(content).toHaveCount(0)
+    })
+
+    test('closes content on click outside', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.locator('h1').click()
+      await expect(content).toHaveCount(0)
+    })
+
+    test('contains chevron SVG in trigger', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').first()
+
+      const chevron = trigger.locator('[data-slot="navigation-menu-chevron"]')
+      await expect(chevron).toBeVisible()
+    })
+
+    test('renders NavigationMenuLink as <a> with href', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      const links = content.locator('[data-slot="navigation-menu-link"]')
+      expect(await links.count()).toBeGreaterThan(0)
+
+      const firstLink = links.first()
+      await expect(firstLink).toHaveAttribute('href')
+    })
+  })
+
+  test.describe('Hover Behavior', () => {
+    test('opens content on hover with delay', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      await trigger.hover()
+
+      // Content should appear after delay
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible({ timeout: 2000 })
+    })
+
+    test('content stays open when mouse moves to it', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      // Open via click for reliability
+      await trigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      // Move mouse to content
+      await content.hover()
+
+      // Content should remain visible
+      await expect(content).toBeVisible()
+    })
+
+    test('roving hover: hovering another trigger switches content', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const gsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+      const compTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Components' })
+
+      // Open Getting Started
+      await gsTrigger.click()
+      const gsContent = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(gsContent).toBeVisible()
+      await expect(gsContent.locator('text=Introduction')).toBeVisible()
+
+      // Hover Components trigger — should switch
+      await compTrigger.hover()
+      await expect(page.locator('[data-slot="navigation-menu-content"][data-state="open"]').locator('text=Button')).toBeVisible({ timeout: 2000 })
+    })
+  })
+
+  test.describe('Keyboard Navigation', () => {
+    test('ArrowRight on trigger navigates to next trigger', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const gsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+      const compTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Components' })
+
+      await gsTrigger.focus()
+      await page.keyboard.press('ArrowRight')
+      await expect(compTrigger).toBeFocused()
+    })
+
+    test('ArrowLeft on trigger navigates to previous trigger', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const gsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+      const compTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Components' })
+
+      await compTrigger.focus()
+      await page.keyboard.press('ArrowLeft')
+      await expect(gsTrigger).toBeFocused()
+    })
+
+    test('ArrowRight with open menu switches to next menu', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuBasicDemo_"]').first()
+      const gsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Getting Started' })
+
+      // Open Getting Started
+      await gsTrigger.click()
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      // ArrowRight should switch to Components
+      await page.keyboard.press('ArrowRight')
+      const compContent = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      await expect(compContent.locator('text=Button')).toBeVisible()
+    })
+  })
+
+  test.describe('With Links Demo', () => {
+    test('renders direct links without trigger', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuWithLinksDemo_"]').first()
+      const blogLink = nav.locator('[data-slot="navigation-menu-link"]').filter({ hasText: 'Blog' })
+
+      await expect(blogLink).toBeVisible()
+      await expect(blogLink).toHaveAttribute('href', '/blog')
+    })
+
+    test('active link has aria-current=page', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuWithLinksDemo_"]').first()
+      const docsTrigger = nav.locator('[data-slot="navigation-menu-trigger"]').filter({ hasText: 'Documentation' })
+
+      await docsTrigger.click()
+
+      const content = page.locator('[data-slot="navigation-menu-content"][data-state="open"]')
+      const activeLink = content.locator('[data-slot="navigation-menu-link"][data-active]')
+      await expect(activeLink).toHaveAttribute('aria-current', 'page')
+    })
+
+    test('mixes trigger items and direct link items', async ({ page }) => {
+      const nav = page.locator('[bf-s^="NavigationMenuWithLinksDemo_"]').first()
+
+      // Should have trigger
+      const trigger = nav.locator('[data-slot="navigation-menu-trigger"]')
+      expect(await trigger.count()).toBe(1)
+
+      // Should have direct links (Blog + About)
+      const directLinks = nav.locator('[data-slot="navigation-menu-item"] > [data-slot="navigation-menu-link"]')
+      expect(await directLinks.count()).toBe(2)
+    })
+  })
+})

--- a/site/ui/pages/navigation-menu.tsx
+++ b/site/ui/pages/navigation-menu.tsx
@@ -1,0 +1,246 @@
+/**
+ * Navigation Menu Documentation Page
+ */
+
+import { NavigationMenuBasicDemo, NavigationMenuWithLinksDemo } from '@/components/navigation-menu-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'features', title: 'Features' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'with-links', title: 'With Links', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const basicCode = `"use client"
+
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+} from '@/components/ui/navigation-menu'
+
+function BasicNavigationMenu() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="getting-started">
+          <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[400px] md:w-[500px]">
+            <ul className="grid gap-3 p-4 md:grid-cols-2">
+              <li>
+                <NavigationMenuLink href="/docs">
+                  <div className="text-sm font-medium">Introduction</div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Learn the basics.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/installation">
+                  <div className="text-sm font-medium">Installation</div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    How to install and configure.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}`
+
+const withLinksCode = `"use client"
+
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+} from '@/components/ui/navigation-menu'
+
+function NavigationWithLinks() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="docs">
+          <NavigationMenuTrigger>Documentation</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[300px]">
+            <ul className="grid gap-3 p-4">
+              <li>
+                <NavigationMenuLink href="/docs/intro">
+                  <div className="text-sm font-medium">Introduction</div>
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="/docs/api" active={true}>
+                  <div className="text-sm font-medium">API Reference</div>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/blog"
+            className="h-9 px-4 py-2 inline-flex items-center text-sm font-medium">
+            Blog
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}`
+
+// Props definitions
+const navigationMenuProps: PropDefinition[] = [
+  {
+    name: 'delayDuration',
+    type: 'number',
+    defaultValue: '200',
+    description: 'Delay in ms before opening on hover.',
+  },
+  {
+    name: 'closeDelay',
+    type: 'number',
+    defaultValue: '300',
+    description: 'Delay in ms before closing after mouse leave.',
+  },
+]
+
+const navigationMenuItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Unique identifier for this item. Required when using Trigger + Content.',
+  },
+]
+
+const navigationMenuTriggerProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Trigger label text.',
+  },
+]
+
+const navigationMenuContentProps: PropDefinition[] = [
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS classes. Use to set width (e.g., "w-[400px]").',
+  },
+]
+
+const navigationMenuLinkProps: PropDefinition[] = [
+  {
+    name: 'href',
+    type: 'string',
+    description: 'Link URL.',
+  },
+  {
+    name: 'active',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this link is the current page. Sets aria-current="page".',
+  },
+]
+
+export function NavigationMenuPage() {
+  return (
+    <DocPage slug="navigation-menu" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Navigation Menu"
+          description="A collection of links for navigating websites, with hover-activated content panels."
+          {...getNavLinks('navigation-menu')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={`<NavigationMenu><NavigationMenuList><NavigationMenuItem>...</NavigationMenuItem></NavigationMenuList></NavigationMenu>`}>
+          <NavigationMenuBasicDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add navigation-menu" />
+        </Section>
+
+        {/* Features */}
+        <Section id="features" title="Features">
+          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
+            <li><strong className="text-foreground">Hover with delay</strong> - Content opens after a configurable delay (200ms default)</li>
+            <li><strong className="text-foreground">Close delay</strong> - Content stays open briefly when moving mouse (300ms default)</li>
+            <li><strong className="text-foreground">Click toggle</strong> - Click triggers to toggle content panels</li>
+            <li><strong className="text-foreground">Keyboard navigation</strong> - ArrowLeft/Right navigates between triggers</li>
+            <li><strong className="text-foreground">Active page</strong> - NavigationMenuLink supports aria-current for active page indication</li>
+            <li><strong className="text-foreground">Mixed content</strong> - Combine trigger menus with direct links</li>
+          </ul>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <NavigationMenuBasicDemo />
+            </Example>
+            <Example title="With Links" code={withLinksCode}>
+              <NavigationMenuWithLinksDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenu</h3>
+              <PropsTable props={navigationMenuProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuList</h3>
+              <p className="text-sm text-muted-foreground">Styled list wrapper. Renders as &lt;ul&gt;.</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuItem</h3>
+              <PropsTable props={navigationMenuItemProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuTrigger</h3>
+              <PropsTable props={navigationMenuTriggerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuContent</h3>
+              <PropsTable props={navigationMenuContentProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuLink</h3>
+              <PropsTable props={navigationMenuLinkProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -94,6 +94,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Input', href: '/docs/components/input' },
       { title: 'Label', href: '/docs/components/label' },
       { title: 'Menubar', href: '/docs/components/menubar' },
+      { title: 'Navigation Menu', href: '/docs/components/navigation-menu' },
       { title: 'Pagination', href: '/docs/components/pagination' },
       { title: 'Popover', href: '/docs/components/popover' },
       { title: 'Progress', href: '/docs/components/progress' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -50,6 +50,7 @@ import { DrawerPage } from './pages/drawer'
 import { SheetPage } from './pages/sheet'
 import { HoverCardPage } from './pages/hover-card'
 import { MenubarPage } from './pages/menubar'
+import { NavigationMenuPage } from './pages/navigation-menu'
 import { TablePage } from './pages/table'
 import { SpinnerPage } from './pages/spinner'
 
@@ -175,6 +176,10 @@ export function createApp() {
             <a href="/docs/components/menubar" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Menubar</h3>
               <p className="text-xs text-muted-foreground">Desktop application menu bar</p>
+            </a>
+            <a href="/docs/components/navigation-menu" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Navigation Menu</h3>
+              <p className="text-xs text-muted-foreground">Hover-activated navigation links</p>
             </a>
             <a href="/docs/components/pagination" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Pagination</h3>
@@ -467,6 +472,11 @@ export function createApp() {
   // Menubar documentation
   app.get('/docs/components/menubar', (c) => {
     return c.render(<MenubarPage />)
+  })
+
+  // Navigation Menu documentation
+  app.get('/docs/components/navigation-menu', (c) => {
+    return c.render(<NavigationMenuPage />)
   })
 
   // Pagination documentation

--- a/ui/components/ui/navigation-menu/index.preview.tsx
+++ b/ui/components/ui/navigation-menu/index.preview.tsx
@@ -1,0 +1,19 @@
+// Auto-generated preview. Customize by editing this file.
+"use client"
+
+import { NavigationMenu, NavigationMenuList, NavigationMenuItem, NavigationMenuTrigger, NavigationMenuContent, NavigationMenuLink } from '../navigation-menu'
+
+export function Default() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="getting-started">
+          <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <NavigationMenuLink href="/docs">Documentation</NavigationMenuLink>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/ui/components/ui/navigation-menu/index.test.tsx
+++ b/ui/components/ui/navigation-menu/index.test.tsx
@@ -1,0 +1,246 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// NavigationMenu (stateful — activeValue signal, Provider wrapping)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenu', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenu')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is NavigationMenu', () => {
+    expect(result.componentName).toBe('NavigationMenu')
+  })
+
+  test('has activeValue signal', () => {
+    expect(result.signals).toContain('activeValue')
+  })
+
+  test('renders as nav with data-slot=navigation-menu', () => {
+    const nav = result.find({ tag: 'nav' })
+    expect(nav).not.toBeNull()
+    expect(nav!.props['data-slot']).toBe('navigation-menu')
+  })
+
+  test('has resolved CSS classes', () => {
+    const nav = result.find({ tag: 'nav' })!
+    expect(nav.classes).toContain('relative')
+  })
+
+  test('toStructure() shows nav element', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('nav')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NavigationMenuList (stateless — styled <ul>)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenuList', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenuList')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NavigationMenuList', () => {
+    expect(result.componentName).toBe('NavigationMenuList')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as ul with data-slot=navigation-menu-list', () => {
+    expect(result.root.tag).toBe('ul')
+    expect(result.root.props['data-slot']).toBe('navigation-menu-list')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NavigationMenuItem (stateless — <li> wrapper with data-value)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenuItem', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenuItem')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NavigationMenuItem', () => {
+    expect(result.componentName).toBe('NavigationMenuItem')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as li with data-slot=navigation-menu-item', () => {
+    expect(result.root.tag).toBe('li')
+    expect(result.root.props['data-slot']).toBe('navigation-menu-item')
+  })
+
+  test('has data-value attribute', () => {
+    expect(result.root.props).toHaveProperty('data-value')
+  })
+
+  test('has relative positioning class', () => {
+    expect(result.root.classes).toContain('relative')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NavigationMenuTrigger (stateful — ref handler with useContext, createEffect)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenuTrigger', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenuTrigger')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NavigationMenuTrigger', () => {
+    expect(result.componentName).toBe('NavigationMenuTrigger')
+  })
+
+  test('renders as <button>', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+  })
+
+  test('has data-slot=navigation-menu-trigger', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.props['data-slot']).toBe('navigation-menu-trigger')
+  })
+
+  test('has aria-haspopup=menu', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.aria).toHaveProperty('haspopup')
+  })
+
+  test('has aria-expanded attribute', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.aria).toHaveProperty('expanded')
+  })
+
+  test('has data-state=closed initially', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.dataState).toBe('closed')
+  })
+
+  test('contains chevron SVG', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+  })
+
+  test('has resolved CSS classes', () => {
+    const button = result.find({ tag: 'button' })!
+    expect(button.classes).toContain('inline-flex')
+    expect(button.classes).toContain('items-center')
+    expect(button.classes).toContain('rounded-md')
+    expect(button.classes).toContain('cursor-pointer')
+  })
+
+  test('toStructure() shows trigger button with ARIA', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('button')
+    expect(structure).toContain('[aria-haspopup]')
+    expect(structure).toContain('[aria-expanded]')
+    expect(structure).toContain('svg')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NavigationMenuContent (stateful — portal, positioning, timer management)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenuContent', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenuContent')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NavigationMenuContent', () => {
+    expect(result.componentName).toBe('NavigationMenuContent')
+  })
+
+  test('root tag is div', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=navigation-menu-content', () => {
+    expect(result.root.props['data-slot']).toBe('navigation-menu-content')
+  })
+
+  test('has data-state=closed initially', () => {
+    expect(result.root.dataState).toBe('closed')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('fixed')
+    expect(result.root.classes).toContain('z-50')
+    expect(result.root.classes).toContain('rounded-md')
+  })
+
+  test('toStructure() shows content with data-state', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('[data-state]')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NavigationMenuLink (stateless — <a> with active page support)
+// ---------------------------------------------------------------------------
+
+describe('NavigationMenuLink', () => {
+  const result = renderToTest(source, 'navigation-menu.tsx', 'NavigationMenuLink')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NavigationMenuLink', () => {
+    expect(result.componentName).toBe('NavigationMenuLink')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <a> with data-slot=navigation-menu-link', () => {
+    expect(result.root.tag).toBe('a')
+    expect(result.root.props['data-slot']).toBe('navigation-menu-link')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('block')
+    expect(result.root.classes).toContain('rounded-md')
+    expect(result.root.classes).toContain('no-underline')
+  })
+
+  test('toStructure() shows link element', () => {
+    const structure = result.toStructure()
+    expect(structure).toContain('a')
+  })
+})

--- a/ui/components/ui/navigation-menu/index.tsx
+++ b/ui/components/ui/navigation-menu/index.tsx
@@ -1,0 +1,475 @@
+"use client"
+
+/**
+ * Navigation Menu Components
+ *
+ * A collection of links for navigating websites. Typically displayed
+ * horizontally at the top of pages. Uses hover-with-delay to show
+ * content panels, unlike Menubar which is click-to-open.
+ *
+ * Architecture: Root-level context with activeValue signal coordinates
+ * which menu is open. Timer IDs stored on root element dataset for
+ * portal-safe access. WeakMap captures trigger refs before portal.
+ *
+ * Features:
+ * - Hover to open with configurable delay (200ms default)
+ * - Close delay (300ms default) allows moving to content
+ * - Click to toggle
+ * - ArrowLeft/Right keyboard navigation between triggers
+ * - ESC to close
+ * - Portal content to body for overflow escape
+ * - NavigationMenuLink with active page support
+ *
+ * @example Basic navigation menu
+ * ```tsx
+ * <NavigationMenu>
+ *   <NavigationMenuList>
+ *     <NavigationMenuItem>
+ *       <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+ *       <NavigationMenuContent>
+ *         <NavigationMenuLink href="/docs">Documentation</NavigationMenuLink>
+ *       </NavigationMenuContent>
+ *     </NavigationMenuItem>
+ *   </NavigationMenuList>
+ * </NavigationMenu>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// Root-level context: coordinates which item is active
+interface NavigationMenuContextValue {
+  activeValue: () => string
+  onActiveValueChange: (value: string) => void
+}
+
+const NavigationMenuContext = createContext<NavigationMenuContextValue>()
+
+// Store Content -> Trigger element mapping for positioning after portal
+const contentTriggerMap = new WeakMap<HTMLElement, HTMLElement>()
+
+// Store Content -> Root element mapping for timer access after portal
+const contentRootMap = new WeakMap<HTMLElement, HTMLElement>()
+
+// CSS classes
+const navigationMenuClasses = 'relative'
+const navigationMenuListClasses = 'group flex flex-1 list-none items-center justify-center gap-1'
+const navigationMenuTriggerBaseClasses = 'group inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 cursor-pointer select-none'
+const navigationMenuTriggerOpenClasses = 'bg-accent/50 text-accent-foreground'
+const navigationMenuContentBaseClasses = 'fixed z-50 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md transform-gpu origin-top transition-[opacity,transform] duration-normal ease-out'
+const navigationMenuContentOpenClasses = 'opacity-100 scale-100'
+const navigationMenuContentClosedClasses = 'opacity-0 scale-95 pointer-events-none'
+const navigationMenuLinkBaseClasses = 'block select-none rounded-md p-3 leading-none no-underline outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
+const navigationMenuLinkActiveClasses = 'bg-accent/50 text-accent-foreground'
+
+// --- NavigationMenu (root) ---
+
+interface NavigationMenuProps extends HTMLBaseAttributes {
+  /** NavigationMenuList children */
+  children?: Child
+  /**
+   * Delay in ms before opening on hover.
+   * @default 200
+   */
+  delayDuration?: number
+  /**
+   * Delay in ms before closing after mouse leave.
+   * @default 300
+   */
+  closeDelay?: number
+}
+
+/**
+ * Navigation menu root component.
+ * Manages which item is currently active via a signal.
+ * Stores timer config and IDs in dataset for portal-safe access.
+ */
+function NavigationMenu(props: NavigationMenuProps) {
+  const [activeValue, setActiveValue] = createSignal('')
+
+  const handleMount = (el: HTMLElement) => {
+    // Store delay config on root for timer helpers
+    el.dataset.nmOpenDelay = String(props.delayDuration ?? 200)
+    el.dataset.nmCloseDelay = String(props.closeDelay ?? 300)
+
+    // Global click-outside handler
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!el.contains(e.target as Node)) {
+        // Also check portaled content
+        const openContent = document.querySelector('[data-slot="navigation-menu-content"][data-state="open"]')
+        if (openContent && openContent.contains(e.target as Node)) return
+        setActiveValue('')
+      }
+    }
+
+    // Global ESC handler
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (activeValue() !== '') {
+          const currentValue = activeValue()
+          setActiveValue('')
+          // Focus back to the trigger that was active
+          const trigger = el.querySelector(`[data-slot="navigation-menu-trigger"][data-value="${currentValue}"]`) as HTMLElement
+          trigger?.focus()
+        }
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleGlobalKeyDown)
+  }
+
+  return (
+    <NavigationMenuContext.Provider value={{
+      activeValue,
+      onActiveValueChange: setActiveValue,
+    }}>
+      <nav
+        data-slot="navigation-menu"
+        id={props.id}
+        className={`${navigationMenuClasses} ${props.className ?? ''}`}
+        ref={handleMount}
+      >
+        {props.children}
+      </nav>
+    </NavigationMenuContext.Provider>
+  )
+}
+
+// --- NavigationMenuList ---
+
+interface NavigationMenuListProps extends HTMLBaseAttributes {
+  /** NavigationMenuItem children */
+  children?: Child
+}
+
+/**
+ * List wrapper for navigation menu items.
+ * Stateless — just a styled <ul>.
+ */
+function NavigationMenuList({ children, className = '', ...props }: NavigationMenuListProps) {
+  return (
+    <ul data-slot="navigation-menu-list" className={`${navigationMenuListClasses} ${className}`} {...props}>
+      {children}
+    </ul>
+  )
+}
+
+// --- NavigationMenuItem ---
+
+interface NavigationMenuItemProps extends HTMLBaseAttributes {
+  /** Unique value identifying this item */
+  value?: string
+  /** NavigationMenuTrigger and NavigationMenuContent, or NavigationMenuLink */
+  children?: Child
+}
+
+/**
+ * Individual navigation menu item wrapper.
+ * Stateless — pure DOM wrapper with data-value for children to read.
+ */
+function NavigationMenuItem(props: NavigationMenuItemProps) {
+  return (
+    <li data-slot="navigation-menu-item" data-value={props.value ?? ''} id={props.id} className={`relative ${props.className ?? ''}`}>
+      {props.children}
+    </li>
+  )
+}
+
+// --- NavigationMenuTrigger ---
+
+interface NavigationMenuTriggerProps extends HTMLBaseAttributes {
+  /** Trigger content (text label) */
+  children?: Child
+}
+
+/**
+ * Button that toggles its content panel.
+ * Hover opens with delay. Click toggles.
+ * ArrowLeft/Right navigates between triggers.
+ * Derives item value from parent NavigationMenuItem's data-value attribute.
+ */
+function NavigationMenuTrigger(props: NavigationMenuTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(NavigationMenuContext)
+    const itemEl = el.closest('[data-slot="navigation-menu-item"]')
+    const itemValue = itemEl?.getAttribute('data-value') ?? ''
+    el.dataset.value = itemValue
+
+    const root = el.closest('[data-slot="navigation-menu"]') as HTMLElement
+
+    // Reactive styling based on open state
+    createEffect(() => {
+      const isOpen = ctx.activeValue() === itemValue
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.setAttribute('aria-expanded', String(isOpen))
+      el.className = `${navigationMenuTriggerBaseClasses} ${isOpen ? navigationMenuTriggerOpenClasses : ''} ${props.className ?? ''}`
+      // Rotate chevron
+      const chevron = el.querySelector('[data-slot="navigation-menu-chevron"]') as HTMLElement
+      if (chevron) {
+        chevron.style.transform = isOpen ? 'rotate(180deg)' : ''
+      }
+    })
+
+    // Click to toggle
+    el.addEventListener('click', () => {
+      const isOpen = ctx.activeValue() === itemValue
+      ctx.onActiveValueChange(isOpen ? '' : itemValue)
+    })
+
+    // Hover enter: cancel close timer, start open timer
+    el.addEventListener('mouseenter', () => {
+      if (!root) return
+
+      // Cancel close timer
+      const ct = root.dataset.nmCloseTimer
+      if (ct) {
+        clearTimeout(Number(ct))
+        root.dataset.nmCloseTimer = ''
+      }
+
+      const openDelay = Number(root.dataset.nmOpenDelay) || 200
+
+      if (openDelay > 0 && ctx.activeValue() !== itemValue) {
+        const timerId = setTimeout(() => {
+          ctx.onActiveValueChange(itemValue)
+          root.dataset.nmOpenTimer = ''
+        }, openDelay) as unknown as number
+        root.dataset.nmOpenTimer = String(timerId)
+      } else if (ctx.activeValue() !== '') {
+        // If any menu is already open, open immediately (roving)
+        ctx.onActiveValueChange(itemValue)
+      }
+    })
+
+    // Hover leave: cancel open timer, start close timer
+    el.addEventListener('mouseleave', () => {
+      if (!root) return
+
+      // Cancel open timer
+      const ot = root.dataset.nmOpenTimer
+      if (ot) {
+        clearTimeout(Number(ot))
+        root.dataset.nmOpenTimer = ''
+      }
+
+      const closeDelay = Number(root.dataset.nmCloseDelay) || 300
+
+      if (closeDelay > 0) {
+        const timerId = setTimeout(() => {
+          ctx.onActiveValueChange('')
+          root.dataset.nmCloseTimer = ''
+        }, closeDelay) as unknown as number
+        root.dataset.nmCloseTimer = String(timerId)
+      } else {
+        ctx.onActiveValueChange('')
+      }
+    })
+
+    // Keyboard navigation between triggers
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        e.preventDefault()
+        const nav = el.closest('[data-slot="navigation-menu"]')
+        if (!nav) return
+        const triggers = Array.from(nav.querySelectorAll('[data-slot="navigation-menu-trigger"]')) as HTMLElement[]
+        const currentIndex = triggers.indexOf(el)
+        let nextIndex: number
+        if (e.key === 'ArrowRight') {
+          nextIndex = currentIndex < triggers.length - 1 ? currentIndex + 1 : 0
+        } else {
+          nextIndex = currentIndex > 0 ? currentIndex - 1 : triggers.length - 1
+        }
+        const nextTrigger = triggers[nextIndex]
+        nextTrigger.focus()
+        // If a menu was open, open the new one
+        if (ctx.activeValue() !== '') {
+          const nextValue = nextTrigger.dataset.value ?? ''
+          ctx.onActiveValueChange(nextValue)
+        }
+      }
+    })
+  }
+
+  return (
+    <button
+      data-slot="navigation-menu-trigger"
+      type="button"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      data-state="closed"
+      className={`${navigationMenuTriggerBaseClasses} ${props.className ?? ''}`}
+      id={props.id}
+      ref={handleMount}
+    >
+      {props.children}
+      <svg data-slot="navigation-menu-chevron" className="relative top-px ml-1 size-3 transition-transform duration-200" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+    </button>
+  )
+}
+
+// --- NavigationMenuContent ---
+
+interface NavigationMenuContentProps extends HTMLBaseAttributes {
+  /** Content panel */
+  children?: Child
+}
+
+/**
+ * Content panel that appears when a trigger is active.
+ * Portaled to body. Positioned below trigger.
+ * Hover enter cancels close timer, hover leave starts close timer.
+ */
+function NavigationMenuContent(props: NavigationMenuContentProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Capture references before portal
+    const itemEl = el.closest('[data-slot="navigation-menu-item"]')
+    const itemValue = itemEl?.getAttribute('data-value') ?? ''
+    const triggerEl = itemEl?.querySelector('[data-slot="navigation-menu-trigger"]') as HTMLElement
+    const rootEl = el.closest('[data-slot="navigation-menu"]') as HTMLElement
+    if (triggerEl) contentTriggerMap.set(el, triggerEl)
+    if (rootEl) contentRootMap.set(el, rootEl)
+
+    // Portal to body
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(NavigationMenuContext)
+
+    // Position content relative to trigger
+    const updatePosition = () => {
+      if (!triggerEl) return
+      const rect = triggerEl.getBoundingClientRect()
+      el.style.top = `${rect.bottom + 8}px`
+      el.style.left = `${rect.left}px`
+    }
+
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + positioning
+    createEffect(() => {
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.activeValue() === itemValue
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${navigationMenuContentBaseClasses} ${isOpen ? navigationMenuContentOpenClasses : navigationMenuContentClosedClasses} ${props.className ?? ''}`
+
+      if (isOpen) {
+        updatePosition()
+
+        const handleScroll = () => updatePosition()
+        window.addEventListener('scroll', handleScroll, true)
+        window.addEventListener('resize', handleScroll)
+
+        cleanupFns.push(
+          () => window.removeEventListener('scroll', handleScroll, true),
+          () => window.removeEventListener('resize', handleScroll),
+        )
+      }
+    })
+
+    // Mouse enter on content: cancel close timer
+    el.addEventListener('mouseenter', () => {
+      const root = contentRootMap.get(el)
+      if (!root) return
+
+      const ct = root.dataset.nmCloseTimer
+      if (ct) {
+        clearTimeout(Number(ct))
+        root.dataset.nmCloseTimer = ''
+      }
+    })
+
+    // Mouse leave on content: start close timer
+    el.addEventListener('mouseleave', () => {
+      const root = contentRootMap.get(el)
+      if (!root) return
+
+      // Cancel open timer
+      const ot = root.dataset.nmOpenTimer
+      if (ot) {
+        clearTimeout(Number(ot))
+        root.dataset.nmOpenTimer = ''
+      }
+
+      const closeDelay = Number(root.dataset.nmCloseDelay) || 300
+
+      if (closeDelay > 0) {
+        const timerId = setTimeout(() => {
+          ctx.onActiveValueChange('')
+          root.dataset.nmCloseTimer = ''
+        }, closeDelay) as unknown as number
+        root.dataset.nmCloseTimer = String(timerId)
+      } else {
+        ctx.onActiveValueChange('')
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="navigation-menu-content"
+      data-state="closed"
+      className={`${navigationMenuContentBaseClasses} ${navigationMenuContentClosedClasses} ${props.className ?? ''}`}
+      id={props.id}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+// --- NavigationMenuLink ---
+
+interface NavigationMenuLinkProps extends HTMLBaseAttributes {
+  /** Link URL */
+  href?: string
+  /** Whether this link is the active page */
+  active?: boolean
+  /** Link content */
+  children?: Child
+}
+
+/**
+ * Navigation link element. Stateless.
+ * When active, renders with aria-current="page" and data-active.
+ */
+function NavigationMenuLink({ children, className = '', ...props }: NavigationMenuLinkProps) {
+  const isActive = props.active ?? false
+
+  return (
+    <a
+      data-slot="navigation-menu-link"
+      href={props.href}
+      aria-current={isActive ? 'page' : undefined}
+      data-active={isActive || undefined}
+      className={`${navigationMenuLinkBaseClasses} ${isActive ? navigationMenuLinkActiveClasses : ''} ${className}`}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+}
+
+export type {
+  NavigationMenuProps,
+  NavigationMenuListProps,
+  NavigationMenuItemProps,
+  NavigationMenuTriggerProps,
+  NavigationMenuContentProps,
+  NavigationMenuLinkProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -148,6 +148,12 @@
       "description": "A visually persistent menu common in desktop applications"
     },
     {
+      "name": "navigation-menu",
+      "type": "registry:ui",
+      "title": "Navigation Menu",
+      "description": "A collection of links for navigating websites with hover-activated content panels"
+    },
+    {
       "name": "progress",
       "type": "registry:ui",
       "title": "Progress",


### PR DESCRIPTION
## Summary

- Add `NavigationMenu` component (Root, List, Item, Trigger, Content, Link) with hover-with-delay content panels, click toggle, keyboard navigation, and active page link support
- Architecture combines Menubar's context-based coordination with HoverCard's timer pattern (dataset storage for portal-safe access)
- Register component in sidebar, routes, homepage grid, and page navigation

## Test plan

- [x] IR tests: 41 pass (`bun test ui/components/ui/navigation-menu/`)
- [x] E2E tests: 15 pass (`bunx playwright test e2e/navigation-menu.spec.ts`)
- [x] Site build succeeds (`bun run build`)
- [ ] Manual: verify hover/click triggers, content positioning, link navigation on `/docs/components/navigation-menu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)