### PR TITLE
Skip ts.createProgram for files without Reactive<T> imports

### DIFF
--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -24,6 +24,25 @@ import path from 'path'
 // =============================================================================
 
 /**
+ * Packages that export Reactive<T>-branded types beyond createSignal/createMemo.
+ * Files importing from these packages need ts.TypeChecker for reactivity detection.
+ * Regex-based detection handles createSignal/createMemo/props; the TypeChecker is
+ * only needed for library accessor patterns like username.error() or form.isSubmitting().
+ */
+const REACTIVE_BRAND_PACKAGES = [
+  '@barefootjs/form',
+]
+
+/**
+ * Check if a source file imports from packages that export Reactive<T>-branded types.
+ * Only these files need ts.createProgram() for type-based detection — all others
+ * can rely on the regex fallback (which handles signals, memos, and props).
+ */
+export function needsTypeBasedDetection(source: string): boolean {
+  return REACTIVE_BRAND_PACKAGES.some(pkg => source.includes(pkg))
+}
+
+/**
  * Create a TypeScript program for a single file to enable type-based reactivity detection.
  * Uses a virtual CompilerHost that injects the source string as a virtual file
  * and delegates to the real file system for node_modules resolution.
@@ -115,8 +134,10 @@ export function analyzeComponent(
     )
   }
 
-  // Try to create a program for type-based reactivity detection
-  if (!checker) {
+  // Create ts.Program only when the file imports from packages that export
+  // Reactive<T>-branded types beyond what regex detection handles.
+  // This avoids ~220ms overhead per file for the majority of components.
+  if (!checker && needsTypeBasedDetection(source)) {
     const result = createProgramForFile(source, filePath)
     if (result) {
       sourceFile = result.sourceFile

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -12,7 +12,7 @@ import type {
   FileOutput,
 } from './types'
 import type { TemplateAdapter } from './adapters/interface'
-import { analyzeComponent, listExportedComponents, createProgramForFile } from './analyzer'
+import { analyzeComponent, listExportedComponents, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
 import { collectComponentNamesFromIR } from './ir-to-client-js/generate-init'
@@ -125,8 +125,8 @@ function compileMultipleComponentsSync(
   // --- Pass 1: analyze + jsxToIR for ALL components ---
   const entries: { componentIR: ComponentIR; ctx: ReturnType<typeof analyzeComponent> }[] = []
 
-  // Create ts.Program once for all components in this file
-  const program = options.program ?? createProgramForFile(source, filePath)?.program
+  // Create ts.Program only when the file needs type-based reactivity detection
+  const program = options.program ?? (needsTypeBasedDetection(source) ? createProgramForFile(source, filePath)?.program : undefined)
 
   for (const componentName of componentNames) {
     const ctx = analyzeComponent(source, filePath, componentName, program)


### PR DESCRIPTION
## Summary

- Skip `ts.createProgram()` for component files that don't import from packages with `Reactive<T>`-branded types
- Add `needsTypeBasedDetection()` to check if a file imports from `@barefootjs/form` (currently the only such package)
- Reduces TypeChecker overhead from ~41s to ~0.5s for a full site build (~99% reduction)

## Context

PR #513 introduced `Reactive<T>` brand type detection using `ts.TypeChecker`. However, `createProgramForFile()` was called unconditionally for every component file (~186 files × ~220ms = ~41s overhead).

Regex-based detection already handles `createSignal`/`createMemo`/`props.xxx` patterns. The TypeChecker is only needed for library accessor patterns like `username.error()` or `form.isSubmitting()` — currently only 2 out of 186 files need this.

## Benchmark

| Metric | Before | After |
|--------|--------|-------|
| `ts.createProgram` calls | 186 | 2 |
| TypeChecker overhead | ~41.3s | ~0.5s |
| `needsTypeBasedDetection` cost | - | 0.2µs/call |

## Test plan

- [x] All 347 compiler tests pass
- [x] DOM tests pass
- [x] Full build completes successfully
- [x] Benchmark confirms ~99% reduction in TypeChecker overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)