### PR TITLE
Add checkbox reference page with Props Playground

### DIFF
--- a/site/ui/components/checkbox-playground.tsx
+++ b/site/ui/components/checkbox-playground.tsx
@@ -1,0 +1,125 @@
+"use client"
+/**
+ * Checkbox Props Playground
+ *
+ * Interactive playground for the Checkbox component.
+ * Allows tweaking checked, disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+// Mirror of Checkbox component class definitions (ui/components/ui/checkbox/index.tsx)
+const checkboxBaseClasses = 'peer size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50'
+const checkboxFocusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50'
+const checkboxErrorClasses = 'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+const checkboxStateClasses = [
+  '[&[data-state=unchecked]]:border-input',
+  'dark:[&[data-state=unchecked]]:bg-input/30',
+  '[&[data-state=unchecked]]:bg-background',
+  '[&[data-state=checked]]:bg-primary',
+  '[&[data-state=checked]]:text-primary-foreground',
+  '[&[data-state=checked]]:border-primary',
+].join(' ')
+
+function highlightCheckboxJsx(defaultChecked: boolean, disabled: boolean): string {
+  const boolProps: string[] = []
+  if (defaultChecked) boolProps.push(` ${hlAttr('defaultChecked')}`)
+  if (disabled) boolProps.push(` ${hlAttr('disabled')}`)
+  return `${hlPlain('&lt;')}${hlTag('Checkbox')}${boolProps.join('')}${hlPlain(' /&gt;')}`
+}
+
+function CheckboxPlayground(_props: {}) {
+  const [defaultChecked, setDefaultChecked] = createSignal(false)
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const parts: string[] = []
+    if (defaultChecked()) parts.push(' defaultChecked')
+    if (disabled()) parts.push(' disabled')
+    return `<Checkbox${parts.join('')} />`
+  })
+
+  createEffect(() => {
+    const dc = defaultChecked()
+    const d = disabled()
+
+    // Update checkbox preview
+    const container = document.querySelector('[data-checkbox-preview]') as HTMLElement
+    if (container) {
+      const state = dc ? 'checked' : 'unchecked'
+      const allClasses = `${checkboxBaseClasses} ${checkboxFocusClasses} ${checkboxErrorClasses} ${checkboxStateClasses} grid place-content-center`
+
+      const btn = document.createElement('button')
+      btn.setAttribute('data-slot', 'checkbox')
+      btn.setAttribute('data-state', state)
+      btn.setAttribute('role', 'checkbox')
+      btn.setAttribute('aria-checked', String(dc))
+      btn.className = allClasses
+      if (d) {
+        btn.disabled = true
+      }
+
+      if (dc) {
+        btn.innerHTML = '<svg data-slot="checkbox-indicator" class="size-3.5 text-current" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>'
+      }
+
+      // Add click handler for interactive preview
+      btn.addEventListener('click', () => {
+        const current = btn.getAttribute('aria-checked') === 'true'
+        const next = !current
+        btn.setAttribute('aria-checked', String(next))
+        btn.setAttribute('data-state', next ? 'checked' : 'unchecked')
+        if (next) {
+          btn.innerHTML = '<svg data-slot="checkbox-indicator" class="size-3.5 text-current" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>'
+        } else {
+          btn.innerHTML = ''
+        }
+      })
+
+      // Add label next to checkbox
+      const wrapper = document.createElement('div')
+      wrapper.className = 'flex items-center space-x-2'
+      const label = document.createElement('span')
+      label.className = 'text-sm font-medium leading-none'
+      label.textContent = 'Accept terms'
+      wrapper.appendChild(btn)
+      wrapper.appendChild(label)
+
+      container.innerHTML = ''
+      container.appendChild(wrapper)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightCheckboxJsx(dc, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-checkbox-preview"
+      controls={<>
+        <PlaygroundControl label="defaultChecked">
+          <Checkbox
+            checked={defaultChecked()}
+            onCheckedChange={setDefaultChecked}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { CheckboxPlayground }

--- a/site/ui/components/checkbox-playground.tsx
+++ b/site/ui/components/checkbox-playground.tsx
@@ -3,7 +3,7 @@
  * Checkbox Props Playground
  *
  * Interactive playground for the Checkbox component.
- * Allows tweaking checked, disabled props with live preview.
+ * Allows tweaking defaultChecked and disabled props with live preview.
  */
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/dom'

