### PR TITLE
Add /components/ reference pages for radio-group, input-otp, slider, toggle-group

### DIFF
--- a/site/ui/components/input-otp-playground.tsx
+++ b/site/ui/components/input-otp-playground.tsx
@@ -8,39 +8,22 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
-import { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator } from '@ui/components/ui/input-otp'
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@ui/components/ui/input-otp'
 
 function highlightInputOTPJsx(maxLength: number, disabled: boolean): string {
   const disabledProp = disabled ? ` ${hlAttr('disabled')}` : ''
   const lines = [
     `${hlPlain('&lt;')}${hlTag('InputOTP')} ${hlAttr('maxLength')}${hlPlain('={')}${maxLength}${hlPlain('}')}${disabledProp}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`,
   ]
-
-  if (maxLength === 4) {
-    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-    for (let i = 0; i < 4; i++) {
-      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
-    }
-    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-  } else {
-    const half = Math.floor(maxLength / 2)
-    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-    for (let i = 0; i < half; i++) {
-      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
-    }
-    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPSeparator')} ${hlPlain('/&gt;')}`)
-    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-    for (let i = half; i < maxLength; i++) {
-      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
-    }
-    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+  for (let i = 0; i < maxLength; i++) {
+    lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
   }
-
+  lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
   lines.push(`${hlPlain('&lt;/')}${hlTag('InputOTP')}${hlPlain('&gt;')}`)
   return lines.join('\n')
 }
@@ -55,7 +38,8 @@ function InputOTPPlayground(_props: {}) {
     const ml = maxLengthNum()
     const parts: string[] = [`maxLength={${ml}}`]
     if (disabled()) parts.push('disabled')
-    return `<InputOTP ${parts.join(' ')}>...</InputOTP>`
+    const slots = Array.from({ length: ml }, (_, i) => `    <InputOTPSlot index={${i}} />`).join('\n')
+    return `<InputOTP ${parts.join(' ')}>\n  <InputOTPGroup>\n${slots}\n  </InputOTPGroup>\n</InputOTP>`
   })
 
   createEffect(() => {
@@ -67,24 +51,45 @@ function InputOTPPlayground(_props: {}) {
     }
   })
 
+  // Toggle visibility of pre-rendered variants based on maxLength
+  const show4 = (el: HTMLElement) => {
+    createEffect(() => {
+      el.style.display = maxLengthNum() === 4 ? '' : 'none'
+    })
+  }
+  const show6 = (el: HTMLElement) => {
+    createEffect(() => {
+      el.style.display = maxLengthNum() === 6 ? '' : 'none'
+    })
+  }
+
   return (
     <PlaygroundLayout
       previewDataAttr="data-input-otp-preview"
-      previewContent={
-        <InputOTP maxLength={maxLengthNum()} disabled={disabled()}>
-          <InputOTPGroup>
-            <InputOTPSlot index={0} />
-            <InputOTPSlot index={1} />
-            <InputOTPSlot index={2} />
-          </InputOTPGroup>
-          <InputOTPSeparator />
-          <InputOTPGroup>
-            <InputOTPSlot index={3} />
-            <InputOTPSlot index={4} />
-            <InputOTPSlot index={5} />
-          </InputOTPGroup>
-        </InputOTP>
-      }
+      previewContent={<>
+        <div ref={show4}>
+          <InputOTP maxLength={4} disabled={disabled()}>
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+              <InputOTPSlot index={3} />
+            </InputOTPGroup>
+          </InputOTP>
+        </div>
+        <div ref={show6}>
+          <InputOTP maxLength={6} disabled={disabled()}>
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+              <InputOTPSlot index={3} />
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+            </InputOTPGroup>
+          </InputOTP>
+        </div>
+      </>}
       controls={<>
         <PlaygroundControl label="maxLength">
           <Select value={maxLength()} onValueChange={(v: string) => setMaxLength(v)}>

--- a/site/ui/components/input-otp-playground.tsx
+++ b/site/ui/components/input-otp-playground.tsx
@@ -1,0 +1,112 @@
+"use client"
+/**
+ * InputOTP Props Playground
+ *
+ * Interactive playground for the InputOTP component.
+ * Allows tweaking maxLength and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator } from '@ui/components/ui/input-otp'
+
+function highlightInputOTPJsx(maxLength: number, disabled: boolean): string {
+  const disabledProp = disabled ? ` ${hlAttr('disabled')}` : ''
+  const lines = [
+    `${hlPlain('&lt;')}${hlTag('InputOTP')} ${hlAttr('maxLength')}${hlPlain('={')}${maxLength}${hlPlain('}')}${disabledProp}${hlPlain('&gt;')}`,
+  ]
+
+  if (maxLength === 4) {
+    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+    for (let i = 0; i < 4; i++) {
+      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
+    }
+    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+  } else {
+    const half = Math.floor(maxLength / 2)
+    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+    for (let i = 0; i < half; i++) {
+      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
+    }
+    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPSeparator')} ${hlPlain('/&gt;')}`)
+    lines.push(`  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+    for (let i = half; i < maxLength; i++) {
+      lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
+    }
+    lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
+  }
+
+  lines.push(`${hlPlain('&lt;/')}${hlTag('InputOTP')}${hlPlain('&gt;')}`)
+  return lines.join('\n')
+}
+
+function InputOTPPlayground(_props: {}) {
+  const [maxLength, setMaxLength] = createSignal('6')
+  const [disabled, setDisabled] = createSignal(false)
+
+  const maxLengthNum = createMemo(() => parseInt(maxLength(), 10))
+
+  const codeText = createMemo(() => {
+    const ml = maxLengthNum()
+    const parts: string[] = [`maxLength={${ml}}`]
+    if (disabled()) parts.push('disabled')
+    return `<InputOTP ${parts.join(' ')}>...</InputOTP>`
+  })
+
+  createEffect(() => {
+    const ml = maxLengthNum()
+    const d = disabled()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightInputOTPJsx(ml, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-input-otp-preview"
+      previewContent={
+        <InputOTP maxLength={maxLengthNum()} disabled={disabled()}>
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+          </InputOTPGroup>
+          <InputOTPSeparator />
+          <InputOTPGroup>
+            <InputOTPSlot index={3} />
+            <InputOTPSlot index={4} />
+            <InputOTPSlot index={5} />
+          </InputOTPGroup>
+        </InputOTP>
+      }
+      controls={<>
+        <PlaygroundControl label="maxLength">
+          <Select value={maxLength()} onValueChange={(v: string) => setMaxLength(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select length..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="4">4</SelectItem>
+              <SelectItem value="6">6</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { InputOTPPlayground }

--- a/site/ui/components/input-otp-usage-demo.tsx
+++ b/site/ui/components/input-otp-usage-demo.tsx
@@ -11,11 +11,12 @@ import {
   InputOTPGroup,
   InputOTPSlot,
   InputOTPSeparator,
+  REGEXP_ONLY_DIGITS_AND_CHARS,
 } from '@ui/components/ui/input-otp'
 
 export function InputOTPUsageDemo() {
   return (
-    <InputOTP maxLength={6}>
+    <InputOTP maxLength={6} pattern={REGEXP_ONLY_DIGITS_AND_CHARS}>
       <InputOTPGroup>
         <InputOTPSlot index={0} />
         <InputOTPSlot index={1} />

--- a/site/ui/components/input-otp-usage-demo.tsx
+++ b/site/ui/components/input-otp-usage-demo.tsx
@@ -15,31 +15,18 @@ import {
 
 export function InputOTPUsageDemo() {
   return (
-    <div className="space-y-6">
-      {/* Basic 6-digit with separator */}
-      <InputOTP maxLength={6}>
-        <InputOTPGroup>
-          <InputOTPSlot index={0} />
-          <InputOTPSlot index={1} />
-          <InputOTPSlot index={2} />
-        </InputOTPGroup>
-        <InputOTPSeparator />
-        <InputOTPGroup>
-          <InputOTPSlot index={3} />
-          <InputOTPSlot index={4} />
-          <InputOTPSlot index={5} />
-        </InputOTPGroup>
-      </InputOTP>
-
-      {/* 4-digit without separator */}
-      <InputOTP maxLength={4}>
-        <InputOTPGroup>
-          <InputOTPSlot index={0} />
-          <InputOTPSlot index={1} />
-          <InputOTPSlot index={2} />
-          <InputOTPSlot index={3} />
-        </InputOTPGroup>
-      </InputOTP>
-    </div>
+    <InputOTP maxLength={6}>
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+      </InputOTPGroup>
+      <InputOTPSeparator />
+      <InputOTPGroup>
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTP>
   )
 }

