### PR TITLE
Fix #570: emit BF045 error for component nodes inside JSX props

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -209,7 +209,7 @@ Add `/* @client */` to evaluate on the client side:
 
 ---
 
-## Component Errors (BF040–BF043)
+## Component Errors (BF040–BF045)
 
 ### BF040 — Component Not Found
 
@@ -259,6 +259,50 @@ function Child({ initialCount }: Props) {
 }
 ```
 
+### BF044 — Signal/Memo Getter Not Called
+
+**Trigger:** A signal or memo getter is passed as a value without calling it, so the receiving side gets the getter function instead of the current value.
+
+```tsx
+// ⚠️ BF044
+<Child count={count} />  // Passing getter function, not the value
+```
+
+**Fix:** Call the getter:
+
+```tsx
+// ✅ Fixed
+<Child count={count()} />
+```
+
+### BF045 — Component in JSX Prop
+
+**Trigger:** A component node (e.g., `<Button />`) appears inside a JSX prop passed to another component. If the target component is stateless (no `"use client"`), the nested component will not hydrate because `initChild` silently no-ops when the wrapper has no hydration boundary.
+
+```tsx
+// ⚠️ BF045
+"use client"
+export function App() {
+  const [val, setVal] = createSignal('')
+  return <Layout controls={<Button label="ok" />} />
+  //                        ^^^^^^^ component inside JSX prop
+}
+```
+
+Native elements (e.g., `<span>`, `<input>`) in JSX props are fine — they get parent-owned slot IDs and hydrate correctly. Only component nodes trigger this error.
+
+**Fix options:**
+
+1. Add `"use client"` to the wrapper component so it gets a hydration boundary:
+
+```tsx
+// ✅ Layout.tsx
+"use client"
+export function Layout(props: LayoutProps) { ... }
+```
+
+2. Inline the wrapper's template into the parent component.
+
 ---
 
 ## Suppressing Warnings
@@ -300,3 +344,5 @@ function Component({ checked }: Props) {
 | BF041 | Error | Circular dependency |
 | BF042 | Error | Invalid component name |
 | BF043 | Warning | Props destructuring breaks reactivity |
+| BF044 | Error | Signal/memo getter passed without calling it |
+| BF045 | Error | Component in JSX prop may cause silent hydration failure |

--- a/packages/jsx/src/__tests__/ir-jsx-props.test.ts
+++ b/packages/jsx/src/__tests__/ir-jsx-props.test.ts
@@ -213,7 +213,7 @@ describe('JSX props (#559)', () => {
       }
     })
 
-    test('component references in JSX props are imported in client JS', () => {
+    test('component references in JSX props are imported in client JS (with BF045)', () => {
       const source = `
         'use client'
         import { createSignal } from '@barefootjs/dom'
@@ -226,11 +226,14 @@ describe('JSX props (#559)', () => {
         }
       `
       const result = compileJSXSync(source, 'App.tsx', { adapter })
-      expect(result.errors).toHaveLength(0)
+      // BF045: component inside JSX prop
+      const bf045Errors = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045Errors).toHaveLength(1)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       // Should import Button component referenced inside JSX prop
+      // (compilation continues despite BF045 — it's a diagnostic, not a hard stop)
       expect(clientJs!.content).toContain('@bf-child:Button')
     })
 
@@ -262,6 +265,100 @@ describe('JSX props (#559)', () => {
       // Event handler should be extracted into addEventListener
       expect(clientJs!.content).toContain('addEventListener')
       expect(clientJs!.content).toContain('change')
+    })
+  })
+
+  describe('BF045: component in JSX prop (#570)', () => {
+    test('component in JSX prop emits BF045', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return <Layout controls={<Button label="ok" />} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(1)
+      expect(bf045[0].message).toContain("'controls'")
+      expect(bf045[0].message).toContain("'Layout'")
+    })
+
+    test('multiple components in JSX props emit BF045 for each', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return <Layout controls={<Select />} extra={<Button />} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(2)
+    })
+
+    test('reactive expression only (no component) does not emit BF045', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [count, setCount] = createSignal(0)
+          return <Layout controls={<span>{count()}</span>} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(0)
+    })
+
+    test('event handler only (no component) does not emit BF045', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return <Layout controls={<button onClick={() => setVal('x')}>Go</button>} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(0)
+    })
+
+    test('static JSX only (no component) does not emit BF045', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return <Layout controls={<input type="text" />} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(0)
+    })
+
+    test('nested component inside element emits BF045', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function App() {
+          const [val, setVal] = createSignal('')
+          return <Layout controls={<div><Button /></div>} />
+        }
+      `
+      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const bf045 = result.errors.filter(e => e.code === 'BF045')
+      expect(bf045).toHaveLength(1)
     })
   })
 })

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -109,6 +109,7 @@ export async function compileJSX(
   })
 
   const clientJs = generateClientJs(componentIR, undefined, undefined, options.localImportPrefixes)
