### PR TITLE
Add RadialChart component

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -41,12 +41,14 @@
     "@barefootjs/dom": ">=0.0.1"
   },
   "dependencies": {
+    "d3-array": "^3.2.4",
     "d3-scale": "^4.0.2",
-    "d3-array": "^3.2.4"
+    "d3-shape": "^3.2.0"
   },
   "devDependencies": {
-    "@types/d3-scale": "^4.0.8",
     "@types/d3-array": "^3.2.1",
+    "@types/d3-scale": "^4.0.8",
+    "@types/d3-shape": "^3.1.8",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/chart/src/context.ts
+++ b/packages/chart/src/context.ts
@@ -1,6 +1,8 @@
 import { createContext } from '@barefootjs/dom'
-import type { BarChartContextValue, ChartConfig } from './types'
+import type { BarChartContextValue, RadialChartContextValue, ChartConfig } from './types'
 
 export const BarChartContext = createContext<BarChartContextValue>()
+
+export const RadialChartContext = createContext<RadialChartContextValue>()
 
 export const ChartConfigContext = createContext<{ config: ChartConfig }>()

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -1,5 +1,5 @@
 // Export context for JSX wrapper components
-export { BarChartContext, ChartConfigContext } from './context'
+export { BarChartContext, RadialChartContext, ChartConfigContext } from './context'
 
 // Export init functions for JSX wrapper ref callbacks
 export { applyChartCSSVariables, initChartContainer } from './chart-container'
@@ -9,11 +9,15 @@ export { initCartesianGrid } from './cartesian-grid'
 export { initXAxis } from './x-axis'
 export { initYAxis } from './y-axis'
 export { initChartTooltip } from './tooltip'
+export { initRadialChart } from './radial-chart'
+export { initRadialBar } from './radial-bar'
+export { initRadialChartLabel } from './radial-chart-label'
 
 // Type exports
 export type {
   ChartConfig,
   BarRegistration,
+  RadialBarRegistration,
   ChartContainerProps,
   BarChartProps,
   BarProps,
@@ -21,4 +25,7 @@ export type {
   XAxisProps,
   YAxisProps,
   ChartTooltipProps,
+  RadialChartProps,
+  RadialBarProps,
+  RadialChartLabelProps,
 } from './types'

--- a/packages/chart/src/radial-bar.ts
+++ b/packages/chart/src/radial-bar.ts
@@ -1,0 +1,138 @@
+import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
+import { RadialChartContext } from './context'
+import { arc as d3Arc } from 'd3-shape'
+import { scaleLinear } from 'd3-scale'
+import { max } from 'd3-array'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Init function for RadialBar component.
+ * Renders arc segments for each data entry in a radial chart.
+ * Each data entry becomes a concentric ring; the arc angle represents the value.
+ */
+export function initRadialBar(_scope: Element, props: Record<string, unknown>): void {
+  const ctx = useContext(RadialChartContext)
+
+  let currentDataKey: string | null = null
+
+  // Registration effect
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const fill = (props.fill as string) ?? 'currentColor'
+
+    if (currentDataKey !== null) {
+      ctx.unregisterRadialBar(currentDataKey)
+    }
+    ctx.registerRadialBar({ dataKey, fill })
+    currentDataKey = dataKey
+  })
+
+  onCleanup(() => {
+    if (currentDataKey !== null) ctx.unregisterRadialBar(currentDataKey)
+  })
+
+  // Rendering effect
+  let arcGroup: SVGGElement | null = null
+
+  createEffect(() => {
+    const dataKey = props.dataKey as string
+    const fill = (props.fill as string) ?? 'currentColor'
+
+    const g = ctx.svgGroup()
+    if (!g) return
+
+    // Clear previous arcs
+    if (arcGroup) {
+      arcGroup.remove()
+      arcGroup = null
+    }
+
+    const data = ctx.data()
+    if (data.length === 0) return
+
+    const innerR = ctx.innerRadius()
+    const outerR = ctx.outerRadius()
+    const startDeg = ctx.startAngle()
+    const endDeg = ctx.endAngle()
+
+    // Convert degrees to radians (SVG arc convention: 0 = top, clockwise)
+    const startRad = (startDeg - 90) * (Math.PI / 180)
+    const endRad = (endDeg - 90) * (Math.PI / 180)
+
+    // Find max value for angle scale
+    const maxValue = max(data, (d) => {
+      const v = d[dataKey]
+      return typeof v === 'number' ? v : 0
+    }) ?? 1
+
+    const angleScale = scaleLinear()
+      .domain([0, maxValue])
+      .range([startRad, endRad])
+
+    // Each data entry gets a concentric ring
+    const ringCount = data.length
+    const ringThickness = (outerR - innerR) / ringCount
+    const ringPadding = Math.max(1, ringThickness * 0.1)
+
+    const arcGenerator = d3Arc<{ innerR: number; outerR: number; startAngle: number; endAngle: number }>()
+      .innerRadius((d) => d.innerR)
+      .outerRadius((d) => d.outerR)
+      .startAngle((d) => d.startAngle)
+      .endAngle((d) => d.endAngle)
+      .cornerRadius(4)
+
+    arcGroup = document.createElementNS(SVG_NS, 'g')
+    arcGroup.setAttribute('class', `chart-radial-bar chart-radial-bar-${dataKey}`)
+
+    for (let i = 0; i < data.length; i++) {
+      const datum = data[i]
+      const value = Number(datum[dataKey]) || 0
+
+      const rInner = innerR + i * ringThickness + ringPadding / 2
+      const rOuter = innerR + (i + 1) * ringThickness - ringPadding / 2
+
+      // Background track
+      const trackPath = document.createElementNS(SVG_NS, 'path')
+      const trackD = arcGenerator({
+        innerR: rInner,
+        outerR: rOuter,
+        startAngle: startRad,
+        endAngle: endRad,
+      })
+      if (trackD) {
+        trackPath.setAttribute('d', trackD)
+        trackPath.setAttribute('fill', 'currentColor')
+        trackPath.setAttribute('opacity', '0.1')
+        arcGroup.appendChild(trackPath)
+      }
+
+      // Value arc
+      const valueAngle = angleScale(value)
+      const arcPath = document.createElementNS(SVG_NS, 'path')
+      const arcD = arcGenerator({
+        innerR: rInner,
+        outerR: rOuter,
+        startAngle: startRad,
+        endAngle: valueAngle,
+      })
+      if (arcD) {
+        arcPath.setAttribute('d', arcD)
+        arcPath.setAttribute('fill', fill)
+        arcPath.setAttribute('data-key', dataKey)
+        arcPath.setAttribute('data-value', String(value))
+        arcPath.setAttribute('data-index', String(i))
+
+        // Use per-item color from config if data has a fill/color property
+        const itemFill = datum.fill as string | undefined
+        if (itemFill) {
+          arcPath.setAttribute('fill', itemFill)
+        }
+
+        arcGroup.appendChild(arcPath)
+      }
+    }
+
+    g.appendChild(arcGroup)
+  })
+}

