### PR TITLE
Fix compiler template generation dropping computed spread attributes

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -53,6 +53,7 @@ export { splitProps } from './split-props'
 // Spread props helpers (internal, for compiler-generated code)
 export { forwardProps } from './forward-props'
 export { applyRestAttrs } from './apply-rest-attrs'
+export { spreadAttrs } from './spread-attrs'
 
 // Runtime helpers (internal, for compiler-generated code)
 export { findScope, find, $, $c, $t } from './query'

--- a/packages/dom/src/spread-attrs.ts
+++ b/packages/dom/src/spread-attrs.ts
@@ -1,0 +1,29 @@
+/**
+ * BarefootJS - Spread Attributes Helper (Template Mode)
+ *
+ * Converts an object to an HTML attribute string for use inside template literals.
+ * Unlike applyRestAttrs (which manipulates DOM elements reactively), this produces
+ * a static string for server/template rendering of computed local spreads.
+ */
+
+/**
+ * Convert an object to an HTML attribute string.
+ * Aligned with applyRestAttrs conventions: skips null/undefined/false,
+ * event handlers, maps className→class and htmlFor→for.
+ */
+export function spreadAttrs(obj: Record<string, unknown>): string {
+  if (!obj || typeof obj !== 'object') return ''
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (value == null || value === false) continue
+    // Skip event handlers
+    if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) continue
+    // Skip children prop
+    if (key === 'children') continue
+    // Map JSX prop names to HTML attribute names
+    const attr = key === 'className' ? 'class' : key === 'htmlFor' ? 'for'
+      : key.replace(/([A-Z])/g, '-$1').toLowerCase()
+    parts.push(value === true ? attr : `${attr}="${value}"`)
+  }
+  return parts.join(' ')
+}

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -4148,6 +4148,70 @@ describe('Compiler', () => {
       // Stateless component must register a template so renderChild() can find it
       expect(content).toContain("hydrate('CheckIcon',")
       expect(content).toContain('template:')
+
+      // Computed spread must use spreadAttrs() to render attributes (#545)
+      expect(content).toContain('spreadAttrs(')
+      expect(content).toMatch(/import \{[^}]*spreadAttrs[^}]*\} from '@barefootjs\/dom'/)
+    })
+
+    test('computed spread with conditional expression emits spreadAttrs (#545)', () => {
+      const source = `
+        export function Icon(props: { large?: boolean }) {
+          const attrs = props.large ? { width: 48, height: 48 } : { width: 24, height: 24 }
+          return <svg {...attrs} viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
+        }
+      `
+      const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      expect(content).toContain('spreadAttrs(')
+    })
+
+    test('multiple computed spreads on same element both emit spreadAttrs (#545)', () => {
+      const source = `
+        export function Icon(props: { size?: string, color?: string }) {
+          const sizeAttrs = { width: props.size ?? '24', height: props.size ?? '24' }
+          const colorAttrs = { fill: props.color ?? 'currentColor' }
+          return <svg {...sizeAttrs} {...colorAttrs} viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
+        }
+      `
+      const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // Both spreads should emit spreadAttrs
+      const matches = content.match(/spreadAttrs\(/g)
+      expect(matches).not.toBeNull()
+      expect(matches!.length).toBeGreaterThanOrEqual(2)
+    })
+
+    test('rest props spread is NOT emitted as spreadAttrs (#545)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Button(props: { variant?: string }) {
+          const { variant, ...rest } = props
+          const [count, setCount] = createSignal(0)
+          return <button {...rest} onClick={() => setCount(c => c + 1)}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // Rest props spread should use applyRestAttrs, not spreadAttrs
+      expect(content).not.toContain('spreadAttrs(')
     })
 
     test('multi-component file: stateless icons in conditional rendering produce renderChild + hydrate', () => {

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -9,6 +9,14 @@ import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBra
 import { irToHtmlTemplate } from './html-template'
 import { expandDynamicPropValue } from './prop-handling'
 
+/** Build rest spread names from context (rest/props spreads handled by applyRestAttrs, not spreadAttrs). */
+function buildRestSpreadNames(ctx: ClientJsContext): Set<string> {
+  const names = new Set<string>()
+  if (ctx.restPropsName) names.add(ctx.restPropsName)
+  if (ctx.propsObjectName) names.add(ctx.propsObjectName)
+  return names
+}
+
 /** Recursively walk the IR tree and populate ctx with interactive/dynamic/loop/conditional elements. */
 export function collectElements(node: IRNode, ctx: ClientJsContext, insideConditional = false): void {
   switch (node.type) {
@@ -40,11 +48,12 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         const whenFalseEvents = collectConditionalBranchEvents(node.whenFalse)
         const whenTrueRefs = collectConditionalBranchRefs(node.whenTrue)
         const whenFalseRefs = collectConditionalBranchRefs(node.whenFalse)
+        const restNames = buildRestSpreadNames(ctx)
         ctx.clientOnlyConditionals.push({
           slotId: node.slotId,
           condition: node.condition,
-          whenTrueHtml: irToHtmlTemplate(node.whenTrue),
-          whenFalseHtml: irToHtmlTemplate(node.whenFalse),
+          whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames),
+          whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames),
           whenTrueEvents,
           whenFalseEvents,
           whenTrueRefs,
@@ -56,11 +65,12 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         const whenTrueRefs = collectConditionalBranchRefs(node.whenTrue)
         const whenFalseRefs = collectConditionalBranchRefs(node.whenFalse)
 
+        const restNames = buildRestSpreadNames(ctx)
         ctx.conditionalElements.push({
           slotId: node.slotId,
           condition: node.condition,
-          whenTrueHtml: irToHtmlTemplate(node.whenTrue),
-          whenFalseHtml: irToHtmlTemplate(node.whenFalse),
+          whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames),
+          whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames),
           whenTrueEvents,
           whenFalseEvents,
           whenTrueRefs,
@@ -99,7 +109,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           param: node.param,
           index: node.index,
           key: node.key,
-          template: node.childComponent ? '' : (node.children[0] ? irToHtmlTemplate(node.children[0]) : ''),
+          template: node.childComponent ? '' : (node.children[0] ? irToHtmlTemplate(node.children[0], buildRestSpreadNames(ctx)) : ''),
           childEventHandlers: childHandlers,
           childEvents,
           childComponent: node.childComponent,

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -1075,13 +1075,18 @@ export function emitRegistrationAndHydration(
   const propNamesForTemplate = new Set(ctx.propsParams.map((p) => p.name))
   const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
 
+  // Build rest spread names: these are rest/props spreads handled by applyRestAttrs, not spreadAttrs
+  const restSpreadNames = new Set<string>()
+  if (ctx.restPropsName) restSpreadNames.add(ctx.restPropsName)
+  if (ctx.propsObjectName) restSpreadNames.add(ctx.propsObjectName)
+
   const isCommentScope = _ir.root.type === 'fragment'
     && (_ir.root as IRFragment).needsScopeComment
 
   // Build ComponentDef object for hydrate()
   const defParts: string[] = [`init: init${name}`]
   if (canGenerateStaticTemplate(_ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
-    const templateHtml = irToComponentTemplate(_ir.root, propNamesForTemplate, inlinableConstants)
+    const templateHtml = irToComponentTemplate(_ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames)
     if (templateHtml) {
       defParts.push(`template: (props) => \`${templateHtml}\``)
     }
@@ -1092,7 +1097,7 @@ export function emitRegistrationAndHydration(
     const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     const templateHtml = generateCsrTemplate(
-      _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap
+      _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames
     )
     if (templateHtml) {
       defParts.push(`template: (props) => \`${templateHtml}\``)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -35,12 +35,19 @@ const VOID_ELEMENTS = new Set([
 ])
 
 /** Convert an IR node tree to an HTML template string (for conditionals/loops). */
-export function irToHtmlTemplate(node: IRNode): string {
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>): string {
+  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames)
+
   switch (node.type) {
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
-          if (a.name === '...') return ''
+          if (a.name === '...') {
+            const spreadValue = typeof a.value === 'string' ? a.value : null
+            if (!spreadValue) return ''
+            if (restSpreadNames?.has(spreadValue)) return ''
+            return `\${spreadAttrs(${spreadValue})}`
+          }
           // Convert JSX `key` to `data-key` so reconcileList can match elements
           const attrName = a.name === 'key' ? 'data-key' : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
@@ -60,7 +67,7 @@ export function irToHtmlTemplate(node: IRNode): string {
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(irToHtmlTemplate).join('')
+      const children = node.children.map(recurse).join('')
 
       // Non-void elements must use open+close tags (HTML parsers ignore self-closing on div, span, etc.)
       if (children || !VOID_ELEMENTS.has(node.tag)) {
@@ -80,21 +87,21 @@ export function irToHtmlTemplate(node: IRNode): string {
       return `\${${node.expr}}`
 
     case 'conditional': {
-      const trueBranch = irToHtmlTemplate(node.whenTrue)
-      const falseBranch = irToHtmlTemplate(node.whenFalse)
+      const trueBranch = recurse(node.whenTrue)
+      const falseBranch = recurse(node.whenFalse)
       const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
       const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
       return `\${${node.condition} ? \`${trueHtml}\` : \`${falseHtml}\`}`
     }
 
     case 'fragment':
-      return node.children.map(irToHtmlTemplate).join('')
+      return node.children.map(recurse).join('')
 
     case 'component': {
       // Portal is a special pass-through component - render its children directly
       // Portal moves content to document.body, so we need the actual content in templates
       if (node.name === 'Portal') {
-        return node.children.map(irToHtmlTemplate).join('')
+        return node.children.map(recurse).join('')
       }
 
       // Use renderChild() to render child component's registered template at runtime.
@@ -115,7 +122,7 @@ export function irToHtmlTemplate(node: IRNode): string {
 
     case 'loop': {
       // Generate inline .map().join('') so loop variables are properly scoped
-      const childTemplate = node.children.map(irToHtmlTemplate).join('')
+      const childTemplate = node.children.map(recurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
       if (node.mapPreamble) {
         return `\${${node.array}.map((${node.param}${indexParam}) => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
@@ -127,7 +134,7 @@ export function irToHtmlTemplate(node: IRNode): string {
       return ''
 
     case 'provider':
-      return node.children.map(irToHtmlTemplate).join('')
+      return node.children.map(recurse).join('')
 
     default:
       return ''
@@ -228,7 +235,8 @@ export function addCondAttrToTemplate(html: string, condId: string): string {
 export function irToComponentTemplate(
   node: IRNode,
   propNames: Set<string>,
-  inlinableConstants?: Map<string, string>
+  inlinableConstants?: Map<string, string>,
+  restSpreadNames?: Set<string>
 ): string {
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
@@ -258,7 +266,12 @@ export function irToComponentTemplate(
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
-          if (a.name === '...') return ''
+          if (a.name === '...') {
+            const spreadValue = attrValueToString(a.value)
+            if (!spreadValue) return ''
+            if (restSpreadNames?.has(spreadValue)) return ''
+            return `\${spreadAttrs(${transformExpr(spreadValue)})}`
+          }
           if (a.name === 'key') return ''
           const attrName = toHtmlAttrName(a.name)
           if (a.value === null) return attrName
@@ -280,7 +293,7 @@ export function irToComponentTemplate(
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants)).join('')
+      const children = node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -299,19 +312,19 @@ export function irToComponentTemplate(
       return `\${${transformExpr(node.expr)}}`
 
     case 'conditional': {
-      const trueBranch = irToComponentTemplate(node.whenTrue, propNames, inlinableConstants)
-      const falseBranch = irToComponentTemplate(node.whenFalse, propNames, inlinableConstants)
+      const trueBranch = irToComponentTemplate(node.whenTrue, propNames, inlinableConstants, restSpreadNames)
+      const falseBranch = irToComponentTemplate(node.whenFalse, propNames, inlinableConstants, restSpreadNames)
       const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
       const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
       return `\${${transformExpr(node.condition)} ? \`${trueHtml}\` : \`${falseHtml}\`}`
     }
 
     case 'fragment':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
 
     case 'component': {
       if (node.name === 'Portal') {
-        return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants)).join('')
+        return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
       }
 
       // Use renderChild() to render child component's template at runtime (#435)
@@ -330,13 +343,13 @@ export function irToComponentTemplate(
     }
 
     case 'loop':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
 
     case 'if-statement':
       return ''
 
     case 'provider':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
 
     default:
       return ''
@@ -398,8 +411,14 @@ export function canGenerateStaticTemplate(
 
     case 'element':
       for (const attr of node.attrs) {
-        // Spread attributes are always dropped by template generators, so skip them.
-        if (attr.name === '...') continue
+        if (attr.name === '...') {
+          // Computed local spreads are now handled by spreadAttrs() at runtime.
+          // Only check for unsafe references that would fail at module scope.
+          const valueStr = attrValueToString(attr.value)
+          if (valueStr && hasUnsafeRef(valueStr)) return false
+          if (valueStr && valueStr.includes('()') && !isSimplePropExpression(valueStr, propNames)) return false
+          continue
+        }
         if (attr.dynamic && attr.value) {
           const valueStr = attrValueToString(attr.value)
           if (valueStr) {
@@ -464,6 +483,7 @@ export function generateCsrTemplate(
   signalMap?: Map<string, string>,
   memoMap?: Map<string, string>,
   insideLoop?: boolean,
+  restSpreadNames?: Set<string>,
 ): string {
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
@@ -513,14 +533,19 @@ export function generateCsrTemplate(
     return restore(result)
   }
 
-  const recurse = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, insideLoop)
-  const recurseInLoop = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, true)
+  const recurse = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames)
+  const recurseInLoop = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, true, restSpreadNames)
 
   switch (node.type) {
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
-          if (a.name === '...') return ''
+          if (a.name === '...') {
+            const spreadValue = attrValueToString(a.value)
+            if (!spreadValue) return ''
+            if (restSpreadNames?.has(spreadValue)) return ''
+            return `\${spreadAttrs(${transformExpr(spreadValue)})}`
+          }
           const attrName = a.name === 'key' ? 'data-key' : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valueStr = attrValueToString(a.value)

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -11,7 +11,7 @@ export const DOM_IMPORT_CANDIDATES = [
   'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker',
   'createPortal',
   'provideContext', 'createContext', 'useContext',
-  'forwardProps', 'applyRestAttrs', 'splitProps',
+  'forwardProps', 'applyRestAttrs', 'splitProps', 'spreadAttrs',
 ] as const
 
 export const IMPORT_PLACEHOLDER = '/* __BAREFOOTJS_DOM_IMPORTS__ */'

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -135,10 +135,15 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   const propNamesForTemplate = new Set(ctx.propsParams.map((p) => p.name))
   const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
 
+  // Build rest spread names: these are rest/props spreads handled by applyRestAttrs, not spreadAttrs
+  const restSpreadNames = new Set<string>()
+  if (ctx.restPropsName) restSpreadNames.add(ctx.restPropsName)
+  if (ctx.propsObjectName) restSpreadNames.add(ctx.propsObjectName)
+
   let templateHtml: string | undefined
 
   if (canGenerateStaticTemplate(ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
-    templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants)
+    templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames)
   }
 
   // CSR fallback: when static template generation fails (e.g., components with
@@ -148,7 +153,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
     const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     templateHtml = generateCsrTemplate(
-      ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap
+      ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames
     )
   }
 


### PR DESCRIPTION
## Summary

- Introduce `spreadAttrs()` runtime helper that converts an object to an HTML attribute string for use inside template literals
- Update all 3 template generators (`irToHtmlTemplate`, `irToComponentTemplate`, `generateCsrTemplate`) to emit `spreadAttrs()` for computed local spreads instead of silently dropping them
- Distinguish rest/props spreads (`{...rest}`, `{...props}`) from computed local spreads (`{...sizeAttrs}`) via `restSpreadNames` parameter — rest spreads retain existing `applyRestAttrs` behavior

## Test plan

- [x] Existing test updated: verify `spreadAttrs(` appears in CheckIcon output
- [x] New test: conditional computed spread emits `spreadAttrs`
- [x] New test: multiple spreads on same element both emit `spreadAttrs`
- [x] New test: rest props spread does NOT use `spreadAttrs` (uses `applyRestAttrs`)
- [x] Full test suite passes (923 tests across 39 package files)

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)