### PR TITLE
Fix #559: reactive JSX props to stateless components

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -700,6 +700,12 @@ export class HonoAdapter implements TemplateAdapter {
     let keyValue: string | null = null
 
     for (const prop of comp.props) {
+      if (prop.jsxChildren?.length) {
+        // JSX prop: render children inline as JSX fragment
+        const rendered = prop.jsxChildren.map(c => this.renderNode(c)).join('')
+        parts.push(`${prop.name}={<>${rendered}</>}`)
+        continue
+      }
       if (prop.name === '...') {
         parts.push(`{...${prop.value}}`)
       } else if (prop.name === 'key') {

--- a/packages/jsx/src/__tests__/ir-jsx-props.test.ts
+++ b/packages/jsx/src/__tests__/ir-jsx-props.test.ts
@@ -1,0 +1,267 @@
+/**
+ * BarefootJS Compiler - JSX Props Tests (#559)
+ *
+ * When a "use client" component passes JSX elements as named props
+ * to a stateless component, the compiler should transform them into
+ * IR nodes (jsxChildren) instead of raw JSX text.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import type { IRComponent, IRElement } from '../types'
+
+const adapter = new TestAdapter()
+
+/** Helper: find first component node in IR tree */
+function findComponent(node: any, name?: string): IRComponent | undefined {
+  if (node.type === 'component' && (!name || node.name === name)) return node
+  const children = node.children || []
+  for (const child of children) {
+    const found = findComponent(child, name)
+    if (found) return found
+  }
+  return undefined
+}
+
+describe('JSX props (#559)', () => {
+  describe('Phase 1: JSX → IR', () => {
+    test('JSX element prop produces jsxChildren in IR', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={<input type="text" />} />
+          )
+        }
+      `
+      const ctx = analyzeComponent(source, 'App.tsx')
+      const ir = jsxToIR(ctx)
+      expect(ir).not.toBeNull()
+
+      const layout = findComponent(ir!, 'Layout')
+      expect(layout).toBeDefined()
+
+      const controlsProp = layout!.props.find(p => p.name === 'controls')
+      expect(controlsProp).toBeDefined()
+      expect(controlsProp!.jsxChildren).toBeDefined()
+      expect(controlsProp!.jsxChildren).toHaveLength(1)
+      expect(controlsProp!.jsxChildren![0].type).toBe('element')
+      expect((controlsProp!.jsxChildren![0] as IRElement).tag).toBe('input')
+    })
+
+    test('parenthesized JSX prop produces jsxChildren', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={(<div><span>hello</span></div>)} />
+          )
+        }
+      `
+      const ctx = analyzeComponent(source, 'App.tsx')
+      const ir = jsxToIR(ctx)
+
+      const layout = findComponent(ir!, 'Layout')
+      const controlsProp = layout!.props.find(p => p.name === 'controls')
+      expect(controlsProp!.jsxChildren).toBeDefined()
+      expect(controlsProp!.jsxChildren).toHaveLength(1)
+      expect(controlsProp!.jsxChildren![0].type).toBe('element')
+      expect((controlsProp!.jsxChildren![0] as IRElement).tag).toBe('div')
+    })
+
+    test('elements inside JSX props get ^-prefixed slot IDs', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={
+              <button onClick={() => setVal('clicked')}>Click</button>
+            } />
+          )
+        }
+      `
+      const ctx = analyzeComponent(source, 'App.tsx')
+      const ir = jsxToIR(ctx)
+
+      const layout = findComponent(ir!, 'Layout')
+      const controlsProp = layout!.props.find(p => p.name === 'controls')
+      const button = controlsProp!.jsxChildren![0] as IRElement
+      expect(button.tag).toBe('button')
+      // Elements in JSX props are parent-owned, so get ^ prefix
+      expect(button.slotId).toMatch(/^\^s\d+$/)
+      expect(button.events).toHaveLength(1)
+      expect(button.events[0].name).toBe('click')
+    })
+
+    test('mixed JSX and non-JSX props on same component', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout
+              title="Hello"
+              controls={<input type="text" />}
+              count={42}
+            />
+          )
+        }
+      `
+      const ctx = analyzeComponent(source, 'App.tsx')
+      const ir = jsxToIR(ctx)
+
+      const layout = findComponent(ir!, 'Layout')
+      expect(layout!.props).toHaveLength(3)
+
+      const titleProp = layout!.props.find(p => p.name === 'title')
+      expect(titleProp!.jsxChildren).toBeUndefined()
+      expect(titleProp!.value).toBe('Hello')
+
+      const controlsProp = layout!.props.find(p => p.name === 'controls')
+      expect(controlsProp!.jsxChildren).toBeDefined()
+
+      const countProp = layout!.props.find(p => p.name === 'count')
+      expect(countProp!.jsxChildren).toBeUndefined()
+      expect(countProp!.value).toBe('42')
+    })
+  })
+
+  describe('Phase 2: Client JS generation', () => {
+    test('events inside JSX props are collected in parent client JS', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={
+              <button onClick={() => setVal('clicked')}>Click</button>
+            }>
+              <p>Content</p>
+            </Layout>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // The client JS should contain event binding for the button
+      expect(clientJs!.content).toContain('addEventListener')
+      expect(clientJs!.content).toContain('click')
+    })
+
+    test('reactive expressions inside JSX props generate proper effects', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [count, setCount] = createSignal(0)
+          return (
+            <Layout
+              controls={<span>{count()}</span>}
+            />
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Should have createEffect for reactive text inside JSX prop
+      expect(clientJs!.content).toContain('createEffect')
+    })
+
+    test('does not generate setAttribute for JSX prop values', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={<input type="text" />} />
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      // Should NOT have setAttribute for the JSX prop —
+      // JSX props are passed via createComponent, not setAttribute
+      if (clientJs) {
+        expect(clientJs.content).not.toContain('setAttribute')
+      }
+    })
+
+    test('component references in JSX props are imported in client JS', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout controls={<Button label="ok" />} />
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Should import Button component referenced inside JSX prop
+      expect(clientJs!.content).toContain('@bf-child:Button')
+    })
+
+    test('client JS does not contain raw JSX syntax', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return (
+            <Layout
+              controls={<select onChange={(e) => setVal(e.target.value)}>
+                <option value="a">A</option>
+                <option value="b">B</option>
+              </select>}
+            />
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Raw JSX with event handlers should NOT appear — handlers are extracted
+      // HTML element tags DO appear in template literals (valid JS), which is correct
+      expect(clientJs!.content).not.toMatch(/onChange=\{/)
+      // Event handler should be extracted into addEventListener
+      expect(clientJs!.content).toContain('addEventListener')
+      expect(clientJs!.content).toContain('change')
+    })
+  })
+})

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -334,6 +334,12 @@ export class TestAdapter extends BaseAdapter {
     const parts: string[] = []
 
     for (const prop of comp.props) {
+      if (prop.jsxChildren?.length) {
+        // JSX prop: render children inline
+        const rendered = prop.jsxChildren.map(c => this.renderNode(c)).join('')
+        parts.push(`${prop.name}={<>${rendered}</>}`)
+        continue
+      }
       if (prop.name === '...') {
         parts.push(`{...${prop.value}}`)
       } else if (prop.dynamic) {

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -6,7 +6,7 @@ import type { IRNode, IRElement, IREvent } from '../types'
 import type { ClientJsContext, LoopChildEvent } from './types'
 import { attrValueToString, quotePropName } from './utils'
 import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectLoopChildEvents } from './reactivity'
-import { irToHtmlTemplate } from './html-template'
+import { irToHtmlTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue } from './prop-handling'
 
 /** Build rest spread names from context (rest/props spreads handled by applyRestAttrs, not spreadAttrs). */
@@ -156,6 +156,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
 
         // Reactive props need effects to update the element when values change
         for (const prop of node.props) {
+          if (prop.jsxChildren) continue
           if (prop.name.startsWith('on') && prop.name.length > 2) continue
           const value = prop.value
           if (value.endsWith('()')) {
@@ -195,6 +196,10 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           prop.name[2] === prop.name[2].toUpperCase()
         if (isEventHandler) {
           propsForInit.push(`${quotePropName(prop.name)}: ${prop.value}`)
+        } else if (prop.jsxChildren) {
+          // JSX prop: generate getter using IR children → JS expression
+          const jsxExpr = irChildrenToJsExpr(prop.jsxChildren)
+          propsForInit.push(`get ${quotePropName(prop.name)}() { return ${jsxExpr} }`)
         } else if (prop.dynamic) {
           const expandedValue = expandDynamicPropValue(prop.value, ctx)
           propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
@@ -235,6 +240,15 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
       })
       for (const child of node.children) {
         collectElements(child, ctx)
+      }
+      // Traverse JSX prop children so events, reactive expressions,
+      // and nested components inside JSX props are collected
+      for (const prop of node.props) {
+        if (prop.jsxChildren) {
+          for (const child of prop.jsxChildren) {
+            collectElements(child, ctx)
+          }
+        }
       }
       break
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -365,6 +365,12 @@ export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>)
     if (node.type === 'component') {
       names.add(node.name)
       collectComponentNamesFromIR(node.children, names)
+      // Traverse JSX prop children for nested component references
+      for (const prop of node.props) {
+        if (prop.jsxChildren) {
+          collectComponentNamesFromIR(prop.jsxChildren, names)
+        }
+      }
     } else if (node.type === 'element' || node.type === 'fragment' || node.type === 'provider') {
       collectComponentNamesFromIR(node.children, names)
     } else if (node.type === 'conditional') {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -111,6 +111,11 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>): s
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          // JSX prop: render children inline as template literal
+          if (p.jsxChildren?.length) {
+            const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
+            return `${quotePropName(p.name)}: \`${childHtml}\``
+          }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
           return `${quotePropName(p.name)}: ${p.value}`
         })
