### PR TITLE
Add NativeSelect component

### DIFF
--- a/site/ui/components/native-select-demo.tsx
+++ b/site/ui/components/native-select-demo.tsx
@@ -1,0 +1,72 @@
+"use client"
+/**
+ * NativeSelectDemo Components
+ *
+ * Interactive demos for NativeSelect component.
+ * Used in native-select documentation page.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { NativeSelect, NativeSelectOption } from '@ui/components/ui/native-select'
+
+/**
+ * Value binding example — shows selected value in real time
+ */
+export function NativeSelectBindingDemo() {
+  const [value, setValue] = createSignal('')
+  return (
+    <div className="space-y-2">
+      <NativeSelect
+        value={value()}
+        onChange={(e) => setValue(e.target.value)}
+      >
+        <NativeSelectOption value="" disabled>Select a fruit...</NativeSelectOption>
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+        <NativeSelectOption value="cherry">Cherry</NativeSelectOption>
+      </NativeSelect>
+      <p className="text-sm text-muted-foreground">
+        Selected: <span className="selected-value font-medium">{value() || 'none'}</span>
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Form example — a realistic settings form with native select
+ */
+export function NativeSelectFormDemo() {
+  const [role, setRole] = createSignal('viewer')
+  const [theme, setTheme] = createSignal('system')
+
+  return (
+    <div className="space-y-4 max-w-sm">
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Role</label>
+        <NativeSelect
+          value={role()}
+          onChange={(e) => setRole(e.target.value)}
+        >
+          <NativeSelectOption value="viewer">Viewer</NativeSelectOption>
+          <NativeSelectOption value="editor">Editor</NativeSelectOption>
+          <NativeSelectOption value="admin">Admin</NativeSelectOption>
+        </NativeSelect>
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Theme</label>
+        <NativeSelect
+          value={theme()}
+          onChange={(e) => setTheme(e.target.value)}
+        >
+          <NativeSelectOption value="system">System</NativeSelectOption>
+          <NativeSelectOption value="light">Light</NativeSelectOption>
+          <NativeSelectOption value="dark">Dark</NativeSelectOption>
+        </NativeSelect>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Role: <span className="form-role font-medium">{role()}</span>,
+        Theme: <span className="form-theme font-medium">{theme()}</span>
+      </p>
+    </div>
+  )
+}

--- a/site/ui/components/native-select-playground.tsx
+++ b/site/ui/components/native-select-playground.tsx
@@ -1,0 +1,79 @@
+"use client"
+/**
+ * NativeSelect Props Playground
+ *
+ * Interactive playground for the NativeSelect component.
+ * Allows tweaking size and disabled props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsxTree, plainJsxTree, type HighlightProp, type JsxTreeNode } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { NativeSelect, NativeSelectOption } from '@ui/components/ui/native-select'
+import { Checkbox } from '@ui/components/ui/checkbox'
+
+type SizeOption = 'default' | 'sm'
+
+function NativeSelectPlayground(_props: {}) {
+  const [size, setSize] = createSignal<SizeOption>('default')
+  const [disabled, setDisabled] = createSignal(false)
+
+  const treeNode = (): JsxTreeNode => ({
+    tag: 'NativeSelect',
+    props: [
+      { name: 'size', value: size(), defaultValue: 'default' },
+      { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' },
+    ] as HighlightProp[],
+    children: [
+      { tag: 'NativeSelectOption', props: [{ name: 'value', value: 'apple', defaultValue: '' }], children: 'Apple' },
+      { tag: 'NativeSelectOption', props: [{ name: 'value', value: 'banana', defaultValue: '' }], children: 'Banana' },
+      { tag: 'NativeSelectOption', props: [{ name: 'value', value: 'cherry', defaultValue: '' }], children: 'Cherry' },
+    ],
+  })
+
+  createEffect(() => {
+    const node = treeNode()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(node)
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-native-select-preview"
+      previewContent={
+        <NativeSelect
+          size={size()}
+          disabled={disabled()}
+        >
+          <NativeSelectOption value="apple">Apple</NativeSelectOption>
+          <NativeSelectOption value="banana">Banana</NativeSelectOption>
+          <NativeSelectOption value="cherry">Cherry</NativeSelectOption>
+        </NativeSelect>
+      }
+      controls={<>
+        <PlaygroundControl label="size">
+          <Select value={size()} onValueChange={(v: string) => setSize(v as SizeOption)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select size..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="sm">sm</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="disabled">
+          <Checkbox
+            checked={disabled()}
+            onCheckedChange={setDisabled}
+          />
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsxTree(treeNode())} />}
+    />
+  )
+}
+
+export { NativeSelectPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -45,6 +45,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'input-group', title: 'Input Group', description: 'Input with addons and affixes', category: 'input' },
   { slug: 'input-otp', title: 'Input OTP', description: 'One-time password input', category: 'input' },
   { slug: 'label', title: 'Label', description: 'Accessible label for form controls', category: 'input' },
+  { slug: 'native-select', title: 'Native Select', description: 'Styled native HTML select', category: 'input' },
   { slug: 'radio-group', title: 'Radio Group', description: 'Single-select option group', category: 'input' },
   { slug: 'select', title: 'Select', description: 'Dropdown selection control', category: 'input' },
   { slug: 'slider', title: 'Slider', description: 'Range value selector', category: 'input' },

--- a/site/ui/e2e/native-select.spec.ts
+++ b/site/ui/e2e/native-select.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('NativeSelect Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/native-select')
+  })
+
+  test.describe('NativeSelect Rendering', () => {
+    test('displays select elements', async ({ page }) => {
+      const selects = page.locator('select[data-slot="native-select"]')
+      await expect(selects.first()).toBeVisible()
+    })
+
+    test('has multiple select examples', async ({ page }) => {
+      const selects = page.locator('select[data-slot="native-select"]')
+      // Should have at least 4 selects on the page (playground + usage + sizes + disabled + optgroup)
+      expect(await selects.count()).toBeGreaterThan(3)
+    })
+  })
+
+  test.describe('Sizes', () => {
+    test('displays sizes section', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Sizes")')).toBeVisible()
+    })
+  })
+
+  test.describe('Disabled', () => {
+    test('displays disabled example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Disabled")')).toBeVisible()
+    })
+
+    test('has disabled select', async ({ page }) => {
+      const disabledSelects = page.locator('select[data-slot="native-select"][disabled]')
+      expect(await disabledSelects.count()).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  test.describe('Value Binding', () => {
+    test('displays value binding section', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Value Binding")')).toBeVisible()
+      const section = page.locator('[bf-s^="NativeSelectBindingDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('updates output when selecting', async ({ page }) => {
+      const section = page.locator('[bf-s^="NativeSelectBindingDemo_"]:not([data-slot])').first()
+      const select = section.locator('select[data-slot="native-select"]')
+      const output = section.locator('.selected-value')
+
+      await select.selectOption('banana')
+      await expect(output).toContainText('banana')
+    })
+  })
+
+  test.describe('Form', () => {
+    test('displays form example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("Form")')).toBeVisible()
+      const section = page.locator('[bf-s^="NativeSelectFormDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+    })
+
+    test('updates role when changed', async ({ page }) => {
+      const section = page.locator('[bf-s^="NativeSelectFormDemo_"]:not([data-slot])').first()
+      const selects = section.locator('select[data-slot="native-select"]')
+      const roleOutput = section.locator('.form-role')
+
+      await selects.first().selectOption('admin')
+      await expect(roleOutput).toContainText('admin')
+    })
+
+    test('updates theme when changed', async ({ page }) => {
+      const section = page.locator('[bf-s^="NativeSelectFormDemo_"]:not([data-slot])').first()
+      const selects = section.locator('select[data-slot="native-select"]')
+      const themeOutput = section.locator('.form-theme')
+
+      await selects.nth(1).selectOption('dark')
+      await expect(themeOutput).toContainText('dark')
+    })
+  })
+
+  test.describe('With OptGroup', () => {
+    test('displays optgroup example', async ({ page }) => {
+      await expect(page.locator('h3:has-text("With OptGroup")')).toBeVisible()
+    })
+
+    test('has optgroup elements', async ({ page }) => {
+      const optgroups = page.locator('optgroup[data-slot="native-select-optgroup"]')
+      expect(await optgroups.count()).toBeGreaterThanOrEqual(2)
+    })
+  })
+})

--- a/site/ui/pages/components/native-select.tsx
+++ b/site/ui/pages/components/native-select.tsx
@@ -1,0 +1,346 @@
+/**
+ * NativeSelect Reference Page (/components/native-select)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import { NativeSelect, NativeSelectOption, NativeSelectOptGroup } from '@/components/ui/native-select'
+import { NativeSelectPlayground } from '@/components/native-select-playground'
+import { NativeSelectBindingDemo, NativeSelectFormDemo } from '@/components/native-select-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'sizes', title: 'Sizes', branch: 'start' },
+  { id: 'disabled', title: 'Disabled', branch: 'child' },
+  { id: 'with-optgroup', title: 'With OptGroup', branch: 'child' },
+  { id: 'value-binding', title: 'Value Binding', branch: 'child' },
+  { id: 'form', title: 'Form', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select"
+
+function NativeSelectDemo() {
+  return (
+    <NativeSelect>
+      <NativeSelectOption value="apple">Apple</NativeSelectOption>
+      <NativeSelectOption value="banana">Banana</NativeSelectOption>
+      <NativeSelectOption value="cherry">Cherry</NativeSelectOption>
+    </NativeSelect>
+  )
+}`
+
+const sizesCode = `import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select"
+
+function NativeSelectSizes() {
+  return (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <NativeSelect>
+        <NativeSelectOption value="default">Default size</NativeSelectOption>
+      </NativeSelect>
+      <NativeSelect size="sm">
+        <NativeSelectOption value="sm">Small size</NativeSelectOption>
+      </NativeSelect>
+    </div>
+  )
+}`
+
+const disabledCode = `import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select"
+
+function NativeSelectDisabled() {
+  return (
+    <NativeSelect disabled>
+      <NativeSelectOption value="disabled">Disabled</NativeSelectOption>
+    </NativeSelect>
+  )
+}`
+
+const optgroupCode = `import {
+  NativeSelect,
+  NativeSelectOption,
+  NativeSelectOptGroup,
+} from "@/components/ui/native-select"
+
+function NativeSelectWithOptGroup() {
+  return (
+    <NativeSelect>
+      <NativeSelectOptGroup label="Fruits">
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+      </NativeSelectOptGroup>
+      <NativeSelectOptGroup label="Vegetables">
+        <NativeSelectOption value="carrot">Carrot</NativeSelectOption>
+        <NativeSelectOption value="broccoli">Broccoli</NativeSelectOption>
+      </NativeSelectOptGroup>
+    </NativeSelect>
+  )
+}`
+
+const bindingCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select"
+
+function NativeSelectBinding() {
+  const [value, setValue] = createSignal("")
+
+  return (
+    <div className="space-y-2">
+      <NativeSelect
+        value={value()}
+        onChange={(e) => setValue(e.target.value)}
+      >
+        <NativeSelectOption value="" disabled>
+          Select a fruit...
+        </NativeSelectOption>
+        <NativeSelectOption value="apple">Apple</NativeSelectOption>
+        <NativeSelectOption value="banana">Banana</NativeSelectOption>
+        <NativeSelectOption value="cherry">Cherry</NativeSelectOption>
+      </NativeSelect>
+      <p className="text-sm text-muted-foreground">
+        Selected: {value() || "none"}
+      </p>
+    </div>
+  )
+}`
+
+const formCode = `"use client"
+
+import { createSignal } from "@barefootjs/dom"
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select"
+
+function NativeSelectForm() {
+  const [role, setRole] = createSignal("viewer")
+  const [theme, setTheme] = createSignal("system")
+
+  return (
+    <div className="space-y-4 max-w-sm">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Role</label>
+        <NativeSelect
+          value={role()}
+          onChange={(e) => setRole(e.target.value)}
+        >
+          <NativeSelectOption value="viewer">Viewer</NativeSelectOption>
+          <NativeSelectOption value="editor">Editor</NativeSelectOption>
+          <NativeSelectOption value="admin">Admin</NativeSelectOption>
+        </NativeSelect>
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Theme</label>
+        <NativeSelect
+          value={theme()}
+          onChange={(e) => setTheme(e.target.value)}
+        >
+          <NativeSelectOption value="system">System</NativeSelectOption>
+          <NativeSelectOption value="light">Light</NativeSelectOption>
+          <NativeSelectOption value="dark">Dark</NativeSelectOption>
+        </NativeSelect>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Role: {role()}, Theme: {theme()}
+      </p>
+    </div>
+  )
+}`
+
+const nativeSelectProps: PropDefinition[] = [
+  {
+    name: 'size',
+    type: "'default' | 'sm'",
+    defaultValue: "'default'",
+    description: 'The size variant of the select.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the select is disabled.',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The controlled value of the select.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names applied to the select element.',
+  },
+  {
+    name: 'onChange',
+    type: '(e: Event) => void',
+    description: 'Event handler called when the selected value changes.',
+  },
+  {
+    name: 'onBlur',
+    type: '(e: FocusEvent) => void',
+    description: 'Event handler called when the select loses focus.',
+  },
+  {
+    name: 'onFocus',
+    type: '(e: FocusEvent) => void',
+    description: 'Event handler called when the select gains focus.',
+  },
+]
+
+const optionProps: PropDefinition[] = [
+  {
+    name: 'value',
+    type: 'string',
+    description: 'The value of the option.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether the option is disabled.',
+  },
+]
+
+const optgroupProps: PropDefinition[] = [
+  {
+    name: 'label',
+    type: 'string',
+    description: 'The label for the option group.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: 'false',
+    description: 'Whether all options in the group are disabled.',
+  },
+]
+
+export function NativeSelectRefPage() {
+  return (
+    <DocPage slug="native-select" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Native Select"
+          description="A styled native HTML select element."
+          {...getNavLinks('native-select')}
+        />
+
+        {/* Props Playground */}
+        <NativeSelectPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add native-select" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <div className="max-w-sm">
+              <NativeSelect>
+                <NativeSelectOption value="apple">Apple</NativeSelectOption>
+                <NativeSelectOption value="banana">Banana</NativeSelectOption>
+                <NativeSelectOption value="cherry">Cherry</NativeSelectOption>
+              </NativeSelect>
+            </div>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Sizes" code={sizesCode}>
+              <div className="flex flex-col gap-4 max-w-sm">
+                <NativeSelect>
+                  <NativeSelectOption value="default">Default size</NativeSelectOption>
+                </NativeSelect>
+                <NativeSelect size="sm">
+                  <NativeSelectOption value="sm">Small size</NativeSelectOption>
+                </NativeSelect>
+              </div>
+            </Example>
+
+            <Example title="Disabled" code={disabledCode}>
+              <div className="max-w-sm">
+                <NativeSelect disabled>
+                  <NativeSelectOption value="disabled">Disabled</NativeSelectOption>
+                </NativeSelect>
+              </div>
+            </Example>
+
+            <Example title="With OptGroup" code={optgroupCode}>
+              <div className="max-w-sm">
+                <NativeSelect>
+                  <NativeSelectOptGroup label="Fruits">
+                    <NativeSelectOption value="apple">Apple</NativeSelectOption>
+                    <NativeSelectOption value="banana">Banana</NativeSelectOption>
+                  </NativeSelectOptGroup>
+                  <NativeSelectOptGroup label="Vegetables">
+                    <NativeSelectOption value="carrot">Carrot</NativeSelectOption>
+                    <NativeSelectOption value="broccoli">Broccoli</NativeSelectOption>
+                  </NativeSelectOptGroup>
+                </NativeSelect>
+              </div>
+            </Example>
+
+            <Example title="Value Binding" code={bindingCode}>
+              <div className="max-w-sm">
+                <NativeSelectBindingDemo />
+              </div>
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <div className="max-w-sm">
+                <NativeSelectFormDemo />
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold mb-4">NativeSelect</h3>
+              <PropsTable props={nativeSelectProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">NativeSelectOption</h3>
+              <PropsTable props={optionProps} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold mb-4">NativeSelectOptGroup</h3>
+              <PropsTable props={optgroupProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -62,6 +62,7 @@ import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
 import { EmptyRefPage } from './pages/components/empty'
 import { KbdRefPage } from './pages/components/kbd'
+import { NativeSelectRefPage } from './pages/components/native-select'
 import { SpinnerRefPage } from './pages/components/spinner'
 import { TypographyRefPage } from './pages/components/typography'
 import { ComponentCatalogPage } from './pages/components/catalog'
@@ -254,6 +255,11 @@ export function createApp() {
   // Kbd reference page
   app.get('/components/kbd', (c) => {
     return c.render(<KbdRefPage />)
+  })
+
+  // Native Select reference page
+  app.get('/components/native-select', (c) => {
+    return c.render(<NativeSelectRefPage />)
   })
 
   // Spinner reference page

--- a/ui/components/ui/native-select/index.test.tsx
+++ b/ui/components/ui/native-select/index.test.tsx
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('NativeSelect', () => {
+  const result = renderToTest(source, 'native-select.tsx', 'NativeSelect')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is NativeSelect', () => {
+    expect(result.componentName).toBe('NativeSelect')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders wrapper div with data-slot', () => {
+    const wrapper = result.find({ tag: 'div' })
+    expect(wrapper).not.toBeNull()
+    expect(wrapper!.props['data-slot']).toBe('native-select-wrapper')
+  })
+
+  test('renders <select> with data-slot', () => {
+    const select = result.find({ tag: 'select' })
+    expect(select).not.toBeNull()
+    expect(select!.props['data-slot']).toBe('native-select')
+  })
+
+  test('has resolved base CSS classes on select', () => {
+    const select = result.find({ tag: 'select' })!
+    expect(select.classes).toContain('rounded-md')
+    expect(select.classes).toContain('border')
+    expect(select.classes).toContain('appearance-none')
+  })
+
+  test('has chevron icon', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+    expect(svg!.props['data-slot']).toBe('native-select-icon')
+    expect(svg!.classes).toContain('pointer-events-none')
+  })
+})
+
+describe('NativeSelectOption', () => {
+  const result = renderToTest(source, 'native-select.tsx', 'NativeSelectOption')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <option>', () => {
+    const option = result.find({ tag: 'option' })
+    expect(option).not.toBeNull()
+    expect(option!.props['data-slot']).toBe('native-select-option')
+  })
+})
+
+describe('NativeSelectOptGroup', () => {
+  const result = renderToTest(source, 'native-select.tsx', 'NativeSelectOptGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as <optgroup>', () => {
+    const optgroup = result.find({ tag: 'optgroup' })
+    expect(optgroup).not.toBeNull()
+    expect(optgroup!.props['data-slot']).toBe('native-select-optgroup')
+  })
+})

