### PR TITLE
Batch element refs and fix CSR conformance tests

### DIFF
--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -232,9 +232,9 @@ export function initCounter(__scope, props = {}) {
   //    $()  — regular elements:  find(scope, '[bf="id"]')
   //    $t() — text nodes:        find comment marker <!--bf:id-->
   //    $c() — child components:  find(scope, '[bf-s$="_id"]')
+  //    Single slot: scalar return.  2+ slots: batch with destructuring.
   const _s3 = $(__scope, 's3')
-  const _s0 = $t(__scope, 's0')
-  const _s2 = $t(__scope, 's2')
+  const [_s0, _s2] = $t(__scope, 's0', 's2')
 
   // 6. Dynamic text updates
   createEffect(() => {

--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -228,12 +228,11 @@ export function initCounter(__scope, props = {}) {
   const doubled = createMemo(() => count() * 2)
   const displayValue = `Count: ${count()}`      // late constant (reactive deps)
 
-  // 5. Element references
+  // 5. Element references (always destructured, always returns array)
   //    $()  — regular elements:  find(scope, '[bf="id"]')
   //    $t() — text nodes:        find comment marker <!--bf:id-->
   //    $c() — child components:  find(scope, '[bf-s$="_id"]')
-  //    Single slot: scalar return.  2+ slots: batch with destructuring.
-  const _s3 = $(__scope, 's3')
+  const [_s3] = $(__scope, 's3')
   const [_s0, _s2] = $t(__scope, 's0', 's2')
 
   // 6. Dynamic text updates

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -7,7 +7,6 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { jsxFixtures } from '../../fixtures'
 import { normalizeHTML } from '../jsx-runner'
 import { renderCsrComponent } from '../csr-render'
@@ -34,11 +33,8 @@ describe('CSR Conformance Tests', () => {
     if (!fixture.expectedHtml) continue
 
     test(`[${fixture.id}] ${fixture.description}`, async () => {
-      const adapter = new HonoAdapter()
-
       const html = await renderCsrComponent({
         source: fixture.source,
-        adapter,
         props: fixture.props,
         components: fixture.components,
       })

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -31,7 +31,7 @@ export async function renderCsrComponent(options: CsrRenderOptions): Promise<str
   const childClientJsList: string[] = []
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
-      const childResult = compileJSXSync(childSource, filename, { adapter })
+      const childResult = compileJSXSync(childSource, filename, { adapter, forceTemplates: true })
       const childErrors = childResult.errors.filter(e => e.severity === 'error')
       if (childErrors.length > 0) {
         throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
@@ -43,8 +43,8 @@ export async function renderCsrComponent(options: CsrRenderOptions): Promise<str
     }
   }
 
-  // Compile parent source
-  const result = compileJSXSync(source, 'component.tsx', { adapter })
+  // Compile parent source with forceTemplates to ensure CSR template generation
+  const result = compileJSXSync(source, 'component.tsx', { adapter, forceTemplates: true })
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {
     throw new Error(`Compilation errors:\n${errors.map(e => e.message).join('\n')}`)

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -8,6 +8,7 @@
 
 import {
   analyzeComponent,
+  buildMetadata,
   jsxToIR,
   generateClientJs,
   analyzeClientNeeds,
@@ -52,24 +53,7 @@ function compileToClientJs(source: string, filePath: string): string {
 
   const componentIR: ComponentIR = {
     version: '0.1',
-    metadata: {
-      componentName: ctx.componentName || 'Unknown',
-      hasDefaultExport: ctx.hasDefaultExport,
-      isClientComponent: ctx.hasUseClientDirective,
-      typeDefinitions: ctx.typeDefinitions,
-      propsType: ctx.propsType,
-      propsParams: ctx.propsParams,
-      propsObjectName: ctx.propsObjectName,
-      restPropsName: ctx.restPropsName,
-      restPropsExpandedKeys: ctx.restPropsExpandedKeys,
-      signals: ctx.signals,
-      memos: ctx.memos,
-      effects: ctx.effects,
-      onMounts: ctx.onMounts,
-      imports: ctx.imports,
-      localFunctions: ctx.localFunctions,
-      localConstants: ctx.localConstants,
-    },
+    metadata: buildMetadata(ctx),
     root: ir,
     errors: [],
   }

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -110,9 +110,9 @@ function renderChild(name, props, key, suffix) {
 }
 
 // Noop stubs for init-phase functions (not needed for template evaluation)
-const $ = () => null
-const $t = () => null
-const $c = () => null
+const $ = (...args) => new Array(args.length - 1).fill(null)
+const $t = (...args) => new Array(args.length - 1).fill(null)
+const $c = (...args) => new Array(args.length - 1).fill(null)
 const createSignal = (v) => [() => v, () => {}]
 const createEffect = () => {}
 const createMemo = (fn) => fn

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -32,24 +32,25 @@ export interface CsrRenderOptions {
  * Compile JSX source to client JS with CSR template via lower-level APIs.
  * Forces template generation by adding the component name to usedAsChild.
  */
+function throwIfErrors(ctx: { errors: Array<{ severity: string; message: string }> }, filePath: string): void {
+  const errors = ctx.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compilation errors in ${filePath}:\n${errors.map(e => e.message).join('\n')}`)
+  }
+}
+
 function compileToClientJs(source: string, filePath: string): string {
   const ctx = analyzeComponent(source, filePath)
 
   if (!ctx.jsxReturn) {
-    const errors = ctx.errors.filter(e => e.severity === 'error')
-    if (errors.length > 0) {
-      throw new Error(`Compilation errors in ${filePath}:\n${errors.map(e => e.message).join('\n')}`)
-    }
+    throwIfErrors(ctx, filePath)
     return ''
   }
 
   const ir = jsxToIR(ctx)
   if (!ir) return ''
 
-  const errors = ctx.errors.filter(e => e.severity === 'error')
-  if (errors.length > 0) {
-    throw new Error(`Compilation errors in ${filePath}:\n${errors.map(e => e.message).join('\n')}`)
-  }
+  throwIfErrors(ctx, filePath)
 
   const componentIR: ComponentIR = {
     version: '0.1',

--- a/packages/dom/__tests__/query.test.ts
+++ b/packages/dom/__tests__/query.test.ts
@@ -287,87 +287,35 @@ describe('find', () => {
   })
 })
 
-describe('$c', () => {
+describe('$', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
 
-  test('returns direct child scope only, not nested grandchild with same suffix', () => {
-    // Regression: suffix match [bf-s$="_s3"] was matching grandchild
-    // Demo_abc_s4_s3 in addition to the intended Demo_abc_s3
+  test('finds single element (destructured)', () => {
     document.body.innerHTML = `
       <div bf-s="Demo_abc">
-        <div bf-s="Demo_abc_s3">direct child</div>
-        <div bf-s="Demo_abc_s4">
-          <div bf-s="Demo_abc_s4_s3">nested grandchild</div>
-        </div>
+        <button bf="s0">btn</button>
       </div>
     `
-    const scope = document.querySelector('[bf-s="Demo_abc"]')!
-    const result = $c(scope, 's3')
-    expect(result).not.toBeNull()
-    expect(result?.getAttribute('bf-s')).toBe('Demo_abc_s3')
+    const scope = document.querySelector('[bf-s="Demo_abc"]')
+    const [btn] = $(scope, 's0')
+    expect(btn?.textContent).toBe('btn')
   })
 
-  test('finds child scope by slot ID', () => {
+  test('finds multiple elements', () => {
     document.body.innerHTML = `
-      <div bf-s="Parent_xyz">
-        <div bf-s="Parent_xyz_s1">slot content</div>
+      <div bf-s="Demo_abc">
+        <button bf="s0">btn0</button>
+        <input bf="s1" />
+        <span bf="s2">text</span>
       </div>
     `
-    const scope = document.querySelector('[bf-s="Parent_xyz"]')!
-    const result = $c(scope, 's1')
-    expect(result).not.toBeNull()
-    expect(result?.getAttribute('bf-s')).toBe('Parent_xyz_s1')
-  })
-
-  test('finds child scope by component name prefix', () => {
-    document.body.innerHTML = `
-      <div bf-s="App_root">
-        <div bf-s="Counter_abc123">counter</div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="App_root"]')!
-    const result = $c(scope, 'Counter')
-    expect(result).not.toBeNull()
-    expect(result?.getAttribute('bf-s')).toBe('Counter_abc123')
-  })
-
-  test('returns null for null scope', () => {
-    const result = $c(null, 's0')
-    expect(result).toBeNull()
-  })
-
-  test('strips ^ prefix defensively for slot IDs', () => {
-    document.body.innerHTML = `
-      <div bf-s="Parent_abc">
-        <div bf-s="~DialogTrigger_Parent_abc_s0">trigger</div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="Parent_abc"]')!
-    // Even if ^ accidentally reaches $c, it should still find the element
-    const result = $c(scope, '^s0')
-    expect(result).not.toBeNull()
-    expect(result?.getAttribute('bf-s')).toBe('~DialogTrigger_Parent_abc_s0')
-  })
-
-  test('strips ^ prefix defensively for component name IDs', () => {
-    document.body.innerHTML = `
-      <div bf-s="App_root">
-        <div bf-s="~Counter_abc123">counter</div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="App_root"]')!
-    // ^ prefix on component name should be stripped
-    const result = $c(scope, '^Counter')
-    expect(result).not.toBeNull()
-    expect(result?.getAttribute('bf-s')).toBe('~Counter_abc123')
-  })
-})
-
-describe('$ (parent-owned slots)', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
+    const scope = document.querySelector('[bf-s="Demo_abc"]')
+    const [el0, el1, el2] = $(scope, 's0', 's1', 's2')
+    expect(el0?.textContent).toBe('btn0')
+    expect(el1?.tagName.toLowerCase()).toBe('input')
+    expect(el2?.textContent).toBe('text')
   })
 
   test('finds ^-prefixed slot inside child scope', () => {
@@ -379,7 +327,7 @@ describe('$ (parent-owned slots)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Parent_abc"]')
-    const btn = $(scope, '^s3')
+    const [btn] = $(scope, '^s3')
     expect(btn).not.toBeNull()
     expect(btn?.textContent).toBe('Click')
   })
@@ -395,7 +343,7 @@ describe('$ (parent-owned slots)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Parent_abc"]')
-    const input = $(scope, '^s5')
+    const [input] = $(scope, '^s5')
     expect(input).not.toBeNull()
     expect(input?.getAttribute('type')).toBe('text')
   })
@@ -410,51 +358,12 @@ describe('$ (parent-owned slots)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Dialog_abc"]')
-    const closeBtn = $(scope, '^s2')
+    const [closeBtn] = $(scope, '^s2')
     expect(closeBtn).not.toBeNull()
     expect(closeBtn?.textContent).toBe('Close')
   })
 
-  test('does NOT find regular slot in child scope (existing behavior preserved)', () => {
-    document.body.innerHTML = `
-      <div bf-s="Parent_abc">
-        <div bf-s="~Child_xyz">
-          <button bf="s3">Click</button>
-        </div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="Parent_abc"]')
-    const btn = $(scope, 's3')
-    expect(btn).toBeNull()
-  })
-
-  test('returns null for null scope with ^-prefixed slot', () => {
-    const el = $(null, '^s0')
-    expect(el).toBeNull()
-  })
-})
-
-describe('$ (batch mode)', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
-  test('returns array for 2+ IDs', () => {
-    document.body.innerHTML = `
-      <div bf-s="Demo_abc">
-        <button bf="s0">btn0</button>
-        <input bf="s1" />
-        <span bf="s2">text</span>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="Demo_abc"]')
-    const [el0, el1, el2] = $(scope, 's0', 's1', 's2') as (Element | null)[]
-    expect(el0?.textContent).toBe('btn0')
-    expect(el1?.tagName.toLowerCase()).toBe('input')
-    expect(el2?.textContent).toBe('text')
-  })
-
-  test('batch with mix of regular and ^-prefixed IDs', () => {
+  test('mix of regular and ^-prefixed IDs', () => {
     document.body.innerHTML = `
       <div bf-s="Parent_abc">
         <button bf="s0">regular</button>
@@ -464,30 +373,144 @@ describe('$ (batch mode)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Parent_abc"]')
-    const [el0, el1] = $(scope, 's0', '^s1') as (Element | null)[]
+    const [el0, el1] = $(scope, 's0', '^s1')
     expect(el0?.textContent).toBe('regular')
     expect(el1?.textContent).toBe('parent-owned')
   })
 
-  test('batch with null scope returns array of nulls', () => {
-    const results = $(null, 's0', 's1') as (Element | null)[]
-    expect(results).toEqual([null, null])
+  test('does NOT find regular slot in child scope', () => {
+    document.body.innerHTML = `
+      <div bf-s="Parent_abc">
+        <div bf-s="~Child_xyz">
+          <button bf="s3">Click</button>
+        </div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Parent_abc"]')
+    const [btn] = $(scope, 's3')
+    expect(btn).toBeNull()
   })
 
-  test('batch with missing elements returns null for those slots', () => {
+  test('null scope returns array of nulls', () => {
+    const [a, b] = $(null, 's0', 's1')
+    expect(a).toBeNull()
+    expect(b).toBeNull()
+  })
+
+  test('missing elements return null', () => {
     document.body.innerHTML = `
       <div bf-s="Demo_abc">
         <button bf="s0">exists</button>
       </div>
     `
     const scope = document.querySelector('[bf-s="Demo_abc"]')
-    const [el0, el1] = $(scope, 's0', 's1') as (Element | null)[]
+    const [el0, el1] = $(scope, 's0', 's1')
     expect(el0?.textContent).toBe('exists')
     expect(el1).toBeNull()
   })
 })
 
-describe('$t (single mode)', () => {
+describe('$c', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('returns direct child scope only, not nested grandchild with same suffix', () => {
+    document.body.innerHTML = `
+      <div bf-s="Demo_abc">
+        <div bf-s="Demo_abc_s3">direct child</div>
+        <div bf-s="Demo_abc_s4">
+          <div bf-s="Demo_abc_s4_s3">nested grandchild</div>
+        </div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Demo_abc"]')!
+    const [result] = $c(scope, 's3')
+    expect(result).not.toBeNull()
+    expect(result?.getAttribute('bf-s')).toBe('Demo_abc_s3')
+  })
+
+  test('finds child scope by slot ID', () => {
+    document.body.innerHTML = `
+      <div bf-s="Parent_xyz">
+        <div bf-s="Parent_xyz_s1">slot content</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Parent_xyz"]')!
+    const [result] = $c(scope, 's1')
+    expect(result).not.toBeNull()
+    expect(result?.getAttribute('bf-s')).toBe('Parent_xyz_s1')
+  })
+
+  test('finds child scope by component name prefix', () => {
+    document.body.innerHTML = `
+      <div bf-s="App_root">
+        <div bf-s="Counter_abc123">counter</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="App_root"]')!
+    const [result] = $c(scope, 'Counter')
+    expect(result).not.toBeNull()
+    expect(result?.getAttribute('bf-s')).toBe('Counter_abc123')
+  })
+
+  test('null scope returns array of nulls', () => {
+    const [result] = $c(null, 's0')
+    expect(result).toBeNull()
+  })
+
+  test('strips ^ prefix defensively for slot IDs', () => {
+    document.body.innerHTML = `
+      <div bf-s="Parent_abc">
+        <div bf-s="~DialogTrigger_Parent_abc_s0">trigger</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Parent_abc"]')!
+    const [result] = $c(scope, '^s0')
+    expect(result).not.toBeNull()
+    expect(result?.getAttribute('bf-s')).toBe('~DialogTrigger_Parent_abc_s0')
+  })
+
+  test('strips ^ prefix defensively for component name IDs', () => {
+    document.body.innerHTML = `
+      <div bf-s="App_root">
+        <div bf-s="~Counter_abc123">counter</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="App_root"]')!
+    const [result] = $c(scope, '^Counter')
+    expect(result).not.toBeNull()
+    expect(result?.getAttribute('bf-s')).toBe('~Counter_abc123')
+  })
+
+  test('finds multiple child scopes', () => {
+    document.body.innerHTML = `
+      <div bf-s="App_abc">
+        <div bf-s="App_abc_s0">child0</div>
+        <div bf-s="App_abc_s1">child1</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="App_abc"]')!
+    const [c0, c1] = $c(scope, 's0', 's1')
+    expect(c0?.textContent).toBe('child0')
+    expect(c1?.textContent).toBe('child1')
+  })
+
+  test('mix of slot IDs and component names', () => {
+    document.body.innerHTML = `
+      <div bf-s="App_abc">
+        <div bf-s="App_abc_s0">slot</div>
+        <div bf-s="~Counter_xyz">counter</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="App_abc"]')!
+    const [c0, c1] = $c(scope, 's0', 'Counter')
+    expect(c0?.textContent).toBe('slot')
+    expect(c1?.textContent).toBe('counter')
+  })
+})
+
+describe('$t', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
@@ -497,7 +520,7 @@ describe('$t (single mode)', () => {
       <div bf-s="Counter_abc"><!--bf:s0-->42<!--/--></div>
     `
     const scope = document.querySelector('[bf-s="Counter_abc"]')
-    const textNode = $t(scope, 's0')
+    const [textNode] = $t(scope, 's0')
     expect(textNode).not.toBeNull()
     expect(textNode?.nodeValue).toBe('42')
   })
@@ -507,13 +530,14 @@ describe('$t (single mode)', () => {
       <div bf-s="Counter_abc"><!--bf:s0--><!--/--></div>
     `
     const scope = document.querySelector('[bf-s="Counter_abc"]')
-    const textNode = $t(scope, 's0')
+    const [textNode] = $t(scope, 's0')
     expect(textNode).not.toBeNull()
     expect(textNode?.nodeValue).toBe('')
   })
 
-  test('returns null for null scope', () => {
-    expect($t(null, 's0')).toBeNull()
+  test('null scope returns array of nulls', () => {
+    const [t] = $t(null, 's0')
+    expect(t).toBeNull()
   })
 
   test('returns null for missing marker', () => {
@@ -521,7 +545,8 @@ describe('$t (single mode)', () => {
       <div bf-s="Counter_abc">no markers here</div>
     `
     const scope = document.querySelector('[bf-s="Counter_abc"]')
-    expect($t(scope, 's0')).toBeNull()
+    const [t] = $t(scope, 's0')
+    expect(t).toBeNull()
   })
 
   test('does not find marker inside nested child scope', () => {
@@ -531,7 +556,8 @@ describe('$t (single mode)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Parent_abc"]')
-    expect($t(scope, 's0')).toBeNull()
+    const [t] = $t(scope, 's0')
+    expect(t).toBeNull()
   })
 
   test('finds ^-prefixed marker (parent-owned)', () => {
@@ -541,15 +567,9 @@ describe('$t (single mode)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Parent_abc"]')
-    const textNode = $t(scope, '^s1')
+    const [textNode] = $t(scope, '^s1')
     expect(textNode).not.toBeNull()
     expect(textNode?.nodeValue).toBe('owned')
-  })
-})
-
-describe('$t (batch mode)', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
   })
 
   test('finds multiple text nodes in single TreeWalker pass', () => {
@@ -560,74 +580,32 @@ describe('$t (batch mode)', () => {
       </div>
     `
     const scope = document.querySelector('[bf-s="Demo_abc"]')
-    const [t0, t1] = $t(scope, 's0', 's1') as (Text | null)[]
+    const [t0, t1] = $t(scope, 's0', 's1')
     expect(t0?.nodeValue).toBe('hello')
     expect(t1?.nodeValue).toBe('world')
   })
 
-  test('batch with null scope returns array of nulls', () => {
-    const results = $t(null, 's0', 's1') as (Text | null)[]
-    expect(results).toEqual([null, null])
-  })
-
-  test('batch with missing markers returns null for those slots', () => {
+  test('missing markers return null', () => {
     document.body.innerHTML = `
       <div bf-s="Demo_abc">
         <p><!--bf:s0-->found<!--/--></p>
       </div>
     `
     const scope = document.querySelector('[bf-s="Demo_abc"]')
-    const [t0, t1] = $t(scope, 's0', 's1') as (Text | null)[]
+    const [t0, t1] = $t(scope, 's0', 's1')
     expect(t0?.nodeValue).toBe('found')
     expect(t1).toBeNull()
   })
 
-  test('batch creates text nodes when none exist after markers', () => {
+  test('creates text nodes when none exist after markers', () => {
     document.body.innerHTML = `
       <div bf-s="Demo_abc"><!--bf:s0--><!--/--><!--bf:s1--><!--/--></div>
     `
     const scope = document.querySelector('[bf-s="Demo_abc"]')
-    const [t0, t1] = $t(scope, 's0', 's1') as (Text | null)[]
+    const [t0, t1] = $t(scope, 's0', 's1')
     expect(t0).not.toBeNull()
     expect(t0?.nodeValue).toBe('')
     expect(t1).not.toBeNull()
     expect(t1?.nodeValue).toBe('')
-  })
-})
-
-describe('$c (batch mode)', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
-  test('finds multiple child scopes by slot ID', () => {
-    document.body.innerHTML = `
-      <div bf-s="App_abc">
-        <div bf-s="App_abc_s0">child0</div>
-        <div bf-s="App_abc_s1">child1</div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="App_abc"]')!
-    const [c0, c1] = $c(scope, 's0', 's1') as (Element | null)[]
-    expect(c0?.textContent).toBe('child0')
-    expect(c1?.textContent).toBe('child1')
-  })
-
-  test('batch with mix of slot IDs and component names', () => {
-    document.body.innerHTML = `
-      <div bf-s="App_abc">
-        <div bf-s="App_abc_s0">slot</div>
-        <div bf-s="~Counter_xyz">counter</div>
-      </div>
-    `
-    const scope = document.querySelector('[bf-s="App_abc"]')!
-    const [c0, c1] = $c(scope, 's0', 'Counter') as (Element | null)[]
-    expect(c0?.textContent).toBe('slot')
-    expect(c1?.textContent).toBe('counter')
-  })
-
-  test('batch with null scope returns array of nulls', () => {
-    const results = $c(null, 's0', 's1') as (Element | null)[]
-    expect(results).toEqual([null, null])
   })
 })

