### PR TITLE
Unify client JS build pipeline (#568)

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { resolveRelativeImports } from '../lib/resolve-imports'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+const TEST_DIR = resolve(tmpdir(), `bf-test-resolve-imports-${Date.now()}`)
+const DIST_DIR = resolve(TEST_DIR, 'dist')
+const COMPONENTS_DIR = resolve(DIST_DIR, 'components')
+const SOURCE_DIR = resolve(TEST_DIR, 'src')
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+  mkdirSync(COMPONENTS_DIR, { recursive: true })
+  mkdirSync(SOURCE_DIR, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe('resolveRelativeImports', () => {
+  test('inlines pure .ts module', async () => {
+    // Write a utility module next to the client JS
+    writeFileSync(resolve(COMPONENTS_DIR, 'utils.ts'), `
+export function highlight(code: string): string {
+  return '<pre>' + code + '</pre>'
+}
+`)
+    // Write client JS that imports the utility
+    const clientJs = `import { highlight } from './utils'
+import { createSignal } from '@barefootjs/dom'
+console.log(highlight('hello'))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Demo-abc123.js'), clientJs)
+
+    const manifest = {
+      Demo: { clientJs: 'components/Demo-abc123.js', markedTemplate: 'components/Demo.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Demo-abc123.js')).text()
+    // Should contain the inlined function (without export keyword)
+    expect(result).toContain('function highlight(code)')
+    // Should NOT contain the original import
+    expect(result).not.toContain("from './utils'")
+    // Should keep package imports untouched
+    expect(result).toContain("from '@barefootjs/dom'")
+  })
+
+  test('strips .tsx server component import', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'ServerComp.tsx'), `
+export function ServerComp() {
+  return <div>server only</div>
+}
+`)
+    const clientJs = `import { ServerComp } from './ServerComp'
+import { createSignal } from '@barefootjs/dom'
+console.log('client code')
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Parent-abc123.js'), clientJs)
+
+    const manifest = {
+      Parent: { clientJs: 'components/Parent-abc123.js', markedTemplate: 'components/Parent.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Parent-abc123.js')).text()
+    expect(result).not.toContain('ServerComp')
+    expect(result).toContain("from '@barefootjs/dom'")
+    expect(result).toContain("console.log('client code')")
+  })
+
+  test('deduplicates same module imported by two client JS files', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'shared-utils.ts'), `
+export const VERSION = '1.0'
+`)
+    const clientJsA = `import { VERSION } from './shared-utils'
+console.log('A', VERSION)
+`
+    const clientJsB = `import { VERSION } from './shared-utils'
+console.log('B', VERSION)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'CompA-aaa.js'), clientJsA)
+    writeFileSync(resolve(COMPONENTS_DIR, 'CompB-bbb.js'), clientJsB)
+
+    const manifest = {
+      CompA: { clientJs: 'components/CompA-aaa.js', markedTemplate: 'components/CompA.tsx' },
+      CompB: { clientJs: 'components/CompB-bbb.js', markedTemplate: 'components/CompB.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const resultA = await Bun.file(resolve(COMPONENTS_DIR, 'CompA-aaa.js')).text()
+    const resultB = await Bun.file(resolve(COMPONENTS_DIR, 'CompB-bbb.js')).text()
+    // Both should have the inlined code (dedup is per-file, not cross-file)
+    expect(resultA).toContain('VERSION')
+    expect(resultB).toContain('VERSION')
+    expect(resultA).not.toContain("from './shared-utils'")
+    expect(resultB).not.toContain("from './shared-utils'")
+  })
+
+  test('no-op when no relative imports', async () => {
+    const clientJs = `import { createSignal } from '@barefootjs/dom'
+const [count, setCount] = createSignal(0)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Counter-xyz.js'), clientJs)
+
+    const manifest = {
+      Counter: { clientJs: 'components/Counter-xyz.js', markedTemplate: 'components/Counter.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Counter-xyz.js')).text()
+    expect(result).toBe(clientJs)
+  })
+
+  test('strips missing module import without crashing', async () => {
+    const clientJs = `import { missing } from './nonexistent'
+console.log('still works')
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Broken-111.js'), clientJs)
+
+    const manifest = {
+      Broken: { clientJs: 'components/Broken-111.js', markedTemplate: 'components/Broken.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Broken-111.js')).text()
+    expect(result).not.toContain('nonexistent')
+    expect(result).toContain("console.log('still works')")
+  })
+
+  test('resolves from sourceDirs when not found relative to client JS', async () => {
+    // Module exists in SOURCE_DIR, not in COMPONENTS_DIR
+    writeFileSync(resolve(SOURCE_DIR, 'helpers.ts'), `
+export function formatDate(d: Date): string {
+  return d.toISOString()
+}
+`)
+    const clientJs = `import { formatDate } from './helpers'
+console.log(formatDate(new Date()))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DatePicker-fff.js'), clientJs)
+
+    const manifest = {
+      DatePicker: { clientJs: 'components/DatePicker-fff.js', markedTemplate: 'components/DatePicker.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest, sourceDirs: [SOURCE_DIR] })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'DatePicker-fff.js')).text()
+    expect(result).toContain('function formatDate(d)')
+    expect(result).not.toContain("from './helpers'")
+  })
+})

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -4,6 +4,9 @@ import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
 import type { TemplateAdapter } from '@barefootjs/jsx'
 import { mkdir, readdir, stat } from 'node:fs/promises'
 import { resolve, basename, relative } from 'node:path'
+import { resolveRelativeImports } from './resolve-imports'
+
+export { resolveRelativeImports } from './resolve-imports'
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -64,8 +67,12 @@ export function hasUseClientDirective(content: string): boolean {
  * Recursively discover .tsx component files in a directory.
  * Skips .test.tsx, .spec.tsx, and .preview.tsx files.
  */
-export async function discoverComponentFiles(dir: string): Promise<string[]> {
+export async function discoverComponentFiles(
+  dir: string,
+  options?: { skipDirs?: string[] }
+): Promise<string[]> {
   const results: string[] = []
+  const skipDirs = options?.skipDirs ? new Set(options.skipDirs) : null
 
   let entries: { name: string; isDirectory(): boolean }[]
   try {
@@ -77,7 +84,8 @@ export async function discoverComponentFiles(dir: string): Promise<string[]> {
   for (const entry of entries) {
     const fullPath = resolve(dir, String(entry.name))
     if (entry.isDirectory()) {
-      results.push(...await discoverComponentFiles(fullPath))
+      if (skipDirs?.has(String(entry.name))) continue
+      results.push(...await discoverComponentFiles(fullPath, options))
     } else if (
       String(entry.name).endsWith('.tsx') &&
       !String(entry.name).endsWith('.test.tsx') &&
@@ -287,6 +295,9 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
       console.log(`Combined: ${entry.clientJs}`)
     }
   }
+
+  // 6b. Resolve relative imports
+  await resolveRelativeImports({ distDir: config.outDir, manifest })
 
   // 7. Minify client JS (after combine so all files are final)
   if (config.minify) {

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -1,0 +1,94 @@
+// Resolve and inline relative imports in compiled client JS files.
+
+import { dirname, resolve } from 'node:path'
+import { RELATIVE_IMPORT_RE } from './patterns'
+
+export interface ResolveRelativeImportsOptions {
+  /** Absolute path to the dist directory (base for manifest paths) */
+  distDir: string
+  /** Build manifest: componentName -> { clientJs?, markedTemplate } */
+  manifest: Record<string, { clientJs?: string; markedTemplate: string }>
+  /** Source directories to search for modules (checked after the client JS file's own directory) */
+  sourceDirs?: string[]
+}
+
+/**
+ * Resolve relative imports in compiled client JS files.
+ *
+ * For each client JS file in the manifest:
+ * - `.ts` imports: transpile with Bun.Transpiler and inline the code
+ * - `.tsx` imports: strip (server component, already rendered at SSR time)
+ * - Not found / already inlined: strip
+ */
+export async function resolveRelativeImports(options: ResolveRelativeImportsOptions): Promise<void> {
+  const { distDir, manifest, sourceDirs = [] } = options
+
+  for (const [, entry] of Object.entries(manifest)) {
+    if (!entry.clientJs) continue
+    const filePath = resolve(distDir, entry.clientJs)
+    let content: string
+    try {
+      content = await Bun.file(filePath).text()
+    } catch {
+      continue
+    }
+
+    // Reset the global regex for each file
+    const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
+    const matches = [...content.matchAll(re)]
+    if (matches.length === 0) continue
+
+    const inlinedPaths = new Set<string>()
+
+    for (const match of matches) {
+      const importPath = match[1]
+      const fullMatch = match[0]
+
+      // Try to resolve source file: first relative to client JS, then sourceDirs
+      const searchDirs = [dirname(filePath), ...sourceDirs]
+      let sourceFile = ''
+      for (const dir of searchDirs) {
+        const basePath = resolve(dir, importPath)
+        for (const ext of ['.ts', '.tsx', '.js']) {
+          if (await Bun.file(basePath + ext).exists()) {
+            sourceFile = basePath + ext
+            break
+          }
+        }
+        if (sourceFile) break
+      }
+
+      if (!sourceFile || inlinedPaths.has(sourceFile)) {
+        // Already inlined or not found — strip the import
+        content = content.replace(fullMatch + '\n', '')
+        continue
+      }
+
+      // Only inline pure TS modules (no JSX). TSX files with JSX are server
+      // components whose rendering was already done at SSR time — their imports
+      // in client JS are for component name matching only, not runtime execution.
+      if (sourceFile.endsWith('.tsx')) {
+        content = content.replace(fullMatch + '\n', '')
+        console.log(`Stripped server component import: ${importPath} from ${entry.clientJs}`)
+        continue
+      }
+
+      // Transpile and inline pure TS utility modules
+      const sourceContent = await Bun.file(sourceFile).text()
+      const transpiler = new Bun.Transpiler({ loader: 'ts' })
+      let jsCode = transpiler.transformSync(sourceContent)
+
+      // Convert exports to plain declarations for inlining
+      jsCode = jsCode
+        .replace(/^import\s+.*$/gm, '')
+        .replace(/^export\s+/gm, '')
+        .trim()
+
+      content = content.replace(fullMatch, jsCode)
+      inlinedPaths.add(sourceFile)
+      console.log(`Inlined: ${importPath} into ${entry.clientJs}`)
+    }
+
+    await Bun.write(filePath, content)
+  }
+}

--- a/packages/preview/src/compile.ts
+++ b/packages/preview/src/compile.ts
@@ -7,91 +7,21 @@
 
 import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
 import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { addScriptCollection } from '@barefootjs/hono/build'
 import { mkdir, readdir, symlink, lstat } from 'node:fs/promises'
 import { dirname, resolve, join, relative, basename } from 'node:path'
+import {
+  hasUseClientDirective,
+  discoverComponentFiles,
+  generateHash,
+} from '../../../cli/src/lib/build'
+import { resolveRelativeImports } from '../../../cli/src/lib/resolve-imports'
 
 const ROOT_DIR = resolve(import.meta.dir, '../../..')
 const UI_COMPONENTS_DIR = resolve(ROOT_DIR, 'ui/components')
 const DOM_PKG_DIR = resolve(ROOT_DIR, 'packages/dom')
 const DIST_DIR = resolve(ROOT_DIR, '.preview-dist')
 const DIST_COMPONENTS_DIR = resolve(DIST_DIR, 'components')
-
-function hasUseClientDirective(content: string): boolean {
-  let trimmed = content.trimStart()
-  while (trimmed.startsWith('/*')) {
-    const endIndex = trimmed.indexOf('*/')
-    if (endIndex === -1) break
-    trimmed = trimmed.slice(endIndex + 2).trimStart()
-  }
-  while (trimmed.startsWith('//')) {
-    const endIndex = trimmed.indexOf('\n')
-    if (endIndex === -1) break
-    trimmed = trimmed.slice(endIndex + 1).trimStart()
-  }
-  return trimmed.startsWith('"use client"') || trimmed.startsWith("'use client'")
-}
-
-function generateHash(content: string): string {
-  return Bun.hash(content).toString(16).slice(0, 8)
-}
-
-/**
- * Add script collection wrapper to SSR component (identical to site/ui/build.ts)
- */
-function addScriptCollection(content: string, componentId: string, clientJsPath: string): string {
-  const importStatement = "import { useRequestContext } from 'hono/jsx-renderer'\n"
-
-  const importMatch = content.match(/^([\s\S]*?)((?:import[^\n]+\n)*)/m)
-  if (!importMatch) return content
-
-  const beforeImports = importMatch[1]
-  const existingImports = importMatch[2]
-  const restOfFile = content.slice(importMatch[0].length)
-
-  const scriptCollector = `
-  try {
-    const __c = useRequestContext()
-    const __scripts: { src: string }[] = __c.get('bfCollectedScripts') || []
-    const __outputScripts: Set<string> = __c.get('bfOutputScripts') || new Set()
-    if (!__outputScripts.has('__barefoot__')) {
-      __outputScripts.add('__barefoot__')
-      __scripts.push({ src: '/static/barefoot.js' })
-    }
-    if (!__outputScripts.has('${componentId}')) {
-      __outputScripts.add('${componentId}')
-      __scripts.push({ src: '/static/components/${clientJsPath}' })
-    }
-    __c.set('bfCollectedScripts', __scripts)
-    __c.set('bfOutputScripts', __outputScripts)
-  } catch {}
-`
-
-  const modifiedRest = restOfFile.replace(
-    /export function (\w+)\(([^)]*)\)([^{]*)\{/g,
-    (match, name, params, rest) =>
-      `export function ${name}(${params})${rest}{${scriptCollector}`
-  )
-
-  return beforeImports + existingImports + importStatement + modifiedRest
-}
-
-/**
- * Discover all .tsx component files under ui/components/ (recursive, skip __previews__ and __tests__)
- */
-async function discoverComponentFiles(dir: string): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true })
-  const files: string[] = []
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      if (entry.name === '__previews__' || entry.name === '__tests__' || entry.name === 'shared') continue
-      files.push(...await discoverComponentFiles(fullPath))
-    } else if (entry.name.endsWith('.tsx')) {
-      files.push(fullPath)
-    }
-  }
-  return files
-}
 
 export interface CompileOptions {
   /** Absolute path to the .previews.tsx file */
@@ -143,7 +73,9 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
   console.log('Generated: .preview-dist/globals.css')
 
   // 3. Discover all component files (dependency compilation)
-  const componentFiles = await discoverComponentFiles(UI_COMPONENTS_DIR)
+  const componentFiles = await discoverComponentFiles(UI_COMPONENTS_DIR, {
+    skipDirs: ['__previews__', '__tests__', 'shared'],
+  })
   // Add the previews file itself
   const allFiles = [...componentFiles, previewsPath]
 
@@ -250,6 +182,9 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     await Bun.write(resolve(DIST_DIR, entry.clientJs), content)
     console.log(`Combined: ${entry.clientJs}`)
   }
+
+  // 5b. Resolve relative imports
+  await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
   // 6. Rewrite imports and add JSX pragma in compiled .tsx files
   const HONO_UTILS_PATH = resolve(ROOT_DIR, 'packages/hono/src/utils')

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -15,7 +15,7 @@
  * - dist/static/snippets/ (code snippet files for LP)
  */
 
-import { compileJSX } from '@barefootjs/jsx'
+import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
 import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { mkdir, readdir } from 'node:fs/promises'
 import { dirname, resolve, join, relative } from 'node:path'
@@ -24,6 +24,7 @@ import {
   hasUseClientDirective,
   discoverComponentFiles,
   generateHash,
+  resolveRelativeImports,
 } from '../../packages/cli/src/lib/build'
 import { addScriptCollection } from '../../packages/hono/src/build'
 
@@ -175,6 +176,31 @@ for (const entryPath of componentFiles) {
 // Output manifest
 await Bun.write(resolve(DIST_COMPONENTS_DIR, 'manifest.json'), JSON.stringify(manifest, null, 2))
 console.log('Generated: dist/components/manifest.json')
+
+// Combine parent-child client JS
+const clientJsFiles = new Map<string, string>()
+for (const [name, entry] of Object.entries(manifest)) {
+  if (!entry.clientJs) continue
+  const filePath = resolve(DIST_DIR, entry.clientJs)
+  try { clientJsFiles.set(name, await Bun.file(filePath).text()) } catch {}
+}
+if (clientJsFiles.size > 0) {
+  const combined = combineParentChildClientJs(clientJsFiles)
+  for (const [name, content] of combined) {
+    const entry = manifest[name]
+    if (entry?.clientJs) {
+      await Bun.write(resolve(DIST_DIR, entry.clientJs), content)
+      console.log(`Combined: ${entry.clientJs}`)
+    }
+  }
+}
+
+// Resolve relative imports
+await resolveRelativeImports({
+  distDir: DIST_DIR,
+  manifest,
+  sourceDirs: [COMPONENTS_DIR, resolve(SHARED_DIR, 'components'), LANDING_COMPONENTS_DIR],
+})
 
 // Generate index.ts for re-exporting all compiled components
 async function collectExports(dir: string, prefix: string = ''): Promise<string[]> {

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -22,8 +22,8 @@ import {
   hasUseClientDirective,
   discoverComponentFiles as discoverFiles,
   generateHash,
+  resolveRelativeImports,
 } from '../../packages/cli/src/lib/build'
-import { RELATIVE_IMPORT_RE } from '../../packages/cli/src/lib/patterns'
 import { addScriptCollection } from '../../packages/hono/src/build'
 
 const ROOT_DIR = dirname(import.meta.path)
@@ -310,67 +310,11 @@ await copyTsFiles(SHARED_DIR, DIST_SHARED_DIR, 'dist/components/shared/')
 // The combiner handles @bf-child placeholders, but relative imports to utility
 // modules (e.g., ./shared/playground-highlight) need to be inlined separately.
 // Component imports that were already inlined via @bf-child are stripped as redundant.
-async function inlineRelativeImports(manifestData: typeof manifest): Promise<void> {
-  for (const [, entry] of Object.entries(manifestData)) {
-    if (!entry.clientJs) continue
-    const filePath = resolve(DIST_DIR, entry.clientJs)
-    let content = await Bun.file(filePath).text()
-
-    const matches = [...content.matchAll(RELATIVE_IMPORT_RE)]
-    if (matches.length === 0) continue
-
-    const inlinedPaths = new Set<string>()
-
-    for (const match of matches) {
-      const importPath = match[1]
-      const fullMatch = match[0]
-
-      // Try to resolve source file
-      const basePath = resolve(dirname(filePath), importPath)
-      let sourceFile = ''
-      for (const ext of ['.ts', '.tsx', '.js']) {
-        if (await Bun.file(basePath + ext).exists()) {
-          sourceFile = basePath + ext
-          break
-        }
-      }
-
-      if (!sourceFile || inlinedPaths.has(sourceFile)) {
-        // Already inlined or not found — strip the import
-        content = content.replace(fullMatch + '\n', '')
-        continue
-      }
-
-      // Only inline pure TS modules (no JSX). TSX files with JSX are server
-      // components whose rendering was already done at SSR time — their imports
-      // in client JS are for component name matching only, not runtime execution.
-      if (sourceFile.endsWith('.tsx')) {
-        content = content.replace(fullMatch + '\n', '')
-        console.log(`Stripped server component import: ${importPath} from ${entry.clientJs}`)
-        continue
-      }
-
-      // Transpile and inline pure TS utility modules
-      const sourceContent = await Bun.file(sourceFile).text()
-      const transpiler = new Bun.Transpiler({ loader: 'ts' })
-      let jsCode = transpiler.transformSync(sourceContent)
-
-      // Convert exports to plain declarations for inlining
-      jsCode = jsCode
-        .replace(/^import\s+.*$/gm, '')
-        .replace(/^export\s+/gm, '')
-        .trim()
-
-      content = content.replace(fullMatch, jsCode)
-      inlinedPaths.add(sourceFile)
-      console.log(`Inlined: ${importPath} into ${entry.clientJs}`)
-    }
-
-    await Bun.write(filePath, content)
-  }
-}
-
-await inlineRelativeImports(manifest)
+await resolveRelativeImports({
+  distDir: DIST_DIR,
+  manifest,
+  sourceDirs: [UI_COMPONENTS_DIR, SHARED_COMPONENTS_DIR, DOCS_COMPONENTS_DIR],
+})
 
 // Generate index.ts for re-exporting all components (handles subdirectories)
 async function collectExports(dir: string, prefix: string = ''): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Extract `resolveRelativeImports()` from `site/ui/build.ts` into shared utility at `packages/cli/src/lib/resolve-imports.ts`
- Add `skipDirs` option to `discoverComponentFiles()` for filtering directories during discovery
- Add combine + resolve steps to `site/core/build.ts` (prevents future breakage with nested `"use client"` components)
- Replace local `inlineRelativeImports` in `site/ui/build.ts` with shared utility
- Deduplicate `packages/preview/src/compile.ts` by importing shared `hasUseClientDirective`, `generateHash`, `discoverComponentFiles`, and `addScriptCollection` instead of copy-pasting

## Test plan

- [x] `bun test packages/cli/` — 198 tests pass (includes 6 new resolve-imports tests)
- [x] `bun test packages/jsx/` — 462 tests pass
- [x] `bun test packages/adapter-tests/` — 69 tests pass
- [x] `cd site/core && bun run build` — build succeeds, resolve works
- [x] `cd site/ui && bun run build` — build succeeds, output unchanged
- [x] No relative `import` statements remain in any `dist/components/*.js` file

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)