### PR TITLE
Add Field component

### DIFF
--- a/site/ui/components/field-demo.tsx
+++ b/site/ui/components/field-demo.tsx
@@ -1,0 +1,140 @@
+"use client"
+/**
+ * FieldDemo Components
+ *
+ * Interactive demos for Field component.
+ * Shows form field patterns with label, description, and error.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Field, FieldContent, FieldDescription, FieldError, FieldLabel, FieldSet, FieldLegend, FieldGroup } from '@ui/components/ui/field'
+import { Input } from '@ui/components/ui/input'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+/**
+ * Basic vertical field with label, input, and description
+ */
+export function FieldBasicDemo() {
+  return (
+    <div className="space-y-4 max-w-sm">
+      <Field>
+        <FieldLabel for="email">Email</FieldLabel>
+        <FieldContent>
+          <Input id="email" type="email" placeholder="you@example.com" />
+          <FieldDescription>We'll never share your email.</FieldDescription>
+        </FieldContent>
+      </Field>
+    </div>
+  )
+}
+
+/**
+ * Field with validation error
+ */
+export function FieldErrorDemo() {
+  const [value, setValue] = createSignal('')
+  const [touched, setTouched] = createSignal(false)
+
+  const hasError = () => touched() && value().length === 0
+
+  return (
+    <div className="space-y-4 max-w-sm">
+      <Field data-invalid={hasError() || undefined}>
+        <FieldLabel for="username">Username</FieldLabel>
+        <FieldContent>
+          <Input
+            id="username"
+            placeholder="Enter username"
+            aria-invalid={hasError() || undefined}
+            value={value()}
+            onInput={(e) => setValue(e.target.value)}
+            onBlur={() => setTouched(true)}
+          />
+          {hasError() ? (
+            <FieldError>Username is required.</FieldError>
+          ) : (
+            <FieldDescription>Choose a unique username.</FieldDescription>
+          )}
+        </FieldContent>
+      </Field>
+    </div>
+  )
+}
+
+/**
+ * Horizontal layout with checkbox
+ */
+export function FieldHorizontalDemo() {
+  const [accepted, setAccepted] = createSignal(false)
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <Field orientation="horizontal">
+        <Checkbox
+          checked={accepted()}
+          onCheckedChange={setAccepted}
+        />
+        <FieldContent>
+          <FieldLabel>Accept terms and conditions</FieldLabel>
+          <FieldDescription>You agree to our Terms of Service and Privacy Policy.</FieldDescription>
+        </FieldContent>
+      </Field>
+      <p className="text-sm text-muted-foreground">
+        Status: <span className="font-medium">{accepted() ? 'Accepted' : 'Not accepted'}</span>
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Registration form using FieldSet and FieldGroup
+ */
+export function FieldFormDemo() {
+  const [submitted, setSubmitted] = createSignal(false)
+
+  const handleSubmit = (e: Event) => {
+    e.preventDefault()
+    setSubmitted(true)
+  }
+
+  return (
+    <form className="max-w-sm" onSubmit={handleSubmit}>
+      <FieldSet>
+        <FieldLegend>Create Account</FieldLegend>
+        <FieldGroup>
+          <Field>
+            <FieldLabel for="reg-name">Full Name</FieldLabel>
+            <FieldContent>
+              <Input id="reg-name" placeholder="John Doe" />
+            </FieldContent>
+          </Field>
+          <Field>
+            <FieldLabel for="reg-email">Email</FieldLabel>
+            <FieldContent>
+              <Input id="reg-email" type="email" placeholder="john@example.com" />
+              <FieldDescription>We'll send a verification email.</FieldDescription>
+            </FieldContent>
+          </Field>
+          <Field>
+            <FieldLabel for="reg-password">Password</FieldLabel>
+            <FieldContent>
+              <Input id="reg-password" type="password" placeholder="••••••••" />
+              <FieldDescription>Must be at least 8 characters.</FieldDescription>
+            </FieldContent>
+          </Field>
+        </FieldGroup>
+      </FieldSet>
+      <div className="mt-6">
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-md text-sm font-medium h-9 px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90"
+        >
+          Create Account
+        </button>
+        {submitted() && (
+          <p className="mt-2 text-sm text-muted-foreground">Form submitted!</p>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -39,6 +39,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'checkbox', title: 'Checkbox', description: 'Toggle selection control', category: 'input' },
   { slug: 'combobox', title: 'Combobox', description: 'Autocomplete input with dropdown', category: 'input' },
   { slug: 'date-picker', title: 'Date Picker', description: 'Date selection with calendar popup', category: 'input' },
+  { slug: 'field', title: 'Field', description: 'Form field wrapper with label and error', category: 'input' },
   { slug: 'input', title: 'Input', description: 'Text input field', category: 'input' },
   { slug: 'input-otp', title: 'Input OTP', description: 'One-time password input', category: 'input' },
   { slug: 'label', title: 'Label', description: 'Accessible label for form controls', category: 'input' },

--- a/ui/components/ui/field/index.test.tsx
+++ b/ui/components/ui/field/index.test.tsx
@@ -1,0 +1,188 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('Field', () => {
+  const result = renderToTest(source, 'field.tsx', 'Field')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is Field', () => {
+    expect(result.componentName).toBe('Field')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=field', () => {
+    expect(result.root.props['data-slot']).toBe('field')
+  })
+
+  test('has role=group', () => {
+    const el = result.find({ role: 'group' })
+    expect(el).not.toBeNull()
+    expect(el!.tag).toBe('div')
+  })
+
+  test('has data-orientation attribute', () => {
+    expect(result.root.props['data-orientation']).not.toBeUndefined()
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('w-full')
+    expect(result.root.classes).toContain('gap-3')
+  })
+})
+
+describe('FieldSet', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldSet')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <fieldset>', () => {
+    expect(result.root.tag).toBe('fieldset')
+  })
+
+  test('has data-slot=field-set', () => {
+    expect(result.root.props['data-slot']).toBe('field-set')
+  })
+})
+
+describe('FieldLegend', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldLegend')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <legend>', () => {
+    expect(result.root.tag).toBe('legend')
+  })
+
+  test('has data-slot=field-legend', () => {
+    expect(result.root.props['data-slot']).toBe('field-legend')
+  })
+
+  test('has data-variant attribute', () => {
+    expect(result.root.props['data-variant']).not.toBeUndefined()
+  })
+})
+
+describe('FieldGroup', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=field-group', () => {
+    expect(result.root.props['data-slot']).toBe('field-group')
+  })
+})
+
+describe('FieldContent', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldContent')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=field-content', () => {
+    expect(result.root.props['data-slot']).toBe('field-content')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-col')
+    expect(result.root.classes).toContain('gap-1.5')
+  })
+})
+
+describe('FieldLabel', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldLabel')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <label>', () => {
+    expect(result.root.tag).toBe('label')
+  })
+
+  test('has data-slot=field-label', () => {
+    expect(result.root.props['data-slot']).toBe('field-label')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+    expect(result.root.classes).toContain('font-medium')
+  })
+})
+
+describe('FieldDescription', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldDescription')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <p>', () => {
+    expect(result.root.tag).toBe('p')
+  })
+
+  test('has data-slot=field-description', () => {
+    expect(result.root.props['data-slot']).toBe('field-description')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+    expect(result.root.classes).toContain('text-muted-foreground')
+  })
+})
+
+describe('FieldError', () => {
+  const result = renderToTest(source, 'field.tsx', 'FieldError')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=field-error', () => {
+    expect(result.root.props['data-slot']).toBe('field-error')
+  })
+
+  test('has role=alert', () => {
+    const el = result.find({ role: 'alert' })
+    expect(el).not.toBeNull()
+    expect(el!.tag).toBe('div')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-destructive')
+  })
+})

