### PR TITLE
Fix token editor swatch colors not resetting

### DIFF
--- a/site/ui/e2e/studio.spec.ts
+++ b/site/ui/e2e/studio.spec.ts
@@ -191,4 +191,38 @@ test.describe('Studio Export & URL', () => {
     const decoded = JSON.parse(atob(decodeURIComponent(cMatch![1])))
     expect(decoded.style).toBe('Compact')
   })
+
+  test('reset clears color swatch previews back to defaults', async ({ page }) => {
+    await page.goto('/studio')
+
+    // Get the default background color of the primary swatch
+    const swatch = page.locator('[data-studio-color-preview="primary"]')
+    const defaultColor = await swatch.evaluate(el => el.style.backgroundColor)
+
+    // Open primary editor and change the color
+    await page.locator('[data-studio-color-edit="primary"]').click()
+    const sliderR = page.locator('[data-studio-slider-r="primary"]')
+    await sliderR.fill('50')
+    await sliderR.dispatchEvent('input')
+
+    // Swatch should now have a different inline color
+    const customColor = await swatch.evaluate(el => el.style.backgroundColor)
+    expect(customColor).not.toBe(defaultColor)
+
+    // Accept the confirm dialog
+    page.on('dialog', dialog => dialog.accept())
+
+    // Click "Reset all customizations"
+    await page.locator('[data-studio-reset]').click()
+
+    // Swatch should be reset back to CSS variable reference
+    const resetColor = await swatch.evaluate(el => el.style.backgroundColor)
+    expect(resetColor).toContain('var(--primary)')
+
+    // localStorage should be cleared
+    const stored = await page.evaluate(() =>
+      localStorage.getItem('barefootjs-studio-tokens')
+    )
+    expect(stored).toBeNull()
+  })
 })

--- a/site/ui/pages/studio.tsx
+++ b/site/ui/pages/studio.tsx
@@ -1736,9 +1736,14 @@ const studioScript = `
     customRadius = null;
     customFont = null;
 
-    // Remove all inline style overrides for color tokens
+    // Remove all inline style overrides for color tokens and reset previews
     Object.keys(defaultColors).forEach(function(token) {
       scopedRemoveProperty('--' + token);
+      // Reset swatch and editor previews back to CSS variable reference
+      var swatch = document.querySelector('[data-studio-color-preview="' + token + '"]');
+      if (swatch) swatch.style.backgroundColor = 'var(--' + token + ')';
+      var editorPreviews = document.querySelectorAll('[data-studio-color-editor-preview="' + token + '"]');
+      editorPreviews.forEach(function(el) { el.style.backgroundColor = 'var(--' + token + ')'; });
     });
 
     // Close all open editors


### PR DESCRIPTION
## Summary
- Fix "Reset all customizations" not clearing token editor color swatch previews
- Swatch and editor preview elements had their `backgroundColor` set to literal color values during customization, but the reset handler only removed scoped CSS variable overrides without restoring the preview elements back to their CSS variable references (`var(--token)`)
- Add E2E test to verify swatch colors reset correctly

## Test plan
- [ ] Open studio page, customize a color token via the editor
- [ ] Click "Reset all customizations" and confirm
- [ ] Verify all color swatches return to their default theme colors
- [ ] Verify localStorage is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)