### PR TITLE
Fix barefoot init --from to work with live registry

### DIFF
--- a/packages/cli/src/__tests__/init-from.test.ts
+++ b/packages/cli/src/__tests__/init-from.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test'
-import { parseStudioUrl, deriveRegistryUrl, applyTokenOverrides, type StudioConfig } from '../commands/init'
+import { parseStudioUrl, deriveRegistryUrl, applyTokenOverrides, appendCSSOverrides, type StudioConfig } from '../commands/init'
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs'
 import path from 'path'
 import os from 'os'
@@ -96,11 +96,11 @@ describe('applyTokenOverrides', () => {
     return JSON.parse(readFileSync(p, 'utf-8'))
   }
 
-  test('applies color overrides to colors array', () => {
+  test('applies color overrides to colors array (bare names)', () => {
     const tokensPath = writeTokens({
       colors: [
-        { name: '--primary', value: 'oklch(0.205 0 0)', dark: 'oklch(0.35 0 0)' },
-        { name: '--secondary', value: 'oklch(0.97 0 0)', dark: 'oklch(0.269 0 0)' },
+        { name: 'primary', value: 'oklch(0.205 0 0)', dark: 'oklch(0.35 0 0)' },
+        { name: 'secondary', value: 'oklch(0.97 0 0)', dark: 'oklch(0.269 0 0)' },
       ],
     })
 
@@ -117,67 +117,108 @@ describe('applyTokenOverrides', () => {
     expect(result.colors[1].value).toBe('oklch(0.97 0 0)')
   })
 
-  test('applies spacing override', () => {
+  test('applies spacing override (bare name in spacing array)', () => {
     const tokensPath = writeTokens({
-      tokens: [{ name: '--spacing', value: '0.25rem' }],
+      spacing: [{ name: 'spacing', value: '0.25rem' }],
     })
 
     applyTokenOverrides(tokensPath, { spacing: '0.3rem' })
 
     const result = readTokens(tokensPath)
-    expect(result.tokens[0].value).toBe('0.3rem')
+    expect(result.spacing[0].value).toBe('0.3rem')
   })
 
-  test('applies radius override', () => {
+  test('applies radius override (bare name in borderRadius array)', () => {
     const tokensPath = writeTokens({
-      tokens: [{ name: '--radius', value: '0.625rem' }],
+      borderRadius: [{ name: 'radius', value: '0.625rem' }],
     })
 
     applyTokenOverrides(tokensPath, { radius: '0' })
 
     const result = readTokens(tokensPath)
-    expect(result.tokens[0].value).toBe('0')
+    expect(result.borderRadius[0].value).toBe('0')
   })
 
-  test('applies font override with key mapping', () => {
+  test('applies font override with key mapping (nested typography)', () => {
     const tokensPath = writeTokens({
-      typography: [{ name: '--font-sans', value: '-apple-system, sans-serif' }],
+      typography: {
+        fontFamily: [{ name: 'font-sans', value: '-apple-system, sans-serif' }],
+      },
     })
 
     applyTokenOverrides(tokensPath, { font: 'inter' })
 
     const result = readTokens(tokensPath)
-    expect(result.typography[0].value).toBe('"Inter", sans-serif')
+    expect(result.typography.fontFamily[0].value).toBe('"Inter", sans-serif')
   })
 
-  test('applies shadow presets for Sharp style', () => {
+  test('applies shadow presets for Sharp style (bare names in shadows)', () => {
     const tokensPath = writeTokens({
-      tokens: [
-        { name: '--shadow-sm', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
-        { name: '--shadow', value: '0 1px 3px 0 rgb(0 0 0 / 0.1)' },
-        { name: '--shadow-md', value: '0 4px 6px -1px rgb(0 0 0 / 0.1)' },
-        { name: '--shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
+      shadows: [
+        { name: 'shadow-sm', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
+        { name: 'shadow', value: '0 1px 3px 0 rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-md', value: '0 4px 6px -1px rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
       ],
     })
 
     applyTokenOverrides(tokensPath, { style: 'Sharp' })
 
     const result = readTokens(tokensPath)
-    expect(result.tokens[0].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.04)')
-    expect(result.tokens[1].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.06)')
+    expect(result.shadows[0].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.04)')
+    expect(result.shadows[1].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.06)')
   })
 
   test('ignores unknown style names for shadow presets', () => {
     const tokensPath = writeTokens({
-      tokens: [
-        { name: '--shadow-sm', value: 'original' },
+      shadows: [
+        { name: 'shadow-sm', value: 'original' },
       ],
     })
 
     applyTokenOverrides(tokensPath, { style: 'Unknown' })
 
     const result = readTokens(tokensPath)
-    expect(result.tokens[0].value).toBe('original')
+    expect(result.shadows[0].value).toBe('original')
+  })
+})
+
+// ── appendCSSOverrides ──
+
+describe('appendCSSOverrides', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-css-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('appends --spacing to :root block', () => {
+    const cssPath = path.join(tmpDir, 'tokens.css')
+    writeFileSync(cssPath, ':root {\n  --radius: 0.625rem;\n}\n')
+
+    appendCSSOverrides(cssPath, { spacing: '0.3rem' })
+
+    const result = readFileSync(cssPath, 'utf-8')
+    expect(result).toContain('--spacing: 0.3rem;')
+    expect(result).toContain('Studio overrides')
+    // Original content preserved
+    expect(result).toContain('--radius: 0.625rem;')
+  })
+
+  test('does nothing when no spacing override', () => {
+    const cssPath = path.join(tmpDir, 'tokens.css')
+    const original = ':root {\n  --radius: 0.625rem;\n}\n'
+    writeFileSync(cssPath, original)
+
+    appendCSSOverrides(cssPath, { style: 'Sharp' })
+
+    const result = readFileSync(cssPath, 'utf-8')
+    expect(result).toBe(original)
   })
 })
 
@@ -201,5 +242,83 @@ describe('round-trip encoding', () => {
     const decoded = parseStudioUrl(url)
 
     expect(decoded).toEqual(original)
+  })
+})
+
+// ── Integration: real tokens.json schema ──
+
+describe('applyTokenOverrides with real tokens.json schema', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-real-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('overrides work against actual tokens.json structure', () => {
+    // Mirrors the real tokens.json schema
+    const tokensPath = path.join(tmpDir, 'tokens.json')
+    writeFileSync(tokensPath, JSON.stringify({
+      version: 1,
+      typography: {
+        fontFamily: [
+          { name: 'font-sans', value: '-apple-system, BlinkMacSystemFont, sans-serif' },
+          { name: 'font-mono', value: 'ui-monospace, monospace' },
+        ],
+        letterSpacing: [],
+      },
+      spacing: [
+        { name: 'space-1', value: '4px' },
+      ],
+      borderRadius: [
+        { name: 'radius', value: '0.625rem' },
+        { name: 'radius-sm', value: 'calc(var(--radius) * 0.6)' },
+      ],
+      colors: [
+        { name: 'background', value: 'oklch(1 0 0)', dark: 'oklch(0.145 0 0)' },
+        { name: 'primary', value: 'oklch(0.205 0 0)', dark: 'oklch(0.35 0 0)' },
+        { name: 'destructive', value: 'oklch(0.577 0.245 27.325)', dark: 'oklch(0.704 0.191 22.216)' },
+      ],
+      shadows: [
+        { name: 'shadow-sm', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
+        { name: 'shadow', value: '0 1px 3px 0 rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-md', value: '0 4px 6px -1px rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
+      ],
+    }, null, 2))
+
+    applyTokenOverrides(tokensPath, {
+      style: 'Sharp',
+      tokens: {
+        primary: { light: 'oklch(0.4 0.15 250)', dark: 'oklch(0.6 0.1 250)' },
+      },
+      spacing: '0.2rem',
+      radius: '0',
+      font: 'inter',
+    })
+
+    const result = JSON.parse(readFileSync(tokensPath, 'utf-8'))
+
+    // Colors
+    expect(result.colors[1].value).toBe('oklch(0.4 0.15 250)')
+    expect(result.colors[1].dark).toBe('oklch(0.6 0.1 250)')
+    // Background unchanged
+    expect(result.colors[0].value).toBe('oklch(1 0 0)')
+
+    // Radius
+    expect(result.borderRadius[0].value).toBe('0')
+
+    // Font
+    expect(result.typography.fontFamily[0].value).toBe('"Inter", sans-serif')
+    // Mono unchanged
+    expect(result.typography.fontFamily[1].value).toBe('ui-monospace, monospace')
+
+    // Shadows (Sharp preset)
+    expect(result.shadows[0].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.04)')
+    expect(result.shadows[1].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.06)')
   })
 })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -5,8 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { findBarefootJson, loadBarefootConfig, type BarefootConfig } from '../context'
 import { resolveDependencies } from '../lib/dependency-resolver'
-import { fetchRegistryItem } from '../lib/meta-loader'
-import type { MetaIndex, MetaIndexEntry, ComponentMeta } from '../lib/types'
+import type { MetaIndex, MetaIndexEntry, ComponentMeta, RegistryItem } from '../lib/types'
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
   const force = args.includes('--force')
@@ -42,16 +41,41 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const config = loadBarefootConfig(configPath)
 
   if (registryUrl) {
-    await addFromRegistry(componentNames, registryUrl, projectDir, config, force)
+    await addFromRegistry(componentNames, registryUrl, projectDir, config, force, false)
   } else {
     addFromLocal(componentNames, ctx, projectDir, config, force)
   }
 }
 
 /**
+ * Fetch a single registry item. Returns null if skipErrors is true and fetch fails.
+ */
+async function tryFetchRegistryItem(
+  registryUrl: string,
+  name: string,
+  skipErrors: boolean,
+): Promise<RegistryItem | null> {
+  const base = registryUrl.endsWith('/') ? registryUrl : `${registryUrl}/`
+  const url = `${base}${name}.json`
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) })
+    if (!res.ok) {
+      if (skipErrors) return null
+      console.error(`Error: Registry returned HTTP ${res.status} for ${url}`)
+      process.exit(1)
+    }
+    return await res.json()
+  } catch (err) {
+    if (skipErrors) return null
+    console.error(`Error: Failed to fetch component "${name}" from ${url}: ${err instanceof Error ? err.message : err}`)
+    process.exit(1)
+  }
+}
+
+/**
  * Add components from a remote registry.
- * Phase 1: Fetch all registry items (all-or-nothing).
- * Phase 2: Write files only if all fetches succeeded.
+ * Phase 1: Fetch all registry items.
+ * Phase 2: Write files only if all fetches succeeded (or skip failures when skipErrors=true).
  */
 export async function addFromRegistry(
   componentNames: string[],
@@ -59,11 +83,17 @@ export async function addFromRegistry(
   projectDir: string,
   config: BarefootConfig,
   force: boolean,
+  skipErrors = false,
 ): Promise<void> {
   // Phase 1: Fetch all registry items
-  const items = await Promise.all(
-    componentNames.map(name => fetchRegistryItem(registryUrl, name))
+  const results = await Promise.all(
+    componentNames.map(name => tryFetchRegistryItem(registryUrl, name, skipErrors))
   )
+  const items = results.filter((item): item is RegistryItem => item !== null)
+  const skippedComponents = componentNames.filter((_, i) => results[i] === null)
+  if (skippedComponents.length > 0) {
+    console.log(`  Skipped ${skippedComponents.length} unavailable component(s)`)
+  }
 
   // Merge all files into a deduplication map (path → content)
   const fileMap = new Map<string, string>()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import type { CliContext } from '../context'
 import type { BarefootConfig } from '../context'
 import { addFromRegistry } from './add'
-import { fetchIndex } from '../lib/meta-loader'
 
 const DEFAULT_CONFIG: BarefootConfig = {
   $schema: 'https://barefootjs.dev/schema/barefoot.json',
@@ -147,13 +146,17 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     const registryUrl = deriveRegistryUrl(fromUrl)
     console.log(`\n  Fetching components from ${registryUrl}...`)
     try {
-      const index = await fetchIndex(registryUrl)
+      const indexUrl = registryUrl.endsWith('/') ? `${registryUrl}index.json` : `${registryUrl}/index.json`
+      const res = await fetch(indexUrl, { signal: AbortSignal.timeout(10_000) })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const index = await res.json() as { components: { name: string }[] }
       const allNames = index.components.map(c => c.name)
       if (allNames.length > 0) {
         await addFromRegistry(allNames, registryUrl, projectDir, config, true)
       }
     } catch (err) {
-      console.error(`  Warning: Could not fetch components from registry: ${err instanceof Error ? err.message : err}`)
+      console.log(`  Skipped component download: ${err instanceof Error ? err.message : err}`)
+      console.log(`  Run \`barefoot add <component...> --registry ${deriveRegistryUrl(fromUrl)}\` to add components later.`)
     }
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -71,6 +71,11 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   // Generate tokens.css from tokens.json
   await generateTokensCSS(ctx.root, destTokensJson, tokensDir, config.paths.tokens)
 
+  // Append CSS variable overrides not in tokens.json (e.g., --spacing from Tailwind)
+  if (studioConfig) {
+    appendCSSOverrides(path.join(tokensDir, 'tokens.css'), studioConfig)
+  }
+
   // 3. Copy types/index.tsx
   const typesDir = path.join(projectDir, 'types')
   mkdirSync(typesDir, { recursive: true })
@@ -268,11 +273,25 @@ function applyColorOverride(
 }
 
 function applySimpleOverride(tokensData: any, name: string, value: string): void {
-  const targets = [tokensData.tokens, tokensData.colors, tokensData.spacing, tokensData.typography]
-  for (const arr of targets) {
+  // Strip leading -- for matching (tokens.json uses bare names like "radius", not "--radius")
+  const bareName = name.startsWith('--') ? name.slice(2) : name
+
+  // Walk all array-valued sections in tokens.json
+  const sections = [
+    tokensData.colors, tokensData.spacing, tokensData.borderRadius,
+    tokensData.shadows, tokensData.layout,
+  ]
+  // Also walk nested objects (typography.fontFamily, typography.letterSpacing, etc.)
+  if (tokensData.typography) {
+    for (const arr of Object.values(tokensData.typography)) {
+      if (Array.isArray(arr)) sections.push(arr as any[])
+    }
+  }
+
+  for (const arr of sections) {
     if (!Array.isArray(arr)) continue
     for (const token of arr) {
-      if (token.name === name) {
+      if (token.name === bareName || token.name === name) {
         token.value = value
         return
       }
@@ -282,24 +301,25 @@ function applySimpleOverride(tokensData: any, name: string, value: string): void
 
 function applyShadowPreset(tokensData: any, styleName: string): void {
   // Style presets (must match Studio's stylePresets)
+  // Use bare names (no -- prefix) to match tokens.json schema
   const presets: Record<string, Record<string, string>> = {
     Sharp: {
-      '--shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
-      '--shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
-      '--shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
-      '--shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
+      'shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
+      'shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
+      'shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
+      'shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
     },
     Soft: {
-      '--shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
-      '--shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
-      '--shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
-      '--shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
+      'shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
+      'shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
+      'shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
+      'shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
     },
     Compact: {
-      '--shadow-sm': 'none',
-      '--shadow': 'none',
-      '--shadow-md': 'none',
-      '--shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+      'shadow-sm': 'none',
+      'shadow': 'none',
+      'shadow-md': 'none',
+      'shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
     },
   }
 
@@ -309,6 +329,32 @@ function applyShadowPreset(tokensData: any, styleName: string): void {
   for (const [name, value] of Object.entries(shadows)) {
     applySimpleOverride(tokensData, name, value)
   }
+}
+
+/**
+ * Append CSS variable overrides that aren't part of tokens.json
+ * (e.g., --spacing is a Tailwind v4 variable, not in our token schema).
+ */
+export function appendCSSOverrides(cssPath: string, config: StudioConfig): void {
+  if (!existsSync(cssPath)) return
+
+  const lines: string[] = []
+  if (config.spacing) {
+    lines.push(`  --spacing: ${config.spacing};`)
+  }
+
+  if (lines.length === 0) return
+
+  const existing = readFileSync(cssPath, 'utf-8')
+  // Insert overrides into the :root block before the closing }
+  const rootCloseIdx = existing.indexOf('}')
+  if (rootCloseIdx === -1) return
+
+  const patched = existing.slice(0, rootCloseIdx) +
+    `\n  /* ── Studio overrides ── */\n${lines.join('\n')}\n` +
+    existing.slice(rootCloseIdx)
+
+  writeFileSync(cssPath, patched)
 }
 
 async function generateTokensCSS(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -154,7 +154,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
       const registry = await res.json() as { items: { name: string }[] }
       const allNames = registry.items.map(i => i.name)
       if (allNames.length > 0) {
-        await addFromRegistry(allNames, registryUrl, projectDir, config, true)
+        await addFromRegistry(allNames, registryUrl, projectDir, config, true, true)
       }
     } catch (err) {
       console.log(`  Skipped component download: ${err instanceof Error ? err.message : err}`)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -146,11 +146,13 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     const registryUrl = deriveRegistryUrl(fromUrl)
     console.log(`\n  Fetching components from ${registryUrl}...`)
     try {
-      const indexUrl = registryUrl.endsWith('/') ? `${registryUrl}index.json` : `${registryUrl}/index.json`
-      const res = await fetch(indexUrl, { signal: AbortSignal.timeout(10_000) })
+      // Use registry.json (build-registry output) instead of index.json (meta output)
+      // to only fetch components that have actual RegistryItem files.
+      const registryJsonUrl = registryUrl.endsWith('/') ? `${registryUrl}registry.json` : `${registryUrl}/registry.json`
+      const res = await fetch(registryJsonUrl, { signal: AbortSignal.timeout(10_000) })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const index = await res.json() as { components: { name: string }[] }
-      const allNames = index.components.map(c => c.name)
+      const registry = await res.json() as { items: { name: string }[] }
+      const allNames = registry.items.map(i => i.name)
       if (allNames.length > 0) {
         await addFromRegistry(allNames, registryUrl, projectDir, config, true)
       }

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run build.ts",
-    "build:registry": "cd ../../ui && bun run build:registry && mkdir -p ../site/ui/dist/r && cp -r dist/r/* ../site/ui/dist/r/ && cp meta/*.json ../site/ui/dist/r/",
+    "build:registry": "cd ../../ui && bun run build:registry && mkdir -p ../site/ui/dist/r ../site/ui/dist/meta && cp -r dist/r/* ../site/ui/dist/r/ && cp meta/index.json ../site/ui/dist/r/index.json && cp meta/*.json ../site/ui/dist/meta/",
     "build:worker": "bun run build && bun run build:registry",
     "dev": "bun run --watch server.tsx",
     "deploy": "bun run build:worker && wrangler deploy",


### PR DESCRIPTION
## Problem

`barefoot init --from "https://ui.barefootjs.dev/studio?c=..."` failed to work end-to-end due to three issues:

1. **Registry format mismatch** — `build:registry` script copied `meta/*.json` (ComponentMeta format) over the RegistryItem JSON files (which contain `files` array with source code), breaking `barefoot add --registry`
2. **Token name prefix mismatch** — `applyTokenOverrides` searched for `--radius`, `--shadow-sm`, `--font-sans` etc., but `tokens.json` uses bare names without `--` prefix (`radius`, `shadow-sm`, `font-sans`)
3. **Missing `--spacing` variable** — `--spacing` is a Tailwind v4 variable not present in `tokens.json`, so it was silently dropped

## Solution

1. **Build script fix** (`site/ui/package.json`): Only copy `meta/index.json` to `/r/` (needed for `fetchIndex`). Component metadata goes to `/meta/` to avoid overwriting RegistryItem files.

2. **Token matching fix** (`packages/cli/src/commands/init.ts`): Strip `--` prefix before matching. Walk correct `tokens.json` sections: `borderRadius`, `shadows`, nested `typography.fontFamily`, etc.

3. **CSS append** (`appendCSSOverrides`): After `tokens.css` generation, append CSS variables that aren't in the token schema (e.g., `--spacing`) directly to the `:root` block.

## How to verify

### Unit tests
```bash
bun test packages/cli/src/__tests__/init-from.test.ts
```
18 tests including an integration test against the real `tokens.json` schema structure.

### Manual end-to-end (after deploy)
```bash
mkdir /tmp/test-project && cd /tmp/test-project
barefoot init --from "https://ui.barefootjs.dev/studio?c=eyJzdHlsZSI6IlNoYXJwIn0%3D"
cat tokens/tokens.json | grep shadow-sm  # Should show Sharp preset shadow
cat tokens/tokens.css | head -30         # Should have proper CSS variables
ls components/ui/                        # Should have components from registry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)