### PR TITLE
Fix: nested createMemo TypeError with function values

### DIFF
--- a/packages/dom/__tests__/reactive.test.ts
+++ b/packages/dom/__tests__/reactive.test.ts
@@ -167,6 +167,68 @@ describe('createMemo', () => {
     expect(calcCount).toBe(3)
   })
 
+  test('stores function value without calling it', () => {
+    const myFn = (x: number) => x * 2
+    const memo = createMemo(() => myFn)
+
+    expect(memo()).toBe(myFn)
+    expect(memo()(3)).toBe(6)
+  })
+
+  test('nested memo with function value (issue #538)', () => {
+    const defaultFormat = (d: Date) => d.toISOString()
+    const customFormat = (d: Date) => d.toLocaleDateString()
+
+    const [useCustom, setUseCustom] = createSignal(false)
+
+    // Memo that returns a function — previously caused TypeError
+    const formatter = createMemo(() =>
+      useCustom() ? customFormat : defaultFormat
+    )
+    const displayText = createMemo(() => {
+      const fmt = formatter()
+      const date = new Date('2025-01-15T00:00:00Z')
+      return fmt(date)
+    })
+
+    expect(displayText()).toBe(new Date('2025-01-15T00:00:00Z').toISOString())
+
+    setUseCustom(true)
+    expect(displayText()).toBe(new Date('2025-01-15T00:00:00Z').toLocaleDateString())
+  })
+
+  test('recomputes function value when signal changes', () => {
+    const fnA = () => 'A'
+    const fnB = () => 'B'
+    const [which, setWhich] = createSignal<'a' | 'b'>('a')
+
+    const memo = createMemo(() => which() === 'a' ? fnA : fnB)
+
+    expect(memo()).toBe(fnA)
+    expect(memo()()).toBe('A')
+
+    setWhich('b')
+    expect(memo()).toBe(fnB)
+    expect(memo()()).toBe('B')
+  })
+
+  test('function value triggers dependent effect', () => {
+    const results: string[] = []
+    const fnA = () => 'A'
+    const fnB = () => 'B'
+    const [which, setWhich] = createSignal<'a' | 'b'>('a')
+
+    const memo = createMemo(() => which() === 'a' ? fnA : fnB)
+
+    createEffect(() => {
+      results.push(memo()())
+    })
+
+    expect(results).toEqual(['A'])
+    setWhich('b')
+    expect(results).toEqual(['A', 'B'])
+  })
+
   test('handles conditional dependencies', () => {
     let calcCount = 0
     const [condition, setCondition] = createSignal(true)

--- a/packages/dom/src/reactive.ts
+++ b/packages/dom/src/reactive.ts
@@ -220,16 +220,10 @@ export function onMount(fn: () => void): void {
  */
 export function createMemo<T>(fn: () => T): Memo<T> {
   const [value, setValue] = createSignal<T>(undefined as T)
-  let initialized = false
 
   createEffect(() => {
     const result = fn()
-    if (initialized) {
-      setValue(result)
-    } else {
-      initialized = true
-      setValue(result)
-    }
+    setValue(() => result)
   })
 
   return value


### PR DESCRIPTION
## Summary

- Fix `createMemo` TypeError when the memo computation returns a **function value** (e.g., `createMemo(() => props.formatDate ?? defaultFormat)`)
- Root cause: `createSignal`'s setter checks `typeof valueOrFn === 'function'` and misinterprets the function as an updater — calling it instead of storing it
- Fix: wrap with `setValue(() => result)` so the value is always stored correctly (same pattern SolidJS uses internally)
- Remove dead `initialized` flag (both branches were identical)

## Test plan

- [x] Add test: memo stores function value without calling it
- [x] Add test: nested memo with function value (reproduces #538)
- [x] Add test: memo recomputes function on signal change
- [x] Add test: function value triggers dependent effect
- [x] All 33 reactive tests pass (`bun test __tests__/reactive.test.ts`)

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)