### PR TITLE
Add Kbd component for keyboard shortcut display

### DIFF
--- a/site/ui/components/kbd-demo.tsx
+++ b/site/ui/components/kbd-demo.tsx
@@ -1,0 +1,28 @@
+"use client"
+/**
+ * KbdDemo Component
+ *
+ * Basic demo showing Kbd and KbdGroup usage for keyboard shortcuts.
+ */
+
+import { Kbd, KbdGroup } from '@ui/components/ui/kbd'
+
+export function KbdDemo() {
+  return (
+    <div className="flex flex-wrap items-center gap-4" data-testid="kbd-demo">
+      <KbdGroup>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </KbdGroup>
+
+      <KbdGroup>
+        <Kbd>Ctrl</Kbd>
+        <Kbd>C</Kbd>
+      </KbdGroup>
+
+      <Kbd>Enter</Kbd>
+      <Kbd>Shift</Kbd>
+      <Kbd>Esc</Kbd>
+    </div>
+  )
+}

--- a/site/ui/components/kbd-playground.tsx
+++ b/site/ui/components/kbd-playground.tsx
@@ -1,0 +1,46 @@
+"use client"
+/**
+ * Kbd Props Playground
+ *
+ * Interactive playground for the Kbd component.
+ * Allows tweaking the children prop with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Input } from '@ui/components/ui/input'
+import { Kbd } from '@ui/components/ui/kbd'
+
+function KbdPlayground(_props: {}) {
+  const [text, setText] = createSignal('⌘')
+
+  const props = (): HighlightProp[] => []
+
+  createEffect(() => {
+    const p = props()
+    const t = text()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsx('Kbd', p, t)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-kbd-preview"
+      previewContent={<Kbd>{text()}</Kbd>}
+      controls={<>
+        <PlaygroundControl label="children">
+          <Input
+            type="text"
+            value={text()}
+            onInput={(e: Event) => setText((e.target as HTMLInputElement).value)}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsx('Kbd', props(), text())} />}
+    />
+  )
+}
+
+export { KbdPlayground }

--- a/site/ui/components/kbd-shortcuts-demo.tsx
+++ b/site/ui/components/kbd-shortcuts-demo.tsx
@@ -1,0 +1,43 @@
+"use client"
+/**
+ * KbdShortcutsDemo Component
+ *
+ * Realistic scenario showing keyboard shortcuts in a settings-like UI.
+ */
+
+import { Kbd, KbdGroup } from '@ui/components/ui/kbd'
+
+export function KbdShortcutsDemo() {
+  return (
+    <div className="w-full max-w-sm space-y-3" data-testid="kbd-shortcuts-demo">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Search</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Copy</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>C</Kbd>
+        </KbdGroup>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Paste</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>V</Kbd>
+        </KbdGroup>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Undo</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>Z</Kbd>
+        </KbdGroup>
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -53,12 +53,13 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'toggle', title: 'Toggle', description: 'Two-state pressed button', category: 'input' },
   { slug: 'toggle-group', title: 'Toggle Group', description: 'Group of toggle buttons', category: 'input' },
 
-  // Display (9)
+  // Display (10)
   { slug: 'aspect-ratio', title: 'Aspect Ratio', description: 'Content within a desired ratio', category: 'display' },
   { slug: 'avatar', title: 'Avatar', description: 'User profile image with fallback', category: 'display' },
   { slug: 'badge', title: 'Badge', description: 'Small status indicator labels', category: 'display' },
   { slug: 'card', title: 'Card', description: 'Container for grouped content', category: 'display' },
   { slug: 'carousel', title: 'Carousel', description: 'Motion and swipe content slider', category: 'display' },
+  { slug: 'kbd', title: 'Kbd', description: 'Keyboard key display for shortcuts', category: 'display' },
   { slug: 'data-table', title: 'Data Table', description: 'Sortable, filterable data table', category: 'display' },
   { slug: 'separator', title: 'Separator', description: 'Visual divider between content', category: 'display' },
   { slug: 'skeleton', title: 'Skeleton', description: 'Placeholder loading indicator', category: 'display' },

--- a/site/ui/e2e/kbd.spec.ts
+++ b/site/ui/e2e/kbd.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Kbd Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/kbd')
+  })
+
+  test.describe('Props Playground', () => {
+    test('changing children text updates preview kbd', async ({ page }) => {
+      const preview = page.locator('[data-kbd-preview]')
+      const section = page.locator('#preview')
+      const input = section.locator('input[type="text"]')
+
+      await input.fill('K')
+      await expect(preview.locator('[data-slot="kbd"]')).toContainText('K')
+    })
+  })
+
+  test.describe('Kbd Demo', () => {
+    test('displays keyboard keys', async ({ page }) => {
+      const demo = page.locator('[data-testid="kbd-demo"]')
+
+      await expect(demo).toBeVisible()
+      // Should contain multiple kbd elements
+      const kbds = demo.locator('[data-slot="kbd"]')
+      await expect(kbds).toHaveCount(7) // ⌘, K, Ctrl, C, Enter, Shift, Esc
+    })
+
+    test('displays kbd-group elements', async ({ page }) => {
+      const demo = page.locator('[data-testid="kbd-demo"]')
+
+      const groups = demo.locator('[data-slot="kbd-group"]')
+      await expect(groups).toHaveCount(2) // ⌘+K, Ctrl+C
+    })
+  })
+
+  test.describe('Shortcuts Demo', () => {
+    test('displays shortcut list', async ({ page }) => {
+      const demo = page.locator('[data-testid="kbd-shortcuts-demo"]')
+
+      await expect(demo).toBeVisible()
+      // Should contain shortcut labels
+      await expect(demo).toContainText('Search')
+      await expect(demo).toContainText('Copy')
+      await expect(demo).toContainText('Paste')
+      await expect(demo).toContainText('Undo')
+    })
+  })
+})