--- a/site/ui/pages/components/checkbox.tsx
+++ b/site/ui/pages/components/checkbox.tsx
@@ -1,0 +1,129 @@
+/**
+ * Checkbox Reference Page (/components/checkbox)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Checkbox } from '@/components/ui/checkbox'
+import { CheckboxPlayground } from '@/components/checkbox-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Checkbox } from "@/components/ui/checkbox"
+
+function CheckboxDemo() {
+  const [accepted, setAccepted] = createSignal(false)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center space-x-2">
+        <Checkbox />
+        <span className="text-sm font-medium leading-none">Remember me</span>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox defaultChecked />
+        <span className="text-sm font-medium leading-none">Subscribe to newsletter</span>
+      </div>
+      <div className="flex items-center space-x-2 opacity-50">
+        <Checkbox disabled />
+        <span className="text-sm font-medium leading-none">Unavailable option</span>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox checked={accepted()} onCheckedChange={setAccepted} />
+        <span className="text-sm font-medium leading-none">Controlled checkbox</span>
+      </div>
+    </div>
+  )
+}`
+
+const checkboxProps: PropDefinition[] = [
+  {
+    name: 'defaultChecked',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'The initial checked state for uncontrolled mode.',
+  },
+  {
+    name: 'checked',
+    type: 'boolean',
+    description: 'The controlled checked state of the checkbox. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the checkbox is disabled.',
+  },
+  {
+    name: 'onCheckedChange',
+    type: '(checked: boolean) => void',
+    description: 'Event handler called when the checked state changes.',
+  },
+]
+
+export function CheckboxRefPage() {
+  return (
+    <DocPage slug="checkbox" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Checkbox"
+          description="A control that allows the user to toggle between checked and not checked."
+          {...getNavLinks('checkbox')}
+        />
+
+        {/* Props Playground */}
+        <CheckboxPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add checkbox" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2">
+                <Checkbox />
+                <span className="text-sm font-medium leading-none">Remember me</span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox defaultChecked />
+                <span className="text-sm font-medium leading-none">Subscribe to newsletter</span>
+              </div>
+              <div className="flex items-center space-x-2 opacity-50">
+                <Checkbox disabled />
+                <span className="text-sm font-medium leading-none">Unavailable option</span>
+              </div>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={checkboxProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -22,6 +22,7 @@ import { CalendarPage } from './pages/calendar'
 import { CarouselPage } from './pages/carousel'
 import { CardPage } from './pages/card'
 import { CheckboxPage } from './pages/checkbox'
+import { CheckboxRefPage } from './pages/components/checkbox'
 import { InputPage } from './pages/input'
 import { InputOTPPage } from './pages/input-otp'
 import { LabelPage } from './pages/label'
@@ -426,6 +427,11 @@ export function createApp() {
   // Checkbox documentation
   app.get('/docs/components/checkbox', (c) => {
     return c.render(<CheckboxPage />)
+  })
+
+  // Checkbox reference page (redesigned #515)
+  app.get('/components/checkbox', (c) => {
+    return c.render(<CheckboxRefPage />)
   })
 
   // Input documentation

--- a/ui/components/ui/checkbox/index.tsx
+++ b/ui/components/ui/checkbox/index.tsx
@@ -107,52 +107,21 @@ function Checkbox(props: CheckboxProps) {
   // Determine current checked state: use controlled if provided, otherwise internal
   const isChecked = createMemo(() => isControlled() ? controlledChecked() : internalChecked())
 
-  // Helper function to update checkbox UI (visual state)
-  // Note: CSS classes are now handled by data-state attribute selectors
-  const updateCheckboxUI = (target: HTMLElement, newValue: boolean) => {
-    // Update ARIA and data attributes (CSS reacts to data-state changes)
-    target.setAttribute('aria-checked', String(newValue))
-    target.setAttribute('data-state', newValue ? 'checked' : 'unchecked')
-
-    // Update SVG checkmark visibility
-    const svg = target.querySelector('svg')
-    if (newValue && !svg) {
-      // Add checkmark SVG
-      target.innerHTML = '<svg data-slot="checkbox-indicator" class="size-3.5 text-current" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>'
-    } else if (!newValue && svg) {
-      // Remove checkmark SVG
-      svg.remove()
-    }
-  }
-
   // Classes - state styling handled by data-state attribute selectors
   const classes = `${baseClasses} ${focusClasses} ${errorClasses} ${stateClasses} ${props.className ?? ''} grid place-content-center`
 
-  // Click handler that works for both controlled and uncontrolled modes
-  const handleClick = (e: MouseEvent) => {
-    const target = e.currentTarget as HTMLElement
-    const currentChecked = target.getAttribute('aria-checked') === 'true'
-    const newValue = !currentChecked
+  // Click handler — only updates signals; the compiler's reactivity handles
+  // data-state, aria-checked, and conditional SVG via insert().
+  const handleClick = () => {
+    const newValue = !isChecked()
 
-    // Update state based on mode
     if (isControlled()) {
-      // In controlled mode, update controlledChecked directly for immediate UI update
       setControlledChecked(newValue)
     } else {
-      // In uncontrolled mode, update internal state
       setInternalChecked(newValue)
     }
 
-    // Update the UI visually
-    updateCheckboxUI(target, newValue)
-
-    // Notify parent if callback provided (works for both modes)
-    // Check scope element for callback (parent sets callback there during hydration)
-    const scope = target.closest('[bf-s]')
-    // @ts-ignore - oncheckedChange is set by parent during hydration
-    const scopeCallback = scope?.oncheckedChange
-    const handler = props.onCheckedChange || scopeCallback
-    handler?.(newValue)
+    props.onCheckedChange?.(newValue)
   }
 
   return (


### PR DESCRIPTION
## Summary

- Add `/components/checkbox` reference page following the badge/button pattern from #515
- Create `CheckboxPlayground` with interactive `defaultChecked` and `disabled` toggles
- Register route in `routes.tsx`
- **Fix: Remove `updateCheckboxUI` from Checkbox component** — it destroyed the compiler's `<!--bf-cond-->` markers by setting `target.innerHTML` directly, breaking the compiler's `insert()` conditional rendering. The compiler's own reactivity (`createEffect` for `data-state`/`aria-checked` + `insert()` for SVG) handles all UI updates correctly without manual DOM manipulation.

## Test plan

- [ ] Visit `/components/checkbox` and verify playground renders
- [ ] Toggle `defaultChecked` and `disabled` in playground controls — checkmarks should appear
- [ ] Click checkbox in preview area to verify interactivity
- [ ] Verify code display updates reactively (e.g. `<Checkbox defaultChecked />`)
- [ ] Visit `/docs/components/checkbox` and verify all existing demos still work
- [ ] Verify Usage section and API Reference table on reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)