### PR TITLE
Add Input reference page with Props Playground (#515)

### DIFF
--- a/site/ui/components/input-playground.tsx
+++ b/site/ui/components/input-playground.tsx
@@ -1,0 +1,111 @@
+"use client"
+/**
+ * Input Props Playground
+ *
+ * Interactive playground for the Input component.
+ * Allows tweaking type, placeholder, and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxSelfClosing } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Input } from '@ui/components/ui/input'
+
+type InputType = 'text' | 'email' | 'password' | 'number'
+
+// Mirror of Input component class definitions (ui/components/ui/input/index.tsx)
+const inputBaseClasses = 'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+const inputFocusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
+const inputErrorClasses = 'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+
+function InputPlayground(_props: {}) {
+  const [type, setType] = createSignal<InputType>('text')
+  const [placeholder, setPlaceholder] = createSignal('Enter text...')
+  const [disabled, setDisabled] = createSignal('false')
+
+  const codeText = createMemo(() => {
+    const t = type()
+    const p = placeholder()
+    const d = disabled()
+    const parts: string[] = []
+    if (t !== 'text') parts.push(`type="${t}"`)
+    if (p) parts.push(`placeholder="${p}"`)
+    if (d === 'true') parts.push('disabled')
+    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
+    return `<Input${propsStr} />`
+  })
+
+  createEffect(() => {
+    const t = type()
+    const p = placeholder()
+    const d = disabled()
+
+    // Update input preview
+    const container = document.querySelector('[data-input-preview]') as HTMLElement
+    if (container) {
+      const input = document.createElement('input')
+      input.setAttribute('type', t)
+      input.setAttribute('data-slot', 'input')
+      if (p) input.setAttribute('placeholder', p)
+      if (d === 'true') input.setAttribute('disabled', '')
+      input.className = `${inputBaseClasses} ${inputFocusClasses} ${inputErrorClasses} max-w-sm`
+      container.innerHTML = ''
+      container.appendChild(input)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      const props = [
+        { name: 'type', value: t, defaultValue: 'text' },
+        { name: 'placeholder', value: p, defaultValue: '' },
+        { name: 'disabled', value: d, defaultValue: 'false' },
+      ]
+      codeEl.innerHTML = highlightJsxSelfClosing('Input', props)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-input-preview"
+      controls={<>
+        <PlaygroundControl label="type">
+          <Select value={type()} onValueChange={(v: string) => setType(v as InputType)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select type..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="text">text</SelectItem>
+              <SelectItem value="email">email</SelectItem>
+              <SelectItem value="password">password</SelectItem>
+              <SelectItem value="number">number</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="placeholder">
+          <Input
+            type="text"
+            value="Enter text..."
+            onInput={(e: Event) => setPlaceholder((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Select value={disabled()} onValueChange={(v: string) => setDisabled(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="false">false</SelectItem>
+              <SelectItem value="true">true</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { InputPlayground }

--- a/site/ui/components/shared/playground-highlight.ts
+++ b/site/ui/components/shared/playground-highlight.ts
@@ -57,3 +57,24 @@ export function highlightJsx(
 
   return `${hlPlain('&lt;')}${hlTag(tagName)}${renderedProps}${hlPlain('&gt;')}${escapedContent}${hlPlain('&lt;/')}${hlTag(tagName)}${hlPlain('&gt;')}`
 }
+
+/**
+ * Generate syntax-highlighted JSX markup for a self-closing component.
+ *
+ * Props whose value matches their defaultValue are omitted from output.
+ *
+ * @example
+ * highlightJsxSelfClosing('Input', [{ name: 'type', value: 'email', defaultValue: 'text' }])
+ * // => highlighted: <Input type="email" />
+ */
+export function highlightJsxSelfClosing(
+  tagName: string,
+  props: HighlightProp[],
+): string {
+  const renderedProps = props
+    .filter((p) => p.value !== p.defaultValue)
+    .map((p) => ` ${hlAttr(p.name)}${hlPlain('=')}${hlStr(`&quot;${p.value}&quot;`)}`)
+    .join('')
+
+  return `${hlPlain('&lt;')}${hlTag(tagName)}${renderedProps} ${hlPlain('/&gt;')}`
+}

--- a/site/ui/pages/components/input.tsx
+++ b/site/ui/pages/components/input.tsx
@@ -1,0 +1,131 @@
+/**
+ * Input Reference Page (/components/input)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Input } from '@/components/ui/input'
+import { InputPlayground } from '@/components/input-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { Input } from "@/components/ui/input"
+
+function InputDemo() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <Input type="text" placeholder="Text input" />
+      <Input type="email" placeholder="Email address" />
+      <Input type="password" placeholder="Password" />
+      <Input type="number" placeholder="Number" />
+      <Input disabled placeholder="Disabled input" />
+    </div>
+  )
+}`
+
+const inputProps: PropDefinition[] = [
+  {
+    name: 'type',
+    type: "'text' | 'email' | 'password' | 'number' | 'search' | 'tel' | 'url'",
+    defaultValue: "'text'",
+    description: 'The type of the input.',
+  },
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text shown when input is empty.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled value of the input.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the input is disabled.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'onInput',
+    type: '(e: InputEvent) => void',
+    description: 'Event handler called on each input change.',
+  },
+  {
+    name: 'onChange',
+    type: '(e: Event) => void',
+    description: 'Event handler called when input value changes and loses focus.',
+  },
+  {
+    name: 'onBlur',
+    type: '(e: FocusEvent) => void',
+    description: 'Event handler called when input loses focus.',
+  },
+  {
+    name: 'onFocus',
+    type: '(e: FocusEvent) => void',
+    description: 'Event handler called when input gains focus.',
+  },
+]
+
+export function InputRefPage() {
+  return (
+    <DocPage slug="input" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Input"
+          description="Displays an input field for user text entry."
+          {...getNavLinks('input')}
+        />
+
+        {/* Props Playground */}
+        <InputPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add input" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="flex flex-col gap-4 max-w-sm">
+              <Input type="text" placeholder="Text input" />
+              <Input type="email" placeholder="Email address" />
+              <Input type="password" placeholder="Password" />
+              <Input type="number" placeholder="Number" />
+              <Input disabled placeholder="Disabled input" />
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={inputProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -94,7 +94,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Drawer', href: '/docs/components/drawer' },
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
       { title: 'Hover Card', href: '/docs/components/hover-card' },
-      { title: 'Input', href: '/docs/components/input' },
+      { title: 'Input', href: '/components/input' },
       { title: 'Input OTP', href: '/docs/components/input-otp' },
       { title: 'Label', href: '/docs/components/label' },
       { title: 'Menubar', href: '/docs/components/menubar' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -16,6 +16,7 @@ import { AvatarPage } from './pages/avatar'
 import { BadgePage } from './pages/badge'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
+import { InputRefPage } from './pages/components/input'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
 import { CalendarPage } from './pages/calendar'
@@ -431,6 +432,11 @@ export function createApp() {
   // Input documentation
   app.get('/docs/components/input', (c) => {
     return c.render(<InputPage />)
+  })
+
+  // Input reference page (redesigned #515)
+  app.get('/components/input', (c) => {
+    return c.render(<InputRefPage />)
   })
 
   // Input OTP documentation


### PR DESCRIPTION
## Summary

- Add `highlightJsxSelfClosing()` to `playground-highlight.ts` for self-closing JSX tag syntax highlighting (e.g., `<Input ... />`)
- Create `InputPlayground` component with interactive controls for type, placeholder, and disabled props
- Create `InputRefPage` at `/components/input` following the badge/button pattern (PageHeader → Playground → Installation → Usage → API Reference)
- Update sidebar navigation to point to the new page
- Old route `/docs/components/input` preserved for backward compatibility

## Test plan

- [x] `bun run build` — no new compile errors
- [x] `bun test` — no regressions (82 fail before and after, all pre-existing)
- [x] `bun run dev` (site/ui) — verify `/components/input` renders correctly
- [x] Playground: type/placeholder/disabled controls update preview and code
- [x] `/docs/components/input` still works (old page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)