### PR TITLE
Add toggle reference page with Props Playground

### DIFF
--- a/site/ui/components/toggle-playground.tsx
+++ b/site/ui/components/toggle-playground.tsx
@@ -1,0 +1,129 @@
+"use client"
+/**
+ * Toggle Props Playground
+ *
+ * Interactive playground for the Toggle component.
+ * Allows tweaking variant, size, and pressed state with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+
+type ToggleVariant = 'default' | 'outline'
+type ToggleSize = 'default' | 'sm' | 'lg'
+
+// Mirror of Toggle component class definitions (ui/components/ui/toggle/index.tsx)
+const toggleBaseClasses = 'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted hover:text-muted-foreground'
+
+const toggleVariantClasses: Record<ToggleVariant, string> = {
+  default: 'bg-transparent',
+  outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+}
+
+const toggleSizeClasses: Record<ToggleSize, string> = {
+  default: 'h-9 px-2 min-w-9',
+  sm: 'h-8 px-1.5 min-w-8',
+  lg: 'h-10 px-2.5 min-w-10',
+}
+
+function TogglePlayground(_props: {}) {
+  const [variant, setVariant] = createSignal<ToggleVariant>('default')
+  const [size, setSize] = createSignal<ToggleSize>('default')
+  const [pressed, setPressed] = createSignal('false')
+
+  const codeText = createMemo(() => {
+    const v = variant()
+    const s = size()
+    const p = pressed()
+    const parts: string[] = []
+    if (v !== 'default') parts.push(`variant="${v}"`)
+    if (s !== 'default') parts.push(`size="${s}"`)
+    if (p === 'true') parts.push('defaultPressed')
+    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
+    return `<Toggle${propsStr}>Toggle</Toggle>`
+  })
+
+  createEffect(() => {
+    const v = variant()
+    const s = size()
+    const p = pressed()
+    const isOn = p === 'true'
+
+    // Update toggle preview
+    const container = document.querySelector('[data-toggle-preview]') as HTMLElement
+    if (container) {
+      const btn = document.createElement('button')
+      btn.setAttribute('data-slot', 'toggle')
+      btn.setAttribute('data-state', isOn ? 'on' : 'off')
+      btn.setAttribute('aria-pressed', String(isOn))
+      btn.className = `${toggleBaseClasses} ${toggleVariantClasses[v]} ${toggleSizeClasses[s]}`
+      btn.textContent = 'Toggle'
+      btn.addEventListener('click', () => {
+        setPressed(pressed() === 'true' ? 'false' : 'true')
+      })
+      container.innerHTML = ''
+      container.appendChild(btn)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightJsx(
+        'Toggle',
+        [
+          { name: 'variant', value: v, defaultValue: 'default' },
+          { name: 'size', value: s, defaultValue: 'default' },
+        ],
+        'Toggle',
+      )
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-toggle-preview"
+      controls={<>
+        <PlaygroundControl label="variant">
+          <Select value={variant()} onValueChange={(v: string) => setVariant(v as ToggleVariant)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="outline">outline</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="size">
+          <Select value={size()} onValueChange={(v: string) => setSize(v as ToggleSize)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select size..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="sm">sm</SelectItem>
+              <SelectItem value="lg">lg</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="pressed">
+          <Select value={pressed()} onValueChange={(v: string) => setPressed(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select state..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="false">off</SelectItem>
+              <SelectItem value="true">on</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { TogglePlayground }

--- a/site/ui/pages/components/toggle.tsx
+++ b/site/ui/pages/components/toggle.tsx
@@ -1,0 +1,120 @@
+/**
+ * Toggle Reference Page (/components/toggle)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Toggle } from '@/components/ui/toggle'
+import { TogglePlayground } from '@/components/toggle-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { Toggle } from "@/components/ui/toggle"
+
+function ToggleDemo() {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Toggle>Default</Toggle>
+      <Toggle variant="outline">Outline</Toggle>
+      <Toggle size="sm">Small</Toggle>
+      <Toggle size="lg">Large</Toggle>
+      <Toggle defaultPressed>Pressed</Toggle>
+      <Toggle disabled>Disabled</Toggle>
+    </div>
+  )
+}`
+
+const toggleProps: PropDefinition[] = [
+  {
+    name: 'defaultPressed',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'The initial pressed state for uncontrolled mode.',
+  },
+  {
+    name: 'pressed',
+    type: 'boolean',
+    description: 'The controlled pressed state of the toggle. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the toggle is disabled.',
+  },
+  {
+    name: 'variant',
+    type: "'default' | 'outline'",
+    defaultValue: "'default'",
+    description: 'The visual variant of the toggle.',
+  },
+  {
+    name: 'size',
+    type: "'default' | 'sm' | 'lg'",
+    defaultValue: "'default'",
+    description: 'The size of the toggle.',
+  },
+  {
+    name: 'onPressedChange',
+    type: '(pressed: boolean) => void',
+    description: 'Event handler called when the toggle state changes.',
+  },
+]
+
+export function ToggleRefPage() {
+  return (
+    <DocPage slug="toggle" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Toggle"
+          description="A two-state button that can be either on or off."
+          {...getNavLinks('toggle')}
+        />
+
+        {/* Props Playground */}
+        <TogglePlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add toggle" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="flex flex-wrap items-center gap-2">
+              <Toggle>Default</Toggle>
+              <Toggle variant="outline">Outline</Toggle>
+              <Toggle size="sm">Small</Toggle>
+              <Toggle size="lg">Large</Toggle>
+              <Toggle defaultPressed>Pressed</Toggle>
+              <Toggle disabled>Disabled</Toggle>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={toggleProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -20,6 +20,7 @@ import { InputRefPage } from './pages/components/input'
 import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
 import { TextareaRefPage } from './pages/components/textarea'
+import { ToggleRefPage } from './pages/components/toggle'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
 import { CalendarPage } from './pages/calendar'
@@ -398,6 +399,11 @@ export function createApp() {
   // Textarea reference page (redesigned #515)
   app.get('/components/textarea', (c) => {
     return c.render(<TextareaRefPage />)
+  })
+
+  // Toggle reference page (redesigned #515)
+  app.get('/components/toggle', (c) => {
+    return c.render(<ToggleRefPage />)
   })
 
   // Breadcrumb documentation


### PR DESCRIPTION
## Summary

- Add interactive Props Playground for Toggle component (variant, size, pressed controls)
- Create new `/components/toggle` reference page with playground, installation, usage examples, and API reference
- Part of #515 page redesign initiative, matching badge/button reference pages

## Test plan

- [ ] `bun run dev` in `site/ui/` — visit `/components/toggle` and verify Playground works
- [ ] Verify existing `/docs/components/toggle` still works
- [ ] Toggle preview responds to variant/size/pressed control changes
- [ ] Copy button copies correct JSX code

🤖 Generated with [Claude Code](https://claude.com/claude-code)