### PR TITLE
Add Combobox component

### DIFF
--- a/site/ui/components/combobox-demo.tsx
+++ b/site/ui/components/combobox-demo.tsx
@@ -1,0 +1,154 @@
+"use client"
+/**
+ * ComboboxDemo Components
+ *
+ * Interactive demos for Combobox component.
+ * Based on shadcn/ui patterns for practical use cases.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import {
+  Combobox,
+  ComboboxTrigger,
+  ComboboxValue,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxSeparator,
+} from '@ui/components/ui/combobox'
+
+/**
+ * Basic combobox example
+ * Framework selector with search and value display
+ */
+export function ComboboxBasicDemo() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <div className="space-y-3">
+      <Combobox value={value()} onValueChange={setValue}>
+        <ComboboxTrigger className="w-[280px]">
+          <ComboboxValue placeholder="Select framework..." />
+        </ComboboxTrigger>
+        <ComboboxContent>
+          <ComboboxInput placeholder="Search framework..." />
+          <ComboboxEmpty>No framework found.</ComboboxEmpty>
+          <ComboboxItem value="next">Next.js</ComboboxItem>
+          <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+          <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+          <ComboboxItem value="remix">Remix</ComboboxItem>
+          <ComboboxItem value="astro">Astro</ComboboxItem>
+        </ComboboxContent>
+      </Combobox>
+      <p className="text-sm text-muted-foreground">
+        Selected: <span className="selected-value font-medium">{value() || 'None'}</span>
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Form example with combobox
+ * Language picker with multiple comboboxes for a developer profile form
+ */
+export function ComboboxFormDemo() {
+  const [language, setLanguage] = createSignal('')
+  const [framework, setFramework] = createSignal('')
+
+  const summary = createMemo(() => {
+    const parts: string[] = []
+    if (language()) parts.push(language())
+    if (framework()) parts.push(`with ${framework()}`)
+    return parts.length > 0 ? parts.join(' ') : 'No selections yet'
+  })
+
+  return (
+    <div className="space-y-4 max-w-sm">
+      <h4 className="text-sm font-medium leading-none">Tech Stack</h4>
+      <div className="grid gap-3">
+        <div className="space-y-1">
+          <span className="text-sm text-muted-foreground">Language</span>
+          <Combobox value={language()} onValueChange={setLanguage}>
+            <ComboboxTrigger>
+              <ComboboxValue placeholder="Select language..." />
+            </ComboboxTrigger>
+            <ComboboxContent>
+              <ComboboxInput placeholder="Search language..." />
+              <ComboboxEmpty>No language found.</ComboboxEmpty>
+              <ComboboxItem value="TypeScript">TypeScript</ComboboxItem>
+              <ComboboxItem value="JavaScript">JavaScript</ComboboxItem>
+              <ComboboxItem value="Python">Python</ComboboxItem>
+              <ComboboxItem value="Go">Go</ComboboxItem>
+              <ComboboxItem value="Rust">Rust</ComboboxItem>
+            </ComboboxContent>
+          </Combobox>
+        </div>
+        <div className="space-y-1">
+          <span className="text-sm text-muted-foreground">Framework</span>
+          <Combobox value={framework()} onValueChange={setFramework}>
+            <ComboboxTrigger>
+              <ComboboxValue placeholder="Select framework..." />
+            </ComboboxTrigger>
+            <ComboboxContent>
+              <ComboboxInput placeholder="Search framework..." />
+              <ComboboxEmpty>No framework found.</ComboboxEmpty>
+              <ComboboxItem value="Next.js">Next.js</ComboboxItem>
+              <ComboboxItem value="Remix">Remix</ComboboxItem>
+              <ComboboxItem value="Hono">Hono</ComboboxItem>
+              <ComboboxItem value="FastAPI">FastAPI</ComboboxItem>
+              <ComboboxItem value="Actix">Actix</ComboboxItem>
+            </ComboboxContent>
+          </Combobox>
+        </div>
+      </div>
+      <div className="text-sm text-muted-foreground pt-2 border-t">
+        Summary: <span className="summary-text font-medium">{summary()}</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Grouped combobox example
+ * Timezone selector with searchable grouped options
+ */
+export function ComboboxGroupedDemo() {
+  const [timezone, setTimezone] = createSignal('')
+
+  return (
+    <div className="space-y-3">
+      <Combobox value={timezone()} onValueChange={setTimezone}>
+        <ComboboxTrigger className="w-[320px]">
+          <ComboboxValue placeholder="Select timezone..." />
+        </ComboboxTrigger>
+        <ComboboxContent>
+          <ComboboxInput placeholder="Search timezone..." />
+          <ComboboxEmpty>No timezone found.</ComboboxEmpty>
+          <ComboboxGroup heading="North America">
+            <ComboboxItem value="est">Eastern Standard Time (EST)</ComboboxItem>
+            <ComboboxItem value="cst">Central Standard Time (CST)</ComboboxItem>
+            <ComboboxItem value="mst">Mountain Standard Time (MST)</ComboboxItem>
+            <ComboboxItem value="pst">Pacific Standard Time (PST)</ComboboxItem>
+          </ComboboxGroup>
+          <ComboboxSeparator />
+          <ComboboxGroup heading="Europe">
+            <ComboboxItem value="gmt">Greenwich Mean Time (GMT)</ComboboxItem>
+            <ComboboxItem value="cet">Central European Time (CET)</ComboboxItem>
+            <ComboboxItem value="eet">Eastern European Time (EET)</ComboboxItem>
+          </ComboboxGroup>
+          <ComboboxSeparator />
+          <ComboboxGroup heading="Asia">
+            <ComboboxItem value="ist">India Standard Time (IST)</ComboboxItem>
+            <ComboboxItem value="cst_china">China Standard Time (CST)</ComboboxItem>
+            <ComboboxItem value="jst">Japan Standard Time (JST)</ComboboxItem>
+          </ComboboxGroup>
+        </ComboboxContent>
+      </Combobox>
+      <p className="text-sm text-muted-foreground">
+        Selected: <span className="selected-timezone font-medium">{timezone() || 'None'}</span>
+      </p>
+    </div>
+  )
+}

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -20,6 +20,7 @@ export const componentOrder = [
   { slug: 'checkbox', title: 'Checkbox' },
   { slug: 'collapsible', title: 'Collapsible' },
   { slug: 'command', title: 'Command' },
+  { slug: 'combobox', title: 'Combobox' },
   { slug: 'context-menu', title: 'Context Menu' },
   { slug: 'data-table', title: 'Data Table' },
   { slug: 'dialog', title: 'Dialog' },

--- a/site/ui/e2e/combobox.spec.ts
+++ b/site/ui/e2e/combobox.spec.ts
@@ -1,0 +1,336 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Combobox Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/components/combobox')
+  })
+
+  test.describe('Basic Demo', () => {
+    test('renders trigger with placeholder', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+      await expect(trigger).toBeVisible()
+      await expect(trigger.locator('[data-slot="combobox-value"]')).toContainText('Select framework...')
+    })
+
+    test('click opens dropdown', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+      await expect(content.locator('[data-slot="combobox-item"][data-value="next"]')).toBeVisible()
+      await expect(content.locator('[data-slot="combobox-item"][data-value="svelte"]')).toBeVisible()
+    })
+
+    test('select item updates trigger label and closes dropdown', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await content.locator('[data-slot="combobox-item"][data-value="next"]').click()
+
+      // Dropdown should close
+      await expect(content).toHaveCount(0)
+
+      // Trigger should show selected label
+      await expect(trigger.locator('[data-slot="combobox-value"]')).toContainText('Next.js')
+    })
+
+    test('ESC closes dropdown', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.keyboard.press('Escape')
+      await expect(content).toHaveCount(0)
+    })
+
+    test('click outside closes dropdown', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await expect(content).toBeVisible()
+
+      await page.locator('h1').click()
+      await expect(content).toHaveCount(0)
+    })
+
+    test('value display updates after selection', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+      const valueText = section.locator('.selected-value')
+
+      // Initially "None"
+      await expect(valueText).toContainText('None')
+
+      // Select Nuxt
+      await trigger.click()
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await content.locator('[data-slot="combobox-item"]').filter({ hasText: 'Nuxt' }).click()
+
+      await expect(valueText).toContainText('nuxt')
+    })
+
+    test('selected item shows check indicator', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      // Select Next.js
+      await trigger.click()
+      let content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await content.locator('[data-slot="combobox-item"][data-value="next"]').click()
+
+      // Reopen to verify check indicator
+      await trigger.click()
+      content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const nextItem = content.locator('[data-slot="combobox-item"][data-value="next"]')
+      await expect(nextItem).toHaveAttribute('data-state', 'checked')
+      await expect(nextItem).toHaveAttribute('aria-selected', 'true')
+    })
+
+    test('has correct ARIA roles', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await expect(trigger).toHaveAttribute('role', 'combobox')
+      await expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+      await trigger.click()
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await expect(content).toHaveAttribute('role', 'listbox')
+
+      const items = content.locator('[data-slot="combobox-item"]')
+      await expect(items.first()).toHaveAttribute('role', 'option')
+    })
+
+    test('search filters items', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const input = content.locator('[data-slot="combobox-input"]')
+
+      // All items visible initially
+      const allItems = content.locator('[data-slot="combobox-item"]')
+      await expect(allItems).toHaveCount(5)
+
+      // Type "next" to filter
+      await input.fill('next')
+
+      // Only Next.js should be visible
+      const visibleItems = content.locator('[data-slot="combobox-item"]:not([hidden])')
+      await expect(visibleItems).toHaveCount(1)
+      await expect(visibleItems.first()).toContainText('Next.js')
+    })
+
+    test('empty state shows when no items match', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const input = content.locator('[data-slot="combobox-input"]')
+
+      // Type something that matches nothing
+      await input.fill('zzzzz')
+
+      const empty = content.locator('[data-slot="combobox-empty"]:not([hidden])')
+      await expect(empty).toBeVisible()
+      await expect(empty).toContainText('No framework found.')
+    })
+
+    test('keyboard navigation with arrow keys', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const items = content.locator('[data-slot="combobox-item"]:not([hidden])')
+
+      // First item should be auto-selected
+      await expect(items.first()).toHaveAttribute('data-selected', 'true')
+
+      // Arrow down should select next item
+      await page.keyboard.press('ArrowDown')
+      await expect(items.nth(0)).toHaveAttribute('data-selected', 'false')
+      await expect(items.nth(1)).toHaveAttribute('data-selected', 'true')
+
+      // Arrow down again
+      await page.keyboard.press('ArrowDown')
+      await expect(items.nth(1)).toHaveAttribute('data-selected', 'false')
+      await expect(items.nth(2)).toHaveAttribute('data-selected', 'true')
+
+      // Arrow up should go back
+      await page.keyboard.press('ArrowUp')
+      await expect(items.nth(2)).toHaveAttribute('data-selected', 'false')
+      await expect(items.nth(1)).toHaveAttribute('data-selected', 'true')
+    })
+
+    test('Enter key selects highlighted item', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+
+      // Navigate to SvelteKit (second item)
+      await page.keyboard.press('ArrowDown')
+
+      // Press Enter to select
+      await page.keyboard.press('Enter')
+
+      // Dropdown should close and value should update
+      await expect(content).toHaveCount(0)
+      await expect(trigger.locator('[data-slot="combobox-value"]')).toContainText('SvelteKit')
+    })
+
+    test('search is cleared after selection', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxBasicDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      let content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const input = content.locator('[data-slot="combobox-input"]')
+
+      // Type to filter
+      await input.fill('nuxt')
+
+      // Select the filtered item
+      const visibleItems = content.locator('[data-slot="combobox-item"]:not([hidden])')
+      await visibleItems.first().click()
+
+      // Reopen
+      await trigger.click()
+      content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+
+      // Search should be cleared, all items visible
+      const allItems = content.locator('[data-slot="combobox-item"]:not([hidden])')
+      await expect(allItems).toHaveCount(5)
+    })
+  })
+
+  test.describe('Form Demo', () => {
+    test('displays two combobox fields', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxFormDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const triggers = section.locator('[data-slot="combobox-trigger"]')
+      await expect(triggers).toHaveCount(2)
+    })
+
+    test('shows initial summary', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxFormDemo_"]:not([data-slot])').first()
+      await expect(section.locator('.summary-text')).toContainText('No selections yet')
+    })
+
+    test('selecting values updates summary', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxFormDemo_"]:not([data-slot])').first()
+      const triggers = section.locator('[data-slot="combobox-trigger"]')
+      const summaryText = section.locator('.summary-text')
+
+      // Select language (first trigger)
+      await triggers.nth(0).click()
+      let content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await content.locator('[data-slot="combobox-item"]').filter({ hasText: 'TypeScript' }).click()
+
+      await expect(summaryText).toContainText('TypeScript')
+
+      // Select framework (second trigger)
+      await triggers.nth(1).click()
+      content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await content.locator('[data-slot="combobox-item"]').filter({ hasText: 'Hono' }).click()
+
+      await expect(summaryText).toContainText('TypeScript')
+      await expect(summaryText).toContainText('Hono')
+    })
+  })
+
+  test.describe('Grouped Demo', () => {
+    test('group headings visible', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxGroupedDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      await expect(content.locator('[data-slot="combobox-group-heading"]').filter({ hasText: 'North America' })).toBeVisible()
+      await expect(content.locator('[data-slot="combobox-group-heading"]').filter({ hasText: 'Europe' })).toBeVisible()
+      await expect(content.locator('[data-slot="combobox-group-heading"]').filter({ hasText: 'Asia' })).toBeVisible()
+    })
+
+    test('separators present', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxGroupedDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const separators = content.locator('[data-slot="combobox-separator"]')
+      expect(await separators.count()).toBe(2)
+    })
+
+    test('selection from groups works', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxGroupedDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+      const valueText = section.locator('.selected-timezone')
+
+      // Initially "None"
+      await expect(valueText).toContainText('None')
+
+      // Select JST from Asia group
+      await trigger.click()
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const jstItem = content.locator('[data-slot="combobox-item"]').filter({ hasText: 'Japan Standard Time' })
+      await jstItem.scrollIntoViewIfNeeded()
+      await jstItem.click()
+
+      await expect(valueText).toContainText('jst')
+      await expect(trigger.locator('[data-slot="combobox-value"]')).toContainText('Japan Standard Time')
+    })
+
+    test('search filters across groups', async ({ page }) => {
+      const section = page.locator('[bf-s^="ComboboxGroupedDemo_"]:not([data-slot])').first()
+      const trigger = section.locator('[data-slot="combobox-trigger"]')
+
+      await trigger.click()
+
+      const content = page.locator('[data-slot="combobox-content"][data-state="open"]')
+      const input = content.locator('[data-slot="combobox-input"]')
+
+      // Type "eastern" to filter
+      await input.fill('eastern')
+
+      // Should match EST and EET
+      const visibleItems = content.locator('[data-slot="combobox-item"]:not([hidden])')
+      await expect(visibleItems).toHaveCount(2)
+
+      // Groups without visible items should be hidden
+      const visibleGroups = content.locator('[data-slot="combobox-group"]:not([hidden])')
+      await expect(visibleGroups).toHaveCount(2) // North America and Europe
+    })
+  })
+})

