### PR TITLE
Add Music Player block and fix caret prefix in variable names

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1141,12 +1141,20 @@ describe('Client JS generation', () => {
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
 
-      // The helper function itself should be emitted (as arrow function constant)
-      expect(clientJs!.content).toContain('const computeError')
+      const content = clientJs!.content
+
+      // Module-level function should be emitted at module scope using var + ??
+      // for safe re-declaration when multiple components share the same bundle
+      expect(content).toContain('var computeError = computeError ?? function(')
+      expect(content).not.toContain('const computeError')
+
+      // The function should appear before the init function (module scope)
+      const fnPos = content.indexOf('var computeError')
+      const initPos = content.indexOf('export function initMyComponent(')
+      expect(fnPos).toBeLessThan(initPos)
 
       // Internal declarations should appear only once (inside the function body),
       // not duplicated at the init function's top level
-      const content = clientJs!.content
       const basicErrorCount = content.split('const basicError').length - 1
       const isDuplicateCount = content.split('const isDuplicate').length - 1
       expect(basicErrorCount).toBe(1) // only inside computeError body

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -773,6 +773,7 @@ function collectFunction(
     returnType,
     containsJsx,
     isExported,
+    isModule: _isModule || undefined,
     isJsxFunction: isJsxFunction || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -487,11 +487,12 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
           attrsBySlot.get(attr.childSlotId)!.push(attr)
         }
         for (const [slotId, attrs] of attrsBySlot) {
-          lines.push(`        const __t_${slotId} = __iterEl.matches('[bf="${slotId}"]') ? __iterEl : __iterEl.querySelector('[bf="${slotId}"]')`)
-          lines.push(`        if (__t_${slotId}) {`)
+          const varName = `__t_${varSlotId(slotId)}`
+          lines.push(`        const ${varName} = __iterEl.matches('[bf="${slotId}"]') ? __iterEl : __iterEl.querySelector('[bf="${slotId}"]')`)
+          lines.push(`        if (${varName}) {`)
           for (const attr of attrs) {
             lines.push(`          createEffect(() => {`)
-            for (const stmt of emitAttrUpdate(`__t_${slotId}`, attr.attrName, attr.expression, attr)) {
+            for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
               lines.push(`            ${stmt}`)
             }
             lines.push(`          })`)

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -7,7 +7,7 @@ import type { AttrMeta, ComponentIR, SignalInfo, IRFragment } from '../types'
 import type { Declaration } from './declaration-sort'
 import { isBooleanAttr } from '../html-constants'
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopElement } from './types'
-import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId, PROPS_PARAM } from './utils'
+import { inferDefaultValue, toHtmlAttrName, toDomEventName, wrapHandlerInBlock, buildChainedArrayExpr, quotePropName, varSlotId, bodyReferencesComponentScope, PROPS_PARAM } from './utils'
 import { addCondAttrToTemplate, canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, irChildrenToJsExpr, createStringProtector } from './html-template'
 
 /**
@@ -1246,6 +1246,9 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
   if (ctx.propsObjectName) componentScopeNames.add(ctx.propsObjectName)
 
   for (const fn of ctx.localFunctions) {
+    // Module-level functions that don't reference component internals
+    // are emitted at module scope, so they are available in the template.
+    if (fn.isModule && !bodyReferencesComponentScope(fn.body, componentScopeNames)) continue
     unsafeLocalNames.add(fn.name)
   }
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -2,9 +2,9 @@
  * generateInitFunction orchestrator + generateElementRefs.
  */
 
-import type { ComponentIR, ConstantInfo, IRNode } from '../types'
+import type { ComponentIR, ConstantInfo, FunctionInfo, IRNode } from '../types'
 import type { ClientJsContext } from './types'
-import { varSlotId, PROPS_PARAM } from './utils'
+import { varSlotId, bodyReferencesComponentScope, PROPS_PARAM } from './utils'
 import { collectUsedIdentifiers, collectUsedFunctions, collectIdentifiersFromIRTree } from './identifiers'
 import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
@@ -171,16 +171,34 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
     })
   }
 
