### PR TITLE
Migrate Breadcrumb from /docs/components/breadcrumb to /components/breadcrumb

### DIFF
--- a/site/ui/components/breadcrumb-playground.tsx
+++ b/site/ui/components/breadcrumb-playground.tsx
@@ -1,0 +1,126 @@
+"use client"
+/**
+ * Breadcrumb Props Playground
+ *
+ * Interactive playground for the Breadcrumb component.
+ * Allows tweaking separator style and ellipsis visibility with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from '@ui/components/ui/breadcrumb'
+
+type SeparatorStyle = 'default' | 'slash'
+
+function BreadcrumbPlayground(_props: {}) {
+  const [separator, setSeparator] = createSignal<SeparatorStyle>('default')
+  const [showEllipsis, setShowEllipsis] = createSignal(false)
+
+  const separatorNode = (): JsxTreeNode => {
+    if (separator() === 'slash') {
+      return { tag: 'BreadcrumbSeparator', children: '/' }
+    }
+    return { tag: 'BreadcrumbSeparator' }
+  }
+
+  const tree = (): JsxTreeNode => {
+    const items: JsxTreeNode[] = [
+      {
+        tag: 'BreadcrumbItem',
+        children: [{ tag: 'BreadcrumbLink', props: [{ name: 'href', value: '#', defaultValue: '' }], children: 'Home' }],
+      },
+      separatorNode(),
+    ]
+
+    if (showEllipsis()) {
+      items.push({ tag: 'BreadcrumbItem', children: [{ tag: 'BreadcrumbEllipsis' }] })
+      items.push(separatorNode())
+    }
+
+    items.push({
+      tag: 'BreadcrumbItem',
+      children: [{ tag: 'BreadcrumbLink', props: [{ name: 'href', value: '#', defaultValue: '' }], children: 'Components' }],
+    })
+    items.push(separatorNode())
+    items.push({
+      tag: 'BreadcrumbItem',
+      children: [{ tag: 'BreadcrumbPage', children: 'Breadcrumb' }],
+    })
+
+    return {
+      tag: 'Breadcrumb',
+      children: [{ tag: 'BreadcrumbList', children: items }],
+    }
+  }
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  const separatorContent = () => separator() === 'slash' ? '/' : undefined
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-breadcrumb-preview"
+      previewContent={
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="#">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>{separatorContent()}</BreadcrumbSeparator>
+            {showEllipsis() && <>
+              <BreadcrumbItem>
+                <BreadcrumbEllipsis />
+              </BreadcrumbItem>
+              <BreadcrumbSeparator>{separatorContent()}</BreadcrumbSeparator>
+            </>}
+            <BreadcrumbItem>
+              <BreadcrumbLink href="#">Components</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>{separatorContent()}</BreadcrumbSeparator>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      }
+      controls={<>
+        <PlaygroundControl label="separator">
+          <Select value={separator()} onValueChange={(v: string) => setSeparator(v as SeparatorStyle)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select separator..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default (chevron)</SelectItem>
+              <SelectItem value="slash">slash (/)</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="ellipsis">
+          <Checkbox
+            checked={showEllipsis()}
+            onCheckedChange={setShowEllipsis}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { BreadcrumbPlayground }

--- a/site/ui/e2e/breadcrumb.spec.ts
+++ b/site/ui/e2e/breadcrumb.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Breadcrumb Documentation Page', () => {
+test.describe('Breadcrumb Reference Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/breadcrumb')
+    await page.goto('/components/breadcrumb')
   })
 
   test.describe('Breadcrumb Structure', () => {

--- a/site/ui/pages/components/breadcrumb.tsx
+++ b/site/ui/pages/components/breadcrumb.tsx
@@ -1,13 +1,16 @@
 /**
- * Breadcrumb Documentation Page
+ * Breadcrumb Reference Page (/components/breadcrumb)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Migrated from /docs/components/breadcrumb.
  */
 
 import {
-  BreadcrumbPreviewDemo,
   BreadcrumbBasicDemo,
   BreadcrumbEllipsisDemo,
   BreadcrumbCustomSeparatorDemo,
 } from '@/components/breadcrumb-demo'
