### PR TITLE
Add Studio export URL and CLI init --from support

### DIFF
--- a/packages/cli/src/__tests__/init-from.test.ts
+++ b/packages/cli/src/__tests__/init-from.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test'
+import { parseStudioUrl, deriveRegistryUrl, applyTokenOverrides, type StudioConfig } from '../commands/init'
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import path from 'path'
+import os from 'os'
+
+// ── parseStudioUrl ──
+
+describe('parseStudioUrl', () => {
+  test('extracts and decodes ?c= param', () => {
+    const config: StudioConfig = { style: 'Sharp', radius: '0' }
+    const encoded = encodeURIComponent(btoa(JSON.stringify(config)))
+    const url = `https://ui.barefootjs.dev/studio?c=${encoded}`
+
+    const result = parseStudioUrl(url)
+    expect(result).toEqual(config)
+  })
+
+  test('returns undefined when no ?c= param', () => {
+    const result = parseStudioUrl('https://ui.barefootjs.dev/studio')
+    expect(result).toBeUndefined()
+  })
+
+  test('returns undefined for malformed Base64', () => {
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    const result = parseStudioUrl('https://ui.barefootjs.dev/studio?c=!!!invalid!!!')
+    expect(result).toBeUndefined()
+    errorSpy.mockRestore()
+  })
+
+  test('returns undefined for invalid URL', () => {
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    const result = parseStudioUrl('not-a-url')
+    expect(result).toBeUndefined()
+    errorSpy.mockRestore()
+  })
+
+  test('decodes config with tokens', () => {
+    const config: StudioConfig = {
+      style: 'Default',
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)', dark: 'oklch(0.7 0.15 240)' },
+      },
+      spacing: '0.3rem',
+      radius: '1rem',
+      font: 'inter',
+    }
+    const encoded = encodeURIComponent(btoa(JSON.stringify(config)))
+    const url = `https://ui.barefootjs.dev/studio?c=${encoded}`
+
+    const result = parseStudioUrl(url)
+    expect(result).toEqual(config)
+  })
+})
+
+// ── deriveRegistryUrl ──
+
+describe('deriveRegistryUrl', () => {
+  test('derives registry URL from studio URL', () => {
+    expect(deriveRegistryUrl('https://ui.barefootjs.dev/studio?c=abc'))
+      .toBe('https://ui.barefootjs.dev/r/')
+  })
+
+  test('falls back to default for invalid URL', () => {
+    expect(deriveRegistryUrl('not-a-url'))
+      .toBe('https://ui.barefootjs.dev/r/')
+  })
+
+  test('works with custom origin', () => {
+    expect(deriveRegistryUrl('http://localhost:3000/studio?c=abc'))
+      .toBe('http://localhost:3000/r/')
+  })
+})
+
+// ── applyTokenOverrides ──
+
+describe('applyTokenOverrides', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeTokens(data: any): string {
+    const p = path.join(tmpDir, 'tokens.json')
+    writeFileSync(p, JSON.stringify(data, null, 2))
+    return p
+  }
+
+  function readTokens(p: string): any {
+    return JSON.parse(readFileSync(p, 'utf-8'))
+  }
+
+  test('applies color overrides to colors array', () => {
+    const tokensPath = writeTokens({
+      colors: [
+        { name: '--primary', value: 'oklch(0.205 0 0)', dark: 'oklch(0.35 0 0)' },
+        { name: '--secondary', value: 'oklch(0.97 0 0)', dark: 'oklch(0.269 0 0)' },
+      ],
+    })
+
+    applyTokenOverrides(tokensPath, {
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)', dark: 'oklch(0.7 0.15 240)' },
+      },
+    })
+
+    const result = readTokens(tokensPath)
+    expect(result.colors[0].value).toBe('oklch(0.5 0.2 240)')
+    expect(result.colors[0].dark).toBe('oklch(0.7 0.15 240)')
+    // Secondary unchanged
+    expect(result.colors[1].value).toBe('oklch(0.97 0 0)')
+  })
+
+  test('applies spacing override', () => {
+    const tokensPath = writeTokens({
+      tokens: [{ name: '--spacing', value: '0.25rem' }],
+    })
+
+    applyTokenOverrides(tokensPath, { spacing: '0.3rem' })
+
+    const result = readTokens(tokensPath)
+    expect(result.tokens[0].value).toBe('0.3rem')
+  })
+
+  test('applies radius override', () => {
+    const tokensPath = writeTokens({
+      tokens: [{ name: '--radius', value: '0.625rem' }],
+    })
+
+    applyTokenOverrides(tokensPath, { radius: '0' })
+
+    const result = readTokens(tokensPath)
+    expect(result.tokens[0].value).toBe('0')
+  })
+
+  test('applies font override with key mapping', () => {
+    const tokensPath = writeTokens({
+      typography: [{ name: '--font-sans', value: '-apple-system, sans-serif' }],
+    })
+
+    applyTokenOverrides(tokensPath, { font: 'inter' })
+
+    const result = readTokens(tokensPath)
+    expect(result.typography[0].value).toBe('"Inter", sans-serif')
+  })
+
+  test('applies shadow presets for Sharp style', () => {
+    const tokensPath = writeTokens({
+      tokens: [
+        { name: '--shadow-sm', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
+        { name: '--shadow', value: '0 1px 3px 0 rgb(0 0 0 / 0.1)' },
+        { name: '--shadow-md', value: '0 4px 6px -1px rgb(0 0 0 / 0.1)' },
+        { name: '--shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
+      ],
+    })
+
+    applyTokenOverrides(tokensPath, { style: 'Sharp' })
+
+    const result = readTokens(tokensPath)
+    expect(result.tokens[0].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.04)')
+    expect(result.tokens[1].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.06)')
+  })
+
+  test('ignores unknown style names for shadow presets', () => {
+    const tokensPath = writeTokens({
+      tokens: [
+        { name: '--shadow-sm', value: 'original' },
+      ],
+    })
+
+    applyTokenOverrides(tokensPath, { style: 'Unknown' })
+
+    const result = readTokens(tokensPath)
+    expect(result.tokens[0].value).toBe('original')
+  })
+})
+
+// ── Round-trip encoding ──
+
+describe('round-trip encoding', () => {
+  test('encode → URL → decode produces same config', () => {
+    const original: StudioConfig = {
+      style: 'Soft',
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)' },
+        destructive: { light: 'oklch(0.6 0.3 30)', dark: 'oklch(0.7 0.2 30)' },
+      },
+      spacing: '0.3rem',
+      radius: '1rem',
+      font: 'figtree',
+    }
+
+    const encoded = encodeURIComponent(btoa(JSON.stringify(original)))
+    const url = `https://ui.barefootjs.dev/studio?c=${encoded}`
+    const decoded = parseStudioUrl(url)
+
+    expect(decoded).toEqual(original)
+  })
+})

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,11 @@
 // `barefoot init` — Initialize a new BarefootJS project.
 
