### PR TITLE
Migrate Collapsible from /docs/components/collapsible to /components/collapsible

### DIFF
--- a/site/ui/components/collapsible-playground.tsx
+++ b/site/ui/components/collapsible-playground.tsx
@@ -1,0 +1,96 @@
+"use client"
+/**
+ * Collapsible Props Playground
+ *
+ * Interactive playground for the Collapsible component.
+ * Allows tweaking open state and disabled props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type HighlightProp, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@ui/components/ui/collapsible'
+import { Button } from '@ui/components/ui/button'
+import { ChevronDownIcon } from '@ui/components/ui/icon'
+
+function CollapsiblePlayground(_props: {}) {
+  const [open, setOpen] = createSignal(true)
+  const [disabled, setDisabled] = createSignal(false)
+
+  const collapsibleProps = (): HighlightProp[] => [
+    { name: 'open', value: String(open()), defaultValue: 'false', kind: 'expression' },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+  ]
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'Collapsible',
+    props: collapsibleProps(),
+    children: [
+      { tag: 'CollapsibleTrigger', children: 'Toggle' },
+      { tag: 'CollapsibleContent', children: 'Hidden content here' },
+    ],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-collapsible-preview"
+      previewContent={
+        <div className="w-full max-w-sm">
+          <Collapsible open={open()} onOpenChange={setOpen} disabled={disabled()} className="space-y-2">
+            <div className="flex items-center justify-between space-x-4">
+              <h4 className="text-sm font-semibold">
+                @barefootjs/dom has 3 repositories
+              </h4>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm" className="w-9 p-0">
+                  <ChevronDownIcon size="sm" className="transition-transform duration-normal" />
+                  <span className="sr-only">Toggle</span>
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+            <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+              @barefootjs/dom
+            </div>
+            <CollapsibleContent className="space-y-2">
+              <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+                @barefootjs/jsx
+              </div>
+              <div className="rounded-md border border-border px-4 py-2 font-mono text-sm shadow-xs">
+                @barefootjs/hono
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="open">
+          <Checkbox
+            checked={open()}
+            onCheckedChange={setOpen}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { CollapsiblePlayground }

--- a/site/ui/e2e/collapsible.spec.ts
+++ b/site/ui/e2e/collapsible.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Collapsible Documentation Page', () => {
+test.describe('Collapsible Reference Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/collapsible')
+    await page.goto('/components/collapsible')
   })
 
   test.describe('Basic Demo', () => {

--- a/site/ui/pages/components/collapsible.tsx
+++ b/site/ui/pages/components/collapsible.tsx
@@ -1,8 +1,12 @@
 /**
- * Collapsible Documentation Page
+ * Collapsible Reference Page (/components/collapsible)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Migrated from /docs/components/collapsible.
  */
 
 import { CollapsibleBasicDemo, CollapsibleControlledDemo, CollapsibleDisabledDemo } from '@/components/collapsible-demo'
+import { CollapsiblePlayground } from '@/components/collapsible-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,20 +16,27 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'controlled', title: 'Controlled', branch: 'child' },
   { id: 'disabled', title: 'Disabled', branch: 'end' },
+  { id: 'accessibility', title: 'Accessibility' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
+const usageCode = `import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'`
+
 const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
@@ -149,7 +160,6 @@ function CollapsibleDisabled() {
   )
 }`
 
-// Props definitions
 const collapsibleProps: PropDefinition[] = [
   {
     name: 'open',
@@ -186,7 +196,7 @@ const collapsibleTriggerProps: PropDefinition[] = [
 
 const collapsibleContentProps: PropDefinition[] = []
 
-export function CollapsiblePage() {
+export function CollapsibleRefPage() {
   return (
     <DocPage slug="collapsible" toc={tocItems}>
       <div className="space-y-12">
@@ -196,14 +206,19 @@ export function CollapsiblePage() {
           {...getNavLinks('collapsible')}
         />
 
-        {/* Preview */}
-        <Example title="" code={`<Collapsible>...</Collapsible>`}>
-          <CollapsibleBasicDemo />
-        </Example>
+        {/* Props Playground */}
+        <CollapsiblePlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add collapsible" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <CollapsibleBasicDemo />
+          </Example>
         </Section>
 
         {/* Examples */}
@@ -221,6 +236,16 @@ export function CollapsiblePage() {
               <CollapsibleDisabledDemo />
             </Example>
           </div>
+        </Section>
+
+        {/* Accessibility */}
+        <Section id="accessibility" title="Accessibility">
+          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
+            <li><strong className="text-foreground">Activation</strong> - Enter/Space to toggle collapsible content</li>
+            <li><strong className="text-foreground">ARIA</strong> - Trigger uses aria-expanded; Content uses aria-labelledby</li>
+            <li><strong className="text-foreground">Disabled State</strong> - data-disabled on the collapsible, interaction is blocked</li>
+            <li><strong className="text-foreground">Screen Readers</strong> - State changes are announced when content is expanded/collapsed</li>
+          </ul>
         </Section>
 
         {/* API Reference */}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -85,7 +85,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Card', href: '/components/card' },
       { title: 'Carousel', href: '/components/carousel' },
       { title: 'Checkbox', href: '/components/checkbox' },
-      { title: 'Collapsible', href: '/docs/components/collapsible' },
+      { title: 'Collapsible', href: '/components/collapsible' },
       { title: 'Command', href: '/docs/components/command' },
       { title: 'Combobox', href: '/components/combobox' },
       { title: 'Context Menu', href: '/docs/components/context-menu' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -36,7 +36,7 @@ import { BreadcrumbPage } from './pages/breadcrumb'
 import { CalendarPage } from './pages/calendar'
 import { CheckboxRefPage } from './pages/components/checkbox'
 import { AccordionRefPage } from './pages/components/accordion'
-import { CollapsiblePage } from './pages/collapsible'
+import { CollapsibleRefPage } from './pages/components/collapsible'
 import { CommandPage } from './pages/command'
 import { TabsPage } from './pages/tabs'
 import { DialogPage } from './pages/dialog'
@@ -148,7 +148,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Checkbox</h3>
               <p className="text-xs text-muted-foreground">Toggle selection control</p>
             </a>
-            <a href="/docs/components/collapsible" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/collapsible" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Collapsible</h3>
               <p className="text-xs text-muted-foreground">Expandable content section</p>
             </a>
@@ -440,9 +440,9 @@ export function createApp() {
     return c.render(<BreadcrumbPage />)
   })
 
-  // Collapsible documentation
-  app.get('/docs/components/collapsible', (c) => {
-    return c.render(<CollapsiblePage />)
+  // Collapsible reference page
+  app.get('/components/collapsible', (c) => {
+    return c.render(<CollapsibleRefPage />)
   })
 
   // Command documentation


### PR DESCRIPTION
## Summary
- Migrate Collapsible component page from `/docs/components/collapsible` to `/components/collapsible` RefPage pattern
- Add interactive Props Playground (`collapsible-playground.tsx`) with open/disabled controls
- Add Usage, Accessibility, and structured Examples sections following the RefPage convention
- Update all navigation links (sidebar, home page card) and E2E tests to use new path

## Test plan
- [x] `bun run build` passes
- [x] `bun run test:e2e -- --grep "Collapsible"` — all 16 tests pass
- [x] No remaining references to `/docs/components/collapsible` in codebase (except migration comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)