### PR TITLE
Scope conditional text effects to branch lifecycle

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   createSignal,
   createEffect,
+  createDisposableEffect,
   createMemo,
   onCleanup,
   onMount,

--- a/packages/dom/src/insert.ts
+++ b/packages/dom/src/insert.ts
@@ -59,12 +59,17 @@ export function insert(
   try {
     const sampleTrue = whenTrue.template()
     isFragmentCond = sampleTrue.includes(`<!--bf-cond-start:${id}-->`)
-  } catch { /* template evaluation failed — not a fragment */ }
+  } catch (err) {
+    // Template may throw TypeError for nullable access (e.g., selectedMail().subject)
+    if (!(err instanceof TypeError)) throw err
+  }
   if (!isFragmentCond) {
     try {
       const sampleFalse = whenFalse.template()
       isFragmentCond = sampleFalse.includes(`<!--bf-cond-start:${id}-->`)
-    } catch { /* template evaluation failed — not a fragment */ }
+    } catch (err) {
+      if (!(err instanceof TypeError)) throw err
+    }
   }
 
   let prevCond: boolean | undefined
@@ -74,10 +79,15 @@ export function insert(
     let currCond: boolean
     try {
       currCond = Boolean(conditionFn())
-    } catch {
-      // Condition evaluation may throw if parent branch is inactive
-      // (e.g., selectedMail().read when selectedMail() is null)
-      currCond = false
+    } catch (err) {
+      // Condition evaluation may throw TypeError if parent branch is inactive
+      // (e.g., selectedMail().read when selectedMail() is null).
+      // Only swallow TypeErrors; rethrow unexpected errors to avoid hiding bugs.
+      if (err instanceof TypeError) {
+        currCond = false
+      } else {
+        throw err
+      }
     }
     const isFirstRun = prevCond === undefined
     const prevVal = prevCond

--- a/packages/dom/src/insert.ts
+++ b/packages/dom/src/insert.ts
@@ -19,11 +19,13 @@ export interface BranchConfig {
   template: () => string
 
   /**
-   * Bind events to elements within the branch.
+   * Bind events and reactive effects to elements within the branch.
    * Called both during hydration (for SSR elements) and after DOM swaps.
    * @param scope - The scope element to search within for event targets
+   * @returns Optional cleanup function, called when the branch is deactivated.
+   *          Used to dispose reactive effects scoped to this branch.
    */
-  bindEvents: (scope: Element) => void
+  bindEvents: (scope: Element) => (() => void) | void
 }
 
 
@@ -49,17 +51,34 @@ export function insert(
 ): void {
   if (!scope) return
 
-  // Check if either branch uses fragment conditional (comment markers)
-  // Both branches need to be checked because SSR may render either branch
-  const sampleTrue = whenTrue.template()
-  const sampleFalse = whenFalse.template()
-  const isFragmentCond = sampleTrue.includes(`<!--bf-cond-start:${id}-->`) ||
-                         sampleFalse.includes(`<!--bf-cond-start:${id}-->`)
+  // Check if either branch uses fragment conditional (comment markers).
+  // Both branches need to be checked because SSR may render either branch.
+  // Use try/catch because template evaluation may access nullable expressions
+  // (e.g., selectedMail().subject when the branch is for the non-null case).
+  let isFragmentCond = false
+  try {
+    const sampleTrue = whenTrue.template()
+    isFragmentCond = sampleTrue.includes(`<!--bf-cond-start:${id}-->`)
+  } catch { /* template evaluation failed — not a fragment */ }
+  if (!isFragmentCond) {
+    try {
+      const sampleFalse = whenFalse.template()
+      isFragmentCond = sampleFalse.includes(`<!--bf-cond-start:${id}-->`)
+    } catch { /* template evaluation failed — not a fragment */ }
+  }
 
   let prevCond: boolean | undefined
+  let branchCleanup: (() => void) | null = null
 
   createEffect(() => {
-    const currCond = Boolean(conditionFn())
+    let currCond: boolean
+    try {
+      currCond = Boolean(conditionFn())
+    } catch {
+      // Condition evaluation may throw if parent branch is inactive
+      // (e.g., selectedMail().read when selectedMail() is null)
+      currCond = false
+    }
     const isFirstRun = prevCond === undefined
     const prevVal = prevCond
     prevCond = currCond
@@ -94,7 +113,8 @@ export function insert(
       }
 
       // Bind events to the (possibly updated) SSR element
-      branch.bindEvents(scope)
+      const result = branch.bindEvents(scope)
+      branchCleanup = typeof result === 'function' ? result : null
 
       // Auto-focus on first run too (for components created via createComponent with editing=true)
       autoFocusConditionalElement(scope, id)
@@ -108,6 +128,12 @@ export function insert(
       return
     }
 
+    // Dispose previous branch's scoped effects before swapping DOM
+    if (branchCleanup) {
+      branchCleanup()
+      branchCleanup = null
+    }
+
     // Branch changed: swap DOM and bind events
     const html = branch.template()
     if (isFragmentCond) {
@@ -117,7 +143,8 @@ export function insert(
     }
 
     // Bind events to the newly inserted element
-    branch.bindEvents(scope)
+    const result = branch.bindEvents(scope)
+      branchCleanup = typeof result === 'function' ? result : null
 
     // Auto-focus elements with autofocus attribute (for dynamically created elements)
     autoFocusConditionalElement(scope, id)

--- a/packages/dom/src/reactive.ts
+++ b/packages/dom/src/reactive.ts
@@ -145,8 +145,13 @@ function runEffect(effect: EffectContext): void {
  * @returns A dispose function that stops the effect and removes it from all signal dependencies.
  */
 export function createDisposableEffect(fn: EffectFn): () => void {
+  let disposed = false
+
   const effect: EffectContext = {
-    fn,
+    fn: () => {
+      if (disposed) return  // Prevent re-activation after disposal
+      return fn()
+    },
     cleanup: null,
     dependencies: new Set(),
   }
@@ -154,6 +159,7 @@ export function createDisposableEffect(fn: EffectFn): () => void {
   runEffect(effect)
 
   return () => {
+    disposed = true
     if (effect.cleanup) {
       effect.cleanup()
       effect.cleanup = null

--- a/packages/dom/src/reactive.ts
+++ b/packages/dom/src/reactive.ts
@@ -139,6 +139,33 @@ function runEffect(effect: EffectContext): void {
 }
 
 /**
+ * Create an effect that can be explicitly disposed (unsubscribed from all signals).
+ * Used for effects inside conditional branches that need cleanup on branch switch.
+ *
+ * @returns A dispose function that stops the effect and removes it from all signal dependencies.
+ */
+export function createDisposableEffect(fn: EffectFn): () => void {
+  const effect: EffectContext = {
+    fn,
+    cleanup: null,
+    dependencies: new Set(),
+  }
+
+  runEffect(effect)
+
+  return () => {
+    if (effect.cleanup) {
+      effect.cleanup()
+      effect.cleanup = null
+    }
+    for (const dep of effect.dependencies) {
+      dep.delete(effect)
+    }
+    effect.dependencies.clear()
+  }
+}
+
+/**
  * Register cleanup function for effects
  *
  * @param fn - Cleanup function

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -340,12 +340,12 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // The expression should be evaluated unconditionally to maintain reactive
-      // subscriptions, but wrapped in try-catch to handle cases where the guard
-      // variable (e.g., prev) is undefined and property access would throw.
-      // Pattern: try { __val = prev.title } catch { return }
-      expect(content).toMatch(/try \{ __val = prev\.title \} catch \{ return \}/)
-      expect(content).toMatch(/if \(__el_\w+ && !__val\?\.__isSlot\) __el_\w+\.nodeValue = String\(__val \?\? ''\)/)
+      // Text effects inside conditional branches are emitted inside bindEvents
+      // using createDisposableEffect, not as top-level try-catch effects.
+      // This ensures they only run when the branch is active.
+      expect(content).toContain('createDisposableEffect')
+      expect(content).toContain('prev.title')
+      expect(content).toContain('bindEvents')
     })
 
     test('still defaults props with property access to {} when not used as conditional guard', () => {
@@ -2232,8 +2232,8 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // text() inside a component inside a conditional must use $t() runtime lookup
-      expect(content).toContain('$t(__scope')
+      // text() inside a component inside a conditional uses $t() in branch-scoped effect
+      expect(content).toContain('$t(__branchScope')
     })
 
     test('propagates insideConditional through fragment children', () => {
@@ -2263,8 +2263,8 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // text() inside a fragment inside a conditional must use $t() runtime lookup
-      expect(content).toContain('$t(__scope')
+      // text() inside a fragment inside a conditional uses $t() in branch-scoped effect
+      expect(content).toContain('$t(__branchScope')
     })
   })
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -166,7 +166,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         })
       }
       // Recurse into conditional branches with insideConditional = true
-      // This is still needed for dynamic text elements inside conditionals
+      // to collect nested conditionals, events, refs, child components, and reactive attrs
       collectElements(node.whenTrue, ctx, true)
       collectElements(node.whenFalse, ctx, true)
       break

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,7 +3,7 @@
  */
 
 import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, LoopChildEvent, LoopChildReactiveAttr } from './types'
+import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopChildReactiveAttr } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildReactiveAttrs } from './reactivity'
 import { irToHtmlTemplate, irChildrenToJsExpr } from './html-template'
@@ -105,11 +105,13 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           slotId: node.slotId,
           expression: node.expr,
         })
-      } else if (node.reactive && node.slotId) {
+      } else if (node.reactive && node.slotId && !insideConditional) {
+        // Only collect as top-level dynamic element if NOT inside a conditional.
+        // Conditional text effects are collected per-branch and emitted inside bindEvents.
         ctx.dynamicElements.push({
           slotId: node.slotId,
           expression: node.expr,
-          insideConditional,
+          insideConditional: false,
         })
       }
       break
@@ -134,6 +136,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseRefs,
           whenTrueChildComponents,
           whenFalseChildComponents,
+          whenTrueTextEffects: collectBranchTextEffects(node.whenTrue),
+          whenFalseTextEffects: collectBranchTextEffects(node.whenFalse),
         })
       } else if (node.reactive && node.slotId) {
         const whenTrueEvents = collectConditionalBranchEvents(node.whenTrue)
@@ -142,6 +146,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         const whenFalseRefs = collectConditionalBranchRefs(node.whenFalse)
         const whenTrueChildComponents = buildBranchChildComponents(collectConditionalBranchChildComponents(node.whenTrue), ctx)
         const whenFalseChildComponents = buildBranchChildComponents(collectConditionalBranchChildComponents(node.whenFalse), ctx)
+        const whenTrueTextEffects = collectBranchTextEffects(node.whenTrue)
+        const whenFalseTextEffects = collectBranchTextEffects(node.whenFalse)
 
         const restNames = buildRestSpreadNames(ctx)
         ctx.conditionalElements.push({
@@ -155,6 +161,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseRefs,
           whenTrueChildComponents,
           whenFalseChildComponents,
+          whenTrueTextEffects,
+          whenFalseTextEffects,
         })
       }
       // Recurse into conditional branches with insideConditional = true
@@ -411,4 +419,41 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
       }
     }
   }
