### PR TITLE
Add Switch reference page with Props Playground

### DIFF
--- a/site/ui/components/switch-playground.tsx
+++ b/site/ui/components/switch-playground.tsx
@@ -1,0 +1,118 @@
+"use client"
+/**
+ * Switch Props Playground
+ *
+ * Interactive playground for the Switch component.
+ * Allows tweaking defaultChecked and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+// Mirror of Switch component class definitions (ui/components/ui/switch/index.tsx)
+const trackBaseClasses = 'peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent p-0 shadow-xs transition-all outline-none disabled:cursor-not-allowed disabled:opacity-50'
+const trackFocusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+const trackStateClasses = [
+  '[&[data-state=unchecked]]:bg-input',
+  'dark:[&[data-state=unchecked]]:bg-input/80',
+  '[&[data-state=checked]]:bg-primary',
+].join(' ')
+
+const thumbBaseClasses = 'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform dark:[&[data-state=unchecked]]:bg-foreground dark:[&[data-state=checked]]:bg-primary-foreground'
+const thumbStateClasses = [
+  '[&[data-state=unchecked]]:translate-x-0',
+  '[&[data-state=checked]]:translate-x-[calc(100%-2px)]',
+].join(' ')
+
+function highlightSwitchJsx(defaultChecked: boolean, disabled: boolean): string {
+  const boolProps: string[] = []
+  if (defaultChecked) boolProps.push(` ${hlAttr('defaultChecked')}`)
+  if (disabled) boolProps.push(` ${hlAttr('disabled')}`)
+  return `${hlPlain('&lt;')}${hlTag('Switch')}${boolProps.join('')}${hlPlain(' /&gt;')}`
+}
+
+function SwitchPlayground(_props: {}) {
+  const [defaultChecked, setDefaultChecked] = createSignal(false)
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const parts: string[] = []
+    if (defaultChecked()) parts.push(' defaultChecked')
+    if (disabled()) parts.push(' disabled')
+    return `<Switch${parts.join('')} />`
+  })
+
+  createEffect(() => {
+    const dc = defaultChecked()
+    const d = disabled()
+
+    // Update switch preview
+    const container = document.querySelector('[data-switch-preview]') as HTMLElement
+    if (container) {
+      const state = dc ? 'checked' : 'unchecked'
+      const trackClasses = `${trackBaseClasses} ${trackFocusClasses} ${trackStateClasses}`
+      const thumbClasses = `${thumbBaseClasses} ${thumbStateClasses}`
+
+      const btn = document.createElement('button')
+      btn.setAttribute('data-slot', 'switch')
+      btn.setAttribute('data-state', state)
+      btn.setAttribute('role', 'switch')
+      btn.setAttribute('aria-checked', String(dc))
+      btn.className = trackClasses
+      if (d) {
+        btn.disabled = true
+      }
+
+      const thumb = document.createElement('span')
+      thumb.setAttribute('data-slot', 'switch-thumb')
+      thumb.setAttribute('data-state', state)
+      thumb.className = thumbClasses
+      btn.appendChild(thumb)
+
+      // Add click handler for interactive preview
+      btn.addEventListener('click', () => {
+        const current = btn.getAttribute('aria-checked') === 'true'
+        const next = !current
+        const nextState = next ? 'checked' : 'unchecked'
+        btn.setAttribute('aria-checked', String(next))
+        btn.setAttribute('data-state', nextState)
+        thumb.setAttribute('data-state', nextState)
+      })
+
+      container.innerHTML = ''
+      container.appendChild(btn)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightSwitchJsx(dc, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-switch-preview"
+      controls={<>
+        <PlaygroundControl label="defaultChecked">
+          <Checkbox
+            checked={defaultChecked()}
+            onCheckedChange={setDefaultChecked}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { SwitchPlayground }

--- a/site/ui/pages/components/switch.tsx
+++ b/site/ui/pages/components/switch.tsx
@@ -1,0 +1,129 @@
+/**
+ * Switch Reference Page (/components/switch)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Switch } from '@/components/ui/switch'
+import { SwitchPlayground } from '@/components/switch-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Switch } from "@/components/ui/switch"
+
+function SwitchDemo() {
+  const [enabled, setEnabled] = createSignal(false)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center space-x-2">
+        <Switch />
+        <span className="text-sm font-medium leading-none">Airplane Mode</span>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Switch defaultChecked />
+        <span className="text-sm font-medium leading-none">Wi-Fi</span>
+      </div>
+      <div className="flex items-center space-x-2 opacity-50">
+        <Switch disabled />
+        <span className="text-sm font-medium leading-none">Unavailable option</span>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Switch checked={enabled()} onCheckedChange={setEnabled} />
+        <span className="text-sm font-medium leading-none">Controlled switch</span>
+      </div>
+    </div>
+  )
+}`
+
+const switchProps: PropDefinition[] = [
+  {
+    name: 'defaultChecked',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'The initial checked state for uncontrolled mode.',
+  },
+  {
+    name: 'checked',
+    type: 'boolean',
+    description: 'The controlled checked state of the switch. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the switch is disabled.',
+  },
+  {
+    name: 'onCheckedChange',
+    type: '(checked: boolean) => void',
+    description: 'Event handler called when the switch state changes.',
+  },
+]
+
+export function SwitchRefPage() {
+  return (
+    <DocPage slug="switch" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Switch"
+          description="A control that allows the user to toggle between checked and not checked."
+          {...getNavLinks('switch')}
+        />
+
+        {/* Props Playground */}
+        <SwitchPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add switch" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2">
+                <Switch />
+                <span className="text-sm font-medium leading-none">Airplane Mode</span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch defaultChecked />
+                <span className="text-sm font-medium leading-none">Wi-Fi</span>
+              </div>
+              <div className="flex items-center space-x-2 opacity-50">
+                <Switch disabled />
+                <span className="text-sm font-medium leading-none">Unavailable option</span>
+              </div>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={switchProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -112,7 +112,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/docs/components/slider' },
       { title: 'Spinner', href: '/docs/components/spinner' },
-      { title: 'Switch', href: '/docs/components/switch' },
+      { title: 'Switch', href: '/components/switch' },
       { title: 'Table', href: '/docs/components/table' },
       { title: 'Tabs', href: '/docs/components/tabs' },
       { title: 'Textarea', href: '/components/textarea' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -20,6 +20,7 @@ import { InputRefPage } from './pages/components/input'
 import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
 import { TextareaRefPage } from './pages/components/textarea'
+import { SwitchRefPage } from './pages/components/switch'
 import { ToggleRefPage } from './pages/components/toggle'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
@@ -492,6 +493,11 @@ export function createApp() {
   // Switch documentation
   app.get('/docs/components/switch', (c) => {
     return c.render(<SwitchPage />)
+  })
+
+  // Switch reference page (redesigned #515)
+  app.get('/components/switch', (c) => {
+    return c.render(<SwitchRefPage />)
   })
 
   // Accordion documentation

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -212,6 +212,12 @@
       "type": "registry:ui",
       "title": "Input OTP",
       "description": "An accessible one-time password input with copy-paste support"
+    },
+    {
+      "name": "switch",
+      "type": "registry:ui",
+      "title": "Switch",
+      "description": "A control that allows the user to toggle between checked and not checked"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `SwitchPlayground` component with interactive `defaultChecked`/`disabled` controls
- Add `SwitchRefPage` at `/components/switch` with Props Playground, Usage example, and API Reference
- Register Switch in `ui/registry.json`
- Update sidebar nav link to point to `/components/switch`
- Original `/docs/components/switch` page is preserved unchanged

Closes #515 (Switch portion)

## Test plan

- [ ] `bun test` — no new failures
- [ ] Dev server: `/components/switch` renders with Props Playground
- [ ] Dev server: `/docs/components/switch` still works as before
- [ ] Sidebar nav links to `/components/switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)