### PR TITLE
Migrate Navigation Menu from /docs/components/ to /components/

### DIFF
--- a/site/ui/components/navigation-menu-playground.tsx
+++ b/site/ui/components/navigation-menu-playground.tsx
@@ -1,0 +1,141 @@
+"use client"
+/**
+ * Navigation Menu Props Playground
+ *
+ * Interactive playground for the NavigationMenu component.
+ * Allows tweaking delayDuration and closeDelay props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type HighlightProp, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+} from '@ui/components/ui/navigation-menu'
+
+const delayOptions = ['0', '100', '200', '400']
+const closeDelayOptions = ['0', '150', '300', '600']
+
+function NavigationMenuPlayground(_props: {}) {
+  const [delayDuration, setDelayDuration] = createSignal('200')
+  const [closeDelay, setCloseDelay] = createSignal('300')
+
+  const menuProps = (): HighlightProp[] => [
+    { name: 'delayDuration', value: delayDuration(), defaultValue: '200', kind: 'expression' },
+    { name: 'closeDelay', value: closeDelay(), defaultValue: '300', kind: 'expression' },
+  ]
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'NavigationMenu',
+    props: menuProps(),
+    children: [{
+      tag: 'NavigationMenuList',
+      children: [{
+        tag: 'NavigationMenuItem',
+        props: [{ name: 'value', value: 'getting-started', defaultValue: '' }],
+        children: [
+          { tag: 'NavigationMenuTrigger', children: 'Getting Started' },
+          { tag: 'NavigationMenuContent', children: '...' },
+        ],
+      }],
+    }],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-navigation-menu-preview"
+      previewContent={
+        <div className="w-full">
+          <NavigationMenu delayDuration={Number(delayDuration())} closeDelay={Number(closeDelay())}>
+            <NavigationMenuList>
+              <NavigationMenuItem value="getting-started">
+                <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+                <NavigationMenuContent className="w-[400px]">
+                  <ul className="grid gap-3 p-4 md:grid-cols-2">
+                    <li>
+                      <NavigationMenuLink href="/docs">
+                        <div className="text-sm font-medium leading-none">Introduction</div>
+                        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                          Learn the basics.
+                        </p>
+                      </NavigationMenuLink>
+                    </li>
+                    <li>
+                      <NavigationMenuLink href="/docs/installation">
+                        <div className="text-sm font-medium leading-none">Installation</div>
+                        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                          How to install and configure.
+                        </p>
+                      </NavigationMenuLink>
+                    </li>
+                  </ul>
+                </NavigationMenuContent>
+              </NavigationMenuItem>
+              <NavigationMenuItem value="components">
+                <NavigationMenuTrigger>Components</NavigationMenuTrigger>
+                <NavigationMenuContent className="w-[400px]">
+                  <ul className="grid gap-3 p-4 md:grid-cols-2">
+                    <li>
+                      <NavigationMenuLink href="/components/button">
+                        <div className="text-sm font-medium leading-none">Button</div>
+                        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                          Clickable actions with multiple variants.
+                        </p>
+                      </NavigationMenuLink>
+                    </li>
+                    <li>
+                      <NavigationMenuLink href="/components/accordion">
+                        <div className="text-sm font-medium leading-none">Accordion</div>
+                        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                          Vertically collapsing content sections.
+                        </p>
+                      </NavigationMenuLink>
+                    </li>
+                  </ul>
+                </NavigationMenuContent>
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="delayDuration">
+          <Select value={delayDuration()} onValueChange={(v: string) => setDelayDuration(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select delay..." />
+            </SelectTrigger>
+            <SelectContent>
+              {delayOptions.map(v => <SelectItem value={v}>{v}ms</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="closeDelay">
+          <Select value={closeDelay()} onValueChange={(v: string) => setCloseDelay(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select close delay..." />
+            </SelectTrigger>
+            <SelectContent>
+              {closeDelayOptions.map(v => <SelectItem value={v}>{v}ms</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { NavigationMenuPlayground }

--- a/site/ui/e2e/navigation-menu.spec.ts
+++ b/site/ui/e2e/navigation-menu.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Navigation Menu Documentation Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/navigation-menu')
+    await page.goto('/components/navigation-menu')
   })
 
   test.describe('Basic Demo', () => {

--- a/site/ui/pages/components/navigation-menu.tsx
+++ b/site/ui/pages/components/navigation-menu.tsx
@@ -1,8 +1,12 @@
 /**
- * Navigation Menu Documentation Page
+ * Navigation Menu Reference Page (/components/navigation-menu)
+ *
+ * Focused developer reference with interactive Props Playground.
+ * Part of the #515 page redesign initiative.
  */
 
 import { NavigationMenuBasicDemo, NavigationMenuWithLinksDemo } from '@/components/navigation-menu-demo'
