### PR TITLE
Migrate AlertDialog from /docs/components/alert-dialog to /components/alert-dialog

### DIFF
--- a/site/ui/components/alert-dialog-playground.tsx
+++ b/site/ui/components/alert-dialog-playground.tsx
@@ -1,0 +1,125 @@
+"use client"
+/**
+ * AlertDialog Props Playground
+ *
+ * Interactive playground for the AlertDialog component.
+ * Allows toggling open state with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@ui/components/ui/alert-dialog'
+
+function AlertDialogPlayground(_props: {}) {
+  const [open, setOpen] = createSignal(false)
+  const [destructive, setDestructive] = createSignal(false)
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'AlertDialog',
+    children: [
+      { tag: 'AlertDialogTrigger', children: destructive() ? 'Delete Account' : 'Show Dialog' },
+      { tag: 'AlertDialogOverlay' },
+      {
+        tag: 'AlertDialogContent',
+        children: [
+          {
+            tag: 'AlertDialogHeader',
+            children: [
+              { tag: 'AlertDialogTitle', children: destructive() ? 'Delete Account' : 'Are you absolutely sure?' },
+              { tag: 'AlertDialogDescription', children: destructive()
+                ? 'All of your data will be permanently removed.'
+                : 'This action cannot be undone.' },
+            ],
+          },
+          {
+            tag: 'AlertDialogFooter',
+            children: [
+              { tag: 'AlertDialogCancel', children: 'Cancel' },
+              {
+                tag: 'AlertDialogAction',
+                props: destructive() ? [{ name: 'className', value: 'bg-destructive text-white hover:bg-destructive/90', defaultValue: '' }] : undefined,
+                children: destructive() ? 'Delete' : 'Continue',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-alert-dialog-preview"
+      previewContent={
+        <div className="flex items-center justify-center">
+          <AlertDialog open={open()} onOpenChange={setOpen}>
+            <AlertDialogTrigger asChild={destructive()}>
+              {destructive()
+                ? <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-10 px-4 py-2 bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete Account
+                  </button>
+                : <>Show Dialog</>
+              }
+            </AlertDialogTrigger>
+            <AlertDialogOverlay />
+            <AlertDialogContent
+              ariaLabelledby="playground-alert-title"
+              ariaDescribedby="playground-alert-desc"
+            >
+              <AlertDialogHeader>
+                <AlertDialogTitle id="playground-alert-title">
+                  {destructive() ? 'Delete Account' : 'Are you absolutely sure?'}
+                </AlertDialogTitle>
+                <AlertDialogDescription id="playground-alert-desc">
+                  {destructive()
+                    ? 'Are you sure you want to delete your account? All of your data will be permanently removed.'
+                    : 'This action cannot be undone. This will permanently delete your account and remove your data from our servers.'}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction className={destructive() ? 'bg-destructive text-white hover:bg-destructive/90' : ''}>
+                  {destructive() ? 'Delete' : 'Continue'}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="destructive">
+          <Checkbox
+            checked={destructive()}
+            onCheckedChange={setDestructive}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { AlertDialogPlayground }

--- a/site/ui/e2e/alert-dialog.spec.ts
+++ b/site/ui/e2e/alert-dialog.spec.ts
@@ -3,16 +3,15 @@ import { test, expect } from '@playwright/test'
 // Click position for overlay outside the alert dialog area.
 const OVERLAY_CLICK_POSITION = { x: 10, y: 10 }
 
-// Fragment-root demos don't have bf-s attributes.
-// Trigger buttons are found directly by text; dialogs by aria-labelledby.
-const BASIC_TRIGGER = 'button:has-text("Show Dialog")'
+// Scope triggers to specific page sections to avoid matching Playground instances.
+const BASIC_TRIGGER = '#usage button:has-text("Show Dialog")'
 const BASIC_DIALOG = '[role="alertdialog"][aria-labelledby="alert-basic-title"]'
-const DESTRUCTIVE_TRIGGER = 'button:has-text("Delete Account")'
+const DESTRUCTIVE_TRIGGER = '#examples button:has-text("Delete Account")'
 const DESTRUCTIVE_DIALOG = '[role="alertdialog"][aria-labelledby="alert-destructive-title"]'
 
 test.describe('AlertDialog Documentation Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/alert-dialog')
+    await page.goto('/components/alert-dialog')
   })
 
   test.describe('Basic AlertDialog', () => {
@@ -243,7 +242,7 @@ test.describe('AlertDialog Documentation Page', () => {
 
 test.describe('AlertDialogTrigger asChild', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/alert-dialog')
+    await page.goto('/components/alert-dialog')
   })
 
   test('custom button renders as trigger with destructive styling', async ({ page }) => {

--- a/site/ui/pages/components/alert-dialog.tsx
+++ b/site/ui/pages/components/alert-dialog.tsx
@@ -1,8 +1,12 @@
 /**
- * AlertDialog Documentation Page
+ * AlertDialog Reference Page (/components/alert-dialog)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Migrated from /docs/components/alert-dialog.
  */
 
 import { AlertDialogBasicDemo, AlertDialogDestructiveDemo } from '@/components/alert-dialog-demo'