-  // Collect functions
+  // Build component-scope name set to check if module-level functions
+  // reference component internals (signals, memos, constants, props).
+  // Functions that reference component-scope names must stay inside init.
+  const componentScopeNames = new Set<string>()
+  for (const s of ctx.signals) {
+    componentScopeNames.add(s.getter)
+    componentScopeNames.add(s.setter)
+  }
+  for (const m of ctx.memos) componentScopeNames.add(m.name)
+  for (const c of ctx.localConstants) componentScopeNames.add(c.name)
+  for (const p of ctx.propsParams) componentScopeNames.add(p.name)
+  if (ctx.propsObjectName) componentScopeNames.add(ctx.propsObjectName)
+
+  // Collect functions (module-level functions that don't reference component
+  // internals are emitted outside init for SSR template accessibility)
+  const moduleLevelFunctions: FunctionInfo[] = []
   for (const fn of ctx.localFunctions) {
     if (fn.isJsxFunction) continue  // Inlined at call sites (#569)
-    if (usedIdentifiers.has(fn.name)) {
-      declarations.push({
-        kind: 'function',
-        info: fn,
-        sourceIndex: fn.loc.start.line,
-      })
+    if (!usedIdentifiers.has(fn.name)) continue
+    if (fn.isModule && !bodyReferencesComponentScope(fn.body, componentScopeNames)) {
+      moduleLevelFunctions.push(fn)
+      continue
     }
+    declarations.push({
+      kind: 'function',
+      info: fn,
+      sourceIndex: fn.loc.start.line,
+    })
   }
 
   // Collect signals
@@ -291,15 +309,27 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 
   // Module-level constants use `var` with nullish coalescing for safe
   // re-declaration when multiple components in the same file share context
-  let moduleConstantsCode = ''
-  if (moduleLevelConstants.length > 0) {
-    const moduleConstantLines: string[] = []
-    for (const constant of moduleLevelConstants) {
-      if (!constant.value) continue
-      moduleConstantLines.push(`var ${constant.name} = ${constant.name} ?? ${constant.value}`)
-    }
-    moduleConstantsCode = moduleConstantLines.join('\n') + '\n'
+  const moduleCodeLines: string[] = []
+  for (const constant of moduleLevelConstants) {
+    if (!constant.value) continue
+    moduleCodeLines.push(`var ${constant.name} = ${constant.name} ?? ${constant.value}`)
   }
+
+  // Module-level functions: emitted at module scope so they are available
+  // in both the init function and the SSR template.
+  // Uses `var` + nullish coalescing for safe re-declaration when multiple
+  // components in the same bundle share the same helper function.
+  // Note: export is intentionally omitted — client JS files are self-contained
+  // entry points, not imported by other modules. Add export when a concrete
+  // cross-module use case arises.
+  for (const fn of moduleLevelFunctions) {
+    const paramStr = fn.params.map(p => p.name).join(', ')
+    moduleCodeLines.push(`var ${fn.name} = ${fn.name} ?? function(${paramStr}) ${fn.body}`)
+  }
+
+  const moduleConstantsCode = moduleCodeLines.length > 0
+    ? moduleCodeLines.join('\n') + '\n'
+    : ''
 
   return generatedCode
     .replace(IMPORT_PLACEHOLDER, allImportLines)
@@ -420,3 +450,4 @@ export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>)
     }
   }
 }
+

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -147,8 +147,12 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
  */
 export function bodyReferencesComponentScope(body: string, scopeNames: Set<string>): boolean {
   for (const name of scopeNames) {
-    if (new RegExp(`\\b${name}\\b`).test(body)) return true
+    if (new RegExp(`\\b${escapeRegExp(name)}\\b`).test(body)) return true
   }
   return false
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -140,3 +140,15 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
   return 'undefined'
 }
 
