### PR TITLE
Fix #581: preserve side-effect imports in codegen

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -105,6 +105,12 @@ export class HonoAdapter implements TemplateAdapter {
     // Re-export original imports (excluding @barefootjs/dom)
     for (const imp of ir.metadata.imports) {
       if (imp.source === '@barefootjs/dom') continue
+      if (imp.specifiers.length === 0) {
+        if (!imp.isTypeOnly) {
+          lines.push(`import '${imp.source}'`)
+        }
+        continue
+      }
       if (imp.isTypeOnly) {
         lines.push(`import type ${this.formatImportSpecifiers(imp.specifiers)} from '${imp.source}'`)
       } else {

--- a/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts
@@ -60,6 +60,15 @@ function makeImport(source: string, specifiers: string[], isTypeOnly = false): I
   }
 }
 
+function makeSideEffectImport(source: string): ImportInfo {
+  return {
+    source,
+    specifiers: [],
+    isTypeOnly: false,
+    loc: dummyLoc,
+  }
+}
+
 describe('collectExternalImports', () => {
   test('preserves third-party library imports used in generated code', () => {
     const ir = makeIR([makeImport('zod', ['z'])])
@@ -183,5 +192,39 @@ describe('collectExternalImports', () => {
     const code = 'useForm()'
     const result = collectExternalImports(ir, code)
     expect(result).toEqual(["import { useForm } from '@barefootjs/form'"])
+  })
+
+  test('preserves side-effect imports (empty specifiers)', () => {
+    const ir = makeIR([makeSideEffectImport('@barefootjs/chart')])
+    const code = ''
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual(["import '@barefootjs/chart'"])
+  })
+
+  test('skips @barefootjs/dom side-effect imports', () => {
+    const ir = makeIR([{ source: '@barefootjs/dom', specifiers: [], isTypeOnly: false, loc: dummyLoc }])
+    const code = ''
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([])
+  })
+
+  test('skips side-effect imports matching localImportPrefixes', () => {
+    const ir = makeIR([makeSideEffectImport('@ui/styles/theme')])
+    const code = ''
+    const result = collectExternalImports(ir, code, ['@ui/'])
+    expect(result).toEqual([])
+  })
+
+  test('preserves side-effect imports alongside normal imports', () => {
+    const ir = makeIR([
+      makeSideEffectImport('@barefootjs/chart'),
+      makeImport('zod', ['z']),
+    ])
+    const code = 'z.string()'
+    const result = collectExternalImports(ir, code)
+    expect(result).toEqual([
+      "import '@barefootjs/chart'",
+      "import { z } from 'zod'",
+    ])
   })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -59,6 +59,12 @@ export class TestAdapter extends BaseAdapter {
 
     for (const imp of ir.metadata.imports) {
       if (imp.source === '@barefootjs/dom') continue
+      if (imp.specifiers.length === 0) {
+        if (!imp.isTypeOnly) {
+          lines.push(`import '${imp.source}'`)
+        }
+        continue
+      }
       if (imp.isTypeOnly) {
         lines.push(`import type ${this.formatImportSpecifiers(imp.specifiers)} from '${imp.source}'`)
       } else {

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -75,6 +75,12 @@ export function collectExternalImports(ir: ComponentIR, generatedCode: string, l
     // Skip local path-alias imports (resolved at build time, not in browser)
     if (localImportPrefixes?.some(prefix => imp.source.startsWith(prefix))) continue
 
+    // Side-effect imports have no specifiers — preserve unconditionally
+    if (imp.specifiers.length === 0) {
+      importLines.push(`import '${imp.source}'`)
+      continue
+    }
+
     // Check which specifiers are actually used in the generated code.
     // Skip component names — they are rendered via initChild(), not imported directly.
     const usedSpecs: string[] = []


### PR DESCRIPTION
## Summary

- Fix `collectExternalImports()` in client JS codegen to emit `import '...'` for side-effect imports (empty `specifiers: []` was causing the specifier loop to skip them entirely)
- Fix `generateImports()` in both `HonoAdapter` and `TestAdapter` to emit `import '...'` instead of invalid `import  from '...'` for side-effect imports
- Add 4 unit tests covering side-effect import preservation, `@barefootjs/dom` filtering, `localImportPrefixes` filtering, and coexistence with normal imports

## Test plan

- [x] New unit tests pass (`bun test packages/jsx/src/__tests__/ir-to-client-js/imports.test.ts` — 21/21)
- [x] All compiler tests pass (`bun test packages/jsx/src/__tests__/` — 466/466)

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)