### PR TITLE
Fix CSS class leaking as text and dark borders in Mail block

### DIFF
--- a/packages/dom/src/component.ts
+++ b/packages/dom/src/component.ts
@@ -290,7 +290,13 @@ function unwrapPropsForTemplate(props: Record<string, unknown>): Record<string, 
  * the opening tag when parsed via innerHTML. The browser decodes &gt;
  * back to ">" in the DOM attribute value, preserving CSS matching.
  */
-function escapeAttrGt(html: string): string {
+/**
+ * Escape ">" inside HTML attribute values to prevent broken parsing.
+ * UnoCSS classes like has-[>svg]:shrink-0 contain ">" which terminates
+ * the opening tag when parsed via innerHTML. The browser decodes &gt;
+ * back to ">" in the DOM attribute value, preserving CSS matching.
+ */
+export function escapeAttrGt(html: string): string {
   return html.replace(/"[^"]*"/g, match => match.replace(/>/g, '&gt;'))
 }
 

--- a/packages/dom/src/insert.ts
+++ b/packages/dom/src/insert.ts
@@ -8,7 +8,7 @@
 
 import { createEffect } from './reactive'
 import { find } from './query'
-import { setParentScopeId } from './component'
+import { setParentScopeId, escapeAttrGt } from './component'
 import { BF_COND, BF_SCOPE, BF_CHILD_PREFIX } from './attrs'
 
 /**
@@ -237,9 +237,10 @@ function updateFragmentConditional(scope: Element, id: string, html: string): vo
     const endComment = node
     nodesToRemove.forEach(n => n.parentNode?.removeChild(n))
 
-    // Insert new content
+    // Insert new content (escapeAttrGt handles ">" inside attribute values
+    // from UnoCSS classes like has-[>svg] that would break innerHTML parsing)
     const template = document.createElement('template')
-    template.innerHTML = html
+    template.innerHTML = escapeAttrGt(html)
     const newNodes: Node[] = []
     let child = template.content.firstChild
     while (child) {
@@ -275,7 +276,7 @@ function updateElementConditional(scope: Element, id: string, html: string): voi
   if (!condEl) return
 
   const template = document.createElement('template')
-  template.innerHTML = html
+  template.innerHTML = escapeAttrGt(html)
   const newEl = template.content.firstChild
   if (newEl) {
     condEl.replaceWith(newEl.cloneNode(true))


### PR DESCRIPTION
## Summary

Fix CSS class text leaking as visible content in conditional branches of the Mail block.

### Root cause

UnoCSS generates classes like `has-[>svg]:shrink-0` where `>` inside a quoted attribute value terminates the opening tag when parsed via `innerHTML`. The remaining class text (`svg]:px-2.5 undefined" bf="s0">`) appeared as visible content.

`insert()`'s `updateFragmentConditional` and `updateElementConditional` used `template.innerHTML = html` without escaping. `createComponent` already had `escapeAttrGt()` for this exact issue (#696), but `insert` did not.

### Fix

Apply `escapeAttrGt()` in both `updateFragmentConditional` and `updateElementConditional`. Export `escapeAttrGt` from `component.ts` for reuse.

The dark border appearance in the screenshot was caused by the broken HTML structure from this escaping issue — `@layer base { border-color: var(--border) }` works correctly and `border-border` is not needed.

## Test plan

- [x] All 979 E2E tests pass
- [x] All 1134 package tests pass
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)