### PR TITLE
Add Direction component (RTL/LTR provider)

### DIFF
--- a/site/ui/components/direction-demo.tsx
+++ b/site/ui/components/direction-demo.tsx
@@ -1,0 +1,61 @@
+import { DirectionProvider } from '@ui/components/ui/direction'
+
+export function DirectionBasicDemo() {
+  return (
+    <div className="flex flex-col gap-4 max-w-md">
+      <DirectionProvider dir="ltr">
+        <div className="rounded-md border border-border p-4">
+          <p className="text-sm font-medium mb-1">Left-to-Right (LTR)</p>
+          <p className="text-sm text-muted-foreground">This text flows from left to right. Numbers like 123 appear naturally.</p>
+        </div>
+      </DirectionProvider>
+      <DirectionProvider dir="rtl">
+        <div className="rounded-md border border-border p-4">
+          <p className="text-sm font-medium mb-1">Right-to-Left (RTL)</p>
+          <p className="text-sm text-muted-foreground">هذا النص يتدفق من اليمين إلى اليسار. الأرقام مثل 123 تظهر بشكل طبيعي.</p>
+        </div>
+      </DirectionProvider>
+    </div>
+  )
+}
+
+export function DirectionNestedDemo() {
+  return (
+    <div className="max-w-md">
+      <DirectionProvider dir="rtl">
+        <div className="rounded-md border border-border p-4 space-y-3">
+          <p className="text-sm font-medium">محتوى RTL خارجي</p>
+          <p className="text-sm text-muted-foreground">هذا القسم يستخدم اتجاه من اليمين إلى اليسار.</p>
+          <DirectionProvider dir="ltr">
+            <div className="rounded-md border border-border bg-muted/50 p-3">
+              <p className="text-sm font-medium">Nested LTR content</p>
+              <p className="text-sm text-muted-foreground">This section overrides to left-to-right inside an RTL parent.</p>
+            </div>
+          </DirectionProvider>
+        </div>
+      </DirectionProvider>
+    </div>
+  )
+}
+
+export function DirectionFormDemo() {
+  const inputClasses = 'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
+  return (
+    <div className="flex flex-col gap-4 max-w-md">
+      <DirectionProvider dir="rtl">
+        <div className="rounded-md border border-border p-4 space-y-3">
+          <h4 className="text-sm font-medium">نموذج تسجيل</h4>
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium">الاسم</label>
+            <input type="text" placeholder="أدخل اسمك" className={inputClasses} />
+          </div>
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium">البريد الإلكتروني</label>
+            <input type="email" placeholder="أدخل بريدك الإلكتروني" className={inputClasses} />
+          </div>
+        </div>
+      </DirectionProvider>
+    </div>
+  )
+}

