### PR TITLE
Unify playground highlights and add props→_p renaming for compiler

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -64,7 +64,7 @@ describe('Client JS generation', () => {
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       // Should use props.onClick directly
-      expect(clientJs?.content).toContain('props.onClick')
+      expect(clientJs?.content).toContain('_p.onClick')
     })
 
     test('extracts props and props-dependent constants in client JS', () => {
@@ -98,7 +98,7 @@ describe('Client JS generation', () => {
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       // Should use props.command directly in fullCommand constant
-      expect(clientJs?.content).toContain('const fullCommand = `npx ${props.command}`')
+      expect(clientJs?.content).toContain('const fullCommand = `npx ${_p.command}`')
     })
 
     test('outputs IR JSON when requested', () => {
@@ -300,10 +300,10 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Props used as conditional guards should NOT get ?? {} default
-      expect(content).toContain('const prev = props.prev\n')
-      expect(content).toContain('const next = props.next\n')
-      expect(content).not.toContain('props.prev ?? {}')
-      expect(content).not.toContain('props.next ?? {}')
+      expect(content).toContain('const prev = _p.prev\n')
+      expect(content).toContain('const next = _p.next\n')
+      expect(content).not.toContain('_p.prev ?? {}')
+      expect(content).not.toContain('_p.next ?? {}')
     })
 
     test('evaluates dynamic text unconditionally inside conditional branches with try-catch', () => {
@@ -382,7 +382,7 @@ describe('Client JS generation', () => {
 
       // config is accessed with dot notation but NOT used as a conditional guard
       // (the guard is open()), so it should still get ?? {} to prevent TypeError.
-      expect(content).toContain('props.config ?? {}')
+      expect(content).toContain('_p.config ?? {}')
     })
   })
 
@@ -631,10 +631,10 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Template should inline the constant value, not reference the local name
-      expect(content).toContain('(props) => `')
+      expect(content).toContain('(_p) => `')
       expect(content).not.toMatch(/\bisDisabled\b.*\?>/)
       // The inlined expression should reference props directly
-      expect(content).toMatch(/props\.disabled/)
+      expect(content).toMatch(/_p\.disabled/)
     })
 
     test('template literal constant is inlined in mount template', () => {
@@ -655,7 +655,7 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Template should inline the template literal, not reference 'classes'
-      expect(content).toContain('(props) => `')
+      expect(content).toContain('(_p) => `')
       expect(content).not.toMatch(/\bclasses\b/)
     })
 
@@ -735,14 +735,14 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Must have a template (the component is simple enough)
-      expect(content).toContain('(props) => `')
+      expect(content).toContain('(_p) => `')
       // Template must NOT reference the local variable name 'isDisabled'
       // It should instead contain the inlined expression with props access
-      const templateMatch = content.match(/\(props\) => `([^`]*)`/)
+      const templateMatch = content.match(/\(_p\) => `([^`]*)`/)
       expect(templateMatch).not.toBeNull()
       const template = templateMatch![1]
       expect(template).not.toContain('isDisabled')
-      expect(template).toContain('props.disabled')
+      expect(template).toContain('_p.disabled')
     })
   })
 
@@ -766,14 +766,14 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Must not contain corrupted props.(props. syntax
-      expect(content).not.toContain('props.(props.')
+      expect(content).not.toContain('_p.(props.')
       // Local constants should be fully resolved
-      const templateMatch = content.match(/\(props\) => `([^`]*)`/)
+      const templateMatch = content.match(/\(_p\) => `([^`]*)`/)
       expect(templateMatch).not.toBeNull()
       const template = templateMatch![1]
       expect(template).not.toContain('outlineShadow')
       // props.variant should appear as valid syntax
-      expect(template).toContain('props.variant')
+      expect(template).toContain('_p.variant')
     })
 
     test('three-level chain: props.kind → kind → color → classes', () => {
@@ -795,12 +795,12 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      expect(content).not.toContain('props.(props.')
-      const templateMatch = content.match(/\(props\) => `([^`]*)`/)
+      expect(content).not.toContain('_p.(props.')
+      const templateMatch = content.match(/\(_p\) => `([^`]*)`/)
       expect(templateMatch).not.toBeNull()
       const template = templateMatch![1]
       expect(template).not.toContain('classes')
-      expect(template).toContain('props.kind')
+      expect(template).toContain('_p.kind')
     })
 
     test('template literal with multi-level chain', () => {
@@ -822,9 +822,9 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       // Must not contain corrupted props.(props. syntax
-      expect(content).not.toContain('props.(props.')
+      expect(content).not.toContain('_p.(props.')
       // The mount call should contain props.variant properly resolved
-      expect(content).toContain('props.variant')
+      expect(content).toContain('_p.variant')
       // Local constant 'classes' should not appear in mount template
       expect(content).not.toMatch(/mount\([^)]*\bclasses\b/)
     })
@@ -846,14 +846,14 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      expect(content).not.toContain('props.(props.')
-      const templateMatch = content.match(/\(props\) => `([^`]*)`/)
+      expect(content).not.toContain('_p.(props.')
+      const templateMatch = content.match(/\(_p\) => `([^`]*)`/)
       expect(templateMatch).not.toBeNull()
       const template = templateMatch![1]
       // props.size should be valid and not corrupted
-      expect(template).toContain('props.size')
+      expect(template).toContain('_p.size')
       // Should not have double-wrapped props references
-      expect(template).not.toMatch(/props\.\(props\./)
+      expect(template).not.toMatch(/_p\.\(props\./)
     })
   })
 