+import { AlertDialogPlayground } from '@/components/alert-dialog-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,19 +16,32 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
-  { id: 'features', title: 'Features' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'destructive', title: 'Destructive', branch: 'end' },
+  { id: 'accessibility', title: 'Accessibility' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
+const usageCode = `import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'`
+
 const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
@@ -192,7 +209,7 @@ const alertDialogActionProps: PropDefinition[] = [
   },
 ]
 
-export function AlertDialogPage() {
+export function AlertDialogRefPage() {
   return (
     <DocPage slug="alert-dialog" toc={tocItems}>
       <div className="space-y-12">
@@ -202,28 +219,21 @@ export function AlertDialogPage() {
           {...getNavLinks('alert-dialog')}
         />
 
-        {/* Preview */}
-        <Example title="" code={basicCode}>
-          <div className="flex gap-4">
-            <AlertDialogBasicDemo />
-          </div>
-        </Example>
+        {/* Props Playground */}
+        <AlertDialogPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add alert-dialog" />
         </Section>
 
-        {/* Features */}
-        <Section id="features" title="Features">
-          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li><strong className="text-foreground">ESC key to close</strong> - Press Escape to close the alert dialog</li>
-            <li><strong className="text-foreground">No outside click dismiss</strong> - Clicking the overlay does NOT close the dialog</li>
-            <li><strong className="text-foreground">Scroll lock</strong> - Body scroll is disabled when alert dialog is open</li>
-            <li><strong className="text-foreground">Focus trap</strong> - Tab/Shift+Tab cycles within the alert dialog</li>
-            <li><strong className="text-foreground">Accessibility</strong> - role="alertdialog", aria-modal="true", aria-labelledby, aria-describedby</li>
-            <li><strong className="text-foreground">Portal rendering</strong> - Alert dialog is mounted to document.body via createPortal</li>
-          </ul>
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="flex gap-4">
+              <AlertDialogBasicDemo />
+            </div>
+          </Example>
         </Section>
 
         {/* Examples */}
@@ -233,6 +243,18 @@ export function AlertDialogPage() {
               <AlertDialogDestructiveDemo />
             </Example>
           </div>
+        </Section>
+
+        {/* Accessibility */}
+        <Section id="accessibility" title="Accessibility">
+          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
+            <li><strong className="text-foreground">ESC key to close</strong> - Press Escape to close the alert dialog</li>
+            <li><strong className="text-foreground">No outside click dismiss</strong> - Clicking the overlay does NOT close the dialog</li>
+            <li><strong className="text-foreground">Scroll lock</strong> - Body scroll is disabled when alert dialog is open</li>
+            <li><strong className="text-foreground">Focus trap</strong> - Tab/Shift+Tab cycles within the alert dialog</li>
+            <li><strong className="text-foreground">ARIA</strong> - role="alertdialog", aria-modal="true", aria-labelledby, aria-describedby</li>
+            <li><strong className="text-foreground">Portal rendering</strong> - Alert dialog is mounted to document.body via createPortal</li>
+          </ul>
         </Section>
 
         {/* API Reference */}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -75,7 +75,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Browse All', href: '/components' },
       { title: 'Accordion', href: '/components/accordion' },
       { title: 'Alert', href: '/docs/components/alert' },
-      { title: 'Alert Dialog', href: '/docs/components/alert-dialog' },
+      { title: 'Alert Dialog', href: '/components/alert-dialog' },
       { title: 'Aspect Ratio', href: '/components/aspect-ratio' },
       { title: 'Avatar', href: '/components/avatar' },
       { title: 'Badge', href: '/components/badge' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -11,7 +11,7 @@ import { renderer } from './renderer'
 // Component pages
 import { AspectRatioRefPage } from './pages/components/aspect-ratio'
 import { AlertPage } from './pages/alert'
-import { AlertDialogPage } from './pages/alert-dialog'
+import { AlertDialogRefPage } from './pages/components/alert-dialog'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
 import { ComboboxRefPage } from './pages/components/combobox'
@@ -108,7 +108,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Alert</h3>
               <p className="text-xs text-muted-foreground">Callout for important content</p>
             </a>
-            <a href="/docs/components/alert-dialog" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/alert-dialog" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Alert Dialog</h3>
               <p className="text-xs text-muted-foreground">Modal dialog for important confirmations</p>
             </a>
@@ -360,9 +360,9 @@ export function createApp() {
     return c.render(<AlertPage />)
   })
 
-  // Alert Dialog documentation
-  app.get('/docs/components/alert-dialog', (c) => {
-    return c.render(<AlertDialogPage />)
+  // Alert Dialog reference page
+  app.get('/components/alert-dialog', (c) => {
+    return c.render(<AlertDialogRefPage />)
   })
 
   // Badge reference page


### PR DESCRIPTION
## Summary
- Migrate AlertDialog documentation page from `/docs/components/alert-dialog` to `/components/alert-dialog` using the new RefPage format
- Add interactive `AlertDialogPlayground` with destructive variant toggle
- Update routes, sidebar nav, home page card link, and E2E tests to use new path
- Delete old `site/ui/pages/alert-dialog.tsx`

## Test plan
- [x] `bun run build` passes
- [x] All 20 alert-dialog E2E tests pass (chromium)
- [x] No remaining references to `/docs/components/alert-dialog` in codebase (except migration comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)