### PR TITLE
Add Reactive<T> brand type for type-based reactivity detection

### DIFF
--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -96,14 +96,18 @@ The `jsxToIR` function (`jsx-to-ir.ts`) transforms the analyzed JSX AST into the
 
 The core decision at this phase is: **is this expression reactive?**
 
-```typescript
-function isReactiveExpression(expr: string, ctx: AnalyzerContext): boolean
-```
+The compiler uses a two-tier detection strategy:
 
-An expression is reactive if it references:
-- A signal getter: `count()` — detected by pattern `\bcount\s*\(`
+1. **TypeChecker path** — Walks the AST and checks each node's type for the `Reactive<T>` brand via `checker.getTypeAtLocation()`. This detects all reactive getters: signals, memos, and library-provided reactive accessors (e.g., `FieldReturn.error`, `FormReturn.isSubmitting`).
+
+2. **Regex fallback** — Pattern-matches known signal/memo names and props references. Used when the TypeChecker cannot resolve imported types.
+
+An expression is reactive if it matches any of:
+- A `Reactive<T>`-branded type (via TypeChecker)
+- A signal getter: `count()` — regex pattern `\bcount\s*\(`
 - A memo: `doubled()` — same pattern
-- A props reference: `props.value` — detected by `\bprops\.\w+`
+- A props reference: `props.value` — per-prop name matching (excludes `children`)
+- A local constant derived from any of the above (taint analysis)
 
 Reactive expressions get a `slotId` assigned, which becomes a `bf` hydration marker in the output.
 

--- a/docs/core/core-concepts/reactivity.md
+++ b/docs/core/core-concepts/reactivity.md
@@ -7,6 +7,8 @@ description: Fine-grained reactivity with signals, effects, and memos
 
 BarefootJS uses fine-grained reactivity inspired by SolidJS. The core primitives are **signals**, **effects**, and **memos**.
 
+All reactive getters carry the `Reactive<T>` phantom brand — a compile-time type marker that the compiler uses to identify reactive expressions. The brand has no runtime cost; it enables the compiler to detect reactivity via TypeScript's type system rather than name-based pattern matching alone.
+
 ## Signals
 
 A signal holds a reactive value. It returns a getter/setter pair:
@@ -19,7 +21,7 @@ setCount(5)          // Write: set to 5
 setCount(n => n + 1) // Write: updater function
 ```
 
-The getter is a **function call** — `count()`, not `count`. This is how the reactivity system tracks which effects depend on which signals.
+The getter is a **function call** — `count()`, not `count`. This is how the reactivity system tracks which effects depend on which signals. The getter is typed as `Reactive<() => T>`, which the compiler recognizes as a reactive expression.
 
 ## Effects
 

--- a/docs/core/reactivity/create-memo.md
+++ b/docs/core/reactivity/create-memo.md
@@ -5,10 +5,10 @@ Creates a cached derived value. Recomputes only when its dependencies change.
 ```tsx
 import { createMemo } from '@barefootjs/dom'
 
-const getter = createMemo<T>(fn: () => T): () => T
+const getter = createMemo<T>(fn: () => T): Memo<T>
 ```
 
-Returns a read-only getter function.
+Returns a read-only getter function typed as `Memo<T>` (alias for `Reactive<() => T>`). The `Reactive<T>` brand is a compile-time marker that the compiler uses to identify reactive expressions.
 
 
 ## Basic Usage

--- a/docs/core/reactivity/create-signal.md
+++ b/docs/core/reactivity/create-signal.md
@@ -11,11 +11,15 @@ const [getter, setter] = createSignal<T>(initialValue: T)
 **Type:**
 
 ```tsx
