### PR TITLE
Fix nullish coalescing with JSX element child

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -3676,6 +3676,99 @@ describe('Compiler', () => {
     })
   })
 
+  describe('nullish coalescing with JSX (#524)', () => {
+    test('compiles stateless ?? with JSX element', () => {
+      const source = `
+        function Separator({ children }: { children?: any }) {
+          return <div>{children ?? <span>Default</span>}</div>
+        }
+        export { Separator }
+      `
+
+      const result = compileJSXSync(source, 'Separator.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      // The condition should use != null check
+      expect(template!.content).toContain('!= null')
+    })
+
+    test('compiles reactive ?? with JSX element', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        export function Fallback() {
+          const [label, setLabel] = createSignal<string | null>(null)
+          return <div>{label() ?? <span>Fallback</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'Fallback.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Raw JSX should not remain in compiled output
+      expect(clientJs!.content).not.toContain('<span>Fallback</span>')
+    })
+
+    test('compiles ?? with JSX inside ternary branch', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        export function Nested() {
+          const [show, setShow] = createSignal(true)
+          const [icon, setIcon] = createSignal<any>(null)
+          return <div>{show() ? icon() ?? <span>Icon</span> : <span>Hidden</span>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'Nested.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).not.toContain('<span>Icon</span>')
+      expect(clientJs!.content).not.toContain('<span>Hidden</span>')
+    })
+
+    test('non-JSX ?? remains as expression', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+        interface Props { initial?: number }
+        export function Counter(props: Props) {
+          const [count, setCount] = createSignal(props.initial ?? 0)
+          return <div>{count()}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // props.initial ?? 0 should remain as a regular expression
+      expect(clientJs!.content).toContain('props.initial ?? 0')
+    })
+
+    test('compiles || with JSX element', () => {
+      const source = `
+        function Label({ text }: { text?: string }) {
+          return <div>{text || <span>Empty</span>}</div>
+        }
+        export { Label }
+      `
+
+      const result = compileJSXSync(source, 'Label.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+    })
+  })
+
   describe('hydrate() template generation for signal-bearing components', () => {
     test('Counter (top-level only): NO CSR fallback template', () => {
       const source = `

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -627,6 +627,23 @@ function transformExpression(
     return result
   }
 
+  // Nullish coalescing / logical OR with JSX: {children ?? <Icon />}, {label || <Fallback />}
+  if (
+    ts.isBinaryExpression(expr) &&
+    (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) &&
+    containsJsxInExpression(expr.right)
+  ) {
+    const result = transformNullishCoalescing(expr, ctx)
+    if (isClientOnly) {
+      result.clientOnly = true
+      if (!result.slotId) {
+        result.slotId = generateSlotId(ctx)
+      }
+    }
+    return result
+  }
+
   // Array map: {items.map(item => <li>{item}</li>)}
   if (ts.isCallExpression(expr) && isMapCall(expr)) {
     return transformMapCall(expr, ctx, isClientOnly)
@@ -708,6 +725,61 @@ function transformLogicalAnd(
   }
 }
 
+/**
+ * Check if an expression contains JSX elements anywhere in its subtree.
+ */
+function containsJsxInExpression(node: ts.Node): boolean {
+  if (
+    ts.isJsxElement(node) ||
+    ts.isJsxSelfClosingElement(node) ||
+    ts.isJsxFragment(node)
+  ) {
+    return true
+  }
+  return ts.forEachChild(node, containsJsxInExpression) ?? false
+}
+
+/**
+ * Transform nullish coalescing (??) and logical OR (||) with JSX fallback.
+ *
+ * - `a ?? b` → condition=`a != null`, whenTrue=`a`, whenFalse=`b`
+ * - `a || b` → condition=`a`, whenTrue=`a`, whenFalse=`b`
+ */
+function transformNullishCoalescing(
+  node: ts.BinaryExpression,
+  ctx: TransformContext
+): IRConditional {
+  const leftText = ctx.getJS(node.left)
+  const isNullish = node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+  const condition = isNullish ? `${leftText} != null` : leftText
+  const reactive = isReactiveExpression(leftText, ctx, node.left)
+  const slotId = reactive ? generateSlotId(ctx) : null
+
+  // whenTrue: the left-hand value itself
+  const whenTrue: IRExpression = {
+    type: 'expression',
+    expr: leftText,
+    typeInfo: inferExpressionType(node.left, ctx),
+    reactive,
+    slotId: null,
+    loc: getSourceLocation(node.left, ctx.sourceFile, ctx.filePath),
+  }
+
+  // whenFalse: recursively transform the right-hand side (may contain JSX)
+  const whenFalse = transformConditionalBranch(node.right, ctx)
+
+  return {
+    type: 'conditional',
+    condition,
+    conditionType: null,
+    reactive,
+    whenTrue,
+    whenFalse,
+    slotId,
+    loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+  }
+}
+
 function transformConditionalBranch(
   node: ts.Expression,
   ctx: TransformContext
@@ -730,6 +802,16 @@ function transformConditionalBranch(
   // Logical AND in branch: cond1 ? <A/> : (cond2 && <B/>)
   if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
     return transformLogicalAnd(node, ctx)
+  }
+
+  // Nullish coalescing / logical OR with JSX in branch
+  if (
+    ts.isBinaryExpression(node) &&
+    (node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+      node.operatorToken.kind === ts.SyntaxKind.BarBarToken) &&
+    containsJsxInExpression(node.right)
+  ) {
+    return transformNullishCoalescing(node, ctx)
   }
 
   // Regular expression (including null)


### PR DESCRIPTION
## Summary

- Add `transformNullishCoalescing()` to handle `??` and `||` operators when the right-hand side contains JSX elements
- Add `containsJsxInExpression()` guard so non-JSX uses (e.g. `props.initial ?? 0`) remain as regular expressions
- Hook into both `transformExpression()` and `transformConditionalBranch()` for top-level and nested contexts

Fixes #524

## Test plan

- [x] Stateless `children ?? <Component />` compiles to `IRConditional` with `!= null` condition
- [x] Reactive `signal() ?? <span>...</span>` produces correct client JS (no raw JSX)
- [x] `??` nested inside ternary branch compiles correctly
- [x] Non-JSX `??` (e.g. `props.initial ?? 0`) remains as a regular expression
- [x] `||` with JSX element compiles correctly
- [x] `ui/components/ui/breadcrumb/` `{children ?? <ChevronRightIcon />}` compiles without errors
- [x] All 353 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)