### PR TITLE
Add Empty component

### DIFF
--- a/site/ui/components/empty-demo.tsx
+++ b/site/ui/components/empty-demo.tsx
@@ -1,0 +1,60 @@
+"use client"
+/**
+ * EmptyDemo Component
+ *
+ * Interactive demo for Empty component showing a realistic
+ * empty state with icon, title, description, and action button.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@ui/components/ui/empty'
+import { Button } from '@ui/components/ui/button'
+
+// Lucide Package icon (inline SVG)
+function PackageIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.5 9.4 7.55 4.24" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <polyline stroke-linecap="round" stroke-linejoin="round" stroke-width="2" points="3.29 7 12 12 20.71 7" />
+      <line stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="22" y2="12" />
+    </svg>
+  )
+}
+
+/**
+ * Empty state demo with action button
+ */
+export function EmptyDemo() {
+  const [items, setItems] = createSignal<string[]>([])
+
+  return (
+    <div className="w-full">
+      {items().length === 0 ? (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <PackageIcon />
+            </EmptyMedia>
+            <EmptyTitle>No items yet</EmptyTitle>
+            <EmptyDescription>
+              Get started by adding your first item.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button onClick={() => setItems(['Item 1'])}>
+              Add item
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <div className="flex flex-col items-center gap-4 p-6 border rounded-lg">
+          <p className="text-sm text-muted-foreground">Items: {items().join(', ')}</p>
+          <Button variant="outline" onClick={() => setItems([])}>
+            Clear all
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/ui/components/empty-playground.tsx
+++ b/site/ui/components/empty-playground.tsx
@@ -1,0 +1,106 @@
+"use client"
+/**
+ * Empty Props Playground
+ *
+ * Interactive playground for the Empty component.
+ * Allows tweaking EmptyMedia variant prop with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@ui/components/ui/empty'
+import { Button } from '@ui/components/ui/button'
+
+type EmptyMediaVariant = 'default' | 'icon'
+
+// Lucide Package icon (inline SVG)
+function PackageIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.5 9.4 7.55 4.24" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <polyline stroke-linecap="round" stroke-linejoin="round" stroke-width="2" points="3.29 7 12 12 20.71 7" />
+      <line stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="22" y2="12" />
+    </svg>
+  )
+}
+
+function EmptyPlayground(_props: {}) {
+  const [variant, setVariant] = createSignal<EmptyMediaVariant>('icon')
+
+  const variantProp = (): HighlightProp => ({
+    name: 'variant',
+    value: variant(),
+    defaultValue: 'default',
+  })
+
+  const tree = (): JsxTreeNode => ({
+    tag: 'Empty',
+    props: [],
+    children: [
+      {
+        tag: 'EmptyHeader',
+        children: [
+          { tag: 'EmptyMedia', props: [variantProp()], children: '<PackageIcon />' },
+          { tag: 'EmptyTitle', children: 'No items yet' },
+          { tag: 'EmptyDescription', children: 'Get started by adding your first item.' },
+        ],
+      },
+      {
+        tag: 'EmptyContent',
+        children: [
+          { tag: 'Button', children: 'Add item' },
+        ],
+      },
+    ],
+  })
+
+  createEffect(() => {
+    const t = tree()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-empty-preview"
+      previewContent={
+        <div className="w-full max-w-md">
+          <Empty className="border">
+            <EmptyHeader>
+              <EmptyMedia variant={variant()}>
+                <PackageIcon />
+              </EmptyMedia>
+              <EmptyTitle>No items yet</EmptyTitle>
+              <EmptyDescription>
+                Get started by adding your first item.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button>Add item</Button>
+            </EmptyContent>
+          </Empty>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="media variant">
+          <Select value={variant()} onValueChange={(v: string) => setVariant(v as EmptyMediaVariant)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="icon">icon</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(tree())} />}
+    />
+  )
+}
+
+export { EmptyPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -65,10 +65,11 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'table', title: 'Table', description: 'Responsive data table', category: 'display' },
   { slug: 'typography', title: 'Typography', description: 'Styled text elements for prose', category: 'display' },
 
-  // Feedback (6)
+  // Feedback (7)
   { slug: 'alert', title: 'Alert', description: 'Callout for important content', category: 'feedback' },
   { slug: 'alert-dialog', title: 'Alert Dialog', description: 'Modal dialog for important confirmations', category: 'feedback' },
   { slug: 'dialog', title: 'Dialog', description: 'Modal overlay with custom content', category: 'feedback' },
+  { slug: 'empty', title: 'Empty', description: 'Empty state placeholder with icon and action', category: 'feedback' },
   { slug: 'progress', title: 'Progress', description: 'Task completion indicator bar', category: 'feedback' },
   { slug: 'spinner', title: 'Spinner', description: 'Animated loading indicator', category: 'feedback' },
   { slug: 'toast', title: 'Toast', description: 'Temporary notification message', category: 'feedback' },

--- a/site/ui/e2e/empty.spec.ts
+++ b/site/ui/e2e/empty.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Empty Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/empty')
+  })
+
+  test.describe('Props Playground', () => {
+    test('changing media variant updates preview', async ({ page }) => {
+      const preview = page.locator('[data-empty-preview]')
+      const section = page.locator('#preview')
+
+      // Default variant is "icon" — should have data-variant=icon
+      const media = preview.locator('[data-slot="empty-icon"]')
+      await expect(media).toHaveAttribute('data-variant', 'icon')
+
+      // Open variant select and pick "default"
+      await section.locator('button[role="combobox"]').first().click()
+      await page.locator('[role="option"]:has-text("default")').click()
+
+      // Media should now have default variant
+      await expect(media).toHaveAttribute('data-variant', 'default')
+    })
+  })
+
+  test.describe('Page Structure', () => {
+    test('renders empty state components with correct data-slots', async ({ page }) => {
+      // Verify usage example renders all sub-components
+      const usageSection = page.locator('#usage')
+      await expect(usageSection.locator('[data-slot="empty"]').first()).toBeVisible()
+      await expect(usageSection.locator('[data-slot="empty-header"]').first()).toBeVisible()
+      await expect(usageSection.locator('[data-slot="empty-icon"]').first()).toBeVisible()
+      await expect(usageSection.locator('[data-slot="empty-title"]').first()).toBeVisible()
+      await expect(usageSection.locator('[data-slot="empty-description"]').first()).toBeVisible()
+      await expect(usageSection.locator('[data-slot="empty-content"]').first()).toBeVisible()
+    })
+
+    test('interactive demo renders with add item button', async ({ page }) => {
+      const demo = page.locator('[bf-s^="EmptyDemo_"]:not([data-slot])')
+
+      // Initially shows empty state with title and add button
+      await expect(demo.locator('[data-slot="empty-title"]')).toContainText('No items yet')
+      await expect(demo.locator('button:has-text("Add item")')).toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/components/empty.tsx
+++ b/site/ui/pages/components/empty.tsx
@@ -1,0 +1,314 @@
+/**
+ * Empty Reference Page (/components/empty)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@/components/ui/empty'
+import { Button } from '@/components/ui/button'
+import { EmptyPlayground } from '@/components/empty-playground'
+import { EmptyDemo } from '@/components/empty-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+// Lucide Package icon (inline SVG)
+function PackageIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.5 9.4 7.55 4.24" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <polyline stroke-linecap="round" stroke-linejoin="round" stroke-width="2" points="3.29 7 12 12 20.71 7" />
+      <line stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="22" y2="12" />
+    </svg>
+  )
+}
+
+// Lucide FileText icon (inline SVG)
+function FileTextIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 2v4a2 2 0 0 0 2 2h4" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9H8" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 13H8" />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 17H8" />
+    </svg>
+  )
+}
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'with-icon-variant', title: 'With Icon Variant', branch: 'start' },
+  { id: 'without-action', title: 'Without Action', branch: 'child' },
+  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty"
+
+function EmptyStateDemo() {
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <PackageIcon />
+        </EmptyMedia>
+        <EmptyTitle>No items yet</EmptyTitle>
+        <EmptyDescription>
+          Get started by adding your first item.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button>Add item</Button>
+      </EmptyContent>
+    </Empty>
+  )
+}`
+
+const iconVariantCode = `<Empty className="border">
+  <EmptyHeader>
+    <EmptyMedia variant="icon">
+      <PackageIcon />
+    </EmptyMedia>
+    <EmptyTitle>No packages</EmptyTitle>
+    <EmptyDescription>
+      Your package list is empty. Add a package to get started.
+    </EmptyDescription>
+  </EmptyHeader>
+  <EmptyContent>
+    <Button>Add package</Button>
+  </EmptyContent>
+</Empty>`
+
+const withoutActionCode = `<Empty className="border">
+  <EmptyHeader>
+    <EmptyMedia>
+      <FileTextIcon />
+    </EmptyMedia>
+    <EmptyTitle>No documents</EmptyTitle>
+    <EmptyDescription>
+      Documents will appear here once they are created.
+    </EmptyDescription>
+  </EmptyHeader>
+</Empty>`
+
+const interactiveCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from "@/components/ui/empty"
+import { Button } from "@/components/ui/button"
+
+function EmptyDemo() {
+  const [items, setItems] = createSignal<string[]>([])
+
+  return items().length === 0 ? (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon"><PackageIcon /></EmptyMedia>
+        <EmptyTitle>No items yet</EmptyTitle>
+        <EmptyDescription>Get started by adding your first item.</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button onClick={() => setItems(["Item 1"])}>Add item</Button>
+      </EmptyContent>
+    </Empty>
+  ) : (
+    <div>
+      <p>Items: {items().join(", ")}</p>
+      <Button variant="outline" onClick={() => setItems([])}>Clear all</Button>
+    </div>
+  )
+}`
+
+const emptyProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The content of the empty state (typically EmptyHeader and EmptyContent).',
+  },
+]
+
+const emptyHeaderProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The header content (typically EmptyMedia, EmptyTitle, and EmptyDescription).',
+  },
+]
+
+const emptyMediaProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: "'default' | 'icon'",
+    defaultValue: "'default'",
+    description: 'The visual style of the media container. "icon" adds a rounded background.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The media content (typically an SVG icon or image).',
+  },
+]
+
+const emptyTitleProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The title text of the empty state.',
+  },
+]
+
+const emptyDescriptionProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The description text of the empty state.',
+  },
+]
+
+const emptyContentProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The content area, typically containing action buttons.',
+  },
+]
+
+export function EmptyRefPage() {
+  return (
+    <DocPage slug="empty" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Empty"
+          description="Empty state placeholder with icon, title, and action."
+          {...getNavLinks('empty')}
+        />
+
+        {/* Props Playground */}
+        <EmptyPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add empty" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="w-full">
+              <Empty className="border">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <PackageIcon />
+                  </EmptyMedia>
+                  <EmptyTitle>No items yet</EmptyTitle>
+                  <EmptyDescription>
+                    Get started by adding your first item.
+                  </EmptyDescription>
+                </EmptyHeader>
+                <EmptyContent>
+                  <Button>Add item</Button>
+                </EmptyContent>
+              </Empty>
+            </div>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="With Icon Variant" code={iconVariantCode} showLineNumbers={false}>
+              <div className="w-full">
+                <Empty className="border">
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                      <PackageIcon />
+                    </EmptyMedia>
+                    <EmptyTitle>No packages</EmptyTitle>
+                    <EmptyDescription>
+                      Your package list is empty. Add a package to get started.
+                    </EmptyDescription>
+                  </EmptyHeader>
+                  <EmptyContent>
+                    <Button>Add package</Button>
+                  </EmptyContent>
+                </Empty>
+              </div>
+            </Example>
+
+            <Example title="Without Action" code={withoutActionCode} showLineNumbers={false}>
+              <div className="w-full">
+                <Empty className="border">
+                  <EmptyHeader>
+                    <EmptyMedia>
+                      <FileTextIcon />
+                    </EmptyMedia>
+                    <EmptyTitle>No documents</EmptyTitle>
+                    <EmptyDescription>
+                      Documents will appear here once they are created.
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
+              </div>
+            </Example>
+
+            <Example title="Interactive" code={interactiveCode}>
+              <div className="w-full">
+                <EmptyDemo />
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-semibold mb-3">Empty</h3>
+              <PropsTable props={emptyProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">EmptyHeader</h3>
+              <PropsTable props={emptyHeaderProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">EmptyMedia</h3>
+              <PropsTable props={emptyMediaProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">EmptyTitle</h3>
+              <PropsTable props={emptyTitleProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">EmptyDescription</h3>
+              <PropsTable props={emptyDescriptionProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-3">EmptyContent</h3>
+              <PropsTable props={emptyContentProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -60,6 +60,7 @@ import { SidebarRefPage } from './pages/components/sidebar'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
+import { EmptyRefPage } from './pages/components/empty'
 import { SpinnerRefPage } from './pages/components/spinner'
 import { TypographyRefPage } from './pages/components/typography'
 import { ComponentCatalogPage } from './pages/components/catalog'
@@ -242,6 +243,11 @@ export function createApp() {
   // Input Group reference page
   app.get('/components/input-group', (c) => {
     return c.render(<InputGroupRefPage />)
+  })
+
+  // Empty reference page
+  app.get('/components/empty', (c) => {
+    return c.render(<EmptyRefPage />)
   })
 
   // Spinner reference page

--- a/ui/components/ui/empty/index.test.tsx
+++ b/ui/components/ui/empty/index.test.tsx
@@ -1,0 +1,122 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const emptySource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('Empty', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'Empty')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is Empty', () => {
+    expect(result.componentName).toBe('Empty')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('rounded-lg')
+    expect(result.root.classes).toContain('border-dashed')
+  })
+})
+
+describe('EmptyHeader', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'EmptyHeader')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty-header')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})
+
+describe('EmptyMedia', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'EmptyMedia')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty-icon', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty-icon')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})
+
+describe('EmptyTitle', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'EmptyTitle')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty-title', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty-title')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('font-medium')
+    expect(result.root.classes).toContain('tracking-tight')
+  })
+})
+
+describe('EmptyDescription', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'EmptyDescription')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty-description', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty-description')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-muted-foreground')
+  })
+})
+
+describe('EmptyContent', () => {
+  const result = renderToTest(emptySource, 'empty.tsx', 'EmptyContent')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=empty-content', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('empty-content')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('text-sm')
+  })
+})