@@ -2059,8 +2059,8 @@ describe('Client JS generation', () => {
       expect(content).toContain("setAttribute('class'")
 
       // Should reference props.variant and props.className (not destructured names)
-      expect(content).toContain('props.variant')
-      expect(content).toContain('props.className')
+      expect(content).toContain('_p.variant')
+      expect(content).toContain('_p.className')
     })
 
     test('expanded constant with single prop reference is detected as reactive', () => {
@@ -2086,7 +2086,7 @@ describe('Client JS generation', () => {
       const content = clientJs!.content
 
       expect(content).toContain('createEffect')
-      expect(content).toContain('props.size')
+      expect(content).toContain('_p.size')
     })
 
     test('prop rewrite does not corrupt identifiers containing the prop name', () => {
@@ -2115,7 +2115,7 @@ describe('Client JS generation', () => {
       expect(content).toContain('sizeMap')
       expect(content).not.toContain('sizeMap'.replace('size', 'props.size'))
       // The standalone size reference should be rewritten
-      expect(content).toContain("props.size ?? 'sm'")
+      expect(content).toContain("_p.size ?? 'sm'")
     })
 
     test('default values from destructuring are included in rewrite', () => {
@@ -2140,7 +2140,7 @@ describe('Client JS generation', () => {
 
       expect(content).toContain('createEffect')
       // Should include the default value in the rewrite
-      expect(content).toContain("props.label ?? 'tag'")
+      expect(content).toContain("_p.label ?? 'tag'")
     })
   })
 })

--- a/packages/jsx/src/__tests__/controlled-prop-detection.test.ts
+++ b/packages/jsx/src/__tests__/controlled-prop-detection.test.ts
@@ -26,7 +26,7 @@ describe('controlled prop detection (#434)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Sync effect for controlled prop should be generated
-    expect(clientJs?.content).toContain('const __val = props.initial')
+    expect(clientJs?.content).toContain('const __val = _p.initial')
   })
 
   test('props.defaultXxx ?? default does NOT generate sync effect', () => {
@@ -50,7 +50,7 @@ describe('controlled prop detection (#434)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // No sync effect for uncontrolled (defaultXxx) props
-    expect(clientJs?.content).not.toContain('const __val = props.')
+    expect(clientJs?.content).not.toContain('const __val = _p.')
   })
 
   test('no redundant double-?? in output', () => {
@@ -100,8 +100,8 @@ describe('controlled prop detection (#434)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Must preserve the original fallback value, NOT replace with undefined
-    expect(clientJs?.content).toContain('props.initial ?? 0')
-    expect(clientJs?.content).not.toContain('props.initial ?? undefined')
+    expect(clientJs?.content).toContain('_p.initial ?? 0')
+    expect(clientJs?.content).not.toContain('_p.initial ?? undefined')
   })
 
   test('preserves boolean fallback value in output', () => {
@@ -125,8 +125,8 @@ describe('controlled prop detection (#434)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Must preserve false, NOT replace with undefined
-    expect(clientJs?.content).toContain('props.defaultChecked ?? false')
-    expect(clientJs?.content).not.toContain('props.defaultChecked ?? undefined')
+    expect(clientJs?.content).toContain('_p.defaultChecked ?? false')
+    expect(clientJs?.content).not.toContain('_p.defaultChecked ?? undefined')
   })
 
   test('preserves string fallback value in output', () => {
@@ -174,10 +174,11 @@ describe('controlled prop detection (#434)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Sync effect should be generated
-    expect(clientJs?.content).toContain('const __val = props.initial')
-    // Output should use 'props.initial' (not 'p.initial')
-    expect(clientJs?.content).toContain('props.initial')
-    expect(clientJs?.content).not.toContain('p.initial')
+    expect(clientJs?.content).toContain('const __val = _p.initial')
+    // Output should use '_p.initial' (normalized from custom 'p.initial')
+    expect(clientJs?.content).toContain('_p.initial')
+    // Should not contain unrewritten 'p.initial' (without underscore prefix)
+    expect(clientJs?.content).not.toMatch(/[^_]p\.initial/)
     // Init function should not contain double ??
     const initFn = clientJs?.content.match(/export function initSlider[\s\S]*?^}/m)?.[0] ?? ''
     expect(initFn).not.toMatch(/\?\?.*\?\?/)

--- a/packages/jsx/src/__tests__/ir-nullish-coalescing.test.ts
+++ b/packages/jsx/src/__tests__/ir-nullish-coalescing.test.ts
@@ -78,7 +78,7 @@ describe('nullish coalescing with JSX (#524)', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // props.initial ?? 0 should remain as a regular expression
-    expect(clientJs!.content).toContain('props.initial ?? 0')
+    expect(clientJs!.content).toContain('_p.initial ?? 0')
   })
 
   test('compiles || with JSX element', () => {

--- a/packages/jsx/src/__tests__/prop-references.test.ts
+++ b/packages/jsx/src/__tests__/prop-references.test.ts
@@ -232,7 +232,7 @@ describe('ClientJS generation with semantic prop refs', () => {
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Should have capture: const open = props.open
-    expect(clientJs?.content).toContain('const open = props.open')
+    expect(clientJs?.content).toContain('const open = _p.open')
     // createEffect should use 'open' directly, NOT 'props.open'
     // (destructured props are static, captured once)
     expect(clientJs?.content).not.toMatch(/insert\([^)]*props\.open/)
@@ -257,9 +257,9 @@ describe('ClientJS generation with semantic prop refs', () => {
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Should keep props.open as-is
-    expect(clientJs?.content).toContain('props.open')
+    expect(clientJs?.content).toContain('_p.open')
     // Should NOT have double-wrapped props.props.open
-    expect(clientJs?.content).not.toContain('props.props')
+    expect(clientJs?.content).not.toContain('_p.props')
   })
 
   test('does NOT transform window.open() in event handler', () => {
@@ -307,7 +307,7 @@ describe('ClientJS generation with semantic prop refs', () => {
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Should capture with default value: const open = props.open ?? false
-    expect(clientJs?.content).toMatch(/const open = props\.open \?\? false/)
+    expect(clientJs?.content).toMatch(/const open = _p\.open \?\? false/)
   })
 })
 
@@ -332,7 +332,7 @@ describe('Issue #257 regression', () => {
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
     // Should keep props.command as-is, NOT transform to props.props.command
-    expect(clientJs?.content).toContain('props.command')
-    expect(clientJs?.content).not.toContain('props.props.command')
+    expect(clientJs?.content).toContain('_p.command')
+    expect(clientJs?.content).not.toContain('_p.props.command')
   })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode, IRElement } from '../types'
 import type { ClientJsContext, LoopChildEvent } from './types'
-import { attrValueToString, quotePropName } from './utils'
+import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectLoopChildEvents } from './reactivity'
 import { irToHtmlTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
@@ -173,12 +173,12 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
       // Detect unexpanded spread props (open type — Phase 1 couldn't resolve keys)
       // Only handle spreads whose source matches the component's rest/props parameter name.
       // Other identifiers (e.g., local variables) may not exist in the compiled init scope.
-      // Always use 'props' as the actual source since the init function parameter is always 'props'.
+      // Always use PROPS_PARAM as the actual source since the init function parameter is PROPS_PARAM.
       const spreadProp = node.props.find(p => p.name === '...' || p.name.startsWith('...'))
       const restName = ctx.restPropsName
       const propsObjName = ctx.propsObjectName
       const isKnownSource = spreadProp && (spreadProp.value === restName || spreadProp.value === propsObjName)
-      const spreadSource = isKnownSource ? 'props' : null
+      const spreadSource = isKnownSource ? PROPS_PARAM : null
 
       const propsForInit: string[] = []
       const explicitPropNames: string[] = []
@@ -299,7 +299,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
       // Track unresolved spread attrs for runtime application.
       // Only handle spreads whose source matches the component's rest/props parameter name.
       // Other identifiers or complex expressions may not exist in the compiled init scope.
-      // Always use 'props' as the source since the init function parameter is always 'props'.
+      // Always use PROPS_PARAM as the source since the init function parameter is PROPS_PARAM.
       if (attr.name === '...' && attr.value) {
         const spreadVal = attrValueToString(attr.value) ?? ''
         const elemRestName = ctx.restPropsName
@@ -310,7 +310,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
             .map(a => a.name)
           ctx.restAttrElements.push({
             slotId: element.slotId,
-            source: 'props',
+            source: PROPS_PARAM,
             excludeKeys,
           })
         }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -1097,12 +1097,17 @@ export function buildCsrInlinableConstants(
 }
 
 /** Emit hydrate() call that registers component, template, and hydrates. */
+/**
+ * Generate the closing brace for the init function and the hydrate() call.
+ * Returns the hydrate line separately so it can be appended after props renaming,
+ * preventing double-replacement of props references in template expressions.
+ */
 export function emitRegistrationAndHydration(
   lines: string[],
   ctx: ClientJsContext,
   _ir: ComponentIR,
   usedAsChild?: Set<string>
-): void {
+): string {
   const name = ctx.componentName
 
   lines.push(`}`)
@@ -1145,5 +1150,5 @@ export function emitRegistrationAndHydration(
     defParts.push('comment: true')
   }
 
-  lines.push(`hydrate('${name}', { ${defParts.join(', ')} })`)
+  return `hydrate('${name}', { ${defParts.join(', ')} })`
 }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -1123,7 +1123,7 @@ export function emitRegistrationAndHydration(
   // Build ComponentDef object for hydrate()
   const defParts: string[] = [`init: init${name}`]
   if (canGenerateStaticTemplate(_ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
-    const templateHtml = irToComponentTemplate(_ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames)
+    const templateHtml = irToComponentTemplate(_ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames, ctx.propsObjectName)
     if (templateHtml) {
       defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)
     }
@@ -1134,7 +1134,7 @@ export function emitRegistrationAndHydration(
     const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     const templateHtml = generateCsrTemplate(
-      _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames
+      _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName
     )
     if (templateHtml) {
       defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -7,7 +7,7 @@ import type { ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, LoopChildEvent } from './types'
-import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId } from './utils'
+import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId, PROPS_PARAM } from './utils'
 import { addCondAttrToTemplate, canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, irChildrenToJsExpr, createStringProtector } from './html-template'
 
 /**
@@ -63,20 +63,20 @@ export function emitPropsExtraction(
         // Wrap arrow function defaults in parentheses to avoid operator precedence issues
         // e.g., `props.onInput ?? () => {}` is a syntax error; must be `props.onInput ?? (() => {})`
         const wrappedDefault = defaultVal.includes('=>') ? `(${defaultVal})` : defaultVal
-        lines.push(`  const ${propName} = props.${propName} ?? ${wrappedDefault}`)
+        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? ${wrappedDefault}`)
       } else if (propsUsedAsLoopArrays.has(propName)) {
-        lines.push(`  const ${propName} = props.${propName} ?? []`)
+        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? []`)
       } else if (propsWithPropertyAccess.has(propName) && !propsUsedAsConditions.has(propName)) {
-        lines.push(`  const ${propName} = props.${propName} ?? {}`)
+        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? {}`)
       } else if (prop?.optional && prop?.type) {
         const inferredDefault = inferDefaultValue(prop.type)
         if (inferredDefault !== 'undefined') {
-          lines.push(`  const ${propName} = props.${propName} ?? ${inferredDefault}`)
+          lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? ${inferredDefault}`)
         } else {
-          lines.push(`  const ${propName} = props.${propName}`)
+          lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName}`)
         }
       } else {
-        lines.push(`  const ${propName} = props.${propName}`)
+        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName}`)
       }
     }
     lines.push('')
@@ -111,24 +111,24 @@ export function emitDeclaration(
 
       let initialValue: string
       if (signal.initialValue.startsWith(propsPrefix) && !signal.initialValue.includes('??')) {
-        const propRef = 'props.' + signal.initialValue.slice(propsPrefix.length)
+        const propRef = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
         initialValue = `${propRef} ?? ${inferDefaultValue(signal.type)}`
       } else {
         const controlled = controlledSignals.find(c => c.signal === signal)
         if (controlled) {
           if (signal.initialValue.includes('??')) {
             if (ctx.propsObjectName && signal.initialValue.startsWith(propsPrefix)) {
-              initialValue = 'props.' + signal.initialValue.slice(propsPrefix.length)
+              initialValue = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
             } else {
               initialValue = signal.initialValue
             }
           } else {
             const prop = ctx.propsParams.find(p => p.name === controlled.propName)
             const defaultVal = prop?.defaultValue ?? inferDefaultValue(signal.type)
-            initialValue = `props.${controlled.propName} ?? ${defaultVal}`
+            initialValue = `${PROPS_PARAM}.${controlled.propName} ?? ${defaultVal}`
           }
         } else if (ctx.propsObjectName && signal.initialValue.startsWith(propsPrefix)) {
-          initialValue = 'props.' + signal.initialValue.slice(propsPrefix.length)
+          initialValue = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
         } else {
           initialValue = signal.initialValue
         }
@@ -159,8 +159,8 @@ export function emitControlledSignalEffect(
 ): void {
   const prop = ctx.propsParams.find(p => p.name === propName)
   const accessor = prop?.defaultValue
-    ? `(props.${propName} ?? ${prop.defaultValue})`
-    : `props.${propName}`
+    ? `(${PROPS_PARAM}.${propName} ?? ${prop.defaultValue})`
+    : `${PROPS_PARAM}.${propName}`
   lines.push(`  createEffect(() => {`)
   lines.push(`    const __val = ${accessor}`)
   lines.push(`    if (__val !== undefined) ${signal.setter}(__val)`)
@@ -185,7 +185,7 @@ export function emitPropsEventHandlers(
 
     const isProp = ctx.propsParams.some((p) => p.name === handlerName)
     if (isProp) {
-      lines.push(`  const ${handlerName} = props.${handlerName}`)
+      lines.push(`  const ${handlerName} = ${PROPS_PARAM}.${handlerName}`)
       addedPropsHandler = true
     }
   }
@@ -316,8 +316,8 @@ function rewriteDestructuredPropsInExpr(expr: string, ctx: ClientJsContext): str
 
     const defaultVal = prop.defaultValue
     const replacement = defaultVal
-      ? `(props.${prop.name} ?? ${defaultVal.includes('=>') ? `(${defaultVal})` : defaultVal})`
-      : `props.${prop.name}`
+      ? `(${PROPS_PARAM}.${prop.name} ?? ${defaultVal.includes('=>') ? `(${defaultVal})` : defaultVal})`
+      : `${PROPS_PARAM}.${prop.name}`
     result = result.replace(new RegExp(`\\b${prop.name}\\b`, 'g'), replacement)
   }
 
@@ -1000,17 +1000,17 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
   const signalMap = new Map<string, string>()
   for (const signal of ctx.signals) {
     let initialValue = signal.initialValue
-    // Normalize custom props object name to 'props.' and add default fallback
+    // Normalize custom props object name to PROPS_PARAM and add default fallback
     // to match emitSignalsAndMemos() behavior (prevents undefined rendering in CSR)
     if (ctx.propsObjectName && initialValue.startsWith(propsPrefix)) {
-      const propRef = 'props.' + initialValue.slice(propsPrefix.length)
+      const propRef = `${PROPS_PARAM}.` + initialValue.slice(propsPrefix.length)
       if (!initialValue.includes('??')) {
         initialValue = `${propRef} ?? ${inferDefaultValue(signal.type)}`
       } else {
         initialValue = propRef
       }
     } else if (initialValue.startsWith('props.') && !initialValue.includes('??')) {
-      initialValue = `${initialValue} ?? ${inferDefaultValue(signal.type)}`
+      initialValue = `${PROPS_PARAM}.${initialValue.slice('props.'.length)} ?? ${inferDefaultValue(signal.type)}`
     }
     signalMap.set(signal.getter, initialValue)
   }
@@ -1125,7 +1125,7 @@ export function emitRegistrationAndHydration(
   if (canGenerateStaticTemplate(_ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
     const templateHtml = irToComponentTemplate(_ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames)
     if (templateHtml) {
-      defParts.push(`template: (props) => \`${templateHtml}\``)
+      defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)
     }
   } else if (usedAsChild?.has(name)) {
     // CSR fallback: only emit when this component is used as a child by another
@@ -1137,7 +1137,7 @@ export function emitRegistrationAndHydration(
       _ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames
     )
     if (templateHtml) {
-      defParts.push(`template: (props) => \`${templateHtml}\``)
+      defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)
     }
   }
   // No else: top-level-only components skip template entirely (save bytes)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -240,7 +240,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   emitRefCallbacks(lines, ctx, conditionalSlotIds)
   emitEffectsAndOnMounts(lines, ctx)
   emitProviderAndChildInits(lines, ctx)
-  emitRegistrationAndHydration(lines, ctx, _ir, usedAsChild)
+  const hydrateLine = emitRegistrationAndHydration(lines, ctx, _ir, usedAsChild)
 
   let generatedCode = lines.join('\n')
 
@@ -248,29 +248,21 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   // User code may use `props.xxx` or a custom name like `p.xxx`;
   // the init function parameter is always PROPS_PARAM.
   // Both property access (props.xxx) and bare references (fn(props)) are renamed.
-  // The hydrate() template line is protected since html-template.ts handles it independently.
+  // The hydrate line is structurally excluded — it was not in `lines` during join,
+  // so template expressions (already using PROPS_PARAM) are never double-replaced.
   const srcPropsName = ctx.propsObjectName ?? 'props'
   if (srcPropsName !== PROPS_PARAM) {
-    // Protect hydrate() template lines from double-replacement.
-    // These are already processed by html-template.ts with PROPS_PARAM.
-    const TEMPLATE_PLACEHOLDER = '__BF_TEMPLATE_LINE__'
-    const templateLines: string[] = []
-    generatedCode = generatedCode.replace(
-      /^hydrate\(.+\)$/gm,
-      (match) => { templateLines.push(match); return `${TEMPLATE_PLACEHOLDER}${templateLines.length - 1}` }
-    )
-
-    generatedCode = generatedCode.replace(
-      new RegExp(`\\b${srcPropsName}\\b`, 'g'),
-      PROPS_PARAM,
-    )
-
-    // Restore protected template lines
-    generatedCode = generatedCode.replace(
-      new RegExp(`${TEMPLATE_PLACEHOLDER}(\\d+)`, 'g'),
-      (_, idx) => templateLines[Number(idx)]
-    )
+    generatedCode = generatedCode.split('\n')
+      .map(line => {
+        // Skip comment lines
+        if (line.trimStart().startsWith('//')) return line
+        return line.replace(new RegExp(`\\b${srcPropsName}\\b`, 'g'), PROPS_PARAM)
+      })
+      .join('\n')
   }
+
+  // Append hydrate line after props renaming (template expressions are already correct)
+  generatedCode += '\n' + hydrateLine
 
   const usedImports = detectUsedImports(generatedCode)
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -247,11 +247,28 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   // Rename source-level props object name to the generated parameter name.
   // User code may use `props.xxx` or a custom name like `p.xxx`;
   // the init function parameter is always PROPS_PARAM.
+  // Both property access (props.xxx) and bare references (fn(props)) are renamed.
+  // The hydrate() template line is protected since html-template.ts handles it independently.
   const srcPropsName = ctx.propsObjectName ?? 'props'
   if (srcPropsName !== PROPS_PARAM) {
+    // Protect hydrate() template lines from double-replacement.
+    // These are already processed by html-template.ts with PROPS_PARAM.
+    const TEMPLATE_PLACEHOLDER = '__BF_TEMPLATE_LINE__'
+    const templateLines: string[] = []
     generatedCode = generatedCode.replace(
-      new RegExp(`\\b${srcPropsName}\\.`, 'g'),
-      `${PROPS_PARAM}.`,
+      /^hydrate\(.+\)$/gm,
+      (match) => { templateLines.push(match); return `${TEMPLATE_PLACEHOLDER}${templateLines.length - 1}` }
+    )
+
+    generatedCode = generatedCode.replace(
+      new RegExp(`\\b${srcPropsName}\\b`, 'g'),
+      PROPS_PARAM,
+    )
+
+    // Restore protected template lines
+    generatedCode = generatedCode.replace(
+      new RegExp(`${TEMPLATE_PLACEHOLDER}(\\d+)`, 'g'),
+      (_, idx) => templateLines[Number(idx)]
     )
   }
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -4,7 +4,7 @@
 
 import type { ComponentIR, ConstantInfo, IRNode } from '../types'
 import type { ClientJsContext } from './types'
-import { varSlotId } from './utils'
+import { varSlotId, PROPS_PARAM } from './utils'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
 import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
@@ -62,7 +62,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   lines.push('')
   lines.push(MODULE_CONSTANTS_PLACEHOLDER)
 
-  lines.push(`export function init${name}(__scope, props = {}) {`)
+  lines.push(`export function init${name}(__scope, ${PROPS_PARAM} = {}) {`)
   lines.push(`  if (!__scope) return`)
   lines.push('')
 
@@ -98,13 +98,11 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
         continue
       }
 
-      if (constant.name !== 'props') {
-        neededConstants.push(constant)
+      neededConstants.push(constant)
 
-        const refs = valueReferencesReactiveData(constant.value, ctx)
-        for (const propName of refs.usedProps) {
-          neededProps.add(propName)
-        }
+      const refs = valueReferencesReactiveData(constant.value, ctx)
+      for (const propName of refs.usedProps) {
+        neededProps.add(propName)
       }
     }
   }
@@ -244,7 +242,19 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   emitProviderAndChildInits(lines, ctx)
   emitRegistrationAndHydration(lines, ctx, _ir, usedAsChild)
 
-  const generatedCode = lines.join('\n')
+  let generatedCode = lines.join('\n')
+
+  // Rename source-level props object name to the generated parameter name.
+  // User code may use `props.xxx` or a custom name like `p.xxx`;
+  // the init function parameter is always PROPS_PARAM.
+  const srcPropsName = ctx.propsObjectName ?? 'props'
+  if (srcPropsName !== PROPS_PARAM) {
+    generatedCode = generatedCode.replace(
+      new RegExp(`\\b${srcPropsName}\\.`, 'g'),
+      `${PROPS_PARAM}.`,
+    )
+  }
+
   const usedImports = detectUsedImports(generatedCode)
 
   for (const userImport of collectUserDomImports(_ir)) {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -229,6 +229,21 @@ export function addCondAttrToTemplate(html: string, condId: string): string {
 }
 
 /**
+ * Options for template generation functions (irToComponentTemplate, generateCsrTemplate).
+ * Consolidates parameters to prevent argument-passing bugs during recursion.
+ */
+export interface TemplateOptions {
+  propNames: Set<string>
+  inlinableConstants?: Map<string, string>
+  restSpreadNames?: Set<string>
+  propsObjectName?: string | null
+  // generateCsrTemplate-specific fields
+  signalMap?: Map<string, string>
+  memoMap?: Map<string, string>
+  insideLoop?: boolean
+}
+
+/**
  * Generate HTML template for registerTemplate().
  * Used for client-side component creation via createComponent().
  *
@@ -236,10 +251,6 @@ export function addCondAttrToTemplate(html: string, condId: string): string {
  * - Expressions are transformed to use the template function's props parameter
  * - Local constant references are inlined with their resolved values (#343)
  * - bf markers ARE included so client code can find elements
- *
- * @param node - IR node to render
- * @param propNames - Set of prop names to prefix with 'props.'
- * @param inlinableConstants - Map of constant names to their resolved values for inlining
  */
 export function irToComponentTemplate(
   node: IRNode,
@@ -248,6 +259,12 @@ export function irToComponentTemplate(
   restSpreadNames?: Set<string>,
   propsObjectName?: string | null
 ): string {
+  return irToComponentTemplateWithOpts(node, { propNames, inlinableConstants, restSpreadNames, propsObjectName })
+}
+
+function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
+  const { propNames, inlinableConstants, restSpreadNames, propsObjectName } = opts
+  const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, opts)
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
     let result = protect(expr)
@@ -312,7 +329,7 @@ export function irToComponentTemplate(
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+      const children = node.children.map(recurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -331,19 +348,19 @@ export function irToComponentTemplate(
       return `\${${transformExpr(node.expr)}}`
 
     case 'conditional': {
-      const trueBranch = irToComponentTemplate(node.whenTrue, propNames, inlinableConstants, restSpreadNames, propsObjectName)
-      const falseBranch = irToComponentTemplate(node.whenFalse, propNames, inlinableConstants, restSpreadNames, propsObjectName)
+      const trueBranch = recurse(node.whenTrue)
+      const falseBranch = recurse(node.whenFalse)
       const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
       const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
       return `\${${transformExpr(node.condition)} ? \`${trueHtml}\` : \`${falseHtml}\`}`
     }
 
     case 'fragment':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+      return node.children.map(recurse).join('')
 
     case 'component': {
       if (node.name === 'Portal') {
-        return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+        return node.children.map(recurse).join('')
       }
 
       // Use renderChild() to render child component's template at runtime (#435)
@@ -352,7 +369,7 @@ export function irToComponentTemplate(
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
           if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(c => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+            const childHtml = p.jsxChildren.map(recurse).join('')
             return `${quotePropName(p.name)}: \`${childHtml}\``
           }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
@@ -366,13 +383,13 @@ export function irToComponentTemplate(
     }
 
     case 'loop':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+      return node.children.map(recurse).join('')
 
     case 'if-statement':
       return ''
 
     case 'provider':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
+      return node.children.map(recurse).join('')
 
     default:
       return ''
@@ -509,6 +526,11 @@ export function generateCsrTemplate(
   restSpreadNames?: Set<string>,
   propsObjectName?: string | null,
 ): string {
+  return generateCsrTemplateWithOpts(node, { propNames, inlinableConstants, restSpreadNames, propsObjectName, signalMap, memoMap, insideLoop })
+}
+
+function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
+  const { propNames, inlinableConstants, restSpreadNames, propsObjectName, signalMap, memoMap, insideLoop } = opts
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
     let result = protect(expr)
@@ -565,8 +587,8 @@ export function generateCsrTemplate(
     return restore(result)
   }
 
-  const recurse = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames, propsObjectName)
-  const recurseInLoop = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, true, restSpreadNames, propsObjectName)
+  const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, opts)
+  const recurseInLoop = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, insideLoop: true })
 
   switch (node.type) {
     case 'element': {
@@ -642,7 +664,7 @@ export function generateCsrTemplate(
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
           if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(c => generateCsrTemplate(c, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames)).join('')
+            const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
             return `${quotePropName(p.name)}: \`${childHtml}\``
           }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -245,7 +245,8 @@ export function irToComponentTemplate(
   node: IRNode,
   propNames: Set<string>,
   inlinableConstants?: Map<string, string>,
-  restSpreadNames?: Set<string>
+  restSpreadNames?: Set<string>,
+  propsObjectName?: string | null
 ): string {
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
@@ -258,6 +259,15 @@ export function irToComponentTemplate(
       for (const [constName, constValue] of inlinableConstants) {
         result = result.replace(new RegExp(`(?<![-.])\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
       }
+    }
+
+    // Normalize source-level props object access (e.g., props.xxx → _p.xxx)
+    // before the bare propName prefixing step to avoid double-prefixing.
+    if (propsObjectName && propsObjectName !== PROPS_PARAM) {
+      result = result.replace(
+        new RegExp(`\\b${propsObjectName}\\.`, 'g'),
+        `${PROPS_PARAM}.`,
+      )
     }
 
     // Then: prefix prop names with PROPS_PARAM
@@ -302,7 +312,7 @@ export function irToComponentTemplate(
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+      const children = node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -321,19 +331,19 @@ export function irToComponentTemplate(
       return `\${${transformExpr(node.expr)}}`
 
     case 'conditional': {
-      const trueBranch = irToComponentTemplate(node.whenTrue, propNames, inlinableConstants, restSpreadNames)
-      const falseBranch = irToComponentTemplate(node.whenFalse, propNames, inlinableConstants, restSpreadNames)
+      const trueBranch = irToComponentTemplate(node.whenTrue, propNames, inlinableConstants, restSpreadNames, propsObjectName)
+      const falseBranch = irToComponentTemplate(node.whenFalse, propNames, inlinableConstants, restSpreadNames, propsObjectName)
       const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
       const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
       return `\${${transformExpr(node.condition)} ? \`${trueHtml}\` : \`${falseHtml}\`}`
     }
 
     case 'fragment':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
 
     case 'component': {
       if (node.name === 'Portal') {
-        return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+        return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
       }
 
       // Use renderChild() to render child component's template at runtime (#435)
@@ -342,7 +352,7 @@ export function irToComponentTemplate(
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
           if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(c => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+            const childHtml = p.jsxChildren.map(c => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
             return `${quotePropName(p.name)}: \`${childHtml}\``
           }
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
@@ -356,13 +366,13 @@ export function irToComponentTemplate(
     }
 
     case 'loop':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
 
     case 'if-statement':
       return ''
 
     case 'provider':
-      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames)).join('')
+      return node.children.map((c) => irToComponentTemplate(c, propNames, inlinableConstants, restSpreadNames, propsObjectName)).join('')
 
     default:
       return ''
@@ -497,6 +507,7 @@ export function generateCsrTemplate(
   memoMap?: Map<string, string>,
   insideLoop?: boolean,
   restSpreadNames?: Set<string>,
+  propsObjectName?: string | null,
 ): string {
   const transformExpr = (expr: string): string => {
     const { protect, restore } = createStringProtector()
@@ -538,6 +549,14 @@ export function generateCsrTemplate(
       }
     }
 
+    // Normalize source-level props object access (e.g., props.xxx → _p.xxx)
+    if (propsObjectName && propsObjectName !== PROPS_PARAM) {
+      result = result.replace(
+        new RegExp(`\\b${propsObjectName}\\.`, 'g'),
+        `${PROPS_PARAM}.`,
+      )
+    }
+
     // Prefix prop names with PROPS_PARAM
     for (const propName of propNames) {
       const pattern = new RegExp(`(?<!${PROPS_PARAM}\\.)(?<!['"\\w])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
@@ -546,8 +565,8 @@ export function generateCsrTemplate(
     return restore(result)
   }
 
-  const recurse = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames)
-  const recurseInLoop = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, true, restSpreadNames)
+  const recurse = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, insideLoop, restSpreadNames, propsObjectName)
+  const recurseInLoop = (n: IRNode): string => generateCsrTemplate(n, propNames, inlinableConstants, signalMap, memoMap, true, restSpreadNames, propsObjectName)
 
   switch (node.type) {
     case 'element': {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -260,13 +260,13 @@ export function irToComponentTemplate(
       }
     }
 
-    // Then: prefix prop names with 'props.'
+    // Then: prefix prop names with PROPS_PARAM
     for (const propName of propNames) {
       // Match propName as standalone identifier or followed by property/index/call access,
-      // but not already prefixed with 'props.' or inside string literals.
+      // but not already prefixed with PROPS_PARAM or inside string literals.
       // Uses negative lookahead for identifier chars to avoid partial matches.
-      const pattern = new RegExp(`(?<!props\\.)(?<!['"\\w])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
-      result = result.replace(pattern, `props.${propName}`)
+      const pattern = new RegExp(`(?<!${PROPS_PARAM}\\.)(?<!['"\\w])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
+      result = result.replace(pattern, `${PROPS_PARAM}.${propName}`)
     }
     return restore(result)
   }
@@ -538,10 +538,10 @@ export function generateCsrTemplate(
       }
     }
 
-    // Prefix prop names with 'props.'
+    // Prefix prop names with PROPS_PARAM
     for (const propName of propNames) {
-      const pattern = new RegExp(`(?<!props\\.)(?<!['"\\w])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
-      result = result.replace(pattern, `props.${propName}`)
+      const pattern = new RegExp(`(?<!${PROPS_PARAM}\\.)(?<!['"\\w])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
+      result = result.replace(pattern, `${PROPS_PARAM}.${propName}`)
     }
     return restore(result)
   }

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -144,7 +144,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   let templateHtml: string | undefined
 
   if (canGenerateStaticTemplate(ir.root, propNamesForTemplate, inlinableConstants, unsafeLocalNames)) {
-    templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames)
+    templateHtml = irToComponentTemplate(ir.root, propNamesForTemplate, inlinableConstants, restSpreadNames, ctx.propsObjectName)
   }
 
   // CSR fallback: when static template generation fails (e.g., components with
@@ -154,7 +154,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
     const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
 
     templateHtml = generateCsrTemplate(
-      ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames
+      ir.root, propNamesForTemplate, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName
     )
   }
 

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -11,6 +11,7 @@ import { generateInitFunction } from './generate-init'
 import { collectUsedIdentifiers, collectUsedFunctions } from './identifiers'
 import { valueReferencesReactiveData } from './prop-handling'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
+import { PROPS_PARAM } from './utils'
 import { buildInlinableConstants, buildSignalAndMemoMaps, buildCsrInlinableConstants } from './emit-init-sections'
 import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
 
@@ -56,11 +57,9 @@ export function analyzeClientNeeds(ir: ComponentIR): { needsInit: boolean; usedP
       if (!constant.value) continue
       const trimmedValue = constant.value.trim()
       if (/^createContext\b/.test(trimmedValue) || /^new WeakMap\b/.test(trimmedValue)) continue
-      if (constant.name !== 'props') {
-        const refs = valueReferencesReactiveData(constant.value, ctx)
-        for (const propName of refs.usedProps) {
-          neededProps.add(propName)
-        }
+      const refs = valueReferencesReactiveData(constant.value, ctx)
+      for (const propName of refs.usedProps) {
+        neededProps.add(propName)
       }
     }
   }
@@ -170,7 +169,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   lines.push('')
   lines.push(`function init${name}() {}`)
   lines.push('')
-  lines.push(`hydrate('${name}', { init: init${name}, template: (props) => \`${templateHtml}\` })`)
+  lines.push(`hydrate('${name}', { init: init${name}, template: (${PROPS_PARAM}) => \`${templateHtml}\` })`)
 
   const generatedCode = lines.join('\n')
   const usedImports = detectUsedImports(generatedCode)

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -4,6 +4,7 @@
 
 import type { ConstantInfo, ParamInfo, SignalInfo } from '../types'
 import type { ClientJsContext } from './types'
+import { PROPS_PARAM } from './utils'
 
 /**
  * Expand dynamic prop value by resolving local constants.
@@ -93,6 +94,7 @@ export function getControlledPropName(
 ): string | null {
   const initialValue = signal.initialValue.trim()
   const isDefaultProp = (propName: string) => propName.startsWith('default')
+  // Use the source-level props name for pattern matching (not the generated PROPS_PARAM)
   const propsName = propsObjectName ?? 'props'
 
   // Direct <propsName>.X reference, optionally with ?? or || fallback

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -7,6 +7,12 @@ import type { IRTemplateLiteral } from '../types'
 import type { LoopElement } from './types'
 
 /**
+ * Parameter name for the props object in generated init/template functions.
+ * Short name to minimize client JS bundle size.
+ */
+export const PROPS_PARAM = '_p'
+
+/**
  * Strip ^ prefix from slot ID for use as JavaScript variable name.
  * `^s3` → `s3` (since `_^s3` is not a valid identifier)
  */

--- a/site/ui/components/badge-playground.tsx
+++ b/site/ui/components/badge-playground.tsx
@@ -6,9 +6,9 @@
  * Allows tweaking variant and children props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { highlightJsx } from './shared/playground-highlight'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Input } from '@ui/components/ui/input'
@@ -20,26 +20,15 @@ function BadgePlayground(_props: {}) {
   const [variant, setVariant] = createSignal<BadgeVariant>('default')
   const [text, setText] = createSignal('Badge')
 
-  const codeText = createMemo(() => {
-    const v = variant()
-    const t = text()
-    const variantProp = v === 'default' ? '' : ` variant="${v}"`
-    return `<Badge${variantProp}>${t}</Badge>`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'variant', value: variant(), defaultValue: 'default' },
+  ]
 
   createEffect(() => {
-    const v = variant()
+    const p = props()
     const t = text()
-
-    // Update highlighted code
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightJsx(
-        'Badge',
-        [{ name: 'variant', value: v, defaultValue: 'default' }],
-        t,
-      )
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsx('Badge', p, t)
   })
 
   return (
@@ -68,7 +57,7 @@ function BadgePlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsx('Badge', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/badge-playground.tsx
+++ b/site/ui/components/badge-playground.tsx
@@ -20,12 +20,12 @@ function BadgePlayground(_props: {}) {
   const [variant, setVariant] = createSignal<BadgeVariant>('default')
   const [text, setText] = createSignal('Badge')
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Badge', p, t)
@@ -57,7 +57,7 @@ function BadgePlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Badge', propDefs(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Badge', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/badge-playground.tsx
+++ b/site/ui/components/badge-playground.tsx
@@ -20,12 +20,12 @@ function BadgePlayground(_props: {}) {
   const [variant, setVariant] = createSignal<BadgeVariant>('default')
   const [text, setText] = createSignal('Badge')
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Badge', p, t)
@@ -57,7 +57,7 @@ function BadgePlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Badge', props(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Badge', propDefs(), text())} />}
     />
   )
 }

--- a/site/ui/components/button-playground.tsx
+++ b/site/ui/components/button-playground.tsx
@@ -6,9 +6,9 @@
  * Allows tweaking variant, size, and children props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { highlightJsx } from './shared/playground-highlight'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Input } from '@ui/components/ui/input'
@@ -22,34 +22,16 @@ function ButtonPlayground(_props: {}) {
   const [size, setSize] = createSignal<ButtonSize>('default')
   const [text, setText] = createSignal('Button')
 
-  const codeText = createMemo(() => {
-    const v = variant()
-    const s = size()
-    const t = text()
-    const parts: string[] = []
-    if (v !== 'default') parts.push(`variant="${v}"`)
-    if (s !== 'default') parts.push(`size="${s}"`)
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<Button${propsStr}>${t}</Button>`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'variant', value: variant(), defaultValue: 'default' },
+    { name: 'size', value: size(), defaultValue: 'default' },
+  ]
 
   createEffect(() => {
-    const v = variant()
-    const s = size()
+    const p = props()
     const t = text()
-
-    // Update highlighted code
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightJsx(
-        'Button',
-        [
-          { name: 'variant', value: v, defaultValue: 'default' },
-          { name: 'size', value: s, defaultValue: 'default' },
-        ],
-        t,
-      )
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsx('Button', p, t)
   })
 
   return (
@@ -95,7 +77,7 @@ function ButtonPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsx('Button', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/button-playground.tsx
+++ b/site/ui/components/button-playground.tsx
@@ -22,13 +22,13 @@ function ButtonPlayground(_props: {}) {
   const [size, setSize] = createSignal<ButtonSize>('default')
   const [text, setText] = createSignal('Button')
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
     { name: 'size', value: size(), defaultValue: 'default' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Button', p, t)
@@ -77,7 +77,7 @@ function ButtonPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Button', props(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Button', propDefs(), text())} />}
     />
   )
 }

--- a/site/ui/components/button-playground.tsx
+++ b/site/ui/components/button-playground.tsx
@@ -22,13 +22,13 @@ function ButtonPlayground(_props: {}) {
   const [size, setSize] = createSignal<ButtonSize>('default')
   const [text, setText] = createSignal('Button')
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
     { name: 'size', value: size(), defaultValue: 'default' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Button', p, t)
@@ -77,7 +77,7 @@ function ButtonPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Button', propDefs(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Button', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/checkbox-playground.tsx
+++ b/site/ui/components/checkbox-playground.tsx
@@ -6,39 +6,25 @@
  * Allows tweaking defaultChecked and disabled props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
-
-function highlightCheckboxJsx(defaultChecked: boolean, disabled: boolean): string {
-  const boolProps: string[] = []
-  if (defaultChecked) boolProps.push(` ${hlAttr('defaultChecked')}`)
-  if (disabled) boolProps.push(` ${hlAttr('disabled')}`)
-  return `${hlPlain('&lt;')}${hlTag('Checkbox')}${boolProps.join('')}${hlPlain(' /&gt;')}`
-}
 
 function CheckboxPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const parts: string[] = []
-    if (defaultChecked()) parts.push(' defaultChecked')
-    if (disabled()) parts.push(' disabled')
-    return `<Checkbox${parts.join('')} />`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+  ]
 
   createEffect(() => {
-    const dc = defaultChecked()
-    const d = disabled()
-
-    // Update highlighted code
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightCheckboxJsx(dc, d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Checkbox', p)
   })
 
   return (
@@ -64,7 +50,7 @@ function CheckboxPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Checkbox', props())} />}
     />
   )
 }

--- a/site/ui/components/checkbox-playground.tsx
+++ b/site/ui/components/checkbox-playground.tsx
@@ -16,13 +16,13 @@ function CheckboxPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Checkbox', p)
   })
@@ -50,7 +50,7 @@ function CheckboxPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Checkbox', props())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Checkbox', propDefs())} />}
     />
   )
 }

--- a/site/ui/components/checkbox-playground.tsx
+++ b/site/ui/components/checkbox-playground.tsx
@@ -16,13 +16,13 @@ function CheckboxPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Checkbox', p)
   })
@@ -50,7 +50,7 @@ function CheckboxPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Checkbox', propDefs())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Checkbox', props())} />}
     />
   )
 }

--- a/site/ui/components/input-playground.tsx
+++ b/site/ui/components/input-playground.tsx
@@ -6,47 +6,31 @@
  * Allows tweaking type, placeholder, and disabled props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { highlightJsxSelfClosing } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Input } from '@ui/components/ui/input'
+import { Checkbox } from '@ui/components/ui/checkbox'
 
 type InputType = 'text' | 'email' | 'password' | 'number'
 
 function InputPlayground(_props: {}) {
   const [type, setType] = createSignal<InputType>('text')
   const [placeholder, setPlaceholder] = createSignal('Enter text...')
-  const [disabled, setDisabled] = createSignal('false')
+  const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const t = type()
-    const p = placeholder()
-    const d = disabled()
-    const parts: string[] = []
-    if (t !== 'text') parts.push(`type="${t}"`)
-    if (p) parts.push(`placeholder="${p}"`)
-    if (d === 'true') parts.push('disabled')
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<Input${propsStr} />`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'type', value: type(), defaultValue: 'text' },
+    { name: 'placeholder', value: placeholder(), defaultValue: '' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+  ]
 
   createEffect(() => {
-    const t = type()
-    const p = placeholder()
-    const d = disabled()
-
-    // Update highlighted code
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      const props = [
-        { name: 'type', value: t, defaultValue: 'text' },
-        { name: 'placeholder', value: p, defaultValue: '' },
-        { name: 'disabled', value: d, defaultValue: 'false' },
-      ]
-      codeEl.innerHTML = highlightJsxSelfClosing('Input', props)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Input', p)
   })
 
   return (
@@ -56,7 +40,7 @@ function InputPlayground(_props: {}) {
         <Input
           type={type()}
           placeholder={placeholder()}
-          disabled={disabled() === 'true'}
+          disabled={disabled()}
           className="max-w-sm"
         />
       }
@@ -82,18 +66,13 @@ function InputPlayground(_props: {}) {
           />
         </PlaygroundControl>
         <PlaygroundControl label="disabled">
-          <Select value={disabled()} onValueChange={(v: string) => setDisabled(v)}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="false">false</SelectItem>
-              <SelectItem value="true">true</SelectItem>
-            </SelectContent>
-          </Select>
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Input', props())} />}
     />
   )
 }

--- a/site/ui/components/input-playground.tsx
+++ b/site/ui/components/input-playground.tsx
@@ -21,14 +21,14 @@ function InputPlayground(_props: {}) {
   const [placeholder, setPlaceholder] = createSignal('Enter text...')
   const [disabled, setDisabled] = createSignal(false)
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'type', value: type(), defaultValue: 'text' },
     { name: 'placeholder', value: placeholder(), defaultValue: '' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Input', p)
   })
@@ -72,7 +72,7 @@ function InputPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Input', propDefs())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Input', props())} />}
     />
   )
 }

--- a/site/ui/components/input-playground.tsx
+++ b/site/ui/components/input-playground.tsx
@@ -21,14 +21,14 @@ function InputPlayground(_props: {}) {
   const [placeholder, setPlaceholder] = createSignal('Enter text...')
   const [disabled, setDisabled] = createSignal(false)
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'type', value: type(), defaultValue: 'text' },
     { name: 'placeholder', value: placeholder(), defaultValue: '' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Input', p)
   })
@@ -72,7 +72,7 @@ function InputPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Input', props())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Input', propDefs())} />}
     />
   )
 }

--- a/site/ui/components/label-playground.tsx
+++ b/site/ui/components/label-playground.tsx
@@ -6,9 +6,9 @@
  * Allows tweaking children and for props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Input } from '@ui/components/ui/input'
 import { Label } from '@ui/components/ui/label'
@@ -17,25 +17,15 @@ function LabelPlayground(_props: {}) {
   const [text, setText] = createSignal('Email')
   const [htmlFor, setHtmlFor] = createSignal('email')
 
-  const codeText = createMemo(() => {
-    const t = text()
-    const f = htmlFor()
-    const forProp = f ? ` for="${f}"` : ''
-    return `<Label${forProp}>${t}</Label>`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'for', value: htmlFor(), defaultValue: '' },
+  ]
 
   createEffect(() => {
+    const p = props()
     const t = text()
-    const f = htmlFor()
-
-    // Update highlighted code
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      const forMarkup = f
-        ? ` ${hlAttr('for')}${hlPlain('=')}${hlStr(`&quot;${f}&quot;`)}`
-        : ''
-      codeEl.innerHTML = `${hlPlain('&lt;')}${hlTag('Label')}${forMarkup}${hlPlain('&gt;')}${t}${hlPlain('&lt;/')}${hlTag('Label')}${hlPlain('&gt;')}`
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsx('Label', p, t)
   })
 
   return (
@@ -58,7 +48,7 @@ function LabelPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsx('Label', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/label-playground.tsx
+++ b/site/ui/components/label-playground.tsx
@@ -17,12 +17,12 @@ function LabelPlayground(_props: {}) {
   const [text, setText] = createSignal('Email')
   const [htmlFor, setHtmlFor] = createSignal('email')
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'for', value: htmlFor(), defaultValue: '' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Label', p, t)
@@ -48,7 +48,7 @@ function LabelPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Label', propDefs(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Label', props(), text())} />}
     />
   )
 }

--- a/site/ui/components/label-playground.tsx
+++ b/site/ui/components/label-playground.tsx
@@ -17,12 +17,12 @@ function LabelPlayground(_props: {}) {
   const [text, setText] = createSignal('Email')
   const [htmlFor, setHtmlFor] = createSignal('email')
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'for', value: htmlFor(), defaultValue: '' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const t = text()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Label', p, t)
@@ -48,7 +48,7 @@ function LabelPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Label', props(), text())} />}
+      copyButton={<CopyButton code={plainJsx('Label', propDefs(), text())} />}
     />
   )
 }

--- a/site/ui/components/shared/playground-highlight.ts
+++ b/site/ui/components/shared/playground-highlight.ts
@@ -64,9 +64,10 @@ export function plainJsxSelfClosing(tagName: string, props: HighlightProp[]): st
 
 function renderProp(p: HighlightProp): string {
   const kind = p.kind ?? 'string'
-  if (kind === 'boolean') return ` ${hlAttr(p.name)}`
-  if (kind === 'expression') return ` ${hlAttr(p.name)}${hlPlain('={')}${hlPlain(escapeHtml(p.value))}${hlPlain('}')}`
-  return ` ${hlAttr(p.name)}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p.value)}&quot;`)}`
+  const safeName = escapeHtml(p.name)
+  if (kind === 'boolean') return ` ${hlAttr(safeName)}`
+  if (kind === 'expression') return ` ${hlAttr(safeName)}${hlPlain('={')}${hlPlain(escapeHtml(p.value))}${hlPlain('}')}`
+  return ` ${hlAttr(safeName)}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p.value)}&quot;`)}`
 }
 
 function isActive(p: HighlightProp): boolean {

--- a/site/ui/components/shared/playground-highlight.ts
+++ b/site/ui/components/shared/playground-highlight.ts
@@ -29,6 +29,8 @@ export interface HighlightProp {
   name: string
   value: string
   defaultValue: string
+  /** 'string' (default): name="value". 'boolean': presence-only. 'expression': name={value}. */
+  kind?: 'string' | 'boolean' | 'expression'
 }
 
 /**
@@ -43,18 +45,41 @@ export interface HighlightProp {
  * highlightJsx('Badge', [{ name: 'variant', value: 'default', defaultValue: 'default' }], 'Hello')
  * // => highlighted: <Badge>Hello</Badge>
  */
+function renderPlainProp(p: HighlightProp): string {
+  const kind = p.kind ?? 'string'
+  if (kind === 'boolean') return ` ${p.name}`
+  if (kind === 'expression') return ` ${p.name}={${p.value}}`
+  return ` ${p.name}="${p.value}"`
+}
+
+export function plainJsx(tagName: string, props: HighlightProp[], content: string): string {
+  const renderedProps = props.filter(isActive).map(renderPlainProp).join('')
+  return `<${tagName}${renderedProps}>${content}</${tagName}>`
+}
+
+export function plainJsxSelfClosing(tagName: string, props: HighlightProp[]): string {
+  const renderedProps = props.filter(isActive).map(renderPlainProp).join('')
+  return `<${tagName}${renderedProps} />`
+}
+
+function renderProp(p: HighlightProp): string {
+  const kind = p.kind ?? 'string'
+  if (kind === 'boolean') return ` ${hlAttr(p.name)}`
+  if (kind === 'expression') return ` ${hlAttr(p.name)}${hlPlain('={')}${hlPlain(escapeHtml(p.value))}${hlPlain('}')}`
+  return ` ${hlAttr(p.name)}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p.value)}&quot;`)}`
+}
+
+function isActive(p: HighlightProp): boolean {
+  return p.value !== p.defaultValue
+}
+
 export function highlightJsx(
   tagName: string,
   props: HighlightProp[],
   content: string,
 ): string {
   const escapedContent = escapeHtml(content)
-
-  const renderedProps = props
-    .filter((p) => p.value !== p.defaultValue)
-    .map((p) => ` ${hlAttr(p.name)}${hlPlain('=')}${hlStr(`&quot;${p.value}&quot;`)}`)
-    .join('')
-
+  const renderedProps = props.filter(isActive).map(renderProp).join('')
   return `${hlPlain('&lt;')}${hlTag(tagName)}${renderedProps}${hlPlain('&gt;')}${escapedContent}${hlPlain('&lt;/')}${hlTag(tagName)}${hlPlain('&gt;')}`
 }
 
@@ -71,10 +96,6 @@ export function highlightJsxSelfClosing(
   tagName: string,
   props: HighlightProp[],
 ): string {
-  const renderedProps = props
-    .filter((p) => p.value !== p.defaultValue)
-    .map((p) => ` ${hlAttr(p.name)}${hlPlain('=')}${hlStr(`&quot;${p.value}&quot;`)}`)
-    .join('')
-
+  const renderedProps = props.filter(isActive).map(renderProp).join('')
   return `${hlPlain('&lt;')}${hlTag(tagName)}${renderedProps} ${hlPlain('/&gt;')}`
 }

--- a/site/ui/components/switch-playground.tsx
+++ b/site/ui/components/switch-playground.tsx
@@ -6,40 +6,26 @@
  * Allows tweaking defaultChecked and disabled props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Switch } from '@ui/components/ui/switch'
-
-function highlightSwitchJsx(defaultChecked: boolean, disabled: boolean): string {
-  const boolProps: string[] = []
-  if (defaultChecked) boolProps.push(` ${hlAttr('defaultChecked')}`)
-  if (disabled) boolProps.push(` ${hlAttr('disabled')}`)
-  return `${hlPlain('&lt;')}${hlTag('Switch')}${boolProps.join('')}${hlPlain(' /&gt;')}`
-}
 
 function SwitchPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const parts: string[] = []
-    if (defaultChecked()) parts.push(' defaultChecked')
-    if (disabled()) parts.push(' disabled')
-    return `<Switch${parts.join('')} />`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+  ]
 
   createEffect(() => {
-    const dc = defaultChecked()
-    const d = disabled()
-
-    // Update highlighted code
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightSwitchJsx(dc, d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Switch', p)
   })
 
   return (
@@ -60,7 +46,7 @@ function SwitchPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Switch', props())} />}
     />
   )
 }

--- a/site/ui/components/switch-playground.tsx
+++ b/site/ui/components/switch-playground.tsx
@@ -17,13 +17,13 @@ function SwitchPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Switch', p)
   })
@@ -46,7 +46,7 @@ function SwitchPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Switch', propDefs())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Switch', props())} />}
     />
   )
 }

--- a/site/ui/components/switch-playground.tsx
+++ b/site/ui/components/switch-playground.tsx
@@ -17,13 +17,13 @@ function SwitchPlayground(_props: {}) {
   const [defaultChecked, setDefaultChecked] = createSignal(false)
   const [disabled, setDisabled] = createSignal(false)
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'defaultChecked', value: String(defaultChecked()), defaultValue: 'false', kind: 'boolean' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Switch', p)
   })
@@ -46,7 +46,7 @@ function SwitchPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Switch', props())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Switch', propDefs())} />}
     />
   )
 }

--- a/site/ui/components/textarea-playground.tsx
+++ b/site/ui/components/textarea-playground.tsx
@@ -6,9 +6,9 @@
  * Allows tweaking placeholder, disabled, error, and rows props with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr, escapeHtml } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Input } from '@ui/components/ui/input'
 import { Checkbox } from '@ui/components/ui/checkbox'
@@ -20,38 +20,17 @@ function TextareaPlayground(_props: {}) {
   const [error, setError] = createSignal(false)
   const [rows, setRows] = createSignal('')
 
-  const codeText = createMemo(() => {
-    const parts: string[] = []
-    const p = placeholder()
-    if (p) parts.push(`placeholder="${p}"`)
-    if (disabled()) parts.push('disabled')
-    if (error()) parts.push('error')
-    const r = rows()
-    if (r) parts.push(`rows={${r}}`)
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<Textarea${propsStr} />`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'placeholder', value: placeholder(), defaultValue: '' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+    { name: 'error', value: String(error()), defaultValue: 'false', kind: 'boolean' },
+    { name: 'rows', value: rows(), defaultValue: '', kind: 'expression' },
+  ]
 
   createEffect(() => {
-    const p = placeholder()
-    const d = disabled()
-    const e = error()
-    const r = rows()
-
-    // Update highlighted code
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      const propParts: string[] = []
-      if (p) {
-        propParts.push(` ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(p)}&quot;`)}`)
-      }
-      if (d) propParts.push(` ${hlAttr('disabled')}`)
-      if (e) propParts.push(` ${hlAttr('error')}`)
-      if (r) {
-        propParts.push(` ${hlAttr('rows')}${hlPlain('={')}${hlPlain(r)}${hlPlain('}')}`)
-      }
-      codeEl.innerHTML = `${hlPlain('&lt;')}${hlTag('Textarea')}${propParts.join('')}${hlPlain(' /&gt;')}`
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Textarea', p)
   })
 
   return (
@@ -75,13 +54,13 @@ function TextareaPlayground(_props: {}) {
         </PlaygroundControl>
         <PlaygroundControl label="disabled">
           <Checkbox
-            defaultChecked={false}
+            checked={disabled()}
             onCheckedChange={(checked: boolean) => setDisabled(checked)}
           />
         </PlaygroundControl>
         <PlaygroundControl label="error">
           <Checkbox
-            defaultChecked={false}
+            checked={error()}
             onCheckedChange={(checked: boolean) => setError(checked)}
           />
         </PlaygroundControl>
@@ -93,7 +72,7 @@ function TextareaPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Textarea', props())} />}
     />
   )
 }

--- a/site/ui/components/textarea-playground.tsx
+++ b/site/ui/components/textarea-playground.tsx
@@ -20,7 +20,7 @@ function TextareaPlayground(_props: {}) {
   const [error, setError] = createSignal(false)
   const [rows, setRows] = createSignal('')
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'placeholder', value: placeholder(), defaultValue: '' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
     { name: 'error', value: String(error()), defaultValue: 'false', kind: 'boolean' },
@@ -28,7 +28,7 @@ function TextareaPlayground(_props: {}) {
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Textarea', p)
   })
@@ -72,7 +72,7 @@ function TextareaPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Textarea', props())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Textarea', propDefs())} />}
     />
   )
 }

--- a/site/ui/components/textarea-playground.tsx
+++ b/site/ui/components/textarea-playground.tsx
@@ -20,7 +20,7 @@ function TextareaPlayground(_props: {}) {
   const [error, setError] = createSignal(false)
   const [rows, setRows] = createSignal('')
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'placeholder', value: placeholder(), defaultValue: '' },
     { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
     { name: 'error', value: String(error()), defaultValue: 'false', kind: 'boolean' },
@@ -28,7 +28,7 @@ function TextareaPlayground(_props: {}) {
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Textarea', p)
   })
@@ -72,7 +72,7 @@ function TextareaPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsxSelfClosing('Textarea', propDefs())} />}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Textarea', props())} />}
     />
   )
 }

--- a/site/ui/components/toggle-playground.tsx
+++ b/site/ui/components/toggle-playground.tsx
@@ -6,11 +6,12 @@
  * Allows tweaking variant, size, and pressed state with live preview.
  */
 
-import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { highlightJsx } from './shared/playground-highlight'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Checkbox } from '@ui/components/ui/checkbox'
 import { Toggle } from '@ui/components/ui/toggle'
 
 type ToggleVariant = 'default' | 'outline'
@@ -19,35 +20,18 @@ type ToggleSize = 'default' | 'sm' | 'lg'
 function TogglePlayground(_props: {}) {
   const [variant, setVariant] = createSignal<ToggleVariant>('default')
   const [size, setSize] = createSignal<ToggleSize>('default')
-  const [pressed, setPressed] = createSignal('false')
+  const [pressed, setPressed] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const v = variant()
-    const s = size()
-    const p = pressed()
-    const parts: string[] = []
-    if (v !== 'default') parts.push(`variant="${v}"`)
-    if (s !== 'default') parts.push(`size="${s}"`)
-    if (p === 'true') parts.push('defaultPressed')
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<Toggle${propsStr}>Toggle</Toggle>`
-  })
+  const props = (): HighlightProp[] => [
+    { name: 'variant', value: variant(), defaultValue: 'default' },
+    { name: 'size', value: size(), defaultValue: 'default' },
+    { name: 'defaultPressed', value: String(pressed()), defaultValue: 'false', kind: 'boolean' },
+  ]
 
   createEffect(() => {
-    const v = variant()
-    const s = size()
-    // Update highlighted code
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightJsx(
-        'Toggle',
-        [
-          { name: 'variant', value: v, defaultValue: 'default' },
-          { name: 'size', value: s, defaultValue: 'default' },
-        ],
-        'Toggle',
-      )
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsx('Toggle', p, 'Toggle')
   })
 
   return (
@@ -57,7 +41,7 @@ function TogglePlayground(_props: {}) {
         <Toggle
           variant={variant()}
           size={size()}
-          pressed={pressed() === 'true'}
+          pressed={pressed()}
         >
           Toggle
         </Toggle>
@@ -87,18 +71,13 @@ function TogglePlayground(_props: {}) {
           </Select>
         </PlaygroundControl>
         <PlaygroundControl label="pressed">
-          <Select value={pressed()} onValueChange={(v: string) => setPressed(v)}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select state..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="false">off</SelectItem>
-              <SelectItem value="true">on</SelectItem>
-            </SelectContent>
-          </Select>
+          <Checkbox
+            checked={pressed()}
+            onCheckedChange={setPressed}
+          />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={codeText()} />}
+      copyButton={<CopyButton code={plainJsx('Toggle', props(), 'Toggle')} />}
     />
   )
 }

--- a/site/ui/components/toggle-playground.tsx
+++ b/site/ui/components/toggle-playground.tsx
@@ -22,14 +22,14 @@ function TogglePlayground(_props: {}) {
   const [size, setSize] = createSignal<ToggleSize>('default')
   const [pressed, setPressed] = createSignal(false)
 
-  const propDefs = (): HighlightProp[] => [
+  const props = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
     { name: 'size', value: size(), defaultValue: 'default' },
     { name: 'defaultPressed', value: String(pressed()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = propDefs()
+    const p = props()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Toggle', p, 'Toggle')
   })
@@ -77,7 +77,7 @@ function TogglePlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Toggle', propDefs(), 'Toggle')} />}
+      copyButton={<CopyButton code={plainJsx('Toggle', props(), 'Toggle')} />}
     />
   )
 }

--- a/site/ui/components/toggle-playground.tsx
+++ b/site/ui/components/toggle-playground.tsx
@@ -22,14 +22,14 @@ function TogglePlayground(_props: {}) {
   const [size, setSize] = createSignal<ToggleSize>('default')
   const [pressed, setPressed] = createSignal(false)
 
-  const props = (): HighlightProp[] => [
+  const propDefs = (): HighlightProp[] => [
     { name: 'variant', value: variant(), defaultValue: 'default' },
     { name: 'size', value: size(), defaultValue: 'default' },
     { name: 'defaultPressed', value: String(pressed()), defaultValue: 'false', kind: 'boolean' },
   ]
 
   createEffect(() => {
-    const p = props()
+    const p = propDefs()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
     if (codeEl) codeEl.innerHTML = highlightJsx('Toggle', p, 'Toggle')
   })
@@ -77,7 +77,7 @@ function TogglePlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={plainJsx('Toggle', props(), 'Toggle')} />}
+      copyButton={<CopyButton code={plainJsx('Toggle', propDefs(), 'Toggle')} />}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Unify playground highlight helpers: all 8 playgrounds now use shared `highlightJsx`/`highlightJsxSelfClosing` with `boolean`/`expression` prop kinds instead of manual `hlPlain`/`hlAttr` assembly
- Add `plainJsx`/`plainJsxSelfClosing` for copy-button text, eliminating duplicated `codeText` memo logic
- Unify boolean props to use `boolean` signals + `Checkbox` controls
- **Compiler**: rename init function parameter from `props` to `_p` to avoid collision with user-defined `props` identifier
- **Compiler**: introduce `TemplateOptions` interface to consolidate template function parameters, fixing `propsObjectName` propagation bug in `generateCsrTemplate` recursion

## Before / After

| Aspect | Before | After |
|--------|--------|-------|
| Highlight code gen | 2 systems (shared helper vs manual hlPlain/hlAttr) | 1 system (shared helper) |
| Boolean prop control | Mixed (string Select vs boolean Checkbox) | All boolean + Checkbox |
| Copy text generation | Separate `createMemo` per playground | `plainJsx()` / `plainJsxSelfClosing()` |
| Prop definition | Duplicated in codeText + createEffect | Single `HighlightProp[]` array |
| Init function param | `props` (collides with user code) | `_p` (no collision) |
| Template fn params | 5-8 positional args (bug-prone) | `TemplateOptions` object (safe recursion) |
| Hydrate line protection | Regex placeholder extract/restore | Structural separation (hydrate appended after renaming) |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/` — 470 pass
- [x] `bun run build` — clean
- [ ] Visual check: all 8 playgrounds render correctly with prop controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)