-import { existsSync, mkdirSync, writeFileSync, copyFileSync } from 'fs'
+import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
 import type { BarefootConfig } from '../context'
+import { addFromRegistry } from './add'
+import { fetchIndex } from '../lib/meta-loader'
 
 const DEFAULT_CONFIG: BarefootConfig = {
   $schema: 'https://barefootjs.dev/schema/barefoot.json',
@@ -14,7 +16,7 @@ const DEFAULT_CONFIG: BarefootConfig = {
   },
 }
 
-export function run(args: string[], ctx: CliContext): void {
+export async function run(args: string[], ctx: CliContext): Promise<void> {
   const projectDir = process.cwd()
 
   // Parse --name flag
@@ -22,6 +24,13 @@ export function run(args: string[], ctx: CliContext): void {
   const nameIdx = args.indexOf('--name')
   if (nameIdx !== -1 && args[nameIdx + 1]) {
     name = args[nameIdx + 1]
+  }
+
+  // Parse --from flag
+  let fromUrl: string | undefined
+  const fromIdx = args.indexOf('--from')
+  if (fromIdx !== -1 && args[fromIdx + 1]) {
+    fromUrl = args[fromIdx + 1]
   }
 
   // Check if already initialized
@@ -49,8 +58,18 @@ export function run(args: string[], ctx: CliContext): void {
     console.log(`  Created ${config.paths.tokens}/tokens.json`)
   }
 
+  // Apply token overrides from Studio URL if provided
+  let studioConfig: StudioConfig | undefined
+  if (fromUrl) {
+    studioConfig = parseStudioUrl(fromUrl)
+    if (studioConfig && existsSync(destTokensJson)) {
+      applyTokenOverrides(destTokensJson, studioConfig)
+      console.log(`  Applied Studio token overrides`)
+    }
+  }
+
   // Generate tokens.css from tokens.json
-  generateTokensCSS(ctx.root, destTokensJson, tokensDir, config.paths.tokens)
+  await generateTokensCSS(ctx.root, destTokensJson, tokensDir, config.paths.tokens)
 
   // 3. Copy types/index.tsx
   const typesDir = path.join(projectDir, 'types')
@@ -118,12 +137,178 @@ export function run(args: string[], ctx: CliContext): void {
     console.log('  Created tsconfig.json')
   }
 
+  // 8. If --from was provided, fetch all components from the registry
+  if (fromUrl) {
+    const registryUrl = deriveRegistryUrl(fromUrl)
+    console.log(`\n  Fetching components from ${registryUrl}...`)
+    try {
+      const index = await fetchIndex(registryUrl)
+      const allNames = index.components.map(c => c.name)
+      if (allNames.length > 0) {
+        await addFromRegistry(allNames, registryUrl, projectDir, config, true)
+      }
+    } catch (err) {
+      console.error(`  Warning: Could not fetch components from registry: ${err instanceof Error ? err.message : err}`)
+    }
+  }
+
   console.log(`\nProject initialized successfully!`)
   console.log(`\nNext steps:`)
   console.log(`  bun install                    # Install dependencies`)
-  console.log(`  barefoot add button checkbox   # Add components`)
+  if (!fromUrl) {
+    console.log(`  barefoot add button checkbox   # Add components`)
+  }
   console.log(`  bun test                       # Run component tests`)
   console.log(`  barefoot search <query>        # Search available components`)
+}
+
+// ── Studio URL parsing ──
+
+export interface StudioConfig {
+  style?: string
+  tokens?: Record<string, { light?: string; dark?: string }>
+  spacing?: string
+  radius?: string
+  font?: string
+}
+
+export function parseStudioUrl(url: string): StudioConfig | undefined {
+  try {
+    const parsed = new URL(url)
+    const encoded = parsed.searchParams.get('c')
+    if (!encoded) return undefined
+    const json = atob(decodeURIComponent(encoded))
+    return JSON.parse(json)
+  } catch {
+    console.error('Warning: Could not parse Studio URL config. Using defaults.')
+    return undefined
+  }
+}
+
+export function deriveRegistryUrl(studioUrl: string): string {
+  try {
+    const parsed = new URL(studioUrl)
+    return `${parsed.origin}/r/`
+  } catch {
+    return 'https://ui.barefootjs.dev/r/'
+  }
+}
+
+// ── Token override logic ──
+
+export function applyTokenOverrides(tokensJsonPath: string, config: StudioConfig): void {
+  const raw = readFileSync(tokensJsonPath, 'utf-8')
+  const tokensData = JSON.parse(raw)
+
+  // Apply color token overrides
+  if (config.tokens) {
+    for (const [name, values] of Object.entries(config.tokens)) {
+      applyColorOverride(tokensData, name, values)
+    }
+  }
+
+  // Apply spacing override
+  if (config.spacing) {
+    applySimpleOverride(tokensData, '--spacing', config.spacing)
+  }
+
+  // Apply radius override
+  if (config.radius) {
+    applySimpleOverride(tokensData, '--radius', config.radius)
+  }
+
+  // Apply font override
+  if (config.font) {
+    // Font key → font-family value mapping (same as Studio)
+    const fontMap: Record<string, string> = {
+      system: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
+      inter: '"Inter", sans-serif',
+      'noto-sans': '"Noto Sans", sans-serif',
+      'nunito-sans': '"Nunito Sans", sans-serif',
+      figtree: '"Figtree", sans-serif',
+    }
+    const fontValue = fontMap[config.font] || config.font
+    applySimpleOverride(tokensData, '--font-sans', fontValue)
+  }
+
+  // Apply shadow overrides from style preset
+  if (config.style) {
+    applyShadowPreset(tokensData, config.style)
+  }
+
+  writeFileSync(tokensJsonPath, JSON.stringify(tokensData, null, 2) + '\n')
+}
+
+function applyColorOverride(
+  tokensData: any,
+  name: string,
+  values: { light?: string; dark?: string },
+): void {
+  // Walk tokens looking for matching CSS variable name
+  const varName = `--${name}`
+  if (Array.isArray(tokensData.colors)) {
+    for (const token of tokensData.colors) {
+      if (token.name === varName || token.name === name) {
+        if (values.light) token.value = values.light
+        if (values.dark) token.dark = values.dark
+        return
+      }
+    }
+  }
+  // Fallback: walk all tokens
+  if (Array.isArray(tokensData.tokens)) {
+    for (const token of tokensData.tokens) {
+      if (token.name === varName || token.name === name) {
+        if (values.light) token.value = values.light
+        if (values.dark) token.dark = values.dark
+        return
+      }
+    }
+  }
+}
+
+function applySimpleOverride(tokensData: any, name: string, value: string): void {
+  const targets = [tokensData.tokens, tokensData.colors, tokensData.spacing, tokensData.typography]
+  for (const arr of targets) {
+    if (!Array.isArray(arr)) continue
+    for (const token of arr) {
+      if (token.name === name) {
+        token.value = value
+        return
+      }
+    }
+  }
+}
+
+function applyShadowPreset(tokensData: any, styleName: string): void {
+  // Style presets (must match Studio's stylePresets)
+  const presets: Record<string, Record<string, string>> = {
+    Sharp: {
+      '--shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
+      '--shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
+      '--shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
+      '--shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
+    },
+    Soft: {
+      '--shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
+      '--shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
+      '--shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
+      '--shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
+    },
+    Compact: {
+      '--shadow-sm': 'none',
+      '--shadow': 'none',
+      '--shadow-md': 'none',
+      '--shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+    },
+  }
+
+  const shadows = presets[styleName]
+  if (!shadows) return
+
+  for (const [name, value] of Object.entries(shadows)) {
+    applySimpleOverride(tokensData, name, value)
+  }
 }
 
 async function generateTokensCSS(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ function printUsage() {
 
 Commands:
   build [--minify]            Compile components using barefoot.config.ts
-  init [--name <name>]        Initialize a new BarefootJS project
+  init [--name <name>] [--from <url>]  Initialize a new BarefootJS project
   add <component...> [--force] [--registry <url>] Add components to your project
   search <query> [--dir <path>] [--registry <url>] Search components and documentation
   ui <component>              Show component documentation (props, examples, a11y)
@@ -51,7 +51,7 @@ switch (command) {
 
   case 'init': {
     const { run } = await import('./commands/init')
-    run(commandArgs, ctx)
+    await run(commandArgs, ctx)
     break
   }
 

--- a/site/ui/e2e/studio.spec.ts
+++ b/site/ui/e2e/studio.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Studio Export & URL', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage to start fresh
+    await page.addInitScript(() => {
+      localStorage.removeItem('barefootjs-studio-tokens')
+    })
+  })
+
+  test('export bar shows a valid barefoot init --from command', async ({ page }) => {
+    await page.goto('/studio')
+    const codeEl = page.locator('[data-studio-export-code]')
+    await expect(codeEl).toBeVisible()
+    const text = await codeEl.textContent()
+    expect(text).toContain('barefoot init --from')
+    expect(text).toContain('/studio')
+  })
+
+  test('changing preset updates the export URL', async ({ page }) => {
+    await page.goto('/studio')
+    const codeEl = page.locator('[data-studio-export-code]')
+
+    // Get initial command text
+    const initialText = await codeEl.textContent()
+
+    // Open style dropdown and select Sharp
+    await page.locator('[data-studio-style-trigger]').click()
+    await page.locator('[data-studio-preset="Sharp"]').click()
+
+    // Export command should update and contain ?c= with encoded config
+    const updatedText = await codeEl.textContent()
+    expect(updatedText).not.toBe(initialText)
+    expect(updatedText).toContain('?c=')
+  })
+
+  test('visiting /studio?c=<encoded> applies tokens from URL', async ({ page }) => {
+    // Encode a Sharp preset config
+    const config = { style: 'Sharp', radius: '0' }
+    const encoded = encodeURIComponent(btoa(JSON.stringify(config)))
+
+    await page.goto(`/studio?c=${encoded}`)
+
+    // The style label should show "Sharp"
+    const styleLabel = page.locator('[data-studio-style-label]')
+    await expect(styleLabel).toHaveText('Sharp')
+
+    // The radius label should show "0"
+    const radiusLabel = page.locator('[data-studio-radius-label]')
+    await expect(radiusLabel).toHaveText('0')
+  })
+
+  test('copy button shows "Copied!" feedback', async ({ page, context }) => {
+    // Grant clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto('/studio')
+
+    const copyLabel = page.locator('[data-studio-copy-label]')
+    await expect(copyLabel).toHaveText('Copy')
+
+    // Click copy button
+    await page.locator('[data-studio-copy]').click()
+
+    // Should show "Copied!" feedback
+    await expect(copyLabel).toHaveText('Copied!')
+
+    // Should revert back to "Copy" after a delay
+    await expect(copyLabel).toHaveText('Copy', { timeout: 5000 })
+  })
+
+  test('exported command contains decodable ?c= payload after customization', async ({ page }) => {
+    await page.goto('/studio')
+
+    // Select a preset to create a non-empty config
+    await page.locator('[data-studio-style-trigger]').click()
+    await page.locator('[data-studio-preset="Soft"]').click()
+
+    const codeEl = page.locator('[data-studio-export-code]')
+    const text = await codeEl.textContent()
+
+    // Extract the ?c= value from the command
+    const match = text?.match(/\?c=([^"]+)/)
+    expect(match).toBeTruthy()
+
+    // Decode and verify it's valid JSON
+    const decoded = JSON.parse(atob(decodeURIComponent(match![1])))
+    expect(decoded.style).toBe('Soft')
+  })
+
+  test('round-trip: encode config → visit URL → values match', async ({ page }) => {
+    const config = {
+      style: 'Compact',
+      spacing: '0.2rem',
+      font: 'inter',
+    }
+    const encoded = encodeURIComponent(btoa(JSON.stringify(config)))
+
+    await page.goto(`/studio?c=${encoded}`)
+
+    // Verify style is applied
+    const styleLabel = page.locator('[data-studio-style-label]')
+    await expect(styleLabel).toHaveText('Compact')
+
+    // Verify the export command re-encodes the same config
+    const codeEl = page.locator('[data-studio-export-code]')
+    const text = await codeEl.textContent()
+    const cMatch = text?.match(/\?c=([^"]+)/)
+    expect(cMatch).toBeTruthy()
+
+    const decoded = JSON.parse(atob(decodeURIComponent(cMatch![1])))
+    expect(decoded.style).toBe('Compact')
+  })
+})

--- a/site/ui/pages/studio.tsx
+++ b/site/ui/pages/studio.tsx
@@ -774,12 +774,12 @@ function ZoomControls() {
 function ExportBar() {
   return (
     <div className="flex items-center justify-center gap-3 px-4 py-2 bg-card border-t border-border">
-      <code className="rounded-md bg-muted border border-border px-3 py-1.5 font-mono text-[11px] text-foreground max-w-xl truncate">
-        barefoot init --from "https://ui.barefootjs.dev/studio?c=eJx..."
+      <code className="rounded-md bg-muted border border-border px-3 py-1.5 font-mono text-[11px] text-foreground max-w-xl truncate" data-studio-export-code>
+        barefoot init --from "https://ui.barefootjs.dev/studio?c=..."
       </code>
-      <button className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium whitespace-nowrap shrink-0">
+      <button className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium whitespace-nowrap shrink-0" data-studio-copy>
         <IconCopy />
-        Copy
+        <span data-studio-copy-label>Copy</span>
       </button>
     </div>
   )
@@ -1061,6 +1061,7 @@ const studioScript = `
       localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     } catch(e) {}
     updateResetButton();
+    updateExportCommand();
   }
 
   function loadFromStorage() {
@@ -1600,6 +1601,74 @@ const studioScript = `
   }
 
 
+  // ── URL encoding/decoding for export ──
+  function buildConfig() {
+    var preset = stylePresets.find(function(p) { return p.name === activeStyle; }) || stylePresets[0];
+    var config = {};
+    if (activeStyle !== 'Default') config.style = activeStyle;
+    if (Object.keys(customTokens).length > 0) config.tokens = customTokens;
+    if (customSpacing !== null && customSpacing !== preset.spacing) config.spacing = customSpacing;
+    if (customRadius !== null && customRadius !== preset.radius) config.radius = customRadius;
+    if (customFont !== null) config.font = customFont;
+    return config;
+  }
+
+  function encodeConfig(config) {
+    return encodeURIComponent(btoa(JSON.stringify(config)));
+  }
+
+  function decodeConfig(str) {
+    return JSON.parse(atob(decodeURIComponent(str)));
+  }
+
+  function updateExportCommand() {
+    var codeEl = document.querySelector('[data-studio-export-code]');
+    if (!codeEl) return;
+    var config = buildConfig();
+    var baseUrl = location.origin + '/studio';
+    if (Object.keys(config).length > 0) {
+      var encoded = encodeConfig(config);
+      codeEl.textContent = 'barefoot init --from "' + baseUrl + '?c=' + encoded + '"';
+    } else {
+      codeEl.textContent = 'barefoot init --from "' + baseUrl + '"';
+    }
+  }
+
+  function loadFromURL() {
+    try {
+      var params = new URLSearchParams(location.search);
+      var encoded = params.get('c');
+      if (!encoded) return false;
+      var config = decodeConfig(encoded);
+      if (config.style) activeStyle = config.style;
+      if (config.tokens) customTokens = config.tokens;
+      if (config.spacing) customSpacing = config.spacing;
+      if (config.radius) customRadius = config.radius;
+      if (config.font) customFont = config.font;
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  // ── Copy button ──
+  document.addEventListener('click', function(e) {
+    var btn = e.target.closest('[data-studio-copy]');
+    if (!btn) return;
+    e.preventDefault();
+    var codeEl = document.querySelector('[data-studio-export-code]');
+    if (!codeEl) return;
+    var text = codeEl.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+      var label = btn.querySelector('[data-studio-copy-label]');
+      if (label) {
+        var original = label.textContent;
+        label.textContent = 'Copied!';
+        setTimeout(function() { label.textContent = original; }, 2000);
+      }
+    });
+  });
+
   // ── Reset button ──
   document.addEventListener('click', function(e) {
     var btn = e.target.closest('[data-studio-reset]');
@@ -1655,8 +1724,11 @@ const studioScript = `
   });
   observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
-  // ── Initialize: restore from localStorage ──
-  loadFromStorage();
+  // ── Initialize: restore from URL (priority) or localStorage ──
+  var loadedFromURL = loadFromURL();
+  if (!loadedFromURL) {
+    loadFromStorage();
+  }
 
   if (activeStyle !== 'Default') {
     applyStyle(activeStyle);
@@ -1706,6 +1778,7 @@ const studioScript = `
   // Apply saved color tokens
   reapplyForMode();
   updateResetButton();
+  updateExportCommand();
 })();
 `
 

--- a/site/ui/pages/studio.tsx
+++ b/site/ui/pages/studio.tsx
@@ -1280,6 +1280,14 @@ const studioScript = `
       }
     });
 
+    // Update swatch previews and open editors for all custom tokens
+    Object.keys(customTokens).forEach(function(token) {
+      var val = getTokenValue(token, mode);
+      // Update swatch preview (token panel is outside canvas, so var(--x) won't reflect scoped overrides)
+      var swatch = document.querySelector('[data-studio-color-preview="' + token + '"]');
+      if (swatch) swatch.style.backgroundColor = val;
+    });
+
     // Update any open editor to show the new mode's values
     document.querySelectorAll('[data-studio-color-editor]').forEach(function(ed) {
       if (ed.classList.contains('hidden')) return;
@@ -1730,9 +1738,19 @@ const studioScript = `
     loadFromStorage();
   }
 
+  // Save custom overrides before applyStyle (which resets them to null)
+  var savedSpacing = customSpacing;
+  var savedRadius = customRadius;
+  var savedFont = customFont;
+
   if (activeStyle !== 'Default') {
     applyStyle(activeStyle);
   }
+
+  // Restore custom overrides that applyStyle cleared
+  customSpacing = savedSpacing;
+  customRadius = savedRadius;
+  customFont = savedFont;
 
   // Apply custom spacing/radius overrides (on top of preset)
   if (customSpacing !== null) {


### PR DESCRIPTION
## Problem

After PR #663 delivered the Studio page with token editing and presets, there was no way for users to take their customizations out of the browser. The Studio was view-only — users could tweak tokens but couldn't export or share their design system configuration.

## Solution

Implements the stateless export flow from issue #516:

**Studio frontend** (`site/ui/pages/studio.tsx`):
- Encodes token customizations into a `?c=` query param (JSON → Base64)
- Only includes non-default values to keep URLs short
- Updates the export command in the bottom bar after every token change
- `loadFromURL()` restores tokens from a shared URL (takes priority over localStorage)
- Copy button writes the `barefoot init --from "..."` command to clipboard with "Copied!" feedback

**CLI** (`packages/cli/src/commands/init.ts`):
- New `--from <url>` flag on `barefoot init`
- Parses and decodes the `?c=` param from the Studio URL
- Applies token overrides (colors, spacing, radius, font, shadows) to `tokens.json` before generating `tokens.css`
- Fetches all components from the registry derived from the URL origin

## How to verify

### Unit tests (CLI)
```bash
bun test packages/cli/src/__tests__/init-from.test.ts
```
15 tests covering URL parsing, token overrides, round-trip encoding.

### E2E tests (Studio)
```bash
cd site/ui && bunx playwright test e2e/studio.spec.ts
```
6 tests: export bar rendering, preset changes updating URL, URL-based token loading, copy button, round-trip encoding.

### Manual verification
1. Visit `/studio`, tweak tokens (e.g., select "Sharp" preset)
2. Export bar at bottom shows a real `barefoot init --from "...?c=..."` command
3. Copy the URL from the command, open it in a new tab — tokens are restored
4. Run the CLI command in an empty directory to bootstrap a project with custom tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)