+import { BreadcrumbPlayground } from '@/components/breadcrumb-playground'
 import {
   DocPage,
   PageHeader,
@@ -17,12 +20,13 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'ellipsis', title: 'Ellipsis', branch: 'child' },
@@ -30,8 +34,7 @@ const tocItems: TocItem[] = [
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
-const previewCode = `import {
+const usageCode = `import {
   Breadcrumb,
   BreadcrumbList,
   BreadcrumbItem,
@@ -39,31 +42,7 @@ const previewCode = `import {
   BreadcrumbPage,
   BreadcrumbSeparator,
   BreadcrumbEllipsis,
-} from '@/components/ui/breadcrumb'
-
-function BreadcrumbPreview() {
-  return (
-    <Breadcrumb>
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink href="#">Home</BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbEllipsis />
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbLink href="#">Components</BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
-  )
-}`
+} from '@/components/ui/breadcrumb'`
 
 const basicCode = `import {
   Breadcrumb,
@@ -222,7 +201,7 @@ const breadcrumbSeparatorProps: PropDefinition[] = [
   },
 ]
 
-export function BreadcrumbPage() {
+export function BreadcrumbRefPage() {
   return (
     <DocPage slug="breadcrumb" toc={tocItems}>
       <div className="space-y-12">
@@ -232,14 +211,19 @@ export function BreadcrumbPage() {
           {...getNavLinks('breadcrumb')}
         />
 
-        {/* Preview */}
-        <Example title="" code={previewCode}>
-          <BreadcrumbPreviewDemo />
-        </Example>
+        {/* Props Playground */}
+        <BreadcrumbPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add breadcrumb" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <BreadcrumbBasicDemo />
+          </Example>
         </Section>
 
         {/* Examples */}
@@ -261,29 +245,29 @@ export function BreadcrumbPage() {
 
         {/* API Reference */}
         <Section id="api-reference" title="API Reference">
-          <div className="space-y-8">
+          <div className="space-y-6">
             <div>
-              <h3 className="text-lg font-semibold mb-4">Breadcrumb</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">Breadcrumb</h3>
               <PropsTable props={breadcrumbProps} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold mb-4">BreadcrumbList</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">BreadcrumbList</h3>
               <PropsTable props={breadcrumbListProps} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold mb-4">BreadcrumbItem</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">BreadcrumbItem</h3>
               <PropsTable props={breadcrumbItemProps} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold mb-4">BreadcrumbLink</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">BreadcrumbLink</h3>
               <PropsTable props={breadcrumbLinkProps} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold mb-4">BreadcrumbPage</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">BreadcrumbPage</h3>
               <PropsTable props={breadcrumbPageProps} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold mb-4">BreadcrumbSeparator</h3>
+              <h3 className="text-lg font-medium text-foreground mb-4">BreadcrumbSeparator</h3>
               <PropsTable props={breadcrumbSeparatorProps} />
             </div>
           </div>

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -79,7 +79,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Aspect Ratio', href: '/components/aspect-ratio' },
       { title: 'Avatar', href: '/components/avatar' },
       { title: 'Badge', href: '/components/badge' },
-      { title: 'Breadcrumb', href: '/docs/components/breadcrumb' },
+      { title: 'Breadcrumb', href: '/components/breadcrumb' },
       { title: 'Button', href: '/components/button' },
       { title: 'Calendar', href: '/components/calendar' },
       { title: 'Card', href: '/components/card' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -32,7 +32,7 @@ import { RadioGroupRefPage } from './pages/components/radio-group'
 import { InputOTPRefPage } from './pages/components/input-otp'
 import { SliderRefPage } from './pages/components/slider'
 import { ToggleGroupRefPage } from './pages/components/toggle-group'
-import { BreadcrumbPage } from './pages/breadcrumb'
+import { BreadcrumbRefPage } from './pages/components/breadcrumb'
 import { CalendarPage } from './pages/calendar'
 import { CheckboxRefPage } from './pages/components/checkbox'
 import { AccordionRefPage } from './pages/components/accordion'
@@ -124,7 +124,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Badge</h3>
               <p className="text-xs text-muted-foreground">Small status indicator labels</p>
             </a>
-            <a href="/docs/components/breadcrumb" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/breadcrumb" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Breadcrumb</h3>
               <p className="text-xs text-muted-foreground">Navigation hierarchy trail</p>
             </a>
@@ -435,9 +435,9 @@ export function createApp() {
     return c.render(<TableRefPage />)
   })
 
-  // Breadcrumb documentation
-  app.get('/docs/components/breadcrumb', (c) => {
-    return c.render(<BreadcrumbPage />)
+  // Breadcrumb reference page
+  app.get('/components/breadcrumb', (c) => {
+    return c.render(<BreadcrumbRefPage />)
   })
 
   // Collapsible documentation


### PR DESCRIPTION
## Summary
- Migrate Breadcrumb documentation page from `/docs/components/breadcrumb` to `/components/breadcrumb` RefPage format
- Add interactive `BreadcrumbPlayground` with separator style and ellipsis toggle controls
- Update all navigation links (sidebar, home page cards, E2E tests) to new route

## Changes
- **New**: `site/ui/pages/components/breadcrumb.tsx` — RefPage with Preview, Installation, Usage, Examples (Basic, Ellipsis, Custom Separator), and API Reference sections
- **New**: `site/ui/components/breadcrumb-playground.tsx` — Interactive playground with separator and ellipsis controls
- **Deleted**: `site/ui/pages/breadcrumb.tsx` — Old documentation page
- **Updated**: `site/ui/routes.tsx` — Route + import + home card link migration
- **Updated**: `site/ui/renderer.tsx` — Sidebar nav link
- **Updated**: `site/ui/e2e/breadcrumb.spec.ts` — Points to new URL

## Test plan
- [x] `bun run build` passes
- [x] Breadcrumb E2E tests pass (8/8)
- [x] No remaining references to `/docs/components/breadcrumb` in codebase (except migration comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)