### PR TITLE
Fix JSX assigned to variable kept as raw JSX in client JS (#547)

### DIFF
--- a/packages/jsx/src/__tests__/jsx-constant-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-constant-inlining.test.ts
@@ -1,0 +1,252 @@
+/**
+ * BarefootJS Compiler - JSX Constant Inlining Tests (#547)
+ *
+ * When JSX is assigned to a variable (e.g., `const icon = <svg>...</svg>`),
+ * it should be inlined at the IR level rather than emitted as raw JSX in client JS.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('JSX constant inlining (#547)', () => {
+  describe('analyzer', () => {
+    test('sets isJsx flag on JSX variable declarations', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = <svg><path d="M0 0" /></svg>
+          return <div>{icon}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const iconConstant = ctx.localConstants.find(c => c.name === 'icon')
+
+      expect(iconConstant).toBeDefined()
+      expect(iconConstant!.isJsx).toBe(true)
+    })
+
+    test('stores JSX AST node in jsxConstants map', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = <svg><path d="M0 0" /></svg>
+          return <div>{icon}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxConstants.has('icon')).toBe(true)
+    })
+
+    test('does not set isJsx for non-JSX constants', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const label = "hello"
+          return <div>{label}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const labelConstant = ctx.localConstants.find(c => c.name === 'label')
+
+      expect(labelConstant).toBeDefined()
+      expect(labelConstant!.isJsx).toBe(false)
+    })
+
+    test('detects JSX self-closing elements', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = <svg />
+          return <div>{icon}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const iconConstant = ctx.localConstants.find(c => c.name === 'icon')
+
+      expect(iconConstant!.isJsx).toBe(true)
+      expect(ctx.jsxConstants.has('icon')).toBe(true)
+    })
+
+    test('detects parenthesized JSX', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = (<svg><path d="M0 0" /></svg>)
+          return <div>{icon}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const iconConstant = ctx.localConstants.find(c => c.name === 'icon')
+
+      expect(iconConstant!.isJsx).toBe(true)
+    })
+
+    test('does not flag ternary with JSX branches as isJsx', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [active, setActive] = createSignal(false)
+          const content = active() ? <span>On</span> : <span>Off</span>
+          return <div>{content}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const contentConstant = ctx.localConstants.find(c => c.name === 'content')
+
+      expect(contentConstant).toBeDefined()
+      expect(contentConstant!.isJsx).toBe(false)
+    })
+  })
+
+  describe('IR transformation', () => {
+    test('inlines JSX variable as IRElement instead of IRExpression', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = <svg className="w-4"><path d="M0 0" /></svg>
+          return <div>{icon}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      expect(ir!.type).toBe('element')
+      if (ir!.type === 'element') {
+        // The div should contain the inlined svg, not an expression node
+        const svgChild = ir!.children.find(
+          (c: any) => c.type === 'element' && c.tag === 'svg'
+        )
+        expect(svgChild).toBeDefined()
+
+        // Should NOT have an expression node with raw JSX text
+        const exprChild = ir!.children.find(
+          (c: any) => c.type === 'expression' && c.expr === 'icon'
+        )
+        expect(exprChild).toBeUndefined()
+      }
+    })
+
+    test('inlines JSX variable used multiple times', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const dot = <span className="dot" />
+          return <div>{dot}{dot}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        const spanChildren = ir!.children.filter(
+          (c: any) => c.type === 'element' && c.tag === 'span'
+        )
+        expect(spanChildren).toHaveLength(2)
+      }
+    })
+  })
+
+  describe('client JS output', () => {
+    test('does not emit raw JSX variable declaration in client JS init function', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [active, setActive] = createSignal(false)
+          const icon = <svg className="w-4"><path d="M0 0" /></svg>
+          return <button onClick={() => setActive(v => !v)}>{icon}</button>
+        }
+      `
+
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // The variable 'icon' should not be declared in client JS
+      // (it would contain raw JSX like `const icon = <svg className=...>`)
+      expect(clientJs!.content).not.toMatch(/\bconst icon\b/)
+      expect(clientJs!.content).not.toMatch(/\blet icon\b/)
+    })
+
+    test('SVG icon in marked template is preserved', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const icon = <svg className="w-4"><path d="M0 0" /></svg>
+          return <div>{icon}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      // The inlined SVG should appear in the template output
+      expect(template!.content).toContain('svg')
+      expect(template!.content).toContain('path')
+    })
+
+    test('compiles Calendar-style pattern without errors', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Calendar() {
+          const [month, setMonth] = createSignal(0)
+          const chevronLeft = <svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6" /></svg>
+          const chevronRight = <svg viewBox="0 0 24 24"><path d="M9 18l6-6-6-6" /></svg>
+          return (
+            <div>
+              <button onClick={() => setMonth(m => m - 1)}>{chevronLeft}</button>
+              <span>Month: {month()}</span>
+              <button onClick={() => setMonth(m => m + 1)}>{chevronRight}</button>
+            </div>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'Calendar.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // JSX variable declarations should not appear in client JS init function
+      expect(clientJs!.content).not.toMatch(/\bconst chevronLeft\b/)
+      expect(clientJs!.content).not.toMatch(/\bconst chevronRight\b/)
+    })
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -62,6 +62,8 @@ export interface AnalyzerContext {
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
   typeDefinitions: TypeDefinition[]
+  /** Maps constant names to their JSX initializer AST nodes (#547) */
+  jsxConstants: Map<string, ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment>
 
   // Props
   propsType: TypeInfo | null
@@ -115,6 +117,7 @@ export function createAnalyzerContext(
     localFunctions: [],
     localConstants: [],
     typeDefinitions: [],
+    jsxConstants: new Map(),
 
     propsType: null,
     propsParams: [],

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -809,6 +809,17 @@ function collectConstant(
     ? ctx.getJS(node.initializer)
     : undefined
 
+  // Detect JSX initializers and store AST nodes for IR-level inlining (#547)
+  let isJsx = false
+  if (node.initializer) {
+    let init: ts.Expression = node.initializer
+    while (ts.isParenthesizedExpression(init)) init = init.expression
+    if (ts.isJsxElement(init) || ts.isJsxSelfClosingElement(init) || ts.isJsxFragment(init)) {
+      isJsx = true
+      ctx.jsxConstants.set(name, init)
+    }
+  }
+
   // Extract structured branch info from ternary initializers
   let valueBranches: string[] | undefined
   if (node.initializer) {
@@ -840,6 +851,7 @@ function collectConstant(
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     freeIdentifiers,
+    isJsx,
   })
 }
 

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -891,6 +891,7 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
   }
 
   for (const constant of ctx.localConstants) {
+    if (constant.isJsx) continue  // Inlined at IR level (#547)
     if (!constant.value) {
       // `let x` with no initializer — not safe for template inlining
       unsafeLocalNames.add(constant.name)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -80,6 +80,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   const moduleLevelConstantNames = new Set<string>()
 
   for (const constant of ctx.localConstants) {
+    if (constant.isJsx) continue  // Inlined at IR level (#547)
     if (usedIdentifiers.has(constant.name)) {
       if (!constant.value) {
         neededConstants.push(constant)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -649,6 +649,14 @@ function transformExpression(
     return transformMapCall(expr, ctx, isClientOnly)
   }
 
+  // Inline JSX constants at the IR level (#547)
+  if (ts.isIdentifier(expr)) {
+    const jsxNode = ctx.analyzer.jsxConstants.get(expr.text)
+    if (jsxNode) {
+      return transformNode(jsxNode, ctx)
+    }
+  }
+
   // Regular expression
   const exprText = ctx.getJS(expr)
   const reactive = isReactiveExpression(exprText, ctx, expr)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -385,6 +385,8 @@ export interface ConstantInfo {
   loc: SourceLocation
   /** Pre-computed free identifier references in the value expression (computed at analysis time). */
   freeIdentifiers?: Set<string>
+  /** When true, the initializer is JSX that is inlined into the IR tree at usage sites (#547). */
+  isJsx?: boolean
 }
 
 export interface TypeDefinition {


### PR DESCRIPTION
Fixed: #547 

## Summary

- When JSX is assigned to a variable (e.g., `const icon = <svg>...</svg>`), the compiler now inlines the JSX at the IR level via `transformNode()` instead of emitting the raw JSX string into client JS
- Adds `isJsx` flag to `ConstantInfo` and `jsxConstants` AST map to `AnalyzerContext` for detection
- Skips JSX constants in client JS emission (`generate-init.ts`, `emit-init-sections.ts`)
- Fixes `SyntaxError: Unexpected token '<'` at runtime when using JSX variables

## Test plan

- [x] 11 new tests covering analyzer detection, IR transformation, and client JS output
- [x] All 421 existing compiler tests pass (no regressions)
- [x] All 69 adapter conformance tests pass
- [ ] E2E verification with Calendar component (PR #534)

🤖 Generated with [Claude Code](https://claude.com/claude-code)