### PR TITLE
Add Item component

### DIFF
--- a/site/ui/components/item-demo.tsx
+++ b/site/ui/components/item-demo.tsx
@@ -1,0 +1,188 @@
+"use client"
+/**
+ * ItemDemo Components
+ *
+ * Interactive demos for Item component.
+ * Shows realistic list layouts with composable sub-components.
+ */
+
+import { createSignal } from '@barefootjs/dom'
+import { Item, ItemGroup, ItemSeparator, ItemContent, ItemTitle, ItemDescription, ItemMedia, ItemActions } from '@ui/components/ui/item'
+import { Button } from '@ui/components/ui/button'
+import { Badge } from '@ui/components/ui/badge'
+
+/**
+ * Basic item list — notification feed
+ */
+export function ItemBasicDemo() {
+  return (
+    <ItemGroup>
+      <Item>
+        <ItemMedia variant="icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>New comment on your post</ItemTitle>
+          <ItemDescription>Alice replied to your discussion thread about the new design system.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <ItemSeparator />
+      <Item>
+        <ItemMedia variant="icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Team invitation</ItemTitle>
+          <ItemDescription>You have been invited to join the Engineering team.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <ItemSeparator />
+      <Item>
+        <ItemMedia variant="icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Task completed</ItemTitle>
+          <ItemDescription>Your deployment to production was successful.</ItemDescription>
+        </ItemContent>
+      </Item>
+    </ItemGroup>
+  )
+}
+
+/**
+ * Variants demo — shows all item visual variants
+ */
+export function ItemVariantsDemo() {
+  return (
+    <div className="space-y-4">
+      <Item variant="default">
+        <ItemContent>
+          <ItemTitle>Default variant</ItemTitle>
+          <ItemDescription>Transparent background, no border.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>Outline variant</ItemTitle>
+          <ItemDescription>Visible border for visual separation.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <Item variant="muted">
+        <ItemContent>
+          <ItemTitle>Muted variant</ItemTitle>
+          <ItemDescription>Subtle background for grouped sections.</ItemDescription>
+        </ItemContent>
+      </Item>
+    </div>
+  )
+}
+
+/**
+ * Settings list — realistic scenario with actions
+ */
+export function ItemSettingsDemo() {
+  const [notificationsEnabled, setNotificationsEnabled] = createSignal(true)
+  const [darkMode, setDarkMode] = createSignal(false)
+
+  return (
+    <ItemGroup>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>Notifications</ItemTitle>
+          <ItemDescription>Receive push notifications for new messages.</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button
+            variant={notificationsEnabled() ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setNotificationsEnabled(v => !v)}
+          >
+            {notificationsEnabled() ? 'On' : 'Off'}
+          </Button>
+        </ItemActions>
+      </Item>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>Dark Mode</ItemTitle>
+          <ItemDescription>Switch between light and dark theme.</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button
+            variant={darkMode() ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setDarkMode(v => !v)}
+          >
+            {darkMode() ? 'On' : 'Off'}
+          </Button>
+        </ItemActions>
+      </Item>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>Language</ItemTitle>
+          <ItemDescription>Choose your preferred language.</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Badge variant="secondary">English</Badge>
+        </ItemActions>
+      </Item>
+    </ItemGroup>
+  )
+}
+
+/**
+ * Team members list — with media images and actions
+ */
+export function ItemTeamDemo() {
+  return (
+    <ItemGroup>
+      <Item size="sm">
+        <ItemMedia variant="image">
+          <img src="https://api.dicebear.com/9.x/initials/svg?seed=AS" alt="Alice Smith" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>
+            Alice Smith
+            <Badge variant="secondary">Admin</Badge>
+          </ItemTitle>
+          <ItemDescription>alice@example.com</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button variant="ghost" size="sm">Edit</Button>
+        </ItemActions>
+      </Item>
+      <ItemSeparator />
+      <Item size="sm">
+        <ItemMedia variant="image">
+          <img src="https://api.dicebear.com/9.x/initials/svg?seed=BJ" alt="Bob Johnson" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>
+            Bob Johnson
+            <Badge variant="outline">Member</Badge>
+          </ItemTitle>
+          <ItemDescription>bob@example.com</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button variant="ghost" size="sm">Edit</Button>
+        </ItemActions>
+      </Item>
+      <ItemSeparator />
+      <Item size="sm">
+        <ItemMedia variant="image">
+          <img src="https://api.dicebear.com/9.x/initials/svg?seed=CW" alt="Carol Williams" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>
+            Carol Williams
+            <Badge variant="outline">Member</Badge>
+          </ItemTitle>
+          <ItemDescription>carol@example.com</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button variant="ghost" size="sm">Edit</Button>
+        </ItemActions>
+      </Item>
+    </ItemGroup>
+  )
+}

