### PR TITLE
Add combobox reference page with props playground

### DIFF
--- a/site/ui/components/combobox-playground.tsx
+++ b/site/ui/components/combobox-playground.tsx
@@ -1,0 +1,117 @@
+"use client"
+/**
+ * Combobox Props Playground
+ *
+ * Interactive playground for the Combobox component.
+ * Allows tweaking placeholder and disabled props with live preview.
+ *
+ * Since Combobox is a compound component, the preview renders
+ * a ComboboxTrigger-equivalent button (matching the real component's classes).
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr, escapeHtml } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Input } from '@ui/components/ui/input'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+// Mirror of ComboboxTrigger class definitions (ui/components/ui/combobox/index.tsx)
+const triggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
+const triggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
+const triggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+
+function ComboboxPlayground(_props: {}) {
+  const [placeholder, setPlaceholder] = createSignal('Select framework...')
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const p = placeholder()
+    const d = disabled()
+    const placeholderAttr = p ? ` placeholder="${p}"` : ''
+    const disabledAttr = d ? ' disabled' : ''
+    return `<Combobox>\n  <ComboboxTrigger${disabledAttr}>\n    <ComboboxValue${placeholderAttr} />\n  </ComboboxTrigger>\n  <ComboboxContent>\n    <ComboboxInput placeholder="Search..." />\n    <ComboboxItem value="next">Next.js</ComboboxItem>\n    <ComboboxItem value="svelte">SvelteKit</ComboboxItem>\n  </ComboboxContent>\n</Combobox>`
+  })
+
+  createEffect(() => {
+    const p = placeholder()
+    const d = disabled()
+
+    // Update combobox trigger preview
+    const container = document.querySelector('[data-combobox-preview]') as HTMLElement
+    if (container) {
+      const btn = document.createElement('button')
+      btn.setAttribute('type', 'button')
+      btn.setAttribute('role', 'combobox')
+      btn.setAttribute('data-placeholder', '')
+      btn.className = `${triggerBaseClasses} ${triggerFocusClasses} ${triggerDisabledClasses} w-[280px]`
+      if (d) btn.disabled = true
+
+      const span = document.createElement('span')
+      span.className = 'pointer-events-none truncate text-muted-foreground'
+      span.textContent = p || ''
+      btn.appendChild(span)
+
+      // Chevron icon
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('class', 'size-4 shrink-0 opacity-50')
+      svg.setAttribute('viewBox', '0 0 24 24')
+      svg.setAttribute('fill', 'none')
+      svg.setAttribute('stroke', 'currentColor')
+      svg.setAttribute('stroke-width', '2')
+      svg.setAttribute('stroke-linecap', 'round')
+      svg.setAttribute('stroke-linejoin', 'round')
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+      path.setAttribute('d', 'm6 9 6 6 6-6')
+      svg.appendChild(path)
+      btn.appendChild(svg)
+
+      container.innerHTML = ''
+      container.appendChild(btn)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      const disabledProp = d ? ` ${hlAttr('disabled')}` : ''
+      const placeholderProp = p
+        ? ` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p)}&quot;`)}`
+        : ''
+      const lines = [
+        `${hlPlain('&lt;')}${hlTag('Combobox')}${hlPlain('&gt;')}`,
+        `  ${hlPlain('&lt;')}${hlTag('ComboboxTrigger')}${disabledProp}${hlPlain('&gt;')}`,
+        `    ${hlPlain('&lt;')}${hlTag('ComboboxValue')}${placeholderProp} ${hlPlain('/&gt;')}`,
+        `  ${hlPlain('&lt;/')}${hlTag('ComboboxTrigger')}${hlPlain('&gt;')}`,
+        `  ${hlPlain('&lt;')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
+        `    ${hlPlain('...')}`,
+        `  ${hlPlain('&lt;/')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
+        `${hlPlain('&lt;/')}${hlTag('Combobox')}${hlPlain('&gt;')}`,
+      ]
+      codeEl.innerHTML = lines.join('\n')
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-combobox-preview"
+      controls={<>
+        <PlaygroundControl label="placeholder">
+          <Input
+            type="text"
+            value="Select framework..."
+            onInput={(e: Event) => setPlaceholder((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            defaultChecked={false}
+            onCheckedChange={(checked: boolean) => setDisabled(checked)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { ComboboxPlayground }

--- a/site/ui/components/combobox-playground.tsx
+++ b/site/ui/components/combobox-playground.tsx
@@ -5,8 +5,8 @@
  * Interactive playground for the Combobox component.
  * Allows tweaking placeholder and disabled props with live preview.
  *
- * Since Combobox is a compound component, the preview renders
- * a ComboboxTrigger-equivalent button (matching the real component's classes).
+ * Renders the actual Combobox component (with ComboboxContent) as preview,
+ * and uses createEffect to update placeholder/disabled via DOM manipulation.
  */
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
@@ -15,13 +15,13 @@ import { hlPlain, hlTag, hlAttr, hlStr, escapeHtml } from './shared/playground-h
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Input } from '@ui/components/ui/input'
 import { Checkbox } from '@ui/components/ui/checkbox'
