### PR TITLE
Fix llms.txt encoding: replace Unicode arrow with ASCII

### DIFF
--- a/docs/core/llms.txt
+++ b/docs/core/llms.txt
@@ -1,6 +1,6 @@
 # BarefootJS
 
-> JSX → Marked Template + client JS compiler. Signal-based reactivity for any backend.
+> JSX -> Marked Template + client JS compiler. Signal-based reactivity for any backend.
 
 ## Core Concepts
 

--- a/packages/cli/src/lib/llms-txt-generator.ts
+++ b/packages/cli/src/lib/llms-txt-generator.ts
@@ -25,7 +25,7 @@ export function generateCoreLlmsTxt(docs: CoreDocMeta[], baseUrl: string): strin
   const lines: string[] = [
     '# BarefootJS',
     '',
-    '> JSX → Marked Template + client JS compiler. Signal-based reactivity for any backend.',
+    '> JSX -> Marked Template + client JS compiler. Signal-based reactivity for any backend.',
     '',
   ]
 


### PR DESCRIPTION
## Summary

- Replace `→` (U+2192) with `->` in llms.txt blockquote to fix character garbling on Cloudflare Workers

The Unicode right arrow was displayed as `竊�` on barefootjs.dev/llms.txt because the static asset response lacks `charset=utf-8` in Content-Type.

## Test plan

- [x] `bun test packages/cli/src/__tests__/llms-txt.test.ts` passes
- [ ] Verify https://barefootjs.dev/llms.txt displays correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)