+import { NavigationMenuPlayground } from '@/components/navigation-menu-playground'
 import {
   DocPage,
   PageHeader,
@@ -12,20 +16,54 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
-  { id: 'features', title: 'Features' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'with-links', title: 'With Links', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
+const usageCode = `"use client"
+
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+} from '@/components/ui/navigation-menu'
+
+function BasicNavigationMenu() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem value="getting-started">
+          <NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
+          <NavigationMenuContent className="w-[400px] md:w-[500px]">
+            <ul className="grid gap-3 p-4 md:grid-cols-2">
+              <li>
+                <NavigationMenuLink href="/docs">
+                  <div className="text-sm font-medium">Introduction</div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Learn the basics.
+                  </p>
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}`
+
 const basicCode = `"use client"
 
 import {
@@ -167,7 +205,7 @@ const navigationMenuLinkProps: PropDefinition[] = [
   },
 ]
 
-export function NavigationMenuPage() {
+export function NavigationMenuRefPage() {
   return (
     <DocPage slug="navigation-menu" toc={tocItems}>
       <div className="space-y-12">
@@ -177,26 +215,19 @@ export function NavigationMenuPage() {
           {...getNavLinks('navigation-menu')}
         />
 
-        {/* Preview */}
-        <Example title="" code={`<NavigationMenu><NavigationMenuList><NavigationMenuItem>...</NavigationMenuItem></NavigationMenuList></NavigationMenu>`}>
-          <NavigationMenuBasicDemo />
-        </Example>
+        {/* Props Playground */}
+        <NavigationMenuPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add navigation-menu" />
         </Section>
 
-        {/* Features */}
-        <Section id="features" title="Features">
-          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
-            <li><strong className="text-foreground">Hover with delay</strong> - Content opens after a configurable delay (200ms default)</li>
-            <li><strong className="text-foreground">Close delay</strong> - Content stays open briefly when moving mouse (300ms default)</li>
-            <li><strong className="text-foreground">Click toggle</strong> - Click triggers to toggle content panels</li>
-            <li><strong className="text-foreground">Keyboard navigation</strong> - ArrowLeft/Right navigates between triggers</li>
-            <li><strong className="text-foreground">Active page</strong> - NavigationMenuLink supports aria-current for active page indication</li>
-            <li><strong className="text-foreground">Mixed content</strong> - Combine trigger menus with direct links</li>
-          </ul>
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <NavigationMenuBasicDemo />
+          </Example>
         </Section>
 
         {/* Examples */}
@@ -215,27 +246,27 @@ export function NavigationMenuPage() {
         <Section id="api-reference" title="API Reference">
           <div className="space-y-6">
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenu</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenu</h3>
               <PropsTable props={navigationMenuProps} />
             </div>
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuList</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenuList</h3>
               <p className="text-sm text-muted-foreground">Styled list wrapper. Renders as &lt;ul&gt;.</p>
             </div>
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuItem</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenuItem</h3>
               <PropsTable props={navigationMenuItemProps} />
             </div>
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuTrigger</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenuTrigger</h3>
               <PropsTable props={navigationMenuTriggerProps} />
             </div>
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuContent</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenuContent</h3>
               <PropsTable props={navigationMenuContentProps} />
             </div>
             <div>
-              <h3 className="text-lg font-medium text-foreground mb-4">NavigationMenuLink</h3>
+              <h3 className="text-lg font-semibold mb-3">NavigationMenuLink</h3>
               <PropsTable props={navigationMenuLinkProps} />
             </div>
           </div>

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -99,7 +99,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Input OTP', href: '/components/input-otp' },
       { title: 'Label', href: '/components/label' },
       { title: 'Menubar', href: '/docs/components/menubar' },
-      { title: 'Navigation Menu', href: '/docs/components/navigation-menu' },
+      { title: 'Navigation Menu', href: '/components/navigation-menu' },
       { title: 'Pagination', href: '/docs/components/pagination' },
       { title: 'Popover', href: '/docs/components/popover' },
       { title: 'Progress', href: '/docs/components/progress' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -57,7 +57,7 @@ import { SheetPage } from './pages/sheet'
 import { SidebarPage } from './pages/sidebar'
 import { HoverCardPage } from './pages/hover-card'
 import { MenubarPage } from './pages/menubar'
-import { NavigationMenuPage } from './pages/navigation-menu'
+import { NavigationMenuRefPage } from './pages/components/navigation-menu'
 import { SpinnerPage } from './pages/spinner'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
@@ -204,7 +204,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Menubar</h3>
               <p className="text-xs text-muted-foreground">Desktop application menu bar</p>
             </a>
-            <a href="/docs/components/navigation-menu" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/navigation-menu" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Navigation Menu</h3>
               <p className="text-xs text-muted-foreground">Hover-activated navigation links</p>
             </a>
@@ -547,9 +547,9 @@ export function createApp() {
     return c.render(<MenubarPage />)
   })
 
-  // Navigation Menu documentation
-  app.get('/docs/components/navigation-menu', (c) => {
-    return c.render(<NavigationMenuPage />)
+  // Navigation Menu reference page
+  app.get('/components/navigation-menu', (c) => {
+    return c.render(<NavigationMenuRefPage />)
   })
 
   // Pagination documentation


### PR DESCRIPTION
## Summary
- Migrate Navigation Menu page from `/docs/components/navigation-menu` to `/components/navigation-menu` (RefPage format)
- Add interactive NavigationMenuPlayground with delayDuration and closeDelay controls
- Update routes, sidebar nav, homepage card link, and E2E test URL
- Delete old page file (`site/ui/pages/navigation-menu.tsx`)

## Test plan
- [x] `bun run build` passes
- [x] All 15 Navigation Menu E2E tests pass
- [x] No remaining references to `/docs/components/navigation-menu` in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)