### PR TITLE
Fix #569: inline JSX-returning helper functions at IR level

### DIFF
--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -1,0 +1,425 @@
+/**
+ * BarefootJS Compiler - JSX Function Inlining Tests (#569)
+ *
+ * When a local function returns JSX (e.g., renderMonthGrid()),
+ * calling it multiple times should produce separate IR subtrees
+ * with unique slot IDs, not opaque expression nodes.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('JSX function inlining (#569)', () => {
+  describe('analyzer', () => {
+    test('stores JSX function info for function declarations', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          function renderItem(label: string) {
+            return <li>{label}</li>
+          }
+          return <ul>{renderItem("a")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxFunctions.has('renderItem')).toBe(true)
+      const info = ctx.jsxFunctions.get('renderItem')!
+      expect(info.params).toEqual(['label'])
+    })
+
+    test('stores JSX function info for arrow function constants', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const renderItem = (label: string) => <li>{label}</li>
+          return <ul>{renderItem("a")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxFunctions.has('renderItem')).toBe(true)
+      const info = ctx.jsxFunctions.get('renderItem')!
+      expect(info.params).toEqual(['label'])
+    })
+
+    test('stores JSX function info for arrow functions with block body', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const renderItem = (label: string) => {
+            return <li>{label}</li>
+          }
+          return <ul>{renderItem("a")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxFunctions.has('renderItem')).toBe(true)
+    })
+
+    test('sets isJsxFunction flag on arrow function constants', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          const renderItem = (label: string) => <li>{label}</li>
+          return <ul>{renderItem("a")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const constant = ctx.localConstants.find(c => c.name === 'renderItem')
+
+      expect(constant).toBeDefined()
+      expect(constant!.isJsxFunction).toBe(true)
+    })
+
+    test('sets isJsxFunction flag on function declarations', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          function renderItem(label: string) {
+            return <li>{label}</li>
+          }
+          return <ul>{renderItem("a")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const fn = ctx.localFunctions.find(f => f.name === 'renderItem')
+
+      expect(fn).toBeDefined()
+      expect(fn!.isJsxFunction).toBe(true)
+    })
+
+    test('does not set isJsxFunction for functions with multiple returns', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          function renderItem(active: boolean) {
+            if (active) return <li className="active">Active</li>
+            return <li>Inactive</li>
+          }
+          return <ul>{renderItem(true)}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxFunctions.has('renderItem')).toBe(false)
+    })
+
+    test('does not set isJsxFunction for non-JSX returning functions', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          function formatLabel(text: string) {
+            return text.toUpperCase()
+          }
+          return <div>{formatLabel("hello")}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+
+      expect(ctx.jsxFunctions.has('formatLabel')).toBe(false)
+    })
+  })
+
+  describe('IR transformation', () => {
+    test('single call inlines to element IR node (not expression)', () => {
+      const source = `
+        'use client'
+
+        export function MyComponent() {
+          function renderItem(label: string) {
+            return <li>{label}</li>
+          }
+          return <ul>{renderItem("hello")}</ul>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        // Should have an inlined <li>, not an expression node
+        const liChild = ir!.children.find(
+          (c: any) => c.type === 'element' && c.tag === 'li'
+        )
+        expect(liChild).toBeDefined()
+
+        // Should NOT have an expression node referencing the function call
+        const exprChild = ir!.children.find(
+          (c: any) => c.type === 'expression' && c.expr.includes('renderItem')
+        )
+        expect(exprChild).toBeUndefined()
+      }
+    })
+
+    test('two calls produce separate IR subtrees with unique slot IDs', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [count, setCount] = createSignal(0)
+          function renderCounter(label: string) {
+            return <span>{label}: {count()}</span>
+          }
+          return <div>{renderCounter("A")}{renderCounter("B")}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+      if (ir!.type === 'element') {
+        const spans = ir!.children.filter(
+          (c: any) => c.type === 'element' && c.tag === 'span'
+        )
+        expect(spans).toHaveLength(2)
+
+        // Collect all slot IDs from both subtrees
+        const slotIds = new Set<string>()
+        function collectSlotIds(node: any): void {
+          if (node.slotId) slotIds.add(node.slotId)
+          if (node.children) node.children.forEach(collectSlotIds)
+        }
+        spans.forEach(collectSlotIds)
+
+        // Each reactive expression should have a unique slot ID
+        expect(slotIds.size).toBeGreaterThanOrEqual(2)
+      }
+    })
+
+    test('function call with loop (.map) produces loop IR node', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [items, setItems] = createSignal([{ name: 'a' }, { name: 'b' }])
+          function renderList(data: any[]) {
+            return <ul>{data.map(item => <li>{item.name}</li>)}</ul>
+          }
+          return <div>{renderList(items())}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+
+      // Walk the IR tree to find the loop node
+      function findLoopNode(node: any): any {
+        if (node.type === 'loop') return node
+        if (node.children) {
+          for (const child of node.children) {
+            const found = findLoopNode(child)
+            if (found) return found
+          }
+        }
+        return null
+      }
+
+      const loopNode = findLoopNode(ir)
+      expect(loopNode).not.toBeNull()
+      expect(loopNode.type).toBe('loop')
+    })
+
+    test('parameter substitution in generated JS', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [items, setItems] = createSignal(["a", "b"])
+          function renderList(data: string[]) {
+            return <ul>{data.map(item => <li>{item}</li>)}</ul>
+          }
+          return <div>{renderList(items())}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      // Find the loop node and verify the array expression was substituted
+      function findLoopNode(node: any): any {
+        if (node.type === 'loop') return node
+        if (node.children) {
+          for (const child of node.children) {
+            const found = findLoopNode(child)
+            if (found) return found
+          }
+        }
+        return null
+      }
+
+      const loopNode = findLoopNode(ir)
+      expect(loopNode).not.toBeNull()
+      // 'data' parameter should be substituted with 'items()'
+      expect(loopNode.array).toContain('items()')
+    })
+
+    test('function call in conditional branch is inlined', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [show, setShow] = createSignal(true)
+          function renderContent() {
+            return <p>Hello</p>
+          }
+          return <div>{show() ? renderContent() : <span>Hidden</span>}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'MyComponent.tsx')
+      const ir = jsxToIR(ctx)
+
+      expect(ir).not.toBeNull()
+
+      // Find the conditional node
+      function findConditional(node: any): any {
+        if (node.type === 'conditional') return node
+        if (node.children) {
+          for (const child of node.children) {
+            const found = findConditional(child)
+            if (found) return found
+          }
+        }
+        return null
+      }
+
+      const cond = findConditional(ir)
+      expect(cond).not.toBeNull()
+      // whenTrue should be an element (inlined <p>), not an expression
+      expect(cond.whenTrue.type).toBe('element')
+      expect(cond.whenTrue.tag).toBe('p')
+    })
+  })
+
+  describe('client JS output', () => {
+    test('does not emit inlined function declaration in client JS', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [count, setCount] = createSignal(0)
+          function renderCount() {
+            return <span>{count()}</span>
+          }
+          return <div onClick={() => setCount(n => n + 1)}>{renderCount()}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // The function 'renderCount' should not appear in client JS
+      expect(clientJs!.content).not.toMatch(/\bfunction renderCount\b/)
+    })
+
+    test('does not emit inlined arrow function constant in client JS', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MyComponent() {
+          const [count, setCount] = createSignal(0)
+          const renderCount = () => <span>{count()}</span>
+          return <div onClick={() => setCount(n => n + 1)}>{renderCount()}</div>
+        }
+      `
+
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+
+      // The constant 'renderCount' should not appear in client JS
+      expect(clientJs!.content).not.toMatch(/\bconst renderCount\b/)
+    })
+
+    test('end-to-end: calendar-style pattern compiles correctly', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        type Week = { days: { date: number; label: string }[] }
+
+        export function Calendar() {
+          const [month, setMonth] = createSignal(0)
+          const [weeks0] = createSignal<Week[]>([])
+          const [weeks1] = createSignal<Week[]>([])
+
+          function renderMonthGrid(weeks: Week[]) {
+            return (
+              <table>
+                <tbody>
+                  {weeks.map(week => (
+                    <tr>
+                      {week.days.map(day => (
+                        <td>{day.label}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )
+          }
+
+          return (
+            <div>
+              <span>Month: {month()}</span>
+              {renderMonthGrid(weeks0())}
+              {renderMonthGrid(weeks1())}
+            </div>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'Calendar.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Inlined function should not appear in client JS
+      expect(clientJs!.content).not.toMatch(/\bfunction renderMonthGrid\b/)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')
+      expect(template).toBeDefined()
+      // Both table instances should appear in the template
+      expect(template!.content).toContain('table')
+    })
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -64,6 +64,11 @@ export interface AnalyzerContext {
   typeDefinitions: TypeDefinition[]
   /** Maps constant names to their JSX initializer AST nodes (#547) */
   jsxConstants: Map<string, ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment>
