### PR TITLE
Support ref callback on components via applyRestAttrs

### DIFF
--- a/packages/dom/src/apply-rest-attrs.ts
+++ b/packages/dom/src/apply-rest-attrs.ts
@@ -30,9 +30,14 @@ export function applyRestAttrs(
 ): void {
   const exclude = new Set(excludeKeys)
 
-  // Wire up event handlers once (not reactively)
+  // Wire up event handlers and ref callbacks once (not reactively)
   for (const key of Object.keys(source)) {
     if (exclude.has(key)) continue
+    if (key === 'ref') {
+      const ref = source[key]
+      if (typeof ref === 'function') (ref as (el: Element) => void)(el)
+      continue
+    }
     if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) {
       const handler = source[key]
       if (typeof handler === 'function') {
@@ -46,7 +51,8 @@ export function applyRestAttrs(
     for (const key of Object.keys(source)) {
       if (exclude.has(key)) continue
 
-      // Event handlers are wired up above, not as attributes
+      // Event handlers and ref are wired up above, not as attributes
+      if (key === 'ref') continue
       if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) continue
 
       const value = source[key]

--- a/site/ui/components/kanban-demo.tsx
+++ b/site/ui/components/kanban-demo.tsx
@@ -142,12 +142,7 @@ export function KanbanDemo() {
                 variant="outline"
                 size="icon-sm"
                 className="add-task-btn"
-                onClick={() => {
-                  setAddingToColumn(addingToColumn() === col.id ? null : col.id)
-                  requestAnimationFrame(() => {
-                    (document.querySelector('.add-task-form input') as HTMLInputElement)?.focus()
-                  })
-                }}
+                onClick={() => setAddingToColumn(addingToColumn() === col.id ? null : col.id)}
               >
                 +
               </Button>
@@ -159,6 +154,7 @@ export function KanbanDemo() {
                   placeholder="Task title"
                   value={newTaskTitle()}
                   onInput={(e) => setNewTaskTitle(e.target.value)}
+                  ref={(el) => requestAnimationFrame(() => el.focus())}
                   className="h-8"
                 />
                 <Button size="sm" onClick={() => addTask(col.id)}>


### PR DESCRIPTION
## Summary

Components with spread props ({...rest}) now support ref callbacks. Previously, ref was treated as a regular attribute by applyRestAttrs, resulting in el.setAttribute('ref', '[function]').

## Changes

- **apply-rest-attrs.ts**: Handle ref like event handlers — call the callback once with the element, skip in the reactive attribute loop
- **kanban-demo.tsx**: Replace requestAnimationFrame + querySelector auto-focus with ref={(el) => requestAnimationFrame(() => el.focus())}

## Test plan

- [x] Runtime unit tests: 165 pass
- [x] Kanban E2E: 12/12 pass
- [x] Mail E2E: 21/21 pass
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)