### PR TITLE
Add Line Chart component

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -41,12 +41,14 @@
     "@barefootjs/dom": ">=0.0.1"
   },
   "dependencies": {
+    "d3-array": "^3.2.4",
     "d3-scale": "^4.0.2",
-    "d3-array": "^3.2.4"
+    "d3-shape": "^3.2.0"
   },
   "devDependencies": {
-    "@types/d3-scale": "^4.0.8",
     "@types/d3-array": "^3.2.1",
+    "@types/d3-scale": "^4.0.8",
+    "@types/d3-shape": "^3.1.8",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -5,6 +5,8 @@ export { BarChartContext, ChartConfigContext } from './context'
 export { applyChartCSSVariables, initChartContainer } from './chart-container'
 export { initBarChart } from './bar-chart'
 export { initBar } from './bar'
+export { initLineChart } from './line-chart'
+export { initLine } from './line'
 export { initCartesianGrid } from './cartesian-grid'
 export { initXAxis } from './x-axis'
 export { initYAxis } from './y-axis'
@@ -17,6 +19,8 @@ export type {
   ChartContainerProps,
   BarChartProps,
   BarProps,
+  LineChartProps,
+  LineProps,
   CartesianGridProps,
   XAxisProps,
   YAxisProps,

--- a/packages/chart/src/line-chart.ts
+++ b/packages/chart/src/line-chart.ts
@@ -1,0 +1,80 @@
+import { createSignal, createEffect, provideContext, useContext } from '@barefootjs/dom'
+import type { BarRegistration } from './types'
+import { BarChartContext, ChartConfigContext } from './context'
+import { createBandScale, createLinearScale } from './utils/scales'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const DEFAULT_MARGIN = { top: 10, right: 12, bottom: 30, left: 40 }
+const ASPECT_RATIO = 0.5
+
+/**
+ * Init function for LineChart component.
+ * Creates SVG, provides BarChartContext to children (Line, XAxis, etc.).
+ * Reuses BarChartContext so shared components (XAxis, YAxis, CartesianGrid,
+ * ChartTooltip) work without modification.
+ */
+export function initLineChart(scope: Element, props: Record<string, unknown>): void {
+  const data = (props.data as Record<string, unknown>[]) ?? []
+  const { config } = useContext(ChartConfigContext)
+
+  const el = scope as HTMLElement
+  const containerRect = el.getBoundingClientRect()
+  const width = containerRect.width || 500
+  const height = Math.round(width * ASPECT_RATIO)
+
+  el.style.height = `${height}px`
+  el.style.minHeight = ''
+
+  const margin = DEFAULT_MARGIN
+  const iw = width - margin.left - margin.right
+  const ih = height - margin.top - margin.bottom
+
+  const svg = document.createElementNS(SVG_NS, 'svg')
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+  svg.style.width = '100%'
+  svg.style.height = `${height}px`
+  svg.style.display = 'block'
+
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('transform', `translate(${margin.left},${margin.top})`)
+  svg.appendChild(g)
+  el.appendChild(svg)
+
+  const [bars, setBars] = createSignal<BarRegistration[]>([])
+  const [xDataKey, setXDataKey] = createSignal('')
+  const [xScale, setXScale] = createSignal<ReturnType<typeof createBandScale> | null>(null)
+  const [yScale, setYScale] = createSignal<ReturnType<typeof createLinearScale> | null>(null)
+
+  const registerBar = (bar: BarRegistration) => {
+    setBars((prev) => [...prev, bar])
+  }
+
+  const unregisterBar = (dataKey: string) => {
+    setBars((prev) => prev.filter((b) => b.dataKey !== dataKey))
+  }
+
+  provideContext(BarChartContext, {
+    svgGroup: () => g,
+    container: () => el,
+    data: () => data,
+    xDataKey,
+    xScale,
+    yScale,
+    innerWidth: () => iw,
+    innerHeight: () => ih,
+    config: () => config,
+    bars,
+    registerBar,
+    unregisterBar,
+    setXDataKey,
+  })
+
+  // Recompute scales when lines or xDataKey change
+  createEffect(() => {
+    const currentBars = bars()
+    const key = xDataKey()
+    if (!key || currentBars.length === 0) return
+    setXScale(() => createBandScale(data, key, iw))
+    setYScale(() => createLinearScale(data, currentBars.map((b) => b.dataKey), ih))
+  })
+}

--- a/packages/chart/src/line.ts
+++ b/packages/chart/src/line.ts
@@ -1,0 +1,115 @@
+import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
+import { line as d3Line, curveMonotoneX, curveLinear } from 'd3-shape'
+import { BarChartContext } from './context'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Init function for Line component.
+ * Registers itself with chart context and renders SVG path + data point circles.
+ * Uses BarChartContext for compatibility with shared components (XAxis, YAxis, etc.).
+ */
+export function initLine(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(BarChartContext)
+
+  let currentDataKey: string | null = null
+
+  // Registration effect: re-register when dataKey changes
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const stroke = (props.stroke as string) ?? 'currentColor'
+
+    if (currentDataKey !== null) {
+      ctx.unregisterBar(currentDataKey)
+    }
+    ctx.registerBar({ dataKey, fill: stroke, radius: 0 })
+    currentDataKey = dataKey
+  })
+
+  onCleanup(() => {
+    if (currentDataKey !== null) ctx.unregisterBar(currentDataKey)
+  })
+
+  // Rendering effect: re-render when signals or props change
+  let lineGroup: SVGGElement | null = null
+
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const stroke = (props.stroke as string) ?? 'currentColor'
+    const strokeWidth = (props.strokeWidth as number) ?? 2
+    const type = (props.type as string) ?? 'monotone'
+    const dot = props.dot !== false
+
+    const g = ctx.svgGroup()
+    const xs = ctx.xScale()
+    const ys = ctx.yScale()
+    if (!g || !xs || !ys) return
+
+    // Clear previous line
+    if (lineGroup) {
+      lineGroup.remove()
+      lineGroup = null
+    }
+
+    const data = ctx.data()
+    const xKey = ctx.xDataKey()
+    const bandwidth = xs.bandwidth()
+
+    lineGroup = document.createElementNS(SVG_NS, 'g')
+    lineGroup.setAttribute('class', `chart-line chart-line-${dataKey}`)
+
+    // Build points array
+    const points: [number, number][] = []
+    for (const datum of data) {
+      const xValue = String(datum[xKey])
+      const yValue = Number(datum[dataKey]) || 0
+      const x = (xs(xValue) ?? 0) + bandwidth / 2
+      const y = ys(yValue)
+      points.push([x, y])
+    }
+
+    // Draw path using d3-line
+    const lineGenerator = d3Line<[number, number]>()
+      .x((d) => d[0])
+      .y((d) => d[1])
+
+    if (type === 'monotone') {
+      lineGenerator.curve(curveMonotoneX)
+    } else {
+      lineGenerator.curve(curveLinear)
+    }
+
+    const pathD = lineGenerator(points)
+    if (pathD) {
+      const path = document.createElementNS(SVG_NS, 'path')
+      path.setAttribute('d', pathD)
+      path.setAttribute('fill', 'none')
+      path.setAttribute('stroke', stroke)
+      path.setAttribute('stroke-width', String(strokeWidth))
+      path.setAttribute('data-key', dataKey)
+      lineGroup.appendChild(path)
+    }
+
+    // Draw dots at data points (for tooltip interaction and visual)
+    if (dot) {
+      for (let i = 0; i < data.length; i++) {
+        const datum = data[i]
+        const xValue = String(datum[xKey])
+        const yValue = Number(datum[dataKey]) || 0
+        const [x, y] = points[i]
+
+        const circle = document.createElementNS(SVG_NS, 'circle')
+        circle.setAttribute('cx', String(x))
+        circle.setAttribute('cy', String(y))
+        circle.setAttribute('r', '4')
+        circle.setAttribute('fill', stroke)
+        circle.setAttribute('data-x', xValue)
+        circle.setAttribute('data-y', String(yValue))
+        circle.setAttribute('data-key', dataKey)
+        lineGroup.appendChild(circle)
+      }
+    }
+
+    g.appendChild(lineGroup)
+  })
+}

