### PR TITLE
Added @barefootjs/chart

### DIFF
--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -106,6 +106,7 @@ jobs:
           cd packages/dom && bun run build
           cd ../jsx && bun run build
           cd ../form && bun run build
+          cd ../chart && bun run build
           cd ../hono && bun run build
 
       - name: Build site/ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - 'packages/jsx/**'
       - 'packages/form/**'
       - 'packages/test/**'
+      - 'packages/chart/**'
       - 'packages/adapter-tests/**'
       - 'ui/**'
       - 'site/ui/**'
@@ -19,6 +20,7 @@ on:
       - 'packages/jsx/**'
       - 'packages/form/**'
       - 'packages/test/**'
+      - 'packages/chart/**'
       - 'packages/adapter-tests/**'
       - 'ui/**'
       - 'site/ui/**'
@@ -89,6 +91,7 @@ jobs:
           cd packages/dom && bun run build
           cd ../jsx && bun run build
           cd ../form && bun run build
+          cd ../chart && bun run build
           cd ../hono && bun run build
 
       - name: Build site/ui

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@barefootjs/chart",
+  "version": "0.0.1",
+  "description": "SVG chart components for BarefootJS with signal-based reactivity",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "test": "bun test",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "chart",
+    "bar-chart",
+    "svg",
+    "signals",
+    "reactive",
+    "barefoot"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kfly8/barefootjs",
+    "directory": "packages/chart"
+  },
+  "peerDependencies": {
+    "@barefootjs/dom": ">=0.0.1"
+  },
+  "dependencies": {
+    "d3-scale": "^4.0.2",
+    "d3-array": "^3.2.4"
+  },
+  "devDependencies": {
+    "@types/d3-scale": "^4.0.8",
+    "@types/d3-array": "^3.2.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/chart/src/__tests__/bar-chart.test.ts
+++ b/packages/chart/src/__tests__/bar-chart.test.ts
@@ -4,9 +4,13 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator'
 // Register happy-dom globals for SVG support
 GlobalRegistrator.register()
 
-import { createBarChart } from '../bar-chart'
-import { applyChartCSSVariables } from '../chart-container'
-import type { ChartConfig, BarChartOptions } from '../types'
+import { applyChartCSSVariables, initChartContainer } from '../chart-container'
+import { initBarChart } from '../bar-chart'
+import { initBar } from '../bar'
+import { initCartesianGrid } from '../cartesian-grid'
+import { initXAxis } from '../x-axis'
+import { initYAxis } from '../y-axis'
+import type { ChartConfig } from '../types'
 
 const chartConfig: ChartConfig = {
   desktop: { label: 'Desktop', color: 'hsl(221 83% 53%)' },
@@ -24,12 +28,58 @@ const chartData = [
 
 function createContainer(): HTMLElement {
   const el = document.createElement('div')
-  // happy-dom doesn't compute layout, so set explicit dimensions
   Object.defineProperty(el, 'getBoundingClientRect', {
     value: () => ({ width: 400, height: 200, top: 0, left: 0, right: 400, bottom: 200, x: 0, y: 0, toJSON: () => {} }),
   })
   document.body.appendChild(el)
   return el
+}
+
+/**
+ * Helper: initialize a full chart by calling init functions in sequence
+ * (simulates what the compiler does with initChild calls)
+ */
+function initFullChart(
+  container: HTMLElement,
+  options: {
+    data: Record<string, unknown>[]
+    config: ChartConfig
+    bars: { dataKey: string; fill?: string; radius?: number }[]
+    xAxis?: { dataKey: string; tickFormatter?: (v: string) => string; hide?: boolean }
+    yAxis?: boolean | { hide?: boolean; tickFormatter?: (v: number) => string }
+    grid?: { vertical?: boolean; horizontal?: boolean }
+  },
+): void {
+  // Init ChartContainer (applies CSS variables, provides config context)
+  initChartContainer(container, { config: options.config })
+
+  // Init BarChart (provides chart context to children)
+  initBarChart(container, { data: options.data })
+
+  // Init grid
+  if (options.grid) {
+    const gridScope = document.createElement('span')
+    initCartesianGrid(gridScope, options.grid)
+  }
+
+  // Init X axis
+  if (options.xAxis) {
+    const xScope = document.createElement('span')
+    initXAxis(xScope, options.xAxis)
+  }
+
+  // Init Y axis
+  if (options.yAxis) {
+    const yScope = document.createElement('span')
+    const yProps = typeof options.yAxis === 'boolean' ? {} : options.yAxis
+    initYAxis(yScope, yProps)
+  }
+
+  // Init bars
+  for (const bar of options.bars) {
+    const barScope = document.createElement('span')
+    initBar(barScope, bar)
+  }
 }
 
 describe('applyChartCSSVariables', () => {
@@ -42,14 +92,14 @@ describe('applyChartCSSVariables', () => {
   })
 })
 
-describe('createBarChart', () => {
+describe('initBarChart + child components', () => {
   let container: HTMLElement
 
   beforeEach(() => {
     container = createContainer()
   })
 
-  const baseOptions: BarChartOptions = {
+  const baseOptions = {
     data: chartData,
     config: chartConfig,
     bars: [{ dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 }],
@@ -59,26 +109,26 @@ describe('createBarChart', () => {
   }
 
   test('creates an SVG element inside the container', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     const svg = container.querySelector('svg')
     expect(svg).not.toBeNull()
   })
 
   test('renders the correct number of bar rects', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     const rects = container.querySelectorAll('rect[data-key="desktop"]')
     expect(rects.length).toBe(chartData.length)
   })
 
   test('renders X axis labels', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     const texts = container.querySelectorAll('.chart-x-axis text')
     expect(texts.length).toBe(chartData.length)
     expect(texts[0].textContent).toBe('Jan')
   })
 
   test('supports tickFormatter for X axis', () => {
-    createBarChart(container, {
+    initFullChart(container, {
       ...baseOptions,
       xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 1) },
     })
@@ -87,19 +137,19 @@ describe('createBarChart', () => {
   })
 
   test('renders Y axis labels', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     const texts = container.querySelectorAll('.chart-y-axis text')
     expect(texts.length).toBeGreaterThan(0)
   })
 
   test('renders grid lines when grid option is provided', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     const lines = container.querySelectorAll('.chart-grid line')
     expect(lines.length).toBeGreaterThan(0)
   })
 
   test('supports multiple bar series', () => {
-    createBarChart(container, {
+    initFullChart(container, {
       ...baseOptions,
       bars: [
         { dataKey: 'desktop', fill: 'var(--color-desktop)' },
@@ -112,15 +162,8 @@ describe('createBarChart', () => {
     expect(mobileBars.length).toBe(chartData.length)
   })
 
-  test('destroy removes the SVG', () => {
-    const instance = createBarChart(container, baseOptions)
-    expect(container.querySelector('svg')).not.toBeNull()
-    instance.destroy()
-    expect(container.querySelector('svg')).toBeNull()
-  })
-
   test('applies CSS variables from config', () => {
-    createBarChart(container, baseOptions)
+    initFullChart(container, baseOptions)
     expect(container.style.getPropertyValue('--color-desktop')).toBe('hsl(221 83% 53%)')
   })
 })

--- a/packages/chart/src/__tests__/bar-chart.test.ts
+++ b/packages/chart/src/__tests__/bar-chart.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+// Register happy-dom globals for SVG support
+GlobalRegistrator.register()
+
+import { createBarChart } from '../bar-chart'
+import { applyChartCSSVariables } from '../chart-container'
+import type { ChartConfig, BarChartOptions } from '../types'
+
+const chartConfig: ChartConfig = {
+  desktop: { label: 'Desktop', color: 'hsl(221 83% 53%)' },
+  mobile: { label: 'Mobile', color: 'hsl(280 65% 60%)' },
+}
+
+const chartData = [
+  { month: 'Jan', desktop: 186, mobile: 80 },
+  { month: 'Feb', desktop: 305, mobile: 200 },
+  { month: 'Mar', desktop: 237, mobile: 120 },
+  { month: 'Apr', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'Jun', desktop: 214, mobile: 140 },
+]
+
+function createContainer(): HTMLElement {
+  const el = document.createElement('div')
+  // happy-dom doesn't compute layout, so set explicit dimensions
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({ width: 400, height: 200, top: 0, left: 0, right: 400, bottom: 200, x: 0, y: 0, toJSON: () => {} }),
+  })
+  document.body.appendChild(el)
+  return el
+}
+
+describe('applyChartCSSVariables', () => {
+  test('sets CSS custom properties on the container', () => {
+    const el = document.createElement('div')
+    applyChartCSSVariables(el, chartConfig)
+
+    expect(el.style.getPropertyValue('--color-desktop')).toBe('hsl(221 83% 53%)')
+    expect(el.style.getPropertyValue('--color-mobile')).toBe('hsl(280 65% 60%)')
+  })
+})
+
+describe('createBarChart', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = createContainer()
+  })
+
+  const baseOptions: BarChartOptions = {
+    data: chartData,
+    config: chartConfig,
+    bars: [{ dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 }],
+    xAxis: { dataKey: 'month' },
+    yAxis: true,
+    grid: { vertical: false },
+  }
+
+  test('creates an SVG element inside the container', () => {
+    createBarChart(container, baseOptions)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+  })
+
+  test('renders the correct number of bar rects', () => {
+    createBarChart(container, baseOptions)
+    const rects = container.querySelectorAll('rect[data-key="desktop"]')
+    expect(rects.length).toBe(chartData.length)
+  })
+
+  test('renders X axis labels', () => {
+    createBarChart(container, baseOptions)
+    const texts = container.querySelectorAll('.chart-x-axis text')
+    expect(texts.length).toBe(chartData.length)
+    expect(texts[0].textContent).toBe('Jan')
+  })
+
+  test('supports tickFormatter for X axis', () => {
+    createBarChart(container, {
+      ...baseOptions,
+      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 1) },
+    })
+    const texts = container.querySelectorAll('.chart-x-axis text')
+    expect(texts[0].textContent).toBe('J')
+  })
+
+  test('renders Y axis labels', () => {
+    createBarChart(container, baseOptions)
+    const texts = container.querySelectorAll('.chart-y-axis text')
+    expect(texts.length).toBeGreaterThan(0)
+  })
+
+  test('renders grid lines when grid option is provided', () => {
+    createBarChart(container, baseOptions)
+    const lines = container.querySelectorAll('.chart-grid line')
+    expect(lines.length).toBeGreaterThan(0)
+  })
+
+  test('supports multiple bar series', () => {
+    createBarChart(container, {
+      ...baseOptions,
+      bars: [
+        { dataKey: 'desktop', fill: 'var(--color-desktop)' },
+        { dataKey: 'mobile', fill: 'var(--color-mobile)' },
+      ],
+    })
+    const desktopBars = container.querySelectorAll('rect[data-key="desktop"]')
+    const mobileBars = container.querySelectorAll('rect[data-key="mobile"]')
+    expect(desktopBars.length).toBe(chartData.length)
+    expect(mobileBars.length).toBe(chartData.length)
+  })
+
+  test('destroy removes the SVG', () => {
+    const instance = createBarChart(container, baseOptions)
+    expect(container.querySelector('svg')).not.toBeNull()
+    instance.destroy()
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  test('applies CSS variables from config', () => {
+    createBarChart(container, baseOptions)
+    expect(container.style.getPropertyValue('--color-desktop')).toBe('hsl(221 83% 53%)')
+  })
+})

--- a/packages/chart/src/bar-chart.ts
+++ b/packages/chart/src/bar-chart.ts
@@ -1,37 +1,31 @@
-import type { BarChartOptions, BarChartInstance } from './types'
+import { createSignal, createEffect, provideContext, useContext } from '@barefootjs/dom'
+import type { BarRegistration } from './types'
+import { BarChartContext, ChartConfigContext } from './context'
 import { createBandScale, createLinearScale } from './utils/scales'
-import { renderGrid } from './cartesian-grid'
-import { renderXAxis } from './x-axis'
-import { renderYAxis } from './y-axis'
-import { renderBars } from './bar'
-import { createTooltip } from './tooltip'
-import { applyChartCSSVariables } from './chart-container'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 const DEFAULT_MARGIN = { top: 10, right: 12, bottom: 30, left: 40 }
-const ASPECT_RATIO = 0.5 // height = width * 0.5
+const ASPECT_RATIO = 0.5
 
 /**
- * Create a bar chart inside the given container element.
- * Returns a handle for updating or destroying the chart.
+ * Init function for BarChart component.
+ * Creates SVG, provides context to children (Bar, XAxis, etc.).
  */
-export function createBarChart(
-  container: HTMLElement,
-  options: BarChartOptions,
-): BarChartInstance {
-  applyChartCSSVariables(container, options.config)
+export function initBarChart(scope: Element, props: Record<string, unknown>): void {
+  const data = (props.data as Record<string, unknown>[]) ?? []
+  const { config } = useContext(ChartConfigContext)
 
-  const containerRect = container.getBoundingClientRect()
+  const el = scope as HTMLElement
+  const containerRect = el.getBoundingClientRect()
   const width = containerRect.width || 500
   const height = Math.round(width * ASPECT_RATIO)
 
-  // Set explicit height on container so layout is stable
-  container.style.height = `${height}px`
-  container.style.minHeight = ''
+  el.style.height = `${height}px`
+  el.style.minHeight = ''
 
   const margin = DEFAULT_MARGIN
-  const innerWidth = width - margin.left - margin.right
-  const innerHeight = height - margin.top - margin.bottom
+  const iw = width - margin.left - margin.right
+  const ih = height - margin.top - margin.bottom
 
   const svg = document.createElementNS(SVG_NS, 'svg')
   svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
@@ -42,59 +36,45 @@ export function createBarChart(
   const g = document.createElementNS(SVG_NS, 'g')
   g.setAttribute('transform', `translate(${margin.left},${margin.top})`)
   svg.appendChild(g)
+  el.appendChild(svg)
 
-  const xDataKey = options.xAxis?.dataKey ?? ''
-  const barDataKeys = options.bars.map((b) => b.dataKey)
-  const xScale = createBandScale(options.data, xDataKey, innerWidth)
-  const yScale = createLinearScale(options.data, barDataKeys, innerHeight)
+  const [bars, setBars] = createSignal<BarRegistration[]>([])
+  const [xDataKey, setXDataKey] = createSignal('')
+  const [xScale, setXScale] = createSignal<ReturnType<typeof createBandScale> | null>(null)
+  const [yScale, setYScale] = createSignal<ReturnType<typeof createLinearScale> | null>(null)
 
-  if (options.grid) {
-    renderGrid(g, innerWidth, innerHeight, yScale, options.grid)
+  const registerBar = (bar: BarRegistration) => {
+    setBars((prev) => [...prev, bar])
   }
 
-  if (options.xAxis) {
-    renderXAxis(g, xScale, innerHeight, options.xAxis)
+  const unregisterBar = (dataKey: string) => {
+    setBars((prev) => prev.filter((b) => b.dataKey !== dataKey))
   }
 
-  if (options.yAxis) {
-    const yAxisConfig =
-      typeof options.yAxis === 'boolean' ? {} : options.yAxis
-    renderYAxis(g, yScale, yAxisConfig)
-  }
+  provideContext(BarChartContext, {
+    svgGroup: () => g,
+    container: () => el,
+    data: () => data,
+    xDataKey,
+    xScale,
+    yScale,
+    innerWidth: () => iw,
+    innerHeight: () => ih,
+    config: () => config,
+    bars,
+    registerBar,
+    unregisterBar,
+    setXDataKey,
+  })
 
-  renderBars(g, options.data, options.bars, xScale, yScale, innerHeight, xDataKey)
-
-  let tooltipHandle: { destroy: () => void } | null = null
-  if (options.tooltip) {
-    const tooltipConfig =
-      typeof options.tooltip === 'boolean' ? {} : options.tooltip
-    tooltipHandle = createTooltip(
-      container,
-      svg,
-      g,
-      options.data,
-      options.bars,
-      options.config,
-      xScale,
-      yScale,
-      tooltipConfig,
-      xDataKey,
-    )
-  }
-
-  container.appendChild(svg)
-
-  return {
-    update(_newOptions) {
-      // Full re-render for simplicity
-      this.destroy()
-      const instance = createBarChart(container, { ...options, ..._newOptions })
-      this.update = instance.update
-      this.destroy = instance.destroy
-    },
-    destroy() {
-      tooltipHandle?.destroy()
-      svg.remove()
-    },
-  }
+  // Recompute scales when bars or xDataKey change
+  createEffect(() => {
+    const currentBars = bars()
+    const key = xDataKey()
+    if (!key || currentBars.length === 0) return
+    // Wrap in arrow functions: D3 scales are functions, and signal setters
+    // interpret function args as updater functions
+    setXScale(() => createBandScale(data, key, iw))
+    setYScale(() => createLinearScale(data, currentBars.map((b) => b.dataKey), ih))
+  })
 }

--- a/packages/chart/src/bar-chart.ts
+++ b/packages/chart/src/bar-chart.ts
@@ -1,0 +1,100 @@
+import type { BarChartOptions, BarChartInstance } from './types'
+import { createBandScale, createLinearScale } from './utils/scales'
+import { renderGrid } from './cartesian-grid'
+import { renderXAxis } from './x-axis'
+import { renderYAxis } from './y-axis'
+import { renderBars } from './bar'
+import { createTooltip } from './tooltip'
+import { applyChartCSSVariables } from './chart-container'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const DEFAULT_MARGIN = { top: 10, right: 12, bottom: 30, left: 40 }
+const ASPECT_RATIO = 0.5 // height = width * 0.5
+
+/**
+ * Create a bar chart inside the given container element.
+ * Returns a handle for updating or destroying the chart.
+ */
+export function createBarChart(
+  container: HTMLElement,
+  options: BarChartOptions,
+): BarChartInstance {
+  applyChartCSSVariables(container, options.config)
+
+  const containerRect = container.getBoundingClientRect()
+  const width = containerRect.width || 500
+  const height = Math.round(width * ASPECT_RATIO)
+
+  // Set explicit height on container so layout is stable
+  container.style.height = `${height}px`
+  container.style.minHeight = ''
+
+  const margin = DEFAULT_MARGIN
+  const innerWidth = width - margin.left - margin.right
+  const innerHeight = height - margin.top - margin.bottom
+
+  const svg = document.createElementNS(SVG_NS, 'svg')
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+  svg.style.width = '100%'
+  svg.style.height = `${height}px`
+  svg.style.display = 'block'
+
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('transform', `translate(${margin.left},${margin.top})`)
+  svg.appendChild(g)
+
+  const xDataKey = options.xAxis?.dataKey ?? ''
+  const barDataKeys = options.bars.map((b) => b.dataKey)
+  const xScale = createBandScale(options.data, xDataKey, innerWidth)
+  const yScale = createLinearScale(options.data, barDataKeys, innerHeight)
+
+  if (options.grid) {
+    renderGrid(g, innerWidth, innerHeight, yScale, options.grid)
+  }
+
+  if (options.xAxis) {
+    renderXAxis(g, xScale, innerHeight, options.xAxis)
+  }
+
+  if (options.yAxis) {
+    const yAxisConfig =
+      typeof options.yAxis === 'boolean' ? {} : options.yAxis
+    renderYAxis(g, yScale, yAxisConfig)
+  }
+
+  renderBars(g, options.data, options.bars, xScale, yScale, innerHeight, xDataKey)
+
+  let tooltipHandle: { destroy: () => void } | null = null
+  if (options.tooltip) {
+    const tooltipConfig =
+      typeof options.tooltip === 'boolean' ? {} : options.tooltip
+    tooltipHandle = createTooltip(
+      container,
+      svg,
+      g,
+      options.data,
+      options.bars,
+      options.config,
+      xScale,
+      yScale,
+      tooltipConfig,
+      xDataKey,
+    )
+  }
+
+  container.appendChild(svg)
+
+  return {
+    update(_newOptions) {
+      // Full re-render for simplicity
+      this.destroy()
+      const instance = createBarChart(container, { ...options, ..._newOptions })
+      this.update = instance.update
+      this.destroy = instance.destroy
+    },
+    destroy() {
+      tooltipHandle?.destroy()
+      svg.remove()
+    },
+  }
+}

--- a/packages/chart/src/bar.ts
+++ b/packages/chart/src/bar.ts
@@ -1,34 +1,72 @@
-import type { BarConfig } from './types'
-import type { ScaleBand, ScaleLinear } from 'd3-scale'
+import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
+import { BarChartContext } from './context'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
- * Render bar rectangles for all series into an SVG group.
+ * Init function for Bar component.
+ * Registers itself with BarChart context and renders bar rects.
+ * Props are read inside effects to support reactive signal-driven values.
  */
-export function renderBars(
-  parent: SVGGElement,
-  data: Record<string, unknown>[],
-  bars: BarConfig[],
-  xScale: ScaleBand<string>,
-  yScale: ScaleLinear<number, number>,
-  height: number,
-  xDataKey: string,
-): void {
-  const bandwidth = xScale.bandwidth()
-  const barWidth = bars.length > 1 ? bandwidth / bars.length : bandwidth
+export function initBar(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
 
-  for (let barIdx = 0; barIdx < bars.length; barIdx++) {
-    const bar = bars[barIdx]
-    const g = document.createElementNS(SVG_NS, 'g')
-    g.setAttribute('class', `chart-bar chart-bar-${bar.dataKey}`)
+  let currentDataKey: string | null = null
+
+  // Registration effect: re-register when dataKey changes
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const fill = (props.fill as string) ?? 'currentColor'
+    const radius = (props.radius as number) ?? 0
+
+    if (currentDataKey !== null) {
+      ctx.unregisterBar(currentDataKey)
+    }
+    ctx.registerBar({ dataKey, fill, radius })
+    currentDataKey = dataKey
+  })
+
+  onCleanup(() => {
+    if (currentDataKey !== null) ctx.unregisterBar(currentDataKey)
+  })
+
+  // Rendering effect: re-render when signals or props change
+  let barGroup: SVGGElement | null = null
+
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const fill = (props.fill as string) ?? 'currentColor'
+    const radius = (props.radius as number) ?? 0
+
+    const g = ctx.svgGroup()
+    const xs = ctx.xScale()
+    const ys = ctx.yScale()
+    if (!g || !xs || !ys) return
+
+    // Clear previous bars
+    if (barGroup) {
+      barGroup.remove()
+      barGroup = null
+    }
+
+    const data = ctx.data()
+    const xKey = ctx.xDataKey()
+    const allBars = ctx.bars()
+    const barCount = allBars.length
+    const bandwidth = xs.bandwidth()
+    const barWidth = barCount > 1 ? bandwidth / barCount : bandwidth
+    const barIndex = allBars.findIndex((b) => b.dataKey === dataKey)
+    const innerHeight = ctx.innerHeight()
+
+    barGroup = document.createElementNS(SVG_NS, 'g')
+    barGroup.setAttribute('class', `chart-bar chart-bar-${dataKey}`)
 
     for (const datum of data) {
-      const xValue = String(datum[xDataKey])
-      const yValue = Number(datum[bar.dataKey]) || 0
-      const x = (xScale(xValue) ?? 0) + barIdx * barWidth
-      const y = yScale(yValue)
-      const barHeight = height - y
+      const xValue = String(datum[xKey])
+      const yValue = Number(datum[dataKey]) || 0
+      const x = (xs(xValue) ?? 0) + barIndex * barWidth
+      const y = ys(yValue)
+      const barHeight = innerHeight - y
 
       if (barHeight <= 0) continue
 
@@ -37,20 +75,20 @@ export function renderBars(
       rect.setAttribute('y', String(y))
       rect.setAttribute('width', String(barWidth))
       rect.setAttribute('height', String(barHeight))
-      rect.setAttribute('fill', bar.fill ?? 'currentColor')
+      rect.setAttribute('fill', fill)
 
-      if (bar.radius && bar.radius > 0) {
-        rect.setAttribute('rx', String(bar.radius))
-        rect.setAttribute('ry', String(bar.radius))
+      if (radius > 0) {
+        rect.setAttribute('rx', String(radius))
+        rect.setAttribute('ry', String(radius))
       }
 
       rect.setAttribute('data-x', xValue)
       rect.setAttribute('data-y', String(yValue))
-      rect.setAttribute('data-key', bar.dataKey)
+      rect.setAttribute('data-key', dataKey)
 
-      g.appendChild(rect)
+      barGroup.appendChild(rect)
     }
 
-    parent.appendChild(g)
-  }
+    g.appendChild(barGroup)
+  })
 }

--- a/packages/chart/src/bar.ts
+++ b/packages/chart/src/bar.ts
@@ -1,0 +1,56 @@
+import type { BarConfig } from './types'
+import type { ScaleBand, ScaleLinear } from 'd3-scale'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Render bar rectangles for all series into an SVG group.
+ */
+export function renderBars(
+  parent: SVGGElement,
+  data: Record<string, unknown>[],
+  bars: BarConfig[],
+  xScale: ScaleBand<string>,
+  yScale: ScaleLinear<number, number>,
+  height: number,
+  xDataKey: string,
+): void {
+  const bandwidth = xScale.bandwidth()
+  const barWidth = bars.length > 1 ? bandwidth / bars.length : bandwidth
+
+  for (let barIdx = 0; barIdx < bars.length; barIdx++) {
+    const bar = bars[barIdx]
+    const g = document.createElementNS(SVG_NS, 'g')
+    g.setAttribute('class', `chart-bar chart-bar-${bar.dataKey}`)
+
+    for (const datum of data) {
+      const xValue = String(datum[xDataKey])
+      const yValue = Number(datum[bar.dataKey]) || 0
+      const x = (xScale(xValue) ?? 0) + barIdx * barWidth
+      const y = yScale(yValue)
+      const barHeight = height - y
+
+      if (barHeight <= 0) continue
+
+      const rect = document.createElementNS(SVG_NS, 'rect')
+      rect.setAttribute('x', String(x))
+      rect.setAttribute('y', String(y))
+      rect.setAttribute('width', String(barWidth))
+      rect.setAttribute('height', String(barHeight))
+      rect.setAttribute('fill', bar.fill ?? 'currentColor')
+
+      if (bar.radius && bar.radius > 0) {
+        rect.setAttribute('rx', String(bar.radius))
+        rect.setAttribute('ry', String(bar.radius))
+      }
+
+      rect.setAttribute('data-x', xValue)
+      rect.setAttribute('data-y', String(yValue))
+      rect.setAttribute('data-key', bar.dataKey)
+
+      g.appendChild(rect)
+    }
+
+    parent.appendChild(g)
+  }
+}

--- a/packages/chart/src/cartesian-grid.ts
+++ b/packages/chart/src/cartesian-grid.ts
@@ -1,0 +1,51 @@
+import type { CartesianGridConfig } from './types'
+import type { ScaleLinear } from 'd3-scale'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Render grid lines into an SVG group.
+ */
+export function renderGrid(
+  parent: SVGGElement,
+  width: number,
+  height: number,
+  yScale: ScaleLinear<number, number>,
+  config: CartesianGridConfig,
+): void {
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('class', 'chart-grid')
+
+  const horizontal = config.horizontal !== false
+  const vertical = config.vertical !== false
+
+  if (horizontal) {
+    for (const tick of yScale.ticks()) {
+      const y = yScale(tick)
+      const line = document.createElementNS(SVG_NS, 'line')
+      line.setAttribute('x1', '0')
+      line.setAttribute('x2', String(width))
+      line.setAttribute('y1', String(y))
+      line.setAttribute('y2', String(y))
+      line.setAttribute('stroke', 'currentColor')
+      line.setAttribute('stroke-opacity', '0.1')
+      g.appendChild(line)
+    }
+  }
+
+  if (vertical) {
+    for (const tick of yScale.ticks()) {
+      const x = (tick / (yScale.domain()[1] || 1)) * width
+      const line = document.createElementNS(SVG_NS, 'line')
+      line.setAttribute('x1', String(x))
+      line.setAttribute('x2', String(x))
+      line.setAttribute('y1', '0')
+      line.setAttribute('y2', String(height))
+      line.setAttribute('stroke', 'currentColor')
+      line.setAttribute('stroke-opacity', '0.1')
+      g.appendChild(line)
+    }
+  }
+
+  parent.appendChild(g)
+}

--- a/packages/chart/src/cartesian-grid.ts
+++ b/packages/chart/src/cartesian-grid.ts
@@ -1,51 +1,63 @@
-import type { CartesianGridConfig } from './types'
-import type { ScaleLinear } from 'd3-scale'
+import { useContext, createEffect } from '@barefootjs/dom'
+import { BarChartContext } from './context'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
- * Render grid lines into an SVG group.
+ * Init function for CartesianGrid component.
+ * Renders horizontal/vertical grid lines via context.
  */
-export function renderGrid(
-  parent: SVGGElement,
-  width: number,
-  height: number,
-  yScale: ScaleLinear<number, number>,
-  config: CartesianGridConfig,
-): void {
-  const g = document.createElementNS(SVG_NS, 'g')
-  g.setAttribute('class', 'chart-grid')
+export function initCartesianGrid(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
+  const horizontal = (props.horizontal as boolean) !== false
+  const vertical = (props.vertical as boolean) ?? true
 
-  const horizontal = config.horizontal !== false
-  const vertical = config.vertical !== false
+  let gridGroup: SVGGElement | null = null
 
-  if (horizontal) {
-    for (const tick of yScale.ticks()) {
-      const y = yScale(tick)
-      const line = document.createElementNS(SVG_NS, 'line')
-      line.setAttribute('x1', '0')
-      line.setAttribute('x2', String(width))
-      line.setAttribute('y1', String(y))
-      line.setAttribute('y2', String(y))
-      line.setAttribute('stroke', 'currentColor')
-      line.setAttribute('stroke-opacity', '0.1')
-      g.appendChild(line)
+  createEffect(() => {
+    const g = ctx.svgGroup()
+    const ys = ctx.yScale()
+    if (!g || !ys) return
+
+    if (gridGroup) {
+      gridGroup.remove()
+      gridGroup = null
     }
-  }
 
-  if (vertical) {
-    for (const tick of yScale.ticks()) {
-      const x = (tick / (yScale.domain()[1] || 1)) * width
-      const line = document.createElementNS(SVG_NS, 'line')
-      line.setAttribute('x1', String(x))
-      line.setAttribute('x2', String(x))
-      line.setAttribute('y1', '0')
-      line.setAttribute('y2', String(height))
-      line.setAttribute('stroke', 'currentColor')
-      line.setAttribute('stroke-opacity', '0.1')
-      g.appendChild(line)
+    const width = ctx.innerWidth()
+    const height = ctx.innerHeight()
+
+    gridGroup = document.createElementNS(SVG_NS, 'g')
+    gridGroup.setAttribute('class', 'chart-grid')
+
+    if (horizontal) {
+      for (const tick of ys.ticks()) {
+        const y = ys(tick)
+        const line = document.createElementNS(SVG_NS, 'line')
+        line.setAttribute('x1', '0')
+        line.setAttribute('x2', String(width))
+        line.setAttribute('y1', String(y))
+        line.setAttribute('y2', String(y))
+        line.setAttribute('stroke', 'currentColor')
+        line.setAttribute('stroke-opacity', '0.1')
+        gridGroup.appendChild(line)
+      }
     }
-  }
 
-  parent.appendChild(g)
+    if (vertical) {
+      for (const tick of ys.ticks()) {
+        const x = (tick / (ys.domain()[1] || 1)) * width
+        const line = document.createElementNS(SVG_NS, 'line')
+        line.setAttribute('x1', String(x))
+        line.setAttribute('x2', String(x))
+        line.setAttribute('y1', '0')
+        line.setAttribute('y2', String(height))
+        line.setAttribute('stroke', 'currentColor')
+        line.setAttribute('stroke-opacity', '0.1')
+        gridGroup.appendChild(line)
+      }
+    }
+
+    g.appendChild(gridGroup)
+  })
 }

--- a/packages/chart/src/chart-container.ts
+++ b/packages/chart/src/chart-container.ts
@@ -1,0 +1,14 @@
+import type { ChartConfig } from './types'
+
+/**
+ * Apply CSS variables from ChartConfig to a container element.
+ * Sets --color-{key} for each config entry.
+ */
+export function applyChartCSSVariables(
+  container: HTMLElement,
+  config: ChartConfig,
+): void {
+  for (const [key, value] of Object.entries(config)) {
+    container.style.setProperty(`--color-${key}`, value.color)
+  }
+}

--- a/packages/chart/src/chart-container.ts
+++ b/packages/chart/src/chart-container.ts
@@ -1,3 +1,5 @@
+import { provideContext } from '@barefootjs/dom'
+import { ChartConfigContext } from './context'
 import type { ChartConfig } from './types'
 
 /**
@@ -11,4 +13,16 @@ export function applyChartCSSVariables(
   for (const [key, value] of Object.entries(config)) {
     container.style.setProperty(`--color-${key}`, value.color)
   }
+}
+
+/**
+ * Init function for ChartContainer component.
+ * Applies CSS variables, sets foreground color, and provides config via context.
+ */
+export function initChartContainer(scope: Element, props: Record<string, unknown>): void {
+  const el = scope as HTMLElement
+  const config = (props.config as ChartConfig) ?? {}
+  applyChartCSSVariables(el, config)
+  el.style.color = 'hsl(var(--foreground))'
+  provideContext(ChartConfigContext, { config })
 }

--- a/packages/chart/src/context.ts
+++ b/packages/chart/src/context.ts
@@ -1,0 +1,6 @@
+import { createContext } from '@barefootjs/dom'
+import type { BarChartContextValue, ChartConfig } from './types'
+
+export const BarChartContext = createContext<BarChartContextValue>()
+
+export const ChartConfigContext = createContext<{ config: ChartConfig }>()

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -1,0 +1,12 @@
+export { createBarChart } from './bar-chart'
+export { applyChartCSSVariables } from './chart-container'
+export type {
+  ChartConfig,
+  BarChartOptions,
+  BarChartInstance,
+  BarConfig,
+  XAxisConfig,
+  YAxisConfig,
+  CartesianGridConfig,
+  TooltipConfig,
+} from './types'

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -1,12 +1,24 @@
-export { createBarChart } from './bar-chart'
-export { applyChartCSSVariables } from './chart-container'
+// Export context for JSX wrapper components
+export { BarChartContext, ChartConfigContext } from './context'
+
+// Export init functions for JSX wrapper ref callbacks
+export { applyChartCSSVariables, initChartContainer } from './chart-container'
+export { initBarChart } from './bar-chart'
+export { initBar } from './bar'
+export { initCartesianGrid } from './cartesian-grid'
+export { initXAxis } from './x-axis'
+export { initYAxis } from './y-axis'
+export { initChartTooltip } from './tooltip'
+
+// Type exports
 export type {
   ChartConfig,
-  BarChartOptions,
-  BarChartInstance,
-  BarConfig,
-  XAxisConfig,
-  YAxisConfig,
-  CartesianGridConfig,
-  TooltipConfig,
+  BarRegistration,
+  ChartContainerProps,
+  BarChartProps,
+  BarProps,
+  CartesianGridProps,
+  XAxisProps,
+  YAxisProps,
+  ChartTooltipProps,
 } from './types'

--- a/packages/chart/src/tooltip.ts
+++ b/packages/chart/src/tooltip.ts
@@ -1,95 +1,111 @@
-import type { BarConfig, ChartConfig, TooltipConfig } from './types'
-import type { ScaleBand, ScaleLinear } from 'd3-scale'
+import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
+import { BarChartContext } from './context'
 
 /**
- * Create a tooltip that follows the mouse over bar elements.
- * Returns a handle with a destroy method to clean up listeners.
+ * Init function for ChartTooltip component.
+ * Creates tooltip div and attaches mouse event listeners.
  */
-export function createTooltip(
-  container: HTMLElement,
-  svg: SVGSVGElement,
-  chartGroup: SVGGElement,
-  data: Record<string, unknown>[],
-  bars: BarConfig[],
-  config: ChartConfig,
-  xScale: ScaleBand<string>,
-  _yScale: ScaleLinear<number, number>,
-  tooltipConfig: TooltipConfig,
-  xDataKey: string,
-): { destroy: () => void } {
-  const tooltip = document.createElement('div')
-  tooltip.className = 'chart-tooltip'
-  Object.assign(tooltip.style, {
-    position: 'absolute',
-    pointerEvents: 'none',
-    opacity: '0',
-    transition: 'opacity 150ms',
-    backgroundColor: 'hsl(var(--popover))',
-    color: 'hsl(var(--popover-foreground))',
-    border: '1px solid hsl(var(--border))',
-    borderRadius: '6px',
-    padding: '8px 12px',
-    fontSize: '12px',
-    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-    zIndex: '50',
-    whiteSpace: 'nowrap',
+export function initChartTooltip(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
+  const labelFormatter = props.labelFormatter as ((label: string) => string) | undefined
+
+  let tooltip: HTMLDivElement | null = null
+  let cleanupFn: (() => void) | null = null
+
+  createEffect(() => {
+    const g = ctx.svgGroup()
+    const container = ctx.container()
+    const xs = ctx.xScale()
+    const ys = ctx.yScale()
+    if (!g || !container || !xs || !ys) return
+
+    // Cleanup previous tooltip
+    if (cleanupFn) {
+      cleanupFn()
+      cleanupFn = null
+    }
+
+    const data = ctx.data()
+    const xKey = ctx.xDataKey()
+    const bars = ctx.bars()
+    const config = ctx.config()
+
+    tooltip = document.createElement('div')
+    tooltip.className = 'chart-tooltip'
+    Object.assign(tooltip.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      opacity: '0',
+      transition: 'opacity 150ms',
+      backgroundColor: 'hsl(var(--popover))',
+      color: 'hsl(var(--popover-foreground))',
+      border: '1px solid hsl(var(--border))',
+      borderRadius: '6px',
+      padding: '8px 12px',
+      fontSize: '12px',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+      zIndex: '50',
+      whiteSpace: 'nowrap',
+    })
+    container.style.position = 'relative'
+    container.appendChild(tooltip)
+
+    const currentTooltip = tooltip
+
+    const handleMouseOver = (e: Event): void => {
+      const target = e.target as SVGElement
+      if (target.tagName !== 'rect' || !target.hasAttribute('data-x')) return
+
+      const xValue = target.getAttribute('data-x') ?? ''
+      const datum = data.find((d) => String(d[xKey]) === xValue)
+      if (!datum) return
+
+      const label = labelFormatter ? labelFormatter(xValue) : xValue
+
+      let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
+      for (const bar of bars) {
+        const value = datum[bar.dataKey]
+        const configEntry = config[bar.dataKey]
+        const color = bar.fill ?? configEntry?.color ?? 'currentColor'
+        const entryLabel = configEntry?.label ?? bar.dataKey
+        html += `<div style="display:flex;align-items:center;gap:8px">`
+        html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
+        html += `<span>${entryLabel}</span>`
+        html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+        html += `</div>`
+      }
+      currentTooltip.innerHTML = html
+      currentTooltip.style.opacity = '1'
+    }
+
+    const handleMouseMove = (e: MouseEvent): void => {
+      const rect = container.getBoundingClientRect()
+      const x = e.clientX - rect.left + 12
+      const y = e.clientY - rect.top - 12
+      currentTooltip.style.left = `${x}px`
+      currentTooltip.style.top = `${y}px`
+    }
+
+    const handleMouseOut = (e: Event): void => {
+      const target = e.target as SVGElement
+      if (target.tagName === 'rect') {
+        currentTooltip.style.opacity = '0'
+      }
+    }
+
+    g.addEventListener('mouseover', handleMouseOver)
+    g.addEventListener('mousemove', handleMouseMove as EventListener)
+    g.addEventListener('mouseout', handleMouseOut)
+
+    cleanupFn = () => {
+      g.removeEventListener('mouseover', handleMouseOver)
+      g.removeEventListener('mousemove', handleMouseMove as EventListener)
+      g.removeEventListener('mouseout', handleMouseOut)
+      currentTooltip.remove()
+    }
   })
-  container.style.position = 'relative'
-  container.appendChild(tooltip)
 
-  const handleMouseOver = (e: Event): void => {
-    const target = e.target as SVGElement
-    if (target.tagName !== 'rect' || !target.hasAttribute('data-x')) return
-
-    const xValue = target.getAttribute('data-x') ?? ''
-    const datum = data.find((d) => String(d[xDataKey]) === xValue)
-    if (!datum) return
-
-    const label = tooltipConfig.labelFormatter
-      ? tooltipConfig.labelFormatter(xValue)
-      : xValue
-
-    let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
-    for (const bar of bars) {
-      const value = datum[bar.dataKey]
-      const configEntry = config[bar.dataKey]
-      const color = bar.fill ?? configEntry?.color ?? 'currentColor'
-      const entryLabel = configEntry?.label ?? bar.dataKey
-      html += `<div style="display:flex;align-items:center;gap:8px">`
-      html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
-      html += `<span>${entryLabel}</span>`
-      html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
-      html += `</div>`
-    }
-    tooltip.innerHTML = html
-    tooltip.style.opacity = '1'
-  }
-
-  const handleMouseMove = (e: MouseEvent): void => {
-    const rect = container.getBoundingClientRect()
-    const x = e.clientX - rect.left + 12
-    const y = e.clientY - rect.top - 12
-    tooltip.style.left = `${x}px`
-    tooltip.style.top = `${y}px`
-  }
-
-  const handleMouseOut = (e: Event): void => {
-    const target = e.target as SVGElement
-    if (target.tagName === 'rect') {
-      tooltip.style.opacity = '0'
-    }
-  }
-
-  chartGroup.addEventListener('mouseover', handleMouseOver)
-  chartGroup.addEventListener('mousemove', handleMouseMove as EventListener)
-  chartGroup.addEventListener('mouseout', handleMouseOut)
-
-  return {
-    destroy: () => {
-      chartGroup.removeEventListener('mouseover', handleMouseOver)
-      chartGroup.removeEventListener('mousemove', handleMouseMove as EventListener)
-      chartGroup.removeEventListener('mouseout', handleMouseOut)
-      tooltip.remove()
-    },
-  }
+  onCleanup(() => {
+    if (cleanupFn) cleanupFn()
+  })
 }

--- a/packages/chart/src/tooltip.ts
+++ b/packages/chart/src/tooltip.ts
@@ -1,0 +1,95 @@
+import type { BarConfig, ChartConfig, TooltipConfig } from './types'
+import type { ScaleBand, ScaleLinear } from 'd3-scale'
+
+/**
+ * Create a tooltip that follows the mouse over bar elements.
+ * Returns a handle with a destroy method to clean up listeners.
+ */
+export function createTooltip(
+  container: HTMLElement,
+  svg: SVGSVGElement,
+  chartGroup: SVGGElement,
+  data: Record<string, unknown>[],
+  bars: BarConfig[],
+  config: ChartConfig,
+  xScale: ScaleBand<string>,
+  _yScale: ScaleLinear<number, number>,
+  tooltipConfig: TooltipConfig,
+  xDataKey: string,
+): { destroy: () => void } {
+  const tooltip = document.createElement('div')
+  tooltip.className = 'chart-tooltip'
+  Object.assign(tooltip.style, {
+    position: 'absolute',
+    pointerEvents: 'none',
+    opacity: '0',
+    transition: 'opacity 150ms',
+    backgroundColor: 'hsl(var(--popover))',
+    color: 'hsl(var(--popover-foreground))',
+    border: '1px solid hsl(var(--border))',
+    borderRadius: '6px',
+    padding: '8px 12px',
+    fontSize: '12px',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+    zIndex: '50',
+    whiteSpace: 'nowrap',
+  })
+  container.style.position = 'relative'
+  container.appendChild(tooltip)
+
+  const handleMouseOver = (e: Event): void => {
+    const target = e.target as SVGElement
+    if (target.tagName !== 'rect' || !target.hasAttribute('data-x')) return
+
+    const xValue = target.getAttribute('data-x') ?? ''
+    const datum = data.find((d) => String(d[xDataKey]) === xValue)
+    if (!datum) return
+
+    const label = tooltipConfig.labelFormatter
+      ? tooltipConfig.labelFormatter(xValue)
+      : xValue
+
+    let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
+    for (const bar of bars) {
+      const value = datum[bar.dataKey]
+      const configEntry = config[bar.dataKey]
+      const color = bar.fill ?? configEntry?.color ?? 'currentColor'
+      const entryLabel = configEntry?.label ?? bar.dataKey
+      html += `<div style="display:flex;align-items:center;gap:8px">`
+      html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
+      html += `<span>${entryLabel}</span>`
+      html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+      html += `</div>`
+    }
+    tooltip.innerHTML = html
+    tooltip.style.opacity = '1'
+  }
+
+  const handleMouseMove = (e: MouseEvent): void => {
+    const rect = container.getBoundingClientRect()
+    const x = e.clientX - rect.left + 12
+    const y = e.clientY - rect.top - 12
+    tooltip.style.left = `${x}px`
+    tooltip.style.top = `${y}px`
+  }
+
+  const handleMouseOut = (e: Event): void => {
+    const target = e.target as SVGElement
+    if (target.tagName === 'rect') {
+      tooltip.style.opacity = '0'
+    }
+  }
+
+  chartGroup.addEventListener('mouseover', handleMouseOver)
+  chartGroup.addEventListener('mousemove', handleMouseMove as EventListener)
+  chartGroup.addEventListener('mouseout', handleMouseOut)
+
+  return {
+    destroy: () => {
+      chartGroup.removeEventListener('mouseover', handleMouseOver)
+      chartGroup.removeEventListener('mousemove', handleMouseMove as EventListener)
+      chartGroup.removeEventListener('mouseout', handleMouseOut)
+      tooltip.remove()
+    },
+  }
+}

--- a/packages/chart/src/types.ts
+++ b/packages/chart/src/types.ts
@@ -1,3 +1,5 @@
+import type { ScaleBand, ScaleLinear } from 'd3-scale'
+
 /** Color and label configuration for chart data series */
 export type ChartConfig = Record<
   string,
@@ -7,51 +9,70 @@ export type ChartConfig = Record<
   }
 >
 
-/** Configuration for a single bar series */
-export interface BarConfig {
+/** Registration info for a bar series */
+export interface BarRegistration {
+  dataKey: string
+  fill: string
+  radius: number
+}
+
+/** Props for ChartContainer */
+export interface ChartContainerProps {
+  config: ChartConfig
+  className?: string
+  children?: unknown
+}
+
+/** Props for BarChart */
+export interface BarChartProps {
+  data: Record<string, unknown>[]
+  children?: unknown
+}
+
+/** Props for Bar */
+export interface BarProps {
   dataKey: string
   fill?: string
   radius?: number
 }
 
-/** Configuration for the X axis */
-export interface XAxisConfig {
+/** Props for CartesianGrid */
+export interface CartesianGridProps {
+  vertical?: boolean
+  horizontal?: boolean
+}
+
+/** Props for XAxis */
+export interface XAxisProps {
   dataKey: string
   tickFormatter?: (value: string) => string
   hide?: boolean
 }
 
-/** Configuration for the Y axis */
-export interface YAxisConfig {
+/** Props for YAxis */
+export interface YAxisProps {
   hide?: boolean
   tickFormatter?: (value: number) => string
 }
 
-/** Configuration for the cartesian grid */
-export interface CartesianGridConfig {
-  vertical?: boolean
-  horizontal?: boolean
-}
-
-/** Configuration for chart tooltip */
-export interface TooltipConfig {
-  enabled?: boolean
+/** Props for ChartTooltip */
+export interface ChartTooltipProps {
   labelFormatter?: (label: string) => string
 }
 
-/** Options for createBarChart */
-export interface BarChartOptions {
-  data: Record<string, unknown>[]
-  config: ChartConfig
-  bars: BarConfig[]
-  xAxis?: XAxisConfig
-  yAxis?: YAxisConfig | boolean
-  grid?: CartesianGridConfig
-  tooltip?: TooltipConfig | boolean
-}
-
-/** Returned handle from createBarChart */
-export interface BarChartInstance {
-  update: (options: Partial<BarChartOptions>) => void
-  destroy: () => void
+/** Context value shared between BarChart and its children */
+export interface BarChartContextValue {
+  svgGroup: () => SVGGElement | null
+  container: () => HTMLElement | null
+  data: () => Record<string, unknown>[]
+  xDataKey: () => string
+  xScale: () => ScaleBand<string> | null
+  yScale: () => ScaleLinear<number, number> | null
+  innerWidth: () => number
+  innerHeight: () => number
+  config: () => ChartConfig
+  bars: () => BarRegistration[]
+  registerBar: (bar: BarRegistration) => void
+  unregisterBar: (dataKey: string) => void
+  setXDataKey: (key: string) => void
 }

--- a/packages/chart/src/types.ts
+++ b/packages/chart/src/types.ts
@@ -1,0 +1,57 @@
+/** Color and label configuration for chart data series */
+export type ChartConfig = Record<
+  string,
+  {
+    label: string
+    color: string
+  }
+>
+
+/** Configuration for a single bar series */
+export interface BarConfig {
+  dataKey: string
+  fill?: string
+  radius?: number
+}
+
+/** Configuration for the X axis */
+export interface XAxisConfig {
+  dataKey: string
+  tickFormatter?: (value: string) => string
+  hide?: boolean
+}
+
+/** Configuration for the Y axis */
+export interface YAxisConfig {
+  hide?: boolean
+  tickFormatter?: (value: number) => string
+}
+
+/** Configuration for the cartesian grid */
+export interface CartesianGridConfig {
+  vertical?: boolean
+  horizontal?: boolean
+}
+
+/** Configuration for chart tooltip */
+export interface TooltipConfig {
+  enabled?: boolean
+  labelFormatter?: (label: string) => string
+}
+
+/** Options for createBarChart */
+export interface BarChartOptions {
+  data: Record<string, unknown>[]
+  config: ChartConfig
+  bars: BarConfig[]
+  xAxis?: XAxisConfig
+  yAxis?: YAxisConfig | boolean
+  grid?: CartesianGridConfig
+  tooltip?: TooltipConfig | boolean
+}
+
+/** Returned handle from createBarChart */
+export interface BarChartInstance {
+  update: (options: Partial<BarChartOptions>) => void
+  destroy: () => void
+}

--- a/packages/chart/src/utils/scales.ts
+++ b/packages/chart/src/utils/scales.ts
@@ -1,0 +1,31 @@
+import { scaleBand, scaleLinear, type ScaleBand, type ScaleLinear } from 'd3-scale'
+import { max } from 'd3-array'
+
+export function createBandScale(
+  data: Record<string, unknown>[],
+  dataKey: string,
+  width: number,
+): ScaleBand<string> {
+  return scaleBand<string>()
+    .domain(data.map((d) => String(d[dataKey])))
+    .range([0, width])
+    .padding(0.2)
+}
+
+export function createLinearScale(
+  data: Record<string, unknown>[],
+  dataKeys: string[],
+  height: number,
+): ScaleLinear<number, number> {
+  const maxValue =
+    max(data, (d) =>
+      max(dataKeys, (key) => {
+        const v = d[key]
+        return typeof v === 'number' ? v : 0
+      }),
+    ) ?? 0
+  return scaleLinear()
+    .domain([0, maxValue])
+    .nice()
+    .range([height, 0])
+}

--- a/packages/chart/src/x-axis.ts
+++ b/packages/chart/src/x-axis.ts
@@ -1,47 +1,66 @@
-import type { XAxisConfig } from './types'
-import type { ScaleBand } from 'd3-scale'
+import { useContext, createEffect } from '@barefootjs/dom'
+import { BarChartContext } from './context'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
- * Render X axis ticks and labels into an SVG group.
+ * Init function for XAxis component.
+ * Sets xDataKey on context and renders X axis labels.
  */
-export function renderXAxis(
-  parent: SVGGElement,
-  scale: ScaleBand<string>,
-  height: number,
-  config: XAxisConfig,
-): void {
-  if (config.hide) return
+export function initXAxis(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
+  const dataKey = props.dataKey as string
+  const tickFormatter = props.tickFormatter as ((value: string) => string) | undefined
+  const hide = props.hide as boolean | undefined
 
-  const g = document.createElementNS(SVG_NS, 'g')
-  g.setAttribute('class', 'chart-x-axis')
-  g.setAttribute('transform', `translate(0,${height})`)
+  // Tell BarChart which key to use for X axis
+  ctx.setXDataKey(dataKey)
 
-  // Axis line
-  const line = document.createElementNS(SVG_NS, 'line')
-  line.setAttribute('x1', '0')
-  line.setAttribute('x2', String(scale.range()[1]))
-  line.setAttribute('y1', '0')
-  line.setAttribute('y2', '0')
-  line.setAttribute('stroke', 'currentColor')
-  line.setAttribute('stroke-opacity', '0.1')
-  g.appendChild(line)
+  if (hide) return
 
-  // Tick labels
-  const bandwidth = scale.bandwidth()
-  for (const value of scale.domain()) {
-    const x = (scale(value) ?? 0) + bandwidth / 2
-    const text = document.createElementNS(SVG_NS, 'text')
-    text.setAttribute('x', String(x))
-    text.setAttribute('y', '20')
-    text.setAttribute('text-anchor', 'middle')
-    text.setAttribute('fill', 'currentColor')
-    text.setAttribute('opacity', '0.5')
-    text.setAttribute('font-size', '12')
-    text.textContent = config.tickFormatter ? config.tickFormatter(value) : value
-    g.appendChild(text)
-  }
+  let axisGroup: SVGGElement | null = null
 
-  parent.appendChild(g)
+  createEffect(() => {
+    const g = ctx.svgGroup()
+    const xs = ctx.xScale()
+    if (!g || !xs) return
+
+    if (axisGroup) {
+      axisGroup.remove()
+      axisGroup = null
+    }
+
+    const height = ctx.innerHeight()
+
+    axisGroup = document.createElementNS(SVG_NS, 'g')
+    axisGroup.setAttribute('class', 'chart-x-axis')
+    axisGroup.setAttribute('transform', `translate(0,${height})`)
+
+    // Axis line
+    const line = document.createElementNS(SVG_NS, 'line')
+    line.setAttribute('x1', '0')
+    line.setAttribute('x2', String(xs.range()[1]))
+    line.setAttribute('y1', '0')
+    line.setAttribute('y2', '0')
+    line.setAttribute('stroke', 'currentColor')
+    line.setAttribute('stroke-opacity', '0.1')
+    axisGroup.appendChild(line)
+
+    // Tick labels
+    const bandwidth = xs.bandwidth()
+    for (const value of xs.domain()) {
+      const x = (xs(value) ?? 0) + bandwidth / 2
+      const text = document.createElementNS(SVG_NS, 'text')
+      text.setAttribute('x', String(x))
+      text.setAttribute('y', '20')
+      text.setAttribute('text-anchor', 'middle')
+      text.setAttribute('fill', 'currentColor')
+      text.setAttribute('opacity', '0.5')
+      text.setAttribute('font-size', '12')
+      text.textContent = tickFormatter ? tickFormatter(value) : value
+      axisGroup.appendChild(text)
+    }
+
+    g.appendChild(axisGroup)
+  })
 }

--- a/packages/chart/src/x-axis.ts
+++ b/packages/chart/src/x-axis.ts
@@ -1,0 +1,47 @@
+import type { XAxisConfig } from './types'
+import type { ScaleBand } from 'd3-scale'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Render X axis ticks and labels into an SVG group.
+ */
+export function renderXAxis(
+  parent: SVGGElement,
+  scale: ScaleBand<string>,
+  height: number,
+  config: XAxisConfig,
+): void {
+  if (config.hide) return
+
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('class', 'chart-x-axis')
+  g.setAttribute('transform', `translate(0,${height})`)
+
+  // Axis line
+  const line = document.createElementNS(SVG_NS, 'line')
+  line.setAttribute('x1', '0')
+  line.setAttribute('x2', String(scale.range()[1]))
+  line.setAttribute('y1', '0')
+  line.setAttribute('y2', '0')
+  line.setAttribute('stroke', 'currentColor')
+  line.setAttribute('stroke-opacity', '0.1')
+  g.appendChild(line)
+
+  // Tick labels
+  const bandwidth = scale.bandwidth()
+  for (const value of scale.domain()) {
+    const x = (scale(value) ?? 0) + bandwidth / 2
+    const text = document.createElementNS(SVG_NS, 'text')
+    text.setAttribute('x', String(x))
+    text.setAttribute('y', '20')
+    text.setAttribute('text-anchor', 'middle')
+    text.setAttribute('fill', 'currentColor')
+    text.setAttribute('opacity', '0.5')
+    text.setAttribute('font-size', '12')
+    text.textContent = config.tickFormatter ? config.tickFormatter(value) : value
+    g.appendChild(text)
+  }
+
+  parent.appendChild(g)
+}

--- a/packages/chart/src/y-axis.ts
+++ b/packages/chart/src/y-axis.ts
@@ -1,0 +1,47 @@
+import type { YAxisConfig } from './types'
+import type { ScaleLinear } from 'd3-scale'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Render Y axis ticks and labels into an SVG group.
+ */
+export function renderYAxis(
+  parent: SVGGElement,
+  scale: ScaleLinear<number, number>,
+  config: YAxisConfig,
+): void {
+  if (config.hide) return
+
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('class', 'chart-y-axis')
+
+  // Axis line
+  const line = document.createElementNS(SVG_NS, 'line')
+  line.setAttribute('x1', '0')
+  line.setAttribute('x2', '0')
+  line.setAttribute('y1', String(scale.range()[0]))
+  line.setAttribute('y2', String(scale.range()[1]))
+  line.setAttribute('stroke', 'currentColor')
+  line.setAttribute('stroke-opacity', '0.1')
+  g.appendChild(line)
+
+  // Tick labels
+  for (const tick of scale.ticks()) {
+    const y = scale(tick)
+    const text = document.createElementNS(SVG_NS, 'text')
+    text.setAttribute('x', '-8')
+    text.setAttribute('y', String(y))
+    text.setAttribute('text-anchor', 'end')
+    text.setAttribute('dominant-baseline', 'middle')
+    text.setAttribute('fill', 'currentColor')
+    text.setAttribute('opacity', '0.5')
+    text.setAttribute('font-size', '12')
+    text.textContent = config.tickFormatter
+      ? config.tickFormatter(tick)
+      : String(tick)
+    g.appendChild(text)
+  }
+
+  parent.appendChild(g)
+}

--- a/packages/chart/src/y-axis.ts
+++ b/packages/chart/src/y-axis.ts
@@ -1,47 +1,59 @@
-import type { YAxisConfig } from './types'
-import type { ScaleLinear } from 'd3-scale'
+import { useContext, createEffect } from '@barefootjs/dom'
+import { BarChartContext } from './context'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
- * Render Y axis ticks and labels into an SVG group.
+ * Init function for YAxis component.
+ * Renders Y axis tick labels via context.
  */
-export function renderYAxis(
-  parent: SVGGElement,
-  scale: ScaleLinear<number, number>,
-  config: YAxisConfig,
-): void {
-  if (config.hide) return
+export function initYAxis(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
+  const hide = props.hide as boolean | undefined
+  const tickFormatter = props.tickFormatter as ((value: number) => string) | undefined
 
-  const g = document.createElementNS(SVG_NS, 'g')
-  g.setAttribute('class', 'chart-y-axis')
+  if (hide) return
 
-  // Axis line
-  const line = document.createElementNS(SVG_NS, 'line')
-  line.setAttribute('x1', '0')
-  line.setAttribute('x2', '0')
-  line.setAttribute('y1', String(scale.range()[0]))
-  line.setAttribute('y2', String(scale.range()[1]))
-  line.setAttribute('stroke', 'currentColor')
-  line.setAttribute('stroke-opacity', '0.1')
-  g.appendChild(line)
+  let axisGroup: SVGGElement | null = null
 
-  // Tick labels
-  for (const tick of scale.ticks()) {
-    const y = scale(tick)
-    const text = document.createElementNS(SVG_NS, 'text')
-    text.setAttribute('x', '-8')
-    text.setAttribute('y', String(y))
-    text.setAttribute('text-anchor', 'end')
-    text.setAttribute('dominant-baseline', 'middle')
-    text.setAttribute('fill', 'currentColor')
-    text.setAttribute('opacity', '0.5')
-    text.setAttribute('font-size', '12')
-    text.textContent = config.tickFormatter
-      ? config.tickFormatter(tick)
-      : String(tick)
-    g.appendChild(text)
-  }
+  createEffect(() => {
+    const g = ctx.svgGroup()
+    const ys = ctx.yScale()
+    if (!g || !ys) return
 
-  parent.appendChild(g)
+    if (axisGroup) {
+      axisGroup.remove()
+      axisGroup = null
+    }
+
+    axisGroup = document.createElementNS(SVG_NS, 'g')
+    axisGroup.setAttribute('class', 'chart-y-axis')
+
+    // Axis line
+    const line = document.createElementNS(SVG_NS, 'line')
+    line.setAttribute('x1', '0')
+    line.setAttribute('x2', '0')
+    line.setAttribute('y1', String(ys.range()[0]))
+    line.setAttribute('y2', String(ys.range()[1]))
+    line.setAttribute('stroke', 'currentColor')
+    line.setAttribute('stroke-opacity', '0.1')
+    axisGroup.appendChild(line)
+
+    // Tick labels
+    for (const tick of ys.ticks()) {
+      const y = ys(tick)
+      const text = document.createElementNS(SVG_NS, 'text')
+      text.setAttribute('x', '-8')
+      text.setAttribute('y', String(y))
+      text.setAttribute('text-anchor', 'end')
+      text.setAttribute('dominant-baseline', 'middle')
+      text.setAttribute('fill', 'currentColor')
+      text.setAttribute('opacity', '0.5')
+      text.setAttribute('font-size', '12')
+      text.textContent = tickFormatter ? tickFormatter(tick) : String(tick)
+      axisGroup.appendChild(text)
+    }
+
+    g.appendChild(axisGroup)
+  })
 }

--- a/packages/chart/tsconfig.json
+++ b/packages/chart/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -122,6 +122,26 @@ if (formBuildResult.outputs.length > 0) {
   console.log('Generated: dist/components/barefoot-form.js')
 }
 
+// Build and copy barefoot-chart.js from @barefootjs/chart
+// External @barefootjs/dom so it resolves via import map
+const CHART_PKG_DIR = resolve(ROOT_DIR, '../../packages/chart')
+const chartEntryFile = resolve(CHART_PKG_DIR, 'src/index.ts')
+
+console.log('Building @barefootjs/chart for site...')
+const chartBuildResult = await Bun.build({
+  entrypoints: [chartEntryFile],
+  format: 'esm',
+  external: ['@barefootjs/dom'],
+})
+
+if (chartBuildResult.outputs.length > 0) {
+  await Bun.write(
+    resolve(DIST_COMPONENTS_DIR, 'barefoot-chart.js'),
+    chartBuildResult.outputs[0]
+  )
+  console.log('Generated: dist/components/barefoot-chart.js')
+}
+
 // Bundle zod for client-side use (needed by createForm demos)
 // Use a wrapper to ensure named exports (z) are preserved in the ESM bundle,
 // since the CJS entry only produces a default export when bundled directly.

--- a/site/ui/components/bar-chart-demo.tsx
+++ b/site/ui/components/bar-chart-demo.tsx
@@ -3,11 +3,20 @@
  * BarChartDemo Components
  *
  * Interactive demos for the Bar Chart component.
- * Uses @barefootjs/chart to render SVG bar charts with D3 scales.
+ * Uses JSX component API with @barefootjs/chart.
  */
 
-import { createSignal, onMount, createEffect, onCleanup } from '@barefootjs/dom'
-import { createBarChart, applyChartCSSVariables, type ChartConfig, type BarChartOptions } from '@barefootjs/chart'
+import { createSignal } from '@barefootjs/dom'
+import type { ChartConfig } from '@barefootjs/chart'
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from '@ui/components/ui/chart'
 
 const chartConfig: ChartConfig = {
   desktop: { label: 'Desktop', color: 'hsl(221 83% 53%)' },
@@ -27,35 +36,21 @@ const chartData = [
  * Preview demo — monthly visitors bar chart
  */
 export function BarChartPreviewDemo() {
-  onMount(() => {
-    const container = document.querySelector('[data-chart-demo="preview"]') as HTMLElement
-    if (!container) return
-    applyChartCSSVariables(container, chartConfig)
-    const instance = createBarChart(container, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
-      ],
-      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-    onCleanup(() => instance.destroy())
-  })
-
   return (
     <div className="w-full space-y-2">
       <div>
         <h4 className="text-sm font-medium">Monthly Visitors</h4>
         <p className="text-xs text-muted-foreground">January - June 2024</p>
       </div>
-      <div
-        data-chart-demo="preview"
-        className="w-full"
-        style="color:hsl(var(--foreground))"
-      />
+      <ChartContainer config={chartConfig} className="w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Bar dataKey="desktop" fill={'var(--color-desktop)'} radius={4} />
+        </BarChart>
+      </ChartContainer>
     </div>
   )
 }
@@ -64,30 +59,16 @@ export function BarChartPreviewDemo() {
  * Basic demo — minimal bar chart
  */
 export function BarChartBasicDemo() {
-  onMount(() => {
-    const container = document.querySelector('[data-chart-demo="basic"]') as HTMLElement
-    if (!container) return
-    applyChartCSSVariables(container, chartConfig)
-    const instance = createBarChart(container, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
-      ],
-      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-    })
-    onCleanup(() => instance.destroy())
-  })
-
   return (
     <div className="w-full">
-      <div
-        data-chart-demo="basic"
-        className="w-full"
-        style="color:hsl(var(--foreground))"
-      />
+      <ChartContainer config={chartConfig} className="w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <Bar dataKey="desktop" fill={'var(--color-desktop)'} radius={4} />
+        </BarChart>
+      </ChartContainer>
     </div>
   )
 }
@@ -96,25 +77,6 @@ export function BarChartBasicDemo() {
  * Multiple series demo — grouped bars for desktop and mobile
  */
 export function BarChartMultipleDemo() {
-  onMount(() => {
-    const container = document.querySelector('[data-chart-demo="multiple"]') as HTMLElement
-    if (!container) return
-    applyChartCSSVariables(container, chartConfig)
-    const instance = createBarChart(container, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
-        { dataKey: 'mobile', fill: 'var(--color-mobile)', radius: 4 },
-      ],
-      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-    onCleanup(() => instance.destroy())
-  })
-
   return (
     <div className="w-full space-y-2">
       <div className="flex items-center gap-4">
@@ -127,11 +89,16 @@ export function BarChartMultipleDemo() {
           <span className="text-xs text-muted-foreground">Mobile</span>
         </div>
       </div>
-      <div
-        data-chart-demo="multiple"
-        className="w-full"
-        style="color:hsl(var(--foreground))"
-      />
+      <ChartContainer config={chartConfig} className="w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Bar dataKey="desktop" fill={'var(--color-desktop)'} radius={4} />
+          <Bar dataKey="mobile" fill={'var(--color-mobile)'} radius={4} />
+        </BarChart>
+      </ChartContainer>
     </div>
   )
 }
@@ -141,31 +108,6 @@ export function BarChartMultipleDemo() {
  */
 export function BarChartInteractiveDemo() {
   const [category, setCategory] = createSignal<'desktop' | 'mobile'>('desktop')
-
-  createEffect(() => {
-    const container = document.querySelector('[data-chart-demo="interactive"]') as HTMLElement
-    if (!container) return
-
-    // Clear previous chart and tooltip
-    const oldSvg = container.querySelector('svg')
-    if (oldSvg) oldSvg.remove()
-    const oldTooltip = container.querySelector('.chart-tooltip')
-    if (oldTooltip) oldTooltip.remove()
-
-    applyChartCSSVariables(container, chartConfig)
-    const currentCategory = category()
-    createBarChart(container, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: currentCategory, fill: `var(--color-${currentCategory})`, radius: 4 },
-      ],
-      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-  })
 
   return (
     <div className="w-full space-y-4">
@@ -192,11 +134,15 @@ export function BarChartInteractiveDemo() {
           Mobile
         </button>
       </div>
-      <div
-        data-chart-demo="interactive"
-        className="w-full"
-        style="color:hsl(var(--foreground))"
-      />
+      <ChartContainer config={chartConfig} className="w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Bar dataKey={category()} fill={`var(--color-${category()})`} radius={4} />
+        </BarChart>
+      </ChartContainer>
     </div>
   )
 }

--- a/site/ui/components/bar-chart-demo.tsx
+++ b/site/ui/components/bar-chart-demo.tsx
@@ -1,0 +1,202 @@
+"use client"
+/**
+ * BarChartDemo Components
+ *
+ * Interactive demos for the Bar Chart component.
+ * Uses @barefootjs/chart to render SVG bar charts with D3 scales.
+ */
+
+import { createSignal, onMount, createEffect, onCleanup } from '@barefootjs/dom'
+import { createBarChart, applyChartCSSVariables, type ChartConfig, type BarChartOptions } from '@barefootjs/chart'
+
+const chartConfig: ChartConfig = {
+  desktop: { label: 'Desktop', color: 'hsl(221 83% 53%)' },
+  mobile: { label: 'Mobile', color: 'hsl(280 65% 60%)' },
+}
+
+const chartData = [
+  { month: 'January', desktop: 186, mobile: 80 },
+  { month: 'February', desktop: 305, mobile: 200 },
+  { month: 'March', desktop: 237, mobile: 120 },
+  { month: 'April', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'June', desktop: 214, mobile: 140 },
+]
+
+/**
+ * Preview demo — monthly visitors bar chart
+ */
+export function BarChartPreviewDemo() {
+  onMount(() => {
+    const container = document.querySelector('[data-chart-demo="preview"]') as HTMLElement
+    if (!container) return
+    applyChartCSSVariables(container, chartConfig)
+    const instance = createBarChart(container, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
+      ],
+      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return (
+    <div className="w-full space-y-2">
+      <div>
+        <h4 className="text-sm font-medium">Monthly Visitors</h4>
+        <p className="text-xs text-muted-foreground">January - June 2024</p>
+      </div>
+      <div
+        data-chart-demo="preview"
+        className="w-full"
+        style="color:hsl(var(--foreground))"
+      />
+    </div>
+  )
+}
+
+/**
+ * Basic demo — minimal bar chart
+ */
+export function BarChartBasicDemo() {
+  onMount(() => {
+    const container = document.querySelector('[data-chart-demo="basic"]') as HTMLElement
+    if (!container) return
+    applyChartCSSVariables(container, chartConfig)
+    const instance = createBarChart(container, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
+      ],
+      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return (
+    <div className="w-full">
+      <div
+        data-chart-demo="basic"
+        className="w-full"
+        style="color:hsl(var(--foreground))"
+      />
+    </div>
+  )
+}
+
+/**
+ * Multiple series demo — grouped bars for desktop and mobile
+ */
+export function BarChartMultipleDemo() {
+  onMount(() => {
+    const container = document.querySelector('[data-chart-demo="multiple"]') as HTMLElement
+    if (!container) return
+    applyChartCSSVariables(container, chartConfig)
+    const instance = createBarChart(container, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: 'desktop', fill: 'var(--color-desktop)', radius: 4 },
+        { dataKey: 'mobile', fill: 'var(--color-mobile)', radius: 4 },
+      ],
+      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return (
+    <div className="w-full space-y-2">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style="background:hsl(221 83% 53%)" />
+          <span className="text-xs text-muted-foreground">Desktop</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style="background:hsl(280 65% 60%)" />
+          <span className="text-xs text-muted-foreground">Mobile</span>
+        </div>
+      </div>
+      <div
+        data-chart-demo="multiple"
+        className="w-full"
+        style="color:hsl(var(--foreground))"
+      />
+    </div>
+  )
+}
+
+/**
+ * Interactive demo — signal-driven category switching
+ */
+export function BarChartInteractiveDemo() {
+  const [category, setCategory] = createSignal<'desktop' | 'mobile'>('desktop')
+
+  createEffect(() => {
+    const container = document.querySelector('[data-chart-demo="interactive"]') as HTMLElement
+    if (!container) return
+
+    // Clear previous chart and tooltip
+    const oldSvg = container.querySelector('svg')
+    if (oldSvg) oldSvg.remove()
+    const oldTooltip = container.querySelector('.chart-tooltip')
+    if (oldTooltip) oldTooltip.remove()
+
+    applyChartCSSVariables(container, chartConfig)
+    const currentCategory = category()
+    createBarChart(container, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: currentCategory, fill: `var(--color-${currentCategory})`, radius: 4 },
+      ],
+      xAxis: { dataKey: 'month', tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+  })
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Show:</span>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            category() === 'desktop'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setCategory('desktop')}
+        >
+          Desktop
+        </button>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            category() === 'mobile'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setCategory('mobile')}
+        >
+          Mobile
+        </button>
+      </div>
+      <div
+        data-chart-demo="interactive"
+        className="w-full"
+        style="color:hsl(var(--foreground))"
+      />
+    </div>
+  )
+}

--- a/site/ui/components/mobile-menu.tsx
+++ b/site/ui/components/mobile-menu.tsx
@@ -58,7 +58,7 @@ export function MobileMenu() {
       openCategory('forms')
     } else if (currentPath.startsWith('/blocks')) {
       openCategory('blocks')
-    } else if (currentPath.startsWith('/charts')) {
+    } else if (currentPath.startsWith('/docs/charts')) {
       openCategory('charts')
     }
 
@@ -247,7 +247,9 @@ export function MobileMenu() {
                   <span>Charts</span>
                   <ChevronRightIcon size="sm" className={chevronClass} />
                 </summary>
-                <div className="pl-2 py-1 space-y-0.5"></div>
+                <div className="pl-2 py-1 space-y-0.5">
+                  <a href="/docs/charts/bar-chart" className={menuLinkClass}>Bar Chart</a>
+                </div>
               </details>
             </div>
           </nav>

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -58,6 +58,28 @@ export const componentOrder = [
   { slug: 'tooltip', title: 'Tooltip' },
 ]
 
+// Chart order for navigation (alphabetical)
+export const chartOrder = [
+  { slug: 'bar-chart', title: 'Bar Chart' },
+]
+
+// Get prev/next links for a chart page
+export function getChartNavLinks(currentSlug: string): {
+  prev?: { href: string; title: string }
+  next?: { href: string; title: string }
+} {
+  const currentIndex = chartOrder.findIndex(c => c.slug === currentSlug)
+  if (currentIndex === -1) return {}
+
+  const prev = currentIndex > 0 ? chartOrder[currentIndex - 1] : undefined
+  const next = currentIndex < chartOrder.length - 1 ? chartOrder[currentIndex + 1] : undefined
+
+  return {
+    prev: prev ? { href: `/docs/charts/${prev.slug}`, title: prev.title } : undefined,
+    next: next ? { href: `/docs/charts/${next.slug}`, title: next.title } : undefined,
+  }
+}
+
 // Get prev/next links for a component
 export function getNavLinks(currentSlug: string): {
   prev?: { href: string; title: string }

--- a/site/ui/e2e/bar-chart.spec.ts
+++ b/site/ui/e2e/bar-chart.spec.ts
@@ -6,19 +6,21 @@ test.describe('Bar Chart Documentation Page', () => {
   })
 
   test.describe('Preview', () => {
+    const scope = '[bf-s^="BarChartPreviewDemo_"]:not([data-slot])'
+
     test('renders an SVG chart', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="preview"]')
+      const container = page.locator(scope)
       await expect(container.locator('svg')).toBeVisible()
     })
 
     test('renders the correct number of bars', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="preview"]')
+      const container = page.locator(scope)
       const bars = container.locator('rect[data-key="desktop"]')
       await expect(bars).toHaveCount(6)
     })
 
     test('renders X axis labels', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="preview"]')
+      const container = page.locator(scope)
       const xAxisTexts = container.locator('.chart-x-axis text')
       await expect(xAxisTexts.first()).toHaveText('Jan')
     })
@@ -26,7 +28,7 @@ test.describe('Bar Chart Documentation Page', () => {
 
   test.describe('Basic', () => {
     test('renders an SVG with bars', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="basic"]')
+      const container = page.locator('[bf-s^="BarChartBasicDemo_"]:not([data-slot])')
       await expect(container.locator('svg')).toBeVisible()
       const bars = container.locator('rect[data-key="desktop"]')
       await expect(bars).toHaveCount(6)
@@ -35,7 +37,7 @@ test.describe('Bar Chart Documentation Page', () => {
 
   test.describe('Multiple', () => {
     test('renders both desktop and mobile bars', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="multiple"]')
+      const container = page.locator('[bf-s^="BarChartMultipleDemo_"]:not([data-slot])')
       const desktopBars = container.locator('rect[data-key="desktop"]')
       const mobileBars = container.locator('rect[data-key="mobile"]')
       await expect(desktopBars).toHaveCount(6)
@@ -46,24 +48,23 @@ test.describe('Bar Chart Documentation Page', () => {
   test.describe('Interactive', () => {
     test('switching category updates the chart', async ({ page }) => {
       const section = page.locator('[bf-s^="BarChartInteractiveDemo_"]:not([data-slot])').first()
-      const container = page.locator('[data-chart-demo="interactive"]')
 
       // Initially shows desktop bars
-      await expect(container.locator('rect[data-key="desktop"]')).toHaveCount(6)
-      await expect(container.locator('rect[data-key="mobile"]')).toHaveCount(0)
+      await expect(section.locator('rect[data-key="desktop"]')).toHaveCount(6)
+      await expect(section.locator('rect[data-key="mobile"]')).toHaveCount(0)
 
       // Click Mobile button
       await section.locator('button:has-text("Mobile")').click()
 
       // Should now show mobile bars
-      await expect(container.locator('rect[data-key="mobile"]')).toHaveCount(6)
-      await expect(container.locator('rect[data-key="desktop"]')).toHaveCount(0)
+      await expect(section.locator('rect[data-key="mobile"]')).toHaveCount(6)
+      await expect(section.locator('rect[data-key="desktop"]')).toHaveCount(0)
     })
   })
 
   test.describe('Tooltip', () => {
     test('tooltip appears on bar hover', async ({ page }) => {
-      const container = page.locator('[data-chart-demo="preview"]')
+      const container = page.locator('[bf-s^="BarChartPreviewDemo_"]:not([data-slot])')
       const tooltip = container.locator('.chart-tooltip')
 
       // Tooltip should be hidden initially

--- a/site/ui/e2e/bar-chart.spec.ts
+++ b/site/ui/e2e/bar-chart.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Bar Chart Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/docs/charts/bar-chart')
+  })
+
+  test.describe('Preview', () => {
+    test('renders an SVG chart', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="preview"]')
+      await expect(container.locator('svg')).toBeVisible()
+    })
+
+    test('renders the correct number of bars', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="preview"]')
+      const bars = container.locator('rect[data-key="desktop"]')
+      await expect(bars).toHaveCount(6)
+    })
+
+    test('renders X axis labels', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="preview"]')
+      const xAxisTexts = container.locator('.chart-x-axis text')
+      await expect(xAxisTexts.first()).toHaveText('Jan')
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('renders an SVG with bars', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="basic"]')
+      await expect(container.locator('svg')).toBeVisible()
+      const bars = container.locator('rect[data-key="desktop"]')
+      await expect(bars).toHaveCount(6)
+    })
+  })
+
+  test.describe('Multiple', () => {
+    test('renders both desktop and mobile bars', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="multiple"]')
+      const desktopBars = container.locator('rect[data-key="desktop"]')
+      const mobileBars = container.locator('rect[data-key="mobile"]')
+      await expect(desktopBars).toHaveCount(6)
+      await expect(mobileBars).toHaveCount(6)
+    })
+  })
+
+  test.describe('Interactive', () => {
+    test('switching category updates the chart', async ({ page }) => {
+      const section = page.locator('[bf-s^="BarChartInteractiveDemo_"]:not([data-slot])').first()
+      const container = page.locator('[data-chart-demo="interactive"]')
+
+      // Initially shows desktop bars
+      await expect(container.locator('rect[data-key="desktop"]')).toHaveCount(6)
+      await expect(container.locator('rect[data-key="mobile"]')).toHaveCount(0)
+
+      // Click Mobile button
+      await section.locator('button:has-text("Mobile")').click()
+
+      // Should now show mobile bars
+      await expect(container.locator('rect[data-key="mobile"]')).toHaveCount(6)
+      await expect(container.locator('rect[data-key="desktop"]')).toHaveCount(0)
+    })
+  })
+
+  test.describe('Tooltip', () => {
+    test('tooltip appears on bar hover', async ({ page }) => {
+      const container = page.locator('[data-chart-demo="preview"]')
+      const tooltip = container.locator('.chart-tooltip')
+
+      // Tooltip should be hidden initially
+      await expect(tooltip).toHaveCSS('opacity', '0')
+
+      // Hover over a bar
+      const bar = container.locator('rect[data-key="desktop"]').first()
+      await bar.hover()
+
+      // Tooltip should become visible
+      await expect(tooltip).toHaveCSS('opacity', '1')
+    })
+  })
+})

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -11,6 +11,7 @@
     "test:e2e:ui": "bunx playwright test --ui"
   },
   "dependencies": {
+    "@barefootjs/chart": "workspace:*",
     "@barefootjs/dom": "workspace:*",
     "@barefootjs/form": "workspace:*",
     "@barefootjs/hono": "workspace:*",

--- a/site/ui/pages/charts/bar-chart.tsx
+++ b/site/ui/pages/charts/bar-chart.tsx
@@ -1,0 +1,286 @@
+/**
+ * Bar Chart Documentation Page
+ */
+
+import {
+  BarChartPreviewDemo,
+  BarChartBasicDemo,
+  BarChartMultipleDemo,
+  BarChartInteractiveDemo,
+} from '@/components/bar-chart-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getChartNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'installation', title: 'Installation' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'multiple', title: 'Multiple', branch: 'child' },
+  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const previewCode = `"use client"
+
+import { onMount, onCleanup } from "@barefootjs/dom"
+import {
+  createBarChart,
+  applyChartCSSVariables,
+  type ChartConfig,
+} from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186 },
+  { month: "February", desktop: 305 },
+  { month: "March", desktop: 237 },
+  { month: "April", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "June", desktop: 214 },
+]
+
+export function BarChartPreviewDemo() {
+  onMount(() => {
+    const container = document.querySelector(
+      '[data-chart-demo="preview"]'
+    ) as HTMLElement
+    if (!container) return
+    applyChartCSSVariables(container, chartConfig)
+    const instance = createBarChart(container, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 },
+      ],
+      xAxis: {
+        dataKey: "month",
+        tickFormatter: (v) => v.slice(0, 3),
+      },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return (
+    <div
+      data-chart-demo="preview"
+      className="w-full"
+      style="min-height:250px"
+    />
+  )
+}`
+
+const basicCode = `"use client"
+
+import { onMount, onCleanup } from "@barefootjs/dom"
+import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186 },
+  { month: "February", desktop: 305 },
+  { month: "March", desktop: 237 },
+  { month: "April", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "June", desktop: 214 },
+]
+
+export function BarChartBasicDemo() {
+  onMount(() => {
+    const el = document.querySelector('[data-chart-demo="basic"]') as HTMLElement
+    if (!el) return
+    applyChartCSSVariables(el, chartConfig)
+    const instance = createBarChart(el, {
+      data: chartData,
+      config: chartConfig,
+      bars: [{ dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 }],
+      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return <div data-chart-demo="basic" className="w-full" style="min-height:250px" />
+}`
+
+const multipleCode = `"use client"
+
+import { onMount, onCleanup } from "@barefootjs/dom"
+import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+  mobile: { label: "Mobile", color: "hsl(280 65% 60%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186, mobile: 80 },
+  { month: "February", desktop: 305, mobile: 200 },
+  // ...
+]
+
+export function BarChartMultipleDemo() {
+  onMount(() => {
+    const el = document.querySelector('[data-chart-demo="multiple"]') as HTMLElement
+    if (!el) return
+    applyChartCSSVariables(el, chartConfig)
+    const instance = createBarChart(el, {
+      data: chartData,
+      config: chartConfig,
+      bars: [
+        { dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 },
+        { dataKey: "mobile", fill: "var(--color-mobile)", radius: 4 },
+      ],
+      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+    onCleanup(() => instance.destroy())
+  })
+
+  return <div data-chart-demo="multiple" className="w-full" style="min-height:250px" />
+}`
+
+const interactiveCode = `"use client"
+
+import { createSignal, createEffect, onCleanup } from "@barefootjs/dom"
+import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+  mobile: { label: "Mobile", color: "hsl(280 65% 60%)" },
+}
+
+export function BarChartInteractiveDemo() {
+  const [category, setCategory] = createSignal<"desktop" | "mobile">("desktop")
+
+  createEffect(() => {
+    const el = document.querySelector('[data-chart-demo="interactive"]') as HTMLElement
+    if (!el) return
+    const oldSvg = el.querySelector("svg")
+    if (oldSvg) oldSvg.remove()
+
+    applyChartCSSVariables(el, chartConfig)
+    const c = category()
+    createBarChart(el, {
+      data: chartData,
+      config: chartConfig,
+      bars: [{ dataKey: c, fill: \\\`var(--color-\\\${c})\\\`, radius: 4 }],
+      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
+      yAxis: true,
+      grid: { vertical: false },
+      tooltip: true,
+    })
+  })
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-4">
+        <button onClick={() => setCategory("desktop")}>Desktop</button>
+        <button onClick={() => setCategory("mobile")}>Mobile</button>
+      </div>
+      <div data-chart-demo="interactive" className="w-full" style="min-height:250px" />
+    </div>
+  )
+}`
+
+const chartProps: PropDefinition[] = [
+  {
+    name: 'data',
+    type: 'Record<string, unknown>[]',
+    description: 'Array of data objects. Each object represents one group on the X axis.',
+  },
+  {
+    name: 'config',
+    type: 'ChartConfig',
+    description: 'Maps each data key to a label and color. Sets CSS variables for theming.',
+  },
+  {
+    name: 'bars',
+    type: 'BarConfig[]',
+    description: 'Array of bar series. Each entry specifies dataKey, fill color, and optional radius.',
+  },
+  {
+    name: 'xAxis',
+    type: 'XAxisConfig',
+    description: 'X axis settings: dataKey for labels, optional tickFormatter.',
+  },
+  {
+    name: 'yAxis',
+    type: 'YAxisConfig | boolean',
+    defaultValue: 'false',
+    description: 'Y axis settings. Pass true for defaults or an object with tickFormatter.',
+  },
+  {
+    name: 'grid',
+    type: 'CartesianGridConfig',
+    description: 'Grid line settings. Control horizontal and vertical grid lines independently.',
+  },
+  {
+    name: 'tooltip',
+    type: 'TooltipConfig | boolean',
+    defaultValue: 'false',
+    description: 'Enable tooltip on bar hover. Pass true for defaults or an object with labelFormatter.',
+  },
+]
+
+export function BarChartPage() {
+  return (
+    <DocPage slug="bar-chart" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Bar Chart"
+          description="A bar chart component built with SVG and D3 scales."
+          {...getChartNavLinks('bar-chart')}
+        />
+
+        <Example title="" code={previewCode}>
+          <BarChartPreviewDemo />
+        </Example>
+
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="bun add @barefootjs/chart" />
+        </Section>
+
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <BarChartBasicDemo />
+            </Example>
+
+            <Example title="Multiple" code={multipleCode}>
+              <BarChartMultipleDemo />
+            </Example>
+
+            <Example title="Interactive" code={interactiveCode}>
+              <BarChartInteractiveDemo />
+            </Example>
+          </div>
+        </Section>
+
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={chartProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/charts/bar-chart.tsx
+++ b/site/ui/pages/charts/bar-chart.tsx
@@ -31,12 +31,7 @@ const tocItems: TocItem[] = [
 
 const previewCode = `"use client"
 
-import { onMount, onCleanup } from "@barefootjs/dom"
-import {
-  createBarChart,
-  applyChartCSSVariables,
-  type ChartConfig,
-} from "@barefootjs/chart"
+import type { ChartConfig } from "@barefootjs/chart"
 
 const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
@@ -52,42 +47,29 @@ const chartData = [
 ]
 
 export function BarChartPreviewDemo() {
-  onMount(() => {
-    const container = document.querySelector(
-      '[data-chart-demo="preview"]'
-    ) as HTMLElement
-    if (!container) return
-    applyChartCSSVariables(container, chartConfig)
-    const instance = createBarChart(container, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 },
-      ],
-      xAxis: {
-        dataKey: "month",
-        tickFormatter: (v) => v.slice(0, 3),
-      },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-    onCleanup(() => instance.destroy())
-  })
-
   return (
-    <div
-      data-chart-demo="preview"
-      className="w-full"
-      style="min-height:250px"
-    />
+    <ChartContainer config={chartConfig} className="w-full">
+      <BarChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <ChartTooltip />
+        <Bar
+          dataKey="desktop"
+          fill="var(--color-desktop)"
+          radius={4}
+        />
+      </BarChart>
+    </ChartContainer>
   )
 }`
 
 const basicCode = `"use client"
 
-import { onMount, onCleanup } from "@barefootjs/dom"
-import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+import type { ChartConfig } from "@barefootjs/chart"
 
 const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
@@ -103,28 +85,28 @@ const chartData = [
 ]
 
 export function BarChartBasicDemo() {
-  onMount(() => {
-    const el = document.querySelector('[data-chart-demo="basic"]') as HTMLElement
-    if (!el) return
-    applyChartCSSVariables(el, chartConfig)
-    const instance = createBarChart(el, {
-      data: chartData,
-      config: chartConfig,
-      bars: [{ dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 }],
-      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-    })
-    onCleanup(() => instance.destroy())
-  })
-
-  return <div data-chart-demo="basic" className="w-full" style="min-height:250px" />
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <BarChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <Bar
+          dataKey="desktop"
+          fill="var(--color-desktop)"
+          radius={4}
+        />
+      </BarChart>
+    </ChartContainer>
+  )
 }`
 
 const multipleCode = `"use client"
 
-import { onMount, onCleanup } from "@barefootjs/dom"
-import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+import type { ChartConfig } from "@barefootjs/chart"
 
 const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
@@ -138,32 +120,27 @@ const chartData = [
 ]
 
 export function BarChartMultipleDemo() {
-  onMount(() => {
-    const el = document.querySelector('[data-chart-demo="multiple"]') as HTMLElement
-    if (!el) return
-    applyChartCSSVariables(el, chartConfig)
-    const instance = createBarChart(el, {
-      data: chartData,
-      config: chartConfig,
-      bars: [
-        { dataKey: "desktop", fill: "var(--color-desktop)", radius: 4 },
-        { dataKey: "mobile", fill: "var(--color-mobile)", radius: 4 },
-      ],
-      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-    onCleanup(() => instance.destroy())
-  })
-
-  return <div data-chart-demo="multiple" className="w-full" style="min-height:250px" />
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <BarChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <ChartTooltip />
+        <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4} />
+        <Bar dataKey="mobile" fill="var(--color-mobile)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  )
 }`
 
 const interactiveCode = `"use client"
 
-import { createSignal, createEffect, onCleanup } from "@barefootjs/dom"
-import { createBarChart, applyChartCSSVariables, type ChartConfig } from "@barefootjs/chart"
+import { createSignal } from "@barefootjs/dom"
+import type { ChartConfig } from "@barefootjs/chart"
 
 const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
@@ -171,75 +148,133 @@ const chartConfig: ChartConfig = {
 }
 
 export function BarChartInteractiveDemo() {
-  const [category, setCategory] = createSignal<"desktop" | "mobile">("desktop")
-
-  createEffect(() => {
-    const el = document.querySelector('[data-chart-demo="interactive"]') as HTMLElement
-    if (!el) return
-    const oldSvg = el.querySelector("svg")
-    if (oldSvg) oldSvg.remove()
-
-    applyChartCSSVariables(el, chartConfig)
-    const c = category()
-    createBarChart(el, {
-      data: chartData,
-      config: chartConfig,
-      bars: [{ dataKey: c, fill: \\\`var(--color-\\\${c})\\\`, radius: 4 }],
-      xAxis: { dataKey: "month", tickFormatter: (v) => v.slice(0, 3) },
-      yAxis: true,
-      grid: { vertical: false },
-      tooltip: true,
-    })
-  })
+  const [category, setCategory] =
+    createSignal<"desktop" | "mobile">("desktop")
 
   return (
     <div>
       <div className="flex gap-2 mb-4">
-        <button onClick={() => setCategory("desktop")}>Desktop</button>
-        <button onClick={() => setCategory("mobile")}>Mobile</button>
+        <button onClick={() => setCategory("desktop")}>
+          Desktop
+        </button>
+        <button onClick={() => setCategory("mobile")}>
+          Mobile
+        </button>
       </div>
-      <div data-chart-demo="interactive" className="w-full" style="min-height:250px" />
+      <ChartContainer config={chartConfig} className="w-full">
+        <BarChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="month"
+            tickFormatter={(v: string) => v.slice(0, 3)}
+          />
+          <YAxis />
+          <ChartTooltip />
+          <Bar
+            dataKey={category()}
+            fill={\\\`var(--color-\\\${category()})\\\`}
+            radius={4}
+          />
+        </BarChart>
+      </ChartContainer>
     </div>
   )
 }`
 
-const chartProps: PropDefinition[] = [
+const barChartProps: PropDefinition[] = [
   {
     name: 'data',
     type: 'Record<string, unknown>[]',
     description: 'Array of data objects. Each object represents one group on the X axis.',
   },
+]
+
+const chartContainerProps: PropDefinition[] = [
   {
     name: 'config',
     type: 'ChartConfig',
     description: 'Maps each data key to a label and color. Sets CSS variables for theming.',
   },
   {
-    name: 'bars',
-    type: 'BarConfig[]',
-    description: 'Array of bar series. Each entry specifies dataKey, fill color, and optional radius.',
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names for the container element.',
+  },
+]
+
+const barProps: PropDefinition[] = [
+  {
+    name: 'dataKey',
+    type: 'string',
+    description: 'The key in the data objects to use for bar values.',
   },
   {
-    name: 'xAxis',
-    type: 'XAxisConfig',
-    description: 'X axis settings: dataKey for labels, optional tickFormatter.',
+    name: 'fill',
+    type: 'string',
+    defaultValue: 'currentColor',
+    description: 'Fill color for the bars. Supports CSS variables like var(--color-desktop).',
   },
   {
-    name: 'yAxis',
-    type: 'YAxisConfig | boolean',
+    name: 'radius',
+    type: 'number',
+    defaultValue: '0',
+    description: 'Border radius for rounded bar corners.',
+  },
+]
+
+const xAxisProps: PropDefinition[] = [
+  {
+    name: 'dataKey',
+    type: 'string',
+    description: 'The key in the data objects to use for X axis labels.',
+  },
+  {
+    name: 'tickFormatter',
+    type: '(value: string) => string',
+    description: 'Custom formatter for tick labels.',
+  },
+  {
+    name: 'hide',
+    type: 'boolean',
     defaultValue: 'false',
-    description: 'Y axis settings. Pass true for defaults or an object with tickFormatter.',
+    description: 'Hide the X axis.',
+  },
+]
+
+const yAxisProps: PropDefinition[] = [
+  {
+    name: 'tickFormatter',
+    type: '(value: number) => string',
+    description: 'Custom formatter for tick labels.',
   },
   {
-    name: 'grid',
-    type: 'CartesianGridConfig',
-    description: 'Grid line settings. Control horizontal and vertical grid lines independently.',
-  },
-  {
-    name: 'tooltip',
-    type: 'TooltipConfig | boolean',
+    name: 'hide',
+    type: 'boolean',
     defaultValue: 'false',
-    description: 'Enable tooltip on bar hover. Pass true for defaults or an object with labelFormatter.',
+    description: 'Hide the Y axis.',
+  },
+]
+
+const cartesianGridProps: PropDefinition[] = [
+  {
+    name: 'vertical',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show vertical grid lines.',
+  },
+  {
+    name: 'horizontal',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show horizontal grid lines.',
+  },
+]
+
+const chartTooltipProps: PropDefinition[] = [
+  {
+    name: 'labelFormatter',
+    type: '(label: string) => string',
+    description: 'Custom formatter for the tooltip label.',
   },
 ]
 
@@ -249,7 +284,7 @@ export function BarChartPage() {
       <div className="space-y-12">
         <PageHeader
           title="Bar Chart"
-          description="A bar chart component built with SVG and D3 scales."
+          description="A composable bar chart built with SVG and D3 scales."
           {...getChartNavLinks('bar-chart')}
         />
 
@@ -278,7 +313,36 @@ export function BarChartPage() {
         </Section>
 
         <Section id="api-reference" title="API Reference">
-          <PropsTable props={chartProps} />
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">BarChart</h3>
+              <PropsTable props={barChartProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ChartContainer</h3>
+              <PropsTable props={chartContainerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">Bar</h3>
+              <PropsTable props={barProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">XAxis</h3>
+              <PropsTable props={xAxisProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">YAxis</h3>
+              <PropsTable props={yAxisProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">CartesianGrid</h3>
+              <PropsTable props={cartesianGridProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ChartTooltip</h3>
+              <PropsTable props={chartTooltipProps} />
+            </div>
+          </div>
         </Section>
       </div>
     </DocPage>

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -138,7 +138,9 @@ const menuEntries: SidebarEntry[] = [
   },
   {
     title: 'Charts',
-    links: [],
+    links: [
+      { title: 'Bar Chart', href: '/docs/charts/bar-chart' },
+    ],
   },
 ]
 
@@ -147,6 +149,7 @@ const importMapScript = JSON.stringify({
   imports: {
     '@barefootjs/dom': '/static/components/barefoot.js',
     '@barefootjs/form': '/static/components/barefoot-form.js',
+    '@barefootjs/chart': '/static/components/barefoot-chart.js',
     'zod': '/static/lib/zod.esm.js',
     'embla-carousel': '/static/lib/embla-carousel.esm.js',
   },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -61,6 +61,9 @@ import { NavigationMenuPage } from './pages/navigation-menu'
 import { TablePage } from './pages/table'
 import { SpinnerPage } from './pages/spinner'
 
+// Chart pages
+import { BarChartPage } from './pages/charts/bar-chart'
+
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
 import { ValidationPage } from './pages/forms/validation'
@@ -598,6 +601,11 @@ export function createApp() {
   // Table documentation
   app.get('/docs/components/table', (c) => {
     return c.render(<TablePage />)
+  })
+
+  // Bar Chart documentation
+  app.get('/docs/charts/bar-chart', (c) => {
+    return c.render(<BarChartPage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/chart/index.tsx
+++ b/ui/components/ui/chart/index.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+/**
+ * Chart JSX Components
+ *
+ * "use client" wrappers that delegate to @barefootjs/chart init functions
+ * via ref callbacks. Follows the Dialog pattern: ref runs during init,
+ * before children's initChild calls, so provideContext/useContext works.
+ */
+
+import {
+  initChartContainer as chartContainerInit,
+  initBarChart as barChartInit,
+  initBar as barInit,
+  initCartesianGrid as cartesianGridInit,
+  initXAxis as xAxisInit,
+  initYAxis as yAxisInit,
+  initChartTooltip as chartTooltipInit,
+} from '@barefootjs/chart'
+
+/** Color and label configuration for chart data series */
+type ChartConfig = Record<string, { label: string; color: string }>
+
+interface ChartContainerProps {
+  config: ChartConfig
+  className?: string
+  children?: unknown
+}
+
+interface BarChartProps {
+  data: Record<string, unknown>[]
+  children?: unknown
+}
+
+interface BarProps {
+  dataKey: string
+  fill?: string
+  radius?: number
+}
+
+interface CartesianGridProps {
+  vertical?: boolean
+  horizontal?: boolean
+}
+
+interface XAxisProps {
+  dataKey: string
+  tickFormatter?: (value: string) => string
+  hide?: boolean
+}
+
+interface YAxisProps {
+  hide?: boolean
+  tickFormatter?: (value: number) => string
+}
+
+interface ChartTooltipProps {
+  labelFormatter?: (label: string) => string
+}
+
+function ChartContainer(props: ChartContainerProps) {
+  const handleMount = (el: HTMLElement) => {
+    chartContainerInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return (
+    <div data-slot="chart-container" className={props.className ?? ''} ref={handleMount}>
+      {props.children}
+    </div>
+  )
+}
+
+function BarChart(props: BarChartProps) {
+  const handleMount = (el: HTMLElement) => {
+    barChartInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return (
+    <div data-slot="bar-chart" ref={handleMount}>
+      {props.children}
+    </div>
+  )
+}
+
+function Bar(props: BarProps) {
+  const handleMount = (el: HTMLElement) => {
+    barInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="bar" style="display:none" ref={handleMount} />
+}
+
+function CartesianGrid(props: CartesianGridProps) {
+  const handleMount = (el: HTMLElement) => {
+    cartesianGridInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="cartesian-grid" style="display:none" ref={handleMount} />
+}
+
+function XAxis(props: XAxisProps) {
+  const handleMount = (el: HTMLElement) => {
+    xAxisInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="x-axis" style="display:none" ref={handleMount} />
+}
+
+function YAxis(props: YAxisProps) {
+  const handleMount = (el: HTMLElement) => {
+    yAxisInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="y-axis" style="display:none" ref={handleMount} />
+}
+
+function ChartTooltip(props: ChartTooltipProps) {
+  const handleMount = (el: HTMLElement) => {
+    chartTooltipInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="chart-tooltip" style="display:none" ref={handleMount} />
+}
+
+export {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+}
+
+export type {
+  ChartContainerProps,
+  BarChartProps,
+  BarProps,
+  CartesianGridProps,
+  XAxisProps,
+  YAxisProps,
+  ChartTooltipProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -52,6 +52,12 @@
       "description": "A date calendar for picking single dates with month navigation"
     },
     {
+      "name": "bar-chart",
+      "type": "registry:ui",
+      "title": "Bar Chart",
+      "description": "A bar chart component built with SVG and D3 scales"
+    },
+    {
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",


### PR DESCRIPTION
## Summary

- Add `@barefootjs/chart` package with SVG bar chart components powered by D3 scales and signal-based reactivity
- JSX component API: `<ChartContainer>`, `<BarChart>`, `<Bar>`, `<XAxis>`, `<YAxis>`, `<CartesianGrid>`, `<ChartTooltip>`
- Uses Dialog pattern (`"use client"` wrappers with `ref` callbacks) for compiler integration
- Reactive props support — signal-driven `dataKey`/`fill` changes re-render bars automatically
- Documentation page with 4 demos: Basic, Multiple series, Interactive (signal switching), Tooltip

## Test plan

- [x] Unit tests: 9 pass (`packages/chart/src/__tests__/bar-chart.test.ts`)
- [x] E2E tests: 7 pass (`site/ui/e2e/bar-chart.spec.ts`)
- [x] Full site E2E: 736 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)