### PR TITLE
Fix non-function exports dropped from "use client" modules

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -74,7 +74,8 @@ export class HonoAdapter implements TemplateAdapter {
       ? `\nexport default ${this.componentName}`
       : ''
 
-    const template = [imports, types, component].filter(Boolean).join('\n\n') + defaultExport
+    const moduleExports = this.generateModuleExports(ir)
+    const template = [imports, types, moduleExports, component].filter(Boolean).join('\n\n') + defaultExport
 
     return {
       template,
@@ -166,6 +167,48 @@ export class HonoAdapter implements TemplateAdapter {
       return ir.metadata.propsType.raw
     }
     return null
+  }
+
+  // ===========================================================================
+  // Module-level Exports
+  // ===========================================================================
+
+  private generateModuleExports(ir: ComponentIR): string | null {
+    const lines: string[] = []
+
+    for (const constant of ir.metadata.localConstants) {
+      if (!constant.isExported) continue
+      const keyword = constant.declarationKind ?? 'const'
+      if (!constant.value) {
+        lines.push(`export ${keyword} ${constant.name}`)
+        continue
+      }
+      const value = constant.value.trim()
+      // Skip client-only constructs
+      if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
+
+      const isArrowFunc =
+        value.startsWith('async (') ||
+        value.startsWith('async(') ||
+        value.startsWith('function') ||
+        /^\w+\s*=>/.test(value) ||
+        /^\([^)]*\)\s*=>/.test(value)
+
+      if (isArrowFunc) {
+        const params = this.extractFunctionParams(value)
+        lines.push(`export ${keyword} ${constant.name} = (${params}) => {}`)
+      } else {
+        lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
+      }
+    }
+
+    for (const func of ir.metadata.localFunctions) {
+      if (!func.isExported) continue
+      const params = func.params.map((p) => p.name).join(', ')
+      lines.push(`export function ${func.name}(${params}) ${func.body}`)
+    }
+
+    return lines.length > 0 ? lines.join('\n') : null
   }
 
   // ===========================================================================
@@ -347,8 +390,9 @@ export class HonoAdapter implements TemplateAdapter {
       lines.push(`  const ${memo.name} = ${memo.computation}`)
     }
 
-    // Include local constants
+    // Include local constants (skip exported ones — they are at module level)
     for (const constant of ir.metadata.localConstants) {
+      if (constant.isExported) continue
       const keyword = constant.declarationKind ?? 'const'
       if (!constant.value) {
         lines.push(`  ${keyword} ${constant.name}`)
@@ -379,8 +423,9 @@ export class HonoAdapter implements TemplateAdapter {
       }
     }
 
-    // Include local functions (helper functions defined at module level)
+    // Include local functions (skip exported ones — they are at module level)
     for (const func of ir.metadata.localFunctions) {
+      if (func.isExported) continue
       const params = func.params.map((p) => p.name).join(', ')
       lines.push(`  function ${func.name}(${params}) ${func.body}`)
     }

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -19,7 +19,9 @@ import {
   type IRTemplateLiteral,
   type ParamInfo,
   type AdapterOutput,
+  type TemplateSections,
   type TemplateAdapter,
+  extractFunctionParams,
   isBooleanAttr,
 } from '@barefootjs/jsx'
 
@@ -69,16 +71,23 @@ export class HonoAdapter implements TemplateAdapter {
     const types = this.generateTypes(ir)
     const component = this.generateComponent(ir)
 
-    // Add default export if the original had one
     const defaultExport = ir.metadata.hasDefaultExport
       ? `\nexport default ${this.componentName}`
       : ''
 
-    const moduleExports = this.generateModuleExports(ir)
-    const template = [imports, types, moduleExports, component].filter(Boolean).join('\n\n') + defaultExport
+    const sections: TemplateSections = {
+      imports,
+      types: types || '',
+      component,
+      defaultExport,
+    }
+
+    // Assemble template for backward compat (external consumers using output.template)
+    const template = [imports, types, component].filter(Boolean).join('\n\n') + defaultExport
 
     return {
       template,
+      sections,
       types: types || undefined,
       extension: this.extension,
     }
@@ -167,48 +176,6 @@ export class HonoAdapter implements TemplateAdapter {
       return ir.metadata.propsType.raw
     }
     return null
-  }
-
-  // ===========================================================================
-  // Module-level Exports
-  // ===========================================================================
-
-  private generateModuleExports(ir: ComponentIR): string | null {
-    const lines: string[] = []
-
-    for (const constant of ir.metadata.localConstants) {
-      if (!constant.isExported) continue
-      const keyword = constant.declarationKind ?? 'const'
-      if (!constant.value) {
-        lines.push(`export ${keyword} ${constant.name}`)
-        continue
-      }
-      const value = constant.value.trim()
-      // Skip client-only constructs
-      if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
-
-      const isArrowFunc =
-        value.startsWith('async (') ||
-        value.startsWith('async(') ||
-        value.startsWith('function') ||
-        /^\w+\s*=>/.test(value) ||
-        /^\([^)]*\)\s*=>/.test(value)
-
-      if (isArrowFunc) {
-        const params = this.extractFunctionParams(value)
-        lines.push(`export ${keyword} ${constant.name} = (${params}) => {}`)
-      } else {
-        lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
-      }
-    }
-
-    for (const func of ir.metadata.localFunctions) {
-      if (!func.isExported) continue
-      const params = func.params.map((p) => p.name).join(', ')
-      lines.push(`export function ${func.name}(${params}) ${func.body}`)
-    }
-
-    return lines.length > 0 ? lines.join('\n') : null
   }
 
   // ===========================================================================
