### PR TITLE
Add requires field to registry for component dependency resolution

### DIFF
--- a/packages/cli/src/__tests__/add-remote.test.ts
+++ b/packages/cli/src/__tests__/add-remote.test.ts
@@ -222,4 +222,72 @@ describe('addFromRegistry', () => {
     // No files should be written since Promise.all fails atomically
     expect(existsSync(path.join(tmpDir, 'components/ui/button/index.tsx'))).toBe(false)
   })
+
+  test('resolves requires dependencies transitively', async () => {
+    const slotItem: RegistryItem = {
+      $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+      name: 'slot',
+      type: 'registry:ui',
+      title: 'Slot',
+      description: 'Polymorphic slot',
+      dependencies: [],
+      files: [
+        { path: 'components/ui/slot/index.tsx', type: 'registry:ui', content: 'export function Slot() {}' },
+      ],
+    }
+
+    const datePickerItem: RegistryItem = {
+      $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+      name: 'date-picker',
+      type: 'registry:ui',
+      title: 'Date Picker',
+      description: 'Date picker with calendar',
+      dependencies: [],
+      requires: ['button', 'calendar'],
+      files: [
+        { path: 'components/ui/date-picker/index.tsx', type: 'registry:ui', content: 'export function DatePicker() {}' },
+      ],
+    }
+
+    const buttonWithReq: RegistryItem = {
+      ...buttonItem,
+      requires: ['slot'],
+    }
+
+    const calendarItem: RegistryItem = {
+      $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+      name: 'calendar',
+      type: 'registry:ui',
+      title: 'Calendar',
+      description: 'Calendar',
+      dependencies: [],
+      files: [
+        { path: 'components/ui/calendar/index.tsx', type: 'registry:ui', content: 'export function Calendar() {}' },
+      ],
+    }
+
+    const items: Record<string, RegistryItem> = {
+      'date-picker': datePickerItem,
+      button: buttonWithReq,
+      calendar: calendarItem,
+      slot: slotItem,
+    }
+
+    globalThis.fetch = async (url: any) => {
+      const name = String(url).match(/\/([a-z-]+)\.json$/)?.[1]
+      if (name && items[name]) return new Response(JSON.stringify(items[name]), { status: 200 })
+      return new Response('Not Found', { status: 404 })
+    }
+
+    // Request only date-picker; it should auto-fetch button, calendar, and slot
+    await addFromRegistry(['date-picker'], 'https://example.com/r/', tmpDir, config, false)
+
+    expect(existsSync(path.join(tmpDir, 'components/ui/date-picker/index.tsx'))).toBe(true)
+    expect(existsSync(path.join(tmpDir, 'components/ui/button/index.tsx'))).toBe(true)
+    expect(existsSync(path.join(tmpDir, 'components/ui/calendar/index.tsx'))).toBe(true)
+    expect(existsSync(path.join(tmpDir, 'components/ui/slot/index.tsx'))).toBe(true)
+
+    // Should log resolved dependencies
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Resolved dependencies'))
+  })
 })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -74,7 +74,7 @@ async function tryFetchRegistryItem(
 
 /**
  * Add components from a remote registry.
- * Phase 1: Fetch all registry items.
+ * Phase 1: Fetch all registry items, resolving `requires` dependencies transitively.
  * Phase 2: Write files only if all fetches succeeded (or skip failures when skipErrors=true).
  */
 export async function addFromRegistry(
@@ -85,14 +85,50 @@ export async function addFromRegistry(
   force: boolean,
   skipErrors = false,
 ): Promise<void> {
-  // Phase 1: Fetch all registry items
-  const results = await Promise.all(
-    componentNames.map(name => tryFetchRegistryItem(registryUrl, name, skipErrors))
-  )
-  const items = results.filter((item): item is RegistryItem => item !== null)
-  const skippedComponents = componentNames.filter((_, i) => results[i] === null)
-  if (skippedComponents.length > 0) {
-    console.log(`  Skipped ${skippedComponents.length} unavailable component(s)`)
+  // Phase 1: Fetch all registry items, resolving requires transitively
+  const fetched = new Map<string, RegistryItem>()
+  const failed = new Set<string>()
+  const queue = [...componentNames]
+
+  while (queue.length > 0) {
+    const pending = queue.filter(n => !fetched.has(n) && !failed.has(n))
+    if (pending.length === 0) break
+
+    const results = await Promise.all(
+      pending.map(name => tryFetchRegistryItem(registryUrl, name, skipErrors))
+    )
+
+    for (let i = 0; i < pending.length; i++) {
+      const item = results[i]
+      if (!item) {
+        failed.add(pending[i])
+        continue
+      }
+      fetched.set(item.name, item)
+      // Enqueue any requires that haven't been fetched yet
+      if (item.requires) {
+        for (const dep of item.requires) {
+          if (!fetched.has(dep) && !failed.has(dep) && !queue.includes(dep)) {
+            queue.push(dep)
+          }
+        }
+      }
+    }
+
+    // Remove processed items from queue
+    queue.splice(0, pending.length)
+  }
+
+  if (failed.size > 0) {
+    console.log(`  Skipped ${failed.size} unavailable component(s)`)
+  }
+
+  const items = Array.from(fetched.values())
+  const autoDeps = items
+    .map(i => i.name)
+    .filter(n => !componentNames.includes(n))
+  if (autoDeps.length > 0) {
+    console.log(`  Resolved dependencies: ${autoDeps.join(', ')}`)
   }
 
   // Merge all files into a deduplication map (path → content)

--- a/packages/cli/src/lib/types.ts
+++ b/packages/cli/src/lib/types.ts
@@ -120,5 +120,6 @@ export interface RegistryItem {
   title: string
   description: string
   dependencies: string[]
+  requires?: string[]
   files: RegistryItemFile[]
 }

--- a/ui/build-registry.ts
+++ b/ui/build-registry.ts
@@ -78,6 +78,7 @@ interface RegistryItem {
   title: string
   description: string
   dependencies: string[]
+  requires?: string[]
   files: Array<{
     path: string
     type: string
@@ -94,12 +95,13 @@ interface RegistryIndex {
     type: string
     title: string
     description: string
+    requires?: string[]
   }>
 }
 
 async function buildRegistryItem(
   name: string,
-  registryMeta: { title: string; description: string },
+  registryMeta: { title: string; description: string; requires?: string[] },
 ): Promise<RegistryItem> {
   const filePaths = await resolveFiles(name)
   const dependencies = await resolveDependencies(filePaths)
@@ -117,7 +119,7 @@ async function buildRegistryItem(
     })
   }
 
-  return {
+  const item: RegistryItem = {
     $schema: 'https://ui.shadcn.com/schema/registry-item.json',
     name,
     type: 'registry:ui',
@@ -126,6 +128,12 @@ async function buildRegistryItem(
     dependencies,
     files,
   }
+
+  if (registryMeta.requires && registryMeta.requires.length > 0) {
+    item.requires = registryMeta.requires
+  }
+
+  return item
 }
 
 async function main() {

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -42,14 +42,16 @@
       "type": "registry:ui",
       "title": "Breadcrumb",
       "description": "Displays the path to the current resource using a hierarchy of links",
-      "tags": ["navigation"]
+      "tags": ["navigation"],
+      "requires": ["slot"]
     },
     {
       "name": "button",
       "type": "registry:ui",
       "title": "Button",
       "description": "A button component with variants and sizes",
-      "tags": ["input"]
+      "tags": ["input"],
+      "requires": ["slot"]
     },
     {
       "name": "calendar",
@@ -113,7 +115,8 @@
       "type": "registry:ui",
       "title": "Command",
       "description": "A command menu with search, keyboard navigation, and filtering",
-      "tags": ["navigation"]
+      "tags": ["navigation"],
+      "requires": ["dialog"]
     },
     {
       "name": "combobox",
@@ -141,7 +144,8 @@
       "type": "registry:ui",
       "title": "Date Picker",
       "description": "A date picker component with calendar popup and range selection",
-      "tags": ["input"]
+      "tags": ["input"],
+      "requires": ["button", "popover", "calendar"]
     },
     {
       "name": "pagination",
@@ -295,7 +299,8 @@
       "type": "registry:ui",
       "title": "Badge",
       "description": "Small status indicator labels",
-      "tags": ["display"]
+      "tags": ["display"],
+      "requires": ["slot"]
     },
     {
       "name": "card",


### PR DESCRIPTION
## Problem

When using `barefoot add date-picker --registry <url>`, the CLI fetches only the requested component. But `date-picker` depends on `button`, `popover`, and `calendar` — the user must manually discover and add these.

The local monorepo mode already resolves dependencies via `resolveDependencies()`, but the remote registry mode had no mechanism for this.

## Solution

Add a `requires` field to `registry.json` and propagate it through the build pipeline and CLI.

### Registry schema (`ui/registry.json`)
```json
{
  "name": "date-picker",
  "requires": ["button", "popover", "calendar"],
  ...
}
```

Components with `requires` added:
- `badge` → `slot`
- `button` → `slot`
- `breadcrumb` → `slot`
- `date-picker` → `button`, `popover`, `calendar`
- `command` → `dialog`

### Build (`ui/build-registry.ts`)
`requires` is passed through to the generated RegistryItem JSON files.

### CLI (`packages/cli/src/commands/add.ts`)
`addFromRegistry` now resolves `requires` transitively:
1. Fetch requested components
2. Inspect `requires` on each, enqueue unfetched dependencies
3. Repeat until all resolved
4. Log auto-resolved dependencies

### Type (`packages/cli/src/lib/types.ts`)
`RegistryItem.requires?: string[]` added.

## How to verify

```bash
bun test packages/cli/src/__tests__/add-remote.test.ts
```
11 tests including transitive dependency resolution: requesting `date-picker` auto-fetches `button`, `calendar`, and `slot` (via button's requires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)