### PR TITLE
Add Typography component

### DIFF
--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -61,6 +61,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'separator', title: 'Separator', description: 'Visual divider between content', category: 'display' },
   { slug: 'skeleton', title: 'Skeleton', description: 'Placeholder loading indicator', category: 'display' },
   { slug: 'table', title: 'Table', description: 'Responsive data table', category: 'display' },
+  { slug: 'typography', title: 'Typography', description: 'Styled text elements for prose', category: 'display' },
 
   // Feedback (6)
   { slug: 'alert', title: 'Alert', description: 'Callout for important content', category: 'feedback' },

--- a/site/ui/components/typography-demo.tsx
+++ b/site/ui/components/typography-demo.tsx
@@ -1,0 +1,127 @@
+/**
+ * TypographyDemo Components
+ *
+ * Demos for Typography components showing realistic content patterns.
+ */
+
+import {
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyH4,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyInlineCode,
+  TypographyLead,
+  TypographyLarge,
+  TypographySmall,
+  TypographyMuted,
+} from '@ui/components/ui/typography'
+
+/**
+ * Showcase of all typography elements
+ */
+export function TypographyAllDemo() {
+  return (
+    <div>
+      <TypographyH1>The Joke Tax Chronicles</TypographyH1>
+      <TypographyP>
+        Once upon a time, in a far-off land, there was a very lazy king who
+        spent all day lounging on his throne. One day, his advisors came to him
+        with a problem: the kingdom was running out of money.
+      </TypographyP>
+      <TypographyH2>The King's Plan</TypographyH2>
+      <TypographyP>
+        The king thought long and hard, and finally came up with{' '}
+        <a href="#" className="font-medium text-primary underline underline-offset-4">
+          a brilliant plan
+        </a>
+        : he would tax the jokes in the kingdom.
+      </TypographyP>
+      <TypographyBlockquote>
+        "After all," he said, "everyone enjoys a good joke, so it's only fair
+        that they should pay for the privilege."
+      </TypographyBlockquote>
+      <TypographyH3>The Joke Tax</TypographyH3>
+      <TypographyP>
+        The king's subjects were not amused. They grumbled and
+        complained, but the king was firm:
+      </TypographyP>
+      <TypographyList>
+        <li>1st level of puns: 5 gold coins</li>
+        <li>2nd level of jokes: 10 gold coins</li>
+        <li>3rd level of one-liners: 20 gold coins</li>
+      </TypographyList>
+      <TypographyP>
+        As a result, people stopped telling jokes, and the kingdom fell into a
+        gloom. But there was one person who refused to stop telling
+        jokes: the court jester.
+      </TypographyP>
+      <TypographyH4>People stopped telling jokes</TypographyH4>
+      <TypographyP>
+        The people of the kingdom, once known for their humor and
+        wit, googled{' '}
+        <TypographyInlineCode>@radix-ui/react-alert-dialog</TypographyInlineCode>{' '}
+        to find a solution.
+      </TypographyP>
+    </div>
+  )
+}
+
+/**
+ * Article preview showing realistic content layout
+ */
+export function TypographyArticleDemo() {
+  return (
+    <article className="max-w-prose">
+      <TypographyH2>Introduction to BarefootJS</TypographyH2>
+      <TypographyLead>
+        A signal-based reactivity framework that compiles JSX to lightweight
+        marked templates, bringing modern DX to any backend.
+      </TypographyLead>
+      <TypographyP>
+        BarefootJS takes a fundamentally different approach to frontend
+        development. Instead of shipping a full runtime to the browser, it
+        compiles your components at build time into minimal client JavaScript.
+      </TypographyP>
+      <TypographyP>
+        The compilation happens in two phases: first, your JSX is transformed
+        into an intermediate representation (IR), then the IR is compiled into
+        marked templates and client-side JavaScript.
+      </TypographyP>
+      <TypographyBlockquote>
+        "The best JavaScript is the JavaScript you never ship."
+      </TypographyBlockquote>
+      <TypographyH3>Key Features</TypographyH3>
+      <TypographyList>
+        <li>Signal-based reactivity with fine-grained updates</li>
+        <li>Two-phase compilation for minimal client bundle</li>
+        <li>Works with any backend (Hono, Go templates, etc.)</li>
+        <li>shadcn/ui-compatible component library</li>
+      </TypographyList>
+      <TypographyP>
+        To get started, install the CLI with{' '}
+        <TypographyInlineCode>bun add @barefootjs/cli</TypographyInlineCode>{' '}
+        and scaffold your first project.
+      </TypographyP>
+    </article>
+  )
+}
+
+/**
+ * Inline text styles showcase
+ */
+export function TypographyInlineDemo() {
+  return (
+    <div className="space-y-4">
+      <TypographyLarge>Are you absolutely sure?</TypographyLarge>
+      <TypographyP>
+        This action cannot be undone. This will permanently delete your
+        account and remove your data from our servers.
+      </TypographyP>
+      <TypographySmall>Email address</TypographySmall>
+      <TypographyMuted>Enter your email address.</TypographyMuted>
+    </div>
+  )
+}

