### PR TITLE
Migrate HoverCard from /docs/components/hover-card to /components/hover-card

### DIFF
--- a/site/ui/components/hover-card-playground.tsx
+++ b/site/ui/components/hover-card-playground.tsx
@@ -1,0 +1,112 @@
+"use client"
+/**
+ * Hover Card Props Playground
+ *
+ * Interactive playground for the HoverCard component.
+ * Allows tweaking align and side props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type HighlightProp, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '@ui/components/ui/hover-card'
+
+function HoverCardPlayground(_props: {}) {
+  const [open, setOpen] = createSignal(false)
+  const [align, setAlign] = createSignal<'start' | 'center' | 'end'>('center')
+  const [side, setSide] = createSignal<'top' | 'bottom'>('bottom')
+
+  const contentProps = (): HighlightProp[] => [
+    { name: 'align', value: align(), defaultValue: 'center' },
+    { name: 'side', value: side(), defaultValue: 'bottom' },
+  ]
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'HoverCard',
+    children: [
+      {
+        tag: 'HoverCardTrigger',
+        children: '@barefootjs',
+      },
+      {
+        tag: 'HoverCardContent',
+        props: contentProps(),
+        children: 'Rich content displayed on hover.',
+      },
+    ],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-hover-card-preview"
+      previewContent={
+        <div className="flex items-center justify-center min-h-[200px]">
+          <HoverCard open={open()} onOpenChange={setOpen}>
+            <HoverCardTrigger>
+              <a
+                href="#"
+                className="text-sm font-medium underline underline-offset-4 decoration-primary hover:text-primary"
+                onClick={(e: MouseEvent) => e.preventDefault()}
+              >
+                @barefootjs
+              </a>
+            </HoverCardTrigger>
+            <HoverCardContent align={align()} side={side()} className="w-80">
+              <div className="flex justify-between space-x-4">
+                <div className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground text-lg font-bold shrink-0">
+                  B
+                </div>
+                <div className="space-y-1">
+                  <h4 className="text-sm font-semibold">@barefootjs</h4>
+                  <p className="text-sm text-muted-foreground">
+                    JSX to Marked Template + client JS compiler.
+                  </p>
+                </div>
+              </div>
+            </HoverCardContent>
+          </HoverCard>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="align">
+          <Select value={align()} onValueChange={(v: string) => setAlign(v as 'start' | 'center' | 'end')}>
+            <SelectTrigger className="w-28 h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="start">start</SelectItem>
+              <SelectItem value="center">center</SelectItem>
+              <SelectItem value="end">end</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="side">
+          <Select value={side()} onValueChange={(v: string) => setSide(v as 'top' | 'bottom')}>
+            <SelectTrigger className="w-28 h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="top">top</SelectItem>
+              <SelectItem value="bottom">bottom</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { HoverCardPlayground }

--- a/site/ui/e2e/hover-card.spec.ts
+++ b/site/ui/e2e/hover-card.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Hover Card Documentation Page', () => {
+test.describe('Hover Card Reference Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/hover-card')
+    await page.goto('/components/hover-card')
   })
 
   test.describe('Preview Demo', () => {

--- a/site/ui/pages/components/hover-card.tsx
+++ b/site/ui/pages/components/hover-card.tsx
@@ -1,8 +1,12 @@
 /**
- * Hover Card Documentation Page
+ * Hover Card Reference Page (/components/hover-card)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Migrated from /docs/components/hover-card.
  */
 
 import { HoverCardPreviewDemo, HoverCardBasicDemo } from '@/components/hover-card-demo'
+import { HoverCardPlayground } from '@/components/hover-card-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,18 +16,24 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
+const usageCode = `import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '@/components/ui/hover-card'`
+
 const basicCode = `"use client"
 
 import { createSignal } from '@barefootjs/dom'
@@ -55,43 +65,6 @@ function BasicHoverCard() {
   )
 }`
 