--- a/ui/components/ui/empty/index.tsx
+++ b/ui/components/ui/empty/index.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+/**
+ * Empty State Components
+ *
+ * A placeholder component for empty states with icon, title, description,
+ * and action slots. Sub-components: Empty, EmptyHeader, EmptyMedia,
+ * EmptyTitle, EmptyDescription, EmptyContent
+ *
+ * @see https://ui.shadcn.com/docs/components/empty
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// --- EmptyMedia variant ---
+
+type EmptyMediaVariant = 'default' | 'icon'
+
+const emptyMediaBaseClasses = 'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0'
+
+const emptyMediaVariantClasses: Record<EmptyMediaVariant, string> = {
+  default: 'bg-transparent',
+  icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+}
+
+// --- CSS class constants ---
+
+const emptyClasses = 'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12'
+const emptyHeaderClasses = 'flex max-w-sm flex-col items-center gap-2 text-center'
+const emptyTitleClasses = 'text-lg font-medium tracking-tight'
+const emptyDescriptionClasses = 'text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary'
+const emptyContentClasses = 'flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance'
+
+// --- Component interfaces ---
+
+interface EmptyProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface EmptyHeaderProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface EmptyMediaProps extends HTMLBaseAttributes {
+  /** @default 'default' */
+  variant?: EmptyMediaVariant
+  children?: Child
+}
+
+interface EmptyTitleProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface EmptyDescriptionProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface EmptyContentProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+// --- Components ---
+
+function Empty({ children, className = '', ...props }: EmptyProps) {
+  return <div data-slot="empty" className={`${emptyClasses} ${className}`} {...props}>{children}</div>
+}
+
+function EmptyHeader({ children, className = '', ...props }: EmptyHeaderProps) {
+  return <div data-slot="empty-header" className={`${emptyHeaderClasses} ${className}`} {...props}>{children}</div>
+}
+
+function EmptyMedia({ children, className = '', variant = 'default', ...props }: EmptyMediaProps) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={`${emptyMediaBaseClasses} ${emptyMediaVariantClasses[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+function EmptyTitle({ children, className = '', ...props }: EmptyTitleProps) {
+  return <div data-slot="empty-title" className={`${emptyTitleClasses} ${className}`} {...props}>{children}</div>
+}
+
+function EmptyDescription({ children, className = '', ...props }: EmptyDescriptionProps) {
+  return <div data-slot="empty-description" className={`${emptyDescriptionClasses} ${className}`} {...props}>{children}</div>
+}
+
+function EmptyContent({ children, className = '', ...props }: EmptyContentProps) {
+  return <div data-slot="empty-content" className={`${emptyContentClasses} ${className}`} {...props}>{children}</div>
+}
+
+export { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent }
+export type { EmptyMediaVariant, EmptyProps, EmptyHeaderProps, EmptyMediaProps, EmptyTitleProps, EmptyDescriptionProps, EmptyContentProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -430,6 +430,13 @@
       "title": "Typography",
       "description": "Styled text elements for headings, paragraphs, and prose content",
       "tags": ["display"]
+    },
+    {
+      "name": "empty",
+      "type": "registry:ui",
+      "title": "Empty",
+      "description": "Empty state placeholder with icon, title, and action",
+      "tags": ["feedback"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Empty component for empty state placeholders with icon, title, description, and action slots
- Sub-components: `Empty`, `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`, `EmptyContent`
- `EmptyMedia` supports `variant` prop (`"default"` | `"icon"`) for icon container styling
- Includes playground, demo, reference page, and E2E tests

Closes #673
Ref #125

## Test plan
- [x] IR unit tests pass (20 tests across 6 sub-components)
- [x] `bun run build` succeeds
- [x] All 804 E2E tests pass (3 new for Empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)