@@ -169,6 +174,10 @@ function irNodeToJsExprs(node: IRNode): string[] {
         .map(p => {
           if (p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()) {
             return `${quotePropName(p.name)}: ${p.value}`
+          }
+          // JSX prop: generate getter using IR children → JS expression
+          if (p.jsxChildren?.length) {
+            return `get ${quotePropName(p.name)}() { return ${irChildrenToJsExpr(p.jsxChildren)} }`
           }
           if (p.isLiteral) {
             return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
@@ -332,6 +341,10 @@ export function irToComponentTemplate(
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          if (p.jsxChildren?.length) {
+            const childHtml = p.jsxChildren.map(c => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+            return `${quotePropName(p.name)}: \`${childHtml}\``
+          }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
           const valueStr = attrValueToString(p.value)
           return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr) : JSON.stringify(p.value)}`
@@ -609,6 +622,10 @@ export function generateCsrTemplate(
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          if (p.jsxChildren?.length) {
+            const childHtml = p.jsxChildren.map(c => generateCsrTemplate(c, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames)).join('')
+            return `${quotePropName(p.name)}: \`${childHtml}\``
+          }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
           const valueStr = attrValueToString(p.value)
           return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr) : JSON.stringify(p.value)}`

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1630,6 +1630,34 @@ function processComponentProps(
     if (!ts.isJsxAttribute(attr)) continue
 
     const name = attr.name.getText(ctx.sourceFile)
+
+    // Detect JSX element/fragment as prop value: controls={<select ... />}
+    // Also handle parenthesized JSX: controls={(<div>...</div>)}
+    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+      let jsxExpr = attr.initializer.expression
+      // Unwrap parenthesized expression: controls={(<div>...</div>)}
+      while (ts.isParenthesizedExpression(jsxExpr)) {
+        jsxExpr = jsxExpr.expression
+      }
+      if (ts.isJsxElement(jsxExpr) || ts.isJsxSelfClosingElement(jsxExpr) || ts.isJsxFragment(jsxExpr)) {
+        const prevInsideComponentChildren = ctx.insideComponentChildren
+        ctx.insideComponentChildren = true
+        const irNode = transformNode(jsxExpr, ctx)
+        ctx.insideComponentChildren = prevInsideComponentChildren
+        if (irNode) {
+          props.push({
+            name,
+            value: '__jsx_prop',
+            dynamic: true,
+            isLiteral: false,
+            loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
+            jsxChildren: [irNode],
+          })
+          continue
+        }
+      }
+    }
+
     const { value, dynamic, isLiteral } = getAttributeValue(attr, ctx)
 
     // For component props, convert IRTemplateLiteral back to string expression

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -318,6 +318,8 @@ export interface IRProp {
   dynamic: boolean
   isLiteral: boolean // true if value came from a string literal attribute (e.g., value="account")
   loc: SourceLocation
+  /** When the prop value is a JSX element/fragment, store the transformed IR nodes here */
+  jsxChildren?: IRNode[]
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixed #559

## Summary

- When a `"use client"` component passes JSX elements as named props to a stateless component (e.g., `<Layout controls={<select onChange={...} />} />`), the compiler previously produced broken client JS by calling `getJS()` on JSX AST nodes
- Extends `IRProp` with `jsxChildren?: IRNode[]` to store transformed IR nodes instead of raw JSX text
- Phase 1 detects JSX element/fragment prop values and transforms them via `transformNode()` with `^`-prefixed parent-owned slot IDs
- Phase 2 generates proper template literals and `createComponent()` calls, skipping broken `setAttribute()` paths
- Updates both Hono and test adapters to render JSX prop children inline

## Test plan

- [x] 9 new test cases in `ir-jsx-props.test.ts` covering IR transformation, slot IDs, events, reactive expressions, import collection, mixed props, and no raw JSX in output
- [x] All 439 compiler unit tests pass
- [x] All 46 Hono adapter tests pass
- [x] All 69 adapter conformance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)