### PR TITLE
Add InputGroup component

### DIFF
--- a/site/ui/components/input-group-demo.tsx
+++ b/site/ui/components/input-group-demo.tsx
@@ -1,0 +1,124 @@
+"use client"
+/**
+ * InputGroupDemo Components
+ *
+ * Interactive demos for InputGroup component.
+ * Shows realistic scenarios with addons, prefixes, and suffixes.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+} from '@ui/components/ui/input-group'
+
+/**
+ * Basic prefix/suffix example
+ * Shows text and icon addons in inline positions
+ */
+export function InputGroupBasicDemo() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>https://</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="example.com" />
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroupInput placeholder="Enter amount" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupText>USD</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-4"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          </InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Search..." />
+      </InputGroup>
+    </div>
+  )
+}
+
+/**
+ * With button addon
+ * Shows interactive buttons within the input group
+ */
+export function InputGroupButtonDemo() {
+  const [value, setValue] = createSignal('')
+
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <InputGroup>
+        <InputGroupInput
+          placeholder="Enter text to copy..."
+          value={value()}
+          onInput={(e) => setValue(e.target.value)}
+        />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            onClick={() => {
+              if (value()) navigator.clipboard.writeText(value())
+            }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-3.5"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+            Copy
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupButton size="icon-xs">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-4"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          </InputGroupButton>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Username" />
+      </InputGroup>
+    </div>
+  )
+}
+
+/**
+ * Password input with visibility toggle
+ * Realistic form pattern for password fields
+ */
+export function InputGroupPasswordDemo() {
+  const [visible, setVisible] = createSignal(false)
+
+  return (
+    <div className="max-w-sm">
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-4"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          </InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput
+          type={visible() ? 'text' : 'password'}
+          placeholder="Enter password"
+        />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            size="icon-xs"
+            onClick={() => setVisible(v => !v)}
+            aria-label={visible() ? 'Hide password' : 'Show password'}
+          >
+            {visible()
+              ? <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-4"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" x2="23" y1="1" y2="23"/></svg>
+              : <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="size-4"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            }
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  )
+}

