### PR TITLE
Fix #560: preserve relative imports used in client JS

### DIFF
--- a/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
@@ -75,11 +75,51 @@ describe('collectExternalImports', () => {
     expect(result).toEqual([])
   })
 
-  test('skips relative imports', () => {
+  test('preserves relative imports when specifiers are used in generated code', () => {
     const ir = makeIR([makeImport('./utils', ['helper'])])
     const code = 'helper()'
     const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { helper } from './utils'"])
+  })
+
+  test('skips relative imports when specifiers are not used in generated code', () => {
+    const ir = makeIR([makeImport('./utils', ['helper'])])
+    const code = 'somethingElse()'
+    const result = collectExternalImports(ir, code)
     expect(result).toEqual([])
+  })
+
+  test('skips relative imports for component names', () => {
+    const ir = makeIR([makeImport('./MyWidget', ['MyWidget'])], ['MyWidget'])
+    const code = 'MyWidget'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  test('preserves parent-relative imports when specifiers are used', () => {
+    const ir = makeIR([makeImport('../shared/format', ['formatCurrency'])])
+    const code = 'formatCurrency(price)'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { formatCurrency } from '../shared/format'"])
+  })
+
+  test('preserves relative import with alias when used', () => {
+    const ir: ReturnType<typeof makeIR> = makeIR([{
+      source: './utils',
+      specifiers: [{ name: 'helper', alias: 'h', isDefault: false, isNamespace: false }],
+      isTypeOnly: false,
+      loc: dummyLoc,
+    }])
+    const code = 'h()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { helper as h } from './utils'"])
+  })
+
+  test('only preserves used specifiers from relative import with mixed usage', () => {
+    const ir = makeIR([makeImport('./utils', ['used', 'unused'])])
+    const code = 'used()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import { used } from './utils'"])
   })
 
   test('preserves @ui/ imports by default (no localImportPrefixes)', () => {

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -71,8 +71,6 @@ export function collectExternalImports(ir: ComponentIR, generatedCode: string, l
   for (const imp of ir.metadata.imports) {
     if (imp.isTypeOnly) continue
     if (imp.source === '@barefootjs/dom') continue
-    // Skip relative imports (resolved by the build, not needed in browser)
-    if (imp.source.startsWith('./') || imp.source.startsWith('../')) continue
     // Skip local path-alias imports (resolved at build time, not in browser)
     if (localImportPrefixes?.some(prefix => imp.source.startsWith(prefix))) continue
 


### PR DESCRIPTION
Fixed #560

## Summary

- Remove blanket relative import skip in `collectExternalImports()` that unconditionally dropped all `./` and `../` imports from generated client JS
- Relative imports are now filtered by the same downstream checks as other imports: unused specifiers are skipped, component names are skipped, type-only imports are skipped
- Fixes `ReferenceError` at runtime when a `"use client"` component imports a utility function from a relative non-`"use client"` module and uses it inside `createEffect`

## Test plan

- [x] Updated "skips relative imports" test → "preserves relative imports when specifiers are used"
- [x] Added tests: unused relative import skipped, component name skipped, `../` parent path preserved, alias preserved, mixed used/unused specifiers
- [x] All 415 compiler unit tests pass
- [x] All 69 adapter conformance tests pass

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)