### PR TITLE
Fix applyRestAttrs to use DOM properties for value and checked

### DIFF
--- a/packages/dom/src/apply-rest-attrs.ts
+++ b/packages/dom/src/apply-rest-attrs.ts
@@ -59,9 +59,21 @@ export function applyRestAttrs(
       const attr = toAttrName(key)
 
       if (value != null && value !== false) {
-        el.setAttribute(attr, String(value))
+        // Use DOM property for value/checked (setAttribute sets the default, not current)
+        if (attr === 'value' && 'value' in el) {
+          const strVal = String(value)
+          if ((el as HTMLInputElement).value !== strVal) (el as HTMLInputElement).value = strVal
+        } else if (attr === 'checked' && 'checked' in el) {
+          (el as HTMLInputElement).checked = !!value
+        } else {
+          el.setAttribute(attr, String(value))
+        }
       } else {
-        el.removeAttribute(attr)
+        if (attr === 'checked' && 'checked' in el) {
+          (el as HTMLInputElement).checked = false
+        } else {
+          el.removeAttribute(attr)
+        }
       }
     }
   })


### PR DESCRIPTION
## Summary

`applyRestAttrs` now uses DOM property assignment (`el.value`, `el.checked`) instead of `setAttribute` for `value` and `checked` on input elements.

## Why

`setAttribute('value', x)` sets the HTML default value, not the displayed text. `setAttribute('checked', x)` doesn't toggle the checkbox visually. This affects components with `{...rest}` spread (like Input) where these props flow through `applyRestAttrs`.

## Fix

```typescript
if (attr === 'value' && 'value' in el) {
  const strVal = String(value)
  if (el.value !== strVal) el.value = strVal  // equality check preserves cursor
} else if (attr === 'checked' && 'checked' in el) {
  el.checked = !!value
}
```

Matches the compiler's `emitAttrUpdate` which already uses this pattern for statically-compiled reactive attributes.

## Test plan

- [x] Runtime unit tests: 165 pass
- [x] Kanban E2E: 12/12 pass
- [x] Mail E2E: 21/21 pass
- [x] Full E2E: 939 pass
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)