### PR TITLE
Fix resolveRelativeImports to handle missing trailing newline

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -118,6 +118,25 @@ const [count, setCount] = createSignal(0)
     expect(result).toBe(clientJs)
   })
 
+  test('strips import at EOF without trailing newline', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'eof-utils.tsx'), `
+export function EofComp() { return <div /> }
+`)
+    // No trailing newline after import
+    const clientJs = `console.log('main code')\nimport { EofComp } from './eof-utils'`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Eof-222.js'), clientJs)
+
+    const manifest = {
+      Eof: { clientJs: 'components/Eof-222.js', markedTemplate: 'components/Eof.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Eof-222.js')).text()
+    expect(result).not.toContain('eof-utils')
+    expect(result).toContain("console.log('main code')")
+  })
+
   test('strips missing module import without crashing', async () => {
     const clientJs = `import { missing } from './nonexistent'
 console.log('still works')

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -3,6 +3,10 @@
 import { dirname, resolve } from 'node:path'
 import { RELATIVE_IMPORT_RE } from './patterns'
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export interface ResolveRelativeImportsOptions {
   /** Absolute path to the dist directory (base for manifest paths) */
   distDir: string
@@ -60,7 +64,7 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
 
       if (!sourceFile || inlinedPaths.has(sourceFile)) {
         // Already inlined or not found — strip the import
-        content = content.replace(fullMatch + '\n', '')
+        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
         continue
       }
 
@@ -68,7 +72,7 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       // components whose rendering was already done at SSR time — their imports
       // in client JS are for component name matching only, not runtime execution.
       if (sourceFile.endsWith('.tsx')) {
-        content = content.replace(fullMatch + '\n', '')
+        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
         console.log(`Stripped server component import: ${importPath} from ${entry.clientJs}`)
         continue
       }


### PR DESCRIPTION
## Summary

`resolveRelativeImports()` silently failed to strip imports at EOF without trailing newline. Use RegExp with optional `\n?` instead of string concatenation.

Closes #575

## Test plan

- [x] `bun test packages/cli/` — 199 tests pass
- [x] New test: `strips import at EOF without trailing newline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)