### PR TITLE
Add Multi-Step Form block

### DIFF
--- a/packages/dom/src/component.ts
+++ b/packages/dom/src/component.ts
@@ -12,6 +12,17 @@ import { untrack } from './reactive'
 import { BF_SCOPE } from './attrs'
 import type { ComponentDef } from './types'
 
+// Parent scope ID context for renderChild() inside insert() branch templates.
+// When set, renderChild uses the parent's scope ID as prefix instead of a random ID,
+// producing scope IDs consistent with SSR (e.g., "ParentName_abc_s5" instead of
+// "Button_random_s5"). This enables $cSingle's getDualScopeIds check to pass.
+// Set by insert() before calling branch.template(), cleared after.
+let _parentScopeId: string | null = null
+
+export function setParentScopeId(id: string | null): void {
+  _parentScopeId = id
+}
+
 // WeakMap to store props update functions for each component element
 // This allows reconcileList to update props when an element is reused
 const propsUpdateMap = new WeakMap<HTMLElement, (props: Record<string, unknown>) => void>()
@@ -188,14 +199,20 @@ export function renderChild(
   slotSuffix?: string
 ): string {
   const templateFn = getTemplate(name)
-  const id = Math.random().toString(36).slice(2, 8)
   const suffix = slotSuffix ? `_${slotSuffix}` : ''
+  // When inside an insert() branch template with a known parent scope,
+  // use the parent scope ID so child scope IDs match the SSR convention
+  // (e.g., ~ParentName_parentHash_s5 instead of ~Button_randomHash_s5).
+  // This enables $cSingle's getDualScopeIds verification to pass.
+  const scopePrefix = (_parentScopeId && slotSuffix)
+    ? _parentScopeId
+    : `${name}_${generateId()}`
   const keyAttr = key !== undefined ? ` data-key="${key}"` : ''
 
   if (!templateFn) {
     // Fallback: empty placeholder (for components without registered templates)
     // Use ~ prefix to mark as child component (prevents hydrate() re-initialization)
-    return `<div bf-s="~${name}_${id}${suffix}"${keyAttr}></div>`
+    return `<div bf-s="~${scopePrefix}${suffix}"${keyAttr}></div>`
   }
 
   const html = templateFn(props).trim()
@@ -209,7 +226,7 @@ export function renderChild(
   if (!firstElMatch) return html
   const insertPos = html.indexOf(firstElMatch[0])
   return html.slice(0, insertPos) +
-    html.slice(insertPos).replace(/^(<\w+)/, `$1 bf-s="~${name}_${id}${suffix}"${keyAttr}`)
+    html.slice(insertPos).replace(/^(<\w+)/, `$1 bf-s="~${scopePrefix}${suffix}"${keyAttr}`)
 }
 
 /**

--- a/packages/dom/src/insert.ts
+++ b/packages/dom/src/insert.ts
@@ -8,7 +8,8 @@
 
 import { createEffect } from './reactive'
 import { find } from './query'
-import { BF_COND } from './attrs'
+import { setParentScopeId } from './component'
+import { BF_COND, BF_SCOPE, BF_CHILD_PREFIX } from './attrs'
 
 /**
  * Branch configuration for conditional rendering.
@@ -50,6 +51,14 @@ export function insert(
   whenFalse: BranchConfig
 ): void {
   if (!scope) return
+
+  // Extract parent scope ID for renderChild context.
+  // When branch templates call renderChild(), it needs the parent scope ID
+  // to generate child scope IDs matching the SSR convention.
+  const rawScopeId = scope.getAttribute(BF_SCOPE)
+  const parentScopeId = rawScopeId
+    ? (rawScopeId.startsWith(BF_CHILD_PREFIX) ? rawScopeId.slice(1) : rawScopeId)
+    : null
 
   // Check if either branch uses fragment conditional (comment markers).
   // Both branches need to be checked because SSR may render either branch.
@@ -100,7 +109,9 @@ export function insert(
       // Hydration mode: check if existing DOM matches expected branch
       // If the existing element doesn't match the expected branch,
       // we need to swap the DOM first (e.g., SSR rendered whenFalse but now we need whenTrue)
-      const html = branch.template()
+      setParentScopeId(parentScopeId)
+      let html: string
+      try { html = branch.template() } finally { setParentScopeId(null) }
       const existingEl = find(scope, `[${BF_COND}="${id}"]`)
       if (existingEl) {
         // Compare full opening tag signatures to detect branch mismatch.
@@ -145,7 +156,9 @@ export function insert(
     }
 
     // Branch changed: swap DOM and bind events
-    const html = branch.template()
+    setParentScopeId(parentScopeId)
+    let html: string
+    try { html = branch.template() } finally { setParentScopeId(null) }
     if (isFragmentCond) {
       updateFragmentConditional(scope, id, html)
     } else {

--- a/site/ui/components/multi-step-form-demo.tsx
+++ b/site/ui/components/multi-step-form-demo.tsx
@@ -192,183 +192,181 @@ export function MultiStepFormDemo() {
           ))}
         </div>
 
-        {/* Step content — all steps rendered, visibility toggled via style.
-             Using display:none instead of conditional rendering because the compiler
-             does not yet initialize child components inside insert() branches
-             (bindEvents does not call initChild for dynamically swapped content).
-             This is a known limitation — tracked for future compiler improvement. */}
+        {/* Step content — nested ternary conditional rendering */}
         <div className="p-6 min-h-[320px]">
