### PR TITLE
Migrate spinner from /docs/components to /components RefPage

### DIFF
--- a/site/ui/components/spinner-playground.tsx
+++ b/site/ui/components/spinner-playground.tsx
@@ -1,0 +1,67 @@
+"use client"
+/**
+ * Spinner Props Playground
+ *
+ * Interactive playground for the Spinner component.
+ * Allows switching between size presets.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Spinner } from '@ui/components/ui/spinner'
+
+type SpinnerSize = 'default' | 'size-4' | 'size-6' | 'size-8' | 'size-12'
+
+const sizeConfig: Record<SpinnerSize, { className: string; display: string }> = {
+  'default': { className: '', display: '(default)' },
+  'size-4': { className: 'size-4', display: 'size-4' },
+  'size-6': { className: 'size-6', display: 'size-6' },
+  'size-8': { className: 'size-8', display: 'size-8' },
+  'size-12': { className: 'size-12', display: 'size-12' },
+}
+
+function SpinnerPlayground(_props: {}) {
+  const [size, setSize] = createSignal<SpinnerSize>('default')
+
+  const props = (): HighlightProp[] => {
+    const cfg = sizeConfig[size()]
+    return cfg.className
+      ? [{ name: 'className', value: cfg.className, defaultValue: '', kind: 'string' }]
+      : []
+  }
+
+  createEffect(() => {
+    const p = props()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Spinner', p)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-spinner-preview"
+      previewContent={<Spinner className={sizeConfig[size()].className} />}
+      controls={<>
+        <PlaygroundControl label="size">
+          <Select value={size()} onValueChange={(v: string) => setSize(v as SpinnerSize)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select size..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="size-4">size-4</SelectItem>
+              <SelectItem value="size-6">size-6</SelectItem>
+              <SelectItem value="size-8">size-8</SelectItem>
+              <SelectItem value="size-12">size-12</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxSelfClosing('Spinner', props())} />}
+    />
+  )
+}
+
+export { SpinnerPlayground }

--- a/site/ui/e2e/spinner.spec.ts
+++ b/site/ui/e2e/spinner.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Spinner Documentation Page', () => {
+test.describe('Spinner Reference Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/docs/components/spinner')
+    await page.goto('/components/spinner')
   })
 
   test.describe('Spinner Display', () => {

--- a/site/ui/pages/components/spinner.tsx
+++ b/site/ui/pages/components/spinner.tsx
@@ -1,8 +1,11 @@
 /**
- * Spinner Documentation Page
+ * Spinner Reference Page (/components/spinner)
+ *
+ * Focused developer reference with interactive Props Playground.
  */
 
 import { Spinner } from '@/components/ui/spinner'
+import { SpinnerPlayground } from '@/components/spinner-playground'
 import { SpinnerSizesDemo, SpinnerButtonDemo } from '@/components/spinner-demo'
 import {
   DocPage,
@@ -13,23 +16,22 @@ import {
   PackageManagerTabs,
   type PropDefinition,
   type TocItem,
-} from '../components/shared/docs'
-import { getNavLinks } from '../components/shared/PageNavigation'
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
 
-// Table of contents items
 const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
   { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
   { id: 'examples', title: 'Examples' },
-  { id: 'default', title: 'Default', branch: 'start' },
-  { id: 'sizes', title: 'Sizes', branch: 'child' },
+  { id: 'sizes', title: 'Sizes', branch: 'start' },
   { id: 'button-loading', title: 'Button Loading', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
-// Code examples
-const defaultCode = `import { Spinner } from '@/components/ui/spinner'
+const usageCode = `import { Spinner } from "@/components/ui/spinner"
 
-function SpinnerDefault() {
+function SpinnerDemo() {
   return <Spinner />
 }`
 
@@ -70,7 +72,6 @@ function SpinnerButton() {
   )
 }`
 
-// Props definition
 const spinnerProps: PropDefinition[] = [
   {
     name: 'className',
@@ -86,7 +87,7 @@ const spinnerProps: PropDefinition[] = [
   },
 ]
 
-export function SpinnerPage() {
+export function SpinnerRefPage() {
   return (
     <DocPage slug="spinner" toc={tocItems}>
       <div className="space-y-12">
@@ -96,23 +97,24 @@ export function SpinnerPage() {
           {...getNavLinks('spinner')}
         />
 
-        {/* Preview */}
-        <Example title="" code={`<Spinner />`}>
-          <Spinner />
-        </Example>
+        {/* Props Playground */}
+        <SpinnerPlayground />
 
         {/* Installation */}
         <Section id="installation" title="Installation">
           <PackageManagerTabs command="barefoot add spinner" />
         </Section>
 
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <Spinner />
+          </Example>
+        </Section>
+
         {/* Examples */}
         <Section id="examples" title="Examples">
           <div className="space-y-8">
-            <Example title="Default" code={defaultCode}>
-              <Spinner />
-            </Example>
-
             <Example title="Sizes" code={sizesCode}>
               <SpinnerSizesDemo />
             </Example>

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -112,7 +112,7 @@ const menuEntries: SidebarEntry[] = [
       { title: 'Skeleton', href: '/components/skeleton' },
       { title: 'Sheet', href: '/docs/components/sheet' },
       { title: 'Slider', href: '/components/slider' },
-      { title: 'Spinner', href: '/docs/components/spinner' },
+      { title: 'Spinner', href: '/components/spinner' },
       { title: 'Switch', href: '/components/switch' },
       { title: 'Table', href: '/components/table' },
       { title: 'Tabs', href: '/docs/components/tabs' },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -57,7 +57,7 @@ import { SidebarPage } from './pages/sidebar'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarPage } from './pages/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
-import { SpinnerPage } from './pages/spinner'
+import { SpinnerRefPage } from './pages/components/spinner'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
@@ -255,7 +255,7 @@ export function createApp() {
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Slider</h3>
               <p className="text-xs text-muted-foreground">Range value selector</p>
             </a>
-            <a href="/docs/components/spinner" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
+            <a href="/components/spinner" className="group flex flex-col rounded-xl border border-border hover:border-ring transition-colors no-underline p-6 space-y-2">
               <h3 className="text-sm font-medium text-foreground group-hover:text-foreground">Spinner</h3>
               <p className="text-xs text-muted-foreground">Animated loading indicator</p>
             </a>
@@ -459,9 +459,9 @@ export function createApp() {
     return c.render(<InputRefPage />)
   })
 
-  // Spinner documentation
-  app.get('/docs/components/spinner', (c) => {
-    return c.render(<SpinnerPage />)
+  // Spinner reference page
+  app.get('/components/spinner', (c) => {
+    return c.render(<SpinnerRefPage />)
   })
 
   // Switch reference page


### PR DESCRIPTION
## Summary
- Replace old `SpinnerPage` at `/docs/components/spinner` with new `SpinnerRefPage` at `/components/spinner`
- Add interactive Props Playground (`spinner-playground.tsx`) with size presets
- Update routes, sidebar navigation, homepage card link, and E2E tests to use new path

## Test plan
- [x] `bun run build` passes
- [x] All 6 spinner E2E tests pass (`bun run test:e2e -- --grep Spinner`)
- [x] No remaining references to `/docs/components/spinner` in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)