### PR TITLE
Fix createComponent innerHTML parsing with > in CSS classes

### DIFF
--- a/packages/dom/src/component.ts
+++ b/packages/dom/src/component.ts
@@ -80,8 +80,11 @@ export function createComponent(
   const html = templateFn(unwrappedProps)
 
   // 4. Create DOM element
+  // Escape ">" inside attribute values to prevent broken HTML parsing.
+  // UnoCSS generates classes like has-[>svg] where ">" would prematurely
+  // close the opening tag when parsed via innerHTML.
   const template = document.createElement('template')
-  template.innerHTML = html.trim()
+  template.innerHTML = escapeAttrGt(html.trim())
   const element = template.content.firstChild as HTMLElement
 
   if (!element) {
@@ -258,6 +261,16 @@ function unwrapPropsForTemplate(props: Record<string, unknown>): Record<string, 
 }
 
 /**
+ * Escape ">" inside HTML attribute values to prevent broken parsing.
+ * UnoCSS classes like has-[>svg]:shrink-0 contain ">" which terminates
+ * the opening tag when parsed via innerHTML. The browser decodes &gt;
+ * back to ">" in the DOM attribute value, preserving CSS matching.
+ */
+function escapeAttrGt(html: string): string {
+  return html.replace(/"[^"]*"/g, match => match.replace(/>/g, '&gt;'))
+}
+
+/**
  * Check if a value contains DOM elements (HTMLElement instances).
  */
 function hasDomElements(value: unknown): boolean {
@@ -303,7 +316,7 @@ function createComponentFromDef(
 
   // Create DOM element
   const template = document.createElement('template')
-  template.innerHTML = html.trim()
+  template.innerHTML = escapeAttrGt(html.trim())
   const element = template.content.firstChild as HTMLElement
 
   if (!element) {

--- a/site/ui/components/kanban-demo.tsx
+++ b/site/ui/components/kanban-demo.tsx
@@ -11,6 +11,7 @@
 import { createSignal, createMemo } from '@barefootjs/dom'
 import { Badge } from '@ui/components/ui/badge'
 import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
 import {
   ToastProvider,
   Toast,
@@ -147,25 +148,17 @@ export function KanbanDemo() {
               </Button>
             </div>
 
-            {/* WORKAROUND: Uses native <input> and <button> in the add form instead of
-                 Input/Button components. Signal reads (newTaskTitle()) in the loop template
-                 cause reconcileElements to replace all items on each keystroke, losing
-                 component state. Fix: compiler should emit reactive attrs (value={signal()})
-                 as separate createEffect instead of inlining in template string. */}
             {addingToColumn() === col.id ? (
               <div className="add-task-form flex gap-2 mb-3">
-                <input
+                <Input
                   placeholder="Task title"
                   value={newTaskTitle()}
                   onInput={(e) => setNewTaskTitle(e.target.value)}
-                  className="flex h-8 w-full rounded-md border border-input bg-transparent px-2 text-sm shadow-xs outline-none"
+                  className="h-8"
                 />
-                <button
-                  className="inline-flex items-center justify-center h-8 px-3 rounded-md bg-primary text-primary-foreground text-sm font-medium"
-                  onClick={() => addTask(col.id)}
-                >
+                <Button size="sm" onClick={() => addTask(col.id)}>
                   Add
-                </button>
+                </Button>
               </div>
             ) : null}
 


### PR DESCRIPTION
## Summary

Fix broken component rendering when UnoCSS classes contain `>` (e.g., `has-[>svg]:shrink-0`). The `>` inside attribute values prematurely terminates the opening tag when parsed via `innerHTML` in `createComponent`.

## Root cause

`createComponent` generates HTML via template functions and sets `template.innerHTML = html`. HTML attribute values containing `>` break the parser:
```html
<!-- What the template generates -->
<button class="...has-[>svg]:shrink-0..." bf="s0">Add</button>

<!-- How the parser reads it -->
<button class="...has-[>  ← tag ends here!
svg]:shrink-0..." bf="s0">Add</button>  ← treated as text content
```

## Fix

Escape `>` to `&gt;` inside double-quoted attribute values before setting `innerHTML`. The browser decodes `&gt;` back to `>` in the DOM attribute value, preserving CSS class matching.

```typescript
function escapeAttrGt(html: string): string {
  return html.replace(/"[^"]*"/g, match => match.replace(/>/g, '&gt;'))
}
```

## Impact

- Eliminates the kanban-demo workaround: all form elements now use `<Input>` and `<Button>` components instead of native `<input>` and `<button>`
- Fixes all components with `has-[>...]` or similar UnoCSS selectors in their class values

## Test plan

- [x] Runtime unit tests: 165 pass
- [x] Compiler unit tests: 481 pass
- [x] Kanban E2E: 12/12 pass (all with UI components, no native workarounds)
- [x] Full E2E: 939 pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)