### PR TITLE
Use addEventListener instead of property assignment for event handlers

### DIFF
--- a/packages/dom/__tests__/insert-integration.test.ts
+++ b/packages/dom/__tests__/insert-integration.test.ts
@@ -74,8 +74,8 @@ describe('insert integration (#526)', () => {
       bindEvents: () => {}
     })
 
-    // Bind onclick
-    if (_s1) (_s1 as HTMLButtonElement).onclick = handleSubmit
+    // Bind click event
+    if (_s1) (_s1 as HTMLButtonElement).addEventListener('click', handleSubmit)
 
     const button = scope.querySelector('button')!
 

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -2688,7 +2688,7 @@ describe('Compiler', () => {
       const content = clientJs!.content
 
       // Event delegation should be generated for the static array
-      expect(content).toContain('.onclick = (e) => {')
+      expect(content).toContain(".addEventListener('click', (e) => {")
       expect(content).toContain('target.closest')
       expect(content).toContain('Array.from(')
       expect(content).toContain('handleClick(item.id)')
@@ -2752,7 +2752,7 @@ describe('Compiler', () => {
 
       // Dynamic array should use reconcileTemplates and event delegation
       expect(content).toContain('reconcileTemplates')
-      expect(content).toContain('.onclick = (e) => {')
+      expect(content).toContain(".addEventListener('click', (e) => {")
       expect(content).toContain('handleClick(item.id)')
     })
   })