--- a/ui/components/ui/field/index.tsx
+++ b/ui/components/ui/field/index.tsx
@@ -1,0 +1,305 @@
+/**
+ * Field Component
+ *
+ * A form field wrapper that provides structure for labels, descriptions,
+ * and error messages. Supports vertical and horizontal orientations.
+ * Based on shadcn/ui Field with native HTML + ARIA.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Field>
+ *   <FieldLabel>Email</FieldLabel>
+ *   <FieldContent>
+ *     <Input type="email" />
+ *     <FieldDescription>Enter your email address.</FieldDescription>
+ *   </FieldContent>
+ * </Field>
+ * ```
+ *
+ * @example With error
+ * ```tsx
+ * <Field data-invalid="true">
+ *   <FieldLabel>Username</FieldLabel>
+ *   <FieldContent>
+ *     <Input aria-invalid />
+ *     <FieldError>Username is required.</FieldError>
+ *   </FieldContent>
+ * </Field>
+ * ```
+ *
+ * @example Horizontal layout
+ * ```tsx
+ * <Field orientation="horizontal">
+ *   <FieldLabel>Newsletter</FieldLabel>
+ *   <Checkbox />
+ * </Field>
+ * ```
+ */
+
+import type { HTMLBaseAttributes, LabelHTMLAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// --- FieldSet ---
+
+const fieldSetClasses = 'flex flex-col gap-6'
+
+/** Props for the FieldSet component. */
+interface FieldSetProps extends HTMLBaseAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the fieldset. */
+  children?: Child
+}
+
+/**
+ * Groups multiple Field components.
+ * Renders as a native <fieldset> element.
+ */
+function FieldSet({ className = '', children, ...props }: FieldSetProps) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={`${fieldSetClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </fieldset>
+  )
+}
+
+// --- FieldLegend ---
+
+type FieldLegendVariant = 'legend' | 'label'
+
+const fieldLegendBaseClasses = 'mb-3 font-medium'
+const fieldLegendVariantClasses: Record<FieldLegendVariant, string> = {
+  legend: 'text-base',
+  label: 'text-sm',
+}
+
+/** Props for the FieldLegend component. */
+interface FieldLegendProps extends HTMLBaseAttributes {
+  /** The visual variant of the legend. */
+  variant?: FieldLegendVariant
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the legend. */
+  children?: Child
+}
+
+/**
+ * A legend element for a FieldSet.
+ * Supports legend and label visual variants.
+ */
+function FieldLegend({ variant = 'legend', className = '', children, ...props }: FieldLegendProps) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={`${fieldLegendBaseClasses} ${fieldLegendVariantClasses[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </legend>
+  )
+}
+
+// --- FieldGroup ---
+
+const fieldGroupClasses = 'flex w-full flex-col gap-7'
+
+/** Props for the FieldGroup component. */
+interface FieldGroupProps extends HTMLBaseAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the group. */
+  children?: Child
+}
+
+/**
+ * Groups multiple fields within a FieldSet.
+ */
+function FieldGroup({ className = '', children, ...props }: FieldGroupProps) {
+  return (
+    <div
+      data-slot="field-group"
+      className={`${fieldGroupClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// --- Field ---
+
+type FieldOrientation = 'vertical' | 'horizontal'
+
+const fieldBaseClasses = 'group/field flex w-full gap-3 data-[invalid=true]:text-destructive'
+const fieldOrientationClasses: Record<FieldOrientation, string> = {
+  vertical: 'flex-col [&>*]:w-full',
+  horizontal: 'flex-row items-center',
+}
+
+/** Props for the Field component. */
+interface FieldProps extends HTMLBaseAttributes {
+  /** Layout orientation. */
+  orientation?: FieldOrientation
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the field. */
+  children?: Child
+}
+
+/**
+ * A form field wrapper providing layout and error state styling.
+ * Use data-invalid="true" to apply error styling.
+ */
+function Field({ orientation = 'vertical', className = '', children, ...props }: FieldProps) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={`${fieldBaseClasses} ${fieldOrientationClasses[orientation]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// --- FieldContent ---
+
+const fieldContentClasses = 'flex flex-1 flex-col gap-1.5 leading-snug'
+
+/** Props for the FieldContent component. */
+interface FieldContentProps extends HTMLBaseAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the field content area. */
+  children?: Child
+}
+
+/**
+ * Wraps the input control, description, and error within a Field.
+ */
+function FieldContent({ className = '', children, ...props }: FieldContentProps) {
+  return (
+    <div
+      data-slot="field-content"
+      className={`${fieldContentClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// --- FieldLabel ---
+
+const fieldLabelClasses = 'flex w-fit gap-2 leading-snug text-sm font-medium select-none group-data-[disabled=true]/field:opacity-50'
+
+/** Props for the FieldLabel component. */
+interface FieldLabelProps extends LabelHTMLAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the label. */
+  children?: Child
+}
+
+/**
+ * A label element within a Field.
+ * Inherits disabled styling from parent Field.
+ */
+function FieldLabel({ className = '', children, ...props }: FieldLabelProps) {
+  return (
+    <label
+      data-slot="field-label"
+      className={`${fieldLabelClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </label>
+  )
+}
+
+// --- FieldDescription ---
+
+const fieldDescriptionClasses = 'text-sm leading-normal font-normal text-muted-foreground'
+
+/** Props for the FieldDescription component. */
+interface FieldDescriptionProps extends HTMLBaseAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Content displayed inside the description. */
+  children?: Child
+}
+
+/**
+ * Descriptive text within a Field, typically placed below the input.
+ */
+function FieldDescription({ className = '', children, ...props }: FieldDescriptionProps) {
+  return (
+    <p
+      data-slot="field-description"
+      className={`${fieldDescriptionClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </p>
+  )
+}
+
+// --- FieldError ---
+
+const fieldErrorClasses = 'text-sm font-normal text-destructive'
+
+/** Props for the FieldError component. */
+interface FieldErrorProps extends HTMLBaseAttributes {
+  /** Additional CSS class names. */
+  className?: string
+  /** Error message content. */
+  children?: Child
+}
+
+/**
+ * Displays validation error messages within a Field.
+ * Uses role="alert" for screen reader announcements.
+ */
+function FieldError({ className = '', children, ...props }: FieldErrorProps) {
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={`${fieldErrorClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+}
+
+export type {
+  FieldProps,
+  FieldContentProps,
+  FieldDescriptionProps,
+  FieldErrorProps,
+  FieldGroupProps,
+  FieldLabelProps,
+  FieldLegendProps,
+  FieldSetProps,
+  FieldOrientation,
+  FieldLegendVariant,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -331,6 +331,14 @@
       "tags": ["navigation"]
     },
     {
+      "name": "field",
+      "type": "registry:ui",
+      "title": "Field",
+      "description": "Form field wrapper with label, description, and error message",
+      "tags": ["input"],
+      "requires": ["label"]
+    },
+    {
       "name": "input",
       "type": "registry:ui",
       "title": "Input",


### PR DESCRIPTION
## Summary

- Add Field component family for form field layout and validation (FieldSet, FieldLegend, FieldGroup, Field, FieldContent, FieldLabel, FieldDescription, FieldError)
- Add IR tests for all 8 sub-components (35 tests passing)
- Add demo components (basic, error validation, horizontal layout, registration form)
- Register in `ui/registry.json` and `component-registry.ts`

## Note

Doc page, playground, E2E test, and route registration are not yet included — will follow up in a subsequent PR.

Closes #670
Part of #125

## Test plan

- [x] `bun run build` passes
- [x] `bun test ui/components/ui/field/` — 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)