### PR TITLE
Migrate Label to new page structure (#515)

### DIFF
--- a/site/ui/components/label-playground.tsx
+++ b/site/ui/components/label-playground.tsx
@@ -1,0 +1,79 @@
+"use client"
+/**
+ * Label Props Playground
+ *
+ * Interactive playground for the Label component.
+ * Allows tweaking children and for props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Input } from '@ui/components/ui/input'
+
+// Mirror of Label component class definitions (ui/components/ui/label/index.tsx)
+const labelClasses = 'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50'
+
+function LabelPlayground(_props: {}) {
+  const [text, setText] = createSignal('Email')
+  const [htmlFor, setHtmlFor] = createSignal('email')
+
+  const codeText = createMemo(() => {
+    const t = text()
+    const f = htmlFor()
+    const forProp = f ? ` for="${f}"` : ''
+    return `<Label${forProp}>${t}</Label>`
+  })
+
+  createEffect(() => {
+    const t = text()
+    const f = htmlFor()
+
+    // Update label preview
+    const container = document.querySelector('[data-label-preview]') as HTMLElement
+    if (container) {
+      const label = document.createElement('label')
+      label.setAttribute('data-slot', 'label')
+      label.className = labelClasses
+      if (f) label.setAttribute('for', f)
+      label.textContent = t
+      container.innerHTML = ''
+      container.appendChild(label)
+    }
+
+    // Update highlighted code
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      const forMarkup = f
+        ? ` ${hlAttr('for')}${hlPlain('=')}${hlStr(`&quot;${f}&quot;`)}`
+        : ''
+      codeEl.innerHTML = `${hlPlain('&lt;')}${hlTag('Label')}${forMarkup}${hlPlain('&gt;')}${t}${hlPlain('&lt;/')}${hlTag('Label')}${hlPlain('&gt;')}`
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-label-preview"
+      controls={<>
+        <PlaygroundControl label="children">
+          <Input
+            type="text"
+            value="Email"
+            onInput={(e: Event) => setText((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="for">
+          <Input
+            type="text"
+            value="email"
+            onInput={(e: Event) => setHtmlFor((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { LabelPlayground }

--- a/site/ui/pages/components/label.tsx
+++ b/site/ui/pages/components/label.tsx
@@ -1,0 +1,99 @@
+/**
+ * Label Reference Page (/components/label)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Label } from '@/components/ui/label'
+import { LabelPlayground } from '@/components/label-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+
+function LabelDemo() {
+  return (
+    <div className="grid w-full max-w-sm items-center gap-1.5">
+      <Label for="email">Email</Label>
+      <Input type="email" id="email" placeholder="Email" />
+    </div>
+  )
+}`
+
+const labelProps: PropDefinition[] = [
+  {
+    name: 'for',
+    type: 'string',
+    description: 'The id of the form control this label is associated with.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'The content displayed inside the label.',
+  },
+]
+
+export function LabelRefPage() {
+  return (
+    <DocPage slug="label" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Label"
+          description="Renders an accessible label associated with controls."
+          {...getNavLinks('label')}
+        />
+
+        {/* Props Playground */}
+        <LabelPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add label" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="grid w-full max-w-sm items-center gap-1.5">
+              <Label for="email">Email</Label>
+              <input
+                type="email"
+                id="email"
+                placeholder="Email"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+              />
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={labelProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -17,6 +17,7 @@ import { BadgePage } from './pages/badge'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
 import { InputRefPage } from './pages/components/input'
+import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
@@ -381,6 +382,11 @@ export function createApp() {
   // Button reference page (redesigned #515)
   app.get('/components/button', (c) => {
     return c.render(<ButtonRefPage />)
+  })
+
+  // Label reference page (redesigned #515)
+  app.get('/components/label', (c) => {
+    return c.render(<LabelRefPage />)
   })
 
   // Select reference page (redesigned #515)


### PR DESCRIPTION
## Summary

- Add `LabelPlayground` component with `children` and `for` prop controls and live preview
- Add `LabelRefPage` following the new page structure: Preview → Installation → Usage → API Reference
- Register `/components/label` route in `routes.tsx`

Follows the same pattern established by Badge and Button reference pages.

## Test plan

- [x] `bun run build` in `site/ui/` succeeds (label-playground correctly compiled)
- [x] No test regressions (82 pre-existing failures unchanged)
- [ ] Visit `/components/label` — verify playground renders and controls work
- [ ] Verify code preview updates when changing `children` and `for` inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)