### PR TITLE
Migrate bar-chart route from /docs/charts/ to /charts/ with playground

### DIFF
--- a/packages/chart/src/cartesian-grid.ts
+++ b/packages/chart/src/cartesian-grid.ts
@@ -9,12 +9,13 @@ const SVG_NS = 'http://www.w3.org/2000/svg'
  */
 export function initCartesianGrid(_scope: Element, props: Record<string, unknown>): void {
   const ctx = useContext(BarChartContext)
-  const horizontal = (props.horizontal as boolean) !== false
-  const vertical = (props.vertical as boolean) ?? true
 
   let gridGroup: SVGGElement | null = null
 
   createEffect(() => {
+    const horizontal = (props.horizontal as boolean) !== false
+    const vertical = (props.vertical as boolean) ?? true
+
     const g = ctx.svgGroup()
     const ys = ctx.yScale()
     if (!g || !ys) return

--- a/packages/chart/src/x-axis.ts
+++ b/packages/chart/src/x-axis.ts
@@ -9,18 +9,25 @@ const SVG_NS = 'http://www.w3.org/2000/svg'
  */
 export function initXAxis(_scope: Element, props: Record<string, unknown>): void {
   const ctx = useContext(BarChartContext)
-  const dataKey = props.dataKey as string
-  const tickFormatter = props.tickFormatter as ((value: string) => string) | undefined
-  const hide = props.hide as boolean | undefined
-
-  // Tell BarChart which key to use for X axis
-  ctx.setXDataKey(dataKey)
-
-  if (hide) return
 
   let axisGroup: SVGGElement | null = null
 
   createEffect(() => {
+    const dataKey = props.dataKey as string
+    const tickFormatter = props.tickFormatter as ((value: string) => string) | undefined
+    const hide = props.hide as boolean | undefined
+
+    // Tell BarChart which key to use for X axis
+    ctx.setXDataKey(dataKey)
+
+    if (hide) {
+      if (axisGroup) {
+        axisGroup.remove()
+        axisGroup = null
+      }
+      return
+    }
+
     const g = ctx.svgGroup()
     const xs = ctx.xScale()
     if (!g || !xs) return

--- a/packages/chart/src/y-axis.ts
+++ b/packages/chart/src/y-axis.ts
@@ -9,14 +9,21 @@ const SVG_NS = 'http://www.w3.org/2000/svg'
  */
 export function initYAxis(_scope: Element, props: Record<string, unknown>): void {
   const ctx = useContext(BarChartContext)
-  const hide = props.hide as boolean | undefined
-  const tickFormatter = props.tickFormatter as ((value: number) => string) | undefined
-
-  if (hide) return
 
   let axisGroup: SVGGElement | null = null
 
   createEffect(() => {
+    const hide = props.hide as boolean | undefined
+    const tickFormatter = props.tickFormatter as ((value: number) => string) | undefined
+
+    if (hide) {
+      if (axisGroup) {
+        axisGroup.remove()
+        axisGroup = null
+      }
+      return
+    }
+
     const g = ctx.svgGroup()
     const ys = ctx.yScale()
     if (!g || !ys) return

--- a/site/ui/components/bar-chart-playground.tsx
+++ b/site/ui/components/bar-chart-playground.tsx
@@ -14,6 +14,7 @@ import {
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Checkbox } from '@ui/components/ui/checkbox'
+import type { ChartConfig } from '@barefootjs/chart'
 import {
   ChartContainer,
   BarChart,
@@ -24,7 +25,7 @@ import {
   ChartTooltip,
 } from '@ui/components/ui/chart'
 
-const chartConfig: Record<string, { label: string; color: string }> = {
+const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
 }
 

--- a/site/ui/components/bar-chart-playground.tsx
+++ b/site/ui/components/bar-chart-playground.tsx
@@ -44,16 +44,13 @@ function buildHighlightedCode(radius: number, vertical: boolean, showGrid: boole
   const indent = '  '
   const lines: string[] = []
 
-  // <ChartContainer config={chartConfig} className="w-full">
   lines.push(
     `${hlPlain('&lt;')}${hlTag('ChartContainer')} ${hlAttr('config')}${hlPlain('={chartConfig}')} ${hlAttr('className')}${hlPlain('=')}${hlStr('&quot;w-full&quot;')}${hlPlain('&gt;')}`
   )
-  // <BarChart data={chartData}>
   lines.push(
     `${indent}${hlPlain('&lt;')}${hlTag('BarChart')} ${hlAttr('data')}${hlPlain('={chartData}')}${hlPlain('&gt;')}`
   )
 
-  // CartesianGrid (only if showGrid)
   if (showGrid) {
     const verticalProp = vertical
       ? ''
@@ -63,20 +60,16 @@ function buildHighlightedCode(radius: number, vertical: boolean, showGrid: boole
     )
   }
 
-  // XAxis
   lines.push(
     `${indent}${indent}${hlPlain('&lt;')}${hlTag('XAxis')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;month&quot;')} ${hlPlain('/&gt;')}`
   )
-  // YAxis
   lines.push(
     `${indent}${indent}${hlPlain('&lt;')}${hlTag('YAxis')} ${hlPlain('/&gt;')}`
   )
-  // ChartTooltip
   lines.push(
     `${indent}${indent}${hlPlain('&lt;')}${hlTag('ChartTooltip')} ${hlPlain('/&gt;')}`
   )
 
-  // Bar
   const radiusProp = radius !== 0
     ? ` ${hlAttr('radius')}${hlPlain('={' + radius + '}')}`
     : ''
@@ -84,11 +77,9 @@ function buildHighlightedCode(radius: number, vertical: boolean, showGrid: boole
     `${indent}${indent}${hlPlain('&lt;')}${hlTag('Bar')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;desktop&quot;')} ${hlAttr('fill')}${hlPlain('=')}${hlStr('&quot;var(--color-desktop)&quot;')}${radiusProp} ${hlPlain('/&gt;')}`
   )
 
-  // </BarChart>
   lines.push(
     `${indent}${hlPlain('&lt;/')}${hlTag('BarChart')}${hlPlain('&gt;')}`
   )
-  // </ChartContainer>
   lines.push(
     `${hlPlain('&lt;/')}${hlTag('ChartContainer')}${hlPlain('&gt;')}`
   )
@@ -144,7 +135,10 @@ function BarChartPlayground(_props: {}) {
         <div className="w-full min-w-[300px]">
           <ChartContainer config={chartConfig} className="w-full">
             <BarChart data={chartData}>
-              {showGrid() ? <CartesianGrid vertical={vertical()} /> : null}
+              <CartesianGrid
+                vertical={vertical()}
+                horizontal={showGrid()}
+              />
               <XAxis dataKey="month" />
               <YAxis />
               <ChartTooltip />
@@ -170,13 +164,13 @@ function BarChartPlayground(_props: {}) {
         <PlaygroundControl label="vertical grid">
           <Checkbox
             checked={vertical()}
-            onCheckedChange={setVertical}
+            onCheckedChange={(v: boolean) => setVertical(v)}
           />
         </PlaygroundControl>
         <PlaygroundControl label="showGrid">
           <Checkbox
             checked={showGrid()}
-            onCheckedChange={setShowGrid}
+            onCheckedChange={(v: boolean) => setShowGrid(v)}
           />
         </PlaygroundControl>
       </>}

--- a/site/ui/components/bar-chart-playground.tsx
+++ b/site/ui/components/bar-chart-playground.tsx
@@ -1,0 +1,188 @@
+"use client"
+/**
+ * Bar Chart Props Playground
+ *
+ * Interactive playground for the BarChart composed component.
+ * Allows tweaking radius, vertical grid lines, and grid visibility.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import {
+  hlPlain, hlTag, hlAttr, hlStr,
+} from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from '@ui/components/ui/chart'
+
+const chartConfig: Record<string, { label: string; color: string }> = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "Jan", desktop: 186 },
+  { month: "Feb", desktop: 305 },
+  { month: "Mar", desktop: 237 },
+  { month: "Apr", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "Jun", desktop: 214 },
+]
+
+/**
+ * Build highlighted JSX string for the composed BarChart pattern.
+ */
+function buildHighlightedCode(radius: number, vertical: boolean, showGrid: boolean): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  // <ChartContainer config={chartConfig} className="w-full">
+  lines.push(
+    `${hlPlain('&lt;')}${hlTag('ChartContainer')} ${hlAttr('config')}${hlPlain('={chartConfig}')} ${hlAttr('className')}${hlPlain('=')}${hlStr('&quot;w-full&quot;')}${hlPlain('&gt;')}`
+  )
+  // <BarChart data={chartData}>
+  lines.push(
+    `${indent}${hlPlain('&lt;')}${hlTag('BarChart')} ${hlAttr('data')}${hlPlain('={chartData}')}${hlPlain('&gt;')}`
+  )
+
+  // CartesianGrid (only if showGrid)
+  if (showGrid) {
+    const verticalProp = vertical
+      ? ''
+      : ` ${hlAttr('vertical')}${hlPlain('={false}')}`
+    lines.push(
+      `${indent}${indent}${hlPlain('&lt;')}${hlTag('CartesianGrid')}${verticalProp} ${hlPlain('/&gt;')}`
+    )
+  }
+
+  // XAxis
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('XAxis')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;month&quot;')} ${hlPlain('/&gt;')}`
+  )
+  // YAxis
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('YAxis')} ${hlPlain('/&gt;')}`
+  )
+  // ChartTooltip
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('ChartTooltip')} ${hlPlain('/&gt;')}`
+  )
+
+  // Bar
+  const radiusProp = radius !== 0
+    ? ` ${hlAttr('radius')}${hlPlain('={' + radius + '}')}`
+    : ''
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('Bar')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;desktop&quot;')} ${hlAttr('fill')}${hlPlain('=')}${hlStr('&quot;var(--color-desktop)&quot;')}${radiusProp} ${hlPlain('/&gt;')}`
+  )
+
+  // </BarChart>
+  lines.push(
+    `${indent}${hlPlain('&lt;/')}${hlTag('BarChart')}${hlPlain('&gt;')}`
+  )
+  // </ChartContainer>
+  lines.push(
+    `${hlPlain('&lt;/')}${hlTag('ChartContainer')}${hlPlain('&gt;')}`
+  )
+
+  return lines.join('\n')
+}
+
+/**
+ * Build plain-text JSX string for clipboard copy.
+ */
+function buildPlainCode(radius: number, vertical: boolean, showGrid: boolean): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  lines.push('<ChartContainer config={chartConfig} className="w-full">')
+  lines.push(`${indent}<BarChart data={chartData}>`)
+
+  if (showGrid) {
+    const verticalProp = vertical ? '' : ' vertical={false}'
+    lines.push(`${indent}${indent}<CartesianGrid${verticalProp} />`)
+  }
+
+  lines.push(`${indent}${indent}<XAxis dataKey="month" />`)
+  lines.push(`${indent}${indent}<YAxis />`)
+  lines.push(`${indent}${indent}<ChartTooltip />`)
+
+  const radiusProp = radius !== 0 ? ` radius={${radius}}` : ''
+  lines.push(`${indent}${indent}<Bar dataKey="desktop" fill="var(--color-desktop)"${radiusProp} />`)
+
+  lines.push(`${indent}</BarChart>`)
+  lines.push('</ChartContainer>')
+
+  return lines.join('\n')
+}
+
+function BarChartPlayground(_props: {}) {
+  const [radius, setRadius] = createSignal(4)
+  const [vertical, setVertical] = createSignal(false)
+  const [showGrid, setShowGrid] = createSignal(true)
+
+  createEffect(() => {
+    const r = radius()
+    const v = vertical()
+    const g = showGrid()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = buildHighlightedCode(r, v, g)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-bar-chart-preview"
+      previewContent={
+        <div className="w-full min-w-[300px]">
+          <ChartContainer config={chartConfig} className="w-full">
+            <BarChart data={chartData}>
+              {showGrid() ? <CartesianGrid vertical={vertical()} /> : null}
+              <XAxis dataKey="month" />
+              <YAxis />
+              <ChartTooltip />
+              <Bar dataKey="desktop" fill={'var(--color-desktop)'} radius={radius()} />
+            </BarChart>
+          </ChartContainer>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="radius">
+          <Select value={String(radius())} onValueChange={(v: string) => setRadius(Number(v))}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select radius..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="0">0</SelectItem>
+              <SelectItem value="2">2</SelectItem>
+              <SelectItem value="4">4</SelectItem>
+              <SelectItem value="8">8</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="vertical grid">
+          <Checkbox
+            checked={vertical()}
+            onCheckedChange={setVertical}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="showGrid">
+          <Checkbox
+            checked={showGrid()}
+            onCheckedChange={setShowGrid}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={buildPlainCode(radius(), vertical(), showGrid())} />}
+    />
+  )
+}
+
+export { BarChartPlayground }

--- a/site/ui/components/bar-chart-playground.tsx
+++ b/site/ui/components/bar-chart-playground.tsx
@@ -14,7 +14,6 @@ import {
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Checkbox } from '@ui/components/ui/checkbox'
-import type { ChartConfig } from '@barefootjs/chart'
 import {
   ChartContainer,
   BarChart,
@@ -25,7 +24,7 @@ import {
   ChartTooltip,
 } from '@ui/components/ui/chart'
 
-const chartConfig: ChartConfig = {
+const chartConfig: Record<string, { label: string; color: string }> = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
 }
 

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -75,8 +75,8 @@ export function getChartNavLinks(currentSlug: string): {
   const next = currentIndex < chartOrder.length - 1 ? chartOrder[currentIndex + 1] : undefined
 
   return {
-    prev: prev ? { href: `/docs/charts/${prev.slug}`, title: prev.title } : undefined,
-    next: next ? { href: `/docs/charts/${next.slug}`, title: next.title } : undefined,
+    prev: prev ? { href: `/charts/${prev.slug}`, title: prev.title } : undefined,
+    next: next ? { href: `/charts/${next.slug}`, title: next.title } : undefined,
   }
 }
 

--- a/site/ui/e2e/bar-chart.spec.ts
+++ b/site/ui/e2e/bar-chart.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Bar Chart Documentation Page', () => {
+test.describe('Bar Chart Reference Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/charts/bar-chart')
+    await page.goto('/charts/bar-chart')
   })
 
   test.describe('Preview', () => {
@@ -23,6 +23,76 @@ test.describe('Bar Chart Documentation Page', () => {
       const container = page.locator(scope)
       const xAxisTexts = container.locator('.chart-x-axis text')
       await expect(xAxisTexts.first()).toHaveText('Jan')
+    })
+  })
+
+  test.describe('Playground', () => {
+    test('renders chart in playground preview', async ({ page }) => {
+      const preview = page.locator('[data-bar-chart-preview]')
+      await expect(preview).toBeVisible()
+      await expect(preview.locator('svg').first()).toBeVisible()
+    })
+
+    test('renders 6 bar rects in playground', async ({ page }) => {
+      const preview = page.locator('[data-bar-chart-preview]')
+      const rects = preview.locator('rect[data-key="desktop"]')
+      await expect(rects).toHaveCount(6)
+    })
+
+    test('changing radius updates bar corners', async ({ page }) => {
+      const preview = page.locator('[data-bar-chart-preview]')
+      const rect = preview.locator('rect[data-key="desktop"]').first()
+
+      // Default radius is 4
+      await expect(rect).toHaveAttribute('rx', '4')
+
+      // Open the radius select (first combobox in the playground controls)
+      const playgroundSection = page.locator('[data-bar-chart-preview]').locator('..').locator('..')
+      const radiusSelect = playgroundSection.locator('button[role="combobox"]').first()
+      await radiusSelect.click()
+      await page.locator('[role="option"]:has-text("0")').click()
+
+      // rx attribute should be removed (radius=0 means no rounding)
+      await expect(rect).not.toHaveAttribute('rx')
+    })
+
+    test('toggling vertical grid adds vertical lines', async ({ page }) => {
+      const preview = page.locator('[data-bar-chart-preview]')
+      const gridGroup = preview.locator('.chart-grid')
+      await expect(gridGroup).toBeVisible()
+
+      // Count initial lines (horizontal only, vertical=false by default)
+      const initialLineCount = await gridGroup.locator('line').count()
+
+      // Click "vertical grid" checkbox
+      const verticalCheckbox = page.locator('text=vertical grid')
+        .locator('..')
+        .locator('button[role="checkbox"]')
+      await verticalCheckbox.click()
+
+      // Should have more lines (horizontal + vertical)
+      const updatedLineCount = await gridGroup.locator('line').count()
+      expect(updatedLineCount).toBeGreaterThan(initialLineCount)
+    })
+
+    test('toggling showGrid hides grid lines', async ({ page }) => {
+      const preview = page.locator('[data-bar-chart-preview]')
+      const gridGroup = preview.locator('.chart-grid')
+      await expect(gridGroup).toBeVisible()
+
+      // Initially has grid lines
+      const initialLineCount = await gridGroup.locator('line').count()
+      expect(initialLineCount).toBeGreaterThan(0)
+
+      // Uncheck showGrid
+      const showGridCheckbox = page.locator('text=showGrid')
+        .locator('..')
+        .locator('button[role="checkbox"]')
+      await showGridCheckbox.click()
+
+      // Grid lines should be gone (horizontal=false hides all lines)
+      const updatedLineCount = await gridGroup.locator('line').count()
+      expect(updatedLineCount).toBe(0)
     })
   })
 

--- a/site/ui/pages/charts/bar-chart.tsx
+++ b/site/ui/pages/charts/bar-chart.tsx
@@ -290,8 +290,7 @@ const chartTooltipProps: PropDefinition[] = [
   },
 ]
 
-/** Legacy export for /docs/charts/bar-chart route */
-export function BarChartPage() {
+export function BarChartRefPage() {
   return (
     <DocPage slug="bar-chart" toc={tocItems}>
       <div className="space-y-12">
@@ -366,6 +365,3 @@ export function BarChartPage() {
     </DocPage>
   )
 }
-
-/** RefPage export for /charts/bar-chart route */
-export { BarChartPage as BarChartRefPage }

--- a/site/ui/pages/charts/bar-chart.tsx
+++ b/site/ui/pages/charts/bar-chart.tsx
@@ -8,6 +8,7 @@ import {
   BarChartMultipleDemo,
   BarChartInteractiveDemo,
 } from '@/components/bar-chart-demo'
+import { BarChartPlayground } from '@/components/bar-chart-playground'
 import {
   DocPage,
   PageHeader,
@@ -21,7 +22,9 @@ import {
 import { getChartNavLinks } from '../../components/shared/PageNavigation'
 
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'multiple', title: 'Multiple', branch: 'child' },
@@ -29,9 +32,18 @@ const tocItems: TocItem[] = [
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-const previewCode = `"use client"
+const usageCode = `"use client"
 
 import type { ChartConfig } from "@barefootjs/chart"
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from "@/components/ui/chart"
 
 const chartConfig: ChartConfig = {
   desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
@@ -46,7 +58,7 @@ const chartData = [
   { month: "June", desktop: 214 },
 ]
 
-export function BarChartPreviewDemo() {
+export function MyBarChart() {
   return (
     <ChartContainer config={chartConfig} className="w-full">
       <BarChart data={chartData}>
@@ -278,6 +290,7 @@ const chartTooltipProps: PropDefinition[] = [
   },
 ]
 
+/** Legacy export for /docs/charts/bar-chart route */
 export function BarChartPage() {
   return (
     <DocPage slug="bar-chart" toc={tocItems}>
@@ -288,12 +301,17 @@ export function BarChartPage() {
           {...getChartNavLinks('bar-chart')}
         />
 
-        <Example title="" code={previewCode}>
-          <BarChartPreviewDemo />
-        </Example>
+        {/* Props Playground */}
+        <BarChartPlayground />
 
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="bun add @barefootjs/chart" />
+        </Section>
+
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <BarChartPreviewDemo />
+          </Example>
         </Section>
 
         <Section id="examples" title="Examples">
@@ -348,3 +366,6 @@ export function BarChartPage() {
     </DocPage>
   )
 }
+
+/** RefPage export for /charts/bar-chart route */
+export { BarChartPage as BarChartRefPage }

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -71,7 +71,7 @@ import { SpinnerPage } from './pages/spinner'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
-import { BarChartPage, BarChartRefPage } from './pages/charts/bar-chart'
+import { BarChartRefPage } from './pages/charts/bar-chart'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -653,11 +653,6 @@ export function createApp() {
   // Bar Chart reference page
   app.get('/charts/bar-chart', (c) => {
     return c.render(<BarChartRefPage />)
-  })
-
-  // Bar Chart documentation (legacy)
-  app.get('/docs/charts/bar-chart', (c) => {
-    return c.render(<BarChartPage />)
   })
 
   // Controlled Input pattern documentation

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -71,7 +71,7 @@ import { SpinnerPage } from './pages/spinner'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
-import { BarChartPage } from './pages/charts/bar-chart'
+import { BarChartPage, BarChartRefPage } from './pages/charts/bar-chart'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -650,7 +650,12 @@ export function createApp() {
     return c.render(<TablePage />)
   })
 
-  // Bar Chart documentation
+  // Bar Chart reference page
+  app.get('/charts/bar-chart', (c) => {
+    return c.render(<BarChartRefPage />)
+  })
+
+  // Bar Chart documentation (legacy)
   app.get('/docs/charts/bar-chart', (c) => {
     return c.render(<BarChartPage />)
   })


### PR DESCRIPTION
## Summary

- Migrate bar-chart route from `/docs/charts/` to `/charts/` (old route removed)
- Add interactive Props Playground (radius, vertical grid, showGrid)
- **Fix chart component props reactivity**: move props reads inside `createEffect` in `cartesian-grid.ts`, `x-axis.ts`, `y-axis.ts` to match the reactive pattern in `bar.ts`
- Update `getChartNavLinks` to use `/charts/` prefix

## Root cause fix

CartesianGrid, XAxis, and YAxis read props outside `createEffect`, making them non-reactive. For example in `cartesian-grid.ts`:

```ts
// Before (broken): props captured once at init, never re-read
const vertical = (props.vertical as boolean) ?? true
createEffect(() => { /* uses captured value */ })

// After (fixed): props read inside effect, re-evaluated on change
createEffect(() => {
  const vertical = (props.vertical as boolean) ?? true
  /* uses reactive value */
})
```

This matches the pattern already established in `bar.ts`, where `props.dataKey`, `props.fill`, and `props.radius` are correctly read inside effects.

## Test plan

- [x] Chart package unit tests: 9 pass
- [x] All package tests: 1106 pass, 1 pre-existing fail (Happy DOM double-registration)
- [x] Full build passes (`bun run build` from root)
- [x] E2E tests: 12 pass (including playground interaction tests)
  - radius change updates bar corners
  - vertical grid toggle adds/removes vertical lines
  - showGrid toggle hides/shows all grid lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)