+type Reactive<T> = T & { readonly __reactive: true }
+
 type Signal<T> = [
-  () => T,                                    // getter
+  Reactive<() => T>,                          // getter (carries Reactive brand)
   (valueOrFn: T | ((prev: T) => T)) => void  // setter
 ]
 ```
+
+The getter carries the `Reactive<T>` phantom brand — a compile-time marker that the compiler uses to identify reactive expressions. The brand has no runtime cost.
 
 
 ## Basic Usage

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -18,6 +18,7 @@ export {
   onCleanup,
   onMount,
   untrack,
+  type Reactive,
   type Signal,
   type Memo,
   type CleanupFn,

--- a/packages/dom/src/reactive.ts
+++ b/packages/dom/src/reactive.ts
@@ -5,16 +5,23 @@
  * Inspired by SolidJS signals.
  */
 
+/**
+ * Phantom brand for compile-time reactivity detection.
+ * The compiler checks for the '__reactive' property via TypeChecker
+ * to identify reactive expressions.
+ */
+export type Reactive<T> = T & { readonly __reactive: true }
+
 export type Signal<T> = [
   /** Get current value (registers dependency when called inside effect) */
-  () => T,
+  Reactive<() => T>,
   /** Update value (accepts value or updater function) */
   (valueOrFn: T | ((prev: T) => T)) => void
 ]
 
 export type CleanupFn = () => void
 export type EffectFn = () => void | CleanupFn
-export type Memo<T> = () => T
+export type Memo<T> = Reactive<() => T>
 
 type EffectContext = {
   fn: EffectFn
@@ -68,7 +75,7 @@ export function createSignal<T>(initialValue: T): Signal<T> {
     }
   }
 
-  return [get, set]
+  return [get, set] as Signal<T>
 }
 
 /**

--- a/packages/form/src/create-form.ts
+++ b/packages/form/src/create-form.ts
@@ -108,7 +108,7 @@ export function createForm<
     }
 
     const fieldReturn: FieldReturn<Input[K]> = {
-      value: signals.value[0] as () => Input[K],
+      value: signals.value[0] as FieldReturn<Input[K]>['value'],
       error: signals.error[0],
       touched: signals.touched[0],
       dirty: signals.dirty[0],

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { Memo } from "@barefootjs/dom";
+import type { Reactive, Memo } from "@barefootjs/dom";
 
 // --- Validation timing ---
 
@@ -23,13 +23,13 @@ export interface CreateFormOptions<
 
 export interface FieldReturn<V> {
   /** Current field value (signal getter) */
-  value: () => V;
+  value: Reactive<() => V>;
   /** Current validation error message (signal getter) */
-  error: () => string;
+  error: Reactive<() => string>;
   /** Whether the field has been touched (signal getter) */
-  touched: () => boolean;
+  touched: Reactive<() => boolean>;
   /** Whether the field value differs from defaultValue (signal getter) */
-  dirty: () => boolean;
+  dirty: Reactive<() => boolean>;
   /** Set field value directly */
   setValue: (value: V) => void;
   /** Input event handler — reads e.target.value */
@@ -48,7 +48,7 @@ export interface FormReturn<
     name: K,
   ) => FieldReturn<StandardSchemaV1.InferInput<TSchema>[K]>;
   /** Whether a submission is in progress (signal getter) */
-  isSubmitting: () => boolean;
+  isSubmitting: Reactive<() => boolean>;
   /** Whether any field value differs from defaults (memo) */
   isDirty: Memo<boolean>;
   /** Whether all fields pass validation (memo) */

--- a/packages/jsx/src/__tests__/reactive-type-detection.test.ts
+++ b/packages/jsx/src/__tests__/reactive-type-detection.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Type-Based Reactivity Detection Tests
+ *
+ * Tests that the compiler correctly detects reactive expressions
+ * using the Reactive<T> brand type via TypeChecker.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import path from 'path'
+import { isReactiveType, containsReactiveExpression } from '../reactivity-checker'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import type { IRExpression, IRConditional } from '../types'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const REACTIVE_TYPES_CONTENT = `
+  export type Reactive<T> = T & { readonly __reactive: true };
+  export type Signal<T> = [Reactive<() => T>, (v: T | ((prev: T) => T)) => void];
+  export type Memo<T> = Reactive<() => T>;
+  export declare function createSignal<T>(initial: T): Signal<T>;
+  export declare function createMemo<T>(fn: () => T): Memo<T>;
+
+  export interface FieldReturn<V> {
+    value: Reactive<() => V>;
+    error: Reactive<() => string>;
+    touched: Reactive<() => boolean>;
+    dirty: Reactive<() => boolean>;
+    setValue: (value: V) => void;
+    handleInput: (e: Event) => void;
+    handleBlur: () => void;
+  }
+
+  export interface FormReturn {
+    isSubmitting: Reactive<() => boolean>;
+    isDirty: Memo<boolean>;
+    isValid: Memo<boolean>;
+    field: (name: string) => FieldReturn<string>;
+  }
+
+  export declare function createForm(): FormReturn;
+  export declare function useField(name: string): FieldReturn<string>;
+`
+
+/**
+ * Create a TypeScript program from source with Reactive<T> brand type definition.
+ * Uses the real CompilerHost for lib files with virtual overrides for test files.
+ */
+function createTestProgram(source: string) {
+  const baseDir = path.resolve(__dirname)
+  const testFilePath = path.join(baseDir, '_test-virtual.ts')
+  const defsFilePath = path.join(baseDir, '_reactive-defs.ts')
+
+  // Prepend import of reactive defs to the source
+  const fullSource = `import { createSignal, createMemo, createForm, useField, type FieldReturn, type FormReturn, type Reactive, type Signal, type Memo } from './_reactive-defs';\n${source}`
+
+  const virtualFiles = new Map<string, string>()
+  virtualFiles.set(testFilePath, fullSource)
+  virtualFiles.set(defsFilePath, REACTIVE_TYPES_CONTENT)
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+  }
+
+  const defaultHost = ts.createCompilerHost(compilerOptions)
+
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    getSourceFile(fileName, languageVersion) {
+      const resolved = path.resolve(fileName)
+      const content = virtualFiles.get(resolved)
+      if (content !== undefined) {
+        return ts.createSourceFile(fileName, content, languageVersion, true)
+      }
+      return defaultHost.getSourceFile(fileName, languageVersion)
+    },
+    fileExists(fileName) {
+      const resolved = path.resolve(fileName)
+      if (virtualFiles.has(resolved)) return true
+      return defaultHost.fileExists(fileName)
+    },
+    readFile(fileName) {
+      const resolved = path.resolve(fileName)
+      const content = virtualFiles.get(resolved)
+      if (content !== undefined) return content
+      return defaultHost.readFile(fileName)
+    },
+  }
+
+  const program = ts.createProgram([testFilePath], compilerOptions, host)
+  const sourceFile = program.getSourceFile(testFilePath)!
+  const checker = program.getTypeChecker()
+
+  return { program, sourceFile, checker }
+}
+
+/**
+ * Find the first expression node matching a predicate in the AST.
+ */
+function findNode(root: ts.Node, predicate: (node: ts.Node) => boolean): ts.Node | undefined {
+  if (predicate(root)) return root
+  return ts.forEachChild(root, child => findNode(child, predicate))
+}
+
+/**
+ * Compile source and return the IR, checking for reactive flags.
+ */
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, 'Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+/**
+ * Walk IR tree to find all expression nodes.
+ */
+function findIRExpressions(node: any): IRExpression[] {
+  const results: IRExpression[] = []
+  if (!node) return results
+
+  if (node.type === 'expression') {
+    results.push(node)
+  }
+  if (node.type === 'conditional') {
+    results.push(...findIRExpressions(node.whenTrue))
+    results.push(...findIRExpressions(node.whenFalse))
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      results.push(...findIRExpressions(child))
+    }
+  }
+  return results
+}
+
+/**
+ * Find IR conditionals in tree.
+ */
+function findIRConditionals(node: any): IRConditional[] {
+  const results: IRConditional[] = []
+  if (!node) return results
+
+  if (node.type === 'conditional') {
+    results.push(node)
+    results.push(...findIRConditionals(node.whenTrue))
+    results.push(...findIRConditionals(node.whenFalse))
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      results.push(...findIRConditionals(child))
+    }
+  }
+  return results
+}
+
+// =============================================================================
+// Unit Tests: isReactiveType
+// =============================================================================
+
+describe('isReactiveType', () => {
+  test('detects Reactive<() => T> branded type', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const x = count;
+    `)
+
+    // Find the 'count' identifier in 'const x = count'
+    const xDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'x'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(xDecl).toBeDefined()
+    const initExpr = xDecl!.initializer!
+    const type = checker.getTypeAtLocation(initExpr)
+    expect(isReactiveType(type)).toBe(true)
+  })
+
+  test('does not detect plain function type', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      function plainFn(): number { return 42; }
+      const x = plainFn;
+    `)
+
+    const xDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'x'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(xDecl).toBeDefined()
+    const type = checker.getTypeAtLocation(xDecl!.initializer!)
+    expect(isReactiveType(type)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Unit Tests: containsReactiveExpression
+// =============================================================================
+
+describe('containsReactiveExpression', () => {
+  test('signal getter call — count() is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const result = count();
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('memo call — doubled() is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const doubled = createMemo(() => count() * 2);
+      const result = doubled();
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('method on branded object — username.error() is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const username = useField('username');
+      const result = username.error();
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('method on form — form.isSubmitting() is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const form = createForm();
+      const result = form.isSubmitting();
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('form.field().value() — nested reactive access', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const form = createForm();
+      const field = form.field('email');
+      const result = field.value();
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('string literal — not reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const result = "hello";
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(false)
+  })
+
+  test('static function call — formatDate(today) is not reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      function formatDate(d: string): string { return d; }
+      const today = "2024-01-01";
+      const result = formatDate(today);
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(false)
+  })
+
+  test('signal reference (not called) — count itself is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const ref = count;
+    `)
+
+    const refDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'ref'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(refDecl).toBeDefined()
+    expect(containsReactiveExpression(refDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('binary expression with reactive — count() > 0 is reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const result = count() > 0;
+    `)
+
+    const resultDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'result'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(resultDecl).toBeDefined()
+    expect(containsReactiveExpression(resultDecl!.initializer!, checker)).toBe(true)
+  })
+
+  test('setter function — setCount is not reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const ref = setCount;
+    `)
+
+    const refDecl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'ref'
+    ) as ts.VariableDeclaration | undefined
+
+    expect(refDecl).toBeDefined()
+    expect(containsReactiveExpression(refDecl!.initializer!, checker)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Integration Tests: IR reactivity detection through full compilation
+// =============================================================================
+
+describe('IR reactivity detection', () => {
+  test('signal getter in JSX expression is marked reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <div>{count()}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const exprs = findIRExpressions(ir!)
+    const countExpr = exprs.find(e => e.expr.includes('count()'))
+    expect(countExpr).toBeDefined()
+    expect(countExpr!.reactive).toBe(true)
+  })
+
+  test('memo in JSX expression is marked reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/dom'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        const doubled = createMemo(() => count() * 2)
+        return <div>{doubled()}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const exprs = findIRExpressions(ir!)
+    const memoExpr = exprs.find(e => e.expr.includes('doubled()'))
+    expect(memoExpr).toBeDefined()
+    expect(memoExpr!.reactive).toBe(true)
+  })
+
+  test('static text in JSX is not reactive', () => {
+    const source = `
+      export function Static() {
+        const message = "hello"
+        return <div>{message}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const exprs = findIRExpressions(ir!)
+    const msgExpr = exprs.find(e => e.expr === 'message')
+    // Static constants not referencing signals should not be reactive
+    expect(msgExpr).toBeDefined()
+    expect(msgExpr!.reactive).toBe(false)
+  })
+
+  test('ternary with signal condition is marked reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Toggle() {
+        const [on, setOn] = createSignal(false)
+        return <div>{on() ? "yes" : "no"}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const conditionals = findIRConditionals(ir!)
+    expect(conditionals.length).toBeGreaterThan(0)
+    expect(conditionals[0].reactive).toBe(true)
+  })
+
+  test('props reference in JSX is marked reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Display(props: { label: string }) {
+        const [count, setCount] = createSignal(0)
+        return <div>{props.label}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const exprs = findIRExpressions(ir!)
+    const propsExpr = exprs.find(e => e.expr.includes('props.label'))
+    expect(propsExpr).toBeDefined()
+    expect(propsExpr!.reactive).toBe(true)
+  })
+
+  test('tainted constant — const derived from signal is reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        const label = count() > 0 ? "positive" : "zero"
+        return <div>{label}</div>
+      }
+    `
+
+    const { ir } = compileToIR(source)
+    expect(ir).toBeDefined()
+
+    const exprs = findIRExpressions(ir!)
+    const labelExpr = exprs.find(e => e.expr === 'label')
+    expect(labelExpr).toBeDefined()
+    expect(labelExpr!.reactive).toBe(true)
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -88,6 +88,9 @@ export interface AnalyzerContext {
   // Pre-computed type ranges for type stripping
   typeExcludeRanges: ExcludeRange[]
 
+  /** TypeScript type checker for type-based reactivity detection (null = regex fallback) */
+  checker: ts.TypeChecker | null
+
   /** Return node text with TypeScript type syntax removed. */
   getJS(node: ts.Node): string
 }
@@ -128,6 +131,7 @@ export function createAnalyzerContext(
     hasUseClientDirective: false,
 
     typeExcludeRanges: collectAllTypeRanges(sourceFile),
+    checker: null,
     getJS(node: ts.Node): string {
       return reconstructWithoutTypes(node, sourceFile, this.typeExcludeRanges)
     },

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -34,10 +34,10 @@ import path from 'path'
  * For full type resolution in build tools, pass a pre-built ts.Program via
  * CompileOptions.program instead.
  */
-function createProgramForFile(
+export function createProgramForFile(
   source: string,
   filePath: string
-): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } | null {
+): { program: ts.Program; sourceFile: ts.SourceFile; checker: ts.TypeChecker } | null {
   try {
     const normalizedPath = path.resolve(filePath)
 
@@ -77,7 +77,7 @@ function createProgramForFile(
 
     if (!sourceFile) return null
 
-    return { sourceFile, checker: program.getTypeChecker() }
+    return { program, sourceFile, checker: program.getTypeChecker() }
   } catch {
     // Fall back to regex-based detection
     return null
@@ -94,16 +94,18 @@ export function analyzeComponent(
   targetComponentName?: string,
   program?: ts.Program
 ): AnalyzerContext {
-  let sourceFile: ts.SourceFile
+  let sourceFile: ts.SourceFile | undefined
   let checker: ts.TypeChecker | null = null
 
   if (program) {
     // Use the pre-built program's source file and checker
-    sourceFile = program.getSourceFile(filePath)!
-    checker = program.getTypeChecker()
+    sourceFile = program.getSourceFile(filePath)
+    if (sourceFile) {
+      checker = program.getTypeChecker()
+    }
   }
 
-  if (!sourceFile!) {
+  if (!sourceFile) {
     sourceFile = ts.createSourceFile(
       filePath,
       source,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -17,6 +17,67 @@ import {
   isArrowComponentFunction,
 } from './analyzer-context'
 import { createError, createWarning, ErrorCodes } from './errors'
+import path from 'path'
+
+// =============================================================================
+// TypeScript Program Creation
+// =============================================================================
+
+/**
+ * Create a TypeScript program for a single file to enable type-based reactivity detection.
+ * Uses a virtual CompilerHost that injects the source string as a virtual file
+ * and delegates to the real file system for node_modules resolution.
+ */
+function createProgramForFile(
+  source: string,
+  filePath: string
+): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } | null {
+  try {
+    const normalizedPath = path.resolve(filePath)
+
+    const compilerOptions: ts.CompilerOptions = {
+      target: ts.ScriptTarget.Latest,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+      // Enable resolving from node_modules
+      baseUrl: path.dirname(normalizedPath),
+    }
+
+    const defaultHost = ts.createCompilerHost(compilerOptions)
+
+    const virtualHost: ts.CompilerHost = {
+      ...defaultHost,
+      getSourceFile(fileName, languageVersion) {
+        if (path.resolve(fileName) === normalizedPath) {
+          return ts.createSourceFile(fileName, source, languageVersion, true, ts.ScriptKind.TSX)
+        }
+        return defaultHost.getSourceFile(fileName, languageVersion)
+      },
+      fileExists(fileName) {
+        if (path.resolve(fileName) === normalizedPath) return true
+        return defaultHost.fileExists(fileName)
+      },
+      readFile(fileName) {
+        if (path.resolve(fileName) === normalizedPath) return source
+        return defaultHost.readFile(fileName)
+      },
+    }
+
+    const program = ts.createProgram([normalizedPath], compilerOptions, virtualHost)
+    const sourceFile = program.getSourceFile(normalizedPath)
+
+    if (!sourceFile) return null
+
+    return { sourceFile, checker: program.getTypeChecker() }
+  } catch {
+    // Fall back to regex-based detection
+    return null
+  }
+}
 
 // =============================================================================
 // Main Entry Point
@@ -25,17 +86,39 @@ import { createError, createWarning, ErrorCodes } from './errors'
 export function analyzeComponent(
   source: string,
   filePath: string,
-  targetComponentName?: string
+  targetComponentName?: string,
+  program?: ts.Program
 ): AnalyzerContext {
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  )
+  let sourceFile: ts.SourceFile
+  let checker: ts.TypeChecker | null = null
+
+  if (program) {
+    // Use the pre-built program's source file and checker
+    sourceFile = program.getSourceFile(filePath)!
+    checker = program.getTypeChecker()
+  }
+
+  if (!sourceFile!) {
+    sourceFile = ts.createSourceFile(
+      filePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    )
+  }
+
+  // Try to create a program for type-based reactivity detection
+  if (!checker) {
+    const result = createProgramForFile(source, filePath)
+    if (result) {
+      sourceFile = result.sourceFile
+      checker = result.checker
+    }
+  }
 
   const ctx = createAnalyzerContext(sourceFile, filePath)
+  ctx.checker = checker
 
   // If no target specified, prioritize the default exported component
   if (!targetComponentName) {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -27,6 +27,12 @@ import path from 'path'
  * Create a TypeScript program for a single file to enable type-based reactivity detection.
  * Uses a virtual CompilerHost that injects the source string as a virtual file
  * and delegates to the real file system for node_modules resolution.
+ *
+ * Note: Module resolution depends on node_modules being reachable from the file's
+ * directory. If the file path is virtual or node_modules isn't accessible,
+ * imported types may resolve to `any` and the signal/memo regex fallback kicks in.
+ * For full type resolution in build tools, pass a pre-built ts.Program via
+ * CompileOptions.program instead.
  */
 function createProgramForFile(
   source: string,
@@ -43,7 +49,6 @@ function createProgramForFile(
       strict: true,
       skipLibCheck: true,
       noEmit: true,
-      // Enable resolving from node_modules
       baseUrl: path.dirname(normalizedPath),
     }
 

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -50,7 +50,7 @@ export async function compileJSX(
   }
 
   // Single component flow
-  const ctx = analyzeComponent(source, entryPath)
+  const ctx = analyzeComponent(source, entryPath, undefined, options.program)
 
   if (!ctx.jsxReturn) {
     errors.push(...ctx.errors)  // Only analyzer errors
@@ -126,7 +126,7 @@ function compileMultipleComponentsSync(
   const entries: { componentIR: ComponentIR; ctx: ReturnType<typeof analyzeComponent> }[] = []
 
   for (const componentName of componentNames) {
-    const ctx = analyzeComponent(source, filePath, componentName)
+    const ctx = analyzeComponent(source, filePath, componentName, options.program)
 
     if (!ctx.jsxReturn) {
       errors.push(...ctx.errors)
@@ -347,7 +347,7 @@ export function compileJSXSync(
   }
 
   // Single component flow
-  const ctx = analyzeComponent(source, filePath)
+  const ctx = analyzeComponent(source, filePath, undefined, options.program)
 
   if (!ctx.jsxReturn) {
     errors.push(...ctx.errors)  // Only analyzer errors

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -12,7 +12,7 @@ import type {
   FileOutput,
 } from './types'
 import type { TemplateAdapter } from './adapters/interface'
-import { analyzeComponent, listExportedComponents } from './analyzer'
+import { analyzeComponent, listExportedComponents, createProgramForFile } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
 import { collectComponentNamesFromIR } from './ir-to-client-js/generate-init'
@@ -125,8 +125,11 @@ function compileMultipleComponentsSync(
   // --- Pass 1: analyze + jsxToIR for ALL components ---
   const entries: { componentIR: ComponentIR; ctx: ReturnType<typeof analyzeComponent> }[] = []
 
+  // Create ts.Program once for all components in this file
+  const program = options.program ?? createProgramForFile(source, filePath)?.program
+
   for (const componentName of componentNames) {
-    const ctx = analyzeComponent(source, filePath, componentName, options.program)
+    const ctx = analyzeComponent(source, filePath, componentName, program)
 
     if (!ctx.jsxReturn) {
       errors.push(...ctx.errors)

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -11,7 +11,11 @@ import type {
 } from './types'
 
 /**
- * Check if an expression references signal getters or memos.
+ * Check if an expression directly references signal getters, memos, or props.
+ *
+ * Note: This function does NOT follow local constants — constant taint analysis
+ * is handled in Phase 1 (jsx-to-ir.ts) when marking IR nodes as reactive.
+ * Phase 2 only checks direct references in the expression string.
  */
 export function isReactiveExpression(expr: string, ctx: ClientJsContext): boolean {
   for (const signal of ctx.signals) {
@@ -26,9 +30,12 @@ export function isReactiveExpression(expr: string, ctx: ClientJsContext): boolea
     }
   }
 
-  // props.xxx may be reactive when passed as getters from parent
-  if (/\bprops\.\w+/.test(expr)) {
-    return true
+  // Check individual prop names (excluding children which is server-rendered)
+  for (const prop of ctx.propsParams) {
+    if (prop.name === 'children') continue
+    if (new RegExp(`\\b${prop.name}\\b`).test(expr)) {
+      return true
+    }
   }
 
   return false

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -34,6 +34,14 @@ import { containsReactiveExpression } from './reactivity-checker'
 // Transform Context
 // =============================================================================
 
+/** Pre-compiled regex patterns for reactivity detection */
+interface ReactivityPatterns {
+  signals: { getter: string; pattern: RegExp }[]
+  memos: { name: string; pattern: RegExp }[]
+  props: { name: string; pattern: RegExp }[]
+  constants: { name: string; value: string | undefined; pattern: RegExp }[]
+}
+
 interface TransformContext {
   analyzer: AnalyzerContext
   sourceFile: ts.SourceFile
@@ -41,6 +49,7 @@ interface TransformContext {
   slotIdCounter: number
   isRoot: boolean
   insideComponentChildren: boolean
+  patterns: ReactivityPatterns
   /** Shortcut for analyzer.getJS(node) */
   getJS(node: ts.Node): string
 }
@@ -53,6 +62,24 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     slotIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
+    patterns: {
+      signals: analyzer.signals.map(s => ({
+        getter: s.getter,
+        pattern: new RegExp(`\\b${s.getter}\\s*\\(`),
+      })),
+      memos: analyzer.memos.map(m => ({
+        name: m.name,
+        pattern: new RegExp(`\\b${m.name}\\s*\\(`),
+      })),
+      props: analyzer.propsParams
+        .filter(p => p.name !== 'children')
+        .map(p => ({ name: p.name, pattern: new RegExp(`\\b${p.name}\\b`) })),
+      constants: analyzer.localConstants.map(c => ({
+        name: c.name,
+        value: c.value,
+        pattern: new RegExp(`\\b${c.name}\\b`),
+      })),
+    },
     getJS(node: ts.Node): string {
       return analyzer.getJS(node)
     },
@@ -1571,22 +1598,12 @@ function checkBareSignalOrMemoIdentifier(
  * Props and local constants are considered static (don't change at runtime).
  */
 function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
-  // Check for signal calls: todos()
-  for (const signal of ctx.analyzer.signals) {
-    const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
-    if (pattern.test(array)) {
-      return true
-    }
+  for (const { pattern } of ctx.patterns.signals) {
+    if (pattern.test(array)) return true
   }
-
-  // Check for memo calls: filteredItems()
-  for (const memo of ctx.analyzer.memos) {
-    const pattern = new RegExp(`\\b${memo.name}\\s*\\(`)
-    if (pattern.test(array)) {
-      return true
-    }
+  for (const { pattern } of ctx.patterns.memos) {
+    if (pattern.test(array)) return true
   }
-
   return false
 }
 
@@ -1627,28 +1644,21 @@ function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.
  * Regex-based signal/memo detection.
  * Complements TypeChecker for cases where imported types can't be resolved.
  */
-function isSignalOrMemoReference(expr: string, ctx: TransformContext): boolean {
-  for (const signal of ctx.analyzer.signals) {
-    const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
-    if (pattern.test(expr)) {
-      return true
-    }
+function isSignalOrMemoReference(expr: string, ctx: TransformContext, visited?: Set<string>): boolean {
+  for (const { pattern } of ctx.patterns.signals) {
+    if (pattern.test(expr)) return true
   }
-
-  for (const memo of ctx.analyzer.memos) {
-    const pattern = new RegExp(`\\b${memo.name}\\s*\\(`)
-    if (pattern.test(expr)) {
-      return true
-    }
+  for (const { pattern } of ctx.patterns.memos) {
+    if (pattern.test(expr)) return true
   }
 
   // Check if expression uses a constant that references signals/memos
-  for (const constant of ctx.analyzer.localConstants) {
-    const constPattern = new RegExp(`\\b${constant.name}\\b`)
-    if (constPattern.test(expr)) {
-      if (constant.value && isSignalOrMemoReference(constant.value, ctx)) {
-        return true
-      }
+  for (const c of ctx.patterns.constants) {
+    if (visited?.has(c.name)) continue
+    if (c.pattern.test(expr) && c.value) {
+      const next = visited ?? new Set<string>()
+      next.add(c.name)
+      if (isSignalOrMemoReference(c.value, ctx, next)) return true
     }
   }
 
@@ -1660,22 +1670,18 @@ function isSignalOrMemoReference(expr: string, ctx: TransformContext): boolean {
  * Props are always treated as reactive because the parent component
  * may pass signal getters as prop values.
  */
-function isPropsReference(expr: string, ctx: TransformContext): boolean {
-  for (const prop of ctx.analyzer.propsParams) {
-    if (prop.name === 'children') continue
-    const pattern = new RegExp(`\\b${prop.name}\\b`)
-    if (pattern.test(expr)) {
-      return true
-    }
+function isPropsReference(expr: string, ctx: TransformContext, visited?: Set<string>): boolean {
+  for (const { pattern } of ctx.patterns.props) {
+    if (pattern.test(expr)) return true
   }
 
   // Check if expression uses a local constant derived from props
-  for (const constant of ctx.analyzer.localConstants) {
-    const constPattern = new RegExp(`\\b${constant.name}\\b`)
-    if (constPattern.test(expr)) {
-      if (constant.value && isPropsReference(constant.value, ctx)) {
-        return true
-      }
+  for (const c of ctx.patterns.constants) {
+    if (visited?.has(c.name)) continue
+    if (c.pattern.test(expr) && c.value) {
+      const next = visited ?? new Set<string>()
+      next.add(c.name)
+      if (isPropsReference(c.value, ctx, next)) return true
     }
   }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -28,6 +28,7 @@ import type {
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
 import { createError, ErrorCodes } from './errors'
+import { containsReactiveExpression } from './reactivity-checker'
 
 // =============================================================================
 // Transform Context
@@ -40,6 +41,8 @@ interface TransformContext {
   slotIdCounter: number
   isRoot: boolean
   insideComponentChildren: boolean
+  /** TypeScript type checker for type-based reactivity detection (null = regex fallback) */
+  checker: ts.TypeChecker | null
   /** Shortcut for analyzer.getJS(node) */
   getJS(node: ts.Node): string
 }
@@ -52,6 +55,7 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     slotIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
+    checker: analyzer.checker,
     getJS(node: ts.Node): string {
       return analyzer.getJS(node)
     },
@@ -606,7 +610,7 @@ function transformExpression(
 
   // Regular expression
   const exprText = ctx.getJS(expr)
-  const reactive = isReactiveExpression(exprText, ctx)
+  const reactive = isReactiveExpression(exprText, ctx, expr)
   // @client expressions always need slotId and are treated as reactive for client-side evaluation
   const needsSlot = reactive || isClientOnly
   const slotId = needsSlot ? generateSlotId(ctx) : null
@@ -631,7 +635,7 @@ function transformConditional(
   ctx: TransformContext
 ): IRConditional {
   const condition = ctx.getJS(node.condition)
-  const reactive = isReactiveExpression(condition, ctx)
+  const reactive = isReactiveExpression(condition, ctx, node.condition)
   const slotId = reactive ? generateSlotId(ctx) : null
 
   // Transform both branches
@@ -655,7 +659,7 @@ function transformLogicalAnd(
   ctx: TransformContext
 ): IRConditional {
   const condition = ctx.getJS(node.left)
-  const reactive = isReactiveExpression(condition, ctx)
+  const reactive = isReactiveExpression(condition, ctx, node.left)
   const slotId = reactive ? generateSlotId(ctx) : null
 
   const whenTrue = transformConditionalBranch(node.right, ctx)
@@ -710,7 +714,7 @@ function transformConditionalBranch(
     type: 'expression',
     expr: exprText,
     typeInfo: inferExpressionType(node, ctx),
-    reactive: isReactiveExpression(exprText, ctx),
+    reactive: isReactiveExpression(exprText, ctx, node),
     slotId: null,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
@@ -1589,7 +1593,23 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
   return false
 }
 
-function isReactiveExpression(expr: string, ctx: TransformContext): boolean {
+/**
+ * Check if an expression is reactive, using the TypeChecker when available
+ * with a regex-based fallback for backward compatibility.
+ */
+function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.Node): boolean {
+  // Type-checker path: walk AST to find Reactive<T> branded types
+  if (ctx.checker && astNode) {
+    if (containsReactiveExpression(astNode, ctx.checker)) {
+      return true
+    }
+  }
+
+  // Regex fallback (always runs to maintain backward compatibility)
+  return isReactiveExpressionRegex(expr, ctx)
+}
+
+function isReactiveExpressionRegex(expr: string, ctx: TransformContext): boolean {
   // Check for signal calls: count()
   for (const signal of ctx.analyzer.signals) {
     const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
@@ -1623,7 +1643,7 @@ function isReactiveExpression(expr: string, ctx: TransformContext): boolean {
     const constPattern = new RegExp(`\\b${constant.name}\\b`)
     if (constPattern.test(expr)) {
       // Check if the constant's value contains reactive references
-      if (constant.value && isReactiveValue(constant.value, ctx)) {
+      if (constant.value && isReactiveValueRegex(constant.value, ctx)) {
         return true
       }
     }
@@ -1632,7 +1652,7 @@ function isReactiveExpression(expr: string, ctx: TransformContext): boolean {
   return false
 }
 
-function isReactiveValue(value: string, ctx: TransformContext): boolean {
+function isReactiveValueRegex(value: string, ctx: TransformContext): boolean {
   // Check for props references in the value
   for (const prop of ctx.analyzer.propsParams) {
     const pattern = new RegExp(`\\b${prop.name}\\b`)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -41,8 +41,6 @@ interface TransformContext {
   slotIdCounter: number
   isRoot: boolean
   insideComponentChildren: boolean
-  /** TypeScript type checker for type-based reactivity detection (null = regex fallback) */
-  checker: ts.TypeChecker | null
   /** Shortcut for analyzer.getJS(node) */
   getJS(node: ts.Node): string
 }
@@ -55,7 +53,6 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     slotIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
-    checker: analyzer.checker,
     getJS(node: ts.Node): string {
       return analyzer.getJS(node)
     },
@@ -1605,8 +1602,8 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
  */
 function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.Node): boolean {
   // Type-checker path: walk AST to find Reactive<T> branded types
-  if (ctx.checker && astNode) {
-    if (containsReactiveExpression(astNode, ctx.checker)) {
+  if (ctx.analyzer.checker && astNode) {
+    if (containsReactiveExpression(astNode, ctx.analyzer.checker)) {
       return true
     }
   }
@@ -1692,26 +1689,10 @@ function isPropsReference(expr: string, ctx: TransformContext): boolean {
 function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boolean {
   for (const attr of attrs) {
     if (attr.dynamic && attr.value) {
-      // Get the string value to check for reactivity
       const valueToCheck = getAttributeValueAsString(attr.value)
       if (!valueToCheck) continue
 
-      // Check for signal getter calls
-      for (const signal of ctx.analyzer.signals) {
-        const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
-        if (pattern.test(valueToCheck)) {
-          return true
-        }
-      }
-      // Check for memo calls
-      for (const memo of ctx.analyzer.memos) {
-        const pattern = new RegExp(`\\b${memo.name}\\s*\\(`)
-        if (pattern.test(valueToCheck)) {
-          return true
-        }
-      }
-      // Check for props references (props.xxx may be reactive when passed as getters from parent)
-      if (/\bprops\.\w+/.test(valueToCheck)) {
+      if (isSignalOrMemoReference(valueToCheck, ctx) || isPropsReference(valueToCheck, ctx)) {
         return true
       }
     }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1594,8 +1594,14 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
 }
 
 /**
- * Check if an expression is reactive, using the TypeChecker when available
- * with a regex-based fallback for backward compatibility.
+ * Check if an expression is reactive.
+ *
+ * Detection strategy:
+ * 1. TypeChecker: walk AST to find Reactive<T> branded types (signals, memos, FieldReturn, etc.)
+ * 2. Signal/memo regex: fallback for when TypeChecker cannot resolve types (e.g., virtual file paths)
+ * 3. Props regex: props are always potentially reactive (parent passes getters) but aren't
+ *    branded with Reactive<T> since users define props interfaces directly.
+ *    Regex is the right tool here — props detection is name-based by design.
  */
 function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.Node): boolean {
   // Type-checker path: walk AST to find Reactive<T> branded types
@@ -1605,12 +1611,26 @@ function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.
     }
   }
 
-  // Regex fallback (always runs to maintain backward compatibility)
-  return isReactiveExpressionRegex(expr, ctx)
+  // Signal/memo regex fallback — needed when TypeChecker cannot resolve imported types
+  // (e.g., virtual file paths in tests, missing type declarations)
+  if (isSignalOrMemoReference(expr, ctx)) {
+    return true
+  }
+
+  // Props are always potentially reactive (parent may pass signal getters),
+  // but they don't carry Reactive<T> brand since users define props types directly.
+  if (isPropsReference(expr, ctx)) {
+    return true
+  }
+
+  return false
 }
 
-function isReactiveExpressionRegex(expr: string, ctx: TransformContext): boolean {
-  // Check for signal calls: count()
+/**
+ * Regex-based signal/memo detection.
+ * Complements TypeChecker for cases where imported types can't be resolved.
+ */
+function isSignalOrMemoReference(expr: string, ctx: TransformContext): boolean {
   for (const signal of ctx.analyzer.signals) {
     const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
     if (pattern.test(expr)) {
@@ -1618,7 +1638,6 @@ function isReactiveExpressionRegex(expr: string, ctx: TransformContext): boolean
     }
   }
 
-  // Check for memo calls: doubled()
   for (const memo of ctx.analyzer.memos) {
     const pattern = new RegExp(`\\b${memo.name}\\s*\\(`)
     if (pattern.test(expr)) {
@@ -1626,24 +1645,11 @@ function isReactiveExpressionRegex(expr: string, ctx: TransformContext): boolean
     }
   }
 
-  // Check for props references (both direct references and function calls)
-  // Props need to be dynamic so SSR can render them correctly
-  // But exclude 'children' as it's server-rendered, not dynamically updated
-  for (const prop of ctx.analyzer.propsParams) {
-    if (prop.name === 'children') continue
-    const pattern = new RegExp(`\\b${prop.name}\\b`)
-    if (pattern.test(expr)) {
-      return true
-    }
-  }
-
-  // Check if expression is a local constant that references props/signals/memos
-  // e.g., const classes = `${className} ${variant}` and then class={classes}
+  // Check if expression uses a constant that references signals/memos
   for (const constant of ctx.analyzer.localConstants) {
     const constPattern = new RegExp(`\\b${constant.name}\\b`)
     if (constPattern.test(expr)) {
-      // Check if the constant's value contains reactive references
-      if (constant.value && isReactiveValueRegex(constant.value, ctx)) {
+      if (constant.value && isSignalOrMemoReference(constant.value, ctx)) {
         return true
       }
     }
@@ -1652,28 +1658,27 @@ function isReactiveExpressionRegex(expr: string, ctx: TransformContext): boolean
   return false
 }
 
-function isReactiveValueRegex(value: string, ctx: TransformContext): boolean {
-  // Check for props references in the value
+/**
+ * Check if an expression references props (excluding children).
+ * Props are always treated as reactive because the parent component
+ * may pass signal getters as prop values.
+ */
+function isPropsReference(expr: string, ctx: TransformContext): boolean {
   for (const prop of ctx.analyzer.propsParams) {
+    if (prop.name === 'children') continue
     const pattern = new RegExp(`\\b${prop.name}\\b`)
-    if (pattern.test(value)) {
+    if (pattern.test(expr)) {
       return true
     }
   }
 
-  // Check for signal calls in the value
-  for (const signal of ctx.analyzer.signals) {
-    const pattern = new RegExp(`\\b${signal.getter}\\s*\\(`)
-    if (pattern.test(value)) {
-      return true
-    }
-  }
-
-  // Check for memo calls in the value
-  for (const memo of ctx.analyzer.memos) {
-    const pattern = new RegExp(`\\b${memo.name}\\s*\\(`)
-    if (pattern.test(value)) {
-      return true
+  // Check if expression uses a local constant derived from props
+  for (const constant of ctx.analyzer.localConstants) {
+    const constPattern = new RegExp(`\\b${constant.name}\\b`)
+    if (constPattern.test(expr)) {
+      if (constant.value && isPropsReference(constant.value, ctx)) {
+        return true
+      }
     }
   }
 

--- a/packages/jsx/src/reactivity-checker.ts
+++ b/packages/jsx/src/reactivity-checker.ts
@@ -1,0 +1,49 @@
+/**
+ * Type-based reactivity detection using TypeScript TypeChecker.
+ *
+ * Detects reactive expressions by checking for the Reactive<T> brand type
+ * from @barefootjs/dom. Any expression involving a value typed as Reactive<T>
+ * is recognized as reactive.
+ */
+
+import ts from 'typescript'
+
+const REACTIVE_BRAND = '__reactive'
+
+/**
+ * Check if a TypeScript type has the Reactive<T> brand.
+ * The brand is a phantom property `[__reactive]: true` added via intersection type.
+ */
+export function isReactiveType(type: ts.Type): boolean {
+  return type.getProperty(REACTIVE_BRAND) !== undefined
+}
+
+/**
+ * Check if an AST node or any sub-expression contains a reactive type.
+ * Walks the AST recursively, checking each identifier and property access
+ * against the TypeChecker to find Reactive<T>-branded types.
+ */
+export function containsReactiveExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
+  // Check identifiers and property accesses directly
+  if (ts.isIdentifier(node) || ts.isPropertyAccessExpression(node)) {
+    try {
+      const type = checker.getTypeAtLocation(node)
+      if (isReactiveType(type)) return true
+    } catch {
+      // Type resolution can fail for some nodes; continue walking
+    }
+  }
+
+  // Check call expressions — the callee might be Reactive<() => T>
+  if (ts.isCallExpression(node)) {
+    try {
+      const calleeType = checker.getTypeAtLocation(node.expression)
+      if (isReactiveType(calleeType)) return true
+    } catch {
+      // continue
+    }
+  }
+
+  // Recurse into children
+  return ts.forEachChild(node, child => containsReactiveExpression(child, checker)) ?? false
+}

--- a/packages/jsx/src/reactivity-checker.ts
+++ b/packages/jsx/src/reactivity-checker.ts
@@ -24,14 +24,27 @@ export function isReactiveType(type: ts.Type): boolean {
  * against the TypeChecker to find Reactive<T>-branded types.
  */
 export function containsReactiveExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
-  // Check identifiers and property accesses directly
-  if (ts.isIdentifier(node) || ts.isPropertyAccessExpression(node)) {
+  // Property access chains (e.g., username.error): check the whole expression,
+  // then recurse only into the object part (not the name) to avoid redundant checks
+  if (ts.isPropertyAccessExpression(node)) {
     try {
       const type = checker.getTypeAtLocation(node)
       if (isReactiveType(type)) return true
     } catch {
       // Type resolution can fail for some nodes; continue walking
     }
+    return containsReactiveExpression(node.expression, checker)
+  }
+
+  // Check identifiers directly
+  if (ts.isIdentifier(node)) {
+    try {
+      const type = checker.getTypeAtLocation(node)
+      if (isReactiveType(type)) return true
+    } catch {
+      // continue
+    }
+    return false
   }
 
   // Check call expressions — the callee might be Reactive<() => T>

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -452,6 +452,8 @@ export interface CompileOptions {
    * Example: 'components' → classes prefixed with 'layer-components:'
    */
   cssLayerPrefix?: string
+  /** Pre-built TypeScript program for type-based reactivity detection */
+  program?: import('typescript').Program
 }
 
 export interface FileOutput {

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -420,11 +420,35 @@ Note: Hono's JSX uses `class=` (HTML-style), but BarefootJS JSX uses React-style
 
 ### Reactivity Classification
 
-| Pattern | Reactive? | Reason |
-|---------|-----------|--------|
-| `count()` (signal getter) | Yes | Signal call detected |
-| `doubled()` (memo call) | Yes | Memo call detected |
-| `props.count` | Yes | Props reference |
+The compiler detects reactive expressions using a two-tier strategy:
+
+1. **Type-based detection** — Uses TypeScript's `TypeChecker` to find expressions typed with the `Reactive<T>` brand. All reactive getters carry this brand: `Signal<T>[0]`, `Memo<T>`, `FieldReturn.value`, `FormReturn.isSubmitting`, etc. This is the primary mechanism and handles both local signals/memos and library-provided reactive accessors.
+
+2. **Regex fallback** — Pattern-matches signal/memo getter names and props references. Used when the TypeChecker cannot resolve imported types (e.g., virtual file paths, missing type declarations). Build tools can pass a pre-built `ts.Program` via `CompileOptions.program` for full type resolution.
+
+#### The `Reactive<T>` Brand
+
+All reactive getters are typed with a phantom brand:
+
+```typescript
+type Reactive<T> = T & { readonly __reactive: true }
+
+type Signal<T> = [Reactive<() => T>, (valueOrFn: T | ((prev: T) => T)) => void]
+type Memo<T> = Reactive<() => T>
+```
+
+The compiler checks for `__reactive` via `checker.getTypeAtLocation(node).getProperty('__reactive')`. Library authors can brand their own reactive accessors by typing them as `Reactive<() => T>`.
+
+#### Classification Table
+
+| Pattern | Reactive? | Detection |
+|---------|-----------|-----------|
+| `count()` (signal getter) | Yes | Brand (`Reactive<() => T>`) or regex |
+| `doubled()` (memo call) | Yes | Brand (`Reactive<() => T>`) or regex |
+| `username.error()` (library accessor) | Yes | Brand (`Reactive<() => string>`) |
+| `form.isSubmitting()` | Yes | Brand (`Reactive<() => boolean>`) |
+| `props.count` | Yes | Regex (props aren't branded) |
+| `label` (const derived from signal) | Yes | Taint analysis (follows constant value) |
 | `count` (destructured prop) | No | Value captured at definition |
 | `"static string"` | No | Literal value |
 | `CONSTANT` (no reactive deps) | No | Pure constant |


### PR DESCRIPTION
## Summary

Closes #512.

- Introduces `Reactive<T>` phantom brand type in `@barefootjs/dom` and applies it to `Signal<T>`, `Memo<T>`, `FieldReturn`, and `FormReturn` reactive getters
- Integrates TypeScript `TypeChecker` into the compiler's reactivity detection, enabling automatic detection of method calls on branded objects (e.g., `username.error()`, `form.isSubmitting()`) that regex-based matching could not detect
- Adds `reactivity-checker.ts` module with `containsReactiveExpression()` that walks AST nodes checking for the `__reactive` brand via `checker.getTypeAtLocation()`
- Splits regex detection into focused responsibilities: signal/memo fallback + props detection

## Detection strategy

| Target | Method | Notes |
|--------|--------|-------|
| `username.error()`, branded methods | TypeChecker | `Reactive<T>` brand detection via `__reactive` property |
| `count()`, `doubled()` — signal/memo | Regex (`isSignalOrMemoReference`) | Fallback for when TypeChecker can't resolve imported types |
| `props.label` — props references | Regex (`isPropsReference`) | Structurally necessary — users define props types directly, not branded |

Signal/memo regex can be removed once build tools pass a pre-built `ts.Program` via `CompileOptions.program` for full type resolution.

## Key changes

| Package | Change |
|---------|--------|
| `@barefootjs/dom` | Define `Reactive<T>` brand, update `Signal<T>[0]` and `Memo<T>` |
| `@barefootjs/form` | Brand `FieldReturn` (`value/error/touched/dirty`) and `FormReturn` (`isSubmitting`) |
| `@barefootjs/jsx` | Add `TypeChecker` to `AnalyzerContext`, create `reactivity-checker.ts`, refactor `isReactiveExpression` |

## Design decisions

- **Props are not branded**: Users define props interfaces directly — adding `Reactive<>` would feel tricky and leak compiler internals into DX. Regex-based props detection remains.
- **No workspace-specific logic in compiler**: `createProgramForFile` does simple module resolution from the file's directory. For full type resolution in monorepos, callers should pass `CompileOptions.program`.
- **`Reactive<T>` uses string property brand** (`{ readonly __reactive: true }`) instead of `unique symbol` — simpler and works reliably across virtual compiler hosts.

## Test plan

- [x] 18 new tests in `reactive-type-detection.test.ts`:
  - Unit: `isReactiveType` detects branded vs plain types
  - Unit: `containsReactiveExpression` for signal/memo/FieldReturn/FormReturn/static/setter
  - Integration: IR reactivity flags for signal, memo, props, ternary, tainted constants
- [x] All existing tests pass (347 jsx, 40 form, 47 dom — pre-existing failures unrelated)
- [x] Core packages build successfully (`@barefootjs/dom`, `@barefootjs/jsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)