--- a/packages/chart/src/tooltip.ts
+++ b/packages/chart/src/tooltip.ts
@@ -54,7 +54,7 @@ export function initChartTooltip(_scope: Element, props: Record<string, unknown>
 
     const handleMouseOver = (e: Event): void => {
       const target = e.target as SVGElement
-      if (target.tagName !== 'rect' || !target.hasAttribute('data-x')) return
+      if (!target.hasAttribute('data-x')) return
 
       const xValue = target.getAttribute('data-x') ?? ''
       const datum = data.find((d) => String(d[xKey]) === xValue)
@@ -88,7 +88,7 @@ export function initChartTooltip(_scope: Element, props: Record<string, unknown>
 
     const handleMouseOut = (e: Event): void => {
       const target = e.target as SVGElement
-      if (target.tagName === 'rect') {
+      if (target.hasAttribute('data-x')) {
         currentTooltip.style.opacity = '0'
       }
     }

--- a/packages/chart/src/types.ts
+++ b/packages/chart/src/types.ts
@@ -55,6 +55,21 @@ export interface YAxisProps {
   tickFormatter?: (value: number) => string
 }
 
+/** Props for LineChart */
+export interface LineChartProps {
+  data: Record<string, unknown>[]
+  children?: unknown
+}
+
+/** Props for Line */
+export interface LineProps {
+  dataKey: string
+  stroke?: string
+  strokeWidth?: number
+  type?: 'linear' | 'monotone'
+  dot?: boolean
+}
+
 /** Props for ChartTooltip */
 export interface ChartTooltipProps {
   labelFormatter?: (label: string) => string

--- a/site/ui/components/line-chart-demo.tsx
+++ b/site/ui/components/line-chart-demo.tsx
@@ -1,0 +1,148 @@
+"use client"
+/**
+ * LineChartDemo Components
+ *
+ * Interactive demos for the Line Chart component.
+ * Uses JSX component API with @barefootjs/chart.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import type { ChartConfig } from '@barefootjs/chart'
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from '@ui/components/ui/chart'
+
+const chartConfig: ChartConfig = {
+  desktop: { label: 'Desktop', color: 'hsl(221 83% 53%)' },
+  mobile: { label: 'Mobile', color: 'hsl(280 65% 60%)' },
+}
+
+const chartData = [
+  { month: 'January', desktop: 186, mobile: 80 },
+  { month: 'February', desktop: 305, mobile: 200 },
+  { month: 'March', desktop: 237, mobile: 120 },
+  { month: 'April', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'June', desktop: 214, mobile: 140 },
+]
+
+/**
+ * Preview demo — monthly visitors line chart
+ */
+export function LineChartPreviewDemo() {
+  return (
+    <div className="w-full space-y-2">
+      <div>
+        <h4 className="text-sm font-medium">Monthly Visitors</h4>
+        <p className="text-xs text-muted-foreground">January - June 2024</p>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Line dataKey="desktop" stroke={'var(--color-desktop)'} type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Basic demo — minimal line chart
+ */
+export function LineChartBasicDemo() {
+  return (
+    <div className="w-full">
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <Line dataKey="desktop" stroke={'var(--color-desktop)'} type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Multiple series demo — desktop and mobile lines
+ */
+export function LineChartMultipleDemo() {
+  return (
+    <div className="w-full space-y-2">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style="background:hsl(221 83% 53%)" />
+          <span className="text-xs text-muted-foreground">Desktop</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style="background:hsl(280 65% 60%)" />
+          <span className="text-xs text-muted-foreground">Mobile</span>
+        </div>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Line dataKey="desktop" stroke={'var(--color-desktop)'} type="monotone" />
+          <Line dataKey="mobile" stroke={'var(--color-mobile)'} type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Interactive demo — signal-driven category switching
+ */
+export function LineChartInteractiveDemo() {
+  const [category, setCategory] = createSignal<'desktop' | 'mobile'>('desktop')
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Show:</span>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            category() === 'desktop'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setCategory('desktop')}
+        >
+          Desktop
+        </button>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            category() === 'mobile'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setCategory('mobile')}
+        >
+          Mobile
+        </button>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Line dataKey={category()} stroke={`var(--color-${category()})`} type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/site/ui/components/line-chart-playground.tsx
+++ b/site/ui/components/line-chart-playground.tsx
@@ -1,0 +1,203 @@
+"use client"
+/**
+ * Line Chart Props Playground
+ *
+ * Interactive playground for the LineChart composed component.
+ * Allows tweaking stroke width, curve type, dot visibility, and grid.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import {
+  hlPlain, hlTag, hlAttr, hlStr,
+} from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from '@ui/components/ui/chart'
+
+const chartConfig: Record<string, { label: string; color: string }> = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "Jan", desktop: 186 },
+  { month: "Feb", desktop: 305 },
+  { month: "Mar", desktop: 237 },
+  { month: "Apr", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "Jun", desktop: 214 },
+]
+
+/**
+ * Build highlighted JSX string for the composed LineChart pattern.
+ */
+function buildHighlightedCode(strokeWidth: number, curveType: string, showDots: boolean, showGrid: boolean): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  lines.push(
+    `${hlPlain('&lt;')}${hlTag('ChartContainer')} ${hlAttr('config')}${hlPlain('={chartConfig}')} ${hlAttr('className')}${hlPlain('=')}${hlStr('&quot;w-full&quot;')}${hlPlain('&gt;')}`
+  )
+  lines.push(
+    `${indent}${hlPlain('&lt;')}${hlTag('LineChart')} ${hlAttr('data')}${hlPlain('={chartData}')}${hlPlain('&gt;')}`
+  )
+
+  if (showGrid) {
+    lines.push(
+      `${indent}${indent}${hlPlain('&lt;')}${hlTag('CartesianGrid')} ${hlAttr('vertical')}${hlPlain('={false}')} ${hlPlain('/&gt;')}`
+    )
+  }
+
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('XAxis')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;month&quot;')} ${hlPlain('/&gt;')}`
+  )
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('YAxis')} ${hlPlain('/&gt;')}`
+  )
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('ChartTooltip')} ${hlPlain('/&gt;')}`
+  )
+
+  const strokeWidthProp = strokeWidth !== 2
+    ? ` ${hlAttr('strokeWidth')}${hlPlain('={' + strokeWidth + '}')}`
+    : ''
+  const typeProp = ` ${hlAttr('type')}${hlPlain('=')}${hlStr('&quot;' + curveType + '&quot;')}`
+  const dotProp = !showDots
+    ? ` ${hlAttr('dot')}${hlPlain('={false}')}`
+    : ''
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('Line')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;desktop&quot;')} ${hlAttr('stroke')}${hlPlain('=')}${hlStr('&quot;var(--color-desktop)&quot;')}${strokeWidthProp}${typeProp}${dotProp} ${hlPlain('/&gt;')}`
+  )
+
+  lines.push(
+    `${indent}${hlPlain('&lt;/')}${hlTag('LineChart')}${hlPlain('&gt;')}`
+  )
+  lines.push(
+    `${hlPlain('&lt;/')}${hlTag('ChartContainer')}${hlPlain('&gt;')}`
+  )
+
+  return lines.join('\n')
+}
+
+/**
+ * Build plain-text JSX string for clipboard copy.
+ */
+function buildPlainCode(strokeWidth: number, curveType: string, showDots: boolean, showGrid: boolean): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  lines.push('<ChartContainer config={chartConfig} className="w-full">')
+  lines.push(`${indent}<LineChart data={chartData}>`)
+
+  if (showGrid) {
+    lines.push(`${indent}${indent}<CartesianGrid vertical={false} />`)
+  }
+
+  lines.push(`${indent}${indent}<XAxis dataKey="month" />`)
+  lines.push(`${indent}${indent}<YAxis />`)
+  lines.push(`${indent}${indent}<ChartTooltip />`)
+
+  const strokeWidthProp = strokeWidth !== 2 ? ` strokeWidth={${strokeWidth}}` : ''
+  const typeProp = ` type="${curveType}"`
+  const dotProp = !showDots ? ' dot={false}' : ''
+  lines.push(`${indent}${indent}<Line dataKey="desktop" stroke="var(--color-desktop)"${strokeWidthProp}${typeProp}${dotProp} />`)
+
+  lines.push(`${indent}</LineChart>`)
+  lines.push('</ChartContainer>')
+
+  return lines.join('\n')
+}
+
+function LineChartPlayground(_props: {}) {
+  const [strokeWidth, setStrokeWidth] = createSignal(2)
+  const [curveType, setCurveType] = createSignal('monotone')
+  const [showDots, setShowDots] = createSignal(true)
+  const [showGrid, setShowGrid] = createSignal(true)
+
+  createEffect(() => {
+    const sw = strokeWidth()
+    const ct = curveType()
+    const d = showDots()
+    const g = showGrid()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = buildHighlightedCode(sw, ct, d, g)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-line-chart-preview"
+      previewContent={
+        <div className="w-full min-w-[300px]">
+          <ChartContainer config={chartConfig} className="w-full">
+            <LineChart data={chartData}>
+              <CartesianGrid
+                vertical={false}
+                horizontal={showGrid()}
+              />
+              <XAxis dataKey="month" />
+              <YAxis />
+              <ChartTooltip />
+              <Line
+                dataKey="desktop"
+                stroke={'var(--color-desktop)'}
+                strokeWidth={strokeWidth()}
+                type={curveType() as 'linear' | 'monotone'}
+                dot={showDots()}
+              />
+            </LineChart>
+          </ChartContainer>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="strokeWidth">
+          <Select value={String(strokeWidth())} onValueChange={(v: string) => setStrokeWidth(Number(v))}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select width..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1">1</SelectItem>
+              <SelectItem value="2">2</SelectItem>
+              <SelectItem value="3">3</SelectItem>
+              <SelectItem value="4">4</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="type">
+          <Select value={curveType()} onValueChange={(v: string) => setCurveType(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select type..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="monotone">monotone</SelectItem>
+              <SelectItem value="linear">linear</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="dots">
+          <Checkbox
+            checked={showDots()}
+            onCheckedChange={(v: boolean) => setShowDots(v)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="showGrid">
+          <Checkbox
+            checked={showGrid()}
+            onCheckedChange={(v: boolean) => setShowGrid(v)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={buildPlainCode(strokeWidth(), curveType(), showDots(), showGrid())} />}
+    />
+  )
+}
+
+export { LineChartPlayground }

--- a/site/ui/components/line-chart-playground.tsx
+++ b/site/ui/components/line-chart-playground.tsx
@@ -9,7 +9,8 @@
 import { createSignal, createEffect } from '@barefootjs/dom'
 import { CopyButton } from './copy-button'
 import {
-  hlPlain, hlTag, hlAttr, hlStr,
+  highlightJsxTree, plainJsxTree,
+  type JsxTreeNode, type HighlightProp,
 } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
@@ -38,83 +39,45 @@ const chartData = [
 ]
 
 /**
- * Build highlighted JSX string for the composed LineChart pattern.
+ * Build the JSX tree description for code display.
  */
-function buildHighlightedCode(strokeWidth: number, curveType: string, showDots: boolean, showGrid: boolean): string {
-  const indent = '  '
-  const lines: string[] = []
-
-  lines.push(
-    `${hlPlain('&lt;')}${hlTag('ChartContainer')} ${hlAttr('config')}${hlPlain('={chartConfig}')} ${hlAttr('className')}${hlPlain('=')}${hlStr('&quot;w-full&quot;')}${hlPlain('&gt;')}`
-  )
-  lines.push(
-    `${indent}${hlPlain('&lt;')}${hlTag('LineChart')} ${hlAttr('data')}${hlPlain('={chartData}')}${hlPlain('&gt;')}`
-  )
+function buildCodeTree(strokeWidth: number, curveType: string, showDots: boolean, showGrid: boolean): JsxTreeNode {
+  const chartChildren: JsxTreeNode[] = []
 
   if (showGrid) {
-    lines.push(
-      `${indent}${indent}${hlPlain('&lt;')}${hlTag('CartesianGrid')} ${hlAttr('vertical')}${hlPlain('={false}')} ${hlPlain('/&gt;')}`
-    )
+    chartChildren.push({
+      tag: 'CartesianGrid',
+      props: [{ name: 'vertical', value: 'false', defaultValue: '', kind: 'expression' }],
+    })
   }
 
-  lines.push(
-    `${indent}${indent}${hlPlain('&lt;')}${hlTag('XAxis')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;month&quot;')} ${hlPlain('/&gt;')}`
-  )
-  lines.push(
-    `${indent}${indent}${hlPlain('&lt;')}${hlTag('YAxis')} ${hlPlain('/&gt;')}`
-  )
-  lines.push(
-    `${indent}${indent}${hlPlain('&lt;')}${hlTag('ChartTooltip')} ${hlPlain('/&gt;')}`
+  chartChildren.push(
+    { tag: 'XAxis', props: [{ name: 'dataKey', value: 'month', defaultValue: '' }] },
+    { tag: 'YAxis' },
+    { tag: 'ChartTooltip' },
   )
 
-  const strokeWidthProp = strokeWidth !== 2
-    ? ` ${hlAttr('strokeWidth')}${hlPlain('={' + strokeWidth + '}')}`
-    : ''
-  const typeProp = ` ${hlAttr('type')}${hlPlain('=')}${hlStr('&quot;' + curveType + '&quot;')}`
-  const dotProp = !showDots
-    ? ` ${hlAttr('dot')}${hlPlain('={false}')}`
-    : ''
-  lines.push(
-    `${indent}${indent}${hlPlain('&lt;')}${hlTag('Line')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;desktop&quot;')} ${hlAttr('stroke')}${hlPlain('=')}${hlStr('&quot;var(--color-desktop)&quot;')}${strokeWidthProp}${typeProp}${dotProp} ${hlPlain('/&gt;')}`
-  )
+  const lineProps: HighlightProp[] = [
+    { name: 'dataKey', value: 'desktop', defaultValue: '' },
+    { name: 'stroke', value: 'var(--color-desktop)', defaultValue: '' },
+    { name: 'strokeWidth', value: String(strokeWidth), defaultValue: '2', kind: 'expression' },
+    { name: 'type', value: curveType, defaultValue: '' },
+    { name: 'dot', value: String(showDots), defaultValue: 'true', kind: 'expression' },
+  ]
+  chartChildren.push({ tag: 'Line', props: lineProps })
 
-  lines.push(
-    `${indent}${hlPlain('&lt;/')}${hlTag('LineChart')}${hlPlain('&gt;')}`
-  )
-  lines.push(
-    `${hlPlain('&lt;/')}${hlTag('ChartContainer')}${hlPlain('&gt;')}`
-  )
-
-  return lines.join('\n')
-}
-
-/**
- * Build plain-text JSX string for clipboard copy.
- */
-function buildPlainCode(strokeWidth: number, curveType: string, showDots: boolean, showGrid: boolean): string {
-  const indent = '  '
-  const lines: string[] = []
-
-  lines.push('<ChartContainer config={chartConfig} className="w-full">')
-  lines.push(`${indent}<LineChart data={chartData}>`)
-
-  if (showGrid) {
-    lines.push(`${indent}${indent}<CartesianGrid vertical={false} />`)
+  return {
+    tag: 'ChartContainer',
+    props: [
+      { name: 'config', value: 'chartConfig', defaultValue: '', kind: 'expression' },
+      { name: 'className', value: 'w-full', defaultValue: '' },
+    ],
+    children: [{
+      tag: 'LineChart',
+      props: [{ name: 'data', value: 'chartData', defaultValue: '', kind: 'expression' }],
+      children: chartChildren,
+    }],
   }
-
-  lines.push(`${indent}${indent}<XAxis dataKey="month" />`)
-  lines.push(`${indent}${indent}<YAxis />`)
-  lines.push(`${indent}${indent}<ChartTooltip />`)
-
-  const strokeWidthProp = strokeWidth !== 2 ? ` strokeWidth={${strokeWidth}}` : ''
-  const typeProp = ` type="${curveType}"`
-  const dotProp = !showDots ? ' dot={false}' : ''
-  lines.push(`${indent}${indent}<Line dataKey="desktop" stroke="var(--color-desktop)"${strokeWidthProp}${typeProp}${dotProp} />`)
-
-  lines.push(`${indent}</LineChart>`)
-  lines.push('</ChartContainer>')
-
-  return lines.join('\n')
 }
 
 function LineChartPlayground(_props: {}) {
@@ -129,7 +92,7 @@ function LineChartPlayground(_props: {}) {
     const d = showDots()
     const g = showGrid()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) codeEl.innerHTML = buildHighlightedCode(sw, ct, d, g)
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(buildCodeTree(sw, ct, d, g))
   })
 
   return (
@@ -195,7 +158,7 @@ function LineChartPlayground(_props: {}) {
           />
         </PlaygroundControl>
       </>}
-      copyButton={<CopyButton code={buildPlainCode(strokeWidth(), curveType(), showDots(), showGrid())} />}
+      copyButton={<CopyButton code={plainJsxTree(buildCodeTree(strokeWidth(), curveType(), showDots(), showGrid()))} />}
     />
   )
 }

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -61,6 +61,7 @@ export const componentOrder = [
 // Chart order for navigation (alphabetical)
 export const chartOrder = [
   { slug: 'bar-chart', title: 'Bar Chart' },
+  { slug: 'line-chart', title: 'Line Chart' },
 ]
 
 // Get prev/next links for a chart page

--- a/site/ui/e2e/line-chart.spec.ts
+++ b/site/ui/e2e/line-chart.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Line Chart Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/charts/line-chart')
+  })
+
+  test.describe('Preview', () => {
+    const scope = '[bf-s^="LineChartPreviewDemo_"]:not([data-slot])'
+
+    test('renders an SVG chart', async ({ page }) => {
+      const container = page.locator(scope)
+      await expect(container.locator('svg')).toBeVisible()
+    })
+
+    test('renders a line path', async ({ page }) => {
+      const container = page.locator(scope)
+      const path = container.locator('path[data-key="desktop"]')
+      await expect(path).toHaveCount(1)
+    })
+
+    test('renders data point circles', async ({ page }) => {
+      const container = page.locator(scope)
+      const dots = container.locator('circle[data-key="desktop"]')
+      await expect(dots).toHaveCount(6)
+    })
+
+    test('renders X axis labels', async ({ page }) => {
+      const container = page.locator(scope)
+      const xAxisTexts = container.locator('.chart-x-axis text')
+      await expect(xAxisTexts.first()).toHaveText('Jan')
+    })
+  })
+
+  test.describe('Playground', () => {
+    test('renders chart in playground preview', async ({ page }) => {
+      const preview = page.locator('[data-line-chart-preview]')
+      await expect(preview).toBeVisible()
+      await expect(preview.locator('svg').first()).toBeVisible()
+    })
+
+    test('renders 6 data point circles in playground', async ({ page }) => {
+      const preview = page.locator('[data-line-chart-preview]')
+      const circles = preview.locator('circle[data-key="desktop"]')
+      await expect(circles).toHaveCount(6)
+    })
+
+    test('changing strokeWidth updates the line', async ({ page }) => {
+      const preview = page.locator('[data-line-chart-preview]')
+      const path = preview.locator('path[data-key="desktop"]')
+
+      // Default strokeWidth is 2
+      await expect(path).toHaveAttribute('stroke-width', '2')
+
+      // Open the strokeWidth select (first combobox in the playground controls)
+      const playgroundSection = page.locator('[data-line-chart-preview]').locator('..').locator('..')
+      const strokeWidthSelect = playgroundSection.locator('button[role="combobox"]').first()
+      await strokeWidthSelect.click()
+      await page.locator('[role="option"]:has-text("4")').click()
+
+      // stroke-width should be updated
+      await expect(path).toHaveAttribute('stroke-width', '4')
+    })
+
+    test('toggling dots hides data point circles', async ({ page }) => {
+      const preview = page.locator('[data-line-chart-preview]')
+
+      // Initially has dots
+      const initialCircleCount = await preview.locator('circle[data-key="desktop"]').count()
+      expect(initialCircleCount).toBe(6)
+
+      // Uncheck dots checkbox
+      const dotsCheckbox = page.locator('text=dots')
+        .locator('..')
+        .locator('button[role="checkbox"]')
+      await dotsCheckbox.click()
+
+      // Circles should be gone
+      const updatedCircleCount = await preview.locator('circle[data-key="desktop"]').count()
+      expect(updatedCircleCount).toBe(0)
+    })
+
+    test('toggling showGrid hides grid lines', async ({ page }) => {
+      const preview = page.locator('[data-line-chart-preview]')
+      const gridGroup = preview.locator('.chart-grid')
+      await expect(gridGroup).toBeVisible()
+
+      // Initially has grid lines
+      const initialLineCount = await gridGroup.locator('line').count()
+      expect(initialLineCount).toBeGreaterThan(0)
+
+      // Uncheck showGrid
+      const showGridCheckbox = page.locator('text=showGrid')
+        .locator('..')
+        .locator('button[role="checkbox"]')
+      await showGridCheckbox.click()
+
+      // Grid lines should be gone
+      const updatedLineCount = await gridGroup.locator('line').count()
+      expect(updatedLineCount).toBe(0)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('renders an SVG with a line path', async ({ page }) => {
+      const container = page.locator('[bf-s^="LineChartBasicDemo_"]:not([data-slot])')
+      await expect(container.locator('svg')).toBeVisible()
+      const path = container.locator('path[data-key="desktop"]')
+      await expect(path).toHaveCount(1)
+    })
+  })
+
+  test.describe('Multiple', () => {
+    test('renders both desktop and mobile lines', async ({ page }) => {
+      const container = page.locator('[bf-s^="LineChartMultipleDemo_"]:not([data-slot])')
+      const desktopPath = container.locator('path[data-key="desktop"]')
+      const mobilePath = container.locator('path[data-key="mobile"]')
+      await expect(desktopPath).toHaveCount(1)
+      await expect(mobilePath).toHaveCount(1)
+    })
+  })
+
+  test.describe('Interactive', () => {
+    test('switching category updates the chart', async ({ page }) => {
+      const section = page.locator('[bf-s^="LineChartInteractiveDemo_"]:not([data-slot])').first()
+
+      // Initially shows desktop line
+      await expect(section.locator('path[data-key="desktop"]')).toHaveCount(1)
+      await expect(section.locator('path[data-key="mobile"]')).toHaveCount(0)
+
+      // Click Mobile button
+      await section.locator('button:has-text("Mobile")').click()
+
+      // Should now show mobile line
+      await expect(section.locator('path[data-key="mobile"]')).toHaveCount(1)
+      await expect(section.locator('path[data-key="desktop"]')).toHaveCount(0)
+    })
+  })
+
+  test.describe('Tooltip', () => {
+    test('tooltip appears on dot hover', async ({ page }) => {
+      const container = page.locator('[bf-s^="LineChartPreviewDemo_"]:not([data-slot])')
+      const tooltip = container.locator('.chart-tooltip')
+
+      // Tooltip should be hidden initially
+      await expect(tooltip).toHaveCSS('opacity', '0')
+
+      // Hover over a data point circle
+      const dot = container.locator('circle[data-key="desktop"]').first()
+      await dot.hover()
+
+      // Tooltip should become visible
+      await expect(tooltip).toHaveCSS('opacity', '1')
+    })
+  })
+})

--- a/site/ui/pages/charts/line-chart.tsx
+++ b/site/ui/pages/charts/line-chart.tsx
@@ -1,0 +1,379 @@
+/**
+ * Line Chart Documentation Page
+ */
+
+import {
+  LineChartPreviewDemo,
+  LineChartBasicDemo,
+  LineChartMultipleDemo,
+  LineChartInteractiveDemo,
+} from '@/components/line-chart-demo'
+import { LineChartPlayground } from '@/components/line-chart-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getChartNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'multiple', title: 'Multiple', branch: 'child' },
+  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import type { ChartConfig } from "@barefootjs/chart"
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+} from "@/components/ui/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186 },
+  { month: "February", desktop: 305 },
+  { month: "March", desktop: 237 },
+  { month: "April", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "June", desktop: 214 },
+]
+
+export function MyLineChart() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <LineChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <ChartTooltip />
+        <Line
+          dataKey="desktop"
+          stroke="var(--color-desktop)"
+          type="monotone"
+        />
+      </LineChart>
+    </ChartContainer>
+  )
+}`
+
+const basicCode = `"use client"
+
+import type { ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186 },
+  { month: "February", desktop: 305 },
+  { month: "March", desktop: 237 },
+  { month: "April", desktop: 73 },
+  { month: "May", desktop: 209 },
+  { month: "June", desktop: 214 },
+]
+
+export function LineChartBasicDemo() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <LineChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <Line
+          dataKey="desktop"
+          stroke="var(--color-desktop)"
+          type="monotone"
+        />
+      </LineChart>
+    </ChartContainer>
+  )
+}`
+
+const multipleCode = `"use client"
+
+import type { ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+  mobile: { label: "Mobile", color: "hsl(280 65% 60%)" },
+}
+
+const chartData = [
+  { month: "January", desktop: 186, mobile: 80 },
+  { month: "February", desktop: 305, mobile: 200 },
+  // ...
+]
+
+export function LineChartMultipleDemo() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <LineChart data={chartData}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={(v: string) => v.slice(0, 3)}
+        />
+        <YAxis />
+        <ChartTooltip />
+        <Line dataKey="desktop" stroke="var(--color-desktop)" type="monotone" />
+        <Line dataKey="mobile" stroke="var(--color-mobile)" type="monotone" />
+      </LineChart>
+    </ChartContainer>
+  )
+}`
+
+const interactiveCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import type { ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(221 83% 53%)" },
+  mobile: { label: "Mobile", color: "hsl(280 65% 60%)" },
+}
+
+export function LineChartInteractiveDemo() {
+  const [category, setCategory] =
+    createSignal<"desktop" | "mobile">("desktop")
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-4">
+        <button onClick={() => setCategory("desktop")}>
+          Desktop
+        </button>
+        <button onClick={() => setCategory("mobile")}>
+          Mobile
+        </button>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="month"
+            tickFormatter={(v: string) => v.slice(0, 3)}
+          />
+          <YAxis />
+          <ChartTooltip />
+          <Line
+            dataKey={category()}
+            stroke={\\\`var(--color-\\\${category()})\\\`}
+            type="monotone"
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}`
+
+const lineChartProps: PropDefinition[] = [
+  {
+    name: 'data',
+    type: 'Record<string, unknown>[]',
+    description: 'Array of data objects. Each object represents one point on the X axis.',
+  },
+]
+
+const chartContainerProps: PropDefinition[] = [
+  {
+    name: 'config',
+    type: 'ChartConfig',
+    description: 'Maps each data key to a label and color. Sets CSS variables for theming.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names for the container element.',
+  },
+]
+
+const lineProps: PropDefinition[] = [
+  {
+    name: 'dataKey',
+    type: 'string',
+    description: 'The key in the data objects to use for line values.',
+  },
+  {
+    name: 'stroke',
+    type: 'string',
+    defaultValue: 'currentColor',
+    description: 'Stroke color for the line. Supports CSS variables like var(--color-desktop).',
+  },
+  {
+    name: 'strokeWidth',
+    type: 'number',
+    defaultValue: '2',
+    description: 'Width of the line stroke in pixels.',
+  },
+  {
+    name: 'type',
+    type: '"linear" | "monotone"',
+    defaultValue: 'monotone',
+    description: 'Curve interpolation type. "monotone" for smooth curves, "linear" for straight segments.',
+  },
+  {
+    name: 'dot',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Whether to show dots at data points.',
+  },
+]
+
+const xAxisProps: PropDefinition[] = [
+  {
+    name: 'dataKey',
+    type: 'string',
+    description: 'The key in the data objects to use for X axis labels.',
+  },
+  {
+    name: 'tickFormatter',
+    type: '(value: string) => string',
+    description: 'Custom formatter for tick labels.',
+  },
+  {
+    name: 'hide',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Hide the X axis.',
+  },
+]
+
+const yAxisProps: PropDefinition[] = [
+  {
+    name: 'tickFormatter',
+    type: '(value: number) => string',
+    description: 'Custom formatter for tick labels.',
+  },
+  {
+    name: 'hide',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Hide the Y axis.',
+  },
+]
+
+const cartesianGridProps: PropDefinition[] = [
+  {
+    name: 'vertical',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show vertical grid lines.',
+  },
+  {
+    name: 'horizontal',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show horizontal grid lines.',
+  },
+]
+
+const chartTooltipProps: PropDefinition[] = [
+  {
+    name: 'labelFormatter',
+    type: '(label: string) => string',
+    description: 'Custom formatter for the tooltip label.',
+  },
+]
+
+export function LineChartRefPage() {
+  return (
+    <DocPage slug="line-chart" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Line Chart"
+          description="A composable line chart built with SVG, D3 scales, and D3 shape."
+          {...getChartNavLinks('line-chart')}
+        />
+
+        {/* Props Playground */}
+        <LineChartPlayground />
+
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="bun add @barefootjs/chart" />
+        </Section>
+
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <LineChartPreviewDemo />
+          </Example>
+        </Section>
+
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <LineChartBasicDemo />
+            </Example>
+
+            <Example title="Multiple" code={multipleCode}>
+              <LineChartMultipleDemo />
+            </Example>
+
+            <Example title="Interactive" code={interactiveCode}>
+              <LineChartInteractiveDemo />
+            </Example>
+          </div>
+        </Section>
+
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">LineChart</h3>
+              <PropsTable props={lineChartProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ChartContainer</h3>
+              <PropsTable props={chartContainerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">Line</h3>
+              <PropsTable props={lineProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">XAxis</h3>
+              <PropsTable props={xAxisProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">YAxis</h3>
+              <PropsTable props={yAxisProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">CartesianGrid</h3>
+              <PropsTable props={cartesianGridProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ChartTooltip</h3>
+              <PropsTable props={chartTooltipProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -141,6 +141,7 @@ const menuEntries: SidebarEntry[] = [
     title: 'Charts',
     links: [
       { title: 'Bar Chart', href: '/docs/charts/bar-chart' },
+      { title: 'Line Chart', href: '/charts/line-chart' },
     ],
   },
 ]

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -62,6 +62,7 @@ import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
 import { BarChartRefPage } from './pages/charts/bar-chart'
+import { LineChartRefPage } from './pages/charts/line-chart'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -601,6 +602,11 @@ export function createApp() {
   // Bar Chart reference page
   app.get('/charts/bar-chart', (c) => {
     return c.render(<BarChartRefPage />)
+  })
+
+  // Line Chart reference page
+  app.get('/charts/line-chart', (c) => {
+    return c.render(<LineChartRefPage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/chart/index.tsx
+++ b/ui/components/ui/chart/index.tsx
@@ -16,6 +16,8 @@ import {
   initXAxis as xAxisInit,
   initYAxis as yAxisInit,
   initChartTooltip as chartTooltipInit,
+  initLineChart as lineChartInit,
+  initLine as lineInit,
 } from '@barefootjs/chart'
 
 /** Color and label configuration for chart data series */
@@ -52,6 +54,19 @@ interface XAxisProps {
 interface YAxisProps {
   hide?: boolean
   tickFormatter?: (value: number) => string
+}
+
+interface LineChartProps {
+  data: Record<string, unknown>[]
+  children?: unknown
+}
+
+interface LineProps {
+  dataKey: string
+  stroke?: string
+  strokeWidth?: number
+  type?: 'linear' | 'monotone'
+  dot?: boolean
 }
 
 interface ChartTooltipProps {
@@ -122,10 +137,32 @@ function ChartTooltip(props: ChartTooltipProps) {
   return <span data-slot="chart-tooltip" style="display:none" ref={handleMount} />
 }
 
+function LineChart(props: LineChartProps) {
+  const handleMount = (el: HTMLElement) => {
+    lineChartInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return (
+    <div data-slot="line-chart" ref={handleMount}>
+      {props.children}
+    </div>
+  )
+}
+
+function Line(props: LineProps) {
+  const handleMount = (el: HTMLElement) => {
+    lineInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="line" style="display:none" ref={handleMount} />
+}
+
 export {
   ChartContainer,
   BarChart,
   Bar,
+  LineChart,
+  Line,
   CartesianGrid,
   XAxis,
   YAxis,
@@ -136,6 +173,8 @@ export type {
   ChartContainerProps,
   BarChartProps,
   BarProps,
+  LineChartProps,
+  LineProps,
   CartesianGridProps,
   XAxisProps,
   YAxisProps,

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -65,6 +65,12 @@
       "description": "A bar chart component built with SVG and D3 scales"
     },
     {
+      "name": "line-chart",
+      "type": "registry:ui",
+      "title": "Line Chart",
+      "description": "A line chart component built with SVG, D3 scales, and D3 shape"
+    },
+    {
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",


### PR DESCRIPTION
## Summary
- Port shadcn/ui line-chart to BarefootJS using D3 scales + D3 shape for SVG path rendering
- Reuses `BarChartContext` so shared chart components (XAxis, YAxis, CartesianGrid, ChartTooltip) work without modification
- Adds `initLineChart` / `initLine` runtime, JSX wrappers (`LineChart`, `Line`), demos (preview, basic, multiple, interactive), playground, documentation page, and E2E tests
- Updates tooltip to support both `<rect>` (bars) and `<circle>` (line dots) hover targets

Closes #134

## Test plan
- [x] `bun run build` passes
- [x] All 13 line-chart E2E tests pass (`site/ui/e2e/line-chart.spec.ts`)
- [x] All 12 bar-chart E2E tests still pass (no regressions from tooltip change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)