--- a/packages/chart/src/radial-chart-label.ts
+++ b/packages/chart/src/radial-chart-label.ts
@@ -1,0 +1,47 @@
+import { useContext, createEffect } from '@barefootjs/dom'
+import { RadialChartContext } from './context'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Init function for RadialChartLabel component.
+ * Renders content in the center of the radial chart using a foreignObject.
+ */
+export function initRadialChartLabel(scope: Element, _props: Record<string, unknown>): void {
+  const ctx = useContext(RadialChartContext)
+
+  createEffect(() => {
+    const g = ctx.svgGroup()
+    if (!g) return
+
+    const innerR = ctx.innerRadius()
+
+    // Create a foreignObject centered in the donut hole
+    const size = innerR * 2 * 0.7 // Use 70% of inner diameter to give padding
+    const fo = document.createElementNS(SVG_NS, 'foreignObject')
+    fo.setAttribute('x', String(-size / 2))
+    fo.setAttribute('y', String(-size / 2))
+    fo.setAttribute('width', String(size))
+    fo.setAttribute('height', String(size))
+    fo.setAttribute('class', 'chart-radial-label')
+
+    // Create a container div for the label content
+    const div = document.createElement('div')
+    div.style.width = '100%'
+    div.style.height = '100%'
+    div.style.display = 'flex'
+    div.style.flexDirection = 'column'
+    div.style.alignItems = 'center'
+    div.style.justifyContent = 'center'
+    div.style.textAlign = 'center'
+
+    // Move children from the scope element into the center label
+    const el = scope as HTMLElement
+    while (el.firstChild) {
+      div.appendChild(el.firstChild)
+    }
+
+    fo.appendChild(div)
+    g.appendChild(fo)
+  })
+}

--- a/packages/chart/src/radial-chart.ts
+++ b/packages/chart/src/radial-chart.ts
@@ -1,0 +1,75 @@
+import { createSignal, provideContext, useContext } from '@barefootjs/dom'
+import type { RadialBarRegistration } from './types'
+import { RadialChartContext, ChartConfigContext } from './context'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const DEFAULT_MARGIN = 10
+
+/**
+ * Init function for RadialChart component.
+ * Creates SVG with a centered coordinate system, provides context to children.
+ * Props are read lazily via accessor functions to support reactive updates.
+ */
+export function initRadialChart(scope: Element, props: Record<string, unknown>): void {
+  const { config } = useContext(ChartConfigContext)
+
+  const el = scope as HTMLElement
+  const containerRect = el.getBoundingClientRect()
+  const size = Math.min(containerRect.width || 300, containerRect.height || 300) || 300
+  const width = containerRect.width || size
+  const height = size
+
+  el.style.height = `${height}px`
+  el.style.minHeight = ''
+
+  const margin = DEFAULT_MARGIN
+  const iw = width - margin * 2
+  const ih = height - margin * 2
+  const cx = width / 2
+  const cy = height / 2
+  const maxRadius = Math.min(iw, ih) / 2
+
+  const svg = document.createElementNS(SVG_NS, 'svg')
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+  svg.style.width = '100%'
+  svg.style.height = `${height}px`
+  svg.style.display = 'block'
+
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('transform', `translate(${cx},${cy})`)
+  svg.appendChild(g)
+  el.appendChild(svg)
+
+  const [radialBars, setRadialBars] = createSignal<RadialBarRegistration[]>([])
+
+  const registerRadialBar = (bar: RadialBarRegistration) => {
+    setRadialBars((prev) => [...prev, bar])
+  }
+
+  const unregisterRadialBar = (dataKey: string) => {
+    setRadialBars((prev) => prev.filter((b) => b.dataKey !== dataKey))
+  }
+
+  // Read props lazily so signal-driven prop changes propagate
+  provideContext(RadialChartContext, {
+    svgGroup: () => g,
+    container: () => el,
+    data: () => (props.data as Record<string, unknown>[]) ?? [],
+    innerRadius: () => {
+      const v = props.innerRadius as number | undefined
+      return v != null ? v : maxRadius * 0.4
+    },
+    outerRadius: () => {
+      const v = props.outerRadius as number | undefined
+      return v != null ? v : maxRadius
+    },
+    startAngle: () => (props.startAngle as number) ?? 0,
+    endAngle: () => (props.endAngle as number) ?? 360,
+    config: () => config,
+    centerX: () => cx,
+    centerY: () => cy,
+    radialBars,
+    registerRadialBar,
+    unregisterRadialBar,
+  })
+}