--- a/site/ui/components/input-group-playground.tsx
+++ b/site/ui/components/input-group-playground.tsx
@@ -1,0 +1,114 @@
+"use client"
+/**
+ * InputGroup Props Playground
+ *
+ * Interactive playground for the InputGroup component.
+ * Allows tweaking addon alignment and content with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Input } from '@ui/components/ui/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupInput,
+} from '@ui/components/ui/input-group'
+
+type AddonAlign = 'inline-start' | 'inline-end' | 'none'
+
+function InputGroupPlayground(_props: {}) {
+  const [align, setAlign] = createSignal<AddonAlign>('inline-start')
+  const [addonText, setAddonText] = createSignal('https://')
+  const [placeholder, setPlaceholder] = createSignal('example.com')
+
+  const props = (): HighlightProp[] => {
+    const items: HighlightProp[] = []
+    if (align() !== 'none') {
+      items.push({ name: 'align', value: align(), defaultValue: 'inline-start' })
+    }
+    return items
+  }
+
+  createEffect(() => {
+    const a = align()
+    const t = addonText()
+    const p = placeholder()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (!codeEl) return
+
+    if (a === 'none') {
+      codeEl.innerHTML = highlightJsx('InputGroup', [], `\n  ${highlightJsx('InputGroupInput', [{ name: 'placeholder', value: p, defaultValue: '' }], '')}\n`)
+    } else {
+      const addonProps = a === 'inline-start'
+        ? []
+        : [{ name: 'align', value: a, defaultValue: 'inline-start' }]
+      const addonJsx = highlightJsx('InputGroupAddon', addonProps, `\n    ${highlightJsx('InputGroupText', [], t)}\n  `)
+      const inputJsx = highlightJsx('InputGroupInput', [{ name: 'placeholder', value: p, defaultValue: '' }], '')
+
+      if (a === 'inline-start') {
+        codeEl.innerHTML = highlightJsx('InputGroup', [], `\n  ${addonJsx}\n  ${inputJsx}\n`)
+      } else {
+        codeEl.innerHTML = highlightJsx('InputGroup', [], `\n  ${inputJsx}\n  ${addonJsx}\n`)
+      }
+    }
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-input-group-preview"
+      previewContent={
+        <div className="w-64">
+          <InputGroup>
+            {align() === 'inline-start' && (
+              <InputGroupAddon align="inline-start">
+                <InputGroupText>{addonText()}</InputGroupText>
+              </InputGroupAddon>
+            )}
+            <InputGroupInput placeholder={placeholder()} />
+            {align() === 'inline-end' && (
+              <InputGroupAddon align="inline-end">
+                <InputGroupText>{addonText()}</InputGroupText>
+              </InputGroupAddon>
+            )}
+          </InputGroup>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="addon position">
+          <Select value={align()} onValueChange={(v: string) => setAlign(v as AddonAlign)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select position..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inline-start">inline-start</SelectItem>
+              <SelectItem value="inline-end">inline-end</SelectItem>
+              <SelectItem value="none">none</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="addon text">
+          <Input
+            type="text"
+            value={addonText()}
+            onInput={(e: Event) => setAddonText((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+        <PlaygroundControl label="placeholder">
+          <Input
+            type="text"
+            value={placeholder()}
+            onInput={(e: Event) => setPlaceholder((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsx('InputGroup', props(), '')} />}
+    />
+  )
+}
+
+export { InputGroupPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -41,6 +41,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'date-picker', title: 'Date Picker', description: 'Date selection with calendar popup', category: 'input' },
   { slug: 'field', title: 'Field', description: 'Form field wrapper with label and error', category: 'input' },
   { slug: 'input', title: 'Input', description: 'Text input field', category: 'input' },
+  { slug: 'input-group', title: 'Input Group', description: 'Input with addons and affixes', category: 'input' },
   { slug: 'input-otp', title: 'Input OTP', description: 'One-time password input', category: 'input' },
   { slug: 'label', title: 'Label', description: 'Accessible label for form controls', category: 'input' },
   { slug: 'radio-group', title: 'Radio Group', description: 'Single-select option group', category: 'input' },

--- a/site/ui/e2e/input-group.spec.ts
+++ b/site/ui/e2e/input-group.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('InputGroup Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/input-group')
+  })
+
+  test.describe('Basic Demo (Prefix & Suffix)', () => {
+    test('renders input groups with addons', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupBasicDemo_"]:not([data-slot])').first()
+      const groups = section.locator('[data-slot="input-group"]')
+
+      // Should have 3 input groups (https://, USD, search icon)
+      await expect(groups).toHaveCount(3)
+    })
+
+    test('first group has prefix addon with text', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupBasicDemo_"]:not([data-slot])').first()
+      const firstGroup = section.locator('[data-slot="input-group"]').first()
+
+      // Has addon with inline-start alignment
+      const addon = firstGroup.locator('[data-slot="input-group-addon"]')
+      await expect(addon).toHaveAttribute('data-align', 'inline-start')
+
+      // Has input control
+      const input = firstGroup.locator('[data-slot="input-group-control"]')
+      await expect(input).toBeVisible()
+    })
+
+    test('second group has suffix addon', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupBasicDemo_"]:not([data-slot])').first()
+      const secondGroup = section.locator('[data-slot="input-group"]').nth(1)
+
+      const addon = secondGroup.locator('[data-slot="input-group-addon"]')
+      await expect(addon).toHaveAttribute('data-align', 'inline-end')
+    })
+
+    test('input accepts text entry', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupBasicDemo_"]:not([data-slot])').first()
+      const input = section.locator('[data-slot="input-group-control"]').first()
+
+      await input.fill('mysite.com')
+      await expect(input).toHaveValue('mysite.com')
+    })
+  })
+
+  test.describe('Button Demo', () => {
+    test('renders input groups with buttons', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupButtonDemo_"]:not([data-slot])').first()
+      const buttons = section.locator('[data-slot="input-group-button"]')
+
+      // Should have buttons (Copy button + icon button)
+      await expect(buttons.first()).toBeVisible()
+    })
+
+    test('copy button is clickable', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupButtonDemo_"]:not([data-slot])').first()
+      const input = section.locator('[data-slot="input-group-control"]').first()
+      const copyButton = section.locator('[data-slot="input-group-button"]').first()
+
+      await input.fill('test text')
+      await expect(copyButton).toBeEnabled()
+    })
+  })
+
+  test.describe('Password Demo', () => {
+    test('input starts as password type', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupPasswordDemo_"]:not([data-slot])').first()
+      const input = section.locator('[data-slot="input-group-control"]')
+
+      await expect(input).toHaveAttribute('type', 'password')
+    })
+
+    test('clicking toggle button changes input type to text', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupPasswordDemo_"]:not([data-slot])').first()
+      const input = section.locator('[data-slot="input-group-control"]')
+      const toggleButton = section.locator('[data-slot="input-group-button"]')
+
+      await toggleButton.click()
+      await expect(input).toHaveAttribute('type', 'text')
+    })
+
+    test('clicking toggle button twice reverts to password', async ({ page }) => {
+      const section = page.locator('[bf-s^="InputGroupPasswordDemo_"]:not([data-slot])').first()
+      const input = section.locator('[data-slot="input-group-control"]')
+      const toggleButton = section.locator('[data-slot="input-group-button"]')
+
+      await toggleButton.click()
+      await expect(input).toHaveAttribute('type', 'text')
+
+      await toggleButton.click()
+      await expect(input).toHaveAttribute('type', 'password')
+    })
+  })
+})

--- a/site/ui/pages/components/input-group.tsx
+++ b/site/ui/pages/components/input-group.tsx
@@ -1,0 +1,378 @@
+/**
+ * InputGroup Reference Page (/components/input-group)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+} from '@/components/ui/input-group'
+import { InputGroupPlayground } from '@/components/input-group-playground'
+import { InputGroupBasicDemo, InputGroupButtonDemo, InputGroupPasswordDemo } from '@/components/input-group-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'prefix-suffix', title: 'Prefix & Suffix', branch: 'start' },
+  { id: 'with-button', title: 'With Button', branch: 'child' },
+  { id: 'password-toggle', title: 'Password Toggle', branch: 'child' },
+  { id: 'disabled', title: 'Disabled', branch: 'child' },
+  { id: 'with-textarea', title: 'With Textarea', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+function InputGroupDemo() {
+  return (
+    <InputGroup>
+      <InputGroupAddon>
+        <InputGroupText>https://</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput placeholder="example.com" />
+    </InputGroup>
+  )
+}`
+
+const prefixSuffixCode = `import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+function PrefixSuffix() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>https://</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="example.com" />
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroupInput placeholder="Enter amount" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupText>USD</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>
+            <SearchIcon />
+          </InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Search..." />
+      </InputGroup>
+    </div>
+  )
+}`
+
+const buttonCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+function WithButton() {
+  const [value, setValue] = createSignal("")
+
+  return (
+    <InputGroup>
+      <InputGroupInput
+        placeholder="Enter text to copy..."
+        value={value()}
+        onInput={(e) => setValue(e.target.value)}
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton
+          onClick={() => navigator.clipboard.writeText(value())}
+        >
+          Copy
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}`
+
+const passwordCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+function PasswordToggle() {
+  const [visible, setVisible] = createSignal(false)
+
+  return (
+    <InputGroup>
+      <InputGroupAddon>
+        <InputGroupText><LockIcon /></InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput
+        type={visible() ? "text" : "password"}
+        placeholder="Enter password"
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton
+          size="icon-xs"
+          onClick={() => setVisible(v => !v)}
+          aria-label={visible() ? "Hide password" : "Show password"}
+        >
+          {visible() ? <EyeOffIcon /> : <EyeIcon />}
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}`
+
+const disabledCode = `import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+function Disabled() {
+  return (
+    <InputGroup data-disabled="true">
+      <InputGroupAddon>
+        <InputGroupText>https://</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput placeholder="example.com" disabled />
+    </InputGroup>
+  )
+}`
+
+const textareaCode = `import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  InputGroupTextarea,
+} from "@/components/ui/input-group"
+
+function WithTextarea() {
+  return (
+    <InputGroup>
+      <InputGroupAddon align="block-start">
+        <InputGroupText>Description</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupTextarea placeholder="Type your message..." rows={3} />
+    </InputGroup>
+  )
+}`
+
+const inputGroupProps: PropDefinition[] = [
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Input controls and addons to render inside the group.',
+  },
+  {
+    name: 'data-disabled',
+    type: "'true'",
+    description: 'Set to "true" to apply disabled styling to addons.',
+  },
+]
+
+const addonProps: PropDefinition[] = [
+  {
+    name: 'align',
+    type: "'inline-start' | 'inline-end' | 'block-start' | 'block-end'",
+    defaultValue: "'inline-start'",
+    description: 'Position of the addon relative to the input control.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Content to display in the addon (text, icons, buttons).',
+  },
+]
+
+const buttonProps: PropDefinition[] = [
+  {
+    name: 'size',
+    type: "'xs' | 'sm' | 'icon-xs' | 'icon-sm'",
+    defaultValue: "'xs'",
+    description: 'Size of the button.',
+  },
+  {
+    name: 'type',
+    type: "'button' | 'submit' | 'reset'",
+    defaultValue: "'button'",
+    description: 'The HTML button type.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Button content (text, icons).',
+  },
+]
+
+const inputProps: PropDefinition[] = [
+  {
+    name: 'type',
+    type: "'text' | 'email' | 'password' | 'number' | 'search' | 'tel' | 'url'",
+    defaultValue: "'text'",
+    description: 'The type of the input.',
+  },
+  {
+    name: 'placeholder',
+    type: 'string',
+    description: 'Placeholder text shown when input is empty.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+]
+
+export function InputGroupRefPage() {
+  return (
+    <DocPage slug="input-group" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Input Group"
+          description="Input with addons, prefixes, and suffixes."
+          {...getNavLinks('input-group')}
+        />
+
+        {/* Props Playground */}
+        <InputGroupPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add input-group" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="max-w-sm">
+              <InputGroup>
+                <InputGroupAddon>
+                  <InputGroupText>https://</InputGroupText>
+                </InputGroupAddon>
+                <InputGroupInput placeholder="example.com" />
+              </InputGroup>
+            </div>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Prefix & Suffix" code={prefixSuffixCode}>
+              <InputGroupBasicDemo />
+            </Example>
+
+            <Example title="With Button" code={buttonCode}>
+              <div className="max-w-sm">
+                <InputGroupButtonDemo />
+              </div>
+            </Example>
+
+            <Example title="Password Toggle" code={passwordCode}>
+              <InputGroupPasswordDemo />
+            </Example>
+
+            <Example title="Disabled" code={disabledCode}>
+              <div className="max-w-sm">
+                <InputGroup data-disabled="true">
+                  <InputGroupAddon>
+                    <InputGroupText>https://</InputGroupText>
+                  </InputGroupAddon>
+                  <InputGroupInput placeholder="example.com" disabled />
+                </InputGroup>
+              </div>
+            </Example>
+
+            <Example title="With Textarea" code={textareaCode}>
+              <div className="max-w-sm">
+                <InputGroup>
+                  <InputGroupAddon align="block-start">
+                    <InputGroupText>Description</InputGroupText>
+                  </InputGroupAddon>
+                  <InputGroupTextarea placeholder="Type your message..." rows={3} />
+                </InputGroup>
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">InputGroup</h3>
+              <PropsTable props={inputGroupProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">InputGroupAddon</h3>
+              <PropsTable props={addonProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">InputGroupButton</h3>
+              <PropsTable props={buttonProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">InputGroupInput</h3>
+              <PropsTable props={inputProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -16,6 +16,7 @@ import { BadgeRefPage } from './pages/components/badge'
 import { ButtonRefPage } from './pages/components/button'
 import { ComboboxRefPage } from './pages/components/combobox'
 import { InputRefPage } from './pages/components/input'
+import { InputGroupRefPage } from './pages/components/input-group'
 import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
 import { TextareaRefPage } from './pages/components/textarea'
@@ -228,6 +229,11 @@ export function createApp() {
   // Input reference page (redesigned #515)
   app.get('/components/input', (c) => {
     return c.render(<InputRefPage />)
+  })
+
+  // Input Group reference page
+  app.get('/components/input-group', (c) => {
+    return c.render(<InputGroupRefPage />)
   })
 
   // Spinner reference page

--- a/ui/components/ui/input-group/index.test.tsx
+++ b/ui/components/ui/input-group/index.test.tsx
@@ -1,0 +1,161 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('InputGroup', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is InputGroup', () => {
+    expect(result.componentName).toBe('InputGroup')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=input-group', () => {
+    expect(result.root.props['data-slot']).toBe('input-group')
+  })
+
+  test('has role=group', () => {
+    const el = result.find({ role: 'group' })
+    expect(el).not.toBeNull()
+    expect(el!.tag).toBe('div')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('w-full')
+    expect(result.root.classes).toContain('items-center')
+    expect(result.root.classes).toContain('rounded-md')
+    expect(result.root.classes).toContain('border')
+  })
+})
+
+describe('InputGroupAddon', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroupAddon')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has data-slot=input-group-addon', () => {
+    expect(result.root.props['data-slot']).toBe('input-group-addon')
+  })
+
+  test('has data-align attribute', () => {
+    expect(result.root.props['data-align']).not.toBeUndefined()
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})
+
+describe('InputGroupButton', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroupButton')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <button>', () => {
+    expect(result.root.tag).toBe('button')
+  })
+
+  test('has data-slot=input-group-button', () => {
+    expect(result.root.props['data-slot']).toBe('input-group-button')
+  })
+
+  test('has data-size attribute', () => {
+    expect(result.root.props['data-size']).not.toBeUndefined()
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('inline-flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})
+
+describe('InputGroupText', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroupText')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <span>', () => {
+    expect(result.root.tag).toBe('span')
+  })
+
+  test('has data-slot=input-group-text', () => {
+    expect(result.root.props['data-slot']).toBe('input-group-text')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})
+
+describe('InputGroupInput', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroupInput')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <input>', () => {
+    expect(result.root.tag).toBe('input')
+  })
+
+  test('has data-slot=input-group-control', () => {
+    expect(result.root.props['data-slot']).toBe('input-group-control')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex-1')
+    expect(result.root.classes).toContain('border-0')
+    expect(result.root.classes).toContain('bg-transparent')
+  })
+})
+
+describe('InputGroupTextarea', () => {
+  const result = renderToTest(source, 'input-group.tsx', 'InputGroupTextarea')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <textarea>', () => {
+    expect(result.root.tag).toBe('textarea')
+  })
+
+  test('has data-slot=input-group-control', () => {
+    expect(result.root.props['data-slot']).toBe('input-group-control')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex-1')
+    expect(result.root.classes).toContain('resize-none')
+    expect(result.root.classes).toContain('border-0')
+  })
+})

--- a/ui/components/ui/input-group/index.tsx
+++ b/ui/components/ui/input-group/index.tsx
@@ -1,0 +1,209 @@
+/**
+ * InputGroup Component
+ *
+ * Input with addons, prefixes, and suffixes.
+ * Groups an input control with decorative or interactive elements.
+ * Based on shadcn/ui InputGroup with native HTML + ARIA.
+ *
+ * @example Basic with icon prefix
+ * ```tsx
+ * <InputGroup>
+ *   <InputGroupAddon>
+ *     <InputGroupText><SearchIcon /></InputGroupText>
+ *   </InputGroupAddon>
+ *   <InputGroupInput placeholder="Search..." />
+ * </InputGroup>
+ * ```
+ *
+ * @example With suffix addon
+ * ```tsx
+ * <InputGroup>
+ *   <InputGroupInput placeholder="Enter amount" />
+ *   <InputGroupAddon align="inline-end">
+ *     <InputGroupText>USD</InputGroupText>
+ *   </InputGroupAddon>
+ * </InputGroup>
+ * ```
+ */
+
+import type { HTMLBaseAttributes, InputHTMLAttributes, TextareaHTMLAttributes, ButtonHTMLAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// --- InputGroup ---
+
+const inputGroupClasses = 'group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30 h-9 min-w-0 has-[>textarea]:h-auto'
+
+// Variants based on alignment of addons
+const inputGroupAlignClasses = [
+  'has-[>[data-align=inline-start]]:[&>input]:pl-2',
+  'has-[>[data-align=inline-end]]:[&>input]:pr-2',
+  'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
+  'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
+].join(' ')
+
+// Focus state propagated from child input
+const inputGroupFocusClasses = 'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50'
+
+// Error state propagated from child input
+const inputGroupErrorClasses = 'has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40'
+
+interface InputGroupProps extends HTMLBaseAttributes {
+  className?: string
+  children?: Child
+}
+
+function InputGroup({ className = '', children, ...props }: InputGroupProps) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={`${inputGroupClasses} ${inputGroupAlignClasses} ${inputGroupFocusClasses} ${inputGroupErrorClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// --- InputGroupAddon ---
+
+type InputGroupAddonAlign = 'inline-start' | 'inline-end' | 'block-start' | 'block-end'
+
+const inputGroupAddonBaseClasses = 'flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*="size-"])]:size-4'
+
+const inputGroupAddonAlignClasses: Record<InputGroupAddonAlign, string> = {
+  'inline-start': 'order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]',
+  'inline-end': 'order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]',
+  'block-start': 'order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3',
+  'block-end': 'order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3',
+}
+
+interface InputGroupAddonProps extends HTMLBaseAttributes {
+  align?: InputGroupAddonAlign
+  className?: string
+  children?: Child
+}
+
+function InputGroupAddon({ align = 'inline-start', className = '', children, ...props }: InputGroupAddonProps) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={`${inputGroupAddonBaseClasses} ${inputGroupAddonAlignClasses[align]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// --- InputGroupButton ---
+
+type InputGroupButtonSize = 'xs' | 'sm' | 'icon-xs' | 'icon-sm'
+
+const inputGroupButtonBaseClasses = 'inline-flex items-center justify-center gap-2 text-sm shadow-none whitespace-nowrap rounded-md font-medium transition-all outline-none text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0'
+
+const inputGroupButtonSizeClasses: Record<InputGroupButtonSize, string> = {
+  xs: 'h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*="size-"])]:size-3.5',
+  sm: 'h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5',
+  'icon-xs': 'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+  'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
+}
+
+interface InputGroupButtonProps extends ButtonHTMLAttributes {
+  size?: InputGroupButtonSize
+  className?: string
+  children?: Child
+}
+
+function InputGroupButton({ size = 'xs', type = 'button', className = '', children, ...props }: InputGroupButtonProps) {
+  return (
+    <button
+      type={type}
+      data-slot="input-group-button"
+      data-size={size}
+      className={`${inputGroupButtonBaseClasses} ${inputGroupButtonSizeClasses[size]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+// --- InputGroupText ---
+
+const inputGroupTextClasses = 'flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4'
+
+interface InputGroupTextProps extends HTMLBaseAttributes {
+  className?: string
+  children?: Child
+}
+
+function InputGroupText({ className = '', children, ...props }: InputGroupTextProps) {
+  return (
+    <span
+      data-slot="input-group-text"
+      className={`${inputGroupTextClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}
+
+// --- InputGroupInput ---
+
+const inputGroupInputClasses = 'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex-1 rounded-none border-0 bg-transparent px-3 py-1 text-base shadow-none outline-none focus-visible:ring-0 dark:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
+interface InputGroupInputProps extends InputHTMLAttributes {
+  className?: string
+}
+
+function InputGroupInput({ className = '', ...props }: InputGroupInputProps) {
+  return (
+    <input
+      data-slot="input-group-control"
+      className={`${inputGroupInputClasses} ${className}`}
+      {...props}
+    />
+  )
+}
+
+// --- InputGroupTextarea ---
+
+const inputGroupTextareaClasses = 'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex-1 resize-none rounded-none border-0 bg-transparent py-3 px-3 text-base shadow-none outline-none focus-visible:ring-0 dark:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
+interface InputGroupTextareaProps extends TextareaHTMLAttributes {
+  className?: string
+}
+
+function InputGroupTextarea({ className = '', ...props }: InputGroupTextareaProps) {
+  return (
+    <textarea
+      data-slot="input-group-control"
+      className={`${inputGroupTextareaClasses} ${className}`}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}
+
+export type {
+  InputGroupProps,
+  InputGroupAddonProps,
+  InputGroupAddonAlign,
+  InputGroupButtonProps,
+  InputGroupButtonSize,
+  InputGroupTextProps,
+  InputGroupInputProps,
+  InputGroupTextareaProps,
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -346,6 +346,14 @@
       "tags": ["input"]
     },
     {
+      "name": "input-group",
+      "type": "registry:ui",
+      "title": "Input Group",
+      "description": "Input with addons, prefixes, and suffixes",
+      "tags": ["input"],
+      "requires": ["input"]
+    },
+    {
       "name": "label",
       "type": "registry:ui",
       "title": "Label",


### PR DESCRIPTION
## Summary

- Add `InputGroup` component with sub-components (`InputGroupAddon`, `InputGroupButton`, `InputGroupText`, `InputGroupInput`, `InputGroupTextarea`) for input with addons, prefixes, and suffixes
- Follow shadcn/ui API with native HTML + ARIA (no Radix dependency), `Record<Variant, string>` for variants
- Include documentation page with interactive playground, 3 demo variants (basic prefix/suffix, button addon, password toggle), and comprehensive E2E tests (9 tests)

Closes #672
See also: #125

## Test plan

- [x] IR unit tests pass (29 tests for all 6 sub-components)
- [x] Full project build passes (`bun run build`)
- [x] E2E tests pass (9 tests covering basic, button, and password demos)
- [ ] Visual review of `/components/input-group` page
- [ ] Verify playground controls update preview correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)