### PR TITLE
Migrate Alert from /docs/components/alert to /components/alert

### DIFF
--- a/site/ui/components/alert-playground.tsx
+++ b/site/ui/components/alert-playground.tsx
@@ -1,0 +1,77 @@
+"use client"
+/**
+ * Alert Props Playground
+ *
+ * Interactive playground for the Alert component.
+ * Allows tweaking variant prop with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Alert, AlertTitle, AlertDescription } from '@ui/components/ui/alert'
+
+type AlertVariant = 'default' | 'destructive'
+
+function AlertPlayground(_props: {}) {
+  const [variant, setVariant] = createSignal<AlertVariant>('default')
+
+  const variantProp = (): HighlightProp => ({
+    name: 'variant',
+    value: variant(),
+    defaultValue: 'default',
+  })
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'Alert',
+    props: [variantProp()],
+    children: [
+      { tag: 'AlertTitle', children: 'Heads up!' },
+      { tag: 'AlertDescription', children: 'You can add components to your app using the CLI.' },
+    ],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-alert-preview"
+      previewContent={
+        <div className="w-full max-w-md">
+          <Alert variant={variant()}>
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="size-4">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m4 17 6-6-6-6" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19h8" />
+            </svg>
+            <AlertTitle>Heads up!</AlertTitle>
+            <AlertDescription>
+              You can add components to your app using the CLI.
+            </AlertDescription>
+          </Alert>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="variant">
+          <Select value={variant()} onValueChange={(v: string) => setVariant(v as AlertVariant)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="destructive">destructive</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { AlertPlayground }

--- a/site/ui/e2e/alert.spec.ts
+++ b/site/ui/e2e/alert.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Alert Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/alert')
+  })
+
+  test.describe('Props Playground', () => {
+    test('default variant renders alert with default styling', async ({ page }) => {
+      const preview = page.locator('[data-alert-preview]')
+      const alert = preview.locator('[role="alert"]')
+      await expect(alert).toBeVisible()
+      await expect(alert).toHaveClass(/bg-card/)
+    })
+
+    test('changing variant to destructive updates preview', async ({ page }) => {
+      const preview = page.locator('[data-alert-preview]')
+      const section = page.locator('#preview')
+
+      // Open variant select and pick "destructive"
+      await section.locator('button[role="combobox"]').first().click()
+      await page.locator('[role="option"]:has-text("destructive")').click()
+
+      // Preview alert should have destructive variant class
+      const alert = preview.locator('[role="alert"]')
+      await expect(alert).toHaveClass(/text-destructive/)
+    })
+  })
+})

--- a/site/ui/pages/components/alert.tsx
+++ b/site/ui/pages/components/alert.tsx
@@ -1,8 +1,12 @@
 /**
- * Alert Documentation Page
+ * Alert Reference Page (/components/alert)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
  */
 
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { AlertPlayground } from '@/components/alert-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,8 +16,8 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
 // Lucide Terminal icon (inline SVG)
 function TerminalIcon() {
@@ -37,14 +41,16 @@ function CircleAlertIcon() {
 }
 
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'default', title: 'Default', branch: 'start' },
   { id: 'destructive', title: 'Destructive', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-const previewCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+const usageCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 
 function AlertDemo() {
   return (
@@ -58,33 +64,21 @@ function AlertDemo() {
   )
 }`
 
-const defaultCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+const defaultCode = `<Alert>
+  <TerminalIcon />
+  <AlertTitle>Heads up!</AlertTitle>
+  <AlertDescription>
+    You can add components to your app using the CLI.
+  </AlertDescription>
+</Alert>`
 
-function AlertDefault() {
-  return (
-    <Alert>
-      <TerminalIcon />
-      <AlertTitle>Heads up!</AlertTitle>
-      <AlertDescription>
-        You can add components to your app using the CLI.
-      </AlertDescription>
-    </Alert>
-  )
-}`
-
-const destructiveCode = `import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
-
-function AlertDestructive() {
-  return (
-    <Alert variant="destructive">
-      <CircleAlertIcon />
-      <AlertTitle>Error</AlertTitle>
-      <AlertDescription>
-        Your session has expired. Please log in again.
-      </AlertDescription>
-    </Alert>
-  )
-}`
+const destructiveCode = `<Alert variant="destructive">
+  <CircleAlertIcon />
+  <AlertTitle>Error</AlertTitle>
+  <AlertDescription>
+    Your session has expired. Please log in again.
+  </AlertDescription>
+</Alert>`
 
 const alertProps: PropDefinition[] = [
   {
@@ -95,7 +89,7 @@ const alertProps: PropDefinition[] = [
   },
   {
     name: 'children',
-    type: 'ReactNode',
+    type: 'Child',
     description: 'The content of the alert (typically an SVG icon, AlertTitle, and AlertDescription).',
   },
 ]
@@ -103,7 +97,7 @@ const alertProps: PropDefinition[] = [
 const alertTitleProps: PropDefinition[] = [
   {
     name: 'children',
-    type: 'ReactNode',
+    type: 'Child',
     description: 'The title text of the alert.',
   },
 ]
@@ -111,12 +105,12 @@ const alertTitleProps: PropDefinition[] = [
 const alertDescriptionProps: PropDefinition[] = [
   {
     name: 'children',
-    type: 'ReactNode',
+    type: 'Child',
     description: 'The description text of the alert.',
   },
 ]
 
-export function AlertPage() {
+export function AlertRefPage() {
   return (
     <DocPage slug="alert" toc={tocItems}>
       <div className="space-y-12">
@@ -126,28 +120,33 @@ export function AlertPage() {
           {...getNavLinks('alert')}
         />
 
-        {/* Preview */}
-        <Example title="" code={previewCode}>
-          <div className="w-full">
-            <Alert>
-              <TerminalIcon />
-              <AlertTitle>Heads up!</AlertTitle>
-              <AlertDescription>
-                You can add components to your app using the CLI.
-              </AlertDescription>
-            </Alert>
-          </div>
-        </Example>
+        {/* Props Playground */}
+        <AlertPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add alert" />
         </Section>
 
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="w-full">
+              <Alert>
+                <TerminalIcon />
+                <AlertTitle>Heads up!</AlertTitle>
+                <AlertDescription>
+                  You can add components to your app using the CLI.
+                </AlertDescription>
+              </Alert>
+            </div>
+          </Example>
+        </Section>
+
         {/* Examples */}
         <Section id="examples" title="Examples">
           <div className="space-y-8">
-            <Example title="Default" code={defaultCode}>
+            <Example title="Default" code={defaultCode} showLineNumbers={false}>
               <div className="w-full">
                 <Alert>
                   <TerminalIcon />
@@ -159,7 +158,7 @@ export function AlertPage() {
               </div>
             </Example>
 
-            <Example title="Destructive" code={destructiveCode}>
+            <Example title="Destructive" code={destructiveCode} showLineNumbers={false}>
               <div className="w-full">
                 <Alert variant="destructive">
                   <CircleAlertIcon />

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -74,7 +74,7 @@ const menuEntries: SidebarEntry[] = [
     links: [
       { title: 'Browse All', href: '/components' },
       { title: 'Accordion', href: '/docs/components/accordion' },
-      { title: 'Alert', href: '/docs/components/alert' },
+      { title: 'Alert', href: '/components/alert' },
       { title: 'Alert Dialog', href: '/docs/components/alert-dialog' },
       { title: 'Aspect Ratio', href: '/components/aspect-ratio' },
       { title: 'Avatar', href: '/components/avatar' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -10,7 +10,7 @@ import { renderer } from './renderer'
 
 // Component pages
 import { AspectRatioRefPage } from './pages/components/aspect-ratio'
-import { AlertPage } from './pages/alert'
+import { AlertRefPage } from './pages/components/alert'
 import { AlertDialogPage } from './pages/alert-dialog'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
@@ -104,7 +104,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Accordion</h3>
               <p className="text-xs text-muted-foreground">Vertically collapsing content sections</p>
             </a>
-            <a href="/docs/components/alert" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/alert" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Alert</h3>
               <p className="text-xs text-muted-foreground">Callout for important content</p>
             </a>
@@ -355,9 +355,9 @@ export function createApp() {
     return c.render(<AspectRatioRefPage />)
   })
 
-  // Alert documentation
-  app.get('/docs/components/alert', (c) => {
-    return c.render(<AlertPage />)
+  // Alert reference page
+  app.get('/components/alert', (c) => {
+    return c.render(<AlertRefPage />)
   })
 
   // Alert Dialog documentation


### PR DESCRIPTION
## Summary
- Migrate Alert component page from legacy `/docs/components/alert` to new RefPage at `/components/alert`
- Add interactive Props Playground with variant control
- Add E2E tests for the playground
- Update all navigation links (sidebar, home page cards)

## Test plan
- [x] `bun run build` passes
- [x] Alert E2E tests pass (2 tests)
- [x] No remaining `/docs/components/alert` references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)