### PR TITLE
Add Button Group component

### DIFF
--- a/site/ui/components/button-group-demo.tsx
+++ b/site/ui/components/button-group-demo.tsx
@@ -1,0 +1,105 @@
+"use client"
+/**
+ * ButtonGroupDemo Components
+ *
+ * Interactive demos for ButtonGroup component.
+ * Each demo shows a realistic usage scenario.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Button } from '@ui/components/ui/button'
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from '@ui/components/ui/button-group'
+
+/**
+ * Basic horizontal button group
+ */
+export function ButtonGroupBasicDemo() {
+  const [active, setActive] = createSignal('inbox')
+
+  return (
+    <div className="space-y-4">
+      <ButtonGroup>
+        <Button
+          variant={active() === 'inbox' ? 'default' : 'outline'}
+          onClick={() => setActive('inbox')}
+        >
+          Inbox
+        </Button>
+        <Button
+          variant={active() === 'drafts' ? 'default' : 'outline'}
+          onClick={() => setActive('drafts')}
+        >
+          Drafts
+        </Button>
+        <Button
+          variant={active() === 'sent' ? 'default' : 'outline'}
+          onClick={() => setActive('sent')}
+        >
+          Sent
+        </Button>
+      </ButtonGroup>
+      <p data-testid="active-view" className="text-sm text-muted-foreground">
+        Viewing: {active()}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Button group with separator — split button pattern
+ */
+export function ButtonGroupSeparatorDemo() {
+  const [saved, setSaved] = createSignal(false)
+
+  return (
+    <ButtonGroup>
+      <Button variant="outline" onClick={() => setSaved(true)}>
+        {saved() ? 'Saved!' : 'Save'}
+      </Button>
+      <ButtonGroupSeparator />
+      <Button variant="outline" size="icon" aria-label="More save options">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </Button>
+    </ButtonGroup>
+  )
+}
+
+/**
+ * Vertical orientation example
+ */
+export function ButtonGroupVerticalDemo() {
+  return (
+    <ButtonGroup orientation="vertical">
+      <Button variant="outline">Profile</Button>
+      <Button variant="outline">Settings</Button>
+      <Button variant="outline">Logout</Button>
+    </ButtonGroup>
+  )
+}
+
+/**
+ * Button group with text label
+ */
+export function ButtonGroupTextDemo() {
+  const [count, setCount] = createSignal(1)
+
+  return (
+    <ButtonGroup>
+      <Button variant="outline" size="icon" onClick={() => setCount(n => Math.max(0, n - 1))} aria-label="Decrease">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
+        </svg>
+      </Button>
+      <ButtonGroupText>
+        <span data-testid="quantity">{count()}</span>
+      </ButtonGroupText>
+      <Button variant="outline" size="icon" onClick={() => setCount(n => n + 1)} aria-label="Increase">
+        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+        </svg>
+      </Button>
+    </ButtonGroup>
+  )
+}

--- a/site/ui/components/button-group-playground.tsx
+++ b/site/ui/components/button-group-playground.tsx
@@ -1,0 +1,78 @@
+"use client"
+/**
+ * ButtonGroup Props Playground
+ *
+ * Interactive playground for the ButtonGroup component.
+ * Allows tweaking orientation prop with live preview.
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Button } from '@ui/components/ui/button'
+import { ButtonGroup } from '@ui/components/ui/button-group'
+
+type Orientation = 'horizontal' | 'vertical'
+
+function highlightButtonGroupJsx(orientation: string): string {
+  const props: string[] = []
+  if (orientation !== 'horizontal') props.push(` ${hlAttr('orientation')}${hlPlain('=')}${hlStr(`&quot;${orientation}&quot;`)}`)
+
+  return [
+    `${hlPlain('&lt;')}${hlTag('ButtonGroup')}${props.join('')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}First${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}Second${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}Third${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
+    `${hlPlain('&lt;/')}${hlTag('ButtonGroup')}${hlPlain('&gt;')}`,
+  ].join('\n')
+}
+
+function ButtonGroupPlayground(_props: {}) {
+  const [orientation, setOrientation] = createSignal<Orientation>('horizontal')
+
+  const codeText = createMemo(() => {
+    const parts: string[] = []
+    if (orientation() !== 'horizontal') parts.push(`orientation="${orientation()}"`)
+    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
+    return `<ButtonGroup${propsStr}>\n  <Button variant="outline">First</Button>\n  <Button variant="outline">Second</Button>\n  <Button variant="outline">Third</Button>\n</ButtonGroup>`
+  })
+
+  createEffect(() => {
+    const o = orientation()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) {
+      codeEl.innerHTML = highlightButtonGroupJsx(o)
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-button-group-preview"
+      previewContent={
+        <ButtonGroup orientation={orientation()}>
+          <Button variant="outline">First</Button>
+          <Button variant="outline">Second</Button>
+          <Button variant="outline">Third</Button>
+        </ButtonGroup>
+      }
+      controls={<>
+        <PlaygroundControl label="orientation">
+          <Select value={orientation()} onValueChange={(v: string) => setOrientation(v as Orientation)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select orientation..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="horizontal">horizontal</SelectItem>
+              <SelectItem value="vertical">vertical</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={codeText()} />}
+    />
+  )
+}
+
+export { ButtonGroupPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -35,6 +35,7 @@ export const categoryLabels: Record<ComponentCategory, string> = {
 export const componentEntries: ComponentEntry[] = [
   // Input (15)
   { slug: 'button', title: 'Button', description: 'Clickable actions with multiple variants', category: 'input' },
+  { slug: 'button-group', title: 'Button Group', description: 'Container for grouping related buttons', category: 'input' },
   { slug: 'calendar', title: 'Calendar', description: 'Date picker with month navigation', category: 'input' },
   { slug: 'checkbox', title: 'Checkbox', description: 'Toggle selection control', category: 'input' },
   { slug: 'combobox', title: 'Combobox', description: 'Autocomplete input with dropdown', category: 'input' },

--- a/site/ui/e2e/button-group.spec.ts
+++ b/site/ui/e2e/button-group.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Button Group Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/button-group')
+  })
+
+  test.describe('Rendering', () => {
+    test('displays button-group elements with data-slot', async ({ page }) => {
+      const groups = page.locator('[data-slot="button-group"]')
+      await expect(groups.first()).toBeVisible()
+    })
+
+    test('has role=group', async ({ page }) => {
+      const group = page.locator('[data-slot="button-group"]').first()
+      await expect(group).toHaveAttribute('role', 'group')
+    })
+  })
+
+  test.describe('Playground', () => {
+    test('displays playground with buttons', async ({ page }) => {
+      const preview = page.locator('#preview')
+      const group = preview.locator('[data-slot="button-group"]').first()
+      await expect(group).toBeVisible()
+
+      const buttons = group.locator('button')
+      await expect(buttons).toHaveCount(3)
+    })
+
+    test('orientation selector changes layout', async ({ page }) => {
+      const preview = page.locator('#preview')
+      const group = preview.locator('[data-slot="button-group"]').first()
+
+      // Default: horizontal
+      await expect(group).toHaveAttribute('data-orientation', 'horizontal')
+    })
+  })
+
+  test.describe('Separator Example', () => {
+    test('has save button and icon button', async ({ page }) => {
+      const section = page.locator('#separator').locator('..')
+      await expect(section.locator('button:has-text("Save")')).toBeVisible()
+      await expect(section.locator('button[aria-label="More save options"]')).toBeVisible()
+    })
+  })
+
+  test.describe('Vertical Example', () => {
+    test('has vertical orientation', async ({ page }) => {
+      const section = page.locator('#vertical').locator('..')
+      const group = section.locator('[data-slot="button-group"]')
+      await expect(group).toHaveAttribute('data-orientation', 'vertical')
+    })
+
+    test('has three buttons', async ({ page }) => {
+      const section = page.locator('#vertical').locator('..')
+      const group = section.locator('[data-slot="button-group"]')
+      const buttons = group.locator('button')
+      await expect(buttons).toHaveCount(3)
+    })
+  })
+
+  test.describe('With Text Example', () => {
+    test('displays quantity counter', async ({ page }) => {
+      const section = page.locator('#with-text').locator('..')
+      const group = section.locator('[data-slot="button-group"]')
+      await expect(group).toBeVisible()
+      await expect(section.locator('button[aria-label="Decrease"]')).toBeVisible()
+      await expect(section.locator('button[aria-label="Increase"]')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/components/button-group.tsx
+++ b/site/ui/pages/components/button-group.tsx
@@ -1,0 +1,181 @@
+/**
+ * Button Group Reference Page (/components/button-group)
+ *
+ * Developer reference with interactive Props Playground.
+ */
+
+import { Button } from '@/components/ui/button'
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from '@/components/ui/button-group'
+import { ButtonGroupPlayground } from '@/components/button-group-playground'
+import {
+  ButtonGroupBasicDemo,
+  ButtonGroupSeparatorDemo,
+  ButtonGroupVerticalDemo,
+  ButtonGroupTextDemo,
+} from '@/components/button-group-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'separator', title: 'Separator', branch: 'start' },
+  { id: 'vertical', title: 'Vertical', branch: 'child' },
+  { id: 'with-text', title: 'With Text', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { Button } from "@/components/ui/button"
+import { ButtonGroup } from "@/components/ui/button-group"
+
+function ButtonGroupDemo() {
+  return (
+    <ButtonGroup>
+      <Button variant="outline">Left</Button>
+      <Button variant="outline">Center</Button>
+      <Button variant="outline">Right</Button>
+    </ButtonGroup>
+  )
+}`
+
+const separatorCode = `<ButtonGroup>
+  <Button variant="outline">Save</Button>
+  <ButtonGroupSeparator />
+  <Button variant="outline" size="icon" aria-label="More options">
+    <ChevronDownIcon />
+  </Button>
+</ButtonGroup>`
+
+const verticalCode = `<ButtonGroup orientation="vertical">
+  <Button variant="outline">Profile</Button>
+  <Button variant="outline">Settings</Button>
+  <Button variant="outline">Logout</Button>
+</ButtonGroup>`
+
+const withTextCode = `<ButtonGroup>
+  <Button variant="outline" size="icon" aria-label="Decrease">
+    <MinusIcon />
+  </Button>
+  <ButtonGroupText>
+    <span>1</span>
+  </ButtonGroupText>
+  <Button variant="outline" size="icon" aria-label="Increase">
+    <PlusIcon />
+  </Button>
+</ButtonGroup>`
+
+const buttonGroupProps: PropDefinition[] = [
+  {
+    name: 'orientation',
+    type: "'horizontal' | 'vertical'",
+    defaultValue: "'horizontal'",
+    description: 'The layout direction of the button group.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The buttons to group together.',
+  },
+]
+
+const buttonGroupTextProps: PropDefinition[] = [
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element instead of <div>.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The text content to display.',
+  },
+]
+
+const buttonGroupSeparatorProps: PropDefinition[] = [
+  {
+    name: 'orientation',
+    type: "'horizontal' | 'vertical'",
+    defaultValue: "'vertical'",
+    description: 'The separator direction.',
+  },
+]
+
+export function ButtonGroupRefPage() {
+  return (
+    <DocPage slug="button-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Button Group"
+          description="Container for grouping related buttons with merged borders and corners."
+          {...getNavLinks('button-group')}
+        />
+
+        {/* Props Playground */}
+        <ButtonGroupPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add button-group" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <ButtonGroup>
+              <Button variant="outline">Left</Button>
+              <Button variant="outline">Center</Button>
+              <Button variant="outline">Right</Button>
+            </ButtonGroup>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Separator" code={separatorCode} showLineNumbers={false}>
+              <ButtonGroupSeparatorDemo />
+            </Example>
+
+            <Example title="Vertical" code={verticalCode} showLineNumbers={false}>
+              <ButtonGroupVerticalDemo />
+            </Example>
+
+            <Example title="With Text" code={withTextCode} showLineNumbers={false}>
+              <ButtonGroupTextDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-3">ButtonGroup</h3>
+              <PropsTable props={buttonGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">ButtonGroupText</h3>
+              <PropsTable props={buttonGroupTextProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">ButtonGroupSeparator</h3>
+              <PropsTable props={buttonGroupSeparatorProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -14,6 +14,7 @@ import { AlertRefPage } from './pages/components/alert'
 import { AlertDialogRefPage } from './pages/components/alert-dialog'
 import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
+import { ButtonGroupRefPage } from './pages/components/button-group'
 import { ComboboxRefPage } from './pages/components/combobox'
 import { InputRefPage } from './pages/components/input'
 import { LabelRefPage } from './pages/components/label'
@@ -143,6 +144,11 @@ export function createApp() {
   // Button reference page (redesigned #515)
   app.get('/components/button', (c) => {
     return c.render(<ButtonRefPage />)
+  })
+
+  // Button Group reference page
+  app.get('/components/button-group', (c) => {
+    return c.render(<ButtonGroupRefPage />)
   })
 
   // Combobox reference page (redesigned #515)

--- a/ui/components/ui/button-group/index.test.tsx
+++ b/ui/components/ui/button-group/index.test.tsx
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('ButtonGroup', () => {
+  const result = renderToTest(source, 'button-group.tsx', 'ButtonGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ButtonGroup', () => {
+    expect(result.componentName).toBe('ButtonGroup')
+  })
+
+  test('no signals (stateless component)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('has role=group', () => {
+    const group = result.find({ role: 'group' })
+    expect(group).not.toBeNull()
+  })
+
+  test('root div has data-slot=button-group', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['data-slot']).toBe('button-group')
+  })
+
+  test('has base layout classes', () => {
+    const div = result.find({ tag: 'div' })!
+    expect(div.classes).toContain('flex')
+    expect(div.classes).toContain('w-fit')
+    expect(div.classes).toContain('items-stretch')
+  })
+})
+
+describe('ButtonGroupText', () => {
+  const result = renderToTest(source, 'button-group.tsx', 'ButtonGroupText')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ButtonGroupText', () => {
+    expect(result.componentName).toBe('ButtonGroupText')
+  })
+
+  test('root is a conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a <div> element', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+  })
+
+  test('contains a Slot component for asChild', () => {
+    const slot = result.find({ componentName: 'Slot' })
+    expect(slot).not.toBeNull()
+  })
+})
+
+describe('ButtonGroupSeparator', () => {
+  const result = renderToTest(source, 'button-group.tsx', 'ButtonGroupSeparator')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is ButtonGroupSeparator', () => {
+    expect(result.componentName).toBe('ButtonGroupSeparator')
+  })
+
+  test('renders Separator component', () => {
+    const separator = result.find({ componentName: 'Separator' })
+    expect(separator).not.toBeNull()
+  })
+})

--- a/ui/components/ui/button-group/index.tsx
+++ b/ui/components/ui/button-group/index.tsx
@@ -1,0 +1,173 @@
+/**
+ * ButtonGroup Component
+ *
+ * A container that groups related buttons together with consistent styling.
+ * Removes inner border-radius and merges borders between adjacent children.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <ButtonGroup>
+ *   <Button variant="outline">Left</Button>
+ *   <Button variant="outline">Center</Button>
+ *   <Button variant="outline">Right</Button>
+ * </ButtonGroup>
+ * ```
+ *
+ * @example Vertical orientation
+ * ```tsx
+ * <ButtonGroup orientation="vertical">
+ *   <Button variant="outline">Top</Button>
+ *   <Button variant="outline">Middle</Button>
+ *   <Button variant="outline">Bottom</Button>
+ * </ButtonGroup>
+ * ```
+ *
+ * @example With separator
+ * ```tsx
+ * <ButtonGroup>
+ *   <Button variant="outline">Save</Button>
+ *   <ButtonGroupSeparator />
+ *   <Button variant="outline" size="icon">▼</Button>
+ * </ButtonGroup>
+ * ```
+ *
+ * @example With text
+ * ```tsx
+ * <ButtonGroup>
+ *   <ButtonGroupText>Label</ButtonGroupText>
+ *   <Button variant="outline">Action</Button>
+ * </ButtonGroup>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+import { Slot } from '../slot'
+import { Separator } from '../separator'
+
+// Orientation type
+type ButtonGroupOrientation = 'horizontal' | 'vertical'
+
+// Base classes for the group container
+const baseClasses = 'flex w-fit items-stretch [&>*]:focus-visible:relative [&>*]:focus-visible:z-10'
+
+// Orientation-specific classes
+const orientationClasses: Record<ButtonGroupOrientation, string> = {
+  horizontal: '[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none',
+  vertical: 'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+}
+
+/**
+ * Props for the ButtonGroup component.
+ */
+interface ButtonGroupProps extends HTMLBaseAttributes {
+  /**
+   * The orientation of the button group.
+   * @default 'horizontal'
+   */
+  orientation?: ButtonGroupOrientation
+  /**
+   * Children to render inside the button group.
+   */
+  children?: Child
+}
+
+/**
+ * ButtonGroup component.
+ * Groups related buttons with merged borders and rounded corners.
+ *
+ * @param props.orientation - Layout direction: 'horizontal' or 'vertical'
+ */
+function ButtonGroup({
+  orientation = 'horizontal',
+  className = '',
+  children,
+  ...props
+}: ButtonGroupProps) {
+  return (
+    <div
+      data-slot="button-group"
+      data-orientation={orientation}
+      role="group"
+      className={`${baseClasses} ${orientationClasses[orientation]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// Base classes for ButtonGroupText
+const textBaseClasses = 'flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4'
+
+/**
+ * Props for the ButtonGroupText component.
+ */
+interface ButtonGroupTextProps extends HTMLBaseAttributes {
+  /**
+   * When true, renders child element instead of `<div>`.
+   * @default false
+   */
+  asChild?: boolean
+  /**
+   * Children to render inside the text container.
+   */
+  children?: Child
+}
+
+/**
+ * ButtonGroupText component.
+ * Displays text content within a button group.
+ *
+ * @param props.asChild - Render child element instead of div
+ */
+function ButtonGroupText({
+  className = '',
+  asChild = false,
+  children,
+  ...props
+}: ButtonGroupTextProps) {
+  const classes = `${textBaseClasses} ${className}`
+
+  if (asChild) {
+    return <Slot className={classes} {...props}>{children}</Slot>
+  }
+  return <div className={classes} {...props}>{children}</div>
+}
+
+/**
+ * Props for the ButtonGroupSeparator component.
+ */
+interface ButtonGroupSeparatorProps extends HTMLBaseAttributes {
+  /**
+   * The separator orientation.
+   * @default 'vertical'
+   */
+  orientation?: 'horizontal' | 'vertical'
+}
+
+/**
+ * ButtonGroupSeparator component.
+ * A visual divider between buttons in a group.
+ *
+ * @param props.orientation - Separator direction
+ */
+function ButtonGroupSeparator({
+  orientation = 'vertical',
+  className = '',
+  ...props
+}: ButtonGroupSeparatorProps) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      decorative
+      className={`!m-0 self-stretch bg-input ${orientation === 'vertical' ? 'h-auto' : ''} ${className}`}
+      {...props}
+    />
+  )
+}
+
+export { ButtonGroup, ButtonGroupText, ButtonGroupSeparator }
+export type { ButtonGroupProps, ButtonGroupTextProps, ButtonGroupSeparatorProps, ButtonGroupOrientation }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -54,6 +54,14 @@
       "requires": ["slot"]
     },
     {
+      "name": "button-group",
+      "type": "registry:ui",
+      "title": "Button Group",
+      "description": "Container for grouping related buttons",
+      "tags": ["input"],
+      "requires": ["slot", "separator"]
+    },
+    {
       "name": "calendar",
       "type": "registry:ui",
       "title": "Calendar",


### PR DESCRIPTION
## Summary

- Add ButtonGroup component family (ButtonGroup, ButtonGroupText, ButtonGroupSeparator)
- Merges borders and corner radius between adjacent children
- Supports horizontal/vertical orientation
- Includes component IR tests, demos (basic, separator, vertical, text counter), playground, doc page, and E2E tests (8 passing)

## Test plan

- [x] `bun run build` passes
- [x] `bun test ui/components/ui/button-group/` — IR tests pass
- [x] `bun run test:e2e -- --grep "Button Group"` — 8 E2E tests pass

Closes #671
Part of #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)