+}
+
+/**
+ * Collect reactive text expressions from a conditional branch IR subtree.
+ * Walks the branch tree to find expression nodes that need createEffect updates.
+ * Does NOT recurse into nested conditionals (they get their own insert() call).
+ */
+function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
+  const effects: ConditionalBranchTextEffect[] = []
+  function walk(n: IRNode): void {
+    switch (n.type) {
+      case 'expression':
+        if (n.reactive && n.slotId && !n.clientOnly) {
+          effects.push({ slotId: n.slotId, expression: n.expr })
+        }
+        break
+      case 'element':
+        for (const child of n.children) walk(child)
+        break
+      case 'component':
+        for (const child of n.children) walk(child)
+        break
+      case 'fragment':
+        for (const child of n.children) walk(child)
+        break
+      // Do NOT recurse into nested conditionals — they have their own insert()
+      case 'conditional':
+        break
+      case 'if-statement':
+        break
+      case 'provider':
+        for (const child of n.children) walk(child)
+        break
+    }
+  }
+  walk(node)
+  return effects
 }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -401,13 +401,14 @@ function emitBranchBindings(
 
   // Emit disposable text effects scoped to this branch.
   // These only run while the branch is active and are disposed on branch switch.
+  // Text node is resolved once (stable while branch is active) and closed over.
   if (textEffects.length > 0) {
     lines.push(`      const __disposers = []`)
     for (const te of textEffects) {
       const v = varSlotId(te.slotId)
+      lines.push(`      const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
       lines.push(`      __disposers.push(createDisposableEffect(() => {`)
       lines.push(`        const __val = ${te.expression}`)
-      lines.push(`        const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
       lines.push(`        if (__el_${v} && !__val?.__isSlot) __el_${v}.nodeValue = String(__val ?? '')`)
       lines.push(`      }))`)
     }

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -6,7 +6,7 @@
 import type { AttrMeta, ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
-import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, LoopChildEvent } from './types'
+import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent } from './types'
 import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId, PROPS_PARAM } from './utils'
 import { addCondAttrToTemplate, canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, irChildrenToJsExpr, createStringProtector } from './html-template'
 
@@ -355,7 +355,8 @@ function emitBranchBindings(
   events: ConditionalBranchEvent[],
   refs: ConditionalBranchRef[],
   childComponents: ConditionalBranchChildComponent[],
-  eventNameFn: (eventName: string) => string
+  eventNameFn: (eventName: string) => string,
+  textEffects: ConditionalBranchTextEffect[] = []
 ): void {
   const allSlotIds = new Set<string>()
   for (const event of events) allSlotIds.add(event.slotId)
@@ -397,6 +398,21 @@ function emitBranchBindings(
     lines.push(`      const [${varName}] = $c(__branchScope, '${selectorArg}')`)
     lines.push(`      if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
   }
+
+  // Emit disposable text effects scoped to this branch.
+  // These only run while the branch is active and are disposed on branch switch.
+  if (textEffects.length > 0) {
+    lines.push(`      const __disposers = []`)
+    for (const te of textEffects) {
+      const v = varSlotId(te.slotId)
+      lines.push(`      __disposers.push(createDisposableEffect(() => {`)
+      lines.push(`        const __val = ${te.expression}`)
+      lines.push(`        const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
+      lines.push(`        if (__el_${v} && !__val?.__isSlot) __el_${v}.nodeValue = String(__val ?? '')`)
+      lines.push(`      }))`)
+    }
+    lines.push(`      return () => __disposers.forEach(d => d())`)
+  }
 }
 
 /** Emit insert() calls for server-rendered reactive conditionals with branch configs. */
@@ -408,12 +424,12 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, toDomEventName)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, toDomEventName, elem.whenTrueTextEffects)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, toDomEventName)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, toDomEventName, elem.whenFalseTextEffects)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')
@@ -431,12 +447,12 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, rawEventName)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, rawEventName, elem.whenTrueTextEffects)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, rawEventName)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, rawEventName, elem.whenFalseTextEffects)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -7,7 +7,7 @@ import type { ComponentIR, IRNode } from '../types'
 // All exports from @barefootjs/dom that may be used in generated code
 export const DOM_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