-
-// Mirror of ComboboxTrigger class definitions (ui/components/ui/combobox/index.tsx)
-const triggerBaseClasses = 'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none'
-const triggerFocusClasses = 'focus:border-ring focus:ring-ring/50 focus:ring-[3px]'
-const triggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@ui/components/ui/combobox'
 
 function ComboboxPlayground(_props: {}) {
+  const [value, setValue] = createSignal('')
   const [placeholder, setPlaceholder] = createSignal('Select framework...')
   const [disabled, setDisabled] = createSignal(false)
 
@@ -30,70 +30,93 @@ function ComboboxPlayground(_props: {}) {
     const d = disabled()
     const placeholderAttr = p ? ` placeholder="${p}"` : ''
     const disabledAttr = d ? ' disabled' : ''
-    return `<Combobox>\n  <ComboboxTrigger${disabledAttr}>\n    <ComboboxValue${placeholderAttr} />\n  </ComboboxTrigger>\n  <ComboboxContent>\n    <ComboboxInput placeholder="Search..." />\n    <ComboboxItem value="next">Next.js</ComboboxItem>\n    <ComboboxItem value="svelte">SvelteKit</ComboboxItem>\n  </ComboboxContent>\n</Combobox>`
+    return `<Combobox value={value()} onValueChange={setValue}>
+  <ComboboxTrigger${disabledAttr}>
+    <ComboboxValue${placeholderAttr} />
+  </ComboboxTrigger>
+  <ComboboxContent>
+    <ComboboxInput placeholder="Search framework..." />
+    <ComboboxEmpty>No framework found.</ComboboxEmpty>
+    <ComboboxItem value="next">Next.js</ComboboxItem>
+    <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+    <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+    <ComboboxItem value="remix">Remix</ComboboxItem>
+    <ComboboxItem value="astro">Astro</ComboboxItem>
+  </ComboboxContent>
+</Combobox>`
   })
 
   createEffect(() => {
     const p = placeholder()
     const d = disabled()
 
-    // Update combobox trigger preview
-    const container = document.querySelector('[data-combobox-preview]') as HTMLElement
-    if (container) {
-      const btn = document.createElement('button')
-      btn.setAttribute('type', 'button')
-      btn.setAttribute('role', 'combobox')
-      btn.setAttribute('data-placeholder', '')
-      btn.className = `${triggerBaseClasses} ${triggerFocusClasses} ${triggerDisabledClasses} w-[280px]`
-      if (d) btn.disabled = true
+    // Update the live Combobox preview via DOM manipulation.
+    // Use requestAnimationFrame to run after the component's own effects.
+    requestAnimationFrame(() => {
+      const container = document.querySelector('[data-combobox-preview]') as HTMLElement
+      if (!container) return
 
-      const span = document.createElement('span')
-      span.className = 'pointer-events-none truncate text-muted-foreground'
-      span.textContent = p || ''
-      btn.appendChild(span)
+      // Update disabled state on trigger
+      const trigger = container.querySelector('[data-slot="combobox-trigger"]') as HTMLButtonElement
+      if (trigger) {
+        trigger.disabled = d
+      }
 
-      // Chevron icon
-      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-      svg.setAttribute('class', 'size-4 shrink-0 opacity-50')
-      svg.setAttribute('viewBox', '0 0 24 24')
-      svg.setAttribute('fill', 'none')
-      svg.setAttribute('stroke', 'currentColor')
-      svg.setAttribute('stroke-width', '2')
-      svg.setAttribute('stroke-linecap', 'round')
-      svg.setAttribute('stroke-linejoin', 'round')
-      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-      path.setAttribute('d', 'm6 9 6 6 6-6')
-      svg.appendChild(path)
-      btn.appendChild(svg)
+      // Update placeholder text (only when no value is selected)
+      const valueEl = container.querySelector('[data-slot="combobox-value"]') as HTMLElement
+      if (valueEl && trigger?.hasAttribute('data-placeholder')) {
+        valueEl.textContent = p
+      }
 
-      container.innerHTML = ''
-      container.appendChild(btn)
-    }
-
-    // Update highlighted code
-    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      const disabledProp = d ? ` ${hlAttr('disabled')}` : ''
-      const placeholderProp = p
-        ? ` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p)}&quot;`)}`
-        : ''
-      const lines = [
-        `${hlPlain('&lt;')}${hlTag('Combobox')}${hlPlain('&gt;')}`,
-        `  ${hlPlain('&lt;')}${hlTag('ComboboxTrigger')}${disabledProp}${hlPlain('&gt;')}`,
-        `    ${hlPlain('&lt;')}${hlTag('ComboboxValue')}${placeholderProp} ${hlPlain('/&gt;')}`,
-        `  ${hlPlain('&lt;/')}${hlTag('ComboboxTrigger')}${hlPlain('&gt;')}`,
-        `  ${hlPlain('&lt;')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
-        `    ${hlPlain('...')}`,
-        `  ${hlPlain('&lt;/')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
-        `${hlPlain('&lt;/')}${hlTag('Combobox')}${hlPlain('&gt;')}`,
-      ]
-      codeEl.innerHTML = lines.join('\n')
-    }
+      // Update highlighted code
+      const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+      if (codeEl) {
+        const disabledProp = d ? ` ${hlAttr('disabled')}` : ''
+        const placeholderProp = p
+          ? ` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p)}&quot;`)}`
+          : ''
+        const valProp = ` ${hlAttr('value')}${hlPlain('={')}${hlPlain('value()')}${hlPlain('}')}`
+        const cbProp = ` ${hlAttr('onValueChange')}${hlPlain('={')}${hlPlain('setValue')}${hlPlain('}')}`
+        const lines = [
+          `${hlPlain('&lt;')}${hlTag('Combobox')}${valProp}${cbProp}${hlPlain('&gt;')}`,
+          `  ${hlPlain('&lt;')}${hlTag('ComboboxTrigger')}${disabledProp}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxValue')}${placeholderProp} ${hlPlain('/&gt;')}`,
+          `  ${hlPlain('&lt;/')}${hlTag('ComboboxTrigger')}${hlPlain('&gt;')}`,
+          `  ${hlPlain('&lt;')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxInput')} ${hlAttr('placeholder')}${hlPlain('=')}${hlStr('&quot;Search framework...&quot;')} ${hlPlain('/&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxEmpty')}${hlPlain('&gt;')}${hlPlain('No framework found.')}${hlPlain('&lt;/')}${hlTag('ComboboxEmpty')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;next&quot;')}${hlPlain('&gt;')}${hlPlain('Next.js')}${hlPlain('&lt;/')}${hlTag('ComboboxItem')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;svelte&quot;')}${hlPlain('&gt;')}${hlPlain('SvelteKit')}${hlPlain('&lt;/')}${hlTag('ComboboxItem')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;nuxt&quot;')}${hlPlain('&gt;')}${hlPlain('Nuxt')}${hlPlain('&lt;/')}${hlTag('ComboboxItem')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;remix&quot;')}${hlPlain('&gt;')}${hlPlain('Remix')}${hlPlain('&lt;/')}${hlTag('ComboboxItem')}${hlPlain('&gt;')}`,
+          `    ${hlPlain('&lt;')}${hlTag('ComboboxItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;astro&quot;')}${hlPlain('&gt;')}${hlPlain('Astro')}${hlPlain('&lt;/')}${hlTag('ComboboxItem')}${hlPlain('&gt;')}`,
+          `  ${hlPlain('&lt;/')}${hlTag('ComboboxContent')}${hlPlain('&gt;')}`,
+          `${hlPlain('&lt;/')}${hlTag('Combobox')}${hlPlain('&gt;')}`,
+        ]
+        codeEl.innerHTML = lines.join('\n')
+      }
+    })
   })
 
   return (
     <PlaygroundLayout
       previewDataAttr="data-combobox-preview"
+      previewContent={
+        <Combobox value={value()} onValueChange={setValue}>
+          <ComboboxTrigger className="w-[280px]">
+            <ComboboxValue placeholder="Select framework..." />
+          </ComboboxTrigger>
+          <ComboboxContent>
+            <ComboboxInput placeholder="Search framework..." />
+            <ComboboxEmpty>No framework found.</ComboboxEmpty>
+            <ComboboxItem value="next">Next.js</ComboboxItem>
+            <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+            <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+            <ComboboxItem value="remix">Remix</ComboboxItem>
+            <ComboboxItem value="astro">Astro</ComboboxItem>
+          </ComboboxContent>
+        </Combobox>
+      }
       controls={<>
         <PlaygroundControl label="placeholder">
           <Input

--- a/site/ui/pages/components/combobox.tsx
+++ b/site/ui/pages/components/combobox.tsx
@@ -6,6 +6,7 @@
  */
 
 import { ComboboxPlayground } from '@/components/combobox-playground'
+import { ComboboxBasicDemo } from '@/components/combobox-demo'
 import {
   DocPage,
   PageHeader,
@@ -17,10 +18,6 @@ import {
   type TocItem,
 } from '../../components/shared/docs'
 import { getNavLinks } from '../../components/shared/PageNavigation'
-import {
-  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
-  ComboboxInput, ComboboxEmpty, ComboboxItem,
-} from '@ui/components/ui/combobox'
 
 const tocItems: TocItem[] = [
   { id: 'preview', title: 'Preview' },
@@ -125,20 +122,7 @@ export function ComboboxRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <Combobox>
-              <ComboboxTrigger className="w-[280px]">
-                <ComboboxValue placeholder="Select framework..." />
-              </ComboboxTrigger>
-              <ComboboxContent>
-                <ComboboxInput placeholder="Search framework..." />
-                <ComboboxEmpty>No framework found.</ComboboxEmpty>
-                <ComboboxItem value="next">Next.js</ComboboxItem>
-                <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
-                <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
-                <ComboboxItem value="remix">Remix</ComboboxItem>
-                <ComboboxItem value="astro">Astro</ComboboxItem>
-              </ComboboxContent>
-            </Combobox>
+            <ComboboxBasicDemo />
           </Example>
         </Section>
 

--- a/site/ui/pages/components/combobox.tsx
+++ b/site/ui/pages/components/combobox.tsx
@@ -1,0 +1,157 @@
+/**
+ * Combobox Reference Page (/components/combobox)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { ComboboxPlayground } from '@/components/combobox-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@ui/components/ui/combobox'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  Combobox, ComboboxTrigger, ComboboxValue, ComboboxContent,
+  ComboboxInput, ComboboxEmpty, ComboboxItem,
+} from '@/components/ui/combobox'
+
+function ComboboxDemo() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <Combobox value={value()} onValueChange={setValue}>
+      <ComboboxTrigger class="w-[280px]">
+        <ComboboxValue placeholder="Select framework..." />
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput placeholder="Search framework..." />
+        <ComboboxEmpty>No framework found.</ComboboxEmpty>
+        <ComboboxItem value="next">Next.js</ComboboxItem>
+        <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+        <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+        <ComboboxItem value="remix">Remix</ComboboxItem>
+        <ComboboxItem value="astro">Astro</ComboboxItem>
+      </ComboboxContent>
+    </Combobox>
+  )
+}`
+
+const comboboxProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'Controlled selected value.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Callback when the selected value changes.',
+  },
+  {
+    name: 'filter',
+    type: '(value: string, search: string) => boolean',
+    description: 'Custom filter function. Defaults to case-insensitive substring match.',
+  },
+]
+
+const comboboxItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this option (required).',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this option is disabled.',
+  },
+]
+
+const comboboxInputProps: PropDefinition[] = [
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text for the search input.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the search input is disabled.',
+  },
+]
+
+export function ComboboxRefPage() {
+  return (
+    <DocPage slug="combobox" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Combobox"
+          description="Autocomplete input with searchable dropdown."
+          {...getNavLinks('combobox')}
+        />
+
+        {/* Props Playground */}
+        <ComboboxPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add combobox" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <Combobox>
+              <ComboboxTrigger className="w-[280px]">
+                <ComboboxValue placeholder="Select framework..." />
+              </ComboboxTrigger>
+              <ComboboxContent>
+                <ComboboxInput placeholder="Search framework..." />
+                <ComboboxEmpty>No framework found.</ComboboxEmpty>
+                <ComboboxItem value="next">Next.js</ComboboxItem>
+                <ComboboxItem value="svelte">SvelteKit</ComboboxItem>
+                <ComboboxItem value="nuxt">Nuxt</ComboboxItem>
+                <ComboboxItem value="remix">Remix</ComboboxItem>
+                <ComboboxItem value="astro">Astro</ComboboxItem>
+              </ComboboxContent>
+            </Combobox>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <h3 className="text-base font-semibold mb-2">Combobox</h3>
+          <PropsTable props={comboboxProps} />
+          <h3 className="text-base font-semibold mt-6 mb-2">ComboboxItem</h3>
+          <PropsTable props={comboboxItemProps} />
+          <h3 className="text-base font-semibold mt-6 mb-2">ComboboxInput</h3>
+          <PropsTable props={comboboxInputProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -16,6 +16,7 @@ import { AvatarPage } from './pages/avatar'
 import { BadgePage } from './pages/badge'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
+import { ComboboxRefPage } from './pages/components/combobox'
 import { InputRefPage } from './pages/components/input'
 import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
@@ -385,6 +386,11 @@ export function createApp() {
   // Button reference page (redesigned #515)
   app.get('/components/button', (c) => {
     return c.render(<ButtonRefPage />)
+  })
+
+  // Combobox reference page (redesigned #515)
+  app.get('/components/combobox', (c) => {
+    return c.render(<ComboboxRefPage />)
   })
 
   // Label reference page (redesigned #515)


### PR DESCRIPTION
## Summary

- Add interactive Props Playground for Combobox at `/components/combobox` (part of #515 page redesign)
- Playground controls: **placeholder** (text input) and **disabled** (checkbox toggle)
- New reference page follows badge/button pattern: PageHeader → Playground → Installation → Usage → API Reference
- API Reference includes PropsTable for Combobox, ComboboxItem, and ComboboxInput
- Existing `/docs/components/combobox` page remains unchanged

## Test plan

- [x] `bun run build` passes (site/ui build complete, combobox-playground compiled)
- [x] Test count unchanged (82 pre-existing failures, no new ones)
- [ ] Manual: visit `/components/combobox` — playground renders with placeholder/disabled controls
- [ ] Manual: visit `/docs/components/combobox` — existing page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)