### PR TITLE
Add Select reference page with Props Playground

### DIFF
--- a/site/ui/components/select-playground.tsx
+++ b/site/ui/components/select-playground.tsx
@@ -4,20 +4,18 @@
  *
  * Interactive playground for the Select component.
  * Allows tweaking placeholder and disabled props with live preview.
+ *
+ * Unlike badge/button playgrounds, the preview uses a real Select component
+ * (not DOM manipulation) because Select requires hydration for interactivity.
  */
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
 import { hlPlain, hlTag, hlAttr, hlStr, escapeHtml } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Input } from '@ui/components/ui/input'
 import { Checkbox } from '@ui/components/ui/checkbox'
-
-// Mirror of Select component class definitions (ui/components/ui/select/index.tsx)
-const selectTriggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
-const selectTriggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
-const selectTriggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
-const selectTriggerDataStateClasses = 'data-[placeholder]:text-muted-foreground'
 
 /**
  * Generate syntax-highlighted JSX for the Select compound component.
@@ -46,6 +44,7 @@ function highlightSelectJsx(placeholder: string, disabled: boolean): string {
 function SelectPlayground(_props: {}) {
   const [placeholder, setPlaceholder] = createSignal('Select a fruit...')
   const [disabled, setDisabled] = createSignal(false)
+  const [value, setValue] = createSignal('')
 
   const codeText = createMemo(() => {
     const p = placeholder()
@@ -54,50 +53,42 @@ function SelectPlayground(_props: {}) {
     return `<Select${disabledProp}>\n  <SelectTrigger>\n    <SelectValue placeholder="${p}" />\n  </SelectTrigger>\n  <SelectContent>\n    <SelectItem value="apple">Apple</SelectItem>\n    <SelectItem value="banana">Banana</SelectItem>\n    <SelectItem value="orange">Orange</SelectItem>\n  </SelectContent>\n</Select>`
   })
 
+  // Update placeholder text on the real Select when control changes
+  createEffect(() => {
+    const p = placeholder()
+    const v = value()
+    const container = document.querySelector('[data-select-preview]') as HTMLElement
+    if (!container) return
+    const valueEl = container.querySelector('[data-slot="select-value"]') as HTMLElement
+    if (valueEl && !v) {
+      valueEl.textContent = p
+    }
+    // Update trigger's data-placeholder attribute
+    const trigger = container.querySelector('[data-slot="select-trigger"]') as HTMLElement
+    if (trigger) {
+      if (!v) {
+        trigger.setAttribute('data-placeholder', '')
+      } else {
+        trigger.removeAttribute('data-placeholder')
+      }
+    }
+  })
+
+  // Update disabled state on the real Select when control changes
+  createEffect(() => {
+    const d = disabled()
+    const container = document.querySelector('[data-select-preview]') as HTMLElement
+    if (!container) return
+    const trigger = container.querySelector('[data-slot="select-trigger"]') as HTMLButtonElement
+    if (trigger) {
+      trigger.disabled = d
+    }
+  })
+
+  // Update highlighted code
   createEffect(() => {
     const p = placeholder()
     const d = disabled()
-
-    // Update select preview
-    const container = document.querySelector('[data-select-preview]') as HTMLElement
-    if (container) {
-      // Rebuild the trigger button to reflect current props
-      const btn = document.createElement('button')
-      btn.setAttribute('data-slot', 'select-trigger')
-      btn.setAttribute('type', 'button')
-      btn.setAttribute('role', 'combobox')
-      btn.setAttribute('aria-expanded', 'false')
-      btn.setAttribute('aria-haspopup', 'listbox')
-      btn.setAttribute('data-state', 'closed')
-      btn.setAttribute('data-placeholder', '')
-      if (d) btn.disabled = true
-      btn.className = `${selectTriggerBaseClasses} ${selectTriggerFocusClasses} ${selectTriggerDisabledClasses} ${selectTriggerDataStateClasses}`
-
-      const valueSpan = document.createElement('span')
-      valueSpan.setAttribute('data-slot', 'select-value')
-      valueSpan.className = 'pointer-events-none truncate'
-      valueSpan.textContent = p
-
-      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-      svg.setAttribute('class', 'size-4 shrink-0 opacity-50')
-      svg.setAttribute('viewBox', '0 0 24 24')
-      svg.setAttribute('fill', 'none')
-      svg.setAttribute('stroke', 'currentColor')
-      svg.setAttribute('stroke-width', '2')
-      svg.setAttribute('stroke-linecap', 'round')
-      svg.setAttribute('stroke-linejoin', 'round')
-      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-      path.setAttribute('d', 'm6 9 6 6 6-6')
-      svg.appendChild(path)
-
-      btn.appendChild(valueSpan)
-      btn.appendChild(svg)
-
-      container.innerHTML = ''
-      container.appendChild(btn)
-    }
-
-    // Update highlighted code
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) {
       codeEl.innerHTML = highlightSelectJsx(p, d)
@@ -107,6 +98,18 @@ function SelectPlayground(_props: {}) {
   return (
     <PlaygroundLayout
       previewDataAttr="data-select-preview"
+      previewContent={
+        <Select value={value()} onValueChange={setValue} disabled={disabled()}>
+          <SelectTrigger>
+            <SelectValue placeholder={placeholder()} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="apple">Apple</SelectItem>
+            <SelectItem value="banana">Banana</SelectItem>
+            <SelectItem value="orange">Orange</SelectItem>
+          </SelectContent>
+        </Select>
+      }
       controls={<>
         <PlaygroundControl label="placeholder">
           <Input

--- a/site/ui/components/select-playground.tsx
+++ b/site/ui/components/select-playground.tsx
@@ -1,0 +1,130 @@
+"use client"
+/**
+ * Select Props Playground
+ *
+ * Interactive playground for the Select component.
+ * Allows tweaking placeholder and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr, escapeHtml } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Input } from '@ui/components/ui/input'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+// Mirror of Select component class definitions (ui/components/ui/select/index.tsx)
+const selectTriggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
+const selectTriggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
+const selectTriggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+const selectTriggerDataStateClasses = 'data-[placeholder]:text-muted-foreground'
+
+/**
+ * Generate syntax-highlighted JSX for the Select compound component.
+ */
+function highlightSelectJsx(placeholder: string, disabled: boolean): string {
+  const disabledAttr = disabled ? ` ${hlAttr('disabled')}` : ''
+  const placeholderAttr = placeholder !== 'Select a fruit...'
+    ? ` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(placeholder)}&quot;`)}`
+    : ` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr('&quot;Select a fruit...&quot;')}`
+
+  const lines = [
+    `${hlPlain('&lt;')}${hlTag('Select')}${disabledAttr}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('SelectTrigger')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('SelectValue')}${placeholderAttr} ${hlPlain('/&gt;')}`,
+    `  ${hlPlain('&lt;/')}${hlTag('SelectTrigger')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('SelectContent')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('SelectItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;apple&quot;')}${hlPlain('&gt;')}Apple${hlPlain('&lt;/')}${hlTag('SelectItem')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('SelectItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;banana&quot;')}${hlPlain('&gt;')}Banana${hlPlain('&lt;/')}${hlTag('SelectItem')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('SelectItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;orange&quot;')}${hlPlain('&gt;')}Orange${hlPlain('&lt;/')}${hlTag('SelectItem')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;/')}${hlTag('SelectContent')}${hlPlain('&gt;')}`,
+    `${hlPlain('&lt;/')}${hlTag('Select')}${hlPlain('&gt;')}`,
+  ]
+  return lines.join('\n')
+}
+
+function SelectPlayground(_props: {}) {
+  const [placeholder, setPlaceholder] = createSignal('Select a fruit...')
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const p = placeholder()
+    const d = disabled()
+    const disabledProp = d ? ' disabled' : ''
+    return `<Select${disabledProp}>\n  <SelectTrigger>\n    <SelectValue placeholder="${p}" />\n  </SelectTrigger>\n  <SelectContent>\n    <SelectItem value="apple">Apple</SelectItem>\n    <SelectItem value="banana">Banana</SelectItem>\n    <SelectItem value="orange">Orange</SelectItem>\n  </SelectContent>\n</Select>`
+  })
+
+  createEffect(() => {
+    const p = placeholder()
+    const d = disabled()
+
+    // Update select preview
+    const container = document.querySelector('[data-select-preview]') as HTMLElement
+    if (container) {
+      // Rebuild the trigger button to reflect current props
+      const btn = document.createElement('button')
+      btn.setAttribute('data-slot', 'select-trigger')
+      btn.setAttribute('type', 'button')
+      btn.setAttribute('role', 'combobox')
+      btn.setAttribute('aria-expanded', 'false')
+      btn.setAttribute('aria-haspopup', 'listbox')
+      btn.setAttribute('data-state', 'closed')
+      btn.setAttribute('data-placeholder', '')
+      if (d) btn.disabled = true
+      btn.className = `${selectTriggerBaseClasses} ${selectTriggerFocusClasses} ${selectTriggerDisabledClasses} ${selectTriggerDataStateClasses}`
+
+      const valueSpan = document.createElement('span')
+      valueSpan.setAttribute('data-slot', 'select-value')
+      valueSpan.className = 'pointer-events-none truncate'
+      valueSpan.textContent = p
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('class', 'size-4 shrink-0 opacity-50')
+      svg.setAttribute('viewBox', '0 0 24 24')
+      svg.setAttribute('fill', 'none')
+      svg.setAttribute('stroke', 'currentColor')
+      svg.setAttribute('stroke-width', '2')
+      svg.setAttribute('stroke-linecap', 'round')
+      svg.setAttribute('stroke-linejoin', 'round')
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+      path.setAttribute('d', 'm6 9 6 6 6-6')
+      svg.appendChild(path)
+
+      btn.appendChild(valueSpan)
+      btn.appendChild(svg)
+
+      container.innerHTML = ''
+      container.appendChild(btn)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightSelectJsx(p, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-select-preview"
+      controls={<>
+        <PlaygroundControl label="placeholder">
+          <Input
+            type="text"
+            value="Select a fruit..."
+            onInput={(e: Event) => setPlaceholder((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            defaultChecked={false}
+            onCheckedChange={(v: boolean) => setDisabled(v)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { SelectPlayground }

--- a/site/ui/components/shared/PlaygroundLayout.tsx
+++ b/site/ui/components/shared/PlaygroundLayout.tsx
@@ -14,18 +14,22 @@ import type { Child } from 'hono/jsx'
 
 interface PlaygroundLayoutProps {
   previewDataAttr: string
+  /** Optional preview content to render inside the preview area */
+  previewContent?: Child
   controls: Child
   copyButton: Child
 }
 
-export function PlaygroundLayout({ previewDataAttr, controls, copyButton }: PlaygroundLayoutProps) {
+export function PlaygroundLayout({ previewDataAttr, previewContent, controls, copyButton }: PlaygroundLayoutProps) {
   return (
     <div id="preview" className="border border-border rounded-lg overflow-hidden scroll-mt-16">
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_240px]">
         {/* Preview */}
         <div className="flex items-center justify-center min-h-[140px] p-8 bg-card relative overflow-hidden">
           <div className="absolute inset-0 bg-[radial-gradient(circle,hsl(var(--muted)/0.5)_1px,transparent_1px)] bg-[length:16px_16px] pointer-events-none" />
-          <div className="relative z-10" {...{ [previewDataAttr]: true }} />
+          <div className="relative z-10" {...{ [previewDataAttr]: true }}>
+            {previewContent}
+          </div>
         </div>
 
         {/* Controls */}

--- a/site/ui/pages/components/select.tsx
+++ b/site/ui/pages/components/select.tsx
@@ -1,0 +1,165 @@
+/**
+ * Select Reference Page (/components/select)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel, SelectSeparator } from '@/components/ui/select'
+import { SelectPlayground } from '@/components/select-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  Select, SelectTrigger, SelectValue,
+  SelectContent, SelectItem, SelectGroup,
+  SelectLabel, SelectSeparator,
+} from "@/components/ui/select"
+
+function SelectDemo() {
+  const [fruit, setFruit] = createSignal("")
+
+  return (
+    <Select value={fruit()} onValueChange={setFruit}>
+      <SelectTrigger>
+        <SelectValue placeholder="Select a fruit..." />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Fruits</SelectLabel>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="orange">Orange</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Vegetables</SelectLabel>
+          <SelectItem value="carrot">Carrot</SelectItem>
+          <SelectItem value="potato">Potato</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  )
+}`
+
+const selectProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled value of the select.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when the selected value changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the select is disabled.',
+  },
+  {
+    name: 'open',
+    type: 'boolean',
+    description: 'Controlled open state of the dropdown.',
+  },
+  {
+    name: 'onOpenChange',
+    type: '(open: boolean) => void',
+    description: 'Callback when the open state changes.',
+  },
+]
+
+const selectItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this item (required).',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this item is disabled.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The display label for this item.',
+  },
+]
+
+export function SelectRefPage() {
+  return (
+    <DocPage slug="select" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Select"
+          description="Displays a list of options for the user to pick from, triggered by a button."
+          {...getNavLinks('select')}
+        />
+
+        {/* Props Playground */}
+        <SelectPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add select" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <Select>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a fruit..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Fruits</SelectLabel>
+                  <SelectItem value="apple">Apple</SelectItem>
+                  <SelectItem value="banana">Banana</SelectItem>
+                  <SelectItem value="orange">Orange</SelectItem>
+                </SelectGroup>
+                <SelectSeparator />
+                <SelectGroup>
+                  <SelectLabel>Vegetables</SelectLabel>
+                  <SelectItem value="carrot">Carrot</SelectItem>
+                  <SelectItem value="potato">Potato</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <h3 className="text-lg font-semibold mb-4">Select</h3>
+          <PropsTable props={selectProps} />
+          <h3 className="text-lg font-semibold mb-4 mt-8">SelectItem</h3>
+          <PropsTable props={selectItemProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/components/select.tsx
+++ b/site/ui/pages/components/select.tsx
@@ -5,8 +5,8 @@
  * Part of the #515 page redesign initiative.
  */
 
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel, SelectSeparator } from '@/components/ui/select'
 import { SelectPlayground } from '@/components/select-playground'
+import { SelectGroupedDemo } from '@/components/select-demo'
 import {
   DocPage,
   PageHeader,
@@ -36,25 +36,26 @@ import {
 } from "@/components/ui/select"
 
 function SelectDemo() {
-  const [fruit, setFruit] = createSignal("")
+  const [timezone, setTimezone] = createSignal("")
 
   return (
-    <Select value={fruit()} onValueChange={setFruit}>
-      <SelectTrigger>
-        <SelectValue placeholder="Select a fruit..." />
+    <Select value={timezone()} onValueChange={setTimezone}>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select timezone..." />
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>
-          <SelectLabel>Fruits</SelectLabel>
-          <SelectItem value="apple">Apple</SelectItem>
-          <SelectItem value="banana">Banana</SelectItem>
-          <SelectItem value="orange">Orange</SelectItem>
+          <SelectLabel>North America</SelectLabel>
+          <SelectItem value="est">Eastern Standard Time (EST)</SelectItem>
+          <SelectItem value="cst">Central Standard Time (CST)</SelectItem>
+          <SelectItem value="mst">Mountain Standard Time (MST)</SelectItem>
+          <SelectItem value="pst">Pacific Standard Time (PST)</SelectItem>
         </SelectGroup>
         <SelectSeparator />
         <SelectGroup>
-          <SelectLabel>Vegetables</SelectLabel>
-          <SelectItem value="carrot">Carrot</SelectItem>
-          <SelectItem value="potato">Potato</SelectItem>
+          <SelectLabel>Europe</SelectLabel>
+          <SelectItem value="gmt">Greenwich Mean Time (GMT)</SelectItem>
+          <SelectItem value="cet">Central European Time (CET)</SelectItem>
         </SelectGroup>
       </SelectContent>
     </Select>
@@ -130,25 +131,7 @@ export function SelectRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <Select>
-              <SelectTrigger>
-                <SelectValue placeholder="Select a fruit..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Fruits</SelectLabel>
-                  <SelectItem value="apple">Apple</SelectItem>
-                  <SelectItem value="banana">Banana</SelectItem>
-                  <SelectItem value="orange">Orange</SelectItem>
-                </SelectGroup>
-                <SelectSeparator />
-                <SelectGroup>
-                  <SelectLabel>Vegetables</SelectLabel>
-                  <SelectItem value="carrot">Carrot</SelectItem>
-                  <SelectItem value="potato">Potato</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+            <SelectGroupedDemo />
           </Example>
         </Section>
 

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -105,7 +105,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Radio Group', href: '/docs/components/radio-group' },
       { title: 'Resizable', href: '/docs/components/resizable' },
       { title: 'Scroll Area', href: '/docs/components/scroll-area' },
-      { title: 'Select', href: '/docs/components/select' },
+      { title: 'Select', href: '/components/select' },
       { title: 'Sidebar', href: '/docs/components/sidebar' },
       { title: 'Separator', href: '/docs/components/separator' },
       { title: 'Skeleton', href: '/docs/components/skeleton' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -17,6 +17,7 @@ import { BadgePage } from './pages/badge'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
 import { InputRefPage } from './pages/components/input'
+import { SelectRefPage } from './pages/components/select'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
 import { CalendarPage } from './pages/calendar'
@@ -380,6 +381,11 @@ export function createApp() {
   // Button reference page (redesigned #515)
   app.get('/components/button', (c) => {
     return c.render(<ButtonRefPage />)
+  })
+
+  // Select reference page (redesigned #515)
+  app.get('/components/select', (c) => {
+    return c.render(<SelectRefPage />)
   })
 
   // Breadcrumb documentation


### PR DESCRIPTION
## Summary

- Add new `/components/select` reference page with Props Playground, matching the badge/button redesign pattern (#515)
- Playground controls: `placeholder` (text input) and `disabled` (checkbox toggle) with live preview
- Custom `highlightSelectJsx()` for compound component code highlighting (Select uses multiple sub-components, so `highlightJsx()` single-tag helper is insufficient)
- Usage section shows grouped items with `SelectGroup`, `SelectLabel`, and `SelectSeparator`
- API Reference covers both `Select` and `SelectItem` props
- Old `/docs/components/select` route preserved for backwards compatibility

## Test plan

- [x] `bun run build` succeeds (site/ui)
- [ ] `bun run dev` → visit `/components/select` and verify page renders
- [ ] Playground: changing placeholder updates preview and code
- [ ] Playground: toggling disabled updates preview and code
- [ ] Sidebar navigation links to `/components/select`
- [ ] Old `/docs/components/select` route still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)