### PR TITLE
Fix .map() key function missing index parameter

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -579,6 +579,34 @@ describe('Compiler', () => {
       // Should include index param in callback (not just item without index)
       expect(clientJs?.content).toContain('(item, i) => `')
     })
+
+    test('includes index parameter in key function when key references index', () => {
+      const source = `
+        'use client'
+        import { createMemo } from '@barefootjs/dom'
+
+        export function List() {
+          const items = createMemo(() => ['a', 'b', 'c'])
+          return (
+            <ul>
+              {items().map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // Key function must include the index parameter to avoid ReferenceError
+      expect(clientJs?.content).toContain('(item, i) => String(i)')
+    })
   })
 
   describe('local constants arrow function detection', () => {

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -450,7 +450,9 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
       continue
     }
 
-    const keyFn = elem.key ? `(${elem.param}) => String(${elem.key})` : 'null'
+    const keyFn = elem.key
+      ? `(${elem.param}${elem.index ? `, ${elem.index}` : ''}) => String(${elem.key})`
+      : 'null'
 
     const vLoop = varSlotId(elem.slotId)
 


### PR DESCRIPTION
## Summary

- Fix key function generation in `emit-init-sections.ts` to include the index parameter when the `.map()` callback's key references it (e.g., `key={i}`)
- Previously, `weeks().map((week, weekIdx) => <tr key={weekIdx}>...</tr>)` generated `(week) => String(weekIdx)`, causing a `ReferenceError` at runtime
- Now correctly generates `(week, weekIdx) => String(weekIdx)`

Closes #519

## Test plan

- [x] Added unit test verifying `(item, i) => String(i)` pattern in generated key function
- [x] All 141 compiler tests pass (`bun test` in `packages/jsx/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)