+/**
+ * Check if a function body references any identifiers from the given scope.
+ * Used to determine if a module-level function can be emitted outside the
+ * component init function, or if it must stay inside due to scope dependencies.
+ */
+export function bodyReferencesComponentScope(body: string, scopeNames: Set<string>): boolean {
+  for (const name of scopeNames) {
+    if (new RegExp(`\\b${name}\\b`).test(body)) return true
+  }
+  return false
+}
+

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -399,6 +399,8 @@ export interface FunctionInfo {
   returnType: TypeInfo | null
   containsJsx: boolean
   isExported?: boolean
+  /** When true, declared at module level (outside the component function). */
+  isModule?: boolean
   /** When true, this function returns JSX and is inlined at call sites (#569). */
   isJsxFunction?: boolean
   loc: SourceLocation

--- a/site/ui/components/music-player-demo.tsx
+++ b/site/ui/components/music-player-demo.tsx
@@ -1,0 +1,325 @@
+"use client"
+/**
+ * MusicPlayerDemo Component
+ *
+ * Music player block with playlist, seek/volume sliders, and timer.
+ * Compiler stress: setInterval + onCleanup (effect cleanup pattern),
+ * Slider bidirectional binding, timer-driven reactive updates,
+ * conditional rendering (playing vs paused), loop + conditional coexistence.
+ */
+
+import { createSignal, createMemo, createEffect, onCleanup } from '@barefootjs/dom'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Slider } from '@ui/components/ui/slider'
+import { Separator } from '@ui/components/ui/separator'
+import { ScrollArea } from '@ui/components/ui/scroll-area'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+
+type Track = {
+  id: number
+  title: string
+  artist: string
+  album: string
+  duration: number // seconds
+  durationStr: string // pre-formatted mm:ss
+}
+
+// Declared as function statement (not arrow) to avoid compiler inline-expansion bug
+function formatTime(totalSeconds: number): string {
+  const mins = Math.floor(totalSeconds / 60)
+  const secs = Math.floor(totalSeconds % 60)
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+const playlist: Track[] = [
+  { id: 1, title: 'Morning Light', artist: 'Solar Wave', album: 'Daybreak', duration: 217, durationStr: '3:37' },
+  { id: 2, title: 'Deep Blue', artist: 'Ocean Drive', album: 'Tides', duration: 185, durationStr: '3:05' },
+  { id: 3, title: 'City Nights', artist: 'Neon Pulse', album: 'Urban', duration: 243, durationStr: '4:03' },
+  { id: 4, title: 'Mountain Echo', artist: 'Alpine', album: 'Heights', duration: 198, durationStr: '3:18' },
+  { id: 5, title: 'Starfall', artist: 'Cosmic Drift', album: 'Nebula', duration: 262, durationStr: '4:22' },
+  { id: 6, title: 'River Flow', artist: 'Calm Waters', album: 'Serenity', duration: 174, durationStr: '2:54' },
+]
+
+/**
+ * Music player — setInterval + onCleanup stress test
+ *
+ * Compiler stress points:
+ * - setInterval + onCleanup: playback timer with proper cleanup on pause/track change
+ * - Slider bidirectional binding: seek position + volume (controlled mode)
+ * - Timer-driven reactive updates: currentTime signal updated every 100ms
+ * - Conditional rendering: now-playing info, play/pause icon
+ * - Loop + conditional coexistence: playlist items with active track highlight
+ * - createMemo chains: currentTrack → progress percentage → formatted times
+ */
+export function MusicPlayerDemo() {
+  const [currentTrackId, setCurrentTrackId] = createSignal(1)
+  const [isPlaying, setIsPlaying] = createSignal(false)
+  const [currentTime, setCurrentTime] = createSignal(0)
+  const [volume, setVolume] = createSignal(75)
+  const [shuffle, setShuffle] = createSignal(false)
+  const [repeat, setRepeat] = createSignal<'off' | 'all' | 'one'>('off')
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  // Memo chain stage 1: current track object
+  const currentTrack = createMemo(() =>
+    playlist.find(t => t.id === currentTrackId()) || playlist[0]
+  )
+
+  // Memo chain stage 2: progress percentage (0-100)
+  const progress = createMemo(() => {
+    const track = currentTrack()
+    return track.duration > 0 ? (currentTime() / track.duration) * 100 : 0
+  })
+
+  // Formatted times as signals (not memos) to avoid formatTime leaking into SSR template.
+  // The compiler inlines createMemo initial values into the template function,
+  // but the template runs outside the component scope where formatTime is unavailable.
+  const [formattedCurrentTime, setFormattedCurrentTime] = createSignal('0:00')
+  const [formattedRemaining, setFormattedRemaining] = createSignal('-3:37')
+
+  // Update formatted times reactively
+  createEffect(() => {
+    setFormattedCurrentTime(formatTime(currentTime()))
+    const remaining = currentTrack().duration - currentTime()
+    setFormattedRemaining(`-${formatTime(Math.max(0, remaining))}`)
+  })
+
+  // Total duration as pre-computed string (avoids formatTime in SSR template)
+  const totalDurationStr = '21:19' // sum of all track durations
+
+  const showToast = (message: string) => {
+    setToastMessage(message)
+    setToastOpen(true)
+    setTimeout(() => setToastOpen(false), 2000)
+  }
+
+  // setInterval + onCleanup: playback timer
+  // This is the primary compiler stress pattern — createEffect with
+  // interval that must be cleaned up when isPlaying changes or component unmounts
+  createEffect(() => {
+    if (!isPlaying()) return
+
+    const interval = setInterval(() => {
+      setCurrentTime(prev => {
+        const next = prev + 0.1
+        if (next >= currentTrack().duration) {
+          // Track ended — handle repeat/next
+          handleTrackEnd()
+          return 0
+        }
+        return next
+      })
+    }, 100)
+
+    onCleanup(() => clearInterval(interval))
+  })
+
+  const handleTrackEnd = () => {
+    if (repeat() === 'one') {
+      setCurrentTime(0)
+      return
+    }
+
+    const currentIdx = playlist.findIndex(t => t.id === currentTrackId())
+    if (currentIdx < playlist.length - 1) {
+      setCurrentTrackId(playlist[currentIdx + 1].id)
+      setCurrentTime(0)
+      showToast('Next track')
+    } else if (repeat() === 'all') {
+      setCurrentTrackId(playlist[0].id)
+      setCurrentTime(0)
+      showToast('Playlist restarted')
+    } else {
+      setIsPlaying(false)
+      setCurrentTime(0)
+      showToast('Playlist ended')
+    }
+  }
+
+  const togglePlay = () => {
+    setIsPlaying(prev => !prev)
+  }
+
+  const playTrack = (trackId: number) => {
+    setCurrentTrackId(trackId)
+    setCurrentTime(0)
+    setIsPlaying(true)
+  }
+
+  const prevTrack = () => {
+    // If past 3 seconds, restart current track; otherwise go to previous
+    if (currentTime() > 3) {
+      setCurrentTime(0)
+      return
+    }
+    const currentIdx = playlist.findIndex(t => t.id === currentTrackId())
+    if (currentIdx > 0) {
+      setCurrentTrackId(playlist[currentIdx - 1].id)
+      setCurrentTime(0)
+    }
+  }
+
+  const nextTrack = () => {
+    const currentIdx = playlist.findIndex(t => t.id === currentTrackId())
+    if (currentIdx < playlist.length - 1) {
+      setCurrentTrackId(playlist[currentIdx + 1].id)
+      setCurrentTime(0)
+    }
+  }
+
+  const seekTo = (value: number) => {
+    const newTime = (value / 100) * currentTrack().duration
+    setCurrentTime(newTime)
+  }
+
+  const cycleRepeat = () => {
+    const modes: Array<'off' | 'all' | 'one'> = ['off', 'all', 'one']
+    const currentIdx = modes.indexOf(repeat())
+    setRepeat(modes[(currentIdx + 1) % modes.length])
+  }
+
+  const repeatLabel: Record<string, string> = {
+    off: '↻',
+    all: '↻ All',
+    one: '↻ 1',
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">Music Player</h2>
+        <span className="total-duration text-sm text-muted-foreground">{playlist.length} tracks · {totalDurationStr}</span>
+      </div>
+
+      <div className="music-player rounded-xl border border-border bg-card overflow-hidden">
+        {/* Now playing + controls */}
+        <div className="now-playing p-5 space-y-4">
+          {/* Track info */}
+          <div className="flex items-center gap-4">
+            <div className="album-art w-16 h-16 rounded-lg bg-muted flex items-center justify-center text-2xl">
+              {isPlaying() ? '♫' : '♪'}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="track-title text-base font-semibold truncate">{currentTrack().title}</p>
+              <p className="track-artist text-sm text-muted-foreground truncate">{currentTrack().artist}</p>
+              <p className="text-xs text-muted-foreground truncate">{currentTrack().album}</p>
+            </div>
+            {isPlaying() ? (
+              <Badge variant="default" className="playing-badge">Playing</Badge>
+            ) : (
+              <Badge variant="outline" className="paused-badge">Paused</Badge>
+            )}
+          </div>
+
+          {/* Seek slider — bidirectional binding stress test */}
+          <div className="space-y-1">
+            <Slider
+              value={progress()}
+              onValueChange={seekTo}
+              min={0}
+              max={100}
+              step={0.1}
+              className="seek-slider"
+            />
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span className="current-time">{formattedCurrentTime()}</span>
+              <span className="remaining-time">{formattedRemaining()}</span>
+            </div>
+          </div>
+
+          {/* Playback controls */}
+          <div className="flex items-center justify-center gap-3">
+            <Button
+              variant={shuffle() ? 'secondary' : 'ghost'}
+              size="icon-sm"
+              className="shuffle-btn"
+              onClick={() => setShuffle(prev => !prev)}
+            >
+              ⇄
+            </Button>
+            <Button variant="ghost" size="icon" className="prev-btn" onClick={prevTrack}>
+              ⏮
+            </Button>
+            <Button
+              variant="default"
+              size="icon-lg"
+              className="play-btn"
+              onClick={togglePlay}
+            >
+              {isPlaying() ? '⏸' : '▶'}
+            </Button>
+            <Button variant="ghost" size="icon" className="next-btn" onClick={nextTrack}>
+              ⏭
+            </Button>
+            <Button
+              variant={repeat() !== 'off' ? 'secondary' : 'ghost'}
+              size="icon-sm"
+              className="repeat-btn"
+              onClick={cycleRepeat}
+            >
+              {repeatLabel[repeat()]}
+            </Button>
+          </div>
+
+          {/* Volume slider — second bidirectional binding */}
+          <div className="flex items-center gap-3">
+            <span className="text-sm">{volume() === 0 ? '🔇' : volume() < 50 ? '🔉' : '🔊'}</span>
+            <Slider
+              value={volume()}
+              onValueChange={setVolume}
+              min={0}
+              max={100}
+              step={1}
+              className="volume-slider flex-1"
+            />
+            <span className="volume-value text-xs text-muted-foreground w-8 text-right">{volume()}%</span>
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Playlist — loop with active track conditional */}
+        <ScrollArea className="playlist" style="height: 240px">
+          <div className="p-2 space-y-0.5">
+            {playlist.map(track => (
+              <button
+                key={track.id}
+                className={`playlist-item w-full flex items-center gap-3 rounded-lg p-2.5 text-left transition-colors hover:bg-accent ${currentTrackId() === track.id ? 'bg-accent' : ''}`}
+                onClick={() => playTrack(track.id)}
+              >
+                <span className="w-6 text-center text-sm text-muted-foreground">
+                  {currentTrackId() === track.id && isPlaying() ? '▶' : track.id}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className={`playlist-track-title text-sm truncate ${currentTrackId() === track.id ? 'font-semibold text-foreground' : 'text-foreground'}`}>
+                    {track.title}
+                  </p>
+                  <p className="text-xs text-muted-foreground truncate">{track.artist}</p>
+                </div>
+                <span className="text-xs text-muted-foreground">{track.durationStr}</span>
+              </button>
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="default" open={toastOpen()}>
+          <div className="flex-1">
+            <ToastTitle>Player</ToastTitle>
+            <ToastDescription className="toast-message">{toastMessage()}</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setToastOpen(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/music-player-demo.tsx
+++ b/site/ui/components/music-player-demo.tsx
@@ -28,10 +28,10 @@ type Track = {
   artist: string
   album: string
   duration: number // seconds
-  durationStr: string // pre-formatted mm:ss
 }
 
-// Declared as function statement (not arrow) to avoid compiler inline-expansion bug
+// Module-level function: emitted at module scope in client JS,
+// accessible from both the init function and the SSR template.
 function formatTime(totalSeconds: number): string {
   const mins = Math.floor(totalSeconds / 60)
   const secs = Math.floor(totalSeconds % 60)
@@ -39,12 +39,12 @@ function formatTime(totalSeconds: number): string {
 }
 
 const playlist: Track[] = [
-  { id: 1, title: 'Morning Light', artist: 'Solar Wave', album: 'Daybreak', duration: 217, durationStr: '3:37' },
-  { id: 2, title: 'Deep Blue', artist: 'Ocean Drive', album: 'Tides', duration: 185, durationStr: '3:05' },
-  { id: 3, title: 'City Nights', artist: 'Neon Pulse', album: 'Urban', duration: 243, durationStr: '4:03' },
-  { id: 4, title: 'Mountain Echo', artist: 'Alpine', album: 'Heights', duration: 198, durationStr: '3:18' },
-  { id: 5, title: 'Starfall', artist: 'Cosmic Drift', album: 'Nebula', duration: 262, durationStr: '4:22' },
-  { id: 6, title: 'River Flow', artist: 'Calm Waters', album: 'Serenity', duration: 174, durationStr: '2:54' },
+  { id: 1, title: 'Morning Light', artist: 'Solar Wave', album: 'Daybreak', duration: 217 },
+  { id: 2, title: 'Deep Blue', artist: 'Ocean Drive', album: 'Tides', duration: 185 },
+  { id: 3, title: 'City Nights', artist: 'Neon Pulse', album: 'Urban', duration: 243 },
+  { id: 4, title: 'Mountain Echo', artist: 'Alpine', album: 'Heights', duration: 198 },
+  { id: 5, title: 'Starfall', artist: 'Cosmic Drift', album: 'Nebula', duration: 262 },
+  { id: 6, title: 'River Flow', artist: 'Calm Waters', album: 'Serenity', duration: 174 },
 ]
 
 /**
@@ -79,21 +79,19 @@ export function MusicPlayerDemo() {
     return track.duration > 0 ? (currentTime() / track.duration) * 100 : 0
   })
 
-  // Formatted times as signals (not memos) to avoid formatTime leaking into SSR template.
-  // The compiler inlines createMemo initial values into the template function,
-  // but the template runs outside the component scope where formatTime is unavailable.
-  const [formattedCurrentTime, setFormattedCurrentTime] = createSignal('0:00')
-  const [formattedRemaining, setFormattedRemaining] = createSignal('-3:37')
+  // Memo chain stage 3: formatted current time
+  const formattedCurrentTime = createMemo(() => formatTime(currentTime()))
 
-  // Update formatted times reactively
-  createEffect(() => {
-    setFormattedCurrentTime(formatTime(currentTime()))
+  // Memo chain stage 4: formatted remaining time
+  const formattedRemaining = createMemo(() => {
     const remaining = currentTrack().duration - currentTime()
-    setFormattedRemaining(`-${formatTime(Math.max(0, remaining))}`)
+    return `-${formatTime(Math.max(0, remaining))}`
   })
 
-  // Total duration as pre-computed string (avoids formatTime in SSR template)
-  const totalDurationStr = '21:19' // sum of all track durations
+  // Memo: total playlist duration
+  const totalDuration = createMemo(() =>
+    playlist.reduce((sum, t) => sum + t.duration, 0)
+  )
 
   const showToast = (message: string) => {
     setToastMessage(message)
@@ -196,7 +194,7 @@ export function MusicPlayerDemo() {
     <div className="w-full">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold">Music Player</h2>
-        <span className="total-duration text-sm text-muted-foreground">{playlist.length} tracks · {totalDurationStr}</span>
+        <span className="total-duration text-sm text-muted-foreground">{playlist.length} tracks · {formatTime(totalDuration())}</span>
       </div>
 
       <div className="music-player rounded-xl border border-border bg-card overflow-hidden">
@@ -304,7 +302,7 @@ export function MusicPlayerDemo() {
                   </p>
                   <p className="text-xs text-muted-foreground truncate">{track.artist}</p>
                 </div>
-                <span className="text-xs text-muted-foreground">{track.durationStr}</span>
+                <span className="text-xs text-muted-foreground">{formatTime(track.duration)}</span>
               </button>
             ))}
           </div>

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -110,6 +110,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'settings', title: 'Settings', description: 'Multi-tab settings page with forms and dialogs' },
   { slug: 'sidebar', title: 'Sidebar', description: 'Collapsible navigation panel' },
   { slug: 'chat', title: 'Chat', description: 'Messaging interface with auto-scroll, typing indicator, and unread counts' },
+  { slug: 'music-player', title: 'Music Player', description: 'Media player with timer, effect cleanup, and slider binding' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/music-player.spec.ts
+++ b/site/ui/e2e/music-player.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Music Player Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/music-player')
+  })
+
+  test.describe('Initial Rendering', () => {
+    test('shows track info for first track', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      await expect(section.locator('.track-title')).toHaveText('Morning Light')
+      await expect(section.locator('.track-artist')).toHaveText('Solar Wave')
+    })
+
+    test('shows paused badge initially', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      await expect(section.locator('.paused-badge')).toBeVisible()
+    })
+
+    test('shows playlist with 6 tracks', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const items = section.locator('.playlist-item')
+      await expect(items).toHaveCount(6)
+    })
+
+    test('shows initial time as 0:00', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      await expect(section.locator('.current-time')).toHaveText('0:00')
+    })
+
+    test('shows volume at 75%', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      await expect(section.locator('.volume-value')).toHaveText('75%')
+    })
+  })
+
+  test.describe('Playback Controls', () => {
+    test('clicking play starts playback and shows playing badge', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const playBtn = section.locator('.play-btn')
+
+      await playBtn.click()
+
+      // Should show playing badge
+      await expect(section.locator('.playing-badge')).toBeVisible()
+
+      // Time should advance (wait for reactive update)
+      await expect(section.locator('.current-time')).not.toHaveText('0:00', { timeout: 3000 })
+    })
+
+    test('clicking pause stops playback', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const playBtn = section.locator('.play-btn')
+
+      // Start playing
+      await playBtn.click()
+      await expect(section.locator('.playing-badge')).toBeVisible()
+
+      // Pause
+      await playBtn.click()
+      await expect(section.locator('.paused-badge')).toBeVisible()
+
+      // Time should stop advancing
+      const time1 = await section.locator('.current-time').textContent()
+      await page.waitForTimeout(300)
+      const time2 = await section.locator('.current-time').textContent()
+      expect(time1).toBe(time2)
+    })
+
+    test('next track switches to second track', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+
+      await section.locator('.next-btn').click()
+      await expect(section.locator('.track-title')).toHaveText('Deep Blue')
+      await expect(section.locator('.track-artist')).toHaveText('Ocean Drive')
+    })
+
+    test('prev track from beginning stays on first track', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+
+      await section.locator('.prev-btn').click()
+      await expect(section.locator('.track-title')).toHaveText('Morning Light')
+    })
+  })
+
+  test.describe('Playlist Interaction', () => {
+    test('clicking playlist item switches track and starts playing', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const items = section.locator('.playlist-item')
+
+      // Click third track
+      await items.nth(2).click()
+
+      await expect(section.locator('.track-title')).toHaveText('City Nights')
+      await expect(section.locator('.track-artist')).toHaveText('Neon Pulse')
+      await expect(section.locator('.playing-badge')).toBeVisible()
+    })
+
+    test('active track is highlighted in playlist', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const items = section.locator('.playlist-item')
+
+      // First track should have bg-accent class initially
+      const firstItem = items.first()
+      await expect(firstItem).toHaveClass(/bg-accent/)
+
+      // Click third track
+      await items.nth(2).click()
+
+      // Third track should now have bg-accent
+      await expect(items.nth(2)).toHaveClass(/bg-accent/)
+    })
+  })
+
+  test.describe('Repeat Control', () => {
+    test('cycling repeat mode changes button text', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const repeatBtn = section.locator('.repeat-btn')
+
+      // Initial: off
+      await expect(repeatBtn).toHaveText('↻')
+
+      // Click: all
+      await repeatBtn.click()
+      await expect(repeatBtn).toHaveText('↻ All')
+
+      // Click: one
+      await repeatBtn.click()
+      await expect(repeatBtn).toHaveText('↻ 1')
+
+      // Click: back to off
+      await repeatBtn.click()
+      await expect(repeatBtn).toHaveText('↻')
+    })
+  })
+
+  test.describe('Timer and Effect Cleanup', () => {
+    test('timer advances during playback and stops when paused', async ({ page }) => {
+      const section = page.locator('[bf-s^="MusicPlayerDemo_"]:not([data-slot])').first()
+      const playBtn = section.locator('.play-btn')
+
+      // Start playing
+      await playBtn.click()
+
+      // Wait for time to advance
+      await expect(section.locator('.current-time')).not.toHaveText('0:00', { timeout: 3000 })
+
+      // Pause
+      await playBtn.click()
+
+      // Record time after pause
+      const pausedTime = await section.locator('.current-time').textContent()
+      await page.waitForTimeout(500)
+      const afterWaitTime = await section.locator('.current-time').textContent()
+
+      // Time should not advance while paused (effect cleanup working)
+      expect(pausedTime).toBe(afterWaitTime)
+    })
+  })
+})

--- a/site/ui/pages/components/music-player.tsx
+++ b/site/ui/pages/components/music-player.tsx
@@ -1,0 +1,114 @@
+/**
+ * Music Player Reference Page (/components/music-player)
+ *
+ * Block-level composition pattern: music player with timer-driven
+ * reactivity, effect cleanup, and slider bidirectional binding.
+ * Compiler stress test for setInterval + onCleanup, timer-driven
+ * signal updates, and controlled Slider components.
+ */
+
+import { MusicPlayerDemo } from '@/components/music-player-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createEffect, onCleanup } from '@barefootjs/dom'
+import { Slider } from '@/components/ui/slider'
+import { Button } from '@/components/ui/button'
+
+function MusicPlayer() {
+  const [isPlaying, setIsPlaying] = createSignal(false)
+  const [currentTime, setCurrentTime] = createSignal(0)
+  const duration = 180 // 3 minutes
+
+  // Timer with cleanup — the key compiler stress test
+  createEffect(() => {
+    if (!isPlaying()) return
+
+    const interval = setInterval(() => {
+      setCurrentTime(prev => prev >= duration ? 0 : prev + 0.1)
+    }, 100)
+
+    onCleanup(() => clearInterval(interval))
+  })
+
+  return (
+    <div>
+      <Slider
+        value={(currentTime() / duration) * 100}
+        onValueChange={(v) => setCurrentTime((v / 100) * duration)}
+      />
+      <Button onClick={() => setIsPlaying(p => !p)}>
+        {isPlaying() ? '⏸' : '▶'}
+      </Button>
+    </div>
+  )
+}`
+
+export function MusicPlayerRefPage() {
+  return (
+    <DocPage slug="music-player" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Music Player"
+          description="A media player with playlist, seek/volume sliders, playback timer with effect cleanup, and track management."
+          {...getNavLinks('music-player')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <MusicPlayerDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">setInterval + onCleanup</h3>
+              <p className="text-sm text-muted-foreground">
+                Playback timer runs at 100ms intervals while playing. When paused or the track changes,
+                the effect re-runs and onCleanup clears the previous interval. Tests the compiler's
+                handling of effect cleanup lifecycle.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Slider Bidirectional Binding</h3>
+              <p className="text-sm text-muted-foreground">
+                Both seek and volume use controlled Slider components. The seek slider is driven by
+                the timer (value updates every 100ms) and also responds to user drag. Tests high-frequency
+                reactive prop updates on child components.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">4-Stage createMemo Chain</h3>
+              <p className="text-sm text-muted-foreground">
+                currentTrack → progress percentage → formattedCurrentTime → formattedRemaining.
+                All derived from currentTrackId and currentTime signals, updated 10 times per second
+                during playback.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Playlist with Active Track</h3>
+              <p className="text-sm text-muted-foreground">
+                Playlist rendered via .map() with conditional styling for the active track.
+                Click to play triggers track switch with timer reset. Tests loop + conditional coexistence.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -65,6 +65,7 @@ import { LoginRefPage } from './pages/components/login'
 import { SettingsRefPage } from './pages/components/settings'
 import { SidebarRefPage } from './pages/components/sidebar'
 import { ChatRefPage } from './pages/components/chat'
+import { MusicPlayerRefPage } from './pages/components/music-player'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -456,6 +457,11 @@ export function createApp() {
   // Chat block page
   app.get('/components/chat', (c) => {
     return c.render(<ChatRefPage />)
+  })
+
+  // Music Player block page
+  app.get('/components/music-player', (c) => {
+    return c.render(<MusicPlayerRefPage />)
   })
 
 


### PR DESCRIPTION
## Summary

- **Add Music Player block** — media player with playlist, seek/volume sliders, playback timer with effect cleanup, and track management
- **Fix caret prefix in generated variable names** — `const __t_^s34` caused syntax error
- **Fix module-level functions inlined into init scope** — module-level `function` declarations were incorrectly placed inside the component init function, making them unavailable in the SSR template. Now emitted at module scope with `var + ??` for safe re-declaration in multi-component bundles. Functions referencing component internals (signals, memos, constants) correctly remain inside init.

### Compiler bugs found and fixed

| Bug | Root cause | Fix |
|-----|-----------|-----|
| `^` in variable names → syntax error | `varSlotId()` not used for loop attr variable | `emit-init-sections.ts` |
| Module-level functions unavailable in SSR template | All functions placed inside init regardless of scope | `isModule` flag on `FunctionInfo` + scope-dependency check |

### Key design decisions

- **`var + ??` pattern** for module-level functions (same as `moduleLevelConstants`): prevents "already declared" error when multiple components in the same bundle share the same helper function
- **`export` intentionally omitted** on module-level functions in client JS: client JS files are self-contained entry points. Add export when a concrete cross-module use case arises.
- **Scope-dependency check**: `bodyReferencesComponentScope()` ensures functions that reference component internals (signals, memos, constants, props) stay inside init

### Compiler stress patterns exercised

| Pattern | Existing blocks | Music Player |
|---------|----------------|------|
| `setInterval` + `onCleanup` | — | ✅ |
| Slider bidirectional binding | — | ✅ |
| 4-stage `createMemo` chain | Chat (3-stage) | ✅ |
| Module-level helper functions | — | ✅ (`formatTime`) |

## Test plan

- [x] 13 E2E tests for Music Player
- [x] All 967 E2E tests pass
- [x] All 1134 package unit tests pass (incl. updated module-level function test)
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)