--- a/site/ui/components/item-playground.tsx
+++ b/site/ui/components/item-playground.tsx
@@ -1,0 +1,80 @@
+"use client"
+/**
+ * Item Props Playground
+ *
+ * Interactive playground for the Item component.
+ * Allows tweaking variant, size, and media variant props with live preview.
+ */
+
+import { createSignal, createEffect } from '@barefootjs/dom'
+import { CopyButton } from './copy-button'
+import { highlightJsx, plainJsx, type HighlightProp } from './shared/playground-highlight'
+import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Item, ItemContent, ItemTitle, ItemDescription, ItemMedia } from '@ui/components/ui/item'
+
+type ItemVariant = 'default' | 'outline' | 'muted'
+type ItemSize = 'default' | 'sm'
+
+function ItemPlayground(_props: {}) {
+  const [variant, setVariant] = createSignal<ItemVariant>('default')
+  const [size, setSize] = createSignal<ItemSize>('default')
+
+  const props = (): HighlightProp[] => [
+    { name: 'variant', value: variant(), defaultValue: 'default' },
+    { name: 'size', value: size(), defaultValue: 'default' },
+  ]
+
+  createEffect(() => {
+    const p = props()
+    const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
+    if (codeEl) codeEl.innerHTML = highlightJsx('Item', p, '...')
+  })
+
+  return (
+    <PlaygroundLayout
+      previewDataAttr="data-item-preview"
+      previewContent={
+        <div className="w-full max-w-md">
+          <Item variant={variant()} size={size()}>
+            <ItemMedia variant="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Notification</ItemTitle>
+              <ItemDescription>You have a new message from the team.</ItemDescription>
+            </ItemContent>
+          </Item>
+        </div>
+      }
+      controls={<>
+        <PlaygroundControl label="variant">
+          <Select value={variant()} onValueChange={(v: string) => setVariant(v as ItemVariant)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select variant..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="outline">outline</SelectItem>
+              <SelectItem value="muted">muted</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+        <PlaygroundControl label="size">
+          <Select value={size()} onValueChange={(v: string) => setSize(v as ItemSize)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select size..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">default</SelectItem>
+              <SelectItem value="sm">sm</SelectItem>
+            </SelectContent>
+          </Select>
+        </PlaygroundControl>
+      </>}
+      copyButton={<CopyButton code={plainJsx('Item', props(), '...')} />}
+    />
+  )
+}
+
+export { ItemPlayground }

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -62,6 +62,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'carousel', title: 'Carousel', description: 'Motion and swipe content slider', category: 'display' },
   { slug: 'kbd', title: 'Kbd', description: 'Keyboard key display for shortcuts', category: 'display' },
   { slug: 'data-table', title: 'Data Table', description: 'Sortable, filterable data table', category: 'display' },
+  { slug: 'item', title: 'Item', description: 'Generic list/menu item with sub-components', category: 'display' },
   { slug: 'separator', title: 'Separator', description: 'Visual divider between content', category: 'display' },
   { slug: 'skeleton', title: 'Skeleton', description: 'Placeholder loading indicator', category: 'display' },
   { slug: 'table', title: 'Table', description: 'Responsive data table', category: 'display' },

--- a/site/ui/e2e/item.spec.ts
+++ b/site/ui/e2e/item.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Item Documentation Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/item')
+  })
+
+  test.describe('Settings List Demo', () => {
+    // Scope to the ItemGroup inside the settings-list example
+    const settingsSelector = ':below(#settings-list) [data-slot="item-group"]'
+
+    test('renders notification toggle button', async ({ page }) => {
+      const group = page.locator(settingsSelector).first()
+      const button = group.locator('button:has-text("On")').first()
+      await expect(button).toBeVisible()
+    })
+
+    test('clicking toggle switches notification state', async ({ page }) => {
+      const group = page.locator(settingsSelector).first()
+      const notifItem = group.locator('[data-slot="item"]').first()
+      const button = notifItem.locator('button')
+
+      // Initially "On"
+      await expect(button).toHaveText('On')
+
+      // Click to turn off
+      await button.click()
+      await expect(button).toHaveText('Off')
+
+      // Click to turn back on
+      await button.click()
+      await expect(button).toHaveText('On')
+    })
+
+    test('dark mode toggle works independently', async ({ page }) => {
+      const group = page.locator(settingsSelector).first()
+      const darkModeItem = group.locator('[data-slot="item"]').nth(1)
+      const darkModeButton = darkModeItem.locator('button')
+
+      // Dark Mode button starts as "Off"
+      await expect(darkModeButton).toHaveText('Off')
+
+      // Click to turn on
+      await darkModeButton.click()
+      await expect(darkModeButton).toHaveText('On')
+    })
+  })
+
+  test.describe('Item Structure', () => {
+    test('item group has data-slot attribute', async ({ page }) => {
+      const itemGroup = page.locator('[data-slot="item-group"]').first()
+      await expect(itemGroup).toBeVisible()
+    })
+
+    test('items have data-slot and data-variant attributes', async ({ page }) => {
+      const item = page.locator('[data-slot="item"]').first()
+      await expect(item).toBeVisible()
+      await expect(item).toHaveAttribute('data-variant')
+    })
+
+    test('item title renders correctly', async ({ page }) => {
+      const title = page.locator('[data-slot="item-title"]').first()
+      await expect(title).toBeVisible()
+    })
+
+    test('item description renders correctly', async ({ page }) => {
+      const description = page.locator('[data-slot="item-description"]').first()
+      await expect(description).toBeVisible()
+    })
+  })
+
+  test.describe('Playground', () => {
+    test('variant selector changes item style', async ({ page }) => {
+      const playground = page.locator('[data-item-preview]')
+      const previewItem = playground.locator('[data-slot="item"]')
+
+      // Default variant
+      await expect(previewItem).toHaveAttribute('data-variant', 'default')
+
+      // Open variant selector (first select trigger in the playground panel)
+      const controls = playground.locator('..').locator('..').locator('[data-slot="select-trigger"]').first()
+      await controls.click()
+
+      // Select outline variant
+      await page.locator('[data-slot="select-item"]:has-text("outline")').click()
+
+      // Verify item has outline variant
+      await expect(previewItem).toHaveAttribute('data-variant', 'outline')
+    })
+  })
+})