--- a/site/ui/components/input-otp-usage-demo.tsx
+++ b/site/ui/components/input-otp-usage-demo.tsx
@@ -15,7 +15,7 @@ import {
 
 export function InputOTPUsageDemo() {
   return (
-    <InputOTP maxLength={6}>
+    <InputOTP maxLength={6} pattern="digits-and-chars">
       <InputOTPGroup>
         <InputOTPSlot index={0} />
         <InputOTPSlot index={1} />

--- a/site/ui/components/input-otp-usage-demo.tsx
+++ b/site/ui/components/input-otp-usage-demo.tsx
@@ -1,0 +1,45 @@
+"use client"
+/**
+ * InputOTP Usage Demo
+ *
+ * "use client" wrapper for InputOTP usage examples in the ref page.
+ * Context-based compound components must be rendered as client components.
+ */
+
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator,
+} from '@ui/components/ui/input-otp'
+
+export function InputOTPUsageDemo() {
+  return (
+    <div className="space-y-6">
+      {/* Basic 6-digit with separator */}
+      <InputOTP maxLength={6}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+        </InputOTPGroup>
+        <InputOTPSeparator />
+        <InputOTPGroup>
+          <InputOTPSlot index={3} />
+          <InputOTPSlot index={4} />
+          <InputOTPSlot index={5} />
+        </InputOTPGroup>
+      </InputOTP>
+
+      {/* 4-digit without separator */}
+      <InputOTP maxLength={4}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+          <InputOTPSlot index={3} />
+        </InputOTPGroup>
+      </InputOTP>
+    </div>
+  )
+}

--- a/site/ui/components/input-otp-usage-demo.tsx
+++ b/site/ui/components/input-otp-usage-demo.tsx
@@ -11,12 +11,11 @@ import {
   InputOTPGroup,
   InputOTPSlot,
   InputOTPSeparator,
-  REGEXP_ONLY_DIGITS_AND_CHARS,
 } from '@ui/components/ui/input-otp'
 
 export function InputOTPUsageDemo() {
   return (
-    <InputOTP maxLength={6} pattern={REGEXP_ONLY_DIGITS_AND_CHARS}>
+    <InputOTP maxLength={6}>
       <InputOTPGroup>
         <InputOTPSlot index={0} />
         <InputOTPSlot index={1} />

--- a/site/ui/components/radio-group-playground.tsx
+++ b/site/ui/components/radio-group-playground.tsx
@@ -1,0 +1,71 @@
+"use client"
+/**
+ * RadioGroup Props Playground
+ *
+ * Interactive playground for the RadioGroup component.
+ * Allows tweaking disabled prop with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
+
+function highlightRadioGroupJsx(disabled: boolean): string {
+  const disabledProp = disabled ? ` ${hlAttr('disabled')}` : ''
+  return [
+    `${hlPlain('&lt;')}${hlTag('RadioGroup')} ${hlAttr('defaultValue')}${hlPlain('=')}${hlStr('&quot;option-1&quot;')}${disabledProp}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('RadioGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;option-1&quot;')} ${hlPlain('/&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('RadioGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;option-2&quot;')} ${hlPlain('/&gt;')}`,
+    `${hlPlain('&lt;/')}${hlTag('RadioGroup')}${hlPlain('&gt;')}`,
+  ].join('\n')
+}
+
+function RadioGroupPlayground(_props: {}) {
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const parts: string[] = ['defaultValue="option-1"']
+    if (disabled()) parts.push('disabled')
+    return `<RadioGroup ${parts.join(' ')}>\n  <RadioGroupItem value="option-1" />\n  <RadioGroupItem value="option-2" />\n</RadioGroup>`
+  })
+
+  createEffect(() => {
+    const d = disabled()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightRadioGroupJsx(d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-radio-group-preview"
+      previewContent={
+        <RadioGroup defaultValue="option-1" disabled={disabled()}>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="option-1" />
+            <span className="text-sm font-medium leading-none">Option 1</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="option-2" />
+            <span className="text-sm font-medium leading-none">Option 2</span>
+          </div>
+        </RadioGroup>
+      }
+      controls={<>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { RadioGroupPlayground }

--- a/site/ui/components/radio-group-usage-demo.tsx
+++ b/site/ui/components/radio-group-usage-demo.tsx
@@ -1,0 +1,58 @@
+"use client"
+/**
+ * RadioGroup Usage Demo
+ *
+ * "use client" wrapper for RadioGroup usage examples in the ref page.
+ * Context-based compound components must be rendered as client components.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
+
+export function RadioGroupUsageDemo() {
+  const [plan, setPlan] = createSignal('free')
+
+  return (
+    <div className="space-y-6">
+      {/* Uncontrolled with defaultValue */}
+      <RadioGroup defaultValue="email">
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="email" />
+          <span className="text-sm font-medium leading-none">Email</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="sms" />
+          <span className="text-sm font-medium leading-none">SMS</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="push" />
+          <span className="text-sm font-medium leading-none">Push notification</span>
+        </div>
+      </RadioGroup>
+
+      {/* Controlled with onValueChange */}
+      <RadioGroup value={plan()} onValueChange={setPlan}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="free" />
+          <span className="text-sm font-medium leading-none">Free</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="pro" />
+          <span className="text-sm font-medium leading-none">Pro</span>
+        </div>
+      </RadioGroup>
+
+      {/* Disabled */}
+      <RadioGroup disabled defaultValue="on">
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="on" />
+          <span className="text-sm font-medium leading-none">On</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="off" />
+          <span className="text-sm font-medium leading-none">Off</span>
+        </div>
+      </RadioGroup>
+    </div>
+  )
+}

--- a/site/ui/components/slider-playground.tsx
+++ b/site/ui/components/slider-playground.tsx
@@ -1,0 +1,69 @@
+"use client"
+/**
+ * Slider Props Playground
+ *
+ * Interactive playground for the Slider component.
+ * Allows tweaking defaultValue, min, max, step, and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Slider } from '@ui/components/ui/slider'
+
+function highlightSliderJsx(value: number, disabled: boolean): string {
+  const props: string[] = []
+  if (value !== 50) props.push(` ${hlAttr('defaultValue')}${hlPlain('={')}${value}${hlPlain('}')}`)
+  if (disabled) props.push(` ${hlAttr('disabled')}`)
+  return `${hlPlain('&lt;')}${hlTag('Slider')}${props.join('')} ${hlPlain('/&gt;')}`
+}
+
+function SliderPlayground(_props: {}) {
+  const [value, setValue] = createSignal(50)
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const parts: string[] = []
+    if (value() !== 50) parts.push(`defaultValue={${value()}}`)
+    if (disabled()) parts.push('disabled')
+    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
+    return `<Slider${propsStr} />`
+  })
+
+  createEffect(() => {
+    const v = value()
+    const d = disabled()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightSliderJsx(v, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-slider-preview"
+      previewContent={
+        <div className="w-full max-w-sm space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium leading-none">Value</span>
+            <span className="text-sm text-muted-foreground tabular-nums">{value()}</span>
+          </div>
+          <Slider value={value()} onValueChange={setValue} disabled={disabled()} />
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { SliderPlayground }

--- a/site/ui/components/toggle-group-playground.tsx
+++ b/site/ui/components/toggle-group-playground.tsx
@@ -36,7 +36,7 @@ function highlightToggleGroupJsx(type: string, variant: string, size: string, di
 
 function ToggleGroupPlayground(_props: {}) {
   const [type, setType] = createSignal<GroupType>('single')
-  const [variant, setVariant] = createSignal<GroupVariant>('default')
+  const [variant, setVariant] = createSignal<GroupVariant>('outline')
   const [size, setSize] = createSignal<GroupSize>('default')
   const [disabled, setDisabled] = createSignal(false)
 

--- a/site/ui/components/toggle-group-playground.tsx
+++ b/site/ui/components/toggle-group-playground.tsx
@@ -1,0 +1,119 @@
+"use client"
+/**
+ * ToggleGroup Props Playground
+ *
+ * Interactive playground for the ToggleGroup component.
+ * Allows tweaking type, variant, size, and disabled props with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { ToggleGroup, ToggleGroupItem } from '@ui/components/ui/toggle-group'
+
+type GroupType = 'single' | 'multiple'
+type GroupVariant = 'default' | 'outline'
+type GroupSize = 'default' | 'sm' | 'lg'
+
+function highlightToggleGroupJsx(type: string, variant: string, size: string, disabled: boolean): string {
+  const props: string[] = []
+  props.push(` ${hlAttr('type')}${hlPlain('=')}${hlStr(`&quot;${type}&quot;`)}`)
+  if (variant !== 'default') props.push(` ${hlAttr('variant')}${hlPlain('=')}${hlStr(`&quot;${variant}&quot;`)}`)
+  if (size !== 'default') props.push(` ${hlAttr('size')}${hlPlain('=')}${hlStr(`&quot;${size}&quot;`)}`)
+  if (disabled) props.push(` ${hlAttr('disabled')}`)
+
+  return [
+    `${hlPlain('&lt;')}${hlTag('ToggleGroup')}${props.join('')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;a&quot;')}${hlPlain('&gt;')}A${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;b&quot;')}${hlPlain('&gt;')}B${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;c&quot;')}${hlPlain('&gt;')}C${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
+    `${hlPlain('&lt;/')}${hlTag('ToggleGroup')}${hlPlain('&gt;')}`,
+  ].join('\n')
+}
+
+function ToggleGroupPlayground(_props: {}) {
+  const [type, setType] = createSignal<GroupType>('single')
+  const [variant, setVariant] = createSignal<GroupVariant>('default')
+  const [size, setSize] = createSignal<GroupSize>('default')
+  const [disabled, setDisabled] = createSignal(false)
+
+  const codeText = createMemo(() => {
+    const parts: string[] = [`type="${type()}"`]
+    if (variant() !== 'default') parts.push(`variant="${variant()}"`)
+    if (size() !== 'default') parts.push(`size="${size()}"`)
+    if (disabled()) parts.push('disabled')
+    return `<ToggleGroup ${parts.join(' ')}>\n  <ToggleGroupItem value="a">A</ToggleGroupItem>\n  <ToggleGroupItem value="b">B</ToggleGroupItem>\n  <ToggleGroupItem value="c">C</ToggleGroupItem>\n</ToggleGroup>`
+  })
+
+  createEffect(() => {
+    const t = type()
+    const v = variant()
+    const s = size()
+    const d = disabled()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightToggleGroupJsx(t, v, s, d)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-toggle-group-preview"
+      previewContent={
+        <ToggleGroup type={type()} variant={variant()} size={size()} disabled={disabled()} defaultValue="a">
+          <ToggleGroupItem value="a">A</ToggleGroupItem>
+          <ToggleGroupItem value="b">B</ToggleGroupItem>
+          <ToggleGroupItem value="c">C</ToggleGroupItem>
+        </ToggleGroup>
+      }
+      controls={<>
+        <PlaygroundControl label="type">
+          <Select value={type()} onValueChange={(v: string) => setType(v as GroupType)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select type..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="single">single</SelectItem>
+              <SelectItem value="multiple">multiple</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="variant">
+          <Select value={variant()} onValueChange={(v: string) => setVariant(v as GroupVariant)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="outline">outline</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="size">
+          <Select value={size()} onValueChange={(v: string) => setSize(v as GroupSize)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select size..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="sm">sm</SelectItem>
+              <SelectItem value="lg">lg</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { ToggleGroupPlayground }

--- a/site/ui/components/toggle-group-usage-demo.tsx
+++ b/site/ui/components/toggle-group-usage-demo.tsx
@@ -11,14 +11,7 @@ import { ToggleGroup, ToggleGroupItem } from '@ui/components/ui/toggle-group'
 export function ToggleGroupUsageDemo() {
   return (
     <div className="space-y-6">
-      {/* Single selection */}
-      <ToggleGroup type="single" defaultValue="center">
-        <ToggleGroupItem value="left">Left</ToggleGroupItem>
-        <ToggleGroupItem value="center">Center</ToggleGroupItem>
-        <ToggleGroupItem value="right">Right</ToggleGroupItem>
-      </ToggleGroup>
-
-      {/* Outline variant */}
+      {/* Outline variant — single selection */}
       <ToggleGroup type="single" variant="outline" defaultValue="M">
         <ToggleGroupItem value="S">S</ToggleGroupItem>
         <ToggleGroupItem value="M">M</ToggleGroupItem>
