### PR TITLE
Fix ternary text branches not quoted in JSX output

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -505,14 +505,6 @@ export class HonoAdapter implements TemplateAdapter {
       if (node.expr === 'null' || node.expr === 'undefined') {
         return 'null'
       }
-      // Strip quotes from string literals for text content
-      const trimmed = node.expr.trim()
-      if (
-        (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-        (trimmed.startsWith('"') && trimmed.endsWith('"'))
-      ) {
-        return trimmed.slice(1, -1)
-      }
       return node.expr
     }
     return this.renderNode(node)
@@ -555,15 +547,8 @@ export class HonoAdapter implements TemplateAdapter {
       }
     }
 
-    // Determine if content should be wrapped in braces
+    // Expression node: wrap in braces for valid JSX
     if (node.type === 'expression') {
-      const trimmed = (node as IRExpression).expr.trim()
-      // String literal: output as text (quotes already stripped by renderNodeRaw)
-      if ((trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-          (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
-        return `<>{bfComment("cond-start:${condId}")}${content}{bfComment("cond-end:${condId}")}</>`
-      }
-      // Other expression: wrap in braces
       return `<>{bfComment("cond-start:${condId}")}{${content}}{bfComment("cond-end:${condId}")}</>`
     }
 

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -3994,4 +3994,81 @@ describe('Compiler', () => {
       expect(signalIndex).toBeLessThan(totalIndex)
     })
   })
+
+  describe('ternary text branches (#521)', () => {
+    test('non-reactive ternary preserves string quotes (TestAdapter)', () => {
+      const source = `
+        export function SubmitButton(props: { isSubmitting: boolean }) {
+          return <button>{props.isSubmitting ? 'Submitting...' : 'Submit'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain("'Submitting...'")
+      expect(template.content).toContain("'Submit'")
+    })
+
+    test('reactive ternary preserves string quotes (TestAdapter)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function SubmitButton() {
+          const [isSubmitting, setIsSubmitting] = createSignal(false)
+          return <button>{isSubmitting() ? 'Submitting...' : 'Submit'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain("'Submitting...'")
+      expect(template.content).toContain("'Submit'")
+    })
+
+    test('non-reactive ternary preserves string quotes (HonoAdapter)', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        export function SubmitButton(props: { isSubmitting: boolean }) {
+          return <button>{props.isSubmitting ? 'Submitting...' : 'Submit'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain("'Submitting...'")
+      expect(template.content).toContain("'Submit'")
+    })
+
+    test('reactive ternary wraps string literals in braces (HonoAdapter)', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function SubmitButton() {
+          const [isSubmitting, setIsSubmitting] = createSignal(false)
+          return <button>{isSubmitting() ? 'Submitting...' : 'Submit'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      // String literals should be wrapped in braces inside cond marker fragments
+      expect(template.content).toContain("{'Submitting...'}")
+      expect(template.content).toContain("{'Submit'}")
+    })
+  })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -269,13 +269,6 @@ export class TestAdapter extends BaseAdapter {
       if (node.expr === 'null' || node.expr === 'undefined') {
         return 'null'
       }
-      const trimmed = node.expr.trim()
-      if (
-        (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-        (trimmed.startsWith('"') && trimmed.endsWith('"'))
-      ) {
-        return trimmed.slice(1, -1)
-      }
       return node.expr
     }
     return this.renderNode(node)


### PR DESCRIPTION
## Summary

- Remove quote-stripping logic from `renderNodeRaw()` in both HonoAdapter and TestAdapter that was producing invalid JS (e.g., `Submitting...` instead of `'Submitting...'`) in ternary branches
- Simplify `wrapWithCondMarker()` in HonoAdapter to uniformly brace-wrap all expression nodes, removing the now-unnecessary string literal special case
- Add 4 regression tests covering non-reactive/reactive ternaries across both adapters

Fixes #521

## Test plan

- [x] `bun test packages/jsx/` — all 351 tests pass (including 4 new regression tests)
- [ ] Verify compiled `.tsx` output contains properly quoted ternary branches in form demos

🤖 Generated with [Claude Code](https://claude.com/claude-code)