@@ -415,7 +382,7 @@ export class HonoAdapter implements TemplateAdapter {
       if (isArrowFunc) {
         // Generate a stub function for SSR (these may be referenced as props)
         // Extract parameters if possible
-        const params = this.extractFunctionParams(value)
+        const params = extractFunctionParams(value)
         lines.push(`  ${keyword} ${constant.name} = (${params}) => {}`)
       } else {
         // Output non-function constants directly
@@ -431,34 +398,6 @@ export class HonoAdapter implements TemplateAdapter {
     }
 
     return lines.join('\n')
-  }
-
-  private extractFunctionParams(value: string): string {
-    // Match arrow function parameters: (a, b) => ... or a => ...
-    const arrowMatch = value.match(/^(?:async\s*)?\(([^)]*)\)\s*(?::\s*[^=]+)?\s*=>/)
-    if (arrowMatch) {
-      // Remove type annotations from parameters
-      return arrowMatch[1]
-        .split(',')
-        .map((p) => p.trim().split(':')[0].split('=')[0].trim())
-        .filter(Boolean)
-        .join(', ')
-    }
-    // Single param arrow function: a => ...
-    const singleMatch = value.match(/^(?:async\s*)?(\w+)\s*=>/)
-    if (singleMatch) {
-      return singleMatch[1]
-    }
-    // Function expression: function(a, b) { ... }
-    const funcMatch = value.match(/^(?:async\s*)?function\s*\w*\s*\(([^)]*)\)/)
-    if (funcMatch) {
-      return funcMatch[1]
-        .split(',')
-        .map((p) => p.trim().split(':')[0].split('=')[0].trim())
-        .filter(Boolean)
-        .join(', ')
-    }
-    return ''
   }
 
   // ===========================================================================

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4277,4 +4277,165 @@ describe('Compiler', () => {
       expect(template?.content).toContain('return')
     })
   })