--- a/packages/jsx/src/__tests__/compiler.test.ts
+++ b/packages/jsx/src/__tests__/compiler.test.ts
@@ -1147,7 +1147,7 @@ describe('Compiler', () => {
       expect(clientJs).toBeDefined()
       expect(clientJs?.content).toContain('initToggle')
       // Both branches should have click handlers collected
-      expect(clientJs?.content).toContain('onclick')
+      expect(clientJs?.content).toContain("addEventListener('click'")
     })
 
     test('collects reactive attributes from conditional return branches', () => {
@@ -4585,8 +4585,8 @@ describe('Compiler', () => {
       // Should include handleSubmit reference
       expect(clientJs!.content).toContain('handleSubmit')
 
-      // Should have onclick binding
-      expect(clientJs!.content).toContain('onclick')
+      // Should have addEventListener click binding
+      expect(clientJs!.content).toContain("addEventListener('click'")
     })
 
     test('insert() template contains comment markers for text branches', () => {

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -7,7 +7,7 @@ import type { ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, LoopChildEvent } from './types'
-import { inferDefaultValue, toHtmlAttrName, toDomEventProp, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId } from './utils'
+import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId } from './utils'
 import { addCondAttrToTemplate, canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, irChildrenToJsExpr, createStringProtector } from './html-template'
 
 /**
@@ -297,7 +297,7 @@ function emitBranchBindings(
   lines: string[],
   events: ConditionalBranchEvent[],
   refs: ConditionalBranchRef[],
-  eventPropFn: (eventName: string) => string
+  eventNameFn: (eventName: string) => string
 ): void {
   const allSlotIds = new Set<string>()
   for (const event of events) allSlotIds.add(event.slotId)
@@ -322,7 +322,7 @@ function emitBranchBindings(
     const v = varSlotId(slotId)
     for (const event of slotEvents) {
       const wrappedHandler = wrapHandlerInBlock(event.handler)
-      lines.push(`      if (_${v}) _${v}.${eventPropFn(event.eventName)} = ${wrappedHandler}`)
+      lines.push(`      if (_${v}) _${v}.addEventListener('${eventNameFn(event.eventName)}', ${wrappedHandler})`)
     }
   }
 
@@ -341,12 +341,12 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, toDomEventProp)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, toDomEventName)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, toDomEventProp)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, toDomEventName)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')
@@ -358,18 +358,18 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
   for (const elem of ctx.clientOnlyConditionals) {
     const whenTrueWithCond = addCondAttrToTemplate(elem.whenTrueHtml, elem.slotId)
     const whenFalseWithCond = addCondAttrToTemplate(elem.whenFalseHtml, elem.slotId)
-    const rawEventProp = (eventName: string) => `on${eventName}`
+    const rawEventName = (eventName: string) => eventName
 
     lines.push(`  // @client conditional: ${elem.slotId}`)
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, rawEventProp)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, rawEventName)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, rawEventProp)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, rawEventName)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')
@@ -580,7 +580,7 @@ function emitLoopEventDelegation(
     if (useCapture) {
       lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${eventName}', (e) => {`)
     } else {
-      lines.push(`  if (${containerVar}) ${containerVar}.${toDomEventProp(eventName)} = (e) => {`)
+      lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${toDomEventName(eventName)}', (e) => {`)
     }
     lines.push(`    const target = e.target`)
     for (const ev of events) {
@@ -596,7 +596,7 @@ function emitLoopEventDelegation(
     if (useCapture) {
       lines.push(`  }, true)`)
     } else {
-      lines.push(`  }`)
+      lines.push(`  })`)
     }
     lines.push('')
   }
@@ -624,13 +624,13 @@ export function emitEventHandlers(
     if (conditionalSlotIds.has(elem.slotId)) continue
 
     for (const event of elem.events) {
-      const eventProp = toDomEventProp(event.name)
+      const eventName = toDomEventName(event.name)
       const wrappedHandler = wrapHandlerInBlock(event.handler)
       if (elem.slotId === '__scope') {
-        lines.push(`  if (__scope) __scope.${eventProp} = ${wrappedHandler}`)
+        lines.push(`  if (__scope) __scope.addEventListener('${eventName}', ${wrappedHandler})`)
       } else {
         const v = varSlotId(elem.slotId)
-        lines.push(`  if (_${v}) _${v}.${eventProp} = ${wrappedHandler}`)
+        lines.push(`  if (_${v}) _${v}.addEventListener('${eventName}', ${wrappedHandler})`)
       }
     }
   }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -65,12 +65,11 @@ export const jsxToDomEventMap: Record<string, string> = {
 }
 
 /**
- * Convert JSX-derived event name to DOM event property name.
- * Example: 'doubleclick' → 'ondblclick'
+ * Convert JSX-derived event name to DOM event name for addEventListener.
+ * Example: 'doubleclick' → 'dblclick'
  */
-export function toDomEventProp(eventName: string): string {
-  const mappedName = jsxToDomEventMap[eventName] ?? eventName
-  return `on${mappedName}`
+export function toDomEventName(eventName: string): string {
+  return jsxToDomEventMap[eventName] ?? eventName
 }
 
 /**

--- a/site/ui/e2e/checkbox.spec.ts
+++ b/site/ui/e2e/checkbox.spec.ts
@@ -17,7 +17,7 @@ test.describe('Checkbox Documentation Page', () => {
       const checkbox = section.locator('button[role="checkbox"]')
       const button = section.locator('button:has-text("Continue")')
 
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
       await expect(button).toBeEnabled()
     })
 
@@ -66,7 +66,7 @@ test.describe('Checkbox Documentation Page', () => {
       const selectedText = section.locator('text=/Selected:/')
 
       // Click Mobile (first checkbox)
-      await checkboxes.first().dispatchEvent('click')
+      await checkboxes.first().click()
       await expect(selectedText).toContainText('Mobile')
       await expect(selectedText).toContainText('Desktop')
     })
@@ -79,7 +79,7 @@ test.describe('Checkbox Documentation Page', () => {
 
       // First checkbox is "select all", second is first email
       const firstEmailCheckbox = checkboxes.nth(1)
-      await firstEmailCheckbox.dispatchEvent('click')
+      await firstEmailCheckbox.click()
 
       // Should show "1 selected"
       await expect(section.locator('text=1 selected')).toBeVisible()
@@ -112,7 +112,7 @@ test.describe('Checkbox Documentation Page', () => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
 
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
       await expect(section.locator('text=1 selected')).toBeVisible()
     })
 
@@ -120,8 +120,8 @@ test.describe('Checkbox Documentation Page', () => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
 
-      await checkboxes.nth(1).dispatchEvent('click')
-      await checkboxes.nth(2).dispatchEvent('click')
+      await checkboxes.nth(1).click()
+      await checkboxes.nth(2).click()
       await expect(section.locator('text=2 selected')).toBeVisible()
     })
 
@@ -129,9 +129,9 @@ test.describe('Checkbox Documentation Page', () => {
       const section = page.locator('[bf-s^="CheckboxEmailListDemo_"]:not([data-slot])').first()
       const checkboxes = section.locator('button[role="checkbox"]')
 
-      await checkboxes.nth(1).dispatchEvent('click')
-      await checkboxes.nth(2).dispatchEvent('click')
-      await checkboxes.nth(3).dispatchEvent('click')
+      await checkboxes.nth(1).click()
+      await checkboxes.nth(2).click()
+      await checkboxes.nth(3).click()
 
       await expect(section.locator('text=3 selected')).toBeVisible()
       await expect(checkboxes.first()).toHaveAttribute('aria-checked', 'true') // Select all
@@ -142,12 +142,12 @@ test.describe('Checkbox Documentation Page', () => {
       const checkboxes = section.locator('button[role="checkbox"]')
 
       // Select 2
-      await checkboxes.nth(1).dispatchEvent('click')
-      await checkboxes.nth(2).dispatchEvent('click')
+      await checkboxes.nth(1).click()
+      await checkboxes.nth(2).click()
       await expect(section.locator('text=2 selected')).toBeVisible()
 
       // Unselect 1
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
       await expect(section.locator('text=1 selected')).toBeVisible()
     })
 
@@ -156,8 +156,8 @@ test.describe('Checkbox Documentation Page', () => {
       const checkboxes = section.locator('button[role="checkbox"]')
 
       // Select 1, then unselect
-      await checkboxes.nth(1).dispatchEvent('click')
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
+      await checkboxes.nth(1).click()
 
       await expect(section.locator('text=Select all')).toBeVisible()
     })
@@ -167,11 +167,11 @@ test.describe('Checkbox Documentation Page', () => {
       const checkboxes = section.locator('button[role="checkbox"]')
 
       // Select 1 email first
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
       await expect(section.locator('text=1 selected')).toBeVisible()
 
       // Click "Select all"
-      await checkboxes.first().dispatchEvent('click')
+      await checkboxes.first().click()
 
       // All should be selected
       await expect(section.locator('text=3 selected')).toBeVisible()
@@ -188,12 +188,12 @@ test.describe('Checkbox Documentation Page', () => {
       await expect(section.locator('text=Mark as read')).not.toBeVisible()
 
       // Select one - visible
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
       await expect(section.locator('text=1 selected')).toBeVisible() // Wait for selection update
       await expect(section.locator('text=Mark as read')).toBeVisible()
 
       // Unselect - hidden again
-      await checkboxes.nth(1).dispatchEvent('click')
+      await checkboxes.nth(1).click()
       await expect(section.locator('text=Select all')).toBeVisible() // Wait for selection reset
       await expect(section.locator('text=Mark as read')).not.toBeVisible()
     })

--- a/site/ui/e2e/pagination.spec.ts
+++ b/site/ui/e2e/pagination.spec.ts
@@ -70,7 +70,7 @@ test.describe('Pagination Documentation Page', () => {
       const section = page.locator('[bf-s^="PaginationDynamicDemo_"]:not([data-slot])').first()
 
       const page2Link = section.locator('[data-slot="pagination-link"]', { hasText: '2' })
-      await page2Link.dispatchEvent('click')
+      await page2Link.click()
 
       await expect(page2Link).toHaveAttribute('data-active', 'true')
 
@@ -82,7 +82,7 @@ test.describe('Pagination Documentation Page', () => {
       const section = page.locator('[bf-s^="PaginationDynamicDemo_"]:not([data-slot])').first()
 
       const nextBtn = section.locator('a[aria-label="Go to next page"]')
-      await nextBtn.dispatchEvent('click')
+      await nextBtn.click()
 
       const page2Link = section.locator('[data-slot="pagination-link"]', { hasText: '2' })
       await expect(page2Link).toHaveAttribute('data-active', 'true')
@@ -99,7 +99,7 @@ test.describe('Pagination Documentation Page', () => {
       await expect(page1Link).toHaveAttribute('aria-current', 'page')
 
       // Click page 3
-      await page3Link.dispatchEvent('click')
+      await page3Link.click()
 
       // Page 3 should become active, page 1 inactive
       await expect(page3Link).toHaveAttribute('data-active', 'true')

--- a/site/ui/e2e/reactivity-patterns.spec.ts
+++ b/site/ui/e2e/reactivity-patterns.spec.ts
@@ -25,7 +25,7 @@ test.describe('Reactivity Patterns', () => {
 
       // Click Mobile checkbox
       const mobileCheckbox = checkboxes.first()
-      await mobileCheckbox.dispatchEvent('click')
+      await mobileCheckbox.click()
 
       // Verify selection updated
       await expect(selectedText).toContainText('Mobile')
@@ -47,7 +47,7 @@ test.describe('Reactivity Patterns', () => {
       await expect(desktopCheckbox).toHaveAttribute('aria-checked', 'true')
 
       // Click to toggle off
-      await desktopCheckbox.dispatchEvent('click')
+      await desktopCheckbox.click()
       await expect(desktopCheckbox).toHaveAttribute('aria-checked', 'false')
 
       // Verify the selected text updated (props reactivity working)
@@ -73,10 +73,10 @@ test.describe('Reactivity Patterns', () => {
       // The isChecked memo should track controlledChecked
 
       // Click to verify memo chain updates correctly
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
       await expect(checkbox).toHaveAttribute('data-state', 'checked')
 
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
       await expect(checkbox).toHaveAttribute('data-state', 'unchecked')
     })
   })
@@ -108,7 +108,7 @@ test.describe('Reactivity Patterns', () => {
 
       // Click Email checkbox (third one)
       const emailCheckbox = checkboxes.nth(2)
-      await emailCheckbox.dispatchEvent('click')
+      await emailCheckbox.click()
 
       // Verify both Desktop and Email are now shown
       await expect(selectedText).toContainText('Desktop')
@@ -128,7 +128,7 @@ test.describe('Reactivity Patterns', () => {
       expect(initialState).toBe('false')
 
       // Click to toggle
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
 
       const newState = await checkbox.getAttribute('aria-checked')
       expect(newState).toBe('true')
@@ -142,7 +142,7 @@ test.describe('Reactivity Patterns', () => {
 
       await expect(checkbox).toHaveAttribute('data-state', 'unchecked')
 
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
 
       await expect(checkbox).toHaveAttribute('data-state', 'checked')
     })
@@ -160,13 +160,13 @@ test.describe('Reactivity Patterns', () => {
       await expect(button).toBeDisabled()
 
       // Check the checkbox
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
 
       // Button should now be enabled
       await expect(button).toBeEnabled()
 
       // Uncheck
-      await checkbox.dispatchEvent('click')
+      await checkbox.click()
 
       // Button should be disabled again
       await expect(button).toBeDisabled()
@@ -185,7 +185,7 @@ test.describe('Reactivity Patterns', () => {
 
       // Click first email checkbox (not the select all)
       const firstEmailCheckbox = checkboxes.nth(1)
-      await firstEmailCheckbox.dispatchEvent('click')
+      await firstEmailCheckbox.click()
 
       // Should show "1 selected"
       await expect(section.locator('text=1 selected')).toBeVisible()

--- a/site/ui/e2e/switch.spec.ts
+++ b/site/ui/e2e/switch.spec.ts
@@ -36,7 +36,7 @@ test.describe('Switch Documentation Page', () => {
       const switchBtn = section.locator('button[role="switch"]')
       const button = section.locator('button:has-text("Save preferences")')
 
-      await switchBtn.dispatchEvent('click')
+      await switchBtn.click()
       await expect(button).toBeEnabled()
     })
 
@@ -143,7 +143,7 @@ test.describe('Switch Documentation Page', () => {
       const enabledText = section.locator('text=/Enabled:/')
 
       // Click Email digest (second switch)
-      await switches.nth(1).dispatchEvent('click')
+      await switches.nth(1).click()
       await expect(enabledText).toContainText('Push notifications')
       await expect(enabledText).toContainText('Email digest')
     })
@@ -168,7 +168,7 @@ test.describe('Switch Documentation Page', () => {
 
       // First switch is "enable all", second is first channel (Email)
       const emailSwitch = switches.nth(1)
-      await emailSwitch.dispatchEvent('click')
+      await emailSwitch.click()
 
       // Should show "1 enabled"
       await expect(section.locator('text=1 enabled')).toBeVisible()
@@ -210,7 +210,7 @@ test.describe('Switch Documentation Page', () => {
       const section = page.locator('[bf-s^="SwitchNotificationDemo_"]:not([data-slot])').first()
       const switches = section.locator('button[role="switch"]')
 
-      await switches.nth(1).dispatchEvent('click')
+      await switches.nth(1).click()
       await expect(section.locator('text=1 enabled')).toBeVisible()
     })
 
@@ -218,8 +218,8 @@ test.describe('Switch Documentation Page', () => {
       const section = page.locator('[bf-s^="SwitchNotificationDemo_"]:not([data-slot])').first()
       const switches = section.locator('button[role="switch"]')
 
-      await switches.nth(1).dispatchEvent('click')
-      await switches.nth(2).dispatchEvent('click')
+      await switches.nth(1).click()
+      await switches.nth(2).click()
       await expect(section.locator('text=2 enabled')).toBeVisible()
     })
 
@@ -227,9 +227,9 @@ test.describe('Switch Documentation Page', () => {
       const section = page.locator('[bf-s^="SwitchNotificationDemo_"]:not([data-slot])').first()
       const switches = section.locator('button[role="switch"]')
 
-      await switches.nth(1).dispatchEvent('click')
-      await switches.nth(2).dispatchEvent('click')
-      await switches.nth(3).dispatchEvent('click')
+      await switches.nth(1).click()
+      await switches.nth(2).click()
+      await switches.nth(3).click()
 
       await expect(section.locator('text=3 enabled')).toBeVisible()
       await expect(switches.first()).toHaveAttribute('aria-checked', 'true') // Enable all
@@ -240,12 +240,12 @@ test.describe('Switch Documentation Page', () => {
       const switches = section.locator('button[role="switch"]')
 
       // Select 2
-      await switches.nth(1).dispatchEvent('click')
-      await switches.nth(2).dispatchEvent('click')
+      await switches.nth(1).click()
+      await switches.nth(2).click()
       await expect(section.locator('text=2 enabled')).toBeVisible()
 
       // Deselect 1
-      await switches.nth(1).dispatchEvent('click')
+      await switches.nth(1).click()
       await expect(section.locator('text=1 enabled')).toBeVisible()
     })
 
@@ -254,8 +254,8 @@ test.describe('Switch Documentation Page', () => {
       const switches = section.locator('button[role="switch"]')
 
       // Select 1, then deselect
-      await switches.nth(1).dispatchEvent('click')
-      await switches.nth(1).dispatchEvent('click')
+      await switches.nth(1).click()
+      await switches.nth(1).click()
 
       await expect(section.locator('text=Enable all')).toBeVisible()
     })
@@ -265,11 +265,11 @@ test.describe('Switch Documentation Page', () => {
       const switches = section.locator('button[role="switch"]')
 
       // Select 1 channel first
-      await switches.nth(1).dispatchEvent('click')
+      await switches.nth(1).click()
       await expect(section.locator('text=1 enabled')).toBeVisible()
 
       // Click "Enable all"
-      await switches.first().dispatchEvent('click')
+      await switches.first().click()
 
       // All should be selected
       await expect(section.locator('text=3 enabled')).toBeVisible()


### PR DESCRIPTION
## Summary

- Replace `element.onclick = handler` with `element.addEventListener('click', handler)` in compiler-generated client JS
- Fix all 47 E2E test workarounds (`dispatchEvent('click')` → `.click()`) across 4 spec files
- Remove `toDomEventProp()` helper, add `toDomEventName()` for addEventListener-compatible event names

Fixes #552

## Details

The compiler was generating DOM property assignments (`element.onclick = handler`) for event handlers. Playwright's `.click()` method uses CDP's `Input.dispatchMouseEvent`, which does not reliably trigger property-assigned handlers. This required `dispatchEvent('click')` workarounds in E2E tests.

`addEventListener` is the industry standard and is compatible with:
- CDP-based clicks (Playwright)
- `element.dispatchEvent()`
- `element.click()`
- Real user clicks

The change also improves consistency — loop non-bubbling events already used `addEventListener`.

### Files changed

| File | Change |
|------|--------|
| `packages/jsx/src/ir-to-client-js/utils.ts` | `toDomEventProp()` → `toDomEventName()` |
| `packages/jsx/src/ir-to-client-js/emit-init-sections.ts` | 4 event emission sites → `addEventListener` |
| `packages/jsx/src/__tests__/compiler.test.ts` | 2 assertion updates |
| `packages/dom/__tests__/insert-integration.test.ts` | 1 assertion update |
| `site/ui/e2e/checkbox.spec.ts` | 18 `dispatchEvent` → `.click()` |
| `site/ui/e2e/switch.spec.ts` | 16 `dispatchEvent` → `.click()` |
| `site/ui/e2e/reactivity-patterns.spec.ts` | 10 `dispatchEvent` → `.click()` |
| `site/ui/e2e/pagination.spec.ts` | 3 `dispatchEvent` → `.click()` |

## Test plan

- [x] `cd packages/jsx && bun test` — compiler tests pass (211/211)
- [x] `cd packages/dom && bun test` — DOM runtime tests pass (161/161)
- [x] Full project build succeeds
- [x] `cd site/ui && npx playwright test` — all 70 E2E tests pass with `.click()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)