--- a/site/ui/components/direction-playground.tsx
+++ b/site/ui/components/direction-playground.tsx
@@ -1,0 +1,59 @@
+"use client"
+/**
+ * Direction Props Playground
+ *
+ * Interactive playground for the DirectionProvider component.
+ * Allows toggling between LTR and RTL with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { DirectionProvider } from '@ui/components/ui/direction'
+
+type Dir = 'ltr' | 'rtl'
+
+function DirectionPlayground(_props: {}) {
+  const [dir, setDir] = createSignal<Dir>('ltr')
+
+  const props = (): HighlightProp[] => [
+    { name: 'dir', value: dir(), defaultValue: 'ltr' },
+  ]
+
+  createEffect(() => {
+    const p = props()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsx('DirectionProvider', p, 'Hello, World! مرحبا بالعالم')
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-direction-preview"
+      previewContent={
+        <DirectionProvider dir={dir()}>
+          <div className="rounded-md border border-border p-4">
+            <p className="text-sm">Hello, World! مرحبا بالعالم</p>
+          </div>
+        </DirectionProvider>
+      }
+      controls={<>
+        <PlaygroundControl label="dir">
+          <Select value={dir()} onValueChange={(v: string) => setDir(v as Dir)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select direction..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ltr">ltr</SelectItem>
+              <SelectItem value="rtl">rtl</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsx('DirectionProvider', props(), 'Hello, World! مرحبا بالعالم')} />}
+    />
+  )
+}
+
+export { DirectionPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -82,7 +82,8 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'pagination', title: 'Pagination', description: 'Page navigation controls', category: 'navigation' },
   { slug: 'tabs', title: 'Tabs', description: 'Tabbed content navigation', category: 'navigation' },
 
-  // Layout (8)
+  // Layout (9)
+  { slug: 'direction', title: 'Direction', description: 'RTL/LTR direction provider', category: 'layout' },
   { slug: 'drawer', title: 'Drawer', description: 'Slide-out panel from screen edge', category: 'layout' },
   { slug: 'hover-card', title: 'Hover Card', description: 'Preview card on hover', category: 'layout' },
   { slug: 'popover', title: 'Popover', description: 'Floating content anchored to a trigger', category: 'layout' },

--- a/site/ui/e2e/direction.spec.ts
+++ b/site/ui/e2e/direction.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Direction Reference Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/direction')
+  })
+
+  test.describe('Basic', () => {
+    test('displays LTR and RTL sections', async ({ page }) => {
+      const section = page.locator('[bf-s^="DirectionBasicDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const ltrProvider = section.locator('[data-slot="direction-provider"][dir="ltr"]').first()
+      await expect(ltrProvider).toBeVisible()
+      await expect(ltrProvider).toHaveAttribute('dir', 'ltr')
+
+      const rtlProvider = section.locator('[data-slot="direction-provider"][dir="rtl"]').first()
+      await expect(rtlProvider).toBeVisible()
+      await expect(rtlProvider).toHaveAttribute('dir', 'rtl')
+    })
+
+    test('LTR section contains left-to-right text', async ({ page }) => {
+      const section = page.locator('[bf-s^="DirectionBasicDemo_"]:not([data-slot])').first()
+      const ltrProvider = section.locator('[data-slot="direction-provider"][dir="ltr"]').first()
+      await expect(ltrProvider.locator('text=Left-to-Right')).toBeVisible()
+    })
+
+    test('RTL section contains right-to-left text', async ({ page }) => {
+      const section = page.locator('[bf-s^="DirectionBasicDemo_"]:not([data-slot])').first()
+      const rtlProvider = section.locator('[data-slot="direction-provider"][dir="rtl"]').first()
+      await expect(rtlProvider.locator('text=Right-to-Left')).toBeVisible()
+    })
+  })
+
+  test.describe('Nested', () => {
+    test('displays nested direction providers', async ({ page }) => {
+      const section = page.locator('[bf-s^="DirectionNestedDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      // Outer RTL provider
+      const outerRtl = section.locator('[data-slot="direction-provider"][dir="rtl"]').first()
+      await expect(outerRtl).toBeVisible()
+
+      // Inner LTR provider nested inside RTL
+      const innerLtr = outerRtl.locator('[data-slot="direction-provider"][dir="ltr"]').first()
+      await expect(innerLtr).toBeVisible()
+      await expect(innerLtr.locator('text=Nested LTR content')).toBeVisible()
+    })
+  })
+
+  test.describe('Form', () => {
+    test('displays RTL form with Arabic labels', async ({ page }) => {
+      const section = page.locator('[bf-s^="DirectionFormDemo_"]:not([data-slot])').first()
+      await expect(section).toBeVisible()
+
+      const rtlProvider = section.locator('[data-slot="direction-provider"][dir="rtl"]').first()
+      await expect(rtlProvider).toBeVisible()
+
+      // Check form inputs exist
+      const inputs = rtlProvider.locator('input')
+      await expect(inputs).toHaveCount(2)
+    })
+  })
+})

--- a/site/ui/pages/components/direction.tsx
+++ b/site/ui/pages/components/direction.tsx
@@ -1,0 +1,173 @@
+/**
+ * Direction Reference Page (/components/direction)
+ *
+ * RTL/LTR direction provider reference with interactive Props Playground.
+ */
+
+import { DirectionProvider } from '@/components/ui/direction'
+import { DirectionPlayground } from '@/components/direction-playground'
+import { DirectionBasicDemo, DirectionNestedDemo, DirectionFormDemo } from '@/components/direction-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'basic', title: 'Basic', branch: 'start' },
+  { id: 'nested', title: 'Nested', branch: 'child' },
+  { id: 'form', title: 'Form', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import { DirectionProvider } from "@/components/ui/direction"
+
+function DirectionDemo() {
+  return (
+    <DirectionProvider dir="rtl">
+      <p>This content will be right-to-left.</p>
+    </DirectionProvider>
+  )
+}`
+
+const basicCode = `import { DirectionProvider } from "@/components/ui/direction"
+
+function BasicExample() {
+  return (
+    <div className="flex flex-col gap-4">
+      <DirectionProvider dir="ltr">
+        <div className="rounded-md border p-4">
+          <p>Left-to-Right (LTR)</p>
+          <p>This text flows from left to right.</p>
+        </div>
+      </DirectionProvider>
+      <DirectionProvider dir="rtl">
+        <div className="rounded-md border p-4">
+          <p>Right-to-Left (RTL)</p>
+          <p>هذا النص يتدفق من اليمين إلى اليسار.</p>
+        </div>
+      </DirectionProvider>
+    </div>
+  )
+}`
+
+const nestedCode = `import { DirectionProvider } from "@/components/ui/direction"
+
+function NestedExample() {
+  return (
+    <DirectionProvider dir="rtl">
+      <div className="rounded-md border p-4">
+        <p>محتوى RTL خارجي</p>
+        <DirectionProvider dir="ltr">
+          <div className="rounded-md border p-3">
+            <p>Nested LTR content</p>
+          </div>
+        </DirectionProvider>
+      </div>
+    </DirectionProvider>
+  )
+}`
+
+const formCode = `import { DirectionProvider } from "@/components/ui/direction"
+
+function FormExample() {
+  return (
+    <DirectionProvider dir="rtl">
+      <div className="rounded-md border p-4 space-y-3">
+        <h4>نموذج تسجيل</h4>
+        <div className="grid gap-1.5">
+          <label>الاسم</label>
+          <input type="text" placeholder="أدخل اسمك" />
+        </div>
+        <div className="grid gap-1.5">
+          <label>البريد الإلكتروني</label>
+          <input type="email" placeholder="أدخل بريدك الإلكتروني" />
+        </div>
+      </div>
+    </DirectionProvider>
+  )
+}`
+
+const directionProviderProps: PropDefinition[] = [
+  {
+    name: 'dir',
+    type: '"ltr" | "rtl"',
+    defaultValue: '"ltr"',
+    description: 'The text direction for child content.',
+  },
+  {
+    name: 'className',
+    type: 'string',
+    description: 'Additional CSS class names.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Content to render within the direction context.',
+  },
+]
+
+export function DirectionRefPage() {
+  return (
+    <DocPage slug="direction" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Direction"
+          description="A provider for setting text direction (LTR/RTL) on child content."
+          {...getNavLinks('direction')}
+        />
+
+        {/* Props Playground */}
+        <DirectionPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add direction" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <DirectionProvider dir="rtl">
+              <div className="rounded-md border border-border p-4">
+                <p className="text-sm">This content will be right-to-left.</p>
+              </div>
+            </DirectionProvider>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Basic" code={basicCode}>
+              <DirectionBasicDemo />
+            </Example>
+
+            <Example title="Nested" code={nestedCode}>
+              <DirectionNestedDemo />
+            </Example>
+
+            <Example title="Form" code={formCode}>
+              <DirectionFormDemo />
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <PropsTable props={directionProviderProps} />
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -51,6 +51,7 @@ import { PortalRefPage } from './pages/components/portal'
 import { PaginationRefPage } from './pages/components/pagination'
 import { PopoverRefPage } from './pages/components/popover'
 import { ProgressRefPage } from './pages/components/progress'
+import { DirectionRefPage } from './pages/components/direction'
 import { DrawerRefPage } from './pages/components/drawer'
 import { SheetRefPage } from './pages/components/sheet'
 import { SidebarRefPage } from './pages/components/sidebar'
@@ -351,6 +352,11 @@ export function createApp() {
   // Scroll Area reference page (redesigned #515)
   app.get('/components/scroll-area', (c) => {
     return c.render(<ScrollAreaRefPage />)
+  })
+
+  // Direction reference page
+  app.get('/components/direction', (c) => {
+    return c.render(<DirectionRefPage />)
   })
 
   // Drawer reference page (migrated from /docs/components/drawer)

--- a/ui/components/ui/direction/index.test.tsx
+++ b/ui/components/ui/direction/index.test.tsx
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const directionSource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('DirectionProvider', () => {
+  const result = renderToTest(directionSource, 'direction.tsx', 'DirectionProvider')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is DirectionProvider', () => {
+    expect(result.componentName).toBe('DirectionProvider')
+  })
+
+  test('isClient is false (no "use client" directive)', () => {
+    expect(result.isClient).toBe(false)
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as <div>', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div).not.toBeNull()
+  })
+
+  test('has data-slot=direction-provider', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['data-slot']).toBe('direction-provider')
+  })
+
+  test('has dir attribute', () => {
+    const div = result.find({ tag: 'div' })
+    expect(div!.props['dir']).toBeDefined()
+  })
+})

--- a/ui/components/ui/direction/index.tsx
+++ b/ui/components/ui/direction/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * Direction Component
+ *
+ * A provider that sets the text direction (LTR/RTL) for its children.
+ * Uses the native HTML `dir` attribute for proper bidirectional text support.
+ *
+ * @example Basic usage
+ * ```tsx
+ * <DirectionProvider dir="rtl">
+ *   <p>This text will be right-to-left</p>
+ * </DirectionProvider>
+ * ```
+ *
+ * @example Nested directions
+ * ```tsx
+ * <DirectionProvider dir="rtl">
+ *   <p>RTL content</p>
+ *   <DirectionProvider dir="ltr">
+ *     <p>LTR content inside RTL</p>
+ *   </DirectionProvider>
+ * </DirectionProvider>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+
+type Direction = 'ltr' | 'rtl'
+
+/**
+ * Props for the DirectionProvider component.
+ */
+interface DirectionProviderProps extends HTMLBaseAttributes {
+  /**
+   * The text direction for child content.
+   * @default 'ltr'
+   */
+  dir?: Direction
+  /**
+   * Additional CSS class names.
+   */
+  className?: string
+  /**
+   * Content to render within the direction context.
+   */
+  children?: Child
+}
+
+/**
+ * Provides text direction context to child elements via the HTML `dir` attribute.
+ * Wraps children in a `<div>` with the specified direction.
+ */
+function DirectionProvider({
+  dir = 'ltr',
+  className = '',
+  children,
+  ...props
+}: DirectionProviderProps) {
+  return (
+    <div
+      data-slot="direction-provider"
+      dir={dir}
+      className={className}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { DirectionProvider }
+export type { DirectionProviderProps, Direction }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -324,6 +324,13 @@
       "tags": ["feedback"]
     },
     {
+      "name": "direction",
+      "type": "registry:ui",
+      "title": "Direction",
+      "description": "A provider for setting text direction (LTR/RTL) on child content",
+      "tags": ["layout"]
+    },
+    {
       "name": "dropdown-menu",
       "type": "registry:ui",
       "title": "Dropdown Menu",


### PR DESCRIPTION
## Summary
- Add `DirectionProvider` component that wraps children with the native HTML `dir` attribute for LTR/RTL text direction support
- Include interactive playground, demos (basic, nested, RTL form), reference page, and E2E tests
- Register component in `ui/registry.json`, `component-registry.ts`, sidebar navigation, and routes

Closes #677
See also #125

## Test plan
- [x] Component IR tests pass (`bun test ui/components/ui/direction/index.test.tsx` — 7 tests)
- [x] Full build succeeds (`bun run build`)
- [x] E2E tests pass (`bun run test:e2e -- --grep Direction` — 5 tests)
- [ ] Visual review: navigate to `/components/direction` and verify LTR/RTL rendering
- [ ] Playground: toggle dir between ltr/rtl and verify live preview updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)