### PR TITLE
Add barefoot build CLI command with config-driven pipeline

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,20 +1,10 @@
 // Build config types for barefoot.config.ts
 
-import type { TemplateAdapter } from '@barefootjs/jsx'
+import type { TemplateAdapter, BuildOptions } from '@barefootjs/jsx'
 
-export interface BarefootBuildConfig {
+export interface BarefootBuildConfig extends BuildOptions {
   /** Adapter instance (e.g. HonoAdapter, GoTemplateAdapter) */
   adapter: TemplateAdapter
-  /** Source component directories relative to config file */
-  components?: string[]
-  /** Output directory relative to config file */
-  outDir?: string
-  /** Minify client JS output */
-  minify?: boolean
-  /** Add content hash to client JS filenames */
-  contentHash?: boolean
-  /** Output only client JS, skip marked templates and manifest */
-  clientOnly?: boolean
   /** Adapter-specific post-processing hook for marked templates */
   transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string
 }

--- a/packages/go-template/src/build.ts
+++ b/packages/go-template/src/build.ts
@@ -1,19 +1,10 @@
 // Go template build config factory for barefoot.config.ts
 
+import type { BuildOptions } from '@barefootjs/jsx'
 import { GoTemplateAdapter } from './adapter'
 import type { GoTemplateAdapterOptions } from './adapter'
 
-export interface GoTemplateBuildOptions {
-  /** Source component directories relative to config file */
-  components?: string[]
-  /** Output directory relative to config file */
-  outDir?: string
-  /** Minify client JS output */
-  minify?: boolean
-  /** Add content hash to client JS filenames */
-  contentHash?: boolean
-  /** Output only client JS, skip marked templates and manifest */
-  clientOnly?: boolean
+export interface GoTemplateBuildOptions extends BuildOptions {
   /** Adapter-specific options passed to GoTemplateAdapter */
   adapterOptions?: GoTemplateAdapterOptions
 }

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -1,19 +1,10 @@
 // Hono build config factory for barefoot.config.ts
 
+import type { BuildOptions } from '@barefootjs/jsx'
 import { HonoAdapter } from './adapter'
 import type { HonoAdapterOptions } from './adapter'
 
-export interface HonoBuildOptions {
-  /** Source component directories relative to config file */
-  components?: string[]
-  /** Output directory relative to config file */
-  outDir?: string
-  /** Minify client JS output */
-  minify?: boolean
-  /** Add content hash to client JS filenames */
-  contentHash?: boolean
-  /** Output only client JS, skip marked templates and manifest */
-  clientOnly?: boolean
+export interface HonoBuildOptions extends BuildOptions {
   /** Inject Hono script collection wrapper (default: true) */
   scriptCollection?: boolean
   /** Adapter-specific options passed to HonoAdapter */

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -49,6 +49,20 @@ export { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
 // Client JS Combiner (for build scripts)
 export { combineParentChildClientJs } from './combine-client-js'
 
+// Build options (shared by adapters and CLI)
+export interface BuildOptions {
+  /** Source component directories relative to config file */
+  components?: string[]
+  /** Output directory relative to config file */
+  outDir?: string
+  /** Minify client JS output */
+  minify?: boolean
+  /** Add content hash to client JS filenames */
+  contentHash?: boolean
+  /** Output only client JS, skip marked templates and manifest */
+  clientOnly?: boolean
+}
+
 // CSS Layer Prefixer
 export { applyCssLayerPrefix } from './css-layer-prefixer'
 


### PR DESCRIPTION
## Summary

- Add `barefoot build` CLI command that reads `barefoot.config.ts` for adapter-driven compilation
- Replace per-project build scripts (`examples/hono/build.ts`, `examples/csr/build.ts`) with shared `barefoot build` command
- Add adapter build config factories: `createConfig()` in `@barefootjs/hono` and `@barefootjs/go-template`
- Extract shared `BuildOptions` interface into `@barefootjs/jsx` to eliminate duplication across adapters and CLI
- Support `--minify`, `--content-hash`, `--client-only` CLI flags with config file defaults
- Refactor site builds (`site/core`, `site/ui`) to use the shared build utilities

## Test plan

- [x] `bun test packages/cli/` — 180 tests pass (build pipeline, config loader)
- [x] `bun test packages/hono/` — 43 tests pass (Hono adapter build, script collection)
- [x] `cd examples/hono && bun run ../../packages/cli/src/index.ts build` — builds successfully
- [x] Verify `BuildOptions` extends work correctly across all adapter packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)