+  /** Maps function names to their JSX return AST and parameter names (#569) */
+  jsxFunctions: Map<string, {
+    jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
+    params: string[]
+  }>
 
   // Props
   propsType: TypeInfo | null
@@ -118,6 +123,7 @@ export function createAnalyzerContext(
     localConstants: [],
     typeDefinitions: [],
     jsxConstants: new Map(),
+    jsxFunctions: new Map(),
 
     propsType: null,
     propsParams: [],

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -696,6 +696,39 @@ function collectTypeAliasDefinition(
 // Function Collection
 // =============================================================================
 
+/**
+ * Extract a single JSX return expression from a function body.
+ * Returns null if the body has multiple returns, conditional returns, or no JSX return.
+ */
+function extractSingleJsxReturn(
+  body: ts.Block
+): ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment | null {
+  let jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment | null = null
+  let returnCount = 0
+
+  function visit(node: ts.Node): void {
+    // Don't descend into nested functions/arrows
+    if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node)) return
+    if (ts.isReturnStatement(node)) {
+      returnCount++
+      if (node.expression) {
+        let expr: ts.Expression = node.expression
+        while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+        if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
+          jsxReturn = expr
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(body, visit)
+
+  // Only inline functions with exactly one return statement
+  if (returnCount !== 1) return null
+  return jsxReturn
+}
+
 function collectFunction(
   node: ts.FunctionDeclaration,
   ctx: AnalyzerContext,
@@ -720,6 +753,19 @@ function collectFunction(
   // Check if function contains JSX
   const containsJsx = body.includes('<') && (body.includes('/>') || body.includes('</'))
 
+  // Store JSX-returning functions for IR-level inlining (#569)
+  let isJsxFunction = false
+  if (containsJsx && node.body) {
+    const jsxReturn = extractSingleJsxReturn(node.body)
+    if (jsxReturn) {
+      isJsxFunction = true
+      ctx.jsxFunctions.set(name, {
+        jsxReturn,
+        params: node.parameters.map(p => p.name.getText(ctx.sourceFile)),
+      })
+    }
+  }
+
   ctx.localFunctions.push({
     name,
     params,
@@ -727,6 +773,7 @@ function collectFunction(
     returnType,
     containsJsx,
     isExported,
+    isJsxFunction: isJsxFunction || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
 }
@@ -811,12 +858,39 @@ function collectConstant(
 
   // Detect JSX initializers and store AST nodes for IR-level inlining (#547)
   let isJsx = false
+  let isJsxFunction = false
   if (node.initializer) {
     let init: ts.Expression = node.initializer
     while (ts.isParenthesizedExpression(init)) init = init.expression
     if (ts.isJsxElement(init) || ts.isJsxSelfClosingElement(init) || ts.isJsxFragment(init)) {
       isJsx = true
       ctx.jsxConstants.set(name, init)
+    }
+
+    // Detect arrow function constants with JSX return (#569)
+    if (ts.isArrowFunction(init)) {
+      const arrowBody = init.body
+      if (ts.isBlock(arrowBody)) {
+        const jsxReturn = extractSingleJsxReturn(arrowBody)
+        if (jsxReturn) {
+          isJsxFunction = true
+          ctx.jsxFunctions.set(name, {
+            jsxReturn,
+            params: init.parameters.map(p => p.name.getText(ctx.sourceFile)),
+          })
+        }
+      } else {
+        // Implicit return: () => <div>...</div>
+        let body: ts.Expression = arrowBody
+        while (ts.isParenthesizedExpression(body)) body = body.expression
+        if (ts.isJsxElement(body) || ts.isJsxSelfClosingElement(body) || ts.isJsxFragment(body)) {
+          isJsxFunction = true
+          ctx.jsxFunctions.set(name, {
+            jsxReturn: body,
+            params: init.parameters.map(p => p.name.getText(ctx.sourceFile)),
+          })
+        }
+      }
     }
   }
 
@@ -852,6 +926,7 @@ function collectConstant(
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     freeIdentifiers,
     isJsx,
+    isJsxFunction: isJsxFunction || undefined,
   })
 }
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -81,6 +81,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 
   for (const constant of ctx.localConstants) {
     if (constant.isJsx) continue  // Inlined at IR level (#547)
+    if (constant.isJsxFunction) continue  // Inlined at call sites (#569)
     if (usedIdentifiers.has(constant.name)) {
       if (!constant.value) {
         neededConstants.push(constant)
@@ -163,6 +164,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 
   // Collect functions
   for (const fn of ctx.localFunctions) {
+    if (fn.isJsxFunction) continue  // Inlined at call sites (#569)
     if (usedIdentifiers.has(fn.name)) {
       declarations.push({
         kind: 'function',

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -661,6 +661,17 @@ function transformExpression(
     }
   }
 
+  // Inline JSX function calls at the IR level (#569)
+  if (ts.isCallExpression(expr)) {
+    const callee = expr.expression
+    if (ts.isIdentifier(callee)) {
+      const jsxFunc = ctx.analyzer.jsxFunctions.get(callee.text)
+      if (jsxFunc) {
+        return transformJsxFunctionCall(expr, jsxFunc, ctx, isClientOnly)
+      }
+    }
+  }
+
   // Regular expression
   const exprText = ctx.getJS(expr)
   const reactive = isReactiveExpression(exprText, ctx, expr)
@@ -682,6 +693,62 @@ function transformExpression(
 // =============================================================================
 // Conditional Transformation
 // =============================================================================
+
+/**
+ * Inline a JSX-returning function call at the IR level (#569).
+ *
+ * Substitutes function parameters with call arguments in getJS output,
+ * then transforms the function's JSX AST — producing proper IR nodes
+ * (loops, conditionals, etc.) with unique scope IDs for each call site.
+ */
+function transformJsxFunctionCall(
+  callExpr: ts.CallExpression,
+  jsxFunc: { jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment; params: string[] },
+  ctx: TransformContext,
+  _isClientOnly: boolean
+): IRNode {
+  // Build substitution map: paramName → argument expression text
+  const substitutions = new Map<string, string>()
+  for (let i = 0; i < jsxFunc.params.length; i++) {
+    const paramName = jsxFunc.params[i]
+    const arg = callExpr.arguments[i]
+    if (arg) {
+      substitutions.set(paramName, ctx.getJS(arg))
+    }
+  }
+
+  // Temporarily override getJS to apply parameter substitutions.
+  // Capture analyzer.getJS (the base implementation) to avoid circular references.
+  const baseGetJS = ctx.analyzer.getJS.bind(ctx.analyzer)
+  const originalCtxGetJS = ctx.getJS
+  const originalAnalyzerGetJS = ctx.analyzer.getJS
+
+  const substitutedGetJS = (node: ts.Node) => {
+    let text = baseGetJS(node)
+    for (const [paramName, argExpr] of substitutions) {
+      text = text.replace(new RegExp(`\\b${paramName}\\b`, 'g'), argExpr)
+    }
+    return text
+  }
+
+  ctx.getJS = substitutedGetJS
+  ctx.analyzer.getJS = substitutedGetJS
+
+  try {
+    const result = transformNode(jsxFunc.jsxReturn, ctx)
+    return result ?? {
+      type: 'expression' as const,
+      expr: 'null',
+      typeInfo: null,
+      reactive: false,
+      slotId: null,
+      loc: getSourceLocation(callExpr, ctx.sourceFile, ctx.filePath),
+    }
+  } finally {
+    ctx.getJS = originalCtxGetJS
+    ctx.analyzer.getJS = originalAnalyzerGetJS
+  }
+}
 
 function transformConditional(
   node: ts.ConditionalExpression,
@@ -824,6 +891,17 @@ function transformConditionalBranch(
     containsJsxInExpression(node.right)
   ) {
     return transformNullishCoalescing(node, ctx)
+  }
+
+  // Inline JSX function calls in conditional branches (#569)
+  if (ts.isCallExpression(node)) {
+    const callee = node.expression
+    if (ts.isIdentifier(callee)) {
+      const jsxFunc = ctx.analyzer.jsxFunctions.get(callee.text)
+      if (jsxFunc) {
+        return transformJsxFunctionCall(node, jsxFunc, ctx, false)
+      }
+    }
   }
 
   // Regular expression (including null)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -374,6 +374,8 @@ export interface FunctionInfo {
   returnType: TypeInfo | null
   containsJsx: boolean
   isExported?: boolean
+  /** When true, this function returns JSX and is inlined at call sites (#569). */
+  isJsxFunction?: boolean
   loc: SourceLocation
 }
 
@@ -389,6 +391,8 @@ export interface ConstantInfo {
   freeIdentifiers?: Set<string>
   /** When true, the initializer is JSX that is inlined into the IR tree at usage sites (#547). */
   isJsx?: boolean
+  /** When true, the initializer is a JSX-returning function inlined at call sites (#569). */
+  isJsxFunction?: boolean
 }
 
 export interface TypeDefinition {


### PR DESCRIPTION
Fixed #569

## Summary

- When a local function returns JSX (single return statement), the compiler now inlines its JSX AST at each call site with parameter substitution
- Produces proper IR nodes (loops, conditionals, reactive expressions) instead of opaque expression nodes, enabling correct `createEffect`/`reconcileTemplates` generation for all call sites
- Supports both `function` declarations and arrow function constants, including implicit return and block body forms

## Changes

| File | Change |
|------|--------|
| `analyzer-context.ts` | Add `jsxFunctions` map to `AnalyzerContext` |
| `analyzer.ts` | Add `extractSingleJsxReturn()` helper; detect JSX-returning functions in `collectFunction()` and arrow function constants in `collectConstant()` |
| `types.ts` | Add `isJsxFunction` flag to `FunctionInfo` and `ConstantInfo` |
| `jsx-to-ir.ts` | Add `transformJsxFunctionCall()` with parameter substitution; detect JSX function calls in `transformExpression()` and `transformConditionalBranch()` |
| `generate-init.ts` | Skip inlined function definitions from client JS emission |
| `jsx-function-inlining.test.ts` | 15 tests covering analyzer detection, IR transformation, and client JS output |

## Known Limitations

- **Single JSX return only**: Functions with multiple/conditional returns are not inlined (fall through to existing behavior)
- **Parameter name shadowing**: If a `.map()` callback parameter has the same name as a function parameter, text substitution may conflict (unlikely in practice)

## Test plan

- [x] `packages/jsx`: 455 pass, 0 fail
- [x] `packages/adapter-tests`: 69 pass, 0 fail
- [x] Full build succeeds
- [ ] Calendar component refactoring (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)