### PR TITLE
Migrate Accordion from /docs/components/ to /components/

### DIFF
--- a/site/ui/components/accordion-playground.tsx
+++ b/site/ui/components/accordion-playground.tsx
@@ -1,0 +1,85 @@
+"use client"
+/**
+ * Accordion Props Playground
+ *
+ * Interactive playground for the Accordion component.
+ * Allows tweaking open state and disabled props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type HighlightProp, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@ui/components/ui/accordion'
+
+function AccordionPlayground(_props: {}) {
+  const [open, setOpen] = createSignal(true)
+  const [disabled, setDisabled] = createSignal(false)
+
+  const itemProps = (): HighlightProp[] => [
+    { name: 'open', value: String(open()), defaultValue: 'false', kind: 'expression' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+  ]
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'Accordion',
+    children: [{
+      tag: 'AccordionItem',
+      props: [
+        { name: 'value', value: 'item-1', defaultValue: '' },
+        ...itemProps(),
+      ],
+      children: [
+        { tag: 'AccordionTrigger', children: 'Is it accessible?' },
+        { tag: 'AccordionContent', children: 'Yes. It adheres to the WAI-ARIA design pattern.' },
+      ],
+    }],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-accordion-preview"
+      previewContent={
+        <div className="w-full max-w-sm">
+          <Accordion>
+            <AccordionItem value="item-1" open={open()} onOpenChange={setOpen} disabled={disabled()}>
+              <AccordionTrigger disabled={disabled()}>Is it accessible?</AccordionTrigger>
+              <AccordionContent>
+                Yes. It adheres to the WAI-ARIA design pattern.
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="open">
+          <Checkbox
+            checked={open()}
+            onCheckedChange={setOpen}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { AccordionPlayground }

--- a/site/ui/components/command-palette.tsx
+++ b/site/ui/components/command-palette.tsx
@@ -21,7 +21,7 @@ const getStartedItems = [
 ]
 
 const componentItems = [
-  { id: 'accordion', title: 'Accordion', href: '/docs/components/accordion', category: 'Components' },
+  { id: 'accordion', title: 'Accordion', href: '/components/accordion', category: 'Components' },
   { id: 'badge', title: 'Badge', href: '/components/badge', category: 'Components' },
   { id: 'button', title: 'Button', href: '/components/button', category: 'Components' },
   { id: 'card', title: 'Card', href: '/components/card', category: 'Components' },

--- a/site/ui/components/mobile-menu.tsx
+++ b/site/ui/components/mobile-menu.tsx
@@ -205,7 +205,7 @@ export function MobileMenu() {
                   <ChevronRightIcon size="sm" className={chevronClass} />
                 </summary>
                 <div className="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/components/accordion" className={menuLinkClass}>Accordion</a>
+                  <a href="/components/accordion" className={menuLinkClass}>Accordion</a>
                   <a href="/components/badge" className={menuLinkClass}>Badge</a>
                   <a href="/components/button" className={menuLinkClass}>Button</a>
                   <a href="/components/card" className={menuLinkClass}>Card</a>

--- a/site/ui/components/navigation-menu-demo.tsx
+++ b/site/ui/components/navigation-menu-demo.tsx
@@ -91,7 +91,7 @@ export function NavigationMenuBasicDemo() {
                 </NavigationMenuLink>
               </li>
               <li>
-                <NavigationMenuLink href="/docs/components/accordion">
+                <NavigationMenuLink href="/components/accordion">
                   <div className="text-sm font-medium leading-none">Accordion</div>
                   <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
                     Vertically collapsing content sections.

--- a/site/ui/e2e/accordion.spec.ts
+++ b/site/ui/e2e/accordion.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Accordion Documentation Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/accordion')
+    await page.goto('/components/accordion')
   })
 
   test.describe('Single Open Accordion', () => {
@@ -149,7 +149,7 @@ test.describe('Accordion Documentation Page', () => {
 
 test.describe('Accordion asChild', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/accordion')
+    await page.goto('/components/accordion')
   })
 
   test('toggles content on click with reactive state', async ({ page }) => {
@@ -206,7 +206,7 @@ test.describe('Accordion asChild', () => {
 
 test.describe('Accordion Keyboard Navigation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/accordion')
+    await page.goto('/components/accordion')
   })
 
   test('ArrowDown navigates to next accordion trigger', async ({ page }) => {

--- a/site/ui/e2e/home.spec.ts
+++ b/site/ui/e2e/home.spec.ts
@@ -18,7 +18,7 @@ test.describe('Home Page', () => {
   })
 
   test('displays component preview cards', async ({ page }) => {
-    await expect(page.locator('#components a[href="/docs/components/accordion"]')).toBeVisible()
+    await expect(page.locator('#components a[href="/components/accordion"]')).toBeVisible()
     await expect(page.locator('#components a[href="/components/button"]')).toBeVisible()
     await expect(page.locator('#components a[href="/components/card"]')).toBeVisible()
     await expect(page.locator('#components a[href="/docs/components/command"]')).toBeVisible()

--- a/site/ui/pages/components/accordion.tsx
+++ b/site/ui/pages/components/accordion.tsx
@@ -1,8 +1,12 @@
 /**
- * Accordion Documentation Page
+ * Accordion Reference Page (/components/accordion)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Migrated from /docs/components/accordion.
  */
 
 import { AccordionSingleOpenDemo, AccordionMultipleOpenDemo, AccordionAsChildDemo } from '@/components/accordion-demo'