--- a/site/ui/pages/components/item.tsx
+++ b/site/ui/pages/components/item.tsx
@@ -1,0 +1,275 @@
+/**
+ * Item Reference Page (/components/item)
+ *
+ * Focused developer reference with interactive Props Playground.
+ */
+
+import { Item, ItemGroup, ItemSeparator, ItemContent, ItemTitle, ItemDescription, ItemMedia, ItemActions } from '@/components/ui/item'
+import { ItemPlayground } from '@/components/item-playground'
+import { ItemSettingsDemo } from '@/components/item-demo'
+import { Button } from '@/components/ui/button'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'variants', title: 'Variants', branch: 'start' },
+  { id: 'sizes', title: 'Sizes', branch: 'child' },
+  { id: 'with-media', title: 'With Media', branch: 'child' },
+  { id: 'with-actions', title: 'With Actions', branch: 'child' },
+  { id: 'settings-list', title: 'Settings List', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `import {
+  Item, ItemGroup, ItemSeparator,
+  ItemContent, ItemTitle, ItemDescription,
+  ItemMedia, ItemActions,
+} from "@/components/ui/item"
+
+function NotificationList() {
+  return (
+    <ItemGroup>
+      <Item>
+        <ItemContent>
+          <ItemTitle>New comment</ItemTitle>
+          <ItemDescription>Alice replied to your post.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <ItemSeparator />
+      <Item>
+        <ItemContent>
+          <ItemTitle>Team update</ItemTitle>
+          <ItemDescription>Sprint review notes available.</ItemDescription>
+        </ItemContent>
+      </Item>
+    </ItemGroup>
+  )
+}`
+
+const variantsCode = `<Item variant="default">...</Item>
+<Item variant="outline">...</Item>
+<Item variant="muted">...</Item>`
+
+const sizesCode = `<Item size="default">...</Item>
+<Item size="sm">...</Item>`
+
+const mediaCode = `<Item>
+  <ItemMedia variant="icon">
+    <BellIcon />
+  </ItemMedia>
+  <ItemContent>
+    <ItemTitle>With icon media</ItemTitle>
+    <ItemDescription>Icon container with border.</ItemDescription>
+  </ItemContent>
+</Item>
+<Item>
+  <ItemMedia variant="image">
+    <img src="..." alt="Avatar" />
+  </ItemMedia>
+  <ItemContent>
+    <ItemTitle>With image media</ItemTitle>
+    <ItemDescription>Image container with cover fit.</ItemDescription>
+  </ItemContent>
+</Item>`
+
+const actionsCode = `<Item variant="outline">
+  <ItemContent>
+    <ItemTitle>Notifications</ItemTitle>
+    <ItemDescription>Receive push notifications.</ItemDescription>
+  </ItemContent>
+  <ItemActions>
+    <Button size="sm">On</Button>
+  </ItemActions>
+</Item>`
+
+const itemProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: "'default' | 'outline' | 'muted'",
+    defaultValue: "'default'",
+    description: 'The visual style of the item.',
+  },
+  {
+    name: 'size',
+    type: "'default' | 'sm'",
+    defaultValue: "'default'",
+    description: 'The size of the item.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The content of the item (typically ItemMedia, ItemContent, ItemActions).',
+  },
+]
+
+const itemMediaProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: "'default' | 'icon' | 'image'",
+    defaultValue: "'default'",
+    description: 'The visual style of the media container.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'The media content (SVG icon or img element).',
+  },
+]
+
+export function ItemRefPage() {
+  return (
+    <DocPage slug="item" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Item"
+          description="A generic list/menu item component with composable sub-components for building notification feeds, settings lists, team rosters, and more."
+          {...getNavLinks('item')}
+        />
+
+        {/* Props Playground */}
+        <ItemPlayground />
+
+        {/* Installation */}
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add item" />
+        </Section>
+
+        {/* Usage */}
+        <Section id="usage" title="Usage">
+          <Example title="" code={usageCode}>
+            <ItemGroup>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>New comment</ItemTitle>
+                  <ItemDescription>Alice replied to your post.</ItemDescription>
+                </ItemContent>
+              </Item>
+              <ItemSeparator />
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Team update</ItemTitle>
+                  <ItemDescription>Sprint review notes available.</ItemDescription>
+                </ItemContent>
+              </Item>
+            </ItemGroup>
+          </Example>
+        </Section>
+
+        {/* Examples */}
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Example title="Variants" code={variantsCode} showLineNumbers={false}>
+              <div className="space-y-4 w-full max-w-md">
+                <Item variant="default">
+                  <ItemContent>
+                    <ItemTitle>Default</ItemTitle>
+                    <ItemDescription>Transparent background.</ItemDescription>
+                  </ItemContent>
+                </Item>
+                <Item variant="outline">
+                  <ItemContent>
+                    <ItemTitle>Outline</ItemTitle>
+                    <ItemDescription>Visible border.</ItemDescription>
+                  </ItemContent>
+                </Item>
+                <Item variant="muted">
+                  <ItemContent>
+                    <ItemTitle>Muted</ItemTitle>
+                    <ItemDescription>Subtle background.</ItemDescription>
+                  </ItemContent>
+                </Item>
+              </div>
+            </Example>
+
+            <Example title="Sizes" code={sizesCode} showLineNumbers={false}>
+              <div className="space-y-4 w-full max-w-md">
+                <Item variant="outline" size="default">
+                  <ItemContent>
+                    <ItemTitle>Default size</ItemTitle>
+                    <ItemDescription>Standard padding and gap.</ItemDescription>
+                  </ItemContent>
+                </Item>
+                <Item variant="outline" size="sm">
+                  <ItemContent>
+                    <ItemTitle>Small size</ItemTitle>
+                    <ItemDescription>Compact padding and gap.</ItemDescription>
+                  </ItemContent>
+                </Item>
+              </div>
+            </Example>
+
+            <Example title="With Media" code={mediaCode}>
+              <div className="space-y-4 w-full max-w-md">
+                <Item>
+                  <ItemMedia variant="icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>With icon media</ItemTitle>
+                    <ItemDescription>Icon container with border and muted background.</ItemDescription>
+                  </ItemContent>
+                </Item>
+                <Item>
+                  <ItemMedia variant="image">
+                    <img src="https://api.dicebear.com/9.x/initials/svg?seed=AS" alt="Avatar" />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>With image media</ItemTitle>
+                    <ItemDescription>Image container with cover fit.</ItemDescription>
+                  </ItemContent>
+                </Item>
+              </div>
+            </Example>
+
+            <Example title="With Actions" code={actionsCode}>
+              <div className="w-full max-w-md">
+                <Item variant="outline">
+                  <ItemContent>
+                    <ItemTitle>Notifications</ItemTitle>
+                    <ItemDescription>Receive push notifications.</ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Button size="sm">On</Button>
+                  </ItemActions>
+                </Item>
+              </div>
+            </Example>
+
+            <Example title="Settings List" code="">
+              <div className="w-full max-w-md">
+                <ItemSettingsDemo />
+              </div>
+            </Example>
+          </div>
+        </Section>
+
+        {/* API Reference */}
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-base font-semibold mb-3">Item</h3>
+              <PropsTable props={itemProps} />
+            </div>
+            <div>
+              <h3 className="text-base font-semibold mb-3">ItemMedia</h3>
+              <PropsTable props={itemMediaProps} />
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -18,6 +18,7 @@ import { ButtonGroupRefPage } from './pages/components/button-group'
 import { ComboboxRefPage } from './pages/components/combobox'
 import { InputRefPage } from './pages/components/input'
 import { InputGroupRefPage } from './pages/components/input-group'
+import { ItemRefPage } from './pages/components/item'
 import { LabelRefPage } from './pages/components/label'
 import { SelectRefPage } from './pages/components/select'
 import { TextareaRefPage } from './pages/components/textarea'
@@ -260,6 +261,11 @@ export function createApp() {
   // Native Select reference page
   app.get('/components/native-select', (c) => {
     return c.render(<NativeSelectRefPage />)
+  })
+
+  // Item reference page
+  app.get('/components/item', (c) => {
+    return c.render(<ItemRefPage />)
   })
 
   // Spinner reference page

--- a/ui/components/ui/item/index.test.tsx
+++ b/ui/components/ui/item/index.test.tsx
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const itemSource = readFileSync(resolve(__dirname, 'index.tsx'), 'utf-8')
+
+describe('Item', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'Item')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is Item', () => {
+    expect(result.componentName).toBe('Item')
+  })
+
+  test('no signals (stateless)', () => {
+    expect(result.signals).toEqual([])
+  })
+
+  test('renders as div with data-slot=item', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item')
+  })
+
+  test('has variant and size data attributes', () => {
+    expect(result.root.props['data-variant']).toBeDefined()
+    expect(result.root.props['data-size']).toBeDefined()
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-wrap')
+    expect(result.root.classes).toContain('items-center')
+    expect(result.root.classes).toContain('rounded-md')
+  })
+})
+
+describe('ItemGroup', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemGroup')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-group', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-group')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-col')
+  })
+})
+
+describe('ItemMedia', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemMedia')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-media', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-media')
+  })
+
+  test('has variant data attribute', () => {
+    expect(result.root.props['data-variant']).toBeDefined()
+  })
+})
+
+describe('ItemContent', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemContent')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-content', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-content')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('flex-1')
+    expect(result.root.classes).toContain('flex-col')
+  })
+})
+
+describe('ItemTitle', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemTitle')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-title', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-title')
+  })
+})
+
+describe('ItemDescription', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemDescription')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as p with data-slot=item-description', () => {
+    expect(result.root.tag).toBe('p')
+    expect(result.root.props['data-slot']).toBe('item-description')
+  })
+})
+
+describe('ItemActions', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemActions')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-actions', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-actions')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})
+
+describe('ItemHeader', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemHeader')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-header', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-header')
+  })
+})
+
+describe('ItemFooter', () => {
+  const result = renderToTest(itemSource, 'item.tsx', 'ItemFooter')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('renders as div with data-slot=item-footer', () => {
+    expect(result.root.tag).toBe('div')
+    expect(result.root.props['data-slot']).toBe('item-footer')
+  })
+
+  test('has resolved CSS classes', () => {
+    expect(result.root.classes).toContain('flex')
+    expect(result.root.classes).toContain('items-center')
+  })
+})

