### PR TITLE
Fix renderChild() failure for stateless components (#536)

### DIFF
--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4030,6 +4030,112 @@ describe('Compiler', () => {
     })
   })
 
+  describe('renderChild for components without registered templates (#536)', () => {
+    test('stateless component with spread attrs and object-literal constants gets template registered', () => {
+      const source = `
+        const sizeMap = { sm: 16, md: 20, lg: 24 }
+        type Size = 'sm' | 'md' | 'lg'
+
+        export function CheckIcon(props: { size?: Size, className?: string }) {
+          const size = props.size ?? 'md'
+          const sizeAttrs = { width: sizeMap[size], height: sizeMap[size] }
+          return (
+            <svg {...sizeAttrs} className={props.className ?? ''} viewBox="0 0 24 24">
+              <path d="M5 13l4 4L19 7" />
+            </svg>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'CheckIcon.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // Stateless component must register a template so renderChild() can find it
+      expect(content).toContain("hydrate('CheckIcon',")
+      expect(content).toContain('template:')
+    })
+
+    test('multi-component file: stateless icons in conditional rendering produce renderChild + hydrate', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        function CopyIcon() {
+          return <svg viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" /></svg>
+        }
+
+        function CheckIcon() {
+          return <svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
+        }
+
+        export function CopyButton() {
+          const [copied, setCopied] = createSignal(false)
+          return (
+            <button onClick={() => setCopied(true)}>
+              {copied() ? <CheckIcon /> : <CopyIcon />}
+            </button>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'CopyButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // Both icon components must have templates registered
+      expect(content).toContain("hydrate('CopyIcon',")
+      expect(content).toContain("hydrate('CheckIcon',")
+
+      // Both should have template functions
+      expect(content).toMatch(/hydrate\('CopyIcon',\s*\{[^}]*template:/)
+      expect(content).toMatch(/hydrate\('CheckIcon',\s*\{[^}]*template:/)
+
+      // Parent should use renderChild for the icons
+      expect(content).toContain("renderChild('CheckIcon'")
+      expect(content).toContain("renderChild('CopyIcon'")
+    })
+
+    test('regression: object key fix does not skip ternary colon identifiers', () => {
+      // The object-key-position fix skips `{ key: value }` patterns.
+      // This tests that identifiers before `:` in TERNARY expressions
+      // (where the preceding char is `?`, not `{` or `,`) are NOT skipped.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        function StatusOn() { return <span>ON</span> }
+        function StatusOff() { return <span>OFF</span> }
+
+        export function Toggle() {
+          const [active, setActive] = createSignal(false)
+          return (
+            <div>
+              {active() ? <StatusOn /> : <StatusOff />}
+              <button onClick={() => setActive(v => !v)}>toggle</button>
+            </div>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // Both child components must have templates registered
+      expect(content).toContain("hydrate('StatusOn',")
+      expect(content).toContain("hydrate('StatusOff',")
+      expect(content).toContain("renderChild('StatusOn'")
+      expect(content).toContain("renderChild('StatusOff'")
+    })
+  })
+
   describe('dependency-based declaration ordering (#508)', () => {
     test('constant depending on call expression with arrow argument preserves source order', () => {
       const source = `

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4100,10 +4100,10 @@ describe('Compiler', () => {
       expect(content).toContain("renderChild('CopyIcon'")
     })
 
-    test('regression: object key fix does not skip ternary colon identifiers', () => {
-      // The object-key-position fix skips `{ key: value }` patterns.
-      // This tests that identifiers before `:` in TERNARY expressions
-      // (where the preceding char is `?`, not `{` or `,`) are NOT skipped.
+    test('regression: AST-based identifier extraction distinguishes property keys from ternary branches', () => {
+      // extractFreeIdentifiers() skips identifiers in PropertyAssignment key position.
+      // This verifies that identifiers in ternary branches (structurally distinct in the AST)
+      // are correctly identified as variable references.
       const source = `
         'use client'
         import { createSignal } from '@barefootjs/dom'

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -752,6 +752,46 @@ function extractValueBranches(node: ts.Expression, ctx: AnalyzerContext): string
   return [ctx.getJS(node)]
 }
 
+/**
+ * Extract free identifier references from an AST node by walking the tree.
+ * Skips property keys, member access properties, and bound parameter names.
+ */
+function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
+  const ids = new Set<string>()
+  const boundNames = new Set<string>()
+
+  function addBindingNames(name: ts.BindingName, out: string[]): void {
+    if (ts.isIdentifier(name)) out.push(name.text)
+    else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => addBindingNames(e.name, out))
+    else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => { if (!ts.isOmittedExpression(e)) addBindingNames(e.name, out) })
+  }
+
+  function visit(n: ts.Node): void {
+    if (ts.isIdentifier(n)) {
+      const parent = n.parent
+      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === n) return
+      if (parent && ts.isPropertyAssignment(parent) && parent.name === n) return
+      if (parent && ts.isParameter(parent) && parent.name === n) return
+      if (parent && ts.isVariableDeclaration(parent) && parent.name === n) return
+      if (boundNames.has(n.text)) return
+      ids.add(n.text)
+      return
+    }
+    if (ts.isArrowFunction(n)) {
+      const params: string[] = []
+      for (const p of n.parameters) addBindingNames(p.name, params)
+      for (const name of params) boundNames.add(name)
+      ts.forEachChild(n, visit)
+      for (const name of params) boundNames.delete(name)
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+
+  visit(node)
+  return ids
+}
+
 function collectConstant(
   node: ts.VariableDeclaration,
   ctx: AnalyzerContext,
@@ -787,6 +827,10 @@ function collectConstant(
     type = inferTypeFromValue(value)
   }
 
+  const freeIdentifiers = node.initializer
+    ? extractFreeIdentifiersFromNode(node.initializer)
+    : undefined
+
   ctx.localConstants.push({
     name,
     value,
@@ -795,6 +839,7 @@ function collectConstant(
     isExported,
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    freeIdentifiers,
   })
 }
 

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -3,6 +3,7 @@
  * Each function appends to a lines[] array.
  */
 
+import ts from 'typescript'
 import type { ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
@@ -754,45 +755,79 @@ const JS_BUILTINS = new Set([
 ])
 
 /**
+ * Extract free variable references from an expression using TypeScript AST.
+ * Returns the set of identifier names that are in "reference" position
+ * (not object property keys, not member access properties, not parameter names).
+ * Returns null if the expression cannot be parsed.
+ */
+function extractFreeIdentifiers(expr: string): Set<string> | null {
+  // Wrap in parens to disambiguate object literals from block statements
+  const sourceFile = ts.createSourceFile(
+    'expr.ts', `(${expr})`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX
+  )
+
+  if (sourceFile.statements.length === 0) return null
+  const firstStmt = sourceFile.statements[0]
+  if (!ts.isExpressionStatement(firstStmt)) return null
+
+  const ids = new Set<string>()
+  const boundNames = new Set<string>()
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) {
+      const parent = node.parent
+
+      // foo.bar → skip bar (property name in member access)
+      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return
+      // { key: value } → skip key (property name in object literal)
+      if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return
+      // function parameters → skip (bound, not free)
+      if (parent && ts.isParameter(parent) && parent.name === node) return
+      // variable declaration names → skip
+      if (parent && ts.isVariableDeclaration(parent) && parent.name === node) return
+      // arrow/function parameters tracked via boundNames
+      if (boundNames.has(node.text)) return
+
+      ids.add(node.text)
+      return
+    }
+
+    // Track arrow function parameters as bound names
+    if (ts.isArrowFunction(node)) {
+      const params: string[] = []
+      for (const p of node.parameters) {
+        if (ts.isIdentifier(p.name)) {
+          params.push(p.name.text)
+          boundNames.add(p.name.text)
+        }
+      }
+      ts.forEachChild(node, visit)
+      for (const p of params) {
+        boundNames.delete(p)
+      }
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(firstStmt.expression)
+  return ids
+}
+
+/**
  * Check that an expression value only references identifiers known within
  * the component scope (or JavaScript built-ins). Returns false if the value
  * contains references to file-scope variables that won't be available in
  * the generated client JS module scope.
  */
 function valueOnlyUsesKnownNames(value: string, knownNames: Set<string>): boolean {
-  // Strip string literal content to avoid false-positive identifier matches.
-  // For template literals, extract only ${...} expression parts.
-  let codeParts = value
-    .replace(/'(?:[^'\\]|\\.)*'/g, '')
-    .replace(/"(?:[^"\\]|\\.)*"/g, '')
+  const freeIds = extractFreeIdentifiers(value)
+  if (freeIds === null) return false // Cannot parse → assume unsafe
 
-  if (codeParts.includes('`')) {
-    const exprParts: string[] = []
-    const templateExprRegex = /\$\{([^}]*)\}/g
-    let match
-    while ((match = templateExprRegex.exec(codeParts)) !== null) {
-      exprParts.push(match[1])
-    }
-    // Keep non-template-literal code, replace template literals with extracted expressions
-    codeParts = codeParts.replace(/`[^`]*`/g, '') + ' ' + exprParts.join(' ')
-  }
-
-  const identifiers = codeParts.matchAll(/\b([a-zA-Z_$][a-zA-Z0-9_$]*)\b/g)
-  for (const m of identifiers) {
-    const id = m[1]
+  for (const id of freeIds) {
     if (JS_BUILTINS.has(id)) continue
     if (knownNames.has(id)) continue
-
-    // Skip identifiers in object property key position: { key: value } or { key1: v1, key2: v2 }
-    // These are property names, not variable references.
-    const beforeStr = codeParts.slice(0, m.index!).trimEnd()
-    const lastCharBefore = beforeStr[beforeStr.length - 1]
-    if (lastCharBefore === '{' || lastCharBefore === ',') {
-      const afterPos = m.index! + id.length
-      const remaining = codeParts.slice(afterPos).trimStart()
-      if (remaining.startsWith(':') && !remaining.startsWith('::')) continue
-    }
-
     return false
   }
   return true

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -3,7 +3,6 @@
  * Each function appends to a lines[] array.
  */
 
-import ts from 'typescript'
 import type { ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
@@ -755,96 +754,14 @@ const JS_BUILTINS = new Set([
 ])
 
 /**
- * Recursively collect all bound identifier names from a binding pattern.
- * Handles simple identifiers, object destructuring, and array destructuring.
- */
-function collectBindingNames(name: ts.BindingName, out: string[]): void {
-  if (ts.isIdentifier(name)) {
-    out.push(name.text)
-  } else if (ts.isObjectBindingPattern(name)) {
-    for (const element of name.elements) {
-      collectBindingNames(element.name, out)
-    }
-  } else if (ts.isArrayBindingPattern(name)) {
-    for (const element of name.elements) {
-      if (!ts.isOmittedExpression(element)) {
-        collectBindingNames(element.name, out)
-      }
-    }
-  }
-}
-
-/**
- * Extract free variable references from an expression using TypeScript AST.
- * Returns the set of identifier names that are in "reference" position
- * (not object property keys, not member access properties, not parameter names).
- * Returns null if the expression cannot be parsed.
- */
-function extractFreeIdentifiers(expr: string): Set<string> | null {
-  // Wrap in parens to disambiguate object literals from block statements
-  const sourceFile = ts.createSourceFile(
-    'expr.ts', `(${expr})`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX
-  )
-
-  if (sourceFile.statements.length === 0) return null
-  const firstStmt = sourceFile.statements[0]
-  if (!ts.isExpressionStatement(firstStmt)) return null
-
-  const ids = new Set<string>()
-  const boundNames = new Set<string>()
-
-  function visit(node: ts.Node): void {
-    if (ts.isIdentifier(node)) {
-      const parent = node.parent
-
-      // foo.bar → skip bar (property name in member access)
-      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return
-      // { key: value } → skip key (property name in object literal)
-      // Note: { key } (ShorthandPropertyAssignment) IS a variable reference and is NOT skipped.
-      if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return
-      // function parameters → skip (bound, not free)
-      if (parent && ts.isParameter(parent) && parent.name === node) return
-      // variable declaration names → skip
-      if (parent && ts.isVariableDeclaration(parent) && parent.name === node) return
-      // arrow/function parameters tracked via boundNames
-      if (boundNames.has(node.text)) return
-
-      ids.add(node.text)
-      return
-    }
-
-    // Track arrow function parameters as bound names
-    if (ts.isArrowFunction(node)) {
-      const params: string[] = []
-      for (const p of node.parameters) {
-        collectBindingNames(p.name, params)
-      }
-      for (const name of params) boundNames.add(name)
-      ts.forEachChild(node, visit)
-      for (const name of params) boundNames.delete(name)
-      return
-    }
-
-    ts.forEachChild(node, visit)
-  }
-
-  visit(firstStmt.expression)
-  return ids
-}
-
-/**
  * Check that an expression value only references identifiers known within
  * the component scope (or JavaScript built-ins). Returns false if the value
  * contains references to file-scope variables that won't be available in
  * the generated client JS module scope.
  *
- * Uses pre-computed freeIdentifiers from the analyzer when available,
- * falling back to extractFreeIdentifiers() for values without pre-computed data.
+ * Uses pre-computed freeIdentifiers from the analyzer phase (ConstantInfo.freeIdentifiers).
  */
-function valueOnlyUsesKnownNames(preComputed: Set<string> | undefined, value: string, knownNames: Set<string>): boolean {
-  const freeIds = preComputed ?? extractFreeIdentifiers(value)
-  if (freeIds === null) return false // Cannot parse → assume unsafe
-
+function valueOnlyUsesKnownNames(freeIds: Set<string>, knownNames: Set<string>): boolean {
   for (const id of freeIds) {
     if (JS_BUILTINS.has(id)) continue
     if (knownNames.has(id)) continue
@@ -958,7 +875,7 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
       continue
     }
 
-    if (!valueOnlyUsesKnownNames(constant.freeIdentifiers, trimmedValue, componentScopeNames)) {
+    if (!valueOnlyUsesKnownNames(constant.freeIdentifiers!, componentScopeNames)) {
       unsafeLocalNames.add(constant.name)
       continue
     }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -755,6 +755,26 @@ const JS_BUILTINS = new Set([
 ])
 
 /**
+ * Recursively collect all bound identifier names from a binding pattern.
+ * Handles simple identifiers, object destructuring, and array destructuring.
+ */
+function collectBindingNames(name: ts.BindingName, out: string[]): void {
+  if (ts.isIdentifier(name)) {
+    out.push(name.text)
+  } else if (ts.isObjectBindingPattern(name)) {
+    for (const element of name.elements) {
+      collectBindingNames(element.name, out)
+    }
+  } else if (ts.isArrayBindingPattern(name)) {
+    for (const element of name.elements) {
+      if (!ts.isOmittedExpression(element)) {
+        collectBindingNames(element.name, out)
+      }
+    }
+  }
+}
+
+/**
  * Extract free variable references from an expression using TypeScript AST.
  * Returns the set of identifier names that are in "reference" position
  * (not object property keys, not member access properties, not parameter names).
@@ -780,6 +800,7 @@ function extractFreeIdentifiers(expr: string): Set<string> | null {
       // foo.bar → skip bar (property name in member access)
       if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return
       // { key: value } → skip key (property name in object literal)
+      // Note: { key } (ShorthandPropertyAssignment) IS a variable reference and is NOT skipped.
       if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return
       // function parameters → skip (bound, not free)
       if (parent && ts.isParameter(parent) && parent.name === node) return
@@ -796,15 +817,11 @@ function extractFreeIdentifiers(expr: string): Set<string> | null {
     if (ts.isArrowFunction(node)) {
       const params: string[] = []
       for (const p of node.parameters) {
-        if (ts.isIdentifier(p.name)) {
-          params.push(p.name.text)
-          boundNames.add(p.name.text)
-        }
+        collectBindingNames(p.name, params)
       }
+      for (const name of params) boundNames.add(name)
       ts.forEachChild(node, visit)
-      for (const p of params) {
-        boundNames.delete(p)
-      }
+      for (const name of params) boundNames.delete(name)
       return
     }
 
@@ -820,9 +837,12 @@ function extractFreeIdentifiers(expr: string): Set<string> | null {
  * the component scope (or JavaScript built-ins). Returns false if the value
  * contains references to file-scope variables that won't be available in
  * the generated client JS module scope.
+ *
+ * Uses pre-computed freeIdentifiers from the analyzer when available,
+ * falling back to extractFreeIdentifiers() for values without pre-computed data.
  */
-function valueOnlyUsesKnownNames(value: string, knownNames: Set<string>): boolean {
-  const freeIds = extractFreeIdentifiers(value)
+function valueOnlyUsesKnownNames(preComputed: Set<string> | undefined, value: string, knownNames: Set<string>): boolean {
+  const freeIds = preComputed ?? extractFreeIdentifiers(value)
   if (freeIds === null) return false // Cannot parse → assume unsafe
 
   for (const id of freeIds) {
@@ -860,7 +880,7 @@ export function resolveChainedRefs(constants: Map<string, string>): void {
       let newValue = protect(constValue)
       for (const [otherName, otherValue] of constants) {
         if (otherName === constName) continue
-        const replaced = newValue.replace(new RegExp(`(?<!\\.)\\b${otherName}\\b`, 'g'), `(${protect(otherValue)})`)
+        const replaced = newValue.replace(new RegExp(`(?<![-.])\\b${otherName}\\b`, 'g'), `(${protect(otherValue)})`)
         if (replaced !== newValue) {
           newValue = replaced
           changed = true
@@ -938,7 +958,7 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
       continue
     }
 
-    if (!valueOnlyUsesKnownNames(trimmedValue, componentScopeNames)) {
+    if (!valueOnlyUsesKnownNames(constant.freeIdentifiers, trimmedValue, componentScopeNames)) {
       unsafeLocalNames.add(constant.name)
       continue
     }
@@ -1046,6 +1066,37 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
   return { signalMap, memoMap }
 }
 
+/**
+ * Build an expanded inlinable constants map for CSR template generation.
+ * Re-promotes constants that were demoted to unsafeLocalNames by resolving
+ * signal/memo call expressions with their initial values.
+ */
+export function buildCsrInlinableConstants(
+  ctx: ClientJsContext,
+  inlinableConstants: Map<string, string>,
+  unsafeLocalNames: Set<string>,
+  signalMap: Map<string, string>,
+  memoMap: Map<string, string>,
+): Map<string, string> {
+  const csrInlinableConstants = new Map(inlinableConstants)
+  for (const constant of ctx.localConstants) {
+    if (unsafeLocalNames.has(constant.name) && constant.value && !constant.value.includes('=>')) {
+      let value = constant.value.trim()
+      for (const [getter, initial] of signalMap) {
+        value = value.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
+      }
+      for (const [memoName, computation] of memoMap) {
+        value = value.replace(new RegExp(`\\b${memoName}\\(\\)`, 'g'), `(${computation})`)
+      }
+      if (!/\b\w+\(\)/.test(value)) {
+        csrInlinableConstants.set(constant.name, value)
+      }
+    }
+  }
+  resolveChainedRefs(csrInlinableConstants)
+  return csrInlinableConstants
+}
+
 /** Emit hydrate() call that registers component, template, and hydrates. */
 export function emitRegistrationAndHydration(
   lines: string[],
@@ -1074,27 +1125,8 @@ export function emitRegistrationAndHydration(
   } else if (usedAsChild?.has(name)) {
     // CSR fallback: only emit when this component is used as a child by another
     // component in the same file. Top-level-only components skip this to save bytes.
-    // transformExpr() uses string literal protection to prevent regex corruption
-    // of CSS class names (e.g., 'size-4' when constant 'size' exists).
     const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-
-    // Re-promote demoted constants by resolving signal/memo references
-    const csrInlinableConstants = new Map(inlinableConstants)
-    for (const constant of ctx.localConstants) {
-      if (unsafeLocalNames.has(constant.name) && constant.value && !constant.value.includes('=>')) {
-        let value = constant.value.trim()
-        for (const [getter, initial] of signalMap) {
-          value = value.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
-        }
-        for (const [name, computation] of memoMap) {
-          value = value.replace(new RegExp(`\\b${name}\\(\\)`, 'g'), `(${computation})`)
-        }
-        if (!/\b\w+\(\)/.test(value)) {
-          csrInlinableConstants.set(constant.name, value)
-        }
-      }
-    }
-    resolveChainedRefs(csrInlinableConstants)
+    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     const templateHtml = generateCsrTemplate(
       _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -782,6 +782,17 @@ function valueOnlyUsesKnownNames(value: string, knownNames: Set<string>): boolea
     const id = m[1]
     if (JS_BUILTINS.has(id)) continue
     if (knownNames.has(id)) continue
+
+    // Skip identifiers in object property key position: { key: value } or { key1: v1, key2: v2 }
+    // These are property names, not variable references.
+    const beforeStr = codeParts.slice(0, m.index!).trimEnd()
+    const lastCharBefore = beforeStr[beforeStr.length - 1]
+    if (lastCharBefore === '{' || lastCharBefore === ',') {
+      const afterPos = m.index! + id.length
+      const remaining = codeParts.slice(afterPos).trimStart()
+      if (remaining.startsWith(':') && !remaining.startsWith('::')) continue
+    }
+
     return false
   }
   return true

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -397,6 +397,8 @@ export function canGenerateStaticTemplate(
 
     case 'element':
       for (const attr of node.attrs) {
+        // Spread attributes are always dropped by template generators, so skip them.
+        if (attr.name === '...') continue
         if (attr.dynamic && attr.value) {
           const valueStr = attrValueToString(attr.value)
           if (valueStr) {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -235,10 +235,11 @@ export function irToComponentTemplate(
     let result = protect(expr)
 
     // First: inline constant references with their resolved values (#343)
-    // Parenthesized to prevent operator precedence issues
+    // Parenthesized to prevent operator precedence issues.
+    // (?<![-.]) avoids matching inside CSS property names (e.g., `width` in `max-width`).
     if (inlinableConstants && inlinableConstants.size > 0) {
       for (const [constName, constValue] of inlinableConstants) {
-        result = result.replace(new RegExp(`(?<!\\.)\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
       }
     }
 
@@ -483,10 +484,11 @@ export function generateCsrTemplate(
       }
     }
 
-    // Inline constant references with their resolved values
+    // Inline constant references with their resolved values.
+    // (?<![-.]) avoids matching inside CSS property names (e.g., `width` in `max-width`).
     if (inlinableConstants && inlinableConstants.size > 0) {
       for (const [constName, constValue] of inlinableConstants) {
-        result = result.replace(new RegExp(`(?<!\\.)\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
       }
     }
 

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -10,8 +10,8 @@ import { collectElements } from './collect-elements'
 import { generateInitFunction } from './generate-init'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
 import { valueReferencesReactiveData } from './prop-handling'
-import { canGenerateStaticTemplate, irToComponentTemplate } from './html-template'
-import { buildInlinableConstants } from './emit-init-sections'
+import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
+import { buildInlinableConstants, buildSignalAndMemoMaps, resolveChainedRefs } from './emit-init-sections'
 import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
 
 /** Public entry point: IR → client JS string. Returns '' if no client JS is needed. */
@@ -135,11 +135,40 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   const propNamesForTemplate = new Set(ctx.propsParams.map((p) => p.name))
   const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
 
-  if (!canGenerateStaticTemplate(ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
-    return ''
+  let templateHtml: string | undefined
+
+  if (canGenerateStaticTemplate(ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
+    templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants)
   }
 
-  const templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants)
+  // CSR fallback: when static template generation fails (e.g., components with
+  // nested child components or loops), try generateCsrTemplate() (#536).
+  if (!templateHtml) {
+    const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
+
+    // Re-promote demoted constants by resolving signal/memo references
+    const csrInlinableConstants = new Map(inlinableConstants)
+    for (const constant of ctx.localConstants) {
+      if (unsafeLocalNames.has(constant.name) && constant.value && !constant.value.includes('=>')) {
+        let value = constant.value.trim()
+        for (const [getter, initial] of signalMap) {
+          value = value.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
+        }
+        for (const [name, computation] of memoMap) {
+          value = value.replace(new RegExp(`\\b${name}\\(\\)`, 'g'), `(${computation})`)
+        }
+        if (!/\b\w+\(\)/.test(value)) {
+          csrInlinableConstants.set(constant.name, value)
+        }
+      }
+    }
+    resolveChainedRefs(csrInlinableConstants)
+
+    templateHtml = generateCsrTemplate(
+      ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap
+    )
+  }
+
   if (!templateHtml) {
     return ''
   }

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -11,7 +11,7 @@ import { generateInitFunction } from './generate-init'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
 import { valueReferencesReactiveData } from './prop-handling'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
-import { buildInlinableConstants, buildSignalAndMemoMaps, resolveChainedRefs } from './emit-init-sections'
+import { buildInlinableConstants, buildSignalAndMemoMaps, buildCsrInlinableConstants } from './emit-init-sections'
 import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
 
 /** Public entry point: IR → client JS string. Returns '' if no client JS is needed. */
@@ -145,24 +145,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   // nested child components or loops), try generateCsrTemplate() (#536).
   if (!templateHtml) {
     const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-
-    // Re-promote demoted constants by resolving signal/memo references
-    const csrInlinableConstants = new Map(inlinableConstants)
-    for (const constant of ctx.localConstants) {
-      if (unsafeLocalNames.has(constant.name) && constant.value && !constant.value.includes('=>')) {
-        let value = constant.value.trim()
-        for (const [getter, initial] of signalMap) {
-          value = value.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
-        }
-        for (const [name, computation] of memoMap) {
-          value = value.replace(new RegExp(`\\b${name}\\(\\)`, 'g'), `(${computation})`)
-        }
-        if (!/\b\w+\(\)/.test(value)) {
-          csrInlinableConstants.set(constant.name, value)
-        }
-      }
-    }
-    resolveChainedRefs(csrInlinableConstants)
+    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     templateHtml = generateCsrTemplate(
       ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -383,6 +383,8 @@ export interface ConstantInfo {
   isExported?: boolean
   type: TypeInfo | null
   loc: SourceLocation
+  /** Pre-computed free identifier references in the value expression (computed at analysis time). */
+  freeIdentifiers?: Set<string>
 }
 
 export interface TypeDefinition {


### PR DESCRIPTION
## Summary

- **Replace regex-based `valueOnlyUsesKnownNames()` with AST-based `extractFreeIdentifiers()`** — the regex identifier extraction treated object property key names as variable references (e.g., `sm` in `{ sm: 16 }`). Now uses TypeScript AST walking to properly distinguish variable references from property keys, member access properties, and bound parameter names
- **Fix `canGenerateStaticTemplate()` rejecting spread attributes** — spread attributes (`{...sizeAttrs}`) are always dropped by template generators, so the gate check should skip them too
- **Add CSR template fallback in `generateTemplateOnlyMount()`** — when static template generation fails, try `generateCsrTemplate()` so stateless components can still register a template for `renderChild()`
- **Fix constant inlining regex to avoid CSS property name collisions** — `(?<!\.)` → `(?<![-.])` prevents matching identifiers inside CSS property names (e.g., `width` in `max-width`)
- **Pre-compute free identifiers at analyzer phase** — `freeIdentifiers` field on `ConstantInfo` stores AST-extracted references at analysis time, avoiding redundant `ts.createSourceFile` calls in codegen
- **Extract `buildCsrInlinableConstants()` shared helper** — deduplicates CSR re-promotion logic between `index.ts` and `emit-init-sections.ts`
- **Handle destructuring params in `extractFreeIdentifiers()`** — `collectBindingNames()` properly walks ObjectBindingPattern/ArrayBindingPattern

Fixes #536

## Test plan

- [x] New compiler tests: stateless component with spread attrs + object-literal constants gets template registered
- [x] New compiler tests: multi-component file with conditional rendering produces `renderChild()` + `hydrate()` with template
- [x] New compiler tests: regression guard ensuring AST-based extraction distinguishes property keys from ternary branches
- [x] All existing compiler tests pass (374 pass, 0 fail)
- [x] IR tests pass (8 pass, 0 fail)
- [x] Full project build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)