--- a/site/ui/pages/components/kbd.tsx
+++ b/site/ui/pages/components/kbd.tsx
@@ -1,0 +1,165 @@
+/**
+ * Kbd Reference Page (/components/kbd)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { KbdPlayground } from '@/components/kbd-playground'
+import { KbdDemo } from '@/components/kbd-demo'
+import { KbdShortcutsDemo } from '@/components/kbd-shortcuts-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'kbd-group', title: 'KbdGroup', branch: 'start' },
+  { id: 'shortcuts', title: 'Shortcuts', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { Kbd, KbdGroup } from "@/components/ui/kbd"
+
+function KbdDemo() {
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <KbdGroup>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </KbdGroup>
+
+      <Kbd>Enter</Kbd>
+      <Kbd>Shift</Kbd>
+      <Kbd>Esc</Kbd>
+    </div>
+  )
+}`
+
+const kbdGroupCode = `<KbdGroup>
+  <Kbd>Ctrl</Kbd>
+  <Kbd>Shift</Kbd>
+  <Kbd>P</Kbd>
+</KbdGroup>`
+
+const shortcutsCode = `import { Kbd, KbdGroup } from "@/components/ui/kbd"
+
+function ShortcutsList() {
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Search</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">Copy</span>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>C</Kbd>
+        </KbdGroup>
+      </div>
+    </div>
+  )
+}`
+
+const kbdProps: PropDefinition[] = [
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element with kbd styling instead of <kbd>.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The key label content.',
+  },
+]
+
+const kbdGroupProps: PropDefinition[] = [
+  {
+    name: 'asChild',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Render child element with group styling instead of <kbd>.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The grouped key elements.',
+  },
+]
+
+export function KbdRefPage() {
+  return (
+    <DocPage slug="kbd" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Kbd"
+          description="Displays a keyboard key or keyboard shortcut."
+          {...getNavLinks('kbd')}
+        />
+
+        {/* Props Playground */}
+        <KbdPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add kbd" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <KbdDemo />
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="KbdGroup" code={kbdGroupCode} showLineNumbers={false}>
+              <KbdGroup>
+                <Kbd>Ctrl</Kbd>
+                <Kbd>Shift</Kbd>
+                <Kbd>P</Kbd>
+              </KbdGroup>
+            </Example>
+
+            <Example title="Shortcuts" code={shortcutsCode}>
+              <KbdShortcutsDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">Kbd</h3>
+              <PropsTable props={kbdProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">KbdGroup</h3>
+              <PropsTable props={kbdGroupProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -61,6 +61,7 @@ import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
 import { EmptyRefPage } from './pages/components/empty'
+import { KbdRefPage } from './pages/components/kbd'
 import { SpinnerRefPage } from './pages/components/spinner'
 import { TypographyRefPage } from './pages/components/typography'
 import { ComponentCatalogPage } from './pages/components/catalog'
@@ -248,6 +249,11 @@ export function createApp() {
   // Empty reference page
   app.get('/components/empty', (c) => {
     return c.render(<EmptyRefPage />)
+  })
+
+  // Kbd reference page
+  app.get('/components/kbd', (c) => {
+    return c.render(<KbdRefPage />)
   })
 
   // Spinner reference page

--- a/ui/components/ui/kbd/index.test.tsx
+++ b/ui/components/ui/kbd/index.test.tsx
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const kbdSource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('Kbd', () => {
+  const result = renderToTest(kbdSource, 'kbd.tsx', 'Kbd')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is Kbd', () => {
+    expect(result.componentName).toBe('Kbd')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a kbd element with data-slot=kbd', () => {
+    const kbd = result.find({ tag: 'kbd' })
+    expect(kbd).not.toBeNull()
+    expect(kbd!.props['data-slot']).toBe('kbd')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const kbd = result.find({ tag: 'kbd' })!
+    expect(kbd.classes).toContain('inline-flex')
+    expect(kbd.classes).toContain('items-center')
+    expect(kbd.classes).toContain('rounded-sm')
+  })
+
+  test('contains Slot component for asChild', () => {
+    const slot = result.find({ componentName: 'Slot' })
+    expect(slot).not.toBeNull()
+  })
+})
+
+describe('KbdGroup', () => {
+  const result = renderToTest(kbdSource, 'kbd.tsx', 'KbdGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is KbdGroup', () => {
+    expect(result.componentName).toBe('KbdGroup')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('root is conditional (asChild branch)', () => {
+    expect(result.root.type).toBe('conditional')
+  })
+
+  test('contains a kbd element with data-slot=kbd-group', () => {
+    const kbd = result.find({ tag: 'kbd' })
+    expect(kbd).not.toBeNull()
+    expect(kbd!.props['data-slot']).toBe('kbd-group')
+  })
+
+  test('has resolved base CSS classes', () => {
+    const kbd = result.find({ tag: 'kbd' })!
+    expect(kbd.classes).toContain('inline-flex')
+    expect(kbd.classes).toContain('items-center')
+    expect(kbd.classes).toContain('gap-1')
+  })
+
+  test('contains Slot component for asChild', () => {
+    const slot = result.find({ componentName: 'Slot' })
+    expect(slot).not.toBeNull()
+  })
+})

--- a/ui/components/ui/kbd/index.tsx
+++ b/ui/components/ui/kbd/index.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+/**
+ * Kbd Component
+ *
+ * Displays a keyboard key or shortcut indicator.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <Kbd>K</Kbd>
+ * ```
+ *
+ * @example Keyboard shortcut
+ * ```tsx
+ * <Kbd>⌘</Kbd><Kbd>K</Kbd>
+ * ```
+ *
+ * @example Grouped keys
+ * ```tsx
+ * <KbdGroup>
+ *   <Kbd>Ctrl</Kbd>
+ *   <Kbd>C</Kbd>
+ * </KbdGroup>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+import { Slot } from '../slot'
+
+// Base classes for individual keyboard key display
+const kbdBaseClasses = 'pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border border-border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3'
+
+// Base classes for grouping multiple keys
+const kbdGroupBaseClasses = 'inline-flex items-center gap-1'
+
+/**
+ * Props for the Kbd component.
+ */
+interface KbdProps extends HTMLBaseAttributes {
+  /**
+   * When true, renders child element with kbd styling instead of `<kbd>`.
+   * Useful for custom elements with keyboard key appearance.
+   * @default false
+   */
+  asChild?: boolean
+  /**
+   * Children to render inside the kbd element.
+   */
+  children?: Child
+}
+
+/**
+ * Props for the KbdGroup component.
+ */
+interface KbdGroupProps extends HTMLBaseAttributes {
+  /**
+   * When true, renders child element with group styling instead of `<kbd>`.
+   * @default false
+   */
+  asChild?: boolean
+  /**
+   * Children to render inside the group.
+   */
+  children?: Child
+}
+
+/**
+ * Kbd component — displays a single keyboard key.
+ *
+ * @param props.asChild - Render child element instead of kbd
+ */
+function Kbd({
+  className = '',
+  asChild = false,
+  children,
+  ...props
+}: KbdProps) {
+  const classes = `${kbdBaseClasses} ${className}`
+
+  if (asChild) {
+    return <Slot className={classes} {...props}>{children}</Slot>
+  }
+  return <kbd data-slot="kbd" className={classes} {...props}>{children}</kbd>
+}
+
+/**
+ * KbdGroup component — groups multiple Kbd elements together.
+ *
+ * @param props.asChild - Render child element instead of kbd
+ */
+function KbdGroup({
+  className = '',
+  asChild = false,
+  children,
+  ...props
+}: KbdGroupProps) {
+  const classes = `${kbdGroupBaseClasses} ${className}`
+
+  if (asChild) {
+    return <Slot className={classes} {...props}>{children}</Slot>
+  }
+  return <kbd data-slot="kbd-group" className={classes} {...props}>{children}</kbd>
+}
+
+export { Kbd, KbdGroup }
+export type { KbdProps, KbdGroupProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -369,6 +369,14 @@
       "requires": ["input"]
     },
     {
+      "name": "kbd",
+      "type": "registry:ui",
+      "title": "Kbd",
+      "description": "Keyboard key display for showing keyboard shortcuts",
+      "tags": ["display"],
+      "requires": ["slot"]
+    },
+    {
       "name": "label",
       "type": "registry:ui",
       "title": "Label",


### PR DESCRIPTION
## Summary
- Add `Kbd` and `KbdGroup` components ported from shadcn/ui for displaying keyboard keys and shortcuts
- Full documentation page with interactive playground, usage examples, and keyboard shortcuts demo
- Component IR tests (14 pass) and E2E tests (4 pass), all 805 E2E tests passing

## Test plan
- [x] `bun test ui/components/ui/kbd/index.test.tsx` — 14 IR tests pass
- [x] `bun run build` — clean build
- [x] `bun run test:e2e` — all 805 E2E tests pass (including 4 new kbd tests)

Closes #675
Ref #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)