--- a/packages/chart/src/radial-chart.ts
+++ b/packages/chart/src/radial-chart.ts
@@ -15,9 +15,8 @@ export function initRadialChart(scope: Element, props: Record<string, unknown>):
 
   const el = scope as HTMLElement
   const containerRect = el.getBoundingClientRect()
-  const size = Math.min(containerRect.width || 300, containerRect.height || 300) || 300
-  const width = containerRect.width || size
-  const height = size
+  const width = containerRect.width || 300
+  const height = width
 
   el.style.height = `${height}px`
   el.style.minHeight = ''

--- a/packages/chart/src/types.ts
+++ b/packages/chart/src/types.ts
@@ -60,6 +60,51 @@ export interface ChartTooltipProps {
   labelFormatter?: (label: string) => string
 }
 
+/** Registration info for a radial bar series */
+export interface RadialBarRegistration {
+  dataKey: string
+  fill: string
+}
+
+/** Props for RadialChart */
+export interface RadialChartProps {
+  data: Record<string, unknown>[]
+  innerRadius?: number
+  outerRadius?: number
+  startAngle?: number
+  endAngle?: number
+  children?: unknown
+}
+
+/** Props for RadialBar */
+export interface RadialBarProps {
+  dataKey: string
+  fill?: string
+  stackId?: string
+}
+
+/** Props for RadialChartLabel */
+export interface RadialChartLabelProps {
+  children?: unknown
+}
+
+/** Context value shared between RadialChart and its children */
+export interface RadialChartContextValue {
+  svgGroup: () => SVGGElement | null
+  container: () => HTMLElement | null
+  data: () => Record<string, unknown>[]
+  innerRadius: () => number
+  outerRadius: () => number
+  startAngle: () => number
+  endAngle: () => number
+  config: () => ChartConfig
+  centerX: () => number
+  centerY: () => number
+  radialBars: () => RadialBarRegistration[]
+  registerRadialBar: (bar: RadialBarRegistration) => void
+  unregisterRadialBar: (dataKey: string) => void
+}
+
 /** Context value shared between BarChart and its children */
 export interface BarChartContextValue {
   svgGroup: () => SVGGElement | null

--- a/site/ui/components/radial-chart-demo.tsx
+++ b/site/ui/components/radial-chart-demo.tsx
@@ -1,0 +1,156 @@
+"use client"
+/**
+ * RadialChartDemo Components
+ *
+ * Interactive demos for the Radial Chart component.
+ * Uses JSX component API with @barefootjs/chart.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import type { ChartConfig } from '@barefootjs/chart'
+import {
+  ChartContainer,
+  RadialChart,
+  RadialBar,
+  RadialChartLabel,
+} from '@ui/components/ui/chart'
+
+const chartConfig: ChartConfig = {
+  safari: { label: 'Safari', color: 'hsl(221 83% 53%)' },
+  chrome: { label: 'Chrome', color: 'hsl(142 76% 36%)' },
+  firefox: { label: 'Firefox', color: 'hsl(38 92% 50%)' },
+  edge: { label: 'Edge', color: 'hsl(280 65% 60%)' },
+  other: { label: 'Other', color: 'hsl(340 75% 55%)' },
+}
+
+const chartData = [
+  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
+  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
+  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
+  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+]
+
+/**
+ * Preview demo — browser visitors radial chart
+ */
+export function RadialChartPreviewDemo() {
+  return (
+    <div className="w-full space-y-2">
+      <div>
+        <h4 className="text-sm font-medium">Browser Visitors</h4>
+        <p className="text-xs text-muted-foreground">January - June 2024</p>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart data={chartData} innerRadius={50} outerRadius={110}>
+          <RadialBar dataKey="visitors" />
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Basic demo — minimal radial chart
+ */
+export function RadialChartBasicDemo() {
+  return (
+    <div className="w-full">
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart data={chartData} innerRadius={50} outerRadius={110}>
+          <RadialBar dataKey="visitors" />
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Label demo — radial chart with center label showing total
+ */
+export function RadialChartLabelDemo() {
+  const total = chartData.reduce((sum, d) => sum + d.visitors, 0)
+
+  return (
+    <div className="w-full space-y-2">
+      <div>
+        <h4 className="text-sm font-medium">Total Visitors</h4>
+        <p className="text-xs text-muted-foreground">With center label</p>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart data={chartData} innerRadius={60} outerRadius={110}>
+          <RadialBar dataKey="visitors" />
+          <RadialChartLabel>
+            <tspan className="text-3xl font-bold" style="fill: var(--foreground)">
+              {total}
+            </tspan>
+            <tspan className="text-xs text-muted-foreground" style="fill: var(--muted-foreground)">
+              Visitors
+            </tspan>
+          </RadialChartLabel>
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Stacked demo — half-circle radial chart
+ */
+export function RadialChartHalfDemo() {
+  return (
+    <div className="w-full space-y-2">
+      <div>
+        <h4 className="text-sm font-medium">Half Circle</h4>
+        <p className="text-xs text-muted-foreground">Custom start and end angle</p>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart data={chartData} startAngle={180} endAngle={0} innerRadius={50} outerRadius={110}>
+          <RadialBar dataKey="visitors" />
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Interactive demo — signal-driven data switching
+ */
+export function RadialChartInteractiveDemo() {
+  const fullData = chartData
+  const topThree = chartData.slice(0, 3)
+  const [showAll, setShowAll] = createSignal(true)
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Show:</span>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            showAll()
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setShowAll(true)}
+        >
+          All Browsers
+        </button>
+        <button
+          className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 ${
+            !showAll()
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+          }`}
+          onClick={() => setShowAll(false)}
+        >
+          Top 3
+        </button>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart data={showAll() ? fullData : topThree} innerRadius={50} outerRadius={110}>
+          <RadialBar dataKey="visitors" />
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/site/ui/components/radial-chart-demo.tsx
+++ b/site/ui/components/radial-chart-demo.tsx
@@ -41,7 +41,7 @@ export function RadialChartPreviewDemo() {
         <h4 className="text-sm font-medium">Browser Visitors</h4>
         <p className="text-xs text-muted-foreground">January - June 2024</p>
       </div>
-      <ChartContainer config={chartConfig} className="w-full">
+      <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
         <RadialChart data={chartData} innerRadius={50} outerRadius={110}>
           <RadialBar dataKey="visitors" />
         </RadialChart>
@@ -55,8 +55,8 @@ export function RadialChartPreviewDemo() {
  */
 export function RadialChartBasicDemo() {
   return (
-    <div className="w-full">
-      <ChartContainer config={chartConfig} className="w-full">
+    <div className="w-full max-w-[400px] mx-auto">
+      <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
         <RadialChart data={chartData} innerRadius={50} outerRadius={110}>
           <RadialBar dataKey="visitors" />
         </RadialChart>
@@ -77,7 +77,7 @@ export function RadialChartLabelDemo() {
         <h4 className="text-sm font-medium">Total Visitors</h4>
         <p className="text-xs text-muted-foreground">With center label</p>
       </div>
-      <ChartContainer config={chartConfig} className="w-full">
+      <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
         <RadialChart data={chartData} innerRadius={60} outerRadius={110}>
           <RadialBar dataKey="visitors" />
           <RadialChartLabel>
@@ -104,7 +104,7 @@ export function RadialChartHalfDemo() {
         <h4 className="text-sm font-medium">Half Circle</h4>
         <p className="text-xs text-muted-foreground">Custom start and end angle</p>
       </div>
-      <ChartContainer config={chartConfig} className="w-full">
+      <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
         <RadialChart data={chartData} startAngle={180} endAngle={0} innerRadius={50} outerRadius={110}>
           <RadialBar dataKey="visitors" />
         </RadialChart>
@@ -146,7 +146,7 @@ export function RadialChartInteractiveDemo() {
           Top 3
         </button>
       </div>
-      <ChartContainer config={chartConfig} className="w-full">
+      <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
         <RadialChart data={showAll() ? fullData : topThree} innerRadius={50} outerRadius={110}>
           <RadialBar dataKey="visitors" />
         </RadialChart>

--- a/site/ui/components/radial-chart-playground.tsx
+++ b/site/ui/components/radial-chart-playground.tsx
@@ -1,0 +1,149 @@
+"use client"
+/**
+ * Radial Chart Props Playground
+ *
+ * Interactive playground for the RadialChart composed component.
+ * Allows tweaking innerRadius, endAngle, and data count.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import {
+  hlPlain, hlTag, hlAttr, hlStr,
+} from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import {
+  ChartContainer,
+  RadialChart,
+  RadialBar,
+} from '@ui/components/ui/chart'
+
+const chartConfig: Record<string, { label: string; color: string }> = {
+  safari: { label: "Safari", color: "hsl(221 83% 53%)" },
+  chrome: { label: "Chrome", color: "hsl(142 76% 36%)" },
+  firefox: { label: "Firefox", color: "hsl(38 92% 50%)" },
+  edge: { label: "Edge", color: "hsl(280 65% 60%)" },
+  other: { label: "Other", color: "hsl(340 75% 55%)" },
+}
+
+const chartData = [
+  { browser: "safari", visitors: 200, fill: "var(--color-safari)" },
+  { browser: "chrome", visitors: 275, fill: "var(--color-chrome)" },
+  { browser: "firefox", visitors: 187, fill: "var(--color-firefox)" },
+  { browser: "edge", visitors: 173, fill: "var(--color-edge)" },
+  { browser: "other", visitors: 90, fill: "var(--color-other)" },
+]
+
+/**
+ * Build highlighted JSX string for the composed RadialChart pattern.
+ */
+function buildHighlightedCode(innerRadius: number, endAngle: number): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  lines.push(
+    `${hlPlain('&lt;')}${hlTag('ChartContainer')} ${hlAttr('config')}${hlPlain('={chartConfig}')} ${hlAttr('className')}${hlPlain('=')}${hlStr('&quot;w-full&quot;')}${hlPlain('&gt;')}`
+  )
+
+  const innerProp = innerRadius !== 50
+    ? ` ${hlAttr('innerRadius')}${hlPlain('={' + innerRadius + '}')}`
+    : ''
+  const endProp = endAngle !== 360
+    ? ` ${hlAttr('endAngle')}${hlPlain('={' + endAngle + '}')}`
+    : ''
+  lines.push(
+    `${indent}${hlPlain('&lt;')}${hlTag('RadialChart')} ${hlAttr('data')}${hlPlain('={chartData}')}${innerProp}${endProp}${hlPlain('&gt;')}`
+  )
+
+  lines.push(
+    `${indent}${indent}${hlPlain('&lt;')}${hlTag('RadialBar')} ${hlAttr('dataKey')}${hlPlain('=')}${hlStr('&quot;visitors&quot;')} ${hlPlain('/&gt;')}`
+  )
+
+  lines.push(
+    `${indent}${hlPlain('&lt;/')}${hlTag('RadialChart')}${hlPlain('&gt;')}`
+  )
+  lines.push(
+    `${hlPlain('&lt;/')}${hlTag('ChartContainer')}${hlPlain('&gt;')}`
+  )
+
+  return lines.join('\n')
+}
+
+/**
+ * Build plain-text JSX string for clipboard copy.
+ */
+function buildPlainCode(innerRadius: number, endAngle: number): string {
+  const indent = '  '
+  const lines: string[] = []
+
+  lines.push('<ChartContainer config={chartConfig} className="w-full">')
+
+  const innerProp = innerRadius !== 50 ? ` innerRadius={${innerRadius}}` : ''
+  const endProp = endAngle !== 360 ? ` endAngle={${endAngle}}` : ''
+  lines.push(`${indent}<RadialChart data={chartData}${innerProp}${endProp}>`)
+
+  lines.push(`${indent}${indent}<RadialBar dataKey="visitors" />`)
+
+  lines.push(`${indent}</RadialChart>`)
+  lines.push('</ChartContainer>')
+
+  return lines.join('\n')
+}
+
+function RadialChartPlayground(_props: {}) {
+  const [innerRadius, setInnerRadius] = createSignal(50)
+  const [endAngle, setEndAngle] = createSignal(360)
+
+  createEffect(() => {
+    const ir = innerRadius()
+    const ea = endAngle()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = buildHighlightedCode(ir, ea)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-radial-chart-preview"
+      previewContent={
+        <div className="w-full min-w-[300px]">
+          <ChartContainer config={chartConfig} className="w-full">
+            <RadialChart data={chartData} innerRadius={innerRadius()} outerRadius={110} endAngle={endAngle()}>
+              <RadialBar dataKey="visitors" />
+            </RadialChart>
+          </ChartContainer>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="innerRadius">
+          <Select value={String(innerRadius())} onValueChange={(v: string) => setInnerRadius(Number(v))}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select inner radius..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="0">0</SelectItem>
+              <SelectItem value="30">30</SelectItem>
+              <SelectItem value="50">50</SelectItem>
+              <SelectItem value="70">70</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="endAngle">
+          <Select value={String(endAngle())} onValueChange={(v: string) => setEndAngle(Number(v))}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select end angle..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="180">180 (half)</SelectItem>
+              <SelectItem value="270">270</SelectItem>
+              <SelectItem value="360">360 (full)</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={buildPlainCode(innerRadius(), endAngle())} />}
+    />
+  )
+}
+
+export { RadialChartPlayground }

--- a/site/ui/components/radial-chart-playground.tsx
+++ b/site/ui/components/radial-chart-playground.tsx
@@ -106,8 +106,8 @@ function RadialChartPlayground(_props: {}) {
     <PlaygroundLayout
       previewDataAttr="data-radial-chart-preview"
       previewContent={
-        <div className="w-full min-w-[300px]">
-          <ChartContainer config={chartConfig} className="w-full">
+        <div className="w-full min-w-[300px] max-w-[400px] mx-auto">
+          <ChartContainer config={chartConfig} className="w-full max-w-[400px] mx-auto">
             <RadialChart data={chartData} innerRadius={innerRadius()} outerRadius={110} endAngle={endAngle()}>
               <RadialBar dataKey="visitors" />
             </RadialChart>

--- a/site/ui/components/shared/PageNavigation.tsx
+++ b/site/ui/components/shared/PageNavigation.tsx
@@ -61,6 +61,7 @@ export const componentOrder = [
 // Chart order for navigation (alphabetical)
 export const chartOrder = [
   { slug: 'bar-chart', title: 'Bar Chart' },
+  { slug: 'radial-chart', title: 'Radial Chart' },
 ]
 
 // Get prev/next links for a chart page

--- a/site/ui/e2e/radial-chart.spec.ts
+++ b/site/ui/e2e/radial-chart.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Radial Chart Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/charts/radial-chart')
+  })
+
+  test.describe('Preview', () => {
+    const scope = '[bf-s^="RadialChartPreviewDemo_"]:not([data-slot])'
+
+    test('renders an SVG chart', async ({ page }) => {
+      const container = page.locator(scope)
+      await expect(container.locator('svg')).toBeVisible()
+    })
+
+    test('renders arc paths for data', async ({ page }) => {
+      const container = page.locator(scope)
+      const arcs = container.locator('path[data-key="visitors"]')
+      await expect(arcs).toHaveCount(5)
+    })
+
+    test('renders background tracks', async ({ page }) => {
+      const container = page.locator(scope)
+      // Background tracks have opacity 0.1
+      const tracks = container.locator('path[opacity="0.1"]')
+      await expect(tracks).toHaveCount(5)
+    })
+  })
+
+  test.describe('Playground', () => {
+    test('renders chart in playground preview', async ({ page }) => {
+      const preview = page.locator('[data-radial-chart-preview]')
+      await expect(preview).toBeVisible()
+      await expect(preview.locator('svg').first()).toBeVisible()
+    })
+
+    test('renders arc paths in playground', async ({ page }) => {
+      const preview = page.locator('[data-radial-chart-preview]')
+      const arcs = preview.locator('path[data-key="visitors"]')
+      await expect(arcs).toHaveCount(5)
+    })
+
+    test('changing innerRadius updates the chart', async ({ page }) => {
+      const preview = page.locator('[data-radial-chart-preview]')
+      const arc = preview.locator('path[data-key="visitors"]').first()
+
+      // Get initial d attribute
+      const initialD = await arc.getAttribute('d')
+
+      // Open the innerRadius select
+      const playgroundSection = page.locator('[data-radial-chart-preview]').locator('..').locator('..')
+      const innerRadiusSelect = playgroundSection.locator('button[role="combobox"]').first()
+      await innerRadiusSelect.click()
+      await page.locator('[role="option"][data-value="0"]').click()
+
+      // d attribute should change
+      const updatedD = await arc.getAttribute('d')
+      expect(updatedD).not.toBe(initialD)
+    })
+
+    test('changing endAngle updates arc extent', async ({ page }) => {
+      const preview = page.locator('[data-radial-chart-preview]')
+      const arc = preview.locator('path[data-key="visitors"]').first()
+
+      // Get initial d attribute
+      const initialD = await arc.getAttribute('d')
+
+      // Open the endAngle select (second combobox)
+      const playgroundSection = page.locator('[data-radial-chart-preview]').locator('..').locator('..')
+      const endAngleSelect = playgroundSection.locator('button[role="combobox"]').nth(1)
+      await endAngleSelect.click()
+      await page.locator('[role="option"]:has-text("180")').click()
+
+      // d attribute should change (half circle)
+      const updatedD = await arc.getAttribute('d')
+      expect(updatedD).not.toBe(initialD)
+    })
+  })
+
+  test.describe('Basic', () => {
+    test('renders an SVG with arcs', async ({ page }) => {
+      const container = page.locator('[bf-s^="RadialChartBasicDemo_"]:not([data-slot])')
+      await expect(container.locator('svg')).toBeVisible()
+      const arcs = container.locator('path[data-key="visitors"]')
+      await expect(arcs).toHaveCount(5)
+    })
+  })
+
+  test.describe('Label', () => {
+    test('renders center label', async ({ page }) => {
+      const container = page.locator('[bf-s^="RadialChartLabelDemo_"]:not([data-slot])')
+      await expect(container.locator('svg')).toBeVisible()
+      const label = container.locator('.chart-radial-label')
+      await expect(label).toBeVisible()
+    })
+  })
+
+  test.describe('Half Circle', () => {
+    test('renders half-circle radial chart', async ({ page }) => {
+      const container = page.locator('[bf-s^="RadialChartHalfDemo_"]:not([data-slot])')
+      await expect(container.locator('svg')).toBeVisible()
+      const arcs = container.locator('path[data-key="visitors"]')
+      await expect(arcs).toHaveCount(5)
+    })
+  })
+
+  test.describe('Interactive', () => {
+    test('switching data set updates the chart', async ({ page }) => {
+      const section = page.locator('[bf-s^="RadialChartInteractiveDemo_"]:not([data-slot])').first()
+
+      // Initially shows all 5 browsers
+      await expect(section.locator('path[data-key="visitors"]')).toHaveCount(5)
+
+      // Click Top 3 button
+      await section.locator('button:has-text("Top 3")').click()
+
+      // Should now show only 3 arcs
+      await expect(section.locator('path[data-key="visitors"]')).toHaveCount(3)
+    })
+  })
+})

--- a/site/ui/pages/charts/radial-chart.tsx
+++ b/site/ui/pages/charts/radial-chart.tsx
@@ -1,0 +1,308 @@
+/**
+ * Radial Chart Documentation Page
+ */
+
+import {
+  RadialChartPreviewDemo,
+  RadialChartBasicDemo,
+  RadialChartLabelDemo,
+  RadialChartHalfDemo,
+  RadialChartInteractiveDemo,
+} from '@/components/radial-chart-demo'
+import { RadialChartPlayground } from '@/components/radial-chart-playground'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getChartNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'label', title: 'Label', branch: 'child' },
+  { id: 'half-circle', title: 'Half Circle', branch: 'child' },
+  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import type { ChartConfig } from "@barefootjs/chart"
+import {
+  ChartContainer,
+  RadialChart,
+  RadialBar,
+} from "@/components/ui/chart"
+
+const chartConfig: ChartConfig = {
+  safari: { label: "Safari", color: "hsl(221 83% 53%)" },
+  chrome: { label: "Chrome", color: "hsl(142 76% 36%)" },
+  firefox: { label: "Firefox", color: "hsl(38 92% 50%)" },
+  edge: { label: "Edge", color: "hsl(280 65% 60%)" },
+  other: { label: "Other", color: "hsl(340 75% 55%)" },
+}
+
+const chartData = [
+  { browser: "safari", visitors: 200, fill: "var(--color-safari)" },
+  { browser: "chrome", visitors: 275, fill: "var(--color-chrome)" },
+  { browser: "firefox", visitors: 187, fill: "var(--color-firefox)" },
+  { browser: "edge", visitors: 173, fill: "var(--color-edge)" },
+  { browser: "other", visitors: 90, fill: "var(--color-other)" },
+]
+
+export function MyRadialChart() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <RadialChart
+        data={chartData}
+        innerRadius={50}
+        outerRadius={110}
+      >
+        <RadialBar dataKey="visitors" />
+      </RadialChart>
+    </ChartContainer>
+  )
+}`
+
+const basicCode = `"use client"
+
+import type { ChartConfig } from "@barefootjs/chart"
+
+const chartConfig: ChartConfig = {
+  safari: { label: "Safari", color: "hsl(221 83% 53%)" },
+  chrome: { label: "Chrome", color: "hsl(142 76% 36%)" },
+  // ...
+}
+
+const chartData = [
+  { browser: "safari", visitors: 200, fill: "var(--color-safari)" },
+  { browser: "chrome", visitors: 275, fill: "var(--color-chrome)" },
+  // ...
+]
+
+export function RadialChartBasicDemo() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <RadialChart data={chartData} innerRadius={50} outerRadius={110}>
+        <RadialBar dataKey="visitors" />
+      </RadialChart>
+    </ChartContainer>
+  )
+}`
+
+const labelCode = `"use client"
+
+import {
+  ChartContainer,
+  RadialChart,
+  RadialBar,
+  RadialChartLabel,
+} from "@/components/ui/chart"
+
+export function RadialChartLabelDemo() {
+  const total = chartData.reduce((sum, d) => sum + d.visitors, 0)
+
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <RadialChart data={chartData} innerRadius={60} outerRadius={110}>
+        <RadialBar dataKey="visitors" />
+        <RadialChartLabel>
+          <tspan className="text-3xl font-bold">{total}</tspan>
+          <tspan className="text-xs">Visitors</tspan>
+        </RadialChartLabel>
+      </RadialChart>
+    </ChartContainer>
+  )
+}`
+
+const halfCode = `"use client"
+
+export function RadialChartHalfDemo() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full">
+      <RadialChart
+        data={chartData}
+        startAngle={180}
+        endAngle={0}
+        innerRadius={50}
+        outerRadius={110}
+      >
+        <RadialBar dataKey="visitors" />
+      </RadialChart>
+    </ChartContainer>
+  )
+}`
+
+const interactiveCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+
+export function RadialChartInteractiveDemo() {
+  const [showAll, setShowAll] = createSignal(true)
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-4">
+        <button onClick={() => setShowAll(true)}>
+          All Browsers
+        </button>
+        <button onClick={() => setShowAll(false)}>
+          Top 3
+        </button>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <RadialChart
+          data={showAll() ? fullData : topThree}
+          innerRadius={50}
+          outerRadius={110}
+        >
+          <RadialBar dataKey="visitors" />
+        </RadialChart>
+      </ChartContainer>
+    </div>
+  )
+}`
+
+const radialChartProps: PropDefinition[] = [
+  {
+    name: 'data',
+    type: 'Record<string, unknown>[]',
+    description: 'Array of data objects. Each object represents one ring in the radial chart.',
+  },
+  {
+    name: 'innerRadius',
+    type: 'number',
+    defaultValue: '40% of max',
+    description: 'Inner radius of the radial chart in pixels.',
+  },
+  {
+    name: 'outerRadius',
+    type: 'number',
+    defaultValue: 'auto',
+    description: 'Outer radius of the radial chart in pixels.',
+  },
+  {
+    name: 'startAngle',
+    type: 'number',
+    defaultValue: '0',
+    description: 'Start angle in degrees (0 = top, clockwise).',
+  },
+  {
+    name: 'endAngle',
+    type: 'number',
+    defaultValue: '360',
+    description: 'End angle in degrees.',
+  },
+]
+
+const chartContainerProps: PropDefinition[] = [
+  {
+    name: 'config',
+    type: 'ChartConfig',
+    description: 'Maps each data key to a label and color. Sets CSS variables for theming.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names for the container element.',
+  },
+]
+
+const radialBarProps: PropDefinition[] = [
+  {
+    name: 'dataKey',
+    type: 'string',
+    description: 'The key in the data objects to use for arc values.',
+  },
+  {
+    name: 'fill',
+    type: 'string',
+    defaultValue: 'currentColor',
+    description: 'Fill color for the arcs. Each data item can override with its own fill property.',
+  },
+]
+
+const radialChartLabelProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description: 'Content to display in the center of the radial chart.',
+  },
+]
+
+export function RadialChartRefPage() {
+  return (
+    <DocPage slug="radial-chart" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Radial Chart"
+          description="A composable radial bar chart built with SVG and D3 scales."
+          {...getChartNavLinks('radial-chart')}
+        />
+
+        {/* Props Playground */}
+        <RadialChartPlayground />
+
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="bun add @barefootjs/chart" />
+        </Section>
+
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <RadialChartPreviewDemo />
+          </Example>
+        </Section>
+
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <RadialChartBasicDemo />
+            </Example>
+
+            <Example title="Label" code={labelCode}>
+              <RadialChartLabelDemo />
+            </Example>
+
+            <Example title="Half Circle" code={halfCode}>
+              <RadialChartHalfDemo />
+            </Example>
+
+            <Example title="Interactive" code={interactiveCode}>
+              <RadialChartInteractiveDemo />
+            </Example>
+          </div>
+        </Section>
+
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">RadialChart</h3>
+              <PropsTable props={radialChartProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">ChartContainer</h3>
+              <PropsTable props={chartContainerProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">RadialBar</h3>
+              <PropsTable props={radialBarProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">RadialChartLabel</h3>
+              <PropsTable props={radialChartLabelProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -140,7 +140,8 @@ const menuEntries: SidebarEntry[] = [
   {
     title: 'Charts',
     links: [
-      { title: 'Bar Chart', href: '/docs/charts/bar-chart' },
+      { title: 'Bar Chart', href: '/charts/bar-chart' },
+      { title: 'Radial Chart', href: '/charts/radial-chart' },
     ],
   },
 ]

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -62,6 +62,7 @@ import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
 import { BarChartRefPage } from './pages/charts/bar-chart'
+import { RadialChartRefPage } from './pages/charts/radial-chart'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -601,6 +602,11 @@ export function createApp() {
   // Bar Chart reference page
   app.get('/charts/bar-chart', (c) => {
     return c.render(<BarChartRefPage />)
+  })
+
+  // Radial Chart reference page
+  app.get('/charts/radial-chart', (c) => {
+    return c.render(<RadialChartRefPage />)
   })
 
   // Controlled Input pattern documentation

--- a/ui/components/ui/chart/index.tsx
+++ b/ui/components/ui/chart/index.tsx
@@ -16,6 +16,9 @@ import {
   initXAxis as xAxisInit,
   initYAxis as yAxisInit,
   initChartTooltip as chartTooltipInit,
+  initRadialChart as radialChartInit,
+  initRadialBar as radialBarInit,
+  initRadialChartLabel as radialChartLabelInit,
 } from '@barefootjs/chart'
 
 /** Color and label configuration for chart data series */
@@ -56,6 +59,25 @@ interface YAxisProps {
 
 interface ChartTooltipProps {
   labelFormatter?: (label: string) => string
+}
+
+interface RadialChartProps {
+  data: Record<string, unknown>[]
+  innerRadius?: number
+  outerRadius?: number
+  startAngle?: number
+  endAngle?: number
+  children?: unknown
+}
+
+interface RadialBarProps {
+  dataKey: string
+  fill?: string
+  stackId?: string
+}
+
+interface RadialChartLabelProps {
+  children?: unknown
 }
 
 function ChartContainer(props: ChartContainerProps) {
@@ -122,6 +144,38 @@ function ChartTooltip(props: ChartTooltipProps) {
   return <span data-slot="chart-tooltip" style="display:none" ref={handleMount} />
 }
 
+function RadialChart(props: RadialChartProps) {
+  const handleMount = (el: HTMLElement) => {
+    radialChartInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return (
+    <div data-slot="radial-chart" ref={handleMount}>
+      {props.children}
+    </div>
+  )
+}
+
+function RadialBar(props: RadialBarProps) {
+  const handleMount = (el: HTMLElement) => {
+    radialBarInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return <span data-slot="radial-bar" style="display:none" ref={handleMount} />
+}
+
+function RadialChartLabel(props: RadialChartLabelProps) {
+  const handleMount = (el: HTMLElement) => {
+    radialChartLabelInit(el, props as unknown as Record<string, unknown>)
+  }
+
+  return (
+    <span data-slot="radial-chart-label" ref={handleMount}>
+      {props.children}
+    </span>
+  )
+}
+
 export {
   ChartContainer,
   BarChart,
@@ -130,6 +184,9 @@ export {
   XAxis,
   YAxis,
   ChartTooltip,
+  RadialChart,
+  RadialBar,
+  RadialChartLabel,
 }
 
 export type {
@@ -140,4 +197,7 @@ export type {
   XAxisProps,
   YAxisProps,
   ChartTooltipProps,
+  RadialChartProps,
+  RadialBarProps,
+  RadialChartLabelProps,
 }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -65,6 +65,12 @@
       "description": "A bar chart component built with SVG and D3 scales"
     },
     {
+      "name": "radial-chart",
+      "type": "registry:ui",
+      "title": "Radial Chart",
+      "description": "A radial bar chart component built with SVG and D3 arc shapes"
+    },
+    {
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",


### PR DESCRIPTION
## Summary
- Port shadcn/ui radial-chart to BarefootJS using D3 `d3-shape` arc generator + native SVG
- Follow the same architecture as BarChart: init functions → JSX wrappers → context-based parent-child communication
- New runtime components: `RadialChart`, `RadialBar`, `RadialChartLabel` in `packages/chart/`
- JSX wrappers added to `ui/components/ui/chart/index.tsx`
- Docs page with playground, 4 demo variants (basic, label, half-circle, interactive), and API reference
- 11 E2E tests covering rendering, playground interactivity, and signal-driven updates

Closes #134

## Test plan
- [x] `bun run build` passes
- [x] 11 new E2E tests pass (`bun run test:e2e -- --grep "Radial Chart"`)
- [x] Full E2E suite passes (743/744, 1 pre-existing menubar failure)
- [ ] Visual review of `/charts/radial-chart` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)