--- a/ui/components/ui/native-select/index.tsx
+++ b/ui/components/ui/native-select/index.tsx
@@ -1,0 +1,110 @@
+/**
+ * NativeSelect Component
+ *
+ * A styled native HTML select element following shadcn/ui design.
+ * Wraps the native <select> in a container with a custom chevron icon.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <NativeSelect>
+ *   <NativeSelectOption value="1">Option 1</NativeSelectOption>
+ *   <NativeSelectOption value="2">Option 2</NativeSelectOption>
+ * </NativeSelect>
+ * ```
+ *
+ * @example With size
+ * ```tsx
+ * <NativeSelect size="sm">
+ *   <NativeSelectOption value="a">Small</NativeSelectOption>
+ * </NativeSelect>
+ * ```
+ */
+
+import type { SelectHTMLAttributes, HTMLBaseAttributes, OptionHTMLAttributes } from '@barefootjs/jsx'
+
+interface OptGroupHTMLAttributes extends HTMLBaseAttributes {
+  disabled?: boolean
+  label?: string
+}
+
+// Size variants
+type NativeSelectSize = 'sm' | 'default'
+
+const sizeClasses: Record<NativeSelectSize, string> = {
+  default: 'h-9 py-2',
+  sm: 'h-8 py-1',
+}
+
+// Base classes for the select element (aligned with shadcn/ui)
+const baseClasses = 'w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50'
+
+// Focus state classes
+const focusClasses = 'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+// Error state classes
+const errorClasses = 'aria-[invalid]:border-destructive aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40'
+
+/**
+ * Props for NativeSelect.
+ * Omits the native `size` attribute (number) and replaces with a string variant.
+ */
+interface NativeSelectProps extends Omit<SelectHTMLAttributes, 'size'> {
+  /** Size variant of the select. */
+  size?: NativeSelectSize
+}
+
+/**
+ * NativeSelect — styled native HTML select element.
+ */
+function NativeSelect({ className = '', size = 'default', ...props }: NativeSelectProps) {
+  return (
+    <div
+      className="group/native-select relative w-fit has-[select:disabled]:opacity-50"
+      data-slot="native-select-wrapper"
+    >
+      <select
+        data-slot="native-select"
+        className={`${baseClasses} ${sizeClasses[size]} ${focusClasses} ${errorClasses} ${className}`}
+        {...props}
+      />
+      <svg
+        className="pointer-events-none absolute top-1/2 right-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none"
+        aria-hidden="true"
+        data-slot="native-select-icon"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    </div>
+  )
+}
+
+/**
+ * NativeSelectOption — an option within a NativeSelect.
+ */
+function NativeSelectOption({ ...props }: OptionHTMLAttributes) {
+  return <option data-slot="native-select-option" {...props} />
+}
+
+/**
+ * NativeSelectOptGroup — a group of options within a NativeSelect.
+ */
+function NativeSelectOptGroup({ className = '', ...props }: OptGroupHTMLAttributes) {
+  return (
+    <optgroup
+      data-slot="native-select-optgroup"
+      className={className}
+      {...props}
+    />
+  )
+}
+
+export { NativeSelect, NativeSelectOption, NativeSelectOptGroup }
+export type { NativeSelectProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -445,6 +445,13 @@
       "title": "Empty",
       "description": "Empty state placeholder with icon, title, and action",
       "tags": ["feedback"]
+    },
+    {
+      "name": "native-select",
+      "type": "registry:ui",
+      "title": "Native Select",
+      "description": "A styled native HTML select element",
+      "tags": ["input"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `NativeSelect`, `NativeSelectOption`, and `NativeSelectOptGroup` components — styled wrappers around the native HTML `<select>` element with custom chevron icon
- Include size variants (`default`, `sm`), disabled state, focus/error styling, and optgroup support
- Add interactive playground, demos (value binding, form settings), documentation page, and 12 E2E tests

Closes #676
See also #125

## Test plan
- [x] Component IR tests pass (11 tests)
- [x] `bun run build` succeeds
- [x] E2E tests pass (12 tests covering rendering, sizes, disabled, value binding, form interactions, optgroup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>