--- a/ui/components/ui/item/index.tsx
+++ b/ui/components/ui/item/index.tsx
@@ -1,0 +1,227 @@
+/**
+ * Item Components
+ *
+ * A generic list/menu item component with composable sub-components.
+ * Supports visual variants and sizes for flexible list layouts.
+ * Inspired by shadcn/ui with CSS variable theming support.
+ *
+ * @example Basic item with content
+ * ```tsx
+ * <Item>
+ *   <ItemContent>
+ *     <ItemTitle>Item Title</ItemTitle>
+ *     <ItemDescription>Item description here</ItemDescription>
+ *   </ItemContent>
+ * </Item>
+ * ```
+ *
+ * @example Item group with separator
+ * ```tsx
+ * <ItemGroup>
+ *   <Item>
+ *     <ItemContent>
+ *       <ItemTitle>First Item</ItemTitle>
+ *     </ItemContent>
+ *   </Item>
+ *   <ItemSeparator />
+ *   <Item>
+ *     <ItemContent>
+ *       <ItemTitle>Second Item</ItemTitle>
+ *     </ItemContent>
+ *   </Item>
+ * </ItemGroup>
+ * ```
+ */
+
+import type { HTMLBaseAttributes } from '@barefootjs/jsx'
+import type { Child } from '../../../types'
+import { Separator } from '../separator'
+
+// --- Variant types ---
+
+type ItemVariant = 'default' | 'outline' | 'muted'
+type ItemSize = 'default' | 'sm'
+type ItemMediaVariant = 'default' | 'icon' | 'image'
+
+// --- Item classes ---
+
+const itemBaseClasses = 'group/item flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+const itemVariantClasses: Record<ItemVariant, string> = {
+  default: 'bg-transparent',
+  outline: 'border-border',
+  muted: 'bg-muted/50',
+}
+
+const itemSizeClasses: Record<ItemSize, string> = {
+  default: 'gap-4 p-4',
+  sm: 'gap-2.5 px-4 py-3',
+}
+
+// --- ItemMedia classes ---
+
+const itemMediaBaseClasses = 'flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none'
+
+const itemMediaVariantClasses: Record<ItemMediaVariant, string> = {
+  default: 'bg-transparent',
+  icon: 'size-8 rounded-sm border bg-muted [&_svg:not([class*="size-"])]:size-4',
+  image: 'size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover',
+}
+
+// --- Sub-component classes ---
+
+const itemGroupClasses = 'group/item-group flex flex-col'
+const itemContentClasses = 'flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none'
+const itemTitleClasses = 'flex w-fit items-center gap-2 text-sm leading-snug font-medium'
+const itemDescriptionClasses = 'line-clamp-2 text-sm leading-normal font-normal text-balance text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary'
+const itemActionsClasses = 'flex items-center gap-2'
+const itemHeaderClasses = 'flex basis-full items-center justify-between gap-2'
+const itemFooterClasses = 'flex basis-full items-center justify-between gap-2'
+
+// --- Props ---
+
+interface ItemGroupProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemSeparatorProps extends HTMLBaseAttributes {
+  decorative?: boolean
+}
+
+interface ItemProps extends HTMLBaseAttributes {
+  /** Visual style of the item. */
+  variant?: ItemVariant
+  /** Size of the item. */
+  size?: ItemSize
+  children?: Child
+}
+
+interface ItemMediaProps extends HTMLBaseAttributes {
+  /** Visual style of the media container. */
+  variant?: ItemMediaVariant
+  children?: Child
+}
+
+interface ItemContentProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemTitleProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemDescriptionProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemActionsProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemHeaderProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+interface ItemFooterProps extends HTMLBaseAttributes {
+  children?: Child
+}
+
+// --- Components ---
+
+function ItemGroup({ children, className = '', ...props }: ItemGroupProps) {
+  return (
+    <div role="list" data-slot="item-group" className={`${itemGroupClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function ItemSeparator({ className = '', decorative = true, ...props }: ItemSeparatorProps) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      decorative={decorative}
+      className={`my-0 ${className}`}
+      {...props}
+    />
+  )
+}
+
+function Item({ children, className = '', variant = 'default', size = 'default', ...props }: ItemProps) {
+  return (
+    <div
+      data-slot="item"
+      data-variant={variant}
+      data-size={size}
+      className={`${itemBaseClasses} ${itemVariantClasses[variant]} ${itemSizeClasses[size]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+function ItemMedia({ children, className = '', variant = 'default', ...props }: ItemMediaProps) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={`${itemMediaBaseClasses} ${itemMediaVariantClasses[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+function ItemContent({ children, className = '', ...props }: ItemContentProps) {
+  return (
+    <div data-slot="item-content" className={`${itemContentClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function ItemTitle({ children, className = '', ...props }: ItemTitleProps) {
+  return (
+    <div data-slot="item-title" className={`${itemTitleClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function ItemDescription({ children, className = '', ...props }: ItemDescriptionProps) {
+  return (
+    <p data-slot="item-description" className={`${itemDescriptionClasses} ${className}`} {...props}>
+      {children}
+    </p>
+  )
+}
+
+function ItemActions({ children, className = '', ...props }: ItemActionsProps) {
+  return (
+    <div data-slot="item-actions" className={`${itemActionsClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function ItemHeader({ children, className = '', ...props }: ItemHeaderProps) {
+  return (
+    <div data-slot="item-header" className={`${itemHeaderClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+function ItemFooter({ children, className = '', ...props }: ItemFooterProps) {
+  return (
+    <div data-slot="item-footer" className={`${itemFooterClasses} ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export { Item, ItemMedia, ItemContent, ItemActions, ItemGroup, ItemSeparator, ItemTitle, ItemDescription, ItemHeader, ItemFooter }
+export type { ItemVariant, ItemSize, ItemMediaVariant, ItemProps, ItemMediaProps, ItemContentProps, ItemActionsProps, ItemGroupProps, ItemSeparatorProps, ItemTitleProps, ItemDescriptionProps, ItemHeaderProps, ItemFooterProps }

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -369,6 +369,14 @@
       "requires": ["input"]
     },
     {
+      "name": "item",
+      "type": "registry:ui",
+      "title": "Item",
+      "description": "A generic list/menu item component with composable sub-components",
+      "tags": ["display"],
+      "requires": ["separator"]
+    },
+    {
       "name": "kbd",
       "type": "registry:ui",
       "title": "Kbd",


### PR DESCRIPTION
## Summary
- Add generic list/menu item component ported from shadcn/ui with composable sub-components (Item, ItemGroup, ItemContent, ItemTitle, ItemDescription, ItemMedia, ItemActions, ItemHeader, ItemFooter, ItemSeparator)
- Support variant (default/outline/muted), size (default/sm), and media variant (default/icon/image) props
- Include demos (notification feed, variants, settings list, team members), interactive playground, RefPage with full documentation, and E2E tests

Closes #678
Ref #125

## Test plan
- [x] Component IR tests pass (`bun test ui/components/ui/item/index.test.tsx` — 27 tests)
- [x] Full build passes (`bun run build`)
- [x] All E2E tests pass (`bun run test:e2e` — 809 tests including 8 new item tests)
- [ ] Visual review of /components/item page
- [ ] Verify playground variant/size controls update preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)