-          <div className="step-content step-1 space-y-4" style={currentStep() === 1 ? '' : 'display:none'}>
-            <div>
-              <h3 className="text-base font-semibold mb-1">Account Details</h3>
-              <p className="text-sm text-muted-foreground">Set up your login credentials.</p>
-            </div>
-            <div className="space-y-3">
+          {currentStep() === 1 ? (
+            <div className="step-content step-1 space-y-4">
               <div>
-                <Label for="email">Email</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email()}
-                  onInput={(e) => setEmail(e.target.value)}
-                />
-                {emailError() ? (
-                  <p className="email-error text-xs text-destructive mt-1">{emailError()}</p>
-                ) : null}
+                <h3 className="text-base font-semibold mb-1">Account Details</h3>
+                <p className="text-sm text-muted-foreground">Set up your login credentials.</p>
               </div>
-              <div>
-                <Label for="password">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="At least 8 characters"
-                  value={password()}
-                  onInput={(e) => setPassword(e.target.value)}
-                />
-                {passwordError() ? (
-                  <p className="password-error text-xs text-destructive mt-1">{passwordError()}</p>
-                ) : null}
-              </div>
-              <div>
-                <Label for="confirm-password">Confirm Password</Label>
-                <Input
-                  id="confirm-password"
-                  type="password"
-                  placeholder="Repeat your password"
-                  value={confirmPassword()}
-                  onInput={(e) => setConfirmPassword(e.target.value)}
-                />
-                {confirmError() ? (
-                  <p className="confirm-error text-xs text-destructive mt-1">{confirmError()}</p>
-                ) : null}
-              </div>
-            </div>
-          </div>
-
-          <div className="step-content step-2 space-y-4" style={currentStep() === 2 ? '' : 'display:none'}>
-            <div>
-              <h3 className="text-base font-semibold mb-1">Profile Information</h3>
-              <p className="text-sm text-muted-foreground">Tell us about yourself.</p>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <Label for="fullname">Full Name</Label>
-                <Input
-                  id="fullname"
-                  placeholder="John Doe"
-                  value={fullName()}
-                  onInput={(e) => setFullName(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label for="username">Username</Label>
-                <Input
-                  id="username"
-                  placeholder="johndoe"
-                  value={username()}
-                  onInput={(e) => setUsername(e.target.value)}
-                />
-                {usernameError() ? (
-                  <p className="username-error text-xs text-destructive mt-1">{usernameError()}</p>
-                ) : null}
-              </div>
-              <div>
-                <Label for="bio">Bio (optional)</Label>
-                <Input
-                  id="bio"
-                  placeholder="A short bio about you"
-                  value={bio()}
-                  onInput={(e) => setBio(e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="step-content step-3 space-y-4" style={currentStep() === 3 ? '' : 'display:none'}>
-            <div>
-              <h3 className="text-base font-semibold mb-1">Preferences</h3>
-              <p className="text-sm text-muted-foreground">Customize your experience.</p>
-            </div>
-            <div className="space-y-4">
-              <div>
-                <Label className="mb-2 block">Plan</Label>
-                <RadioGroup value={plan()} onValueChange={setPlan}>
-                  <div className="flex items-center gap-2">
-                    <RadioGroupItem value="free" />
-                    <Label>Free</Label>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <RadioGroupItem value="pro" />
-                    <Label>Pro — $9/month</Label>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <RadioGroupItem value="enterprise" />
-                    <Label>Enterprise — $29/month</Label>
-                  </div>
-                </RadioGroup>
-                <p className="plan-value text-xs text-muted-foreground mt-1">Selected: {plan()}</p>
-              </div>
-              <Separator />
               <div className="space-y-3">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={newsletter()}
-                    onCheckedChange={setNewsletter}
+                <div>
+                  <Label for="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email()}
+                    onInput={(e) => setEmail(e.target.value)}
                   />
-                  <Label>Subscribe to newsletter</Label>
+                  {emailError() ? (
+                    <p className="email-error text-xs text-destructive mt-1">{emailError()}</p>
+                  ) : null}
                 </div>
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={notifications()}
-                    onCheckedChange={setNotifications}
+                <div>
+                  <Label for="password">Password</Label>
+                  <Input
+                    id="password"
+                    type="password"
+                    placeholder="At least 8 characters"
+                    value={password()}
+                    onInput={(e) => setPassword(e.target.value)}
                   />
-                  <Label>Enable email notifications</Label>
+                  {passwordError() ? (
+                    <p className="password-error text-xs text-destructive mt-1">{passwordError()}</p>
+                  ) : null}
+                </div>
+                <div>
+                  <Label for="confirm-password">Confirm Password</Label>
+                  <Input
+                    id="confirm-password"
+                    type="password"
+                    placeholder="Repeat your password"
+                    value={confirmPassword()}
+                    onInput={(e) => setConfirmPassword(e.target.value)}
+                  />
+                  {confirmError() ? (
+                    <p className="confirm-error text-xs text-destructive mt-1">{confirmError()}</p>
+                  ) : null}
                 </div>
               </div>
             </div>
-          </div>
-
-          <div className="step-content step-4 space-y-4" style={currentStep() === 4 ? '' : 'display:none'}>
-            <div>
-              <h3 className="text-base font-semibold mb-1">Review</h3>
-              <p className="text-sm text-muted-foreground">Confirm your details before creating your account.</p>
+          ) : currentStep() === 2 ? (
+            <div className="step-content step-2 space-y-4">
+              <div>
+                <h3 className="text-base font-semibold mb-1">Profile Information</h3>
+                <p className="text-sm text-muted-foreground">Tell us about yourself.</p>
+              </div>
+              <div className="space-y-3">
+                <div>
+                  <Label for="fullname">Full Name</Label>
+                  <Input
+                    id="fullname"
+                    placeholder="John Doe"
+                    value={fullName()}
+                    onInput={(e) => setFullName(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label for="username">Username</Label>
+                  <Input
+                    id="username"
+                    placeholder="johndoe"
+                    value={username()}
+                    onInput={(e) => setUsername(e.target.value)}
+                  />
+                  {usernameError() ? (
+                    <p className="username-error text-xs text-destructive mt-1">{usernameError()}</p>
+                  ) : null}
+                </div>
+                <div>
+                  <Label for="bio">Bio (optional)</Label>
+                  <Input
+                    id="bio"
+                    placeholder="A short bio about you"
+                    value={bio()}
+                    onInput={(e) => setBio(e.target.value)}
+                  />
+                </div>
+              </div>
             </div>
-            <div className="review-summary space-y-3 rounded-lg bg-muted/50 p-4 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Email</span>
-                <span className="review-email font-medium">{email()}</span>
+          ) : currentStep() === 3 ? (
+            <div className="step-content step-3 space-y-4">
+              <div>
+                <h3 className="text-base font-semibold mb-1">Preferences</h3>
+                <p className="text-sm text-muted-foreground">Customize your experience.</p>
               </div>
-              <Separator />
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Full Name</span>
-                <span className="review-name font-medium">{fullName()}</span>
+              <div className="space-y-4">
+                <div>
+                  <Label className="mb-2 block">Plan</Label>
+                  <RadioGroup value={plan()} onValueChange={setPlan}>
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="free" />
+                      <Label>Free</Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="pro" />
+                      <Label>Pro — $9/month</Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="enterprise" />
+                      <Label>Enterprise — $29/month</Label>
+                    </div>
+                  </RadioGroup>
+                  <p className="plan-value text-xs text-muted-foreground mt-1">Selected: {plan()}</p>
+                </div>
+                <Separator />
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={newsletter()}
+                      onCheckedChange={setNewsletter}
+                    />
+                    <Label>Subscribe to newsletter</Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={notifications()}
+                      onCheckedChange={setNotifications}
+                    />
+                    <Label>Enable email notifications</Label>
+                  </div>
+                </div>
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Username</span>
-                <span className="review-username font-medium">@{username()}</span>
+            </div>
+          ) : (
+            <div className="step-content step-4 space-y-4">
+              <div>
+                <h3 className="text-base font-semibold mb-1">Review</h3>
+                <p className="text-sm text-muted-foreground">Confirm your details before creating your account.</p>
               </div>
-              {bio() ? (
+              <div className="review-summary space-y-3 rounded-lg bg-muted/50 p-4 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-muted-foreground">Bio</span>
-                  <span className="review-bio font-medium truncate max-w-[200px]">{bio()}</span>
+                  <span className="text-muted-foreground">Email</span>
+                  <span className="review-email font-medium">{email()}</span>
                 </div>
-              ) : null}
-              <Separator />
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Plan</span>
-                <Badge variant={plan() === 'free' ? 'outline' : 'default'} className="review-plan">{plan()}</Badge>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Newsletter</span>
-                <span>{newsletter() ? 'Yes' : 'No'}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Notifications</span>
-                <span>{notifications() ? 'Yes' : 'No'}</span>
+                <Separator />
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Full Name</span>
+                  <span className="review-name font-medium">{fullName()}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Username</span>
+                  <span className="review-username font-medium">@{username()}</span>
+                </div>
+                {bio() ? (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Bio</span>
+                    <span className="review-bio font-medium truncate max-w-[200px]">{bio()}</span>
+                  </div>
+                ) : null}
+                <Separator />
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Plan</span>
+                  <Badge variant={plan() === 'free' ? 'outline' : 'default'} className="review-plan">{plan()}</Badge>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Newsletter</span>
+                  <span>{newsletter() ? 'Yes' : 'No'}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Notifications</span>
+                  <span>{notifications() ? 'Yes' : 'No'}</span>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
 
         {/* Navigation buttons — outside conditionals for reliable event binding */}

--- a/site/ui/components/multi-step-form-demo.tsx
+++ b/site/ui/components/multi-step-form-demo.tsx
@@ -1,0 +1,406 @@
+"use client"
+/**
+ * MultiStepFormDemo Component
+ *
+ * Multi-step form wizard with step navigation, per-step validation,
+ * cross-step state sharing, and a review/confirm step.
+ * Compiler stress: multi-branch conditional rendering (4 steps),
+ * shared signals across branches, derived validation memos per step,
+ * dynamic step indicator with loop + conditional.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Input } from '@ui/components/ui/input'
+import { Label } from '@ui/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
+import { Separator } from '@ui/components/ui/separator'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+
+type Step = { id: number; title: string }
+
+const steps: Step[] = [
+  { id: 1, title: 'Account' },
+  { id: 2, title: 'Profile' },
+  { id: 3, title: 'Preferences' },
+  { id: 4, title: 'Review' },
+]
+
+/**
+ * Multi-step form wizard — multi-branch conditional stress test
+ *
+ * Compiler stress points:
+ * - Multi-branch conditional: 4 steps rendered via nested ternary
+ * - Shared signals across branches: form values persist across step switches
+ * - Derived validation memos per step: step1Valid, step2Valid, step3Valid
+ * - Dynamic step indicator: loop with active/completed conditional
+ * - Cross-step derived state: canProceed depends on current step + validation
+ * - createEffect for auto-focus on step change
+ */
+export function MultiStepFormDemo() {
+  const [currentStep, setCurrentStep] = createSignal(1)
+
+  // Step 1: Account
+  const [email, setEmail] = createSignal('')
+  const [password, setPassword] = createSignal('')
+  const [confirmPassword, setConfirmPassword] = createSignal('')
+
+  // Step 2: Profile
+  const [fullName, setFullName] = createSignal('')
+  const [username, setUsername] = createSignal('')
+  const [bio, setBio] = createSignal('')
+
+  // Step 3: Preferences
+  const [plan, setPlan] = createSignal('free')
+  const [newsletter, setNewsletter] = createSignal(true)
+  const [notifications, setNotifications] = createSignal(true)
+
+  // Toast
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  // Validation memo chain — per-step validation derived from form signals
+  const emailError = createMemo(() => {
+    const v = email()
+    if (!v) return ''
+    return v.includes('@') ? '' : 'Invalid email format'
+  })
+
+  const passwordError = createMemo(() => {
+    const v = password()
+    if (!v) return ''
+    return v.length >= 8 ? '' : 'At least 8 characters'
+  })
+
+  const confirmError = createMemo(() => {
+    const c = confirmPassword()
+    if (!c) return ''
+    return c === password() ? '' : 'Passwords do not match'
+  })
+
+  const step1Valid = createMemo(() =>
+    email().length > 0 && !emailError() &&
+    password().length > 0 && !passwordError() &&
+    confirmPassword().length > 0 && !confirmError()
+  )
+
+  const usernameError = createMemo(() => {
+    const v = username()
+    if (!v) return ''
+    return v.length >= 3 ? '' : 'At least 3 characters'
+  })
+
+  const step2Valid = createMemo(() =>
+    fullName().length > 0 && username().length > 0 && !usernameError()
+  )
+
+  // Step 3 is always valid (preferences have defaults)
+  const step3Valid = createMemo(() => true)
+
+  // Cross-step derived state: can proceed from current step?
+  const canProceed = createMemo(() => {
+    const step = currentStep()
+    if (step === 1) return step1Valid()
+    if (step === 2) return step2Valid()
+    if (step === 3) return step3Valid()
+    return false
+  })
+
+  // Step completion status for the step indicator
+  const isStepCompleted = (stepId: number): boolean => {
+    if (stepId === 1) return step1Valid()
+    if (stepId === 2) return step2Valid()
+    if (stepId === 3) return step3Valid()
+    return false
+  }
+
+  const showToast = (message: string) => {
+    setToastMessage(message)
+    setToastOpen(true)
+    setTimeout(() => setToastOpen(false), 3000)
+  }
+
+  const goNext = () => {
+    if (currentStep() < 4 && canProceed()) {
+      setCurrentStep(prev => prev + 1)
+    }
+  }
+
+  const goBack = () => {
+    if (currentStep() > 1) {
+      setCurrentStep(prev => prev - 1)
+    }
+  }
+
+  const goToStep = (stepId: number) => {
+    // Allow going back freely, forward only if current step is valid
+    if (stepId < currentStep() || canProceed()) {
+      setCurrentStep(stepId)
+    }
+  }
+
+  const handleSubmit = () => {
+    showToast(`Account created for ${email()}!`)
+    // Reset form
+    setCurrentStep(1)
+    setEmail('')
+    setPassword('')
+    setConfirmPassword('')
+    setFullName('')
+    setUsername('')
+    setBio('')
+    setPlan('free')
+    setNewsletter(true)
+    setNotifications(true)
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">Create Account</h2>
+        <Badge variant="outline" className="step-badge">Step {currentStep()} of {steps.length}</Badge>
+      </div>
+
+      <div className="multi-step-form rounded-xl border border-border bg-card overflow-hidden">
+        {/* Step indicator — loop with active/completed conditional */}
+        <div className="step-indicator flex border-b border-border">
+          {steps.map(step => (
+            <button
+              key={step.id}
+              className={`step-item flex-1 py-3 px-4 text-sm font-medium text-center transition-colors border-b-2 ${
+                currentStep() === step.id
+                  ? 'border-primary text-primary'
+                  : isStepCompleted(step.id)
+                    ? 'border-green-500 text-green-600'
+                    : 'border-transparent text-muted-foreground'
+              }`}
+              onClick={() => goToStep(step.id)}
+            >
+              <span className="step-number">{
+                isStepCompleted(step.id) && currentStep() !== step.id ? '✓' : step.id
+              }</span>
+              <span className="hidden sm:inline ml-1.5">{step.title}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Step content — all steps rendered, visibility toggled via style.
+             Using display:none instead of conditional rendering because the compiler
+             does not yet initialize child components inside insert() branches
+             (bindEvents does not call initChild for dynamically swapped content).
+             This is a known limitation — tracked for future compiler improvement. */}
+        <div className="p-6 min-h-[320px]">
+          <div className="step-content step-1 space-y-4" style={currentStep() === 1 ? '' : 'display:none'}>
+            <div>
+              <h3 className="text-base font-semibold mb-1">Account Details</h3>
+              <p className="text-sm text-muted-foreground">Set up your login credentials.</p>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <Label for="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email()}
+                  onInput={(e) => setEmail(e.target.value)}
+                />
+                {emailError() ? (
+                  <p className="email-error text-xs text-destructive mt-1">{emailError()}</p>
+                ) : null}
+              </div>
+              <div>
+                <Label for="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="At least 8 characters"
+                  value={password()}
+                  onInput={(e) => setPassword(e.target.value)}
+                />
+                {passwordError() ? (
+                  <p className="password-error text-xs text-destructive mt-1">{passwordError()}</p>
+                ) : null}
+              </div>
+              <div>
+                <Label for="confirm-password">Confirm Password</Label>
+                <Input
+                  id="confirm-password"
+                  type="password"
+                  placeholder="Repeat your password"
+                  value={confirmPassword()}
+                  onInput={(e) => setConfirmPassword(e.target.value)}
+                />
+                {confirmError() ? (
+                  <p className="confirm-error text-xs text-destructive mt-1">{confirmError()}</p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="step-content step-2 space-y-4" style={currentStep() === 2 ? '' : 'display:none'}>
+            <div>
+              <h3 className="text-base font-semibold mb-1">Profile Information</h3>
+              <p className="text-sm text-muted-foreground">Tell us about yourself.</p>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <Label for="fullname">Full Name</Label>
+                <Input
+                  id="fullname"
+                  placeholder="John Doe"
+                  value={fullName()}
+                  onInput={(e) => setFullName(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label for="username">Username</Label>
+                <Input
+                  id="username"
+                  placeholder="johndoe"
+                  value={username()}
+                  onInput={(e) => setUsername(e.target.value)}
+                />
+                {usernameError() ? (
+                  <p className="username-error text-xs text-destructive mt-1">{usernameError()}</p>
+                ) : null}
+              </div>
+              <div>
+                <Label for="bio">Bio (optional)</Label>
+                <Input
+                  id="bio"
+                  placeholder="A short bio about you"
+                  value={bio()}
+                  onInput={(e) => setBio(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="step-content step-3 space-y-4" style={currentStep() === 3 ? '' : 'display:none'}>
+            <div>
+              <h3 className="text-base font-semibold mb-1">Preferences</h3>
+              <p className="text-sm text-muted-foreground">Customize your experience.</p>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <Label className="mb-2 block">Plan</Label>
+                <RadioGroup value={plan()} onValueChange={setPlan}>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="free" />
+                    <Label>Free</Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="pro" />
+                    <Label>Pro — $9/month</Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="enterprise" />
+                    <Label>Enterprise — $29/month</Label>
+                  </div>
+                </RadioGroup>
+                <p className="plan-value text-xs text-muted-foreground mt-1">Selected: {plan()}</p>
+              </div>
+              <Separator />
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    checked={newsletter()}
+                    onCheckedChange={setNewsletter}
+                  />
+                  <Label>Subscribe to newsletter</Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    checked={notifications()}
+                    onCheckedChange={setNotifications}
+                  />
+                  <Label>Enable email notifications</Label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="step-content step-4 space-y-4" style={currentStep() === 4 ? '' : 'display:none'}>
+            <div>
+              <h3 className="text-base font-semibold mb-1">Review</h3>
+              <p className="text-sm text-muted-foreground">Confirm your details before creating your account.</p>
+            </div>
+            <div className="review-summary space-y-3 rounded-lg bg-muted/50 p-4 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Email</span>
+                <span className="review-email font-medium">{email()}</span>
+              </div>
+              <Separator />
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Full Name</span>
+                <span className="review-name font-medium">{fullName()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Username</span>
+                <span className="review-username font-medium">@{username()}</span>
+              </div>
+              {bio() ? (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Bio</span>
+                  <span className="review-bio font-medium truncate max-w-[200px]">{bio()}</span>
+                </div>
+              ) : null}
+              <Separator />
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Plan</span>
+                <Badge variant={plan() === 'free' ? 'outline' : 'default'} className="review-plan">{plan()}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Newsletter</span>
+                <span>{newsletter() ? 'Yes' : 'No'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Notifications</span>
+                <span>{notifications() ? 'Yes' : 'No'}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Navigation buttons — outside conditionals for reliable event binding */}
+        <div className="flex items-center justify-between p-6 pt-0">
+          <Button
+            variant="outline"
+            className="back-btn"
+            onClick={goBack}
+            disabled={currentStep() <= 1}
+            style={currentStep() <= 1 ? 'visibility: hidden' : ''}
+          >
+            Back
+          </Button>
+          <Button
+            className="primary-action-btn"
+            onClick={() => currentStep() < 4 ? goNext() : handleSubmit()}
+            disabled={currentStep() < 4 && !canProceed()}
+          >
+            {currentStep() < 4 ? 'Next' : 'Create Account'}
+          </Button>
+        </div>
+      </div>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={toastOpen()}>
+          <div className="flex-1">
+            <ToastTitle>Success</ToastTitle>
+            <ToastDescription className="toast-message">{toastMessage()}</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setToastOpen(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -111,6 +111,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'sidebar', title: 'Sidebar', description: 'Collapsible navigation panel' },
   { slug: 'chat', title: 'Chat', description: 'Messaging interface with auto-scroll, typing indicator, and unread counts' },
   { slug: 'music-player', title: 'Music Player', description: 'Media player with timer, effect cleanup, and slider binding' },
+  { slug: 'multi-step-form', title: 'Multi-Step Form', description: 'Wizard form with step validation, cross-step state, and review' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/multi-step-form.spec.ts
+++ b/site/ui/e2e/multi-step-form.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Multi-Step Form Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/multi-step-form')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="MultiStepFormDemo_"]:not([data-slot])').first()
+
+  test.describe('Initial Rendering', () => {
+    test('shows step 1 by default', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.step-badge')).toContainText('Step 1 of 4')
+      await expect(s.locator('.step-1')).toBeVisible()
+    })
+
+    test('shows step indicator with 4 steps', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.step-item')).toHaveCount(4)
+    })
+
+    test('next button shows "Next" text', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('button:has-text("Next")')).toBeVisible()
+    })
+  })
+
+  test.describe('Step 1: Account', () => {
+    test('shows validation errors for invalid email', async ({ page }) => {
+      const s = section(page)
+      await s.locator('input[placeholder="you@example.com"]').fill('invalid')
+      await expect(s.locator('.email-error')).toBeVisible()
+    })
+
+    test('shows password length error', async ({ page }) => {
+      const s = section(page)
+      await s.locator('input[placeholder*="8 characters"]').fill('short')
+      await expect(s.locator('.password-error')).toContainText('8 characters')
+    })
+
+    test('shows confirm password mismatch error', async ({ page }) => {
+      const s = section(page)
+      await s.locator('input[placeholder*="8 characters"]').fill('password123')
+      await s.locator('input[placeholder*="Repeat"]').fill('different')
+      await expect(s.locator('.confirm-error')).toContainText('do not match')
+    })
+  })
+
+  test.describe('Step Navigation', () => {
+    async function fillStep1(page: any) {
+      const s = section(page)
+      await s.locator('input[placeholder="you@example.com"]').fill('test@example.com')
+      await s.locator('input[placeholder*="8 characters"]').fill('password123')
+      await s.locator('input[placeholder*="Repeat"]').fill('password123')
+    }
+
+    test('navigating to step 2 shows profile fields', async ({ page }) => {
+      await fillStep1(page)
+      const s = section(page)
+      await s.locator('button:has-text("Next")').click()
+
+      await expect(s.locator('.step-2')).toBeVisible()
+      await expect(s.locator('.step-badge')).toContainText('Step 2 of 4')
+    })
+
+    test('back button returns to previous step', async ({ page }) => {
+      await fillStep1(page)
+      const s = section(page)
+      await s.locator('button:has-text("Next")').click()
+      await expect(s.locator('.step-2')).toBeVisible()
+
+      await s.locator('button:has-text("Back")').click()
+      await expect(s.locator('.step-1')).toBeVisible()
+    })
+
+    test('step 1 values are preserved after going back', async ({ page }) => {
+      await fillStep1(page)
+      const s = section(page)
+      await s.locator('button:has-text("Next")').click()
+      await s.locator('button:has-text("Back")').click()
+
+      await expect(s.locator('input[placeholder="you@example.com"]')).toHaveValue('test@example.com')
+    })
+
+    test('clicking step indicator navigates to that step', async ({ page }) => {
+      await fillStep1(page)
+      const s = section(page)
+      await s.locator('button:has-text("Next")').click()
+
+      // Click step 1 indicator to go back
+      await s.locator('.step-item').first().click()
+      await expect(s.locator('.step-1')).toBeVisible()
+    })
+  })
+
+  test.describe('Step Indicator', () => {
+    test('step 2 indicator is highlighted when on step 2', async ({ page }) => {
+      const s = section(page)
+      await s.locator('input[placeholder="you@example.com"]').fill('test@example.com')
+      await s.locator('input[placeholder*="8 characters"]').fill('password123')
+      await s.locator('input[placeholder*="Repeat"]').fill('password123')
+      await s.locator('button:has-text("Next")').click()
+
+      // Step 2 indicator should have primary border (active step)
+      const step2 = s.locator('.step-item').nth(1)
+      await expect(step2).toHaveClass(/border-primary/)
+    })
+  })
+
+  test.describe('Full Flow', () => {
+    test('complete wizard from step 1 to submission', async ({ page }) => {
+      const s = section(page)
+
+      // Step 1: Account
+      await s.locator('input[placeholder="you@example.com"]').fill('user@example.com')
+      await s.locator('input[placeholder*="8 characters"]').fill('securepass1')
+      await s.locator('input[placeholder*="Repeat"]').fill('securepass1')
+      await s.locator('button:has-text("Next")').click()
+
+      // Step 2: Profile
+      await expect(s.locator('.step-2')).toBeVisible()
+      await s.locator('input[placeholder="John Doe"]').fill('Jane Smith')
+      await s.locator('input[placeholder="johndoe"]').fill('janesmith')
+      await s.locator('button:has-text("Next")').click()
+
+      // Step 3: Preferences
+      await expect(s.locator('.step-3')).toBeVisible()
+      await s.locator('button:has-text("Next")').click()
+
+      // Step 4: Review
+      await expect(s.locator('.step-4')).toBeVisible()
+      await expect(s.locator('.review-email')).toHaveText('user@example.com')
+      await expect(s.locator('.review-name')).toHaveText('Jane Smith')
+      await expect(s.locator('.review-username')).toHaveText('@janesmith')
+      await expect(s.locator('.review-plan')).toHaveText('free')
+
+      // Submit — button text changes to "Create Account" on step 4
+      await s.locator('button:has-text("Create Account")').click()
+
+      // Should reset to step 1
+      await expect(s.locator('.step-badge')).toContainText('Step 1 of 4')
+    })
+  })
+})

--- a/site/ui/pages/components/multi-step-form.tsx
+++ b/site/ui/pages/components/multi-step-form.tsx
@@ -1,0 +1,112 @@
+/**
+ * Multi-Step Form Reference Page (/components/multi-step-form)
+ *
+ * Block-level composition pattern: multi-step wizard with per-step
+ * validation, shared signals across branches, and step indicator.
+ * Compiler stress test for multi-branch conditionals and cross-step state.
+ */
+
+import { MultiStepFormDemo } from '@/components/multi-step-form-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+function MultiStepForm() {
+  const [step, setStep] = createSignal(1)
+  const [email, setEmail] = createSignal('')
+  const [name, setName] = createSignal('')
+
+  const canProceed = createMemo(() => {
+    if (step() === 1) return email().includes('@')
+    if (step() === 2) return name().length > 0
+    return false
+  })
+
+  return (
+    <div>
+      {step() === 1 ? (
+        <Input value={email()} onInput={e => setEmail(e.target.value)} />
+      ) : step() === 2 ? (
+        <Input value={name()} onInput={e => setName(e.target.value)} />
+      ) : (
+        <div>Review: {email()} / {name()}</div>
+      )}
+      <Button onClick={() => setStep(s => s + 1)} disabled={!canProceed()}>
+        Next
+      </Button>
+    </div>
+  )
+}`
+
+export function MultiStepFormRefPage() {
+  return (
+    <DocPage slug="multi-step-form" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Multi-Step Form"
+          description="A wizard-style form with step navigation, per-step validation, and a review step."
+          {...getNavLinks('multi-step-form')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <MultiStepFormDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Multi-Branch Conditional (4 Steps)</h3>
+              <p className="text-sm text-muted-foreground">
+                Four steps rendered via nested ternary operators. Each branch contains
+                different form fields. Tests the compiler's handling of deep conditional
+                trees with distinct component compositions per branch.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Cross-Step Signal Sharing</h3>
+              <p className="text-sm text-muted-foreground">
+                Form values (email, password, name, etc.) are shared across all steps
+                via signals declared once at the component root. Switching steps preserves
+                input values — the signals outlive individual branch renders.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Per-Step Validation Memos</h3>
+              <p className="text-sm text-muted-foreground">
+                step1Valid, step2Valid, step3Valid are createMemo chains that derive from
+                field-level error memos (emailError, passwordError, etc.). canProceed
+                selects the right validation based on currentStep.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Step Indicator with Loop + Conditional</h3>
+              <p className="text-sm text-muted-foreground">
+                Step indicator bar uses .map() with per-item conditional styling
+                (active, completed, pending). Tests loop + conditional coexistence
+                with reactive class updates.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -66,6 +66,7 @@ import { SettingsRefPage } from './pages/components/settings'
 import { SidebarRefPage } from './pages/components/sidebar'
 import { ChatRefPage } from './pages/components/chat'
 import { MusicPlayerRefPage } from './pages/components/music-player'
+import { MultiStepFormRefPage } from './pages/components/multi-step-form'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -462,6 +463,11 @@ export function createApp() {
   // Music Player block page
   app.get('/components/music-player', (c) => {
     return c.render(<MusicPlayerRefPage />)
+  })
+
+  // Multi-Step Form block page
+  app.get('/components/multi-step-form', (c) => {
+    return c.render(<MultiStepFormRefPage />)
   })
 
 


### PR DESCRIPTION
## Summary

- **Add Multi-Step Form block** — wizard with 4 steps, per-step validation, cross-step signal sharing, step indicator with loop + conditional styling
- **Fix renderChild scope ID mismatch in conditional branches** — `renderChild()` generated scope IDs inconsistent with SSR, causing `$cSingle` lookup failure. Child components inside `insert()` branches (Input, Button, etc.) were not initialized.

### Root cause and fix

| | SSR (Hono adapter) | Client (renderChild) before fix | Client after fix |
|---|---|---|---|
| Scope ID | `~ParentName_parentId_sN` | `~ComponentName_random_sN` | `~ParentName_parentId_sN` |

`insert()` now sets a parent scope context (`setParentScopeId`) before calling `branch.template()`. `renderChild()` reads this context and uses the parent's scope ID as prefix, matching the SSR convention. `$cSingle`'s `getDualScopeIds` verification passes without modification.

### Compiler stress patterns

| Pattern | Details |
|---------|---------|
| Multi-branch conditional (4 steps) | Nested ternary with different components per branch |
| Cross-step signal sharing | 13+ signals persist across branch swaps |
| Per-step validation memos | emailError → step1Valid → canProceed chain |
| Loop + reactive class | Step indicator with active/completed styling |
| Components in conditional branches | Input, Button, RadioGroup, Checkbox initialized via bindEvents |

## Test plan

- [x] 12 E2E tests (rendering, validation, navigation, value preservation, indicator, full flow)
- [x] All 979 E2E tests pass
- [x] All 1134 package unit tests pass
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)