### PR TITLE
Fix .map() callback returning function call producing empty body (#546)

### DIFF
--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -518,6 +518,106 @@ describe('child components inside .map() (#344)', () => {
     expect(content).toContain('setValue(item.value)')
   })
 
+  describe('callback returning function call (#546)', () => {
+    test('arrow expression body: items().map(item => renderItem(item))', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function List() {
+          const [items, setItems] = createSignal([{ id: '1' }, { id: '2' }])
+          const renderItem = (item: any) => <li>{item.id}</li>
+          return (
+            <ul>
+              {items().map(item => renderItem(item))}
+            </ul>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      // The .map() call should become an expression, not a loop with empty children
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('renderItem')
+    })
+
+    test('parenthesized expression: items().map(item => (renderItem(item)))', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function List() {
+          const [items, setItems] = createSignal([{ id: '1' }, { id: '2' }])
+          const renderItem = (item: any) => <li>{item.id}</li>
+          return (
+            <ul>
+              {items().map(item => (renderItem(item)))}
+            </ul>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('renderItem')
+    })
+
+    test('block body with function call return: items().map(item => { return renderItem(item) })', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function List() {
+          const [items, setItems] = createSignal([{ id: '1' }, { id: '2' }])
+          const renderItem = (item: any) => <li>{item.id}</li>
+          return (
+            <ul>
+              {items().map(item => { const label = item.id; return renderItem(label) })}
+            </ul>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      expect(clientJs!.content).toContain('renderItem')
+    })
+
+    test('SSR template output does not contain empty arrow body', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function List() {
+          const [items, setItems] = createSignal([{ id: '1' }, { id: '2' }])
+          const renderItem = (item: any) => <li>{item.id}</li>
+          return (
+            <ul>
+              {items().map(item => renderItem(item))}
+            </ul>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'List.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      // Should contain the .map() call with renderItem, not an empty arrow body
+      expect(template!.content).toContain('.map(')
+      expect(template!.content).toContain('renderItem')
+      // Must NOT contain the broken pattern: => )
+      expect(template!.content).not.toMatch(/=>\s*\)/)
+    })
+  })
+
   test('dynamic signal array: onClick on plain element still works (regression guard)', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -646,7 +646,11 @@ function transformExpression(
 
   // Array map: {items.map(item => <li>{item}</li>)}
   if (ts.isCallExpression(expr) && isMapCall(expr)) {
-    return transformMapCall(expr, ctx, isClientOnly)
+    const mapResult = transformMapCall(expr, ctx, isClientOnly)
+    if (mapResult) {
+      return mapResult
+    }
+    // Callback body is not JSX (e.g., function call). Fall through to expression handling.
   }
 
   // Regular expression
@@ -1028,7 +1032,7 @@ function transformMapCall(
   node: ts.CallExpression,
   ctx: TransformContext,
   isClientOnly = false
-): IRLoop {
+): IRLoop | null {
   const propAccess = node.expression as ts.PropertyAccessExpression
   const mapSource = propAccess.expression
 
@@ -1224,6 +1228,12 @@ function transformMapCall(
         }
       }
     }
+  }
+
+  // If no JSX children were found (e.g., callback returns a function call),
+  // fall back to treating the entire .map() expression as an IRExpression.
+  if (children.length === 0) {
+    return null
   }
 
   // Look for key prop in first child (element or component)


### PR DESCRIPTION
Fixed #546

## Summary

- When a `.map()` callback returns a function call instead of JSX (e.g., `items.map(x => renderItem(x))`), the compiler's `transformMapCall` produced an `IRLoop` with empty `children`, causing invalid SSR template output like `{items.map((item) => )}` — a syntax error.
- `transformMapCall` now returns `null` when no JSX children are found, letting `transformExpression` fall through to regular `IRExpression` handling. The full `.map()` call is serialized as an expression and evaluated at runtime.
- Added 4 tests covering arrow expression, parenthesized expression, block body with function call return, and SSR template output validation.

## Test plan

- [x] `bun test ./packages/jsx/src/__tests__/child-components-in-map.test.ts` — 22 tests pass (including 4 new)
- [x] `bun test ./packages/jsx/` — 414 tests pass
- [x] `bun test ./packages/adapter-tests/` — 69 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)