+
+  describe('non-function exports from "use client" modules (#523)', () => {
+    test('export const is preserved at module level', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export const REGEXP_ONLY_DIGITS = '^\\\\d+$'
+
+        export function OTPInput(props: { pattern?: string }) {
+          const [value, setValue] = createSignal('')
+          return <input pattern={props.pattern ?? REGEXP_ONLY_DIGITS} />
+        }
+      `
+      const result = compileJSXSync(source, 'OTPInput.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      const content = template!.content
+
+      // export const should appear before the component function, at module level
+      expect(content).toContain("export const REGEXP_ONLY_DIGITS = '^\\\\d+$'")
+
+      // It should NOT appear indented inside the function body
+      const funcStart = content.indexOf('export function OTPInput')
+      const exportConstIndex = content.indexOf("export const REGEXP_ONLY_DIGITS")
+      expect(exportConstIndex).toBeLessThan(funcStart)
+    })
+
+    test('export { X } named export syntax sets isExported on analyzer', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        const MY_CONST = 42
+
+        export { MY_CONST }
+
+        export function Widget() {
+          const [val, setVal] = createSignal(0)
+          return <div>{MY_CONST}</div>
+        }
+      `
+      const ctx = analyzeComponent(source, 'Widget.tsx')
+      const constInfo = ctx.localConstants.find(c => c.name === 'MY_CONST')
+      expect(constInfo).toBeDefined()
+      expect(constInfo!.isExported).toBe(true)
+    })
+
+    test('non-exported const stays inside function body', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        const INTERNAL_VALUE = 'secret'
+
+        export function MyComponent() {
+          const [count, setCount] = createSignal(0)
+          return <div>{INTERNAL_VALUE}</div>
+        }
+      `
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      const content = template.content
+
+      // Non-exported const should NOT appear as 'export const' at module level
+      expect(content).not.toContain('export const INTERNAL_VALUE')
+
+      // It should appear inside the function body (indented)
+      const funcStart = content.indexOf('export function MyComponent')
+      const constIndex = content.indexOf("INTERNAL_VALUE = 'secret'")
+      expect(constIndex).toBeGreaterThan(funcStart)
+    })
+
+    test('exported non-component function at module level', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function helperFn(x: number) { return x * 2 }
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <div>{helperFn(count())}</div>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      const content = template.content
+
+      // Exported helper function should be at module level
+      expect(content).toContain('export function helperFn(x)')
+
+      // It should appear before the component
+      const helperIndex = content.indexOf('export function helperFn')
+      const componentIndex = content.indexOf('export function Counter')
+      expect(helperIndex).toBeLessThan(componentIndex)
+    })
+
+    test('analyzer sets isExported flag correctly', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export const EXPORTED_A = 'aaa'
+        const INTERNAL_B = 'bbb'
+        export let EXPORTED_C = 100
+
+        export function MyComponent() {
+          const [val, setVal] = createSignal(0)
+          return <div />
+        }
+      `
+      const ctx = analyzeComponent(source, 'Test.tsx')
+
+      const a = ctx.localConstants.find(c => c.name === 'EXPORTED_A')
+      expect(a).toBeDefined()
+      expect(a!.isExported).toBe(true)
+      expect(a!.declarationKind).toBe('const')
+
+      const b = ctx.localConstants.find(c => c.name === 'INTERNAL_B')
+      expect(b).toBeDefined()
+      expect(b!.isExported).toBeFalsy()
+
+      const c = ctx.localConstants.find(c => c.name === 'EXPORTED_C')
+      expect(c).toBeDefined()
+      expect(c!.isExported).toBe(true)
+      expect(c!.declarationKind).toBe('let')
+    })
+
+    test('Hono adapter: exported const appears before component', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export const PATTERN = /^[0-9]+$/
+
+        export function InputField() {
+          const [val, setVal] = createSignal('')
+          return <input />
+        }
+      `
+      const result = compileJSXSync(source, 'InputField.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      const content = template.content
+
+      expect(content).toContain('export const PATTERN = /^[0-9]+$/')
+
+      const exportIndex = content.indexOf('export const PATTERN')
+      const componentIndex = content.indexOf('export function InputField')
+      expect(exportIndex).toBeLessThan(componentIndex)
+    })
+  })
 })

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -14,8 +14,19 @@ import type {
   IRComponent,
 } from '../types'
 
+export interface TemplateSections {
+  imports: string
+  types: string
+  component: string
+  defaultExport: string
+}
+
 export interface AdapterOutput {
+  /** Complete assembled template string (backward compat for external consumers) */
   template: string
+  /** Structured sections for compiler assembly. When present, compiler uses these
+   *  instead of re-parsing template. */
+  sections?: TemplateSections
   types?: string // Generated types (for typed languages)
   extension: string
 }

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -36,7 +36,8 @@ export class TestAdapter extends BaseAdapter {
       ? `\nexport default ${this.componentName}`
       : ''
 
-    const template = [imports, types, component].filter(Boolean).join('\n\n') + defaultExport
+    const moduleExports = this.generateModuleExports(ir)
+    const template = [imports, types, moduleExports, component].filter(Boolean).join('\n\n') + defaultExport
 
     return {
       template,
@@ -101,6 +102,39 @@ export class TestAdapter extends BaseAdapter {
       lines.push('  __instanceId?: string')
       lines.push('  __bfScope?: string')
       lines.push('}')
+    }
+
+    return lines.length > 0 ? lines.join('\n') : null
+  }
+
+  private generateModuleExports(ir: ComponentIR): string | null {
+    const lines: string[] = []
+
+    for (const constant of ir.metadata.localConstants) {
+      if (!constant.isExported) continue
+      const keyword = constant.declarationKind ?? 'const'
+      if (!constant.value) {
+        lines.push(`export ${keyword} ${constant.name}`)
+        continue
+      }
+      const value = constant.value.trim()
+      const isArrowFunc =
+        value.startsWith('async (') ||
+        value.startsWith('function') ||
+        /^\w+\s*=>/.test(value) ||
+        /^\([^)]*\)\s*=>/.test(value)
+
+      if (isArrowFunc) {
+        lines.push(`export ${keyword} ${constant.name} = () => {}`)
+      } else {
+        lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
+      }
+    }
+
+    for (const func of ir.metadata.localFunctions) {
+      if (!func.isExported) continue
+      const params = func.params.map((p) => p.name).join(', ')
+      lines.push(`export function ${func.name}(${params}) ${func.body}`)
     }
 
     return lines.length > 0 ? lines.join('\n') : null
@@ -176,6 +210,7 @@ export class TestAdapter extends BaseAdapter {
     }
 
     for (const constant of ir.metadata.localConstants) {
+      if (constant.isExported) continue
       const keyword = constant.declarationKind ?? 'const'
       if (!constant.value) {
         lines.push(`  ${keyword} ${constant.name}`)
@@ -193,6 +228,13 @@ export class TestAdapter extends BaseAdapter {
       } else {
         lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
       }
+    }
+
+    // Include local functions (skip exported ones — they are at module level)
+    for (const func of ir.metadata.localFunctions) {
+      if (func.isExported) continue
+      const params = func.params.map((p) => p.name).join(', ')
+      lines.push(`  function ${func.name}(${params}) ${func.body}`)
     }
 
     return lines.join('\n')

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -17,7 +17,7 @@ import type {
   IRFragment,
   ParamInfo,
 } from '../types'
-import { type AdapterOutput, BaseAdapter } from './interface'
+import { type AdapterOutput, type TemplateSections, BaseAdapter } from './interface'
 
 export class TestAdapter extends BaseAdapter {
   name = 'test'
@@ -36,11 +36,19 @@ export class TestAdapter extends BaseAdapter {
       ? `\nexport default ${this.componentName}`
       : ''
 
-    const moduleExports = this.generateModuleExports(ir)
-    const template = [imports, types, moduleExports, component].filter(Boolean).join('\n\n') + defaultExport
+    const sections: TemplateSections = {
+      imports,
+      types: types || '',
+      component,
+      defaultExport,
+    }
+
+    // Assemble template for backward compat
+    const template = [imports, types, component].filter(Boolean).join('\n\n') + defaultExport
 
     return {
       template,
+      sections,
       types: types || undefined,
       extension: this.extension,
     }
@@ -102,39 +110,6 @@ export class TestAdapter extends BaseAdapter {
       lines.push('  __instanceId?: string')
       lines.push('  __bfScope?: string')
       lines.push('}')
-    }
-
-    return lines.length > 0 ? lines.join('\n') : null
-  }
-
-  private generateModuleExports(ir: ComponentIR): string | null {
-    const lines: string[] = []
-
-    for (const constant of ir.metadata.localConstants) {
-      if (!constant.isExported) continue
-      const keyword = constant.declarationKind ?? 'const'
-      if (!constant.value) {
-        lines.push(`export ${keyword} ${constant.name}`)
-        continue
-      }
-      const value = constant.value.trim()
-      const isArrowFunc =
-        value.startsWith('async (') ||
-        value.startsWith('function') ||
-        /^\w+\s*=>/.test(value) ||
-        /^\([^)]*\)\s*=>/.test(value)
-
-      if (isArrowFunc) {
-        lines.push(`export ${keyword} ${constant.name} = () => {}`)
-      } else {
-        lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
-      }
-    }
-
-    for (const func of ir.metadata.localFunctions) {
-      if (!func.isExported) continue
-      const params = func.params.map((p) => p.name).join(', ')
-      lines.push(`export function ${func.name}(${params}) ${func.body}`)
     }
 
     return lines.length > 0 ? lines.join('\n') : null

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -245,21 +245,37 @@ function visit(
 
   // Module-level constants (outside component)
   if (ts.isVariableStatement(node) && !ctx.componentNode) {
+    const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+    const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
     for (const decl of node.declarationList.declarations) {
       if (
         ts.isIdentifier(decl.name) &&
         decl.initializer &&
         !isArrowComponentFunction(decl)
       ) {
-        collectConstant(decl, ctx, true, 'const')
+        collectConstant(decl, ctx, true, isLet ? 'let' : 'const', isExported)
       }
     }
   }
 
   // Module-level functions (outside component)
   if (ts.isFunctionDeclaration(node) && node.name && !isComponentFunction(node)) {
-    collectFunction(node, ctx, true)
+    const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+    collectFunction(node, ctx, true, isExported)
     return // Body is captured as string; don't walk internals
+  }
+
+  // Named exports: export { X, Y } — mark already-collected items as exported
+  if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+    for (const specifier of node.exportClause.elements) {
+      const name = specifier.name.text
+      for (const c of ctx.localConstants) {
+        if (c.name === name) c.isExported = true
+      }
+      for (const f of ctx.localFunctions) {
+        if (f.name === name) f.isExported = true
+      }
+    }
   }
 
   // Default export: export default ComponentName
@@ -683,7 +699,8 @@ function collectTypeAliasDefinition(
 function collectFunction(
   node: ts.FunctionDeclaration,
   ctx: AnalyzerContext,
-  _isModule: boolean
+  _isModule: boolean,
+  isExported: boolean = false
 ): void {
   if (!node.name) return
 
@@ -709,6 +726,7 @@ function collectFunction(
     body,
     returnType,
     containsJsx,
+    isExported,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
 }
@@ -721,7 +739,8 @@ function collectConstant(
   node: ts.VariableDeclaration,
   ctx: AnalyzerContext,
   _isModule: boolean,
-  declarationKind: 'const' | 'let' = 'const'
+  declarationKind: 'const' | 'let' = 'const',
+  isExported: boolean = false
 ): void {
   if (!ts.isIdentifier(node.name)) return
 
@@ -745,6 +764,7 @@ function collectConstant(
     name,
     value,
     declarationKind,
+    isExported,
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -163,28 +163,34 @@ function compileMultipleComponentsSync(
   }
 
   // --- Pass 2: adapter.generate + generateClientJs ---
-  const allOutputs: { imports: string; types: string; component: string; clientJs?: string }[] = []
+  const allOutputs: { imports: string; types: string; moduleExports: string; component: string; clientJs?: string }[] = []
 
   for (const { componentIR } of entries) {
     const adapterOutput = adapter.generate(componentIR)
     const fullContent = adapterOutput.template
 
-    // Parse output to separate imports, types, and component
+    // Parse output to separate imports, types, module exports, and component
     const lines = fullContent.split('\n')
     const importLines: string[] = []
     const typeLines: string[] = []
+    const moduleExportLines: string[] = []
     const componentLines: string[] = []
     let inComponent = false
 
     for (const line of lines) {
       if (line.startsWith('export function ')) {
-        inComponent = true
+        const funcName = line.match(/^export function (\w+)/)?.[1]
+        if (funcName && componentNames.includes(funcName)) {
+          inComponent = true
+        }
       }
 
       if (inComponent) {
         componentLines.push(line)
       } else if (line.startsWith('import ')) {
         importLines.push(line)
+      } else if (line.startsWith('export const ') || line.startsWith('export let ') || line.startsWith('export function ')) {
+        moduleExportLines.push(line)
       } else if (line.trim()) {
         typeLines.push(line)
       }
@@ -193,6 +199,7 @@ function compileMultipleComponentsSync(
     allOutputs.push({
       imports: importLines.join('\n'),
       types: typeLines.join('\n'),
+      moduleExports: moduleExportLines.join('\n'),
       component: componentLines.join('\n'),
       clientJs: generateClientJs(componentIR, componentNames, usedAsChild) || undefined,
     })
@@ -213,11 +220,25 @@ function compileMultipleComponentsSync(
     }
   }
 
+  // Deduplicate module-level exports across components
+  const seenModuleExports = new Set<string>()
+  const uniqueModuleExports: string[] = []
+  for (const output of allOutputs) {
+    if (output.moduleExports) {
+      for (const line of output.moduleExports.split('\n')) {
+        if (line.trim() && !seenModuleExports.has(line)) {
+          seenModuleExports.add(line)
+          uniqueModuleExports.push(line)
+        }
+      }
+    }
+  }
+
   // Combine all components
   const combinedTemplate = [
     allOutputs[0].imports,
     uniqueTypes.join('\n\n'),
-    '',
+    uniqueModuleExports.length > 0 ? uniqueModuleExports.join('\n') : '',
     ...allOutputs.map(o => o.component),
   ]
     .filter(Boolean)

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -15,6 +15,7 @@ import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listExportedComponents, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
+import { generateModuleExports } from './module-exports'
 import { collectComponentNamesFromIR } from './ir-to-client-js/generate-init'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
 
@@ -89,10 +90,21 @@ export async function compileJSX(
 
   const adapter = options.adapter
   const adapterOutput = adapter.generate(componentIR)
+  const moduleExports = generateModuleExports(componentIR)
+
+  // Use structured sections if available, otherwise fall back to template
+  let content: string
+  if (adapterOutput.sections) {
+    const s = adapterOutput.sections
+    content = [s.imports, s.types, moduleExports, s.component]
+      .filter(Boolean).join('\n\n') + (s.defaultExport || '')
+  } else {
+    content = adapterOutput.template
+  }
 
   files.push({
     path: entryPath.replace(/\.tsx?$/, adapter.extension),
-    content: adapterOutput.template,
+    content,
     type: 'markedTemplate',
   })
 
@@ -167,40 +179,53 @@ function compileMultipleComponentsSync(
 
   for (const { componentIR } of entries) {
     const adapterOutput = adapter.generate(componentIR)
-    const fullContent = adapterOutput.template
+    const moduleExports = generateModuleExports(componentIR)
 
-    // Parse output to separate imports, types, module exports, and component
-    const lines = fullContent.split('\n')
-    const importLines: string[] = []
-    const typeLines: string[] = []
-    const moduleExportLines: string[] = []
-    const componentLines: string[] = []
-    let inComponent = false
+    let imports: string
+    let types: string
+    let component: string
 
-    for (const line of lines) {
-      if (line.startsWith('export function ')) {
-        const funcName = line.match(/^export function (\w+)/)?.[1]
-        if (funcName && componentNames.includes(funcName)) {
-          inComponent = true
+    if (adapterOutput.sections) {
+      // Use structured sections directly — no string parsing needed
+      const s = adapterOutput.sections
+      imports = s.imports
+      types = s.types
+      component = s.component + (s.defaultExport || '')
+    } else {
+      // Fallback: parse template string (for adapters without sections)
+      const lines = adapterOutput.template.split('\n')
+      const importLines: string[] = []
+      const typeLines: string[] = []
+      const componentLines: string[] = []
+      let inComponent = false
+
+      for (const line of lines) {
+        if (line.startsWith('export function ')) {
+          const funcName = line.match(/^export function (\w+)/)?.[1]
+          if (funcName && componentNames.includes(funcName)) {
+            inComponent = true
+          }
+        }
+
+        if (inComponent) {
+          componentLines.push(line)
+        } else if (line.startsWith('import ')) {
+          importLines.push(line)
+        } else if (line.trim()) {
+          typeLines.push(line)
         }
       }
 
-      if (inComponent) {
-        componentLines.push(line)
-      } else if (line.startsWith('import ')) {
-        importLines.push(line)
-      } else if (line.startsWith('export const ') || line.startsWith('export let ') || line.startsWith('export function ')) {
-        moduleExportLines.push(line)
-      } else if (line.trim()) {
-        typeLines.push(line)
-      }
+      imports = importLines.join('\n')
+      types = typeLines.join('\n')
+      component = componentLines.join('\n')
     }
 
     allOutputs.push({
-      imports: importLines.join('\n'),
-      types: typeLines.join('\n'),
-      moduleExports: moduleExportLines.join('\n'),
-      component: componentLines.join('\n'),
+      imports,
+      types,
+      moduleExports: moduleExports || '',
+      component,
       clientJs: generateClientJs(componentIR, componentNames, usedAsChild) || undefined,
     })
   }
@@ -410,10 +435,21 @@ export function compileJSXSync(
 
   const adapter = options.adapter
   const adapterOutput = adapter.generate(componentIR)
+  const moduleExports = generateModuleExports(componentIR)
+
+  // Use structured sections if available, otherwise fall back to template
+  let content: string
+  if (adapterOutput.sections) {
+    const s = adapterOutput.sections
+    content = [s.imports, s.types, moduleExports, s.component]
+      .filter(Boolean).join('\n\n') + (s.defaultExport || '')
+  } else {
+    content = adapterOutput.template
+  }
 
   files.push({
     path: filePath.replace(/\.tsx?$/, adapter.extension),
-    content: adapterOutput.template,
+    content,
     type: 'markedTemplate',
   })
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -39,9 +39,12 @@ export { analyzeComponent, listExportedComponents, type AnalyzerContext } from '
 // JSX to IR transformer
 export { jsxToIR } from './jsx-to-ir'
 
+// Module exports generation (compiler layer)
+export { generateModuleExports, extractFunctionParams } from './module-exports'
+
 // Adapters
 export { BaseAdapter } from './adapters/interface'
-export type { TemplateAdapter, AdapterOutput, AdapterGenerateOptions } from './adapters/interface'
+export type { TemplateAdapter, AdapterOutput, AdapterGenerateOptions, TemplateSections } from './adapters/interface'
 
 // Client JS Generator
 export { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -1,0 +1,83 @@
+/**
+ * BarefootJS Compiler - Module Exports Generation
+ *
+ * Generates module-level export statements from ComponentIR.
+ * This is a compiler-layer concern, not adapter-specific.
+ */
+
+import type { ComponentIR } from './types'
+
+/**
+ * Generate module-level export statements for constants and functions.
+ * Skips client-only constructs (createContext, new WeakMap).
+ * Arrow functions are stubbed with extracted parameters.
+ */
+export function generateModuleExports(ir: ComponentIR): string | null {
+  const lines: string[] = []
+
+  for (const constant of ir.metadata.localConstants) {
+    if (!constant.isExported) continue
+    const keyword = constant.declarationKind ?? 'const'
+    if (!constant.value) {
+      lines.push(`export ${keyword} ${constant.name}`)
+      continue
+    }
+    const value = constant.value.trim()
+    // Skip client-only constructs
+    if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
+
+    const isArrowFunc =
+      value.startsWith('async (') ||
+      value.startsWith('async(') ||
+      value.startsWith('function') ||
+      /^\w+\s*=>/.test(value) ||
+      /^\([^)]*\)\s*=>/.test(value)
+
+    if (isArrowFunc) {
+      const params = extractFunctionParams(value)
+      lines.push(`export ${keyword} ${constant.name} = (${params}) => {}`)
+    } else {
+      lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
+    }
+  }
+
+  for (const func of ir.metadata.localFunctions) {
+    if (!func.isExported) continue
+    const params = func.params.map((p) => p.name).join(', ')
+    lines.push(`export function ${func.name}(${params}) ${func.body}`)
+  }
+
+  return lines.length > 0 ? lines.join('\n') : null
+}
+
+/**
+ * Extract parameter names from a function expression string.
+ * Handles: arrow functions, single-param arrows, function expressions.
+ * Strips type annotations and default values.
+ */
+export function extractFunctionParams(value: string): string {
+  // Match arrow function parameters: (a, b) => ... or async (a, b) => ...
+  const arrowMatch = value.match(/^(?:async\s*)?\(([^)]*)\)\s*(?::\s*[^=]+)?\s*=>/)
+  if (arrowMatch) {
+    return arrowMatch[1]
+      .split(',')
+      .map((p) => p.trim().split(':')[0].split('=')[0].trim())
+      .filter(Boolean)
+      .join(', ')
+  }
+  // Single param arrow function: a => ...
+  const singleMatch = value.match(/^(?:async\s*)?(\w+)\s*=>/)
+  if (singleMatch) {
+    return singleMatch[1]
+  }
+  // Function expression: function(a, b) { ... }
+  const funcMatch = value.match(/^(?:async\s*)?function\s*\w*\s*\(([^)]*)\)/)
+  if (funcMatch) {
+    return funcMatch[1]
+      .split(',')
+      .map((p) => p.trim().split(':')[0].split('=')[0].trim())
+      .filter(Boolean)
+      .join(', ')
+  }
+  return ''
+}

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -371,6 +371,7 @@ export interface FunctionInfo {
   body: string
   returnType: TypeInfo | null
   containsJsx: boolean
+  isExported?: boolean
   loc: SourceLocation
 }
 
@@ -378,6 +379,7 @@ export interface ConstantInfo {
   name: string
   value?: string
   declarationKind: 'const' | 'let'
+  isExported?: boolean
   type: TypeInfo | null
   loc: SourceLocation
 }


### PR DESCRIPTION
## Summary

- **Problem**: `export const`, `export let`, and non-component `export function` declarations in `"use client"` files were silently dropped during compilation, causing `SyntaxError: Export named 'X' not found` at runtime
- **Root cause**: The compiler's 4 layers (analyzer, adapters, multi-component combiner) had no tracking for `isExported` on constants/functions — all non-component items were placed inside the component function body, never at module level
- **Fix**: Added `isExported` flag to `ConstantInfo`/`FunctionInfo`, detect export modifiers in the analyzer (including `export { X }` syntax), emit exported items at module level via a shared utility, and correctly categorize them in the multi-component combiner

## Changes

### Initial fix (8e110d2)

| File | Change |
|------|--------|
| `packages/jsx/src/types.ts` | Add `isExported?: boolean` to `FunctionInfo` and `ConstantInfo` |
| `packages/jsx/src/analyzer.ts` | Detect `export` modifier on `VariableStatement`/`FunctionDeclaration`, handle `export { X }` syntax, fix `let` detection bug |
| `packages/jsx/src/__tests__/compiler.test.ts` | 6 new tests covering export const, `export { X }`, non-exported const, exported function, analyzer flags, Hono adapter |

### Refactor: move module exports to compiler layer (e500789)

Module exports generation was duplicated across HonoAdapter and TestAdapter. This refactoring moves it to the compiler layer where it belongs.

| File | Change |
|------|--------|
| `packages/jsx/src/module-exports.ts` | **New**: shared `generateModuleExports()` and `extractFunctionParams()` utility |
| `packages/jsx/src/adapters/interface.ts` | Add `TemplateSections` interface and `sections?` field to `AdapterOutput` |
| `packages/jsx/src/index.ts` | Export new module and `TemplateSections` type |
| `packages/hono/src/adapter/hono-adapter.ts` | Remove `generateModuleExports()`/`extractFunctionParams()` methods, return `sections` from `generate()`, use shared `extractFunctionParams` |
| `packages/jsx/src/adapters/test-adapter.ts` | Remove `generateModuleExports()` method, return `sections` from `generate()` |
| `packages/jsx/src/compiler.ts` | Import shared `generateModuleExports`, assemble template from `sections` (eliminating fragile string-parsing in multi-component combiner) |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/compiler.test.ts` — 156 tests pass (6 new for #523)
- [x] `bun test packages/` — 858 pass, 1 pre-existing fail (unrelated `@barefootjs/dom` resolution in `packages/form`)

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)