-  'hydrate', 'insert', 'reconcileElements', 'reconcileTemplates',
+  'hydrate', 'insert', 'reconcileElements', 'reconcileTemplates', 'createDisposableEffect',
   'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker',
   'createPortal',
   'provideContext', 'createContext', 'useContext',

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -95,6 +95,11 @@ export interface ConditionalBranchChildComponent {
   propsExpr: string
 }
 
+export interface ConditionalBranchTextEffect {
+  slotId: string
+  expression: string
+}
+
 export interface ConditionalElement {
   slotId: string
   condition: string
@@ -106,6 +111,8 @@ export interface ConditionalElement {
   whenFalseRefs: ConditionalBranchRef[]
   whenTrueChildComponents: ConditionalBranchChildComponent[]
   whenFalseChildComponents: ConditionalBranchChildComponent[]
+  whenTrueTextEffects: ConditionalBranchTextEffect[]
+  whenFalseTextEffects: ConditionalBranchTextEffect[]
 }
 
 export interface LoopChildEvent {
@@ -179,6 +186,8 @@ export interface ClientOnlyConditional {
   whenFalseRefs: ConditionalBranchRef[]
   whenTrueChildComponents: ConditionalBranchChildComponent[]
   whenFalseChildComponents: ConditionalBranchChildComponent[]
+  whenTrueTextEffects: ConditionalBranchTextEffect[]
+  whenFalseTextEffects: ConditionalBranchTextEffect[]
 }
 
 export interface RestAttrElement {

--- a/site/ui/components/mail-demo.tsx
+++ b/site/ui/components/mail-demo.tsx
@@ -163,14 +163,6 @@ export function MailInboxDemo() {
     mails().find((m) => m.id === selectedId())
   )
 
-  // Derived properties with safe defaults — avoids null access in conditional templates
-  const detailSubject = createMemo(() => selectedMail()?.subject ?? '')
-  const detailFrom = createMemo(() => selectedMail()?.from ?? '')
-  const detailDate = createMemo(() => selectedMail()?.date ?? '')
-  const detailBody = createMemo(() => selectedMail()?.body ?? '')
-  const detailRead = createMemo(() => selectedMail()?.read ?? false)
-  const detailId = createMemo(() => selectedMail()?.id ?? 0)
-
   const selectedCount = createMemo(() =>
     mails().filter((m) => m.selected).length
   )
@@ -323,9 +315,9 @@ export function MailInboxDemo() {
                 <div className="mail-detail p-4 space-y-4">
                   <div className="flex items-start justify-between">
                     <div>
-                      <h3 className="mail-detail-subject text-lg font-semibold">{detailSubject()}</h3>
-                      <p className="mail-detail-from text-sm text-muted-foreground">From: {detailFrom()}</p>
-                      <p className="text-xs text-muted-foreground">{detailDate()}</p>
+                      <h3 className="mail-detail-subject text-lg font-semibold">{selectedMail().subject}</h3>
+                      <p className="mail-detail-from text-sm text-muted-foreground">From: {selectedMail().from}</p>
+                      <p className="text-xs text-muted-foreground">{selectedMail().date}</p>
                     </div>
                     <div className="flex gap-2">
                       <Button
@@ -333,12 +325,12 @@ export function MailInboxDemo() {
                         size="sm"
                         onClick={handleToggleRead}
                       >
-                        <span className="read-toggle-text">{detailRead() ? 'Mark unread' : 'Mark read'}</span>
+                        <span className="read-toggle-text">{selectedMail().read ? 'Mark unread' : 'Mark read'}</span>
                       </Button>
                       <Button
                         variant="destructive"
                         size="sm"
-                        onClick={() => handleDeleteClick(detailId())}
+                        onClick={() => handleDeleteClick(selectedMail().id)}
                       >
                         Delete
                       </Button>
@@ -347,7 +339,7 @@ export function MailInboxDemo() {
 
                   <Separator />
 
-                  <div className="mail-body text-sm whitespace-pre-line">{detailBody()}</div>
+                  <div className="mail-body text-sm whitespace-pre-line">{selectedMail().body}</div>
                 </div>
               ) : (
                 <div className="mail-empty flex items-center justify-center h-full text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary

- Conditional branch text effects (e.g., `{selectedMail().subject}` inside `{selectedMail() ? ... : ...}`) were emitted as top-level `createEffect` calls that ran even when the branch was inactive, causing null reference errors
- Now emitted inside `bindEvents` using `createDisposableEffect`, scoped to the branch — only run when the branch is active, disposed on branch switch
- Mail demo: removed 6 workaround memos — `selectedMail().subject` works directly

## Changes

**Runtime** (`packages/dom`):
- `createDisposableEffect()` — returns a dispose function that unsubscribes from all signals
- `insert()` — tracks `bindEvents` return value for branch cleanup; wraps template sampling and condition evaluation in try/catch

**Compiler** (`packages/jsx`):
- Collect text effects per conditional branch (`whenTrueTextEffects` / `whenFalseTextEffects`)
- Emit inside `bindEvents` with `createDisposableEffect` + cleanup return
- Skip `insideConditional` expressions from top-level `dynamicElements`

## Test plan
- [x] 481 compiler unit tests pass
- [x] 1148 IR tests pass
- [x] 927 E2E tests pass (0 regressions)
- [x] Mail demo works without workaround memos

🤖 Generated with [Claude Code](https://claude.com/claude-code)