--- a/packages/dom/src/query.ts
+++ b/packages/dom/src/query.ts
@@ -377,30 +377,15 @@ function findInPortals(scopeId: string, selector: string): Element | null {
 // --- shorthand finders ---
 
 /**
- * Shorthand for find(scope, '[bf="id"]').
+ * Find elements within a scope by slot IDs.
  * Used by compiler-generated code for regular slot element references.
+ * Always returns an array — callers use destructuring.
  *
  * For parent-owned slots (^-prefixed IDs like '^s3'), searches all descendants
  * ignoring scope boundaries. This handles elements passed as children to child
  * components — they are owned by the parent but rendered inside the child's scope.
- *
- * Supports batch mode: pass multiple IDs to get an array of results.
- * Single ID returns a scalar (backward compatible).
- *
- * @param scope - The scope element to search within
- * @param id - The slot ID (e.g., 's0' or '^s3')
- * @returns The matching element or null (scalar for 1 ID, array for 2+)
  */
-export function $(scope: Element | null, id: string): Element | null
-export function $(scope: Element | null, id1: string, id2: string, ...rest: string[]): (Element | null)[]
-export function $(scope: Element | null, ...ids: string[]): Element | null | (Element | null)[] {
-  if (ids.length === 1) {
-    const id = ids[0]
-    if (id.startsWith(BF_PARENT_OWNED_PREFIX)) {
-      return findParentOwned(scope, id)
-    }
-    return find(scope, `[${BF_SLOT}="${id}"]`)
-  }
+export function $(scope: Element | null, ...ids: string[]): (Element | null)[] {
   return ids.map(id => {
     if (id.startsWith(BF_PARENT_OWNED_PREFIX)) {
       return findParentOwned(scope, id)
@@ -461,22 +446,12 @@ function findParentOwned(scope: Element | null, id: string): Element | null {
 }
 
 /**
- * Shorthand for finding child component scope elements.
+ * Find child component scope elements by slot ID or component name.
  * - Slot ID (e.g., 's1'): uses suffix match [bf-s$="_s1"]
  * - Component name (e.g., 'Counter'): uses prefix match [bf-s^="Counter_"]
- *
- * Supports batch mode: pass multiple IDs to get an array of results.
- *
- * @param scope - The scope element to search within
- * @param id - Slot ID suffix or component name
- * @returns The matching element or null (scalar for 1 ID, array for 2+)
+ * Always returns an array — callers use destructuring.
  */
-export function $c(scope: Element | null, id: string): Element | null
-export function $c(scope: Element | null, id1: string, id2: string, ...rest: string[]): (Element | null)[]
-export function $c(scope: Element | null, ...ids: string[]): Element | null | (Element | null)[] {
-  if (ids.length === 1) {
-    return $cSingle(scope, ids[0])
-  }
+export function $c(scope: Element | null, ...ids: string[]): (Element | null)[] {
   return ids.map(id => $cSingle(scope, id))
 }
 
@@ -495,60 +470,14 @@ function $cSingle(scope: Element | null, id: string): Element | null {
 // --- $t: text node finder via comment markers ---
 
 /**
- * Find the Text node for a reactive text expression marked by comment nodes.
+ * Find Text nodes for reactive text expressions marked by comment nodes.
  * Expects marker format: <!--bf:sX-->text<!--/-->
+ * Always returns an array — callers use destructuring.
  *
- * Used by compiler-generated code for reactive text expressions (e.g., {count()}).
- * Returns the Text node after the start comment marker so that
- * createEffect can update it via .nodeValue without needing a wrapper <span>.
- *
- * Supports batch mode: pass multiple IDs to find all text nodes in a single
- * TreeWalker pass, with early exit when all markers are found.
- *
- * @param scope - The component scope element to search within
- * @param id - The slot ID (e.g., 's0' or '^s3')
- * @returns The Text node or null (scalar for 1 ID, array for 2+)
+ * Uses a single TreeWalker pass to find all markers at once,
+ * with early exit when all are found.
  */
-export function $t(scope: Element | null, id: string): Text | null
-export function $t(scope: Element | null, id1: string, id2: string, ...rest: string[]): (Text | null)[]
-export function $t(scope: Element | null, ...ids: string[]): Text | null | (Text | null)[] {
-  if (ids.length === 1) {
-    return $tSingle(scope, ids[0])
-  }
-  return $tBatch(scope, ids)
-}
-
-function $tSingle(scope: Element | null, id: string): Text | null {
-  if (!scope) return null
-  // Keep the full id (including ^ prefix) for marker matching —
-  // parent-owned slots produce <!--bf:^sN--> in the HTML.
-  const marker = `bf:${id}`
-  const isParentOwned = id.startsWith(BF_PARENT_OWNED_PREFIX)
-
-  // Determine search root
-  const commentInfo = commentScopeRegistry.get(scope)
-  const searchRoot: Node = commentInfo ? (commentInfo.commentNode.parentNode ?? scope) : scope
-
-  const walker = document.createTreeWalker(searchRoot, NodeFilter.SHOW_COMMENT)
-  while (walker.nextNode()) {
-    const comment = walker.currentNode as Comment
-    if (comment.nodeValue === marker) {
-      // For non-parent-owned slots, verify the comment belongs to this scope
-      // (not inside a nested child component scope)
-      if (!isParentOwned && !commentBelongsToScope(comment, scope, commentInfo)) {
-        continue
-      }
-      return textNodeAfterComment(comment)
-    }
-  }
-  return null
-}
-
-/**
- * Batch mode: single TreeWalker pass to find all text node markers at once.
- * Early-exits when all markers are found.
- */
-function $tBatch(scope: Element | null, ids: string[]): (Text | null)[] {
+export function $t(scope: Element | null, ...ids: string[]): (Text | null)[] {
   const results: (Text | null)[] = new Array(ids.length).fill(null)
   if (!scope) return results
 

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -96,7 +96,12 @@ export async function compileJSX(
     type: 'markedTemplate',
   })
 
-  const clientJs = generateClientJs(componentIR)
+  // When forceTemplates is enabled, treat the component as "used as child"
+  // so that CSR fallback template is always generated.
+  const usedAsChild = options.forceTemplates
+    ? new Set([componentIR.metadata.componentName])
+    : undefined
+  const clientJs = generateClientJs(componentIR, undefined, usedAsChild)
   if (clientJs) {
     files.push({
       path: entryPath.replace(/\.tsx?$/, '.client.js'),
@@ -157,6 +162,12 @@ function compileMultipleComponentsSync(
   const usedAsChild = new Set<string>()
   for (const { componentIR } of entries) {
     collectComponentNamesFromIR([componentIR.root], usedAsChild)
+  }
+  // When forceTemplates is enabled, include all component names
+  if (options.forceTemplates) {
+    for (const name of componentNames) {
+      usedAsChild.add(name)
+    }
   }
 
   // --- Pass 2: adapter.generate + generateClientJs ---
@@ -393,7 +404,12 @@ export function compileJSXSync(
     type: 'markedTemplate',
   })
 
-  const clientJs = generateClientJs(componentIR)
+  // When forceTemplates is enabled, treat the component as "used as child"
+  // so that CSR fallback template is always generated.
+  const usedAsChild = options.forceTemplates
+    ? new Set([componentIR.metadata.componentName])
+    : undefined
+  const clientJs = generateClientJs(componentIR, undefined, usedAsChild)
   if (clientJs) {
     files.push({
       path: filePath.replace(/\.tsx?$/, '.client.js'),

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -303,7 +303,7 @@ async function compileMultipleComponents(
 // Helpers
 // =============================================================================
 
-function buildMetadata(
+export function buildMetadata(
   ctx: ReturnType<typeof analyzeComponent>
 ): IRMetadata {
   return {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -96,12 +96,7 @@ export async function compileJSX(
     type: 'markedTemplate',
   })
 
-  // When forceTemplates is enabled, treat the component as "used as child"
-  // so that CSR fallback template is always generated.
-  const usedAsChild = options.forceTemplates
-    ? new Set([componentIR.metadata.componentName])
-    : undefined
-  const clientJs = generateClientJs(componentIR, undefined, usedAsChild)
+  const clientJs = generateClientJs(componentIR)
   if (clientJs) {
     files.push({
       path: entryPath.replace(/\.tsx?$/, '.client.js'),
@@ -162,12 +157,6 @@ function compileMultipleComponentsSync(
   const usedAsChild = new Set<string>()
   for (const { componentIR } of entries) {
     collectComponentNamesFromIR([componentIR.root], usedAsChild)
-  }
-  // When forceTemplates is enabled, include all component names
-  if (options.forceTemplates) {
-    for (const name of componentNames) {
-      usedAsChild.add(name)
-    }
   }
 
   // --- Pass 2: adapter.generate + generateClientJs ---
@@ -404,12 +393,7 @@ export function compileJSXSync(
     type: 'markedTemplate',
   })
 
-  // When forceTemplates is enabled, treat the component as "used as child"
-  // so that CSR fallback template is always generated.
-  const usedAsChild = options.forceTemplates
-    ? new Set([componentIR.metadata.componentName])
-    : undefined
-  const clientJs = generateClientJs(componentIR, undefined, usedAsChild)
+  const clientJs = generateClientJs(componentIR)
   if (clientJs) {
     files.push({
       path: filePath.replace(/\.tsx?$/, '.client.js'),

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Main compiler API
-export { compileJSX, compileJSXSync } from './compiler'
+export { compileJSX, compileJSXSync, buildMetadata } from './compiler'
 export type { CompileResult, CompileOptions, CompileOptionsWithAdapter, FileOutput } from './compiler'
 
 // Pure IR types

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -686,10 +686,8 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
       const first = props[0]
       const varSuffix = first.slotId ? varSlotId(first.slotId).replace(/-/g, '_') : first.componentName
       const varName = `__${first.componentName}_${varSuffix}El`
-      const selectorBase = first.slotId
-        ? `$c(__scope, '${first.slotId}')`
-        : `$c(__scope, '${first.componentName}')`
-      lines.push(`    const ${varName} = ${selectorBase}`)
+      const selectorArg = first.slotId ? first.slotId : first.componentName
+      lines.push(`    const [${varName}] = $c(__scope, '${selectorArg}')`)
       lines.push(`    if (${varName}) {`)
       for (const prop of props) {
         if (prop.attrName === 'class') {

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -248,7 +248,7 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
         }
         for (const elem of conditionalElems) {
           const v = varSlotId(elem.slotId)
-          lines.push(`    const __el_${v} = $t(__scope, '${elem.slotId}')`)
+          lines.push(`    const [__el_${v}] = $t(__scope, '${elem.slotId}')`)
           lines.push(`    if (__el_${v}) __el_${v}.nodeValue = String(__val)`)
         }
       } else {
@@ -257,7 +257,7 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
         // parent prop is undefined (e.g. prev?.title when prev is undefined).
         for (const elem of conditionalElems) {
           const v = varSlotId(elem.slotId)
-          lines.push(`    const __el_${v} = $t(__scope, '${elem.slotId}')`)
+          lines.push(`    const [__el_${v}] = $t(__scope, '${elem.slotId}')`)
           lines.push(`    if (__el_${v}) __el_${v}.nodeValue = String(${expr})`)
         }
       }
@@ -337,8 +337,11 @@ function emitBranchBindings(
     eventsBySlot.get(event.slotId)!.push(event)
   }
 
-  for (const slotId of allSlotIds) {
-    lines.push(`      const _${varSlotId(slotId)} = $(__branchScope, '${slotId}')`)
+  if (allSlotIds.size > 0) {
+    const slotArr = [...allSlotIds]
+    const vars = slotArr.map(id => `_${varSlotId(id)}`).join(', ')
+    const args = slotArr.map(id => `'${id}'`).join(', ')
+    lines.push(`      const [${vars}] = $(__branchScope, ${args})`)
   }
 
   for (const [slotId, slotEvents] of eventsBySlot) {

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -309,22 +309,29 @@ export function generateElementRefs(ctx: ClientJsContext): string {
 
   const refLines: string[] = []
 
-  // Regular element slots use $() shorthand for find(scope, '[bf="id"]')
-  for (const slotId of regularSlots) {
-    refLines.push(`  const _${varSlotId(slotId)} = $(__scope, '${slotId}')`)
-  }
-
-  // Text slots use $t() to find Text nodes via comment markers <!--bf:id-->
-  for (const slotId of textSlots) {
-    refLines.push(`  const _${varSlotId(slotId)} = $t(__scope, '${slotId}')`)
-  }
-
-  // Component slots use $c() shorthand for find(scope, '[bf-s$="_id"]')
-  for (const slotId of componentSlots) {
-    refLines.push(`  const _${varSlotId(slotId)} = $c(__scope, '${slotId}')`)
-  }
+  // Emit element ref declarations, batching 2+ slots into destructured calls
+  emitSlotRefs(refLines, [...regularSlots], '$')
+  emitSlotRefs(refLines, [...textSlots], '$t')
+  emitSlotRefs(refLines, [...componentSlots], '$c')
 
   return refLines.join('\n')
+}
+
+/**
+ * Emit element ref declarations for a set of slot IDs using the given finder function.
+ * Single slot: `const _sN = fn(__scope, 'sN')`
+ * Multiple slots: `const [_sN, _sM] = fn(__scope, 'sN', 'sM')`
+ */
+function emitSlotRefs(lines: string[], slotIds: string[], fn: string): void {
+  if (slotIds.length === 0) return
+  if (slotIds.length === 1) {
+    const id = slotIds[0]
+    lines.push(`  const _${varSlotId(id)} = ${fn}(__scope, '${id}')`)
+    return
+  }
+  const vars = slotIds.map(id => `_${varSlotId(id)}`).join(', ')
+  const args = slotIds.map(id => `'${id}'`).join(', ')
+  lines.push(`  const [${vars}] = ${fn}(__scope, ${args})`)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -319,16 +319,10 @@ export function generateElementRefs(ctx: ClientJsContext): string {
 
 /**
  * Emit element ref declarations for a set of slot IDs using the given finder function.
- * Single slot: `const _sN = fn(__scope, 'sN')`
- * Multiple slots: `const [_sN, _sM] = fn(__scope, 'sN', 'sM')`
+ * Always emits destructured form: `const [_sN, ...] = fn(__scope, 'sN', ...)`
  */
 function emitSlotRefs(lines: string[], slotIds: string[], fn: string): void {
   if (slotIds.length === 0) return
-  if (slotIds.length === 1) {
-    const id = slotIds[0]
-    lines.push(`  const _${varSlotId(id)} = ${fn}(__scope, '${id}')`)
-    return
-  }
   const vars = slotIds.map(id => `_${varSlotId(id)}`).join(', ')
   const args = slotIds.map(id => `'${id}'`).join(', ')
   lines.push(`  const [${vars}] = ${fn}(__scope, ${args})`)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -452,11 +452,6 @@ export interface CompileOptions {
    * Example: 'components' → classes prefixed with 'layer-components:'
    */
   cssLayerPrefix?: string
-  /** Force CSR template generation for all components, even top-level ones.
-   * Normally only components used as children get CSR templates to save bytes.
-   * Enable for CSR conformance testing or standalone CSR rendering.
-   */
-  forceTemplates?: boolean
 }
 
 export interface FileOutput {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -452,6 +452,11 @@ export interface CompileOptions {
    * Example: 'components' → classes prefixed with 'layer-components:'
    */
   cssLayerPrefix?: string
+  /** Force CSR template generation for all components, even top-level ones.
+   * Normally only components used as children get CSR templates to save bytes.
+   * Enable for CSR conformance testing or standalone CSR rendering.
+   */
+  forceTemplates?: boolean
 }
 
 export interface FileOutput {


### PR DESCRIPTION
## Summary

- **Batch element refs**: `$`, `$t`, `$c` always return arrays. Generated client JS always uses destructured assignments, reducing code size by eliminating repeated `$(__scope, ` prefixes for multi-slot components.
- **`$t` single TreeWalker pass**: Multiple text node markers are found in one tree walk with early exit.
- **CSR conformance tests**: Rewrite `csr-render.ts` to use lower-level compiler APIs (`analyzeComponent`, `jsxToIR`, `generateClientJs`) directly, removing the need for an adapter and the removed `forceTemplates` option.
- **Export `buildMetadata`**: Exposed from `@barefootjs/jsx` to avoid duplicating IR construction logic in test utilities.
- **Fix conditional branch codegen**: Update `$`/`$t` calls inside conditional branch `bindEvents` callbacks to use destructured form.

### Before (6 lines, ~180 bytes)
```javascript
const _s0 = $(__scope, 's0')
const _s1 = $(__scope, 's1')
const _s3 = $(__scope, 's3')
const _s2 = $t(__scope, 's2')
const _s5 = $t(__scope, 's5')
```

### After (2 lines, ~110 bytes)
```javascript
const [_s0, _s1, _s3] = $(__scope, 's0', 's1', 's3')
const [_s2, _s5] = $t(__scope, 's2', 's5')
```

## Test plan

- [x] `bun test packages/dom` — 48 tests pass
- [x] `bun test packages/jsx` — 135 tests pass
- [x] `bun test packages/test` — all pass
- [x] `bun test packages/adapter-tests` — 63 tests pass
- [x] E2E (e2e-hono) — 98/98 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)