--- a/site/ui/components/typography-playground.tsx
+++ b/site/ui/components/typography-playground.tsx
@@ -1,0 +1,133 @@
+"use client"
+/**
+ * Typography Props Playground
+ *
+ * Interactive playground for the Typography components.
+ * Uses raw HTML elements with matching classes for client-side reactivity,
+ * since Typography components are stateless (no "use client").
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Input } from '@ui/components/ui/input'
+
+type TypographyElement = 'H1' | 'H2' | 'H3' | 'H4' | 'P' | 'Blockquote' | 'List' | 'InlineCode' | 'Lead' | 'Large' | 'Small' | 'Muted'
+
+const defaultTexts: Record<TypographyElement, string> = {
+  H1: 'The Joke Tax Chronicles',
+  H2: 'The People of the Kingdom',
+  H3: 'The Joke Tax',
+  H4: 'People stopped telling jokes',
+  P: 'The king, seeing how the people of his kingdom were suffering, decided to repeal the joke tax.',
+  Blockquote: '"After all," he said, "everyone enjoys a good joke."',
+  List: 'List item text',
+  InlineCode: '@barefootjs/dom',
+  Lead: 'A modal dialog that interrupts the user with important content and expects a response.',
+  Large: 'Are you absolutely sure?',
+  Small: 'Email address',
+  Muted: 'Enter your email address.',
+}
+
+// Classes matching the Typography component definitions
+const elementClasses: Record<TypographyElement, string> = {
+  H1: 'scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl',
+  H2: 'scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0',
+  H3: 'scroll-m-20 text-2xl font-semibold tracking-tight',
+  H4: 'scroll-m-20 text-xl font-semibold tracking-tight',
+  P: 'leading-7 [&:not(:first-child)]:mt-6',
+  Blockquote: 'mt-6 border-l-2 pl-6 italic',
+  List: 'my-6 ml-6 list-disc [&>li]:mt-2',
+  InlineCode: 'relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold',
+  Lead: 'text-xl text-muted-foreground',
+  Large: 'text-lg font-semibold',
+  Small: 'text-sm font-medium leading-none',
+  Muted: 'text-sm text-muted-foreground',
+}
+
+function TypographyPlayground(_props: {}) {
+  const [element, setElement] = createSignal<TypographyElement>('H1')
+  const [text, setText] = createSignal(defaultTexts['H1'])
+
+  const componentName = () => `Typography${element()}`
+
+  const props = (): HighlightProp[] => []
+
+  createEffect(() => {
+    const p = props()
+    const t = text()
+    const name = componentName()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsx(name, p, t)
+  })
+
+  // Update preview element reactively via DOM manipulation
+  createEffect(() => {
+    const el = element()
+    const t = text()
+    const previewEl = document.querySelector('[data-typography-preview]')
+    if (!previewEl) return
+
+    const classes = elementClasses[el]
+    const tagMap: Record<TypographyElement, string> = {
+      H1: 'h1', H2: 'h2', H3: 'h3', H4: 'h4',
+      P: 'p', Blockquote: 'blockquote', List: 'ul',
+      InlineCode: 'code', Lead: 'p', Large: 'div',
+      Small: 'small', Muted: 'p',
+    }
+    const tag = tagMap[el]
+
+    if (el === 'List') {
+      previewEl.innerHTML = `<${tag} class="${classes}"><li>${t}</li><li>Another item</li><li>Third item</li></${tag}>`
+    } else {
+      previewEl.innerHTML = `<${tag} class="${classes}">${t}</${tag}>`
+    }
+  })
+
+  const handleElementChange = (v: string) => {
+    setElement(v as TypographyElement)
+    setText(defaultTexts[v as TypographyElement])
+  }
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-typography-preview"
+      previewContent={<h1 className={elementClasses['H1']}>{text()}</h1>}
+      controls={<>
+        <PlaygroundControl label="element">
+          <Select value={element()} onValueChange={handleElementChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select element..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="H1">H1</SelectItem>
+              <SelectItem value="H2">H2</SelectItem>
+              <SelectItem value="H3">H3</SelectItem>
+              <SelectItem value="H4">H4</SelectItem>
+              <SelectItem value="P">P</SelectItem>
+              <SelectItem value="Blockquote">Blockquote</SelectItem>
+              <SelectItem value="List">List</SelectItem>
+              <SelectItem value="InlineCode">InlineCode</SelectItem>
+              <SelectItem value="Lead">Lead</SelectItem>
+              <SelectItem value="Large">Large</SelectItem>
+              <SelectItem value="Small">Small</SelectItem>
+              <SelectItem value="Muted">Muted</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="children">
+          <Input
+            type="text"
+            value={text()}
+            onInput={(e: Event) => setText((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsx(componentName(), props(), text())} />}
+    />
+  )
+}
+
+export { TypographyPlayground }

--- a/site/ui/e2e/typography.spec.ts
+++ b/site/ui/e2e/typography.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Typography Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/typography')
+  })
+
+  test.describe('Props Playground', () => {
+    test('changing children text updates preview', async ({ page }) => {
+      const preview = page.locator('[data-typography-preview]')
+      const section = page.locator('#preview')
+      const input = section.locator('input[type="text"]')
+
+      await input.fill('Custom heading text')
+      await expect(preview).toContainText('Custom heading text')
+    })
+
+    test('changing element to H2 updates preview', async ({ page }) => {
+      const preview = page.locator('[data-typography-preview]')
+      const section = page.locator('#preview')
+
+      // Open element select and pick "H2"
+      await section.locator('button[role="combobox"]').first().click()
+      await page.locator('[role="option"]:has-text("H2")').click()
+
+      // Preview should contain an h2 element
+      await expect(preview.locator('h2')).toBeVisible()
+    })
+
+    test('changing element to Blockquote renders blockquote', async ({ page }) => {
+      const preview = page.locator('[data-typography-preview]')
+      const section = page.locator('#preview')
+
+      // Open element select and pick "Blockquote"
+      await section.locator('button[role="combobox"]').first().click()
+      await page.locator('[role="option"]:has-text("Blockquote")').click()
+
+      // Preview should contain a blockquote element
+      await expect(preview.locator('blockquote')).toBeVisible()
+    })
+  })
+
+  test.describe('Headings Example', () => {
+    test('renders all heading levels', async ({ page }) => {
+      const section = page.locator('#headings').locator('..')
+
+      await expect(section.locator('[data-slot="typography-h1"]')).toContainText('This is H1')
+      await expect(section.locator('[data-slot="typography-h2"]')).toContainText('This is H2')
+      await expect(section.locator('[data-slot="typography-h3"]')).toContainText('This is H3')
+      await expect(section.locator('[data-slot="typography-h4"]')).toContainText('This is H4')
+    })
+  })
+
+  test.describe('Blockquote Example', () => {
+    test('renders blockquote with italic text', async ({ page }) => {
+      const section = page.locator('#blockquote').locator('..')
+      const blockquote = section.locator('[data-slot="typography-blockquote"]')
+
+      await expect(blockquote).toContainText('After all')
+      await expect(blockquote).toHaveClass(/italic/)
+    })
+  })
+
+  test.describe('List Example', () => {
+    test('renders list with items', async ({ page }) => {
+      const section = page.locator('#list').locator('..')
+      const list = section.locator('[data-slot="typography-list"]')
+
+      await expect(list.locator('li').first()).toContainText('1st level of puns')
+      await expect(list.locator('li')).toHaveCount(3)
+    })
+  })
+
+  test.describe('Text Styles Example', () => {
+    test('renders large, small, and muted text', async ({ page }) => {
+      const section = page.locator('#text-styles').locator('..')
+
+      await expect(section.locator('[data-slot="typography-large"]')).toContainText('Are you absolutely sure?')
+      await expect(section.locator('[data-slot="typography-small"]')).toContainText('Email address')
+      await expect(section.locator('[data-slot="typography-muted"]')).toContainText('Enter your email address')
+    })
+  })
+})

--- a/site/ui/pages/components/typography.tsx
+++ b/site/ui/pages/components/typography.tsx
@@ -1,0 +1,259 @@
+/**
+ * Typography Reference Page (/components/typography)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import {
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyH4,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyInlineCode,
+  TypographyLead,
+  TypographyLarge,
+  TypographySmall,
+  TypographyMuted,
+} from '@/components/ui/typography'
+import { TypographyPlayground } from '@/components/typography-playground'
+import { TypographyArticleDemo } from '@/components/typography-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'headings', title: 'Headings', branch: 'start' },
+  { id: 'paragraph', title: 'Paragraph', branch: 'child' },
+  { id: 'blockquote', title: 'Blockquote', branch: 'child' },
+  { id: 'list', title: 'List', branch: 'child' },
+  { id: 'inline-code', title: 'Inline Code', branch: 'child' },
+  { id: 'lead', title: 'Lead', branch: 'child' },
+  { id: 'text-styles', title: 'Text Styles', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import {
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyInlineCode,
+  TypographyLead,
+  TypographyLarge,
+  TypographySmall,
+  TypographyMuted,
+} from "@/components/ui/typography"
+
+function TypographyDemo() {
+  return (
+    <div>
+      <TypographyH1>Heading 1</TypographyH1>
+      <TypographyH2>Heading 2</TypographyH2>
+      <TypographyH3>Heading 3</TypographyH3>
+      <TypographyP>A paragraph of body text.</TypographyP>
+      <TypographyLead>A lead paragraph.</TypographyLead>
+      <TypographyBlockquote>A blockquote.</TypographyBlockquote>
+      <TypographyList>
+        <li>List item one</li>
+        <li>List item two</li>
+      </TypographyList>
+      <TypographyInlineCode>code</TypographyInlineCode>
+      <TypographyLarge>Large text</TypographyLarge>
+      <TypographySmall>Small text</TypographySmall>
+      <TypographyMuted>Muted text</TypographyMuted>
+    </div>
+  )
+}`
+
+const headingsCode = `<TypographyH1>This is H1</TypographyH1>
+<TypographyH2>This is H2</TypographyH2>
+<TypographyH3>This is H3</TypographyH3>
+<TypographyH4>This is H4</TypographyH4>`
+
+const paragraphCode = `<TypographyP>
+  The king, seeing how the people of his kingdom were suffering,
+  decided to repeal the joke tax and allow laughter to flourish
+  once more.
+</TypographyP>`
+
+const blockquoteCode = `<TypographyBlockquote>
+  "After all," he said, "everyone enjoys a good joke, so it's
+  only fair that they should pay for the privilege."
+</TypographyBlockquote>`
+
+const listCode = `<TypographyList>
+  <li>1st level of puns: 5 gold coins</li>
+  <li>2nd level of jokes: 10 gold coins</li>
+  <li>3rd level of one-liners: 20 gold coins</li>
+</TypographyList>`
+
+const inlineCodeCode = `<TypographyP>
+  Install the package with{" "}
+  <TypographyInlineCode>bun add @barefootjs/dom</TypographyInlineCode>.
+</TypographyP>`
+
+const leadCode = `<TypographyLead>
+  A modal dialog that interrupts the user with important content
+  and expects a response.
+</TypographyLead>`
+
+const textStylesCode = `<TypographyLarge>Are you absolutely sure?</TypographyLarge>
+<TypographySmall>Email address</TypographySmall>
+<TypographyMuted>Enter your email address.</TypographyMuted>`
+
+const typographyProps: PropDefinition[] = [
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The text content to render.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS classes.',
+  },
+]
+
+export function TypographyRefPage() {
+  return (
+    <DocPage slug="typography" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Typography"
+          description="Styled text elements for headings, paragraphs, and prose content."
+          {...getNavLinks('typography')}
+        />
+
+        {/* Props Playground */}
+        <TypographyPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add typography" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <TypographyArticleDemo />
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Headings" code={headingsCode} showLineNumbers={false}>
+              <div className="space-y-4">
+                <TypographyH1>This is H1</TypographyH1>
+                <TypographyH2>This is H2</TypographyH2>
+                <TypographyH3>This is H3</TypographyH3>
+                <TypographyH4>This is H4</TypographyH4>
+              </div>
+            </Example>
+
+            <Example title="Paragraph" code={paragraphCode} showLineNumbers={false}>
+              <TypographyP>
+                The king, seeing how the people of his kingdom were suffering,
+                decided to repeal the joke tax and allow laughter to flourish
+                once more.
+              </TypographyP>
+            </Example>
+
+            <Example title="Blockquote" code={blockquoteCode} showLineNumbers={false}>
+              <TypographyBlockquote>
+                "After all," he said, "everyone enjoys a good joke, so it's
+                only fair that they should pay for the privilege."
+              </TypographyBlockquote>
+            </Example>
+
+            <Example title="List" code={listCode} showLineNumbers={false}>
+              <TypographyList>
+                <li>1st level of puns: 5 gold coins</li>
+                <li>2nd level of jokes: 10 gold coins</li>
+                <li>3rd level of one-liners: 20 gold coins</li>
+              </TypographyList>
+            </Example>
+
+            <Example title="Inline Code" code={inlineCodeCode} showLineNumbers={false}>
+              <TypographyP>
+                Install the package with{' '}
+                <TypographyInlineCode>bun add @barefootjs/dom</TypographyInlineCode>.
+              </TypographyP>
+            </Example>
+
+            <Example title="Lead" code={leadCode} showLineNumbers={false}>
+              <TypographyLead>
+                A modal dialog that interrupts the user with important content
+                and expects a response.
+              </TypographyLead>
+            </Example>
+
+            <Example title="Text Styles" code={textStylesCode} showLineNumbers={false}>
+              <div className="space-y-4">
+                <TypographyLarge>Are you absolutely sure?</TypographyLarge>
+                <TypographySmall>Email address</TypographySmall>
+                <TypographyMuted>Enter your email address.</TypographyMuted>
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <TypographyP>
+              All typography components share the same props interface.
+              Each renders a semantic HTML element with appropriate styling.
+            </TypographyP>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-left py-2 pr-4 font-medium">Component</th>
+                    <th className="text-left py-2 pr-4 font-medium">Element</th>
+                    <th className="text-left py-2 font-medium">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyH1</td><td className="py-2 pr-4">h1</td><td className="py-2">Page title, largest heading</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyH2</td><td className="py-2 pr-4">h2</td><td className="py-2">Section heading with bottom border</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyH3</td><td className="py-2 pr-4">h3</td><td className="py-2">Sub-section heading</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyH4</td><td className="py-2 pr-4">h4</td><td className="py-2">Minor heading</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyP</td><td className="py-2 pr-4">p</td><td className="py-2">Body text paragraph</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyBlockquote</td><td className="py-2 pr-4">blockquote</td><td className="py-2">Quoted text with left border</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyList</td><td className="py-2 pr-4">ul</td><td className="py-2">Bulleted list</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyInlineCode</td><td className="py-2 pr-4">code</td><td className="py-2">Inline code snippet</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyLead</td><td className="py-2 pr-4">p</td><td className="py-2">Larger introductory text</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographyLarge</td><td className="py-2 pr-4">div</td><td className="py-2">Large emphasis text</td></tr>
+                  <tr className="border-b"><td className="py-2 pr-4 font-mono text-xs">TypographySmall</td><td className="py-2 pr-4">small</td><td className="py-2">Small caption text</td></tr>
+                  <tr><td className="py-2 pr-4 font-mono text-xs">TypographyMuted</td><td className="py-2 pr-4">p</td><td className="py-2">Muted secondary text</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-foreground mb-4">Shared Props</h3>
+              <PropsTable props={typographyProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -58,6 +58,7 @@ import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
 import { SpinnerRefPage } from './pages/components/spinner'
+import { TypographyRefPage } from './pages/components/typography'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
@@ -233,6 +234,11 @@ export function createApp() {
   // Spinner reference page
   app.get('/components/spinner', (c) => {
     return c.render(<SpinnerRefPage />)
+  })
+
+  // Typography reference page
+  app.get('/components/typography', (c) => {
+    return c.render(<TypographyRefPage />)
   })
 
   // Switch reference page

--- a/ui/components/ui/typography/index.test.tsx
+++ b/ui/components/ui/typography/index.test.tsx
@@ -1,0 +1,228 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const typographySource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('TypographyH1', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyH1')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is TypographyH1', () => {
+    expect(result.componentName).toBe('TypographyH1')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as h1 with data-slot=typography-h1', () => {
+    expect(result.root.tag).toBe('h1')
+    expect(result.root.props['data-slot']).toBe('typography-h1')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('scroll-m-20')
+    expect(result.root.classes).toContain('text-4xl')
+    expect(result.root.classes).toContain('font-extrabold')
+  })
+})
+
+describe('TypographyH2', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyH2')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as h2 with data-slot=typography-h2', () => {
+    expect(result.root.tag).toBe('h2')
+    expect(result.root.props['data-slot']).toBe('typography-h2')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-3xl')
+    expect(result.root.classes).toContain('font-semibold')
+    expect(result.root.classes).toContain('border-b')
+  })
+})
+
+describe('TypographyH3', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyH3')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as h3 with data-slot=typography-h3', () => {
+    expect(result.root.tag).toBe('h3')
+    expect(result.root.props['data-slot']).toBe('typography-h3')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-2xl')
+    expect(result.root.classes).toContain('font-semibold')
+  })
+})
+
+describe('TypographyH4', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyH4')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as h4 with data-slot=typography-h4', () => {
+    expect(result.root.tag).toBe('h4')
+    expect(result.root.props['data-slot']).toBe('typography-h4')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-xl')
+    expect(result.root.classes).toContain('font-semibold')
+  })
+})
+
+describe('TypographyP', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyP')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as p with data-slot=typography-p', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('typography-p')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('leading-7')
+  })
+})
+
+describe('TypographyBlockquote', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyBlockquote')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as blockquote with data-slot=typography-blockquote', () => {
+    expect(result.root.tag).toBe('blockquote')
+    expect(result.root.props['data-slot']).toBe('typography-blockquote')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('border-l-2')
+    expect(result.root.classes).toContain('italic')
+  })
+})
+
+describe('TypographyList', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyList')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as ul with data-slot=typography-list', () => {
+    expect(result.root.tag).toBe('ul')
+    expect(result.root.props['data-slot']).toBe('typography-list')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('list-disc')
+  })
+})
+
+describe('TypographyInlineCode', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyInlineCode')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as code with data-slot=typography-inline-code', () => {
+    expect(result.root.tag).toBe('code')
+    expect(result.root.props['data-slot']).toBe('typography-inline-code')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('font-mono')
+    expect(result.root.classes).toContain('rounded')
+  })
+})
+
+describe('TypographyLead', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyLead')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as p with data-slot=typography-lead', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('typography-lead')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-xl')
+  })
+})
+
+describe('TypographyLarge', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyLarge')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=typography-large', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('typography-large')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-lg')
+    expect(result.root.classes).toContain('font-semibold')
+  })
+})
+
+describe('TypographySmall', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographySmall')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as small with data-slot=typography-small', () => {
+    expect(result.root.tag).toBe('small')
+    expect(result.root.props['data-slot']).toBe('typography-small')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+    expect(result.root.classes).toContain('font-medium')
+  })
+})
+
+describe('TypographyMuted', () => {
+  const result = renderToTest(typographySource, 'typography.tsx', 'TypographyMuted')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as p with data-slot=typography-muted', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('typography-muted')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('text-sm')
+  })
+})