--- a/site/ui/pages/combobox.tsx
+++ b/site/ui/pages/combobox.tsx
@@ -1,0 +1,272 @@
+/**
+ * Combobox Documentation Page
+ */
+
+import { ComboboxBasicDemo, ComboboxFormDemo, ComboboxGroupedDemo } from '@/components/combobox-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../components/shared/docs'
+import { getNavLinks } from '../components/shared/PageNavigation'
+
+// Table of contents items
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'form', title: 'Form', branch: 'child' },
+  { id: 'grouped', title: 'Grouped', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+// Code examples
+const previewCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@/components/ui/combobox'
+
+function ComboboxBasicDemo() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <Combobox value={value()} onValueChange={setValue}>
+      <ComboboxTrigger class="w-[280px]">
+        <ComboboxValue placeholder="Select framework..." />
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput placeholder="Search framework..." />
+        <ComboboxEmpty>No framework found.</ComboboxEmpty>
+        <ComboboxItem value="next">Next.js</ComboboxItem>
+        <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+        <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+        <ComboboxItem value="remix">Remix</ComboboxItem>
+        <ComboboxItem value="astro">Astro</ComboboxItem>
+      </ComboboxContent>
+    </Combobox>
+  )
+}`
+
+const basicCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@/components/ui/combobox'
+
+function ComboboxBasicDemo() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <div className="space-y-3">
+      <Combobox value={value()} onValueChange={setValue}>
+        <ComboboxTrigger class="w-[280px]">
+          <ComboboxValue placeholder="Select framework..." />
+        </ComboboxTrigger>
+        <ComboboxContent>
+          <ComboboxInput placeholder="Search framework..." />
+          <ComboboxEmpty>No framework found.</ComboboxEmpty>
+          <ComboboxItem value="next">Next.js</ComboboxItem>
+          <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+          <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+          <ComboboxItem value="remix">Remix</ComboboxItem>
+          <ComboboxItem value="astro">Astro</ComboboxItem>
+        </ComboboxContent>
+      </Combobox>
+      <p className="text-sm text-muted-foreground">
+        Selected: {value() || 'None'}
+      </p>
+    </div>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@/components/ui/combobox'
+
+function ComboboxFormDemo() {
+  const [language, setLanguage] = createSignal('')
+  const [framework, setFramework] = createSignal('')
+
+  const summary = createMemo(() => {
+    const parts: string[] = []
+    if (language()) parts.push(language())
+    if (framework()) parts.push(\`with \${framework()}\`)
+    return parts.length > 0 ? parts.join(' ') : 'No selections yet'
+  })
+
+  return (
+    <div className="space-y-4 max-w-sm">
+      <h4 className="text-sm font-medium">Tech Stack</h4>
+      <div className="grid gap-3">
+        <Combobox value={language()} onValueChange={setLanguage}>
+          <ComboboxTrigger>
+            <ComboboxValue placeholder="Select language..." />
+          </ComboboxTrigger>
+          <ComboboxContent>
+            <ComboboxInput placeholder="Search language..." />
+            <ComboboxEmpty>No language found.</ComboboxEmpty>
+            <ComboboxItem value="TypeScript">TypeScript</ComboboxItem>
+            <ComboboxItem value="JavaScript">JavaScript</ComboboxItem>
+            <ComboboxItem value="Python">Python</ComboboxItem>
+            <ComboboxItem value="Go">Go</ComboboxItem>
+            <ComboboxItem value="Rust">Rust</ComboboxItem>
+          </ComboboxContent>
+        </Combobox>
+        {/* ... more comboboxes ... */}
+      </div>
+      <p>Summary: {summary()}</p>
+    </div>
+  )
+}`
+
+const groupedCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+  ComboboxGroup, ComboboxSeparator,
+} from '@/components/ui/combobox'
+
+function ComboboxGroupedDemo() {
+  const [timezone, setTimezone] = createSignal('')
+
+  return (
+    <Combobox value={timezone()} onValueChange={setTimezone}>
+      <ComboboxTrigger class="w-[320px]">
+        <ComboboxValue placeholder="Select timezone..." />
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput placeholder="Search timezone..." />
+        <ComboboxEmpty>No timezone found.</ComboboxEmpty>
+        <ComboboxGroup heading="North America">
+          <ComboboxItem value="est">Eastern Standard Time (EST)</ComboboxItem>
+          <ComboboxItem value="cst">Central Standard Time (CST)</ComboboxItem>
+          <ComboboxItem value="pst">Pacific Standard Time (PST)</ComboboxItem>
+        </ComboboxGroup>
+        <ComboboxSeparator />
+        <ComboboxGroup heading="Europe">
+          <ComboboxItem value="gmt">Greenwich Mean Time (GMT)</ComboboxItem>
+          <ComboboxItem value="cet">Central European Time (CET)</ComboboxItem>
+        </ComboboxGroup>
+        <ComboboxSeparator />
+        <ComboboxGroup heading="Asia">
+          <ComboboxItem value="jst">Japan Standard Time (JST)</ComboboxItem>
+          <ComboboxItem value="cst_china">China Standard Time (CST)</ComboboxItem>
+        </ComboboxGroup>
+      </ComboboxContent>
+    </Combobox>
+  )
+}`
+
+// Props definitions
+const comboboxProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Controlled selected value.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when the selected value changes.',
+  },
+  {
+    name: 'filter',
+    type: '(value: string, search: string) => boolean',
+    description: 'Custom filter function. Defaults to case-insensitive substring match.',
+  },
+]
+
+const comboboxItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this option (required).',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this option is disabled.',
+  },
+]
+
+const comboboxInputProps: PropDefinition[] = [
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text for the search input.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the search input is disabled.',
+  },
+]
+
+export function ComboboxPage() {
+  return (
+    <DocPage slug="combobox" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Combobox"
+          description="Autocomplete input with searchable dropdown."
+          {...getNavLinks('combobox')}
+        />
+
+        {/* Preview */}
+        <Example title="" code={previewCode}>
+          <ComboboxBasicDemo />
+        </Example>
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add combobox" />
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <ComboboxBasicDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <ComboboxFormDemo />
+            </Example>
+
+            <Example title="Grouped" code={groupedCode}>
+              <ComboboxGroupedDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <h3 className="text-base font-semibold mb-2">Combobox</h3>
+          <PropsTable props={comboboxProps} />
+          <h3 className="text-base font-semibold mt-6 mb-2">ComboboxItem</h3>
+          <PropsTable props={comboboxItemProps} />
+          <h3 className="text-base font-semibold mt-6 mb-2">ComboboxInput</h3>
+          <PropsTable props={comboboxInputProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -85,6 +85,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Checkbox', href: '/docs/components/checkbox' },
       { title: 'Collapsible', href: '/docs/components/collapsible' },
       { title: 'Command', href: '/docs/components/command' },
+      { title: 'Combobox', href: '/docs/components/combobox' },
       { title: 'Context Menu', href: '/docs/components/context-menu' },
       { title: 'Data Table', href: '/docs/components/data-table' },
       { title: 'Dialog', href: '/docs/components/dialog' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -26,6 +26,7 @@ import { SwitchPage } from './pages/switch'
 import { AccordionPage } from './pages/accordion'
 import { CollapsiblePage } from './pages/collapsible'
 import { CommandPage } from './pages/command'
+import { ComboboxPage } from './pages/combobox'
 import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
 import { ContextMenuPage } from './pages/context-menu'
@@ -142,6 +143,10 @@ export function createApp() {
             <a href="/docs/components/command" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Command</h3>
               <p className="text-xs text-muted-foreground">Search and command menu</p>
+            </a>
+            <a href="/docs/components/combobox" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+              <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Combobox</h3>
+              <p className="text-xs text-muted-foreground">Autocomplete input with searchable dropdown</p>
             </a>
             <a href="/docs/components/context-menu" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Context Menu</h3>
@@ -376,6 +381,11 @@ export function createApp() {
   // Command documentation
   app.get('/docs/components/command', (c) => {
     return c.render(<CommandPage />)
+  })
+
+  // Combobox documentation
+  app.get('/docs/components/combobox', (c) => {
+    return c.render(<ComboboxPage />)
   })
 
   // Checkbox documentation

--- a/ui/components/ui/combobox/index.preview.tsx
+++ b/ui/components/ui/combobox/index.preview.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Combobox,
+  ComboboxTrigger,
+  ComboboxValue,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxEmpty,
+  ComboboxItem,
+} from '../combobox'
+
+export function Default() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <Combobox value={value()} onValueChange={setValue}>
+      <ComboboxTrigger className="w-[280px]">
+        <ComboboxValue placeholder="Select framework..." />
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput placeholder="Search framework..." />
+        <ComboboxEmpty>No framework found.</ComboboxEmpty>
+        <ComboboxItem value="next">Next.js</ComboboxItem>
+        <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+        <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+        <ComboboxItem value="remix">Remix</ComboboxItem>
+        <ComboboxItem value="astro">Astro</ComboboxItem>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/ui/components/ui/combobox/index.test.tsx
+++ b/ui/components/ui/combobox/index.test.tsx
@@ -1,0 +1,269 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const comboboxSource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Combobox (stateful — open signal, search signal, context)
+// ---------------------------------------------------------------------------
+
+describe('Combobox', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'Combobox')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('isClient is true', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('componentName is Combobox', () => {
+    expect(result.componentName).toBe('Combobox')
+  })
+
+  test('has signal: open (createSignal)', () => {
+    expect(result.signals).toContain('open')
+  })
+
+  test('has signal: search (createSignal)', () => {
+    expect(result.signals).toContain('search')
+  })
+
+  test('renders a div with data-slot=combobox', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.props['data-slot']).toBe('combobox')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxTrigger (stateful — reads context, effects for aria-expanded)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxTrigger', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxTrigger')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxTrigger', () => {
+    expect(result.componentName).toBe('ComboboxTrigger')
+  })
+
+  test('has role=combobox', () => {
+    const trigger = result.find({ role: 'combobox' })
+    expect(trigger).not.toBeNull()
+    expect(trigger!.tag).toBe('button')
+  })
+
+  test('has aria-expanded attribute', () => {
+    const trigger = result.find({ role: 'combobox' })!
+    expect(trigger.aria).toHaveProperty('expanded')
+  })
+
+  test('has aria-haspopup attribute', () => {
+    const trigger = result.find({ role: 'combobox' })!
+    expect(trigger.aria).toHaveProperty('haspopup')
+  })
+
+  test('has aria-autocomplete=list', () => {
+    const trigger = result.find({ role: 'combobox' })!
+    expect(trigger.aria).toHaveProperty('autocomplete')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxValue (stateful — reads context value, updates text)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxValue', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxValue')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxValue', () => {
+    expect(result.componentName).toBe('ComboboxValue')
+  })
+
+  test('renders as span with data-slot=combobox-value', () => {
+    expect(result.root.tag).toBe('span')
+    expect(result.root.props['data-slot']).toBe('combobox-value')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxContent (stateful — portal, positioning, global listeners)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxContent', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxContent')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxContent', () => {
+    expect(result.componentName).toBe('ComboboxContent')
+  })
+
+  test('has role=listbox', () => {
+    const listbox = result.find({ role: 'listbox' })
+    expect(listbox).not.toBeNull()
+    expect(listbox!.props['data-slot']).toBe('combobox-content')
+  })
+
+  test('has data-state attribute', () => {
+    const listbox = result.find({ role: 'listbox' })!
+    expect(listbox.dataState).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxInput (stateful — writes to context search)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxInput', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxInput')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxInput', () => {
+    expect(result.componentName).toBe('ComboboxInput')
+  })
+
+  test('renders wrapper with data-slot=combobox-input-wrapper', () => {
+    expect(result.root.props['data-slot']).toBe('combobox-input-wrapper')
+  })
+
+  test('contains an input element', () => {
+    const input = result.find({ tag: 'input' })
+    expect(input).not.toBeNull()
+    expect(input!.props['data-slot']).toBe('combobox-input')
+  })
+
+  test('contains a search icon (svg)', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxEmpty (stateful — checks visible items to toggle visibility)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxEmpty', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxEmpty')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxEmpty', () => {
+    expect(result.componentName).toBe('ComboboxEmpty')
+  })
+
+  test('renders as div with data-slot=combobox-empty', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('combobox-empty')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-center')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxItem (stateful — self-filters, click handler, check indicator)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxItem', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxItem')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxItem', () => {
+    expect(result.componentName).toBe('ComboboxItem')
+  })
+
+  test('renders as div with data-slot=combobox-item', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('combobox-item')
+  })
+
+  test('has role=option', () => {
+    expect(result.root.role).toBe('option')
+  })
+
+  test('has aria-selected attribute', () => {
+    expect(result.root.aria).toHaveProperty('selected')
+  })
+
+  test('has data-selected attribute', () => {
+    expect(result.root.props['data-selected']).toBe('false')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxGroup (stateful — auto-hides when all items filtered)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxGroup', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxGroup', () => {
+    expect(result.componentName).toBe('ComboboxGroup')
+  })
+
+  test('renders as div with data-slot=combobox-group', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('combobox-group')
+  })
+
+  test('has role=group', () => {
+    expect(result.root.role).toBe('group')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComboboxSeparator (stateless)
+// ---------------------------------------------------------------------------
+
+describe('ComboboxSeparator', () => {
+  const result = renderToTest(comboboxSource, 'combobox.tsx', 'ComboboxSeparator')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ComboboxSeparator', () => {
+    expect(result.componentName).toBe('ComboboxSeparator')
+  })
+
+  test('renders as div with data-slot=combobox-separator', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('combobox-separator')
+  })
+
+  test('has role=separator', () => {
+    expect(result.root.role).toBe('separator')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('bg-border')
+  })
+})

--- a/ui/components/ui/combobox/index.tsx
+++ b/ui/components/ui/combobox/index.tsx
@@ -1,0 +1,660 @@
+"use client"
+
+/**
+ * Combobox Components
+ *
+ * An autocomplete input with searchable dropdown.
+ * Composes Popover (portal, positioning, click-outside, ESC) with
+ * Command-style search filtering and keyboard navigation.
+ *
+ * State management uses createContext/useContext for parent-child communication.
+ * Root Combobox manages open/value/search state, children consume via context.
+ *
+ * Features:
+ * - Search filtering (case-insensitive substring)
+ * - Arrow key navigation within filtered results
+ * - Enter to select, ESC to close
+ * - Click outside to close
+ * - Check indicator on selected item
+ * - Portal for Content (escape overflow clipping)
+ * - Accessibility (role="combobox", role="listbox", role="option")
+ * - data-state attribute-driven styling
+ *
+ * @example Basic usage
+ * ```tsx
+ * const [value, setValue] = createSignal('')
+ *
+ * <Combobox value={value()} onValueChange={setValue}>
+ *   <ComboboxTrigger>
+ *     <ComboboxValue placeholder="Select framework..." />
+ *   </ComboboxTrigger>
+ *   <ComboboxContent>
+ *     <ComboboxInput placeholder="Search..." />
+ *     <ComboboxEmpty>No results found.</ComboboxEmpty>
+ *     <ComboboxItem value="next">Next.js</ComboboxItem>
+ *     <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+ *   </ComboboxContent>
+ * </Combobox>
+ * ```
+ */
+
+import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/dom'
+import type { HTMLBaseAttributes, ButtonHTMLAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// --- Context ---
+
+interface ComboboxContextValue {
+  open: () => boolean
+  onOpenChange: (open: boolean) => void
+  value: () => string
+  onValueChange: (value: string) => void
+  search: () => string
+  onSearchChange: (value: string) => void
+  filter: (value: string, search: string) => boolean
+}
+
+const ComboboxContext = createContext<ComboboxContextValue>()
+
+// Store Content -> Trigger element mapping for positioning after portal
+const contentTriggerMap = new WeakMap<HTMLElement, HTMLElement>()
+
+// --- CSS Classes ---
+
+// Trigger (same pattern as SelectTrigger)
+const triggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
+const triggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
+const triggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+const triggerDataStateClasses = 'data-[placeholder]:text-muted-foreground'
+
+// Content (portal dropdown)
+const contentBaseClasses = 'fixed z-50 max-h-[min(var(--radix-select-content-available-height,384px),384px)] min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover shadow-md transform-gpu origin-top transition-[opacity,transform] duration-normal ease-out'
+const contentOpenClasses = 'opacity-100 scale-100'
+const contentClosedClasses = 'opacity-0 scale-95 pointer-events-none'
+
+// Input (search)
+const inputWrapperClasses = 'flex items-center border-b px-3'
+const inputClasses = 'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50'
+
+// Item
+const itemBaseClasses = 'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden'
+const itemDefaultClasses = 'text-popover-foreground hover:bg-accent/50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground'
+const itemDisabledClasses = 'pointer-events-none opacity-50'
+
+// Check indicator
+const indicatorClasses = 'absolute left-2 flex size-3.5 shrink-0 items-center justify-center'
+
+// Empty
+const emptyClasses = 'py-6 text-center text-sm'
+
+// Group
+const groupClasses = 'overflow-hidden p-1 text-foreground [&_[data-slot=combobox-group-heading]]:px-2 [&_[data-slot=combobox-group-heading]]:py-1.5 [&_[data-slot=combobox-group-heading]]:text-xs [&_[data-slot=combobox-group-heading]]:font-medium [&_[data-slot=combobox-group-heading]]:text-muted-foreground'
+
+// Separator
+const separatorClasses = '-mx-1 my-1 h-px bg-border'
+
+// --- Props ---
+
+interface ComboboxProps extends HTMLBaseAttributes {
+  /** Controlled selected value */
+  value?: string
+  /** Callback when the selected value changes */
+  onValueChange?: (value: string) => void
+  /** Custom filter function */
+  filter?: (value: string, search: string) => boolean
+  /** Children */
+  children?: Child
+}
+
+interface ComboboxTriggerProps extends ButtonHTMLAttributes {
+  /** Trigger content (typically ComboboxValue) */
+  children?: Child
+}
+
+interface ComboboxValueProps extends HTMLBaseAttributes {
+  /** Placeholder text when no value is selected */
+  placeholder?: string
+}
+
+interface ComboboxContentProps extends HTMLBaseAttributes {
+  /** Content children */
+  children?: Child
+  /** Alignment relative to trigger */
+  align?: 'start' | 'end'
+}
+
+interface ComboboxInputProps extends HTMLBaseAttributes {
+  /** Placeholder text */
+  placeholder?: string
+  /** Whether disabled */
+  disabled?: boolean
+}
+
+interface ComboboxEmptyProps extends HTMLBaseAttributes {
+  /** Children */
+  children?: Child
+}
+
+interface ComboboxItemProps extends HTMLBaseAttributes {
+  /** The value for this item */
+  value: string
+  /** Whether this item is disabled */
+  disabled?: boolean
+  /** Item content (label text) */
+  children?: Child
+}
+
+interface ComboboxGroupProps extends HTMLBaseAttributes {
+  /** Group heading text */
+  heading?: string
+  /** Children */
+  children?: Child
+}
+
+interface ComboboxSeparatorProps extends HTMLBaseAttributes {
+}
+
+// --- Components ---
+
+/**
+ * Combobox root component.
+ * Manages open/value/search state and provides context to children.
+ */
+function Combobox(props: ComboboxProps) {
+  const [open, setOpen] = createSignal(false)
+  const [search, setSearch] = createSignal('')
+
+  const filterFn = props.filter ?? ((value: string, search: string) => {
+    if (!search) return true
+    return value.toLowerCase().includes(search.toLowerCase())
+  })
+
+  return (
+    <ComboboxContext.Provider value={{
+      open,
+      onOpenChange: (v: boolean) => {
+        setOpen(v)
+        // Clear search when closing
+        if (!v) setSearch('')
+      },
+      value: () => props.value ?? '',
+      onValueChange: props.onValueChange ?? (() => {}),
+      search,
+      onSearchChange: setSearch,
+      filter: filterFn,
+    }}>
+      <div data-slot="combobox" id={props.id} className={`relative inline-block ${props.className ?? ''}`}>
+        {props.children}
+      </div>
+    </ComboboxContext.Provider>
+  )
+}
+
+/**
+ * Button that toggles the combobox dropdown.
+ * Shows a chevron icon and reads state from context.
+ */
+function ComboboxTrigger(props: ComboboxTriggerProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+
+    createEffect(() => {
+      el.setAttribute('aria-expanded', String(ctx.open()))
+      el.dataset.state = ctx.open() ? 'open' : 'closed'
+    })
+
+    el.addEventListener('click', () => {
+      ctx.onOpenChange(!ctx.open())
+    })
+
+    // Allow keyboard open
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (!ctx.open()) {
+          ctx.onOpenChange(true)
+        }
+      }
+    })
+  }
+
+  const classes = `${triggerBaseClasses} ${triggerFocusClasses} ${triggerDisabledClasses} ${triggerDataStateClasses} ${props.className ?? ''}`
+
+  return (
+    <button
+      data-slot="combobox-trigger"
+      type="button"
+      role="combobox"
+      id={props.id}
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-autocomplete="list"
+      data-state="closed"
+      className={classes}
+      ref={handleMount}
+    >
+      {props.children}
+      <svg className="size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+  )
+}
+
+/**
+ * Displays the selected value label or placeholder.
+ * Resolves the display text by querying portaled content DOM.
+ */
+function ComboboxValue(props: ComboboxValueProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+
+    createEffect(() => {
+      const val = ctx.value()
+      if (val) {
+        // Query the portaled content for the matching item's label
+        const itemEl = document.querySelector(`[data-slot="combobox-item"][data-value="${val}"]`) as HTMLElement
+        const label = itemEl?.textContent ?? val
+        el.textContent = label
+        // Remove placeholder attribute when value is selected
+        const trigger = el.closest('[data-slot="combobox-trigger"]')
+        trigger?.removeAttribute('data-placeholder')
+      } else {
+        el.textContent = props.placeholder ?? ''
+        // Set placeholder attribute for styling
+        const trigger = el.closest('[data-slot="combobox-trigger"]')
+        if (props.placeholder) {
+          trigger?.setAttribute('data-placeholder', '')
+        }
+      }
+    })
+  }
+
+  return (
+    <span data-slot="combobox-value" id={props.id} className="pointer-events-none truncate" ref={handleMount}>
+      {props.placeholder ?? ''}
+    </span>
+  )
+}
+
+/**
+ * Content container for combobox items.
+ * Portaled to body. Contains search input and scrollable item list.
+ */
+function ComboboxContent(props: ComboboxContentProps) {
+  const handleMount = (el: HTMLElement) => {
+    // Get trigger ref before portal
+    const triggerEl = el.parentElement?.querySelector('[data-slot="combobox-trigger"]') as HTMLElement
+    if (triggerEl) contentTriggerMap.set(el, triggerEl)
+
+    // Portal to body to escape overflow clipping
+    if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
+      const ownerScope = el.closest('[bf-s]') ?? undefined
+      createPortal(el, document.body, { ownerScope })
+    }
+
+    const ctx = useContext(ComboboxContext)
+
+    // Position content relative to trigger, clamped to viewport
+    const updatePosition = () => {
+      if (!triggerEl) return
+      const rect = triggerEl.getBoundingClientRect()
+      const gap = 4
+      const top = rect.bottom + gap
+      const availableHeight = window.innerHeight - top - gap
+      el.style.top = `${top}px`
+      el.style.setProperty('--radix-select-content-available-height', `${availableHeight}px`)
+      el.style.minWidth = `${rect.width}px`
+      if (props.align === 'end') {
+        el.style.left = `${rect.right - el.offsetWidth}px`
+      } else {
+        el.style.left = `${rect.left}px`
+      }
+    }
+
+    // Track cleanup functions for global listeners
+    let cleanupFns: Function[] = []
+
+    // Reactive show/hide + positioning + global listeners
+    createEffect(() => {
+      // Clean up previous listeners
+      for (const fn of cleanupFns) fn()
+      cleanupFns = []
+
+      const isOpen = ctx.open()
+      el.dataset.state = isOpen ? 'open' : 'closed'
+      el.className = `${contentBaseClasses} ${isOpen ? contentOpenClasses : contentClosedClasses} ${props.className ?? ''}`
+
+      if (isOpen) {
+        updatePosition()
+
+        // Focus the search input when opened
+        setTimeout(() => {
+          const input = el.querySelector('[data-slot="combobox-input"]') as HTMLInputElement
+          input?.focus()
+        }, 0)
+
+        // Close on click outside
+        const handleClickOutside = (e: MouseEvent) => {
+          if (!el.contains(e.target as Node) && !triggerEl?.contains(e.target as Node)) {
+            ctx.onOpenChange(false)
+          }
+        }
+
+        // Keyboard navigation: ESC to close, ArrowDown/Up to move, Enter to select
+        const handleGlobalKeyDown = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            ctx.onOpenChange(false)
+            triggerEl?.focus()
+            return
+          }
+
+          const items = Array.from(el.querySelectorAll('[data-slot="combobox-item"]:not([hidden]):not([aria-disabled="true"])')) as HTMLElement[]
+          if (items.length === 0) return
+
+          const currentSelected = el.querySelector('[data-slot="combobox-item"][data-selected="true"]') as HTMLElement
+          const currentIndex = currentSelected ? items.indexOf(currentSelected) : -1
+
+          switch (e.key) {
+            case 'ArrowDown': {
+              e.preventDefault()
+              const nextIndex = currentIndex < items.length - 1 ? currentIndex + 1 : 0
+              items.forEach((item, i) => {
+                item.setAttribute('data-selected', String(i === nextIndex))
+              })
+              items[nextIndex].scrollIntoView({ block: 'nearest' })
+              break
+            }
+            case 'ArrowUp': {
+              e.preventDefault()
+              const prevIndex = currentIndex > 0 ? currentIndex - 1 : items.length - 1
+              items.forEach((item, i) => {
+                item.setAttribute('data-selected', String(i === prevIndex))
+              })
+              items[prevIndex].scrollIntoView({ block: 'nearest' })
+              break
+            }
+            case 'Enter': {
+              e.preventDefault()
+              if (currentSelected && currentSelected.getAttribute('aria-disabled') !== 'true') {
+                currentSelected.click()
+              }
+              break
+            }
+          }
+        }
+
+        // Reposition on scroll and resize
+        const handleScroll = () => updatePosition()
+
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('keydown', handleGlobalKeyDown)
+        window.addEventListener('scroll', handleScroll, true)
+        window.addEventListener('resize', handleScroll)
+
+        cleanupFns.push(
+          () => document.removeEventListener('mousedown', handleClickOutside),
+          () => document.removeEventListener('keydown', handleGlobalKeyDown),
+          () => window.removeEventListener('scroll', handleScroll, true),
+          () => window.removeEventListener('resize', handleScroll),
+        )
+      }
+    })
+
+    // Auto-select first visible item when search changes
+    createEffect(() => {
+      ctx.search() // track dependency
+      requestAnimationFrame(() => {
+        const visibleItems = Array.from(el.querySelectorAll('[data-slot="combobox-item"]:not([hidden])')) as HTMLElement[]
+        visibleItems.forEach((item, i) => {
+          item.setAttribute('data-selected', String(i === 0))
+        })
+      })
+    })
+
+  }
+
+  return (
+    <div
+      data-slot="combobox-content"
+      data-state="closed"
+      role="listbox"
+      id={props.id}
+      tabindex={-1}
+      className={`${contentBaseClasses} ${contentClosedClasses} ${props.className ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Search input inside the combobox dropdown.
+ * Writes to context's search state.
+ */
+function ComboboxInput(props: ComboboxInputProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+    const input = el.querySelector('input') as HTMLInputElement
+    if (!input) return
+
+    input.addEventListener('input', () => {
+      ctx.onSearchChange(input.value)
+    })
+
+    // Keep input in sync with search state (e.g., cleared on close)
+    createEffect(() => {
+      const val = ctx.search()
+      if (input.value !== val) {
+        input.value = val
+      }
+    })
+  }
+
+  return (
+    <div
+      data-slot="combobox-input-wrapper"
+      className={inputWrapperClasses}
+      ref={handleMount}
+    >
+      <svg className="mr-2 size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg>
+      <input
+        data-slot="combobox-input"
+        id={props.id}
+        type="text"
+        placeholder={props.placeholder}
+        disabled={props.disabled ?? false}
+        className={`${inputClasses} ${props.className ?? ''}`}
+        autocomplete="off"
+      />
+    </div>
+  )
+}
+
+/**
+ * "No results" message. Auto-shows when no items are visible.
+ */
+function ComboboxEmpty(props: ComboboxEmptyProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+
+    createEffect(() => {
+      ctx.search() // track dependency
+      // Check after items have updated their visibility
+      requestAnimationFrame(() => {
+        const container = el.closest('[data-slot="combobox-content"]')
+        if (!container) return
+        const visibleItems = container.querySelectorAll('[data-slot="combobox-item"]:not([hidden])')
+        el.hidden = visibleItems.length > 0
+      })
+    })
+  }
+
+  return (
+    <div
+      data-slot="combobox-empty"
+      id={props.id}
+      hidden
+      className={`${emptyClasses} ${props.className ?? ''}`}
+      ref={handleMount}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Individual selectable item in the combobox.
+ * Self-filters based on search. Shows check indicator when selected.
+ * On select: update value, close dropdown.
+ */
+function ComboboxItem(props: ComboboxItemProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+
+    // Set data-value for querying
+    el.setAttribute('data-value', props.value)
+
+    // Self-filter based on search
+    createEffect(() => {
+      const s = ctx.search()
+      const label = el.textContent?.trim() ?? props.value
+      const visible = ctx.filter(label, s)
+      el.hidden = !visible
+    })
+
+    // Selected (checked) state + data-selected highlight
+    createEffect(() => {
+      const isChecked = ctx.value() === props.value
+      el.setAttribute('aria-selected', String(isChecked))
+      el.dataset.state = isChecked ? 'checked' : 'unchecked'
+
+      // Update check indicator visibility
+      const indicator = el.querySelector('[data-slot="combobox-item-indicator"]') as HTMLElement
+      if (indicator) {
+        indicator.style.display = isChecked ? '' : 'none'
+      }
+    })
+
+    // Click handler: select value, close dropdown, focus trigger
+    el.addEventListener('click', () => {
+      if (el.getAttribute('aria-disabled') === 'true') return
+      ctx.onValueChange(props.value)
+      ctx.onOpenChange(false)
+
+      // Focus return to trigger
+      const content = el.closest('[data-slot="combobox-content"]') as HTMLElement
+      const trigger = content ? contentTriggerMap.get(content) : null
+      setTimeout(() => trigger?.focus(), 0)
+    })
+
+    // Hover to highlight
+    el.addEventListener('pointerenter', () => {
+      if (el.getAttribute('aria-disabled') === 'true') return
+      const container = el.closest('[data-slot="combobox-content"]')
+      if (!container) return
+      const allItems = container.querySelectorAll('[data-slot="combobox-item"]:not([hidden])')
+      allItems.forEach(item => item.setAttribute('data-selected', 'false'))
+      el.setAttribute('data-selected', 'true')
+    })
+  }
+
+  const isDisabled = props.disabled ?? false
+  const stateClasses = isDisabled ? itemDisabledClasses : itemDefaultClasses
+
+  return (
+    <div
+      data-slot="combobox-item"
+      data-value={props.value}
+      data-state="unchecked"
+      data-selected="false"
+      role="option"
+      id={props.id}
+      aria-selected="false"
+      aria-disabled={isDisabled || undefined}
+      tabindex={-1}
+      className={`${itemBaseClasses} ${stateClasses} ${props.className ?? ''}`}
+      ref={handleMount}
+    >
+      <span data-slot="combobox-item-indicator" className={indicatorClasses} style="display:none">
+        <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+      </span>
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Group of related combobox items with an optional heading.
+ * Auto-hides when all items within are filtered out.
+ */
+function ComboboxGroup(props: ComboboxGroupProps) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(ComboboxContext)
+
+    createEffect(() => {
+      ctx.search() // track dependency
+      requestAnimationFrame(() => {
+        const items = el.querySelectorAll('[data-slot="combobox-item"]')
+        const visibleItems = el.querySelectorAll('[data-slot="combobox-item"]:not([hidden])')
+        el.hidden = items.length > 0 && visibleItems.length === 0
+      })
+    })
+  }
+
+  return (
+    <div
+      data-slot="combobox-group"
+      id={props.id}
+      role="group"
+      className={`${groupClasses} ${props.className ?? ''}`}
+      ref={handleMount}
+    >
+      {props.heading && (
+        <div data-slot="combobox-group-heading" aria-hidden="true">
+          {props.heading}
+        </div>
+      )}
+      {props.children}
+    </div>
+  )
+}
+
+/**
+ * Visual separator between combobox groups.
+ */
+function ComboboxSeparator({ className = '', ...props }: ComboboxSeparatorProps) {
+  return (
+    <div
+      data-slot="combobox-separator"
+      role="separator"
+      className={`${separatorClasses} ${className}`}
+      {...props}
+    />
+  )
+}
+
+export {
+  Combobox,
+  ComboboxTrigger,
+  ComboboxValue,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxSeparator,
+}
+
+export type {
+  ComboboxProps,
+  ComboboxTriggerProps,
+  ComboboxValueProps,
+  ComboboxContentProps,
+  ComboboxInputProps,
+  ComboboxEmptyProps,
+  ComboboxItemProps,
+  ComboboxGroupProps,
+  ComboboxSeparatorProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -64,6 +64,12 @@
       "description": "A command menu with search, keyboard navigation, and filtering"
     },
     {
+      "name": "combobox",
+      "type": "registry:ui",
+      "title": "Combobox",
+      "description": "Autocomplete input with searchable dropdown"
+    },
+    {
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",


### PR DESCRIPTION
## Summary

- Add `Combobox` component (`ui/components/ui/combobox/`) with search filtering, keyboard navigation, portal positioning, and accessibility (ARIA combobox/listbox/option)
- Sub-components: `Combobox`, `ComboboxTrigger`, `ComboboxValue`, `ComboboxContent`, `ComboboxInput`, `ComboboxEmpty`, `ComboboxItem`, `ComboboxGroup`, `ComboboxSeparator`
- Add demos: Basic (framework picker), Form (multi-field with summary), Grouped (timezone picker with groups/separators)
- Add documentation page with installation, examples, and API reference

## Test plan

- [x] IR tests: 43 passing (`ui/components/ui/combobox/index.test.tsx`)
- [x] E2E tests: 20 passing (`site/ui/e2e/combobox.spec.ts`)
  - Open/close (click, ESC, click-outside)
  - Search filtering and empty state
  - Item selection with value update
  - Keyboard navigation (ArrowDown/ArrowUp/Enter)
  - ARIA roles and attributes
  - Grouped items with separators
  - Form integration with multiple comboboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)