### PR TITLE
Add regression tests for #526: onClick signal update + conditional text

### DIFF
--- a/packages/dom/__tests__/insert-integration.test.ts
+++ b/packages/dom/__tests__/insert-integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration test: onClick → signal update → conditional text update (#526)
+ *
+ * Simulates the full hydration + click scenario to verify
+ * that text-only ternary branches update correctly.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { insert } from '../src/insert'
+import { createSignal, createEffect } from '../src/reactive'
+import { $ as query } from '../src/query'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('insert integration (#526)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('onClick handler → signal update → text ternary updates', () => {
+    // Simulate SSR-rendered HTML (status() returns 'idle', condition is false)
+    document.body.innerHTML = `
+      <div bf-s="VerifyForm_test1" bf="s4">
+        <button bf="s1"><!--bf-cond-start:s0-->Verify<!--bf-cond-end:s0--></button>
+        <!--bf-cond-start:s2--><!--bf-cond-end:s2-->
+        <!--bf-cond-start:s3--><!--bf-cond-end:s3-->
+      </div>
+    `
+
+    const scope = document.querySelector('[bf-s]')!
+    expect(scope).not.toBeNull()
+
+    // Simulate initVerifyForm (generated code)
+    const [status, setStatus] = createSignal('idle')
+    const handleSubmit = () => { setStatus('loading') }
+
+    const [_s1] = query(scope, 's1')
+
+    // disabled attribute effect
+    createEffect(() => {
+      if (_s1) {
+        ;(_s1 as HTMLButtonElement).disabled = !!(status() === 'loading')
+      }
+    })
+
+    // Text ternary: {status() === 'loading' ? 'Verifying...' : 'Verify'}
+    insert(scope, 's0', () => status() === 'loading', {
+      template: () => `<!--bf-cond-start:s0-->${'Verifying...'}<!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    }, {
+      template: () => `<!--bf-cond-start:s0-->${'Verify'}<!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    })
+
+    // Logical AND: {status() === 'success' && <p>Success!</p>}
+    insert(scope, 's2', () => status() === 'success', {
+      template: () => '<p bf-c="s2">Success!</p>',
+      bindEvents: () => {}
+    }, {
+      template: () => '<!--bf-cond-start:s2--><!--bf-cond-end:s2-->',
+      bindEvents: () => {}
+    })
+
+    // Logical AND: {status() === 'error' && <p>Error occurred</p>}
+    insert(scope, 's3', () => status() === 'error', {
+      template: () => '<p bf-c="s3">Error occurred</p>',
+      bindEvents: () => {}
+    }, {
+      template: () => '<!--bf-cond-start:s3--><!--bf-cond-end:s3-->',
+      bindEvents: () => {}
+    })
+
+    // Bind onclick
+    if (_s1) (_s1 as HTMLButtonElement).onclick = handleSubmit
+
+    const button = scope.querySelector('button')!
+
+    // Verify initial state
+    expect(button.textContent).toBe('Verify')
+    expect((button as HTMLButtonElement).disabled).toBe(false)
+    expect(scope.querySelector('p')).toBeNull()
+
+    // Simulate click → setStatus('loading')
+    handleSubmit()
+
+    // Text should update to "Verifying..."
+    expect(button.textContent).toBe('Verifying...')
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+
+    // setStatus('success')
+    setStatus('success')
+
+    // Text should go back to "Verify" (not loading)
+    expect(button.textContent).toBe('Verify')
+    expect((button as HTMLButtonElement).disabled).toBe(false)
+
+    // Success message should appear
+    const successEl = scope.querySelector('p')
+    expect(successEl).not.toBeNull()
+    expect(successEl!.textContent).toBe('Success!')
+  })
+
+  test('multiple signal updates toggle text correctly', () => {
+    document.body.innerHTML = `
+      <div bf-s="Toggle_test1">
+        <button bf="s1"><!--bf-cond-start:s0-->Off<!--bf-cond-end:s0--></button>
+      </div>
+    `
+
+    const scope = document.querySelector('[bf-s]')!
+    const [active, setActive] = createSignal(false)
+
+    insert(scope, 's0', () => active(), {
+      template: () => `<!--bf-cond-start:s0-->${'On'}<!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    }, {
+      template: () => `<!--bf-cond-start:s0-->${'Off'}<!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    })
+
+    const button = scope.querySelector('button')!
+    expect(button.textContent).toBe('Off')
+
+    // Toggle on
+    setActive(true)
+    expect(button.textContent).toBe('On')
+
+    // Toggle off
+    setActive(false)
+    expect(button.textContent).toBe('Off')
+
+    // Toggle on again
+    setActive(true)
+    expect(button.textContent).toBe('On')
+  })
+})

--- a/packages/dom/__tests__/insert.test.ts
+++ b/packages/dom/__tests__/insert.test.ts
@@ -123,4 +123,67 @@ describe('insert', () => {
     setShow(true)
     expect(trueBound.length).toBe(2)
   })
+
+  describe('fragment conditional (comment markers) (#526)', () => {
+    test('text swap via comment markers', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <button><!--bf-cond-start:c1-->Verify<!--bf-cond-end:c1--></button>
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const [show, setShow] = createSignal(false)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        { template: () => '<!--bf-cond-start:c1-->Verifying...<!--bf-cond-end:c1-->', bindEvents: () => {} },
+        { template: () => '<!--bf-cond-start:c1-->Verify<!--bf-cond-end:c1-->', bindEvents: () => {} }
+      )
+
+      // Initial: condition is false, should show "Verify"
+      const button = scope.querySelector('button')!
+      expect(button.textContent).toBe('Verify')
+
+      // Toggle to true → "Verifying..."
+      setShow(true)
+      expect(button.textContent).toBe('Verifying...')
+
+      // Toggle back to false → "Verify"
+      setShow(false)
+      expect(button.textContent).toBe('Verify')
+    })
+
+    test('null-to-element branch switch via comment markers', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <!--bf-cond-start:c1--><!--bf-cond-end:c1-->
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const [show, setShow] = createSignal(false)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        { template: () => '<!--bf-cond-start:c1--><p bf-c="c1">Success!</p><!--bf-cond-end:c1-->', bindEvents: () => {} },
+        { template: () => '<!--bf-cond-start:c1--><!--bf-cond-end:c1-->', bindEvents: () => {} }
+      )
+
+      // Initial: condition is false, should be empty
+      expect(scope.querySelector('p')).toBeNull()
+
+      // Set condition true → <p>Success!</p> appears
+      setShow(true)
+      const p = scope.querySelector('p')
+      expect(p).not.toBeNull()
+      expect(p!.textContent).toBe('Success!')
+
+      // Set back to false → element removed
+      setShow(false)
+      expect(scope.querySelector('p')).toBeNull()
+    })
+  })
 })

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4245,6 +4245,112 @@ describe('Compiler', () => {
     })
   })
 
+  describe('reactive text-only ternary generates insert() (#526)', () => {
+    test('text ternary with string equality condition generates insert()', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function SubmitButton() {
+          const [status, setStatus] = createSignal('idle')
+          return <button>{status() === 'loading' ? 'Verifying...' : 'Verify'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('insert(')
+      expect(clientJs!.content).toContain("status() === 'loading'")
+    })
+
+    test('logical AND with string equality generates insert()', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function StatusMessage() {
+          const [status, setStatus] = createSignal('idle')
+          return <div>{status() === 'success' && <p>Done!</p>}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'StatusMessage.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('insert(')
+      expect(clientJs!.content).toContain("status() === 'success'")
+    })
+
+    test('full onClick scenario with text ternary and multiple conditionals', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function VerifyForm() {
+          const [status, setStatus] = createSignal('idle')
+
+          const handleSubmit = () => {
+            setStatus('loading')
+          }
+
+          return (
+            <div>
+              <button onClick={handleSubmit} disabled={status() === 'loading'}>
+                {status() === 'loading' ? 'Verifying...' : 'Verify'}
+              </button>
+              {status() === 'success' && <p>Success!</p>}
+              {status() === 'error' && <p>Error occurred</p>}
+            </div>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'VerifyForm.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // Should have insert() calls for each conditional
+      const insertCount = (clientJs!.content.match(/insert\(/g) || []).length
+      expect(insertCount).toBeGreaterThanOrEqual(3)
+
+      // Should include handleSubmit reference
+      expect(clientJs!.content).toContain('handleSubmit')
+
+      // Should have onclick binding
+      expect(clientJs!.content).toContain('onclick')
+    })
+
+    test('insert() template contains comment markers for text branches', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function SubmitButton() {
+          const [status, setStatus] = createSignal('idle')
+          return <button>{status() === 'loading' ? 'Verifying...' : 'Verify'}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // Text branches should have comment markers in insert() templates
+      expect(clientJs!.content).toContain('bf-cond-start:')
+      expect(clientJs!.content).toContain('bf-cond-end:')
+    })
+  })
+
   describe('.map() with block body (#520)', () => {
     test('handles block body with variable declaration and return JSX', () => {
       const source = `


### PR DESCRIPTION
## Summary

- Add compiler tests verifying `insert()` generation for text-only ternary branches and logical AND conditionals with reactive conditions (#526)
- Add runtime tests for fragment conditional (comment marker) text swap and null-to-element branch switching
- Add integration test simulating full hydration → onClick → signal update → DOM update scenario

## Investigation result

The reported issue (onClick handler calling `setStatus('loading')` not updating `{status() === 'loading' ? 'Verifying...' : 'Verify'}`) is **not reproducible on current main**. All compiler, runtime, and integration tests pass. The issue was likely resolved by #521 (ternary text branch quoting fix).

These tests serve as **regression tests** to prevent the issue from reoccurring.

## Test plan

- [x] `bun test` in `packages/jsx` — 375 tests pass
- [x] `bun test` in `packages/dom` — 157 tests pass
- [x] New tests: 8 tests covering text ternary insert(), logical AND insert(), full onClick scenario, comment marker swap, null-to-element switch, and integration hydration flow

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)