@@ -30,12 +23,6 @@ export function ToggleGroupUsageDemo() {
         <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
         <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
         <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
-      </ToggleGroup>
-
-      {/* Disabled */}
-      <ToggleGroup type="single" disabled>
-        <ToggleGroupItem value="a">A</ToggleGroupItem>
-        <ToggleGroupItem value="b">B</ToggleGroupItem>
       </ToggleGroup>
     </div>
   )

--- a/site/ui/components/toggle-group-usage-demo.tsx
+++ b/site/ui/components/toggle-group-usage-demo.tsx
@@ -1,0 +1,42 @@
+"use client"
+/**
+ * ToggleGroup Usage Demo
+ *
+ * "use client" wrapper for ToggleGroup usage examples in the ref page.
+ * Context-based compound components must be rendered as client components.
+ */
+
+import { ToggleGroup, ToggleGroupItem } from '@ui/components/ui/toggle-group'
+
+export function ToggleGroupUsageDemo() {
+  return (
+    <div className="space-y-6">
+      {/* Single selection */}
+      <ToggleGroup type="single" defaultValue="center">
+        <ToggleGroupItem value="left">Left</ToggleGroupItem>
+        <ToggleGroupItem value="center">Center</ToggleGroupItem>
+        <ToggleGroupItem value="right">Right</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Outline variant */}
+      <ToggleGroup type="single" variant="outline" defaultValue="M">
+        <ToggleGroupItem value="S">S</ToggleGroupItem>
+        <ToggleGroupItem value="M">M</ToggleGroupItem>
+        <ToggleGroupItem value="L">L</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Multiple selection */}
+      <ToggleGroup type="multiple">
+        <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
+        <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
+        <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Disabled */}
+      <ToggleGroup type="single" disabled>
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+        <ToggleGroupItem value="b">B</ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
+}

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -34,51 +34,25 @@ import {
   InputOTPGroup,
   InputOTPSlot,
   InputOTPSeparator,
-  REGEXP_ONLY_DIGITS_AND_CHARS,
 } from "@/components/ui/input-otp"
 
 function InputOTPDemo() {
   const [value, setValue] = createSignal("")
 
   return (
-    <div className="space-y-6">
-      {/* Basic 6-digit with separator */}
-      <InputOTP maxLength={6} value={value()} onValueChange={setValue}>
-        <InputOTPGroup>
-          <InputOTPSlot index={0} />
-          <InputOTPSlot index={1} />
-          <InputOTPSlot index={2} />
-        </InputOTPGroup>
-        <InputOTPSeparator />
-        <InputOTPGroup>
-          <InputOTPSlot index={3} />
-          <InputOTPSlot index={4} />
-          <InputOTPSlot index={5} />
-        </InputOTPGroup>
-      </InputOTP>
-
-      {/* 4-digit without separator */}
-      <InputOTP maxLength={4}>
-        <InputOTPGroup>
-          <InputOTPSlot index={0} />
-          <InputOTPSlot index={1} />
-          <InputOTPSlot index={2} />
-          <InputOTPSlot index={3} />
-        </InputOTPGroup>
-      </InputOTP>
-
-      {/* Letters and numbers */}
-      <InputOTP maxLength={6} pattern={REGEXP_ONLY_DIGITS_AND_CHARS}>
-        <InputOTPGroup>
-          <InputOTPSlot index={0} />
-          <InputOTPSlot index={1} />
-          <InputOTPSlot index={2} />
-          <InputOTPSlot index={3} />
-          <InputOTPSlot index={4} />
-          <InputOTPSlot index={5} />
-        </InputOTPGroup>
-      </InputOTP>
-    </div>
+    <InputOTP maxLength={6} value={value()} onValueChange={setValue}>
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+      </InputOTPGroup>
+      <InputOTPSeparator />
+      <InputOTPGroup>
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTP>
   )
 }`
 

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -34,13 +34,19 @@ import {
   InputOTPGroup,
   InputOTPSlot,
   InputOTPSeparator,
+  REGEXP_ONLY_DIGITS_AND_CHARS,
 } from "@/components/ui/input-otp"
 
 function InputOTPDemo() {
   const [value, setValue] = createSignal("")
 
   return (
-    <InputOTP maxLength={6} value={value()} onValueChange={setValue}>
+    <InputOTP
+      maxLength={6}
+      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+      value={value()}
+      onValueChange={setValue}
+    >
       <InputOTPGroup>
         <InputOTPSlot index={0} />
         <InputOTPSlot index={1} />

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -34,7 +34,6 @@ import {
   InputOTPGroup,
   InputOTPSlot,
   InputOTPSeparator,
-  REGEXP_ONLY_DIGITS_AND_CHARS,
 } from "@/components/ui/input-otp"
 
 function InputOTPDemo() {
@@ -43,7 +42,7 @@ function InputOTPDemo() {
   return (
     <InputOTP
       maxLength={6}
-      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+      pattern="digits-and-chars"
       value={value()}
       onValueChange={setValue}
     >
@@ -91,9 +90,9 @@ const inputOTPProps: PropDefinition[] = [
   },
   {
     name: 'pattern',
-    type: 'RegExp',
-    defaultValue: 'REGEXP_ONLY_DIGITS',
-    description: 'Regular expression to validate each character. Use REGEXP_ONLY_DIGITS, REGEXP_ONLY_CHARS, or REGEXP_ONLY_DIGITS_AND_CHARS.',
+    type: "RegExp | 'digits' | 'chars' | 'digits-and-chars'",
+    defaultValue: "'digits'",
+    description: "Pattern to validate each character. Use a preset name ('digits', 'chars', 'digits-and-chars') or a RegExp.",
   },
   {
     name: 'disabled',

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -1,0 +1,185 @@
+/**
+ * InputOTP Reference Page (/components/input-otp)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator,
+} from '@/components/ui/input-otp'
+import { InputOTPPlayground } from '@/components/input-otp-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator,
+  REGEXP_ONLY_DIGITS_AND_CHARS,
+} from "@/components/ui/input-otp"
+
+function InputOTPDemo() {
+  const [value, setValue] = createSignal("")
+
+  return (
+    <div className="space-y-6">
+      {/* Basic 6-digit with separator */}
+      <InputOTP maxLength={6} value={value()} onValueChange={setValue}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+        </InputOTPGroup>
+        <InputOTPSeparator />
+        <InputOTPGroup>
+          <InputOTPSlot index={3} />
+          <InputOTPSlot index={4} />
+          <InputOTPSlot index={5} />
+        </InputOTPGroup>
+      </InputOTP>
+
+      {/* 4-digit without separator */}
+      <InputOTP maxLength={4}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+          <InputOTPSlot index={3} />
+        </InputOTPGroup>
+      </InputOTP>
+
+      {/* Letters and numbers */}
+      <InputOTP maxLength={6} pattern={REGEXP_ONLY_DIGITS_AND_CHARS}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+          <InputOTPSlot index={3} />
+          <InputOTPSlot index={4} />
+          <InputOTPSlot index={5} />
+        </InputOTPGroup>
+      </InputOTP>
+    </div>
+  )
+}`
+
+const inputOTPProps: PropDefinition[] = [
+  {
+    name: 'maxLength',
+    type: 'number',
+    description: 'The maximum number of characters. Determines how many slots to fill.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled value of the OTP input.',
+  },
+  {
+    name: 'defaultValue',
+    type: 'string',
+    defaultValue: "''",
+    description: 'The default value for uncontrolled mode.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Event handler called when the value changes.',
+  },
+  {
+    name: 'onComplete',
+    type: '(value: string) => void',
+    description: 'Event handler called when all slots are filled.',
+  },
+  {
+    name: 'pattern',
+    type: 'RegExp',
+    defaultValue: 'REGEXP_ONLY_DIGITS',
+    description: 'Regular expression to validate each character. Use REGEXP_ONLY_DIGITS, REGEXP_ONLY_CHARS, or REGEXP_ONLY_DIGITS_AND_CHARS.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the input is disabled.',
+  },
+]
+
+export function InputOTPRefPage() {
+  return (
+    <DocPage slug="input-otp" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Input OTP"
+          description="An accessible one-time password input component with copy-paste support."
+          {...getNavLinks('input-otp')}
+        />
+
+        {/* Props Playground */}
+        <InputOTPPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add input-otp" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-6">
+              <InputOTP maxLength={6}>
+                <InputOTPGroup>
+                  <InputOTPSlot index={0} />
+                  <InputOTPSlot index={1} />
+                  <InputOTPSlot index={2} />
+                </InputOTPGroup>
+                <InputOTPSeparator />
+                <InputOTPGroup>
+                  <InputOTPSlot index={3} />
+                  <InputOTPSlot index={4} />
+                  <InputOTPSlot index={5} />
+                </InputOTPGroup>
+              </InputOTP>
+              <InputOTP maxLength={4}>
+                <InputOTPGroup>
+                  <InputOTPSlot index={0} />
+                  <InputOTPSlot index={1} />
+                  <InputOTPSlot index={2} />
+                  <InputOTPSlot index={3} />
+                </InputOTPGroup>
+              </InputOTP>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={inputOTPProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -5,13 +5,8 @@
  * Part of the #515 page redesign initiative.
  */
 
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSlot,
-  InputOTPSeparator,
-} from '@/components/ui/input-otp'
 import { InputOTPPlayground } from '@/components/input-otp-playground'
+import { InputOTPUsageDemo } from '@/components/input-otp-usage-demo'
 import {
   DocPage,
   PageHeader,
@@ -149,29 +144,7 @@ export function InputOTPRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <div className="space-y-6">
-              <InputOTP maxLength={6}>
-                <InputOTPGroup>
-                  <InputOTPSlot index={0} />
-                  <InputOTPSlot index={1} />
-                  <InputOTPSlot index={2} />
-                </InputOTPGroup>
-                <InputOTPSeparator />
-                <InputOTPGroup>
-                  <InputOTPSlot index={3} />
-                  <InputOTPSlot index={4} />
-                  <InputOTPSlot index={5} />
-                </InputOTPGroup>
-              </InputOTP>
-              <InputOTP maxLength={4}>
-                <InputOTPGroup>
-                  <InputOTPSlot index={0} />
-                  <InputOTPSlot index={1} />
-                  <InputOTPSlot index={2} />
-                  <InputOTPSlot index={3} />
-                </InputOTPGroup>
-              </InputOTP>
-            </div>
+            <InputOTPUsageDemo />
           </Example>
         </Section>
 

--- a/site/ui/pages/components/radio-group.tsx
+++ b/site/ui/pages/components/radio-group.tsx
@@ -32,32 +32,49 @@ import { createSignal } from "@barefootjs/dom"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 
 function RadioGroupDemo() {
-  const [value, setValue] = createSignal("default")
+  const [plan, setPlan] = createSignal("free")
 
   return (
-    <div className="space-y-4">
-      <RadioGroup defaultValue="default" onValueChange={setValue}>
+    <div className="space-y-6">
+      {/* Uncontrolled with defaultValue */}
+      <RadioGroup defaultValue="email">
         <div className="flex items-center space-x-2">
-          <RadioGroupItem value="default" />
-          <span className="text-sm font-medium leading-none">Default</span>
+          <RadioGroupItem value="email" />
+          <span className="text-sm font-medium leading-none">Email</span>
         </div>
         <div className="flex items-center space-x-2">
-          <RadioGroupItem value="comfortable" />
-          <span className="text-sm font-medium leading-none">Comfortable</span>
+          <RadioGroupItem value="sms" />
+          <span className="text-sm font-medium leading-none">SMS</span>
         </div>
         <div className="flex items-center space-x-2">
-          <RadioGroupItem value="compact" />
-          <span className="text-sm font-medium leading-none">Compact</span>
+          <RadioGroupItem value="push" />
+          <span className="text-sm font-medium leading-none">Push notification</span>
         </div>
       </RadioGroup>
-      <div className="flex items-center space-x-2 opacity-50">
-        <RadioGroup disabled>
-          <div className="flex items-center space-x-2">
-            <RadioGroupItem value="disabled" />
-            <span className="text-sm font-medium leading-none">Disabled</span>
-          </div>
-        </RadioGroup>
-      </div>
+
+      {/* Controlled with onValueChange */}
+      <RadioGroup value={plan()} onValueChange={setPlan}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="free" />
+          <span className="text-sm font-medium leading-none">Free</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="pro" />
+          <span className="text-sm font-medium leading-none">Pro</span>
+        </div>
+      </RadioGroup>
+
+      {/* Disabled */}
+      <RadioGroup disabled defaultValue="on">
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="on" />
+          <span className="text-sm font-medium leading-none">On</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="off" />
+          <span className="text-sm font-medium leading-none">Off</span>
+        </div>
+      </RadioGroup>
     </div>
   )
 }`
@@ -121,29 +138,41 @@ export function RadioGroupRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <div className="space-y-4">
-              <RadioGroup defaultValue="default">
+            <div className="space-y-6">
+              <RadioGroup defaultValue="email">
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="default" />
-                  <span className="text-sm font-medium leading-none">Default</span>
+                  <RadioGroupItem value="email" />
+                  <span className="text-sm font-medium leading-none">Email</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="comfortable" />
-                  <span className="text-sm font-medium leading-none">Comfortable</span>
+                  <RadioGroupItem value="sms" />
+                  <span className="text-sm font-medium leading-none">SMS</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="compact" />
-                  <span className="text-sm font-medium leading-none">Compact</span>
+                  <RadioGroupItem value="push" />
+                  <span className="text-sm font-medium leading-none">Push notification</span>
                 </div>
               </RadioGroup>
-              <div className="opacity-50">
-                <RadioGroup disabled>
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="disabled" />
-                    <span className="text-sm font-medium leading-none">Disabled</span>
-                  </div>
-                </RadioGroup>
-              </div>
+              <RadioGroup defaultValue="free">
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="free" />
+                  <span className="text-sm font-medium leading-none">Free</span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="pro" />
+                  <span className="text-sm font-medium leading-none">Pro</span>
+                </div>
+              </RadioGroup>
+              <RadioGroup disabled defaultValue="on">
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="on" />
+                  <span className="text-sm font-medium leading-none">On</span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="off" />
+                  <span className="text-sm font-medium leading-none">Off</span>
+                </div>
+              </RadioGroup>
             </div>
           </Example>
         </Section>

--- a/site/ui/pages/components/radio-group.tsx
+++ b/site/ui/pages/components/radio-group.tsx
@@ -5,8 +5,8 @@
  * Part of the #515 page redesign initiative.
  */
 
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { RadioGroupPlayground } from '@/components/radio-group-playground'
+import { RadioGroupUsageDemo } from '@/components/radio-group-usage-demo'
 import {
   DocPage,
   PageHeader,
@@ -138,42 +138,7 @@ export function RadioGroupRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <div className="space-y-6">
-              <RadioGroup defaultValue="email">
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="email" />
-                  <span className="text-sm font-medium leading-none">Email</span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="sms" />
-                  <span className="text-sm font-medium leading-none">SMS</span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="push" />
-                  <span className="text-sm font-medium leading-none">Push notification</span>
-                </div>
-              </RadioGroup>
-              <RadioGroup defaultValue="free">
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="free" />
-                  <span className="text-sm font-medium leading-none">Free</span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="pro" />
-                  <span className="text-sm font-medium leading-none">Pro</span>
-                </div>
-              </RadioGroup>
-              <RadioGroup disabled defaultValue="on">
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="on" />
-                  <span className="text-sm font-medium leading-none">On</span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="off" />
-                  <span className="text-sm font-medium leading-none">Off</span>
-                </div>
-              </RadioGroup>
-            </div>
+            <RadioGroupUsageDemo />
           </Example>
         </Section>
 

--- a/site/ui/pages/components/radio-group.tsx
+++ b/site/ui/pages/components/radio-group.tsx
@@ -1,0 +1,161 @@
+/**
+ * RadioGroup Reference Page (/components/radio-group)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { RadioGroupPlayground } from '@/components/radio-group-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+
+function RadioGroupDemo() {
+  const [value, setValue] = createSignal("default")
+
+  return (
+    <div className="space-y-4">
+      <RadioGroup defaultValue="default" onValueChange={setValue}>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="default" />
+          <span className="text-sm font-medium leading-none">Default</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="comfortable" />
+          <span className="text-sm font-medium leading-none">Comfortable</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="compact" />
+          <span className="text-sm font-medium leading-none">Compact</span>
+        </div>
+      </RadioGroup>
+      <div className="flex items-center space-x-2 opacity-50">
+        <RadioGroup disabled>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="disabled" />
+            <span className="text-sm font-medium leading-none">Disabled</span>
+          </div>
+        </RadioGroup>
+      </div>
+    </div>
+  )
+}`
+
+const radioGroupProps: PropDefinition[] = [
+  {
+    name: 'defaultValue',
+    type: 'string',
+    description: 'The initial selected value for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled selected value. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Event handler called when the selected value changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the entire radio group is disabled.',
+  },
+]
+
+const radioGroupItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value of this radio item. Required.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this radio item is disabled.',
+  },
+]
+
+export function RadioGroupRefPage() {
+  return (
+    <DocPage slug="radio-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Radio Group"
+          description="A set of checkable buttons where only one can be checked at a time."
+          {...getNavLinks('radio-group')}
+        />
+
+        {/* Props Playground */}
+        <RadioGroupPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add radio-group" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-4">
+              <RadioGroup defaultValue="default">
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="default" />
+                  <span className="text-sm font-medium leading-none">Default</span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="comfortable" />
+                  <span className="text-sm font-medium leading-none">Comfortable</span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="compact" />
+                  <span className="text-sm font-medium leading-none">Compact</span>
+                </div>
+              </RadioGroup>
+              <div className="opacity-50">
+                <RadioGroup disabled>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="disabled" />
+                    <span className="text-sm font-medium leading-none">Disabled</span>
+                  </div>
+                </RadioGroup>
+              </div>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <h3 className="text-lg font-semibold mb-4">RadioGroup</h3>
+          <PropsTable props={radioGroupProps} />
+          <h3 className="text-lg font-semibold mb-4 mt-8">RadioGroupItem</h3>
+          <PropsTable props={radioGroupItemProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/components/slider.tsx
+++ b/site/ui/pages/components/slider.tsx
@@ -1,0 +1,158 @@
+/**
+ * Slider Reference Page (/components/slider)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { Slider } from '@/components/ui/slider'
+import { SliderPlayground } from '@/components/slider-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Slider } from "@/components/ui/slider"
+
+function SliderDemo() {
+  const [volume, setVolume] = createSignal(50)
+
+  return (
+    <div className="space-y-6 w-full max-w-sm">
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Default</span>
+        <Slider />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">With initial value</span>
+        <Slider defaultValue={50} />
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium leading-none">Controlled</span>
+          <span className="text-sm text-muted-foreground tabular-nums">{volume()}%</span>
+        </div>
+        <Slider value={volume()} onValueChange={setVolume} />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Custom range (step=5)</span>
+        <Slider min={0} max={100} step={5} defaultValue={50} />
+      </div>
+      <div className="space-y-2">
+        <span className="text-sm font-medium leading-none">Disabled</span>
+        <Slider defaultValue={33} disabled />
+      </div>
+    </div>
+  )
+}`
+
+const sliderProps: PropDefinition[] = [
+  {
+    name: 'defaultValue',
+    type: 'number',
+    defaultValue: '0',
+    description: 'The initial value for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'number',
+    description: 'The controlled value of the slider. When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'min',
+    type: 'number',
+    defaultValue: '0',
+    description: 'The minimum value of the slider.',
+  },
+  {
+    name: 'max',
+    type: 'number',
+    defaultValue: '100',
+    description: 'The maximum value of the slider.',
+  },
+  {
+    name: 'step',
+    type: 'number',
+    defaultValue: '1',
+    description: 'The step increment for value changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the slider is disabled.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: number) => void',
+    description: 'Event handler called when the slider value changes.',
+  },
+]
+
+export function SliderRefPage() {
+  return (
+    <DocPage slug="slider" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Slider"
+          description="An input where the user selects a value from within a given range."
+          {...getNavLinks('slider')}
+        />
+
+        {/* Props Playground */}
+        <SliderPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add slider" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-6 w-full max-w-sm">
+              <div className="space-y-2">
+                <span className="text-sm font-medium leading-none">Default</span>
+                <Slider />
+              </div>
+              <div className="space-y-2">
+                <span className="text-sm font-medium leading-none">With initial value</span>
+                <Slider defaultValue={50} />
+              </div>
+              <div className="space-y-2">
+                <span className="text-sm font-medium leading-none">Custom range (step=5)</span>
+                <Slider min={0} max={100} step={5} defaultValue={50} />
+              </div>
+              <div className="space-y-2">
+                <span className="text-sm font-medium leading-none">Disabled</span>
+                <Slider defaultValue={33} disabled />
+              </div>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={sliderProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/components/toggle-group.tsx
+++ b/site/ui/pages/components/toggle-group.tsx
@@ -1,0 +1,186 @@
+/**
+ * ToggleGroup Reference Page (/components/toggle-group)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
+ */
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { ToggleGroupPlayground } from '@/components/toggle-group-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+function ToggleGroupDemo() {
+  const [alignment, setAlignment] = createSignal("center")
+  const [formats, setFormats] = createSignal<string[]>([])
+
+  return (
+    <div className="space-y-6">
+      {/* Single selection */}
+      <ToggleGroup type="single" defaultValue="center" onValueChange={setAlignment}>
+        <ToggleGroupItem value="left">Left</ToggleGroupItem>
+        <ToggleGroupItem value="center">Center</ToggleGroupItem>
+        <ToggleGroupItem value="right">Right</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Outline variant */}
+      <ToggleGroup type="single" variant="outline" defaultValue="M">
+        <ToggleGroupItem value="S">S</ToggleGroupItem>
+        <ToggleGroupItem value="M">M</ToggleGroupItem>
+        <ToggleGroupItem value="L">L</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Multiple selection */}
+      <ToggleGroup type="multiple" onValueChange={setFormats}>
+        <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
+        <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
+        <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* Disabled */}
+      <ToggleGroup type="single" disabled>
+        <ToggleGroupItem value="a">A</ToggleGroupItem>
+        <ToggleGroupItem value="b">B</ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
+}`
+
+const toggleGroupProps: PropDefinition[] = [
+  {
+    name: 'type',
+    type: "'single' | 'multiple'",
+    description: 'The selection mode. "single" allows one item, "multiple" allows many.',
+  },
+  {
+    name: 'defaultValue',
+    type: 'string | string[]',
+    description: 'The default selected value(s) for uncontrolled mode.',
+  },
+  {
+    name: 'value',
+    type: 'string | string[]',
+    description: 'The controlled selected value(s). When provided, the component is in controlled mode.',
+  },
+  {
+    name: 'onValueChange',
+    type: '(value: string | string[]) => void',
+    description: 'Event handler called when the selection changes.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the entire group is disabled.',
+  },
+  {
+    name: 'variant',
+    type: "'default' | 'outline'",
+    defaultValue: "'default'",
+    description: 'The visual variant applied to all items.',
+  },
+  {
+    name: 'size',
+    type: "'default' | 'sm' | 'lg'",
+    defaultValue: "'default'",
+    description: 'The size applied to all items.',
+  },
+]
+
+const toggleGroupItemProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value for this toggle item.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether this item is disabled.',
+  },
+]
+
+export function ToggleGroupRefPage() {
+  return (
+    <DocPage slug="toggle-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Toggle Group"
+          description="A set of two-state buttons that can be toggled on or off."
+          {...getNavLinks('toggle-group')}
+        />
+
+        {/* Props Playground */}
+        <ToggleGroupPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add toggle-group" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="space-y-6">
+              <ToggleGroup type="single" defaultValue="center">
+                <ToggleGroupItem value="left">Left</ToggleGroupItem>
+                <ToggleGroupItem value="center">Center</ToggleGroupItem>
+                <ToggleGroupItem value="right">Right</ToggleGroupItem>
+              </ToggleGroup>
+              <ToggleGroup type="single" variant="outline" defaultValue="M">
+                <ToggleGroupItem value="S">S</ToggleGroupItem>
+                <ToggleGroupItem value="M">M</ToggleGroupItem>
+                <ToggleGroupItem value="L">L</ToggleGroupItem>
+              </ToggleGroup>
+              <ToggleGroup type="multiple">
+                <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
+                <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
+                <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
+              </ToggleGroup>
+              <ToggleGroup type="single" disabled>
+                <ToggleGroupItem value="a">A</ToggleGroupItem>
+                <ToggleGroupItem value="b">B</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          </Example>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ToggleGroup</h3>
+              <PropsTable props={toggleGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ToggleGroupItem</h3>
+              <PropsTable props={toggleGroupItemProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/pages/components/toggle-group.tsx
+++ b/site/ui/pages/components/toggle-group.tsx
@@ -5,8 +5,8 @@
  * Part of the #515 page redesign initiative.
  */
 
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { ToggleGroupPlayground } from '@/components/toggle-group-playground'
+import { ToggleGroupUsageDemo } from '@/components/toggle-group-usage-demo'
 import {
   DocPage,
   PageHeader,
@@ -143,27 +143,7 @@ export function ToggleGroupRefPage() {
         {/* Usage */}
         <Section id="usage" title="Usage">
           <Example title="" code={usageCode}>
-            <div className="space-y-6">
-              <ToggleGroup type="single" defaultValue="center">
-                <ToggleGroupItem value="left">Left</ToggleGroupItem>
-                <ToggleGroupItem value="center">Center</ToggleGroupItem>
-                <ToggleGroupItem value="right">Right</ToggleGroupItem>
-              </ToggleGroup>
-              <ToggleGroup type="single" variant="outline" defaultValue="M">
-                <ToggleGroupItem value="S">S</ToggleGroupItem>
-                <ToggleGroupItem value="M">M</ToggleGroupItem>
-                <ToggleGroupItem value="L">L</ToggleGroupItem>
-              </ToggleGroup>
-              <ToggleGroup type="multiple">
-                <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
-                <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
-                <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
-              </ToggleGroup>
-              <ToggleGroup type="single" disabled>
-                <ToggleGroupItem value="a">A</ToggleGroupItem>
-                <ToggleGroupItem value="b">B</ToggleGroupItem>
-              </ToggleGroup>
-            </div>
+            <ToggleGroupUsageDemo />
           </Example>
         </Section>
 

--- a/site/ui/pages/components/toggle-group.tsx
+++ b/site/ui/pages/components/toggle-group.tsx
@@ -32,20 +32,13 @@ import { createSignal } from "@barefootjs/dom"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 function ToggleGroupDemo() {
-  const [alignment, setAlignment] = createSignal("center")
+  const [size, setSize] = createSignal("M")
   const [formats, setFormats] = createSignal<string[]>([])
 
   return (
     <div className="space-y-6">
-      {/* Single selection */}
-      <ToggleGroup type="single" defaultValue="center" onValueChange={setAlignment}>
-        <ToggleGroupItem value="left">Left</ToggleGroupItem>
-        <ToggleGroupItem value="center">Center</ToggleGroupItem>
-        <ToggleGroupItem value="right">Right</ToggleGroupItem>
-      </ToggleGroup>
-
-      {/* Outline variant */}
-      <ToggleGroup type="single" variant="outline" defaultValue="M">
+      {/* Outline variant — single selection */}
+      <ToggleGroup type="single" variant="outline" defaultValue="M" onValueChange={setSize}>
         <ToggleGroupItem value="S">S</ToggleGroupItem>
         <ToggleGroupItem value="M">M</ToggleGroupItem>
         <ToggleGroupItem value="L">L</ToggleGroupItem>
@@ -56,12 +49,6 @@ function ToggleGroupDemo() {
         <ToggleGroupItem value="bold">Bold</ToggleGroupItem>
         <ToggleGroupItem value="italic">Italic</ToggleGroupItem>
         <ToggleGroupItem value="underline">Underline</ToggleGroupItem>
-      </ToggleGroup>
-
-      {/* Disabled */}
-      <ToggleGroup type="single" disabled>
-        <ToggleGroupItem value="a">A</ToggleGroupItem>
-        <ToggleGroupItem value="b">B</ToggleGroupItem>
       </ToggleGroup>
     </div>
   )

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -31,6 +31,10 @@ import { CarouselRefPage } from './pages/components/carousel'
 import { DataTableRefPage } from './pages/components/data-table'
 import { SkeletonRefPage } from './pages/components/skeleton'
 import { TableRefPage } from './pages/components/table'
+import { RadioGroupRefPage } from './pages/components/radio-group'
+import { InputOTPRefPage } from './pages/components/input-otp'
+import { SliderRefPage } from './pages/components/slider'
+import { ToggleGroupRefPage } from './pages/components/toggle-group'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { ButtonPage } from './pages/button'
 import { CalendarPage } from './pages/calendar'
@@ -611,6 +615,26 @@ export function createApp() {
   // Toggle Group documentation
   app.get('/docs/components/toggle-group', (c) => {
     return c.render(<ToggleGroupPage />)
+  })
+
+  // Radio Group reference page (redesigned #515)
+  app.get('/components/radio-group', (c) => {
+    return c.render(<RadioGroupRefPage />)
+  })
+
+  // Input OTP reference page (redesigned #515)
+  app.get('/components/input-otp', (c) => {
+    return c.render(<InputOTPRefPage />)
+  })
+
+  // Slider reference page (redesigned #515)
+  app.get('/components/slider', (c) => {
+    return c.render(<SliderRefPage />)
+  })
+
+  // Toggle Group reference page (redesigned #515)
+  app.get('/components/toggle-group', (c) => {
+    return c.render(<ToggleGroupRefPage />)
   })
 
   // Tooltip documentation

--- a/ui/components/ui/input-otp/index.tsx
+++ b/ui/components/ui/input-otp/index.tsx
@@ -38,6 +38,20 @@ export const REGEXP_ONLY_DIGITS = /^\d+$/
 export const REGEXP_ONLY_CHARS = /^[a-zA-Z]+$/
 export const REGEXP_ONLY_DIGITS_AND_CHARS = /^[a-zA-Z0-9]+$/
 
+// String preset names (serializable for hydration)
+type PatternPreset = 'digits' | 'chars' | 'digits-and-chars'
+const patternPresets: Record<PatternPreset, RegExp> = {
+  'digits': REGEXP_ONLY_DIGITS,
+  'chars': REGEXP_ONLY_CHARS,
+  'digits-and-chars': REGEXP_ONLY_DIGITS_AND_CHARS,
+}
+
+function resolvePattern(pattern: RegExp | PatternPreset | undefined): RegExp {
+  if (pattern === undefined) return REGEXP_ONLY_DIGITS
+  if (typeof pattern === 'string') return patternPresets[pattern] ?? REGEXP_ONLY_DIGITS
+  return pattern
+}
+
 // Context for InputOTP → InputOTPSlot state sharing
 interface InputOTPContextValue {
   value: () => string
@@ -76,8 +90,8 @@ interface InputOTPProps extends HTMLBaseAttributes {
   onValueChange?: (value: string) => void
   /** Callback when all slots are filled */
   onComplete?: (value: string) => void
-  /** Pattern to validate input (default: digits only) */
-  pattern?: RegExp
+  /** Pattern to validate input. Accepts a RegExp or a preset name: 'digits' | 'chars' | 'digits-and-chars'. Default: 'digits'. */
+  pattern?: RegExp | PatternPreset
   /** Whether the input is disabled */
   disabled?: boolean
   /** Container className override */
@@ -103,7 +117,7 @@ function InputOTP(props: InputOTPProps) {
   const [isFocused, setIsFocused] = createSignal(false)
 
   const getValue = () => props.value !== undefined ? (props.value ?? '') : internalValue()
-  const pattern = props.pattern ?? REGEXP_ONLY_DIGITS
+  const pattern = resolvePattern(props.pattern)
 
   const updateValue = (newValue: string) => {
     const truncated = newValue.slice(0, props.maxLength)

--- a/ui/components/ui/radio-group/index.tsx
+++ b/ui/components/ui/radio-group/index.tsx
@@ -127,6 +127,14 @@ function RadioGroupItem(props: RadioGroupItemProps) {
       el.setAttribute('aria-checked', String(isSelected))
       el.setAttribute('data-state', isSelected ? 'checked' : 'unchecked')
 
+      // Reflect group-level disabled onto the button element
+      const isDisabled = props.disabled || ctx.disabled()
+      if (isDisabled) {
+        el.setAttribute('disabled', '')
+      } else {
+        el.removeAttribute('disabled')
+      }
+
       // Update indicator dot visibility
       const indicator = el.querySelector('[data-slot="radio-group-indicator"]') as HTMLElement
       if (indicator) {

--- a/ui/components/ui/radio-group/index.tsx
+++ b/ui/components/ui/radio-group/index.tsx
@@ -38,13 +38,13 @@ interface RadioGroupContextValue {
 
 const RadioGroupContext = createContext<RadioGroupContextValue>()
 
-// CSS classes for RadioGroupItem (module-level constants)
-const itemBaseClasses = 'aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none'
-const itemFocusClasses = 'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
-const itemStateClasses = '[&[data-state=unchecked]]:border-input [&[data-state=unchecked]]:text-primary dark:[&[data-state=unchecked]]:bg-input/30 [&[data-state=checked]]:border-primary [&[data-state=checked]]:text-primary'
-const itemErrorClasses = 'aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive'
+// CSS classes for RadioGroupItem (matching shadcn/ui)
+const itemBaseClasses = 'relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none transition-[color,box-shadow]'
+const itemFocusClasses = 'focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50'
+const itemStateClasses = '[&[data-state=checked]]:border-primary [&[data-state=checked]]:bg-primary [&[data-state=checked]]:text-primary-foreground dark:bg-input/30 dark:[&[data-state=checked]]:bg-primary'
+const itemErrorClasses = 'aria-[invalid]:border-destructive aria-[invalid]:ring-3 aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40'
 const itemDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50'
-const itemClasses = `${itemBaseClasses} ${itemFocusClasses} ${itemStateClasses} ${itemErrorClasses} ${itemDisabledClasses} grid place-content-center`
+const itemClasses = `${itemBaseClasses} ${itemFocusClasses} ${itemStateClasses} ${itemErrorClasses} ${itemDisabledClasses}`
 
 /**
  * Props for the RadioGroup component.
@@ -130,12 +130,7 @@ function RadioGroupItem(props: RadioGroupItemProps) {
       // Update indicator dot visibility
       const indicator = el.querySelector('[data-slot="radio-group-indicator"]') as HTMLElement
       if (indicator) {
-        const circle = indicator.querySelector('circle')
-        if (isSelected && !circle) {
-          indicator.innerHTML = '<svg class="size-3.5 fill-primary" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" /></svg>'
-        } else if (!isSelected && circle) {
-          indicator.innerHTML = ''
-        }
+        indicator.style.display = isSelected ? 'flex' : 'none'
       }
     })
 
@@ -156,8 +151,8 @@ function RadioGroupItem(props: RadioGroupItemProps) {
       className={`${itemClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
-      <span data-slot="radio-group-indicator" className="flex items-center justify-center">
-        {/* Dot indicator rendered reactively via effect */}
+      <span data-slot="radio-group-indicator" className="flex size-4 items-center justify-center" style="display:none">
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
       </span>
     </button>
   )

--- a/ui/components/ui/toggle-group/index.tsx
+++ b/ui/components/ui/toggle-group/index.tsx
@@ -183,27 +183,33 @@ function ToggleGroupItem(props: ToggleGroupItemProps) {
   const handleMount = (el: HTMLElement) => {
     const ctx = useContext(ToggleGroupContext)
 
-    const variant: ToggleVariant = ctx.variant()
-    const size: ToggleSize = ctx.size()
-
-    // Apply variant/size classes at mount time
-    const variantClass = toggleVariantClasses[variant]
-    const sizeClass = toggleSizeClasses[size]
-    for (const cls of variantClass.split(' ')) {
-      if (cls) el.classList.add(cls)
-    }
-    for (const cls of sizeClass.split(' ')) {
-      if (cls) el.classList.add(cls)
-    }
-
-    // Set data-variant for CSS styling (outline border handling)
-    el.setAttribute('data-variant', variant)
-    el.setAttribute('data-size', size)
+    let prevVariantClasses: string[] = []
+    let prevSizeClasses: string[] = []
 
     createEffect(() => {
+      const variant = ctx.variant()
+      const size = ctx.size()
       const isSelected = ctx.value().includes(props.value)
+
+      // Update selection state
       el.setAttribute('aria-pressed', String(isSelected))
       el.setAttribute('data-state', isSelected ? 'on' : 'off')
+
+      // Update variant classes reactively
+      for (const cls of prevVariantClasses) el.classList.remove(cls)
+      const variantClasses = toggleVariantClasses[variant].split(' ').filter(Boolean)
+      for (const cls of variantClasses) el.classList.add(cls)
+      prevVariantClasses = variantClasses
+
+      // Update size classes reactively
+      for (const cls of prevSizeClasses) el.classList.remove(cls)
+      const sizeClasses = toggleSizeClasses[size].split(' ').filter(Boolean)
+      for (const cls of sizeClasses) el.classList.add(cls)
+      prevSizeClasses = sizeClasses
+
+      // Set data attributes for CSS styling
+      el.setAttribute('data-variant', variant)
+      el.setAttribute('data-size', size)
     })
 
     el.addEventListener('click', () => {

--- a/ui/components/ui/toggle-group/index.tsx
+++ b/ui/components/ui/toggle-group/index.tsx
@@ -36,16 +36,12 @@ type ToggleSize = 'default' | 'sm' | 'lg'
 // Base classes from shadcn/ui toggleVariants
 const toggleBaseClasses = 'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive whitespace-nowrap data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted hover:text-muted-foreground'
 
-const toggleVariantClasses: Record<ToggleVariant, string> = {
-  default: 'bg-transparent',
-  outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
-}
+// Variant/size classes defined via data-attribute selectors so they stay in the
+// compiled className (with layer-components: prefix). This avoids CSS @layer
+// conflicts that occur when classes are added dynamically via classList.add().
+const toggleVariantClasses = 'bg-transparent data-[variant=outline]:border data-[variant=outline]:border-input data-[variant=outline]:shadow-xs data-[variant=outline]:hover:bg-accent data-[variant=outline]:hover:text-accent-foreground'
 
-const toggleSizeClasses: Record<ToggleSize, string> = {
-  default: 'h-9 px-2 min-w-9',
-  sm: 'h-8 px-1.5 min-w-8',
-  lg: 'h-10 px-2.5 min-w-10',
-}
+const toggleSizeClasses = 'data-[size=default]:h-9 data-[size=default]:px-2 data-[size=default]:min-w-9 data-[size=sm]:h-8 data-[size=sm]:px-1.5 data-[size=sm]:min-w-8 data-[size=lg]:h-10 data-[size=lg]:px-2.5 data-[size=lg]:min-w-10'
 
 // ToggleGroupItem extra classes from shadcn/ui (applied on top of toggle base)
 const toggleGroupItemClasses = 'w-auto min-w-0 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l'
@@ -183,9 +179,6 @@ function ToggleGroupItem(props: ToggleGroupItemProps) {
   const handleMount = (el: HTMLElement) => {
     const ctx = useContext(ToggleGroupContext)
 
-    let prevVariantClasses: string[] = []
-    let prevSizeClasses: string[] = []
-
     createEffect(() => {
       const variant = ctx.variant()
       const size = ctx.size()
@@ -195,19 +188,10 @@ function ToggleGroupItem(props: ToggleGroupItemProps) {
       el.setAttribute('aria-pressed', String(isSelected))
       el.setAttribute('data-state', isSelected ? 'on' : 'off')
 
-      // Update variant classes reactively
-      for (const cls of prevVariantClasses) el.classList.remove(cls)
-      const variantClasses = toggleVariantClasses[variant].split(' ').filter(Boolean)
-      for (const cls of variantClasses) el.classList.add(cls)
-      prevVariantClasses = variantClasses
-
-      // Update size classes reactively
-      for (const cls of prevSizeClasses) el.classList.remove(cls)
-      const sizeClasses = toggleSizeClasses[size].split(' ').filter(Boolean)
-      for (const cls of sizeClasses) el.classList.add(cls)
-      prevSizeClasses = sizeClasses
-
-      // Set data attributes for CSS styling
+      // Set data attributes — variant/size styling is driven by these via
+      // data-[variant=...] / data-[size=...] selectors in the static className.
+      // This keeps all classes in the compiled output with layer-components: prefix,
+      // avoiding CSS @layer specificity conflicts from runtime classList.add().
       el.setAttribute('data-variant', variant)
       el.setAttribute('data-size', size)
     })
@@ -225,7 +209,7 @@ function ToggleGroupItem(props: ToggleGroupItemProps) {
       aria-pressed="false"
       disabled={props.disabled ?? false}
       id={props.id}
-      className={`${toggleBaseClasses} ${toggleGroupItemClasses} ${props.className ?? ''}`}
+      className={`${toggleBaseClasses} ${toggleVariantClasses} ${toggleSizeClasses} ${toggleGroupItemClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       {props.children}


### PR DESCRIPTION
## Summary
- Add redesigned reference pages at `/components/` for **radio-group**, **input-otp**, **slider**, **toggle-group** (part of #515)
- Each page has: Props Playground, Installation, Usage, API Reference
- Fix context-based compound components (RadioGroup, ToggleGroup, InputOTP) in Usage sections — wrap in `"use client"` demo components since `createContext`/`useContext` breaks across server/client boundary
- Fix ToggleGroupItem variant/size classes not updating reactively — move into `createEffect`
- Fix RadioGroupItem not reflecting group-level `disabled` on button element
- Add string pattern presets to InputOTP (`'digits'` | `'chars'` | `'digits-and-chars'`) for hydration compatibility — RegExp objects serialize to `{}` during hydration
- InputOTP playground: remove separator, sync slot count with maxLength selection

## Test plan
- [x] Unit tests pass (radio-group, toggle-group, input-otp)
- [x] E2E tests pass (radio-group: 20, toggle-group: 18, input-otp: 15)
- [x] Build succeeds
- [x] Manual verification: RadioGroup disabled styling, ToggleGroup playground controls, InputOTP accepts letters with `pattern="digits-and-chars"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)