### PR TITLE
Fix flaky menubar ArrowRight/ArrowLeft roving focus test

### DIFF
--- a/ui/components/ui/menubar/index.tsx
+++ b/ui/components/ui/menubar/index.tsx
@@ -361,10 +361,10 @@ function MenubarContent(props: MenubarContentProps) {
           } else {
             // Navigate to next menubar trigger
             e.preventDefault()
-            const bar = document.querySelector('[data-slot="menubar"]')
+            const currentTrigger = contentTriggerMap.get(el)
+            const bar = currentTrigger?.closest('[data-slot="menubar"]')
             if (!bar) break
             const triggers = Array.from(bar.querySelectorAll('[data-slot="menubar-trigger"]')) as HTMLElement[]
-            const currentTrigger = contentTriggerMap.get(el)
             const triggerIndex = currentTrigger ? triggers.indexOf(currentTrigger) : -1
             const nextIndex = triggerIndex < triggers.length - 1 ? triggerIndex + 1 : 0
             const nextTrigger = triggers[nextIndex]
@@ -377,10 +377,10 @@ function MenubarContent(props: MenubarContentProps) {
         case 'ArrowLeft': {
           // Navigate to previous menubar trigger
           e.preventDefault()
-          const bar = document.querySelector('[data-slot="menubar"]')
+          const currentTrigger = contentTriggerMap.get(el)
+          const bar = currentTrigger?.closest('[data-slot="menubar"]')
           if (!bar) break
           const triggers = Array.from(bar.querySelectorAll('[data-slot="menubar-trigger"]')) as HTMLElement[]
-          const currentTrigger = contentTriggerMap.get(el)
           const triggerIndex = currentTrigger ? triggers.indexOf(currentTrigger) : -1
           const prevIndex = triggerIndex > 0 ? triggerIndex - 1 : triggers.length - 1
           const prevTrigger = triggers[prevIndex]


### PR DESCRIPTION
## Summary

- Fix `MenubarContent` keyboard handlers (`ArrowRight`/`ArrowLeft`) using `document.querySelector('[data-slot="menubar"]')` which always returns the **first** menubar on the page
- Replace with `contentTriggerMap.get(el)?.closest('[data-slot="menubar"]')` to find the correct parent menubar via the existing trigger-to-content mapping
- This fixes the flaky E2E test `ArrowRight in content navigates to next menu trigger` (#660) which failed when multiple menubars existed on the page

## Root Cause

The test page renders 3 menubars (2x BasicDemo + 1x ApplicationDemo). The test interacts with the 3rd one (ApplicationDemo), but `document.querySelector` always returned the 1st menubar. When triggers from the wrong menubar were used, `indexOf` returned -1 and navigation silently targeted the wrong trigger.

## Test plan

- [x] E2E menubar tests pass with `--repeat-each=5` (120/120 passed)
- [x] Full build succeeds

Fixes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)