### PR TITLE
Fix renderChild failing for multi-component file children (#553)

### DIFF
--- a/packages/jsx/src/__tests__/combine-client-js.test.ts
+++ b/packages/jsx/src/__tests__/combine-client-js.test.ts
@@ -1,0 +1,155 @@
+/**
+ * combineParentChildClientJs - Unit Tests
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { combineParentChildClientJs } from '../combine-client-js'
+
+describe('combineParentChildClientJs', () => {
+  test('resolves single-component file by file name', () => {
+    const files = new Map([
+      ['CopyButton', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:Icon */'",
+        "hydrate('CopyButton', (el) => {})",
+      ].join('\n')],
+      ['Icon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "hydrate('Icon', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    expect(result.has('CopyButton')).toBe(true)
+    const combined = result.get('CopyButton')!
+    expect(combined).toContain("hydrate('Icon',")
+    expect(combined).toContain("hydrate('CopyButton',")
+    expect(combined).not.toContain('@bf-child:')
+  })
+
+  test('resolves multi-component file by component name from hydrate() calls', () => {
+    // icon/index.tsx exports CopyIcon + CheckIcon, keyed as "icon" in the manifest
+    const files = new Map([
+      ['CopyButton', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:CopyIcon */'",
+        "hydrate('CopyButton', (el) => {})",
+      ].join('\n')],
+      ['icon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "hydrate('CopyIcon', (el) => {})",
+        "hydrate('CheckIcon', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    expect(result.has('CopyButton')).toBe(true)
+    const combined = result.get('CopyButton')!
+    // Should inline the icon file content via component name fallback
+    expect(combined).toContain("hydrate('CopyIcon',")
+    expect(combined).toContain("hydrate('CheckIcon',")
+    expect(combined).toContain("hydrate('CopyButton',")
+    expect(combined).not.toContain('@bf-child:')
+  })
+
+  test('gracefully handles missing child', () => {
+    const files = new Map([
+      ['Parent', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "import '/* @bf-child:NonExistent */'",
+        "hydrate('Parent', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    expect(result.has('Parent')).toBe(true)
+    const combined = result.get('Parent')!
+    // Parent code still emitted, missing child silently skipped
+    expect(combined).toContain("hydrate('Parent',")
+    expect(combined).not.toContain('@bf-child:')
+  })
+
+  test('resolves grandchild through multi-component file', () => {
+    const files = new Map([
+      ['Page', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:CopyButton */'",
+        "hydrate('Page', (el) => {})",
+      ].join('\n')],
+      ['CopyButton', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:CopyIcon */'",
+        "hydrate('CopyButton', (el) => {})",
+      ].join('\n')],
+      ['icon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "hydrate('CopyIcon', (el) => {})",
+        "hydrate('CheckIcon', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    expect(result.has('Page')).toBe(true)
+    const combined = result.get('Page')!
+    // Grandchild (icon file) resolved through CopyButton → CopyIcon
+    expect(combined).toContain("hydrate('CopyIcon',")
+    expect(combined).toContain("hydrate('CopyButton',")
+    expect(combined).toContain("hydrate('Page',")
+  })
+
+  test('file name lookup takes precedence over component name', () => {
+    // If a file is named "CopyIcon" AND another file contains hydrate('CopyIcon'),
+    // the file-name match should win
+    const files = new Map([
+      ['Parent', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "import '/* @bf-child:CopyIcon */'",
+        "hydrate('Parent', (el) => {})",
+      ].join('\n')],
+      ['CopyIcon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "hydrate('CopyIcon', (el) => { /* file-name match */ })",
+      ].join('\n')],
+      ['icon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "hydrate('CopyIcon', (el) => { /* component-name match */ })",
+        "hydrate('CheckIcon', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    const combined = result.get('Parent')!
+    // Should use the file-name match (CopyIcon file), not the component-name match (icon file)
+    expect(combined).toContain('file-name match')
+    expect(combined).not.toContain('component-name match')
+  })
+
+  test('deduplicates imports from shared sources', () => {
+    const files = new Map([
+      ['Parent', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:Child */'",
+        "hydrate('Parent', (el) => {})",
+      ].join('\n')],
+      ['Child', [
+        "import { hydrate, insert } from '@barefootjs/dom'",
+        "hydrate('Child', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    const combined = result.get('Parent')!
+    // All imports from @barefootjs/dom merged into one line
+    const importLines = combined.split('\n').filter(l => l.startsWith('import '))
+    expect(importLines).toHaveLength(1)
+    expect(importLines[0]).toContain('hydrate')
+    expect(importLines[0]).toContain('insert')
+    expect(importLines[0]).toContain('renderChild')
+  })
+})

--- a/packages/jsx/src/__tests__/combine-client-js.test.ts
+++ b/packages/jsx/src/__tests__/combine-client-js.test.ts
@@ -38,7 +38,9 @@ describe('combineParentChildClientJs', () => {
       ].join('\n')],
       ['icon', [
         "import { hydrate } from '@barefootjs/dom'",
+        "export function initCopyIcon(__scope) {}",
         "hydrate('CopyIcon', (el) => {})",
+        "export function initCheckIcon(__scope) {}",
         "hydrate('CheckIcon', (el) => {})",
       ].join('\n')],
     ])
@@ -47,11 +49,42 @@ describe('combineParentChildClientJs', () => {
 
     expect(result.has('CopyButton')).toBe(true)
     const combined = result.get('CopyButton')!
-    // Should inline the icon file content via component name fallback
+    // Inlines the entire icon file (both CopyIcon and CheckIcon)
     expect(combined).toContain("hydrate('CopyIcon',")
     expect(combined).toContain("hydrate('CheckIcon',")
     expect(combined).toContain("hydrate('CopyButton',")
     expect(combined).not.toContain('@bf-child:')
+  })
+
+  test('does not duplicate when multiple children resolve to the same file', () => {
+    // CopyButton uses both CopyIcon and CheckIcon, both from "icon" file.
+    // The icon file must be inlined only ONCE to prevent duplicate declarations.
+    const files = new Map([
+      ['CopyButton', [
+        "import { hydrate, renderChild } from '@barefootjs/dom'",
+        "import '/* @bf-child:CopyIcon */'",
+        "import '/* @bf-child:CheckIcon */'",
+        "hydrate('CopyButton', (el) => {})",
+      ].join('\n')],
+      ['icon', [
+        "import { hydrate } from '@barefootjs/dom'",
+        "export function initCopyIcon(__scope) {}",
+        "hydrate('CopyIcon', { init: initCopyIcon })",
+        "export function initCheckIcon(__scope) {}",
+        "hydrate('CheckIcon', { init: initCheckIcon })",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+
+    const combined = result.get('CopyButton')!
+    // Icon file content appears exactly once
+    const copyIconCount = combined.split('initCopyIcon').length - 1
+    const checkIconCount = combined.split('initCheckIcon').length - 1
+    // initCopyIcon appears in: function declaration + hydrate call = 2
+    expect(copyIconCount).toBe(2)
+    // initCheckIcon appears in: function declaration + hydrate call = 2
+    expect(checkIconCount).toBe(2)
   })
 
   test('gracefully handles missing child', () => {

--- a/packages/jsx/src/combine-client-js.ts
+++ b/packages/jsx/src/combine-client-js.ts
@@ -27,13 +27,13 @@ export function combineParentChildClientJs(
     lookup.set(name.toLowerCase(), content)
   }
 
-  // Secondary lookup: by component name extracted from hydrate() calls.
-  // Handles multi-component files where file name ≠ component name
-  // (e.g., icon/index.tsx exports CopyIcon + CheckIcon, keyed as "icon").
-  const componentLookup = new Map<string, string>()
-  for (const [_, content] of files) {
+  // Secondary lookup: map component name → file name for multi-component files.
+  // e.g., icon/index.tsx exports CopyIcon + CheckIcon, keyed as "icon" in the manifest.
+  // componentToFile maps "copyicon" → "icon", "checkicon" → "icon".
+  const componentToFile = new Map<string, string>()
+  for (const [name, content] of files) {
     for (const match of content.matchAll(/hydrate\('(\w+)'/g)) {
-      componentLookup.set(match[1].toLowerCase(), content)
+      componentToFile.set(match[1].toLowerCase(), name.toLowerCase())
     }
   }
 
@@ -51,7 +51,17 @@ export function combineParentChildClientJs(
       if (processed.has(key)) return
       processed.add(key)
 
-      const childContent = lookup.get(key) ?? componentLookup.get(key)
+      let childContent = lookup.get(key)
+      if (!childContent) {
+        // Fallback: resolve component name → file name for multi-component files.
+        // Also mark the file name as processed so that other components from the
+        // same file (e.g., CheckIcon when CopyIcon was already resolved from "icon")
+        // don't inline the same file content again.
+        const fileName = componentToFile.get(key)
+        if (!fileName || processed.has(fileName)) return
+        processed.add(fileName)
+        childContent = lookup.get(fileName)
+      }
       if (!childContent) return
 
       // Depth-first: collect grandchildren before the child itself

--- a/packages/jsx/src/combine-client-js.ts
+++ b/packages/jsx/src/combine-client-js.ts
@@ -21,10 +21,20 @@ export function combineParentChildClientJs(
 ): Map<string, string> {
   const result = new Map<string, string>()
 
-  // Build case-insensitive lookup
+  // Build case-insensitive lookup by file/manifest name
   const lookup = new Map<string, string>()
   for (const [name, content] of files) {
     lookup.set(name.toLowerCase(), content)
+  }
+
+  // Secondary lookup: by component name extracted from hydrate() calls.
+  // Handles multi-component files where file name ≠ component name
+  // (e.g., icon/index.tsx exports CopyIcon + CheckIcon, keyed as "icon").
+  const componentLookup = new Map<string, string>()
+  for (const [_, content] of files) {
+    for (const match of content.matchAll(/hydrate\('(\w+)'/g)) {
+      componentLookup.set(match[1].toLowerCase(), content)
+    }
   }
 
   for (const [name, content] of files) {
@@ -41,7 +51,7 @@ export function combineParentChildClientJs(
       if (processed.has(key)) return
       processed.add(key)
 
-      const childContent = lookup.get(key)
+      const childContent = lookup.get(key) ?? componentLookup.get(key)
       if (!childContent) return
 
       // Depth-first: collect grandchildren before the child itself


### PR DESCRIPTION
## Summary

- `combineParentChildClientJs()` resolved `@bf-child:` placeholders by file/manifest name only. For multi-component files (e.g., `icon/index.tsx` exporting `CopyIcon` + `CheckIcon`, keyed as `"icon"`), `@bf-child:CopyIcon` failed to resolve because `"copyicon" ≠ "icon"`.
- Added a secondary lookup by component name extracted from `hydrate()` calls, used as fallback when the file-name lookup misses.
- Added 6 unit tests covering single-component resolution, multi-component resolution, missing child handling, grandchild resolution, file-name precedence, and import deduplication.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/combine-client-js.test.ts` — 6/6 pass
- [x] `bun test packages/jsx/` — 217/218 pass (1 pre-existing failure unrelated to this change)
- [ ] CI green

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)