### PR TITLE
Fix className via intermediate variable not resolved (#525)

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -215,6 +215,58 @@ describe('Compiler', () => {
         }
       }
     })
+
+    test('ternary constant has valueBranches', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Demo() {
+          const [active, setActive] = createSignal(false)
+          const cls = active() ? 'a b' : 'c d'
+          return <div className={cls}></div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'test.tsx')
+      const cls = ctx.localConstants.find(c => c.name === 'cls')
+      expect(cls).toBeDefined()
+      expect(cls!.valueBranches).toEqual(["'a b'", "'c d'"])
+    })
+
+    test('nested ternary constant has flattened valueBranches', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Demo() {
+          const [state, setState] = createSignal(0)
+          const cls = state() === 0 ? 'a' : state() === 1 ? 'b' : 'c'
+          return <div className={cls}></div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'test.tsx')
+      const cls = ctx.localConstants.find(c => c.name === 'cls')
+      expect(cls).toBeDefined()
+      expect(cls!.valueBranches).toEqual(["'a'", "'b'", "'c'"])
+    })
+
+    test('non-ternary constant has no valueBranches', () => {
+      const source = `
+        'use client'
+
+        export function Demo() {
+          const cls = 'hello world'
+          return <div className={cls}></div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'test.tsx')
+      const cls = ctx.localConstants.find(c => c.name === 'cls')
+      expect(cls).toBeDefined()
+      expect(cls!.valueBranches).toBeUndefined()
+    })
   })
 
   describe('compileJSXSync', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -717,6 +717,23 @@ function collectFunction(
 // Constant Collection
 // =============================================================================
 
+/**
+ * Recursively flatten ternary (conditional) branches at the AST level,
+ * returning leaf expressions as code strings.
+ */
+function extractValueBranches(node: ts.Expression, ctx: AnalyzerContext): string[] {
+  if (ts.isParenthesizedExpression(node)) {
+    return extractValueBranches(node.expression, ctx)
+  }
+  if (ts.isConditionalExpression(node)) {
+    return [
+      ...extractValueBranches(node.whenTrue, ctx),
+      ...extractValueBranches(node.whenFalse, ctx),
+    ]
+  }
+  return [ctx.getJS(node)]
+}
+
 function collectConstant(
   node: ts.VariableDeclaration,
   ctx: AnalyzerContext,
@@ -733,6 +750,16 @@ function collectConstant(
     ? ctx.getJS(node.initializer)
     : undefined
 
+  // Extract structured branch info from ternary initializers
+  let valueBranches: string[] | undefined
+  if (node.initializer) {
+    let inner: ts.Expression = node.initializer
+    while (ts.isParenthesizedExpression(inner)) inner = inner.expression
+    if (ts.isConditionalExpression(inner)) {
+      valueBranches = extractValueBranches(node.initializer, ctx)
+    }
+  }
+
   // Get type from annotation or infer
   let type: TypeInfo | null = null
   if (node.type) {
@@ -744,6 +771,7 @@ function collectConstant(
   ctx.localConstants.push({
     name,
     value,
+    valueBranches,
     declarationKind,
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -370,6 +370,7 @@ export interface FunctionInfo {
 export interface ConstantInfo {
   name: string
   value?: string
+  valueBranches?: string[]
   declarationKind: 'const' | 'let'
   type: TypeInfo | null
   loc: SourceLocation

--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -5,6 +5,76 @@ import { renderToTest } from '../src/index'
 // renderToTest API behavior (not component-specific)
 // ---------------------------------------------------------------------------
 
+describe('className via intermediate variable (#525)', () => {
+  test('ternary with template literal + identifier branches', () => {
+    const source = `
+"use client"
+
+import { createSignal } from '@barefootjs/dom'
+
+function MyComponent(props: { extra?: boolean }) {
+  const baseClasses = 'flex items-center gap-2'
+  const cls = props.extra ? \`\${baseClasses} p-4 font-bold\` : baseClasses
+  return <div className={cls}>content</div>
+}
+
+export { MyComponent }
+`
+    const result = renderToTest(source, 'my-component.tsx')
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.classes).toContain('flex')
+    expect(div!.classes).toContain('items-center')
+    expect(div!.classes).toContain('gap-2')
+    expect(div!.classes).toContain('p-4')
+    expect(div!.classes).toContain('font-bold')
+    // Should NOT contain the variable name
+    expect(div!.classes).not.toContain('cls')
+    expect(div!.classes).not.toContain('baseClasses')
+  })
+
+  test('ternary with string literal branches', () => {
+    const source = `
+"use client"
+
+import { createSignal } from '@barefootjs/dom'
+
+function Compact(props: { compact?: boolean }) {
+  const cls = props.compact ? 'p-2 text-sm' : 'p-4 text-base'
+  return <div className={cls}>content</div>
+}
+
+export { Compact }
+`
+    const result = renderToTest(source, 'compact.tsx')
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+    expect(div!.classes).toContain('p-2')
+    expect(div!.classes).toContain('text-sm')
+    expect(div!.classes).toContain('p-4')
+    expect(div!.classes).toContain('text-base')
+  })
+
+  test('plain identifier alias', () => {
+    const source = `
+function Label() {
+  const sharedClasses = 'text-sm font-medium leading-none'
+  const cls = sharedClasses
+  return <label className={cls}>Name</label>
+}
+
+export { Label }
+`
+    const result = renderToTest(source, 'label.tsx')
+    const label = result.find({ tag: 'label' })
+    expect(label).not.toBeNull()
+    expect(label!.classes).toContain('text-sm')
+    expect(label!.classes).toContain('font-medium')
+    expect(label!.classes).toContain('leading-none')
+    expect(label!.classes).not.toContain('cls')
+  })
+})
+
 describe('Error detection', () => {
   test('missing "use client" reports BF001', () => {
     const source = `

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -2,14 +2,17 @@
  * Constant resolution for test IR.
  *
  * Resolves string-valued constants (string literals, template literals,
- * array.join() patterns) into their actual string values. This enables
- * className assertions on resolved CSS class names instead of variable names.
+ * array.join() patterns, ternary expressions, and identifier references)
+ * into their actual string values. This enables className assertions on
+ * resolved CSS class names instead of variable names.
  */
 
 /**
  * Build a map of constant name → resolved string value.
- * Only resolves string literals, template literals, and array.join() patterns.
- * Record lookups, function expressions, and other complex values are skipped.
+ * Resolves string literals, template literals, array.join() patterns,
+ * ternary expressions (union of both branches), and plain identifier
+ * references. Record lookups, function expressions, and other complex
+ * values are skipped.
  */
 export function resolveConstants(constants: Array<{ name: string; value?: string }>): Map<string, string> {
   const resolved = new Map<string, string>()
@@ -59,6 +62,104 @@ function tryResolve(raw: string, resolved: Map<string, string>): string | null {
       strings.push(m[1] ?? m[2])
     }
     return strings.join(separator)
+  }
+
+  // Ternary expression: condition ? trueExpr : falseExpr
+  // Resolve both branches and merge unique class tokens (union semantics).
+  const ternary = parseTernary(value)
+  if (ternary) {
+    const trueVal = tryResolve(ternary.trueBranch, resolved)
+    const falseVal = tryResolve(ternary.falseBranch, resolved)
+    if (trueVal !== null || falseVal !== null) {
+      const tokens = new Set<string>()
+      for (const v of [trueVal, falseVal]) {
+        if (v) for (const t of v.split(/\s+/)) if (t) tokens.add(t)
+      }
+      return [...tokens].join(' ')
+    }
+  }
+
+  // Plain identifier reference: look up a previously resolved constant
+  if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(value) && resolved.has(value)) {
+    return resolved.get(value)!
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Ternary expression parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if the character at `pos` is escaped by a preceding backslash.
+ */
+function isEscaped(s: string, pos: number): boolean {
+  let backslashes = 0
+  for (let i = pos - 1; i >= 0 && s[i] === '\\'; i--) backslashes++
+  return backslashes % 2 === 1
+}
+
+/**
+ * Parse a ternary expression `condition ? trueBranch : falseBranch`.
+ *
+ * Uses a bracket/string-aware scanner to find the top-level `?` and `:`
+ * while skipping:
+ * - Nested brackets: `()`, `[]`, `{}`
+ * - String literals: `'...'`, `"..."`, `` `...` ``
+ * - Optional chaining: `?.`
+ * - Nullish coalescing: `??`
+ */
+function parseTernary(value: string): { trueBranch: string; falseBranch: string } | null {
+  let depth = 0
+  let questionPos = -1
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i]
+
+    // Skip string/template literals
+    if ((ch === "'" || ch === '"' || ch === '`') && !isEscaped(value, i)) {
+      const quote = ch
+      i++
+      while (i < value.length) {
+        if (value[i] === '\\') { i++; i++; continue }
+        if (value[i] === quote) break
+        // Template literal interpolation — skip ${...}
+        if (quote === '`' && value[i] === '$' && value[i + 1] === '{') {
+          let braceDepth = 1
+          i += 2
+          while (i < value.length && braceDepth > 0) {
+            if (value[i] === '{') braceDepth++
+            else if (value[i] === '}') braceDepth--
+            i++
+          }
+          continue
+        }
+        i++
+      }
+      continue
+    }
+
+    // Track bracket depth
+    if (ch === '(' || ch === '[' || ch === '{') { depth++; continue }
+    if (ch === ')' || ch === ']' || ch === '}') { depth--; continue }
+
+    // Only match at top level (depth === 0)
+    if (depth !== 0) continue
+
+    if (ch === '?') {
+      // Skip optional chaining `?.` and nullish coalescing `??`
+      if (value[i + 1] === '.' || value[i + 1] === '?') continue
+      questionPos = i
+    }
+
+    if (ch === ':' && questionPos >= 0) {
+      const trueBranch = value.slice(questionPos + 1, i).trim()
+      const falseBranch = value.slice(i + 1).trim()
+      if (trueBranch && falseBranch) {
+        return { trueBranch, falseBranch }
+      }
+    }
   }
 
   return null

--- a/packages/test/src/resolve-constants.ts
+++ b/packages/test/src/resolve-constants.ts
@@ -2,23 +2,42 @@
  * Constant resolution for test IR.
  *
  * Resolves string-valued constants (string literals, template literals,
- * array.join() patterns, ternary expressions, and identifier references)
- * into their actual string values. This enables className assertions on
- * resolved CSS class names instead of variable names.
+ * array.join() patterns, and identifier references) into their actual
+ * string values. When the analyzer provides structured `valueBranches`
+ * (from ternary initializers), those are used directly instead of
+ * re-parsing from the string representation.
  */
 
 /**
  * Build a map of constant name → resolved string value.
  * Resolves string literals, template literals, array.join() patterns,
- * ternary expressions (union of both branches), and plain identifier
- * references. Record lookups, function expressions, and other complex
- * values are skipped.
+ * and plain identifier references. When `valueBranches` is present
+ * (from ternary initializers), each branch is resolved and merged
+ * with union semantics. Record lookups, function expressions, and
+ * other complex values are skipped.
  */
-export function resolveConstants(constants: Array<{ name: string; value?: string }>): Map<string, string> {
+export function resolveConstants(
+  constants: Array<{ name: string; value?: string; valueBranches?: string[] }>
+): Map<string, string> {
   const resolved = new Map<string, string>()
 
   for (const c of constants) {
     if (!c.value) continue
+
+    // When the analyzer provides structured branch info, resolve each
+    // branch and merge unique class tokens (union semantics).
+    if (c.valueBranches) {
+      const tokens = new Set<string>()
+      for (const branch of c.valueBranches) {
+        const v = tryResolve(branch, resolved)
+        if (v) for (const t of v.split(/\s+/)) if (t) tokens.add(t)
+      }
+      if (tokens.size > 0) {
+        resolved.set(c.name, [...tokens].join(' '))
+      }
+      continue
+    }
+
     const value = tryResolve(c.value, resolved)
     if (value !== null) {
       resolved.set(c.name, value)
@@ -64,102 +83,9 @@ function tryResolve(raw: string, resolved: Map<string, string>): string | null {
     return strings.join(separator)
   }
 
-  // Ternary expression: condition ? trueExpr : falseExpr
-  // Resolve both branches and merge unique class tokens (union semantics).
-  const ternary = parseTernary(value)
-  if (ternary) {
-    const trueVal = tryResolve(ternary.trueBranch, resolved)
-    const falseVal = tryResolve(ternary.falseBranch, resolved)
-    if (trueVal !== null || falseVal !== null) {
-      const tokens = new Set<string>()
-      for (const v of [trueVal, falseVal]) {
-        if (v) for (const t of v.split(/\s+/)) if (t) tokens.add(t)
-      }
-      return [...tokens].join(' ')
-    }
-  }
-
   // Plain identifier reference: look up a previously resolved constant
   if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(value) && resolved.has(value)) {
     return resolved.get(value)!
-  }
-
-  return null
-}
-
-// ---------------------------------------------------------------------------
-// Ternary expression parser
-// ---------------------------------------------------------------------------
-
-/**
- * Check if the character at `pos` is escaped by a preceding backslash.
- */
-function isEscaped(s: string, pos: number): boolean {
-  let backslashes = 0
-  for (let i = pos - 1; i >= 0 && s[i] === '\\'; i--) backslashes++
-  return backslashes % 2 === 1
-}
-
-/**
- * Parse a ternary expression `condition ? trueBranch : falseBranch`.
- *
- * Uses a bracket/string-aware scanner to find the top-level `?` and `:`
- * while skipping:
- * - Nested brackets: `()`, `[]`, `{}`
- * - String literals: `'...'`, `"..."`, `` `...` ``
- * - Optional chaining: `?.`
- * - Nullish coalescing: `??`
- */
-function parseTernary(value: string): { trueBranch: string; falseBranch: string } | null {
-  let depth = 0
-  let questionPos = -1
-
-  for (let i = 0; i < value.length; i++) {
-    const ch = value[i]
-
-    // Skip string/template literals
-    if ((ch === "'" || ch === '"' || ch === '`') && !isEscaped(value, i)) {
-      const quote = ch
-      i++
-      while (i < value.length) {
-        if (value[i] === '\\') { i++; i++; continue }
-        if (value[i] === quote) break
-        // Template literal interpolation — skip ${...}
-        if (quote === '`' && value[i] === '$' && value[i + 1] === '{') {
-          let braceDepth = 1
-          i += 2
-          while (i < value.length && braceDepth > 0) {
-            if (value[i] === '{') braceDepth++
-            else if (value[i] === '}') braceDepth--
-            i++
-          }
-          continue
-        }
-        i++
-      }
-      continue
-    }
-
-    // Track bracket depth
-    if (ch === '(' || ch === '[' || ch === '{') { depth++; continue }
-    if (ch === ')' || ch === ']' || ch === '}') { depth--; continue }
-
-    // Only match at top level (depth === 0)
-    if (depth !== 0) continue
-
-    if (ch === '?') {
-      // Skip optional chaining `?.` and nullish coalescing `??`
-      if (value[i + 1] === '.' || value[i + 1] === '?') continue
-      questionPos = i
-    }
-
-    if (ch === ':' && questionPos >= 0) {
-      const trueBranch = value.slice(questionPos + 1, i).trim()
-      const falseBranch = value.slice(i + 1).trim()
-      if (trueBranch && falseBranch) {
-        return { trueBranch, falseBranch }
-      }
-    }
   }
 
   return null


### PR DESCRIPTION
## Summary

- Extend `tryResolve()` in `packages/test/src/resolve-constants.ts` to handle **ternary expressions** and **plain identifier references**, so `renderToTest()` resolves intermediate variables to their CSS class tokens instead of returning variable names.
- Add a bracket/string-aware `parseTernary()` scanner that correctly skips nested brackets, string/template literals, optional chaining (`?.`), and nullish coalescing (`??`).
- Ternary resolution uses **union semantics** — both branches contribute class tokens for test assertions.
- Add 3 test cases in `packages/test/__tests__/render-to-test.test.ts` covering ternary with template literal + identifier branches, ternary with string literal branches, and plain identifier alias.

### Refactor: AST-based `valueBranches`

- Replace ad-hoc `parseTernary()` string parser with structured `valueBranches` propagated from the TypeScript AST in the analyzer.
- Add `valueBranches?: string[]` to `ConstantInfo` — leaf branch expressions from ternary initializers.
- Add `extractValueBranches()` in `analyzer.ts` that recursively flattens ternary branches at the AST level.
- Update `resolveConstants()` to use `valueBranches` directly, removing ~70 lines of fragile string-based ternary parsing (`parseTernary()` + `isEscaped()`).
- Add 3 compiler unit tests for `valueBranches` (basic ternary, nested ternary, non-ternary).

## Test plan

- [x] `cd packages/jsx && bun test` — 148 pass, 0 fail
- [x] `cd packages/test && bun test` — 8 pass, 0 fail
- [x] `bun test packages/` — 853 pass, no new failures (1 pre-existing unrelated failure in `packages/form`)

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)