### PR TITLE
Fix arrow function bodies stripped in SSR template

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -21,7 +21,6 @@ import {
   type AdapterOutput,
   type TemplateSections,
   type TemplateAdapter,
-  extractFunctionParams,
   isBooleanAttr,
 } from '@barefootjs/jsx'
 
@@ -371,23 +370,7 @@ export class HonoAdapter implements TemplateAdapter {
       // - new WeakMap() — client-side cross-component shared state
       if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
 
-      // Check if it's an arrow function or function expression
-      const isArrowFunc =
-        value.startsWith('async (') ||
-        value.startsWith('async(') ||
-        value.startsWith('function') ||
-        /^\w+\s*=>/.test(value) ||
-        /^\([^)]*\)\s*=>/.test(value)
-
-      if (isArrowFunc) {
-        // Generate a stub function for SSR (these may be referenced as props)
-        // Extract parameters if possible
-        const params = extractFunctionParams(value)
-        lines.push(`  ${keyword} ${constant.name} = (${params}) => {}`)
-      } else {
-        // Output non-function constants directly
-        lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
-      }
+      lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }
 
     // Include local functions (skip exported ones — they are at module level)

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4887,4 +4887,72 @@ describe('Compiler', () => {
       expect(exportIndex).toBeLessThan(componentIndex)
     })
   })
+
+  describe('arrow function bodies preserved in SSR (#543)', () => {
+    test('simple derived-state arrow function body is preserved in markedTemplate', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Calendar(props) {
+          const [mode, setMode] = createSignal(props.mode ?? 'single')
+          const isRangeMode = () => mode() === 'range'
+          return <div>{isRangeMode() ? 'range' : 'single'}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'Calendar.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain("const isRangeMode = () => mode() === 'range'")
+    })
+
+    test('parameterized arrow function body is preserved in markedTemplate', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent(props) {
+          const normalize = (val) => val == null ? '' : String(val)
+          const [value, setValue] = createSignal(normalize(props.defaultValue))
+          return <input value={value()} />
+        }
+      `
+
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain('normalize')
+      expect(template.content).not.toContain('normalize = () => {}')
+      expect(template.content).not.toContain('normalize = (val) => {}')
+    })
+
+    test('exported arrow function body is preserved in module exports', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export const formatDate = (d) => d.toISOString().split('T')[0]
+
+        export function DatePicker() {
+          const [date, setDate] = createSignal(new Date())
+          return <span>{formatDate(date())}</span>
+        }
+      `
+
+      const result = compileJSXSync(source, 'DatePicker.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template).toBeDefined()
+      expect(template.content).toContain("export const formatDate = (d) => d.toISOString().split('T')[0]")
+    })
+  })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -191,18 +191,7 @@ export class TestAdapter extends BaseAdapter {
         lines.push(`  ${keyword} ${constant.name}`)
         continue
       }
-      const value = constant.value.trim()
-      const isArrowFunc =
-        value.startsWith('async (') ||
-        value.startsWith('function') ||
-        /^\w+\s*=>/.test(value) ||
-        /^\([^)]*\)\s*=>/.test(value)
-
-      if (isArrowFunc) {
-        lines.push(`  ${keyword} ${constant.name} = () => {}`)
-      } else {
-        lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
-      }
+      lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }
 
     // Include local functions (skip exported ones — they are at module level)

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -10,7 +10,6 @@ import type { ComponentIR } from './types'
 /**
  * Generate module-level export statements for constants and functions.
  * Skips client-only constructs (createContext, new WeakMap).
- * Arrow functions are stubbed with extracted parameters.
  */
 export function generateModuleExports(ir: ComponentIR): string | null {
   const lines: string[] = []
@@ -26,19 +25,7 @@ export function generateModuleExports(ir: ComponentIR): string | null {
     // Skip client-only constructs
     if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
 
-    const isArrowFunc =
-      value.startsWith('async (') ||
-      value.startsWith('async(') ||
-      value.startsWith('function') ||
-      /^\w+\s*=>/.test(value) ||
-      /^\([^)]*\)\s*=>/.test(value)
-
-    if (isArrowFunc) {
-      const params = extractFunctionParams(value)
-      lines.push(`export ${keyword} ${constant.name} = (${params}) => {}`)
-    } else {
-      lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
-    }
+    lines.push(`export ${keyword} ${constant.name} = ${constant.value}`)
   }
 
   for (const func of ir.metadata.localFunctions) {


### PR DESCRIPTION
## Summary

- Remove the `isArrowFunc` detection and stub generation (`() => {}`) from three locations in the adapter layer (hono-adapter, test-adapter, module-exports), emitting `constant.value` directly
- Arrow function constants like `const isRangeMode = () => mode() === 'range'` now preserve their bodies in SSR output, matching how `localFunctions` already work
- Add three compiler tests verifying arrow function body preservation in `markedTemplate`

Closes #543

## Test plan

- [x] `packages/jsx` — 384 tests pass (including 3 new tests for #543)
- [x] `packages/test` — 8 tests pass
- [x] `packages/hono` — 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)