-const profileCode = `"use client"
-
-import { createSignal } from '@barefootjs/dom'
-import {
-  HoverCard,
-  HoverCardTrigger,
-  HoverCardContent,
-} from '@/components/ui/hover-card'
-
-function ProfileHoverCard() {
-  const [open, setOpen] = createSignal(false)
-
-  return (
-    <HoverCard open={open()} onOpenChange={setOpen}>
-      <HoverCardTrigger>
-        <a href="#" className="text-sm font-medium underline underline-offset-4">
-          @barefootjs
-        </a>
-      </HoverCardTrigger>
-      <HoverCardContent align="start" class="w-80">
-        <div className="flex justify-between space-x-4">
-          <div className="flex size-10 items-center justify-center rounded-full bg-muted text-lg font-bold shrink-0">
-            B
-          </div>
-          <div className="space-y-1">
-            <h4 className="text-sm font-semibold">@barefootjs</h4>
-            <p className="text-sm text-muted-foreground">
-              JSX to Marked Template + client JS compiler.
-            </p>
-          </div>
-        </div>
-      </HoverCardContent>
-    </HoverCard>
-  )
-}`
-
-// Props definitions
 const hoverCardProps: PropDefinition[] = [
   {
     name: 'open',
@@ -142,7 +115,7 @@ const hoverCardContentProps: PropDefinition[] = [
   },
 ]
 
-export function HoverCardPage() {
+export function HoverCardRefPage() {
   return (
     <DocPage slug="hover-card" toc={tocItems}>
       <div className="space-y-12">
@@ -152,16 +125,21 @@ export function HoverCardPage() {
           {...getNavLinks('hover-card')}
         />
 
-        {/* Preview */}
-        <Example title="" code={profileCode}>
-          <div className="flex gap-4">
-            <HoverCardPreviewDemo />
-          </div>
-        </Example>
+        {/* Props Playground */}
+        <HoverCardPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add hover-card" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="flex gap-4">
+              <HoverCardPreviewDemo />
+            </div>
+          </Example>
         </Section>
 
         {/* Examples */}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -94,7 +94,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Dialog', href: '/docs/components/dialog' },
       { title: 'Drawer', href: '/docs/components/drawer' },
       { title: 'Dropdown Menu', href: '/docs/components/dropdown-menu' },
-      { title: 'Hover Card', href: '/docs/components/hover-card' },
+      { title: 'Hover Card', href: '/components/hover-card' },
       { title: 'Input', href: '/components/input' },
       { title: 'Input OTP', href: '/components/input-otp' },
       { title: 'Label', href: '/components/label' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -55,7 +55,7 @@ import { ProgressPage } from './pages/progress'
 import { DrawerPage } from './pages/drawer'
 import { SheetPage } from './pages/sheet'
 import { SidebarPage } from './pages/sidebar'
-import { HoverCardPage } from './pages/hover-card'
+import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarPage } from './pages/menubar'
 import { NavigationMenuPage } from './pages/navigation-menu'
 import { SpinnerPage } from './pages/spinner'
@@ -184,7 +184,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Dropdown Menu</h3>
               <p className="text-xs text-muted-foreground">Action menu triggered by a button</p>
             </a>
-            <a href="/docs/components/hover-card" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/hover-card" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Hover Card</h3>
               <p className="text-xs text-muted-foreground">Preview card on hover</p>
             </a>
@@ -568,9 +568,9 @@ export function createApp() {
   })
 
 
-  // Hover Card documentation
-  app.get('/docs/components/hover-card', (c) => {
-    return c.render(<HoverCardPage />)
+  // Hover Card reference page
+  app.get('/components/hover-card', (c) => {
+    return c.render(<HoverCardRefPage />)
   })
 
   // Resizable reference page


### PR DESCRIPTION
## Summary

- Create new RefPage at `site/ui/pages/components/hover-card.tsx` with interactive Props Playground, Installation, Usage, Examples, and API Reference sections
- Create `site/ui/components/hover-card-playground.tsx` with align/side prop controls
- Delete old page `site/ui/pages/hover-card.tsx`
- Update routes, sidebar nav, home page card link, and E2E tests to use `/components/hover-card`

## Test plan

- [x] `bun run build` passes
- [x] `bun run test:e2e -- --grep "Hover Card"` — all 7 tests pass
- [x] No remaining references to `/docs/components/hover-card` in codebase (except migration comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)