+import { AccordionPlayground } from '@/components/accordion-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,12 +16,13 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'single-open', title: 'Single Open', branch: 'start' },
   { id: 'multiple-open', title: 'Multiple Open', branch: 'child' },
@@ -26,7 +31,13 @@ const tocItems: TocItem[] = [
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
+const usageCode = `import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion'`
+
 const singleCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
@@ -137,7 +148,6 @@ function AccordionAsChild() {
   )
 }`
 
-// Props definition
 const accordionItemProps: PropDefinition[] = [
   {
     name: 'value',
@@ -180,7 +190,7 @@ const accordionTriggerProps: PropDefinition[] = [
 
 const accordionContentProps: PropDefinition[] = []
 
-export function AccordionPage() {
+export function AccordionRefPage() {
   return (
     <DocPage slug="accordion" toc={tocItems}>
       <div className="space-y-12">
@@ -190,16 +200,21 @@ export function AccordionPage() {
           {...getNavLinks('accordion')}
         />
 
-        {/* Preview */}
-        <Example title="" code={`<Accordion>...</Accordion>`}>
-          <div className="w-full max-w-md">
-            <AccordionSingleOpenDemo />
-          </div>
-        </Example>
+        {/* Props Playground */}
+        <AccordionPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add accordion" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="w-full max-w-md">
+              <AccordionSingleOpenDemo />
+            </div>
+          </Example>
         </Section>
 
         {/* Examples */}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -73,7 +73,7 @@ const menuEntries: SidebarEntry[] = [
     title: 'Components',
     links: [
       { title: 'Browse All', href: '/components' },
-      { title: 'Accordion', href: '/docs/components/accordion' },
+      { title: 'Accordion', href: '/components/accordion' },
       { title: 'Alert', href: '/docs/components/alert' },
       { title: 'Alert Dialog', href: '/docs/components/alert-dialog' },
       { title: 'Aspect Ratio', href: '/components/aspect-ratio' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -35,7 +35,7 @@ import { ToggleGroupRefPage } from './pages/components/toggle-group'
 import { BreadcrumbPage } from './pages/breadcrumb'
 import { CalendarPage } from './pages/calendar'
 import { CheckboxRefPage } from './pages/components/checkbox'
-import { AccordionPage } from './pages/accordion'
+import { AccordionRefPage } from './pages/components/accordion'
 import { CollapsiblePage } from './pages/collapsible'
 import { CommandPage } from './pages/command'
 import { TabsPage } from './pages/tabs'
@@ -100,7 +100,7 @@ export function createApp() {
           <h2 className="text-xl font-semibold tracking-tight text-foreground">Components</h2>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <a href="/docs/components/accordion" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/accordion" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Accordion</h3>
               <p className="text-xs text-muted-foreground">Vertically collapsing content sections</p>
             </a>
@@ -470,9 +470,9 @@ export function createApp() {
     return c.render(<SwitchRefPage />)
   })
 
-  // Accordion documentation
-  app.get('/docs/components/accordion', (c) => {
-    return c.render(<AccordionPage />)
+  // Accordion reference page
+  app.get('/components/accordion', (c) => {
+    return c.render(<AccordionRefPage />)
   })
 
   // Tabs documentation


### PR DESCRIPTION
## Summary
- Migrate Accordion page from `/docs/components/accordion` to `/components/accordion` RefPage format
- Add interactive Props Playground (`accordion-playground.tsx`) with open/disabled controls
- Update all navigation links (sidebar, mobile menu, command palette, navigation-menu demo, home page)
- Update E2E tests and home page tests to use new route

## Test plan
- [x] `bun run build` passes (site/ui)
- [x] All 18 accordion E2E tests pass
- [x] All 7 home page E2E tests pass (28 total tests passing)
- [x] No remaining references to `/docs/components/accordion` in codebase (except migration comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)