--- a/ui/components/ui/typography/index.tsx
+++ b/ui/components/ui/typography/index.tsx
@@ -1,0 +1,175 @@
+/**
+ * Typography Components
+ *
+ * A collection of styled text elements for consistent typographic hierarchy.
+ * Inspired by shadcn/ui typography with CSS variable theming support.
+ *
+ * @example Headings
+ * ```tsx
+ * <TypographyH1>Main Heading</TypographyH1>
+ * <TypographyH2>Section Heading</TypographyH2>
+ * <TypographyH3>Sub Heading</TypographyH3>
+ * <TypographyH4>Minor Heading</TypographyH4>
+ * ```
+ *
+ * @example Paragraph and lead
+ * ```tsx
+ * <TypographyLead>A larger introductory paragraph.</TypographyLead>
+ * <TypographyP>Regular body text paragraph.</TypographyP>
+ * ```
+ *
+ * @example Inline styles
+ * ```tsx
+ * <TypographyLarge>Large emphasis text</TypographyLarge>
+ * <TypographySmall>Small caption text</TypographySmall>
+ * <TypographyMuted>Muted secondary text</TypographyMuted>
+ * <TypographyInlineCode>code</TypographyInlineCode>
+ * ```
+ *
+ * @example Blockquote and list
+ * ```tsx
+ * <TypographyBlockquote>A notable quote.</TypographyBlockquote>
+ * <TypographyList>
+ *   <li>First item</li>
+ *   <li>Second item</li>
+ * </TypographyList>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+// --- Class definitions ---
+
+const h1Classes = 'scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl'
+const h2Classes = 'scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0'
+const h3Classes = 'scroll-m-20 text-2xl font-semibold tracking-tight'
+const h4Classes = 'scroll-m-20 text-xl font-semibold tracking-tight'
+const pClasses = 'leading-7 [&:not(:first-child)]:mt-6'
+const blockquoteClasses = 'mt-6 border-l-2 pl-6 italic'
+const listClasses = 'my-6 ml-6 list-disc [&>li]:mt-2'
+const inlineCodeClasses = 'relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold'
+const leadClasses = 'text-xl text-muted-foreground'
+const largeClasses = 'text-lg font-semibold'
+const smallClasses = 'text-sm font-medium leading-none'
+const mutedClasses = 'text-sm text-muted-foreground'
+
+// --- Props interfaces ---
+
+interface TypographyProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+// --- Components ---
+
+function TypographyH1({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <h1 data-slot="typography-h1" className={`${h1Classes} ${className}`} {...props}>
+      {children}
+    </h1>
+  )
+}
+
+function TypographyH2({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <h2 data-slot="typography-h2" className={`${h2Classes} ${className}`} {...props}>
+      {children}
+    </h2>
+  )
+}
+
+function TypographyH3({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <h3 data-slot="typography-h3" className={`${h3Classes} ${className}`} {...props}>
+      {children}
+    </h3>
+  )
+}
+
+function TypographyH4({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <h4 data-slot="typography-h4" className={`${h4Classes} ${className}`} {...props}>
+      {children}
+    </h4>
+  )
+}
+
+function TypographyP({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <p data-slot="typography-p" className={`${pClasses} ${className}`} {...props}>
+      {children}
+    </p>
+  )
+}
+
+function TypographyBlockquote({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <blockquote data-slot="typography-blockquote" className={`${blockquoteClasses} ${className}`} {...props}>
+      {children}
+    </blockquote>
+  )
+}
+
+function TypographyList({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <ul data-slot="typography-list" className={`${listClasses} ${className}`} {...props}>
+      {children}
+    </ul>
+  )
+}
+
+function TypographyInlineCode({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <code data-slot="typography-inline-code" className={`${inlineCodeClasses} ${className}`} {...props}>
+      {children}
+    </code>
+  )
+}
+
+function TypographyLead({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <p data-slot="typography-lead" className={`${leadClasses} ${className}`} {...props}>
+      {children}
+    </p>
+  )
+}
+
+function TypographyLarge({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <div data-slot="typography-large" className={`${largeClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function TypographySmall({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <small data-slot="typography-small" className={`${smallClasses} ${className}`} {...props}>
+      {children}
+    </small>
+  )
+}
+
+function TypographyMuted({ children, className = '', ...props }: TypographyProps) {
+  return (
+    <p data-slot="typography-muted" className={`${mutedClasses} ${className}`} {...props}>
+      {children}
+    </p>
+  )
+}
+
+export {
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyH4,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyInlineCode,
+  TypographyLead,
+  TypographyLarge,
+  TypographySmall,
+  TypographyMuted,
+}
+export type { TypographyProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -400,6 +400,13 @@
       "title": "Toggle",
       "description": "A two-state button that can be on or off",
       "tags": ["input"]
+    },
+    {
+      "name": "typography",
+      "type": "registry:ui",
+      "title": "Typography",
+      "description": "Styled text elements for headings, paragraphs, and prose content",
+      "tags": ["display"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Typography component with 12 styled text sub-components (H1–H4, P, Blockquote, List, InlineCode, Lead, Large, Small, Muted)
- Follow shadcn/ui typography patterns with CSS variable theming and Tailwind classes
- Include interactive playground, demo components, documentation page, and E2E tests

## Components
| Component | Element | Description |
|-----------|---------|-------------|
| TypographyH1 | h1 | Page title, largest heading |
| TypographyH2 | h2 | Section heading with bottom border |
| TypographyH3 | h3 | Sub-section heading |
| TypographyH4 | h4 | Minor heading |
| TypographyP | p | Body text paragraph |
| TypographyBlockquote | blockquote | Quoted text with left border |
| TypographyList | ul | Bulleted list |
| TypographyInlineCode | code | Inline code snippet |
| TypographyLead | p | Larger introductory text |
| TypographyLarge | div | Large emphasis text |
| TypographySmall | small | Small caption text |
| TypographyMuted | p | Muted secondary text |

## Files Changed
- `ui/components/ui/typography/index.tsx` — Component implementation
- `ui/components/ui/typography/index.test.tsx` — IR tests (38 tests)
- `ui/registry.json` — Registry entry
- `site/ui/components/typography-demo.tsx` — Demo components
- `site/ui/components/typography-playground.tsx` — Interactive playground
- `site/ui/pages/components/typography.tsx` — Documentation page
- `site/ui/components/shared/component-registry.ts` — Category registration
- `site/ui/routes.tsx` — Route registration
- `site/ui/e2e/typography.spec.ts` — E2E tests (7 tests)

## Test plan
- [x] IR tests pass (38 tests, 60 assertions)
- [x] Full build succeeds (`bun run build`)
- [x] Typography E2E tests pass (7 tests)
- [x] All existing E2E tests pass (808 tests)

Closes #674
Ref #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)