+  errors.push(...componentIR.errors)
   if (clientJs) {
     files.push({
       path: entryPath.replace(/\.tsx?$/, '.client.js'),
@@ -228,6 +229,7 @@ function compileMultipleComponentsSync(
       component,
       clientJs: generateClientJs(componentIR, componentNames, usedAsChild, options.localImportPrefixes) || undefined,
     })
+    errors.push(...componentIR.errors)
   }
 
   if (allOutputs.length === 0) {
@@ -454,6 +456,7 @@ export function compileJSXSync(
   })
 
   const clientJs = generateClientJs(componentIR, undefined, undefined, options.localImportPrefixes)
+  errors.push(...componentIR.errors)
   if (clientJs) {
     files.push({
       path: filePath.replace(/\.tsx?$/, '.client.js'),

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -40,6 +40,7 @@ export const ErrorCodes = {
   INVALID_COMPONENT_NAME: 'BF042',
   PROPS_DESTRUCTURING: 'BF043',
   SIGNAL_GETTER_NOT_CALLED: 'BF044',
+  COMPONENT_IN_JSX_PROP: 'BF045',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -78,6 +79,8 @@ const errorMessages: Record<ErrorCode, string> = {
     'Props destructuring in function parameters breaks reactivity. Use props object directly.',
   [ErrorCodes.SIGNAL_GETTER_NOT_CALLED]:
     'Signal/memo getter passed without calling it. Use getter() to read the value.',
+  [ErrorCodes.COMPONENT_IN_JSX_PROP]:
+    'Component in JSX prop may cause silent hydration failure. The target component needs "use client" or the wrapper template should be inlined.',
 }
 
 // =============================================================================

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -8,6 +8,20 @@ import { attrValueToString, quotePropName } from './utils'
 import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectLoopChildEvents } from './reactivity'
 import { irToHtmlTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue } from './prop-handling'
+import { ErrorCodes, createError } from '../errors'
+
+/** Check whether an array of IR nodes contains any component nodes (recursively). */
+function jsxChildrenContainComponent(nodes: IRNode[]): boolean {
+  for (const node of nodes) {
+    if (node.type === 'component') return true
+    if (node.type === 'element' && jsxChildrenContainComponent(node.children)) return true
+    if (node.type === 'fragment' && jsxChildrenContainComponent(node.children)) return true
+    if (node.type === 'conditional') {
+      if (jsxChildrenContainComponent([node.whenTrue, node.whenFalse])) return true
+    }
+  }
+  return false
+}
 
 /** Build rest spread names from context (rest/props spreads handled by applyRestAttrs, not spreadAttrs). */
 function buildRestSpreadNames(ctx: ClientJsContext): Set<string> {
@@ -221,6 +235,20 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
       })
       for (const child of node.children) {
         collectElements(child, ctx)
+      }
+      // Detect component nodes inside JSX prop children (BF045)
+      for (const prop of node.props) {
+        if (prop.jsxChildren && jsxChildrenContainComponent(prop.jsxChildren)) {
+          ctx.warnings.push(createError(
+            ErrorCodes.COMPONENT_IN_JSX_PROP,
+            prop.loc,
+            {
+              message: `Component found inside JSX prop '${prop.name}' passed to '${node.name}'. ` +
+                `If '${node.name}' is stateless (no "use client"), nested components will not hydrate. ` +
+                `Add "use client" to '${node.name}' or inline its template.`,
+            }
+          ))
+        }
       }
       // Traverse JSX prop children so events, reactive expressions,
       // and nested components inside JSX props are collected

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -18,6 +18,7 @@ import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
 export function generateClientJs(ir: ComponentIR, siblingComponents?: string[], usedAsChild?: Set<string>, localImportPrefixes?: string[]): string {
   const ctx = createContext(ir)
   collectElements(ir.root, ctx)
+  ir.errors.push(...ctx.warnings)
 
   if (!needsClientJs(ctx)) {
     // Stateless components still need template registration so renderChild() can find them (#435)
@@ -101,6 +102,7 @@ function createContext(ir: ComponentIR): ClientJsContext {
     clientOnlyConditionals: [],
     providerSetups: [],
     restAttrElements: [],
+    warnings: [],
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -12,6 +12,7 @@ import type {
   FunctionInfo,
   ConstantInfo,
   ParamInfo,
+  CompilerError,
 } from '../types'
 
 export interface ClientJsContext {
@@ -41,6 +42,8 @@ export interface ClientJsContext {
   providerSetups: Array<{ contextName: string; valueExpr: string }>
   /** HTML elements with unresolved spread attrs (open types, need applyRestAttrs at runtime) */
   restAttrElements: RestAttrElement[]
+  /** Warnings collected during client JS generation (e.g., BF045) */
+  warnings: CompilerError[]
 }
 
 export interface InteractiveElement {

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -293,6 +293,7 @@ interface TemplateAdapter {
 | BF031 | Props type mismatch |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |
+| BF045 | Component in JSX prop may cause silent hydration failure |
 
 ### Error Format
 

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -49,7 +49,7 @@ Test the compiler's internal logic: parsing, analysis, transformation rules, and
 ### What to test here
 
 - **Analysis:** Signal/memo/effect detection, props extraction, import resolution
-- **Error codes:** BF001, BF002, BF021, BF043, BF044, etc.
+- **Error codes:** BF001, BF002, BF021, BF043, BF044, BF045, etc.
 - **Expression parsing:** Ternary evaluation, filter/sort pattern detection, constant resolution
 - **Client JS generation:** Import deduplication, module combination, declaration ordering
 - **CSS processing:** `@layer` prefixing, type stripping


### PR DESCRIPTION
Fixed #570

## Summary

- Add **BF045** (`COMPONENT_IN_JSX_PROP`) compiler diagnostic that detects component nodes (e.g., `<Button />`, `<Select />`) inside JSX props passed to wrapper components
- When a `"use client"` component passes a component node as a JSX prop to a stateless wrapper, `initChild` silently no-ops because the wrapper has no hydration boundary (`bf-s`). BF045 warns about this pattern so developers can add `"use client"` to the wrapper or inline its template
- Native elements in JSX props (e.g., `<span>{count()}</span>`) are not flagged — they work correctly via `^`-prefixed slot IDs

## Changed files

| File | Change |
|------|--------|
| `packages/jsx/src/errors.ts` | Add `COMPONENT_IN_JSX_PROP: 'BF045'` + message |
| `packages/jsx/src/ir-to-client-js/types.ts` | Add `warnings: CompilerError[]` to `ClientJsContext` |
| `packages/jsx/src/ir-to-client-js/collect-elements.ts` | Add `jsxChildrenContainComponent()` + emit BF045 |
| `packages/jsx/src/ir-to-client-js/index.ts` | Init `warnings: []`, propagate to `ir.errors` |
| `packages/jsx/src/compiler.ts` | Merge `componentIR.errors` into result `errors` |
| `packages/jsx/src/__tests__/ir-jsx-props.test.ts` | Add 6 BF045 tests, update existing test expectation |

## Test plan

- [x] `bun test` — 446/446 tests pass
- [x] BF045 emitted for component in JSX prop (`<Layout controls={<Button />} />`)
- [x] BF045 emitted per-prop when multiple JSX props contain components
- [x] No BF045 for native elements (`<span>`, `<input>`, `<button>`)
- [x] No BF045 for reactive expressions or event handlers only
- [x] BF045 emitted for nested component inside element (`<div><Button /></div>`)
- [x] Compilation continues despite BF045 (diagnostic, not hard stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)