### PR TITLE
Fix: strip TypeScript optional parameter `?` in client JS

### DIFF
--- a/packages/jsx/src/__tests__/strip-types.test.ts
+++ b/packages/jsx/src/__tests__/strip-types.test.ts
@@ -60,6 +60,24 @@ describe('strip-types', () => {
         '(items) => items.length'
       )
     })
+
+    test('strips optional parameter type annotation (issue #544)', () => {
+      expect(stripExpr('(x?: string) => x')).toBe('(x) => x')
+    })
+
+    test('strips optional parameter with union type', () => {
+      expect(stripExpr('(x?: string | undefined) => x')).toBe('(x) => x')
+    })
+
+    test('strips mixed required and optional parameters', () => {
+      expect(stripExpr('(a: number, b?: string) => a')).toBe('(a, b) => a')
+    })
+
+    test('strips optional parameter with return type', () => {
+      expect(stripExpr('(x?: number): string => String(x)')).toBe(
+        '(x) => String(x)'
+      )
+    })
   })
 
   describe('type assertions (as)', () => {

--- a/packages/jsx/src/strip-types.ts
+++ b/packages/jsx/src/strip-types.ts
@@ -94,12 +94,23 @@ function collectTypeRanges(
   fullText: string,
   ranges: ExcludeRange[]
 ): void {
-  // Parameter type annotation: (x: Type)
-  if (ts.isParameter(node) && node.type) {
-    // Exclude from colon (after name/initializer/questionToken) through type end
-    const colonPos = findColonBefore(node.type, fullText, node.name.getEnd())
-    if (colonPos >= 0) {
-      ranges.push({ start: colonPos, end: node.type.getEnd() })
+  // Parameter type annotation: (x: Type) or optional parameter: (x?: Type)
+  if (ts.isParameter(node)) {
+    const hasQuestion = !!node.questionToken
+    const hasType = !!node.type
+
+    if (hasQuestion && hasType) {
+      // Optional param with type: strip "?: Type"
+      ranges.push({ start: node.questionToken!.getStart(sourceFile), end: node.type!.getEnd() })
+    } else if (hasQuestion) {
+      // Optional param without type: strip "?"
+      ranges.push({ start: node.questionToken!.getStart(sourceFile), end: node.questionToken!.getEnd() })
+    } else if (hasType) {
+      // Required param with type: strip ": Type" (existing behavior)
+      const colonPos = findColonBefore(node.type!, fullText, node.name.getEnd())
+      if (colonPos >= 0) {
+        ranges.push({ start: colonPos, end: node.type!.getEnd() })
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix `strip-types.ts` to handle `questionToken` (`?`) in optional parameters — previously `(x?: string)` emitted invalid JS `(x?)` instead of `(x)`
- Extend `collectTypeRanges()` to cover all three parameter cases: `?: Type`, `?` only, and `: Type` (existing)
- Add 4 regression tests for optional parameter stripping

Closes #544

## Test plan

- [x] `bun test packages/jsx/src/__tests__/strip-types.test.ts` — all 37 tests pass
- [x] `bun test --cwd packages/jsx` — 211 pass (1 unrelated module resolution failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)