### PR TITLE
Refactor Phase 3: centralize constants and add contract tests

### DIFF
--- a/packages/dom/src/attrs.ts
+++ b/packages/dom/src/attrs.ts
@@ -38,11 +38,20 @@ export const BF_PARENT_OWNED_PREFIX = '^'
 /** Comment-based scope marker prefix: `<!--bf-scope:ComponentName_abc123-->` */
 export const BF_SCOPE_COMMENT_PREFIX = 'bf-scope:'
 
-/** Key attribute for list reconciliation: `data-key="1"` */
+/**
+ * Key attribute for list reconciliation: `data-key="1"`
+ * @see packages/jsx/src/ir-to-client-js/utils.ts — DATA_KEY (compiler-side mirror)
+ */
 export const BF_KEY = 'data-key'
 
-/** Nested loop key attribute prefix: `data-key-1`, `data-key-2` */
+/**
+ * Nested loop key attribute prefix: `data-key-1`, `data-key-2`
+ * @see packages/jsx/src/ir-to-client-js/utils.ts — DATA_KEY_PREFIX (compiler-side mirror)
+ */
 export const BF_KEY_PREFIX = 'data-key-'
 
-/** Component placeholder in loop templates: `data-bf-ph="s5"` */
+/**
+ * Component placeholder in loop templates: `data-bf-ph="s5"`
+ * @see packages/jsx/src/ir-to-client-js/utils.ts — DATA_BF_PH (compiler-side mirror)
+ */
 export const BF_PLACEHOLDER = 'data-bf-ph'

--- a/packages/dom/src/attrs.ts
+++ b/packages/dom/src/attrs.ts
@@ -37,3 +37,12 @@ export const BF_PARENT_OWNED_PREFIX = '^'
 
 /** Comment-based scope marker prefix: `<!--bf-scope:ComponentName_abc123-->` */
 export const BF_SCOPE_COMMENT_PREFIX = 'bf-scope:'
+
+/** Key attribute for list reconciliation: `data-key="1"` */
+export const BF_KEY = 'data-key'
+
+/** Nested loop key attribute prefix: `data-key-1`, `data-key-2` */
+export const BF_KEY_PREFIX = 'data-key-'
+
+/** Component placeholder in loop templates: `data-bf-ph="s5"` */
+export const BF_PLACEHOLDER = 'data-bf-ph'

--- a/packages/dom/src/component.ts
+++ b/packages/dom/src/component.ts
@@ -9,7 +9,7 @@ import { getTemplate } from './template'
 import { getComponentInit } from './registry'
 import { hydratedScopes } from './hydration-state'
 import { untrack } from './reactive'
-import { BF_SCOPE } from './attrs'
+import { BF_SCOPE, BF_KEY } from './attrs'
 import type { ComponentDef } from './types'
 
 // Parent scope ID context for renderChild() inside insert() branch templates.
@@ -114,7 +114,7 @@ export function createComponent(
   const scopeId = `${name}_${generateId()}`
   element.setAttribute(BF_SCOPE, scopeId)
   if (key !== undefined) {
-    element.setAttribute('data-key', String(key))
+    element.setAttribute(BF_KEY, String(key))
   }
 
   // 7. Initialize the component synchronously
@@ -202,7 +202,7 @@ export function renderChild(
   const scopePrefix = (_parentScopeId && slotSuffix)
     ? _parentScopeId
     : `${name}_${generateId()}`
-  const keyAttr = key !== undefined ? ` data-key="${key}"` : ''
+  const keyAttr = key !== undefined ? ` ${BF_KEY}="${key}"` : ''
 
   if (!templateFn) {
     // Fallback: empty placeholder (for components without registered templates)
@@ -238,7 +238,7 @@ function createPlaceholder(name: string, key?: string | number): HTMLElement {
   const el = document.createElement('div')
   el.setAttribute(BF_SCOPE, `${name}_placeholder`)
   if (key !== undefined) {
-    el.setAttribute('data-key', String(key))
+    el.setAttribute(BF_KEY, String(key))
   }
   el.textContent = `[${name}]`
   el.style.cssText = 'color: red; border: 1px dashed red; padding: 4px;'
@@ -365,7 +365,7 @@ function createComponentFromDef(
   const scopeId = `${name}_${generateId()}`
   element.setAttribute(BF_SCOPE, scopeId)
   if (key !== undefined) {
-    element.setAttribute('data-key', String(key))
+    element.setAttribute(BF_KEY, String(key))
   }
 
   // Initialize

--- a/packages/dom/src/reconcile-elements.ts
+++ b/packages/dom/src/reconcile-elements.ts
@@ -6,7 +6,7 @@
  */
 
 import { hydratedScopes } from './hydration-state'
-import { BF_SCOPE, BF_SLOT, BF_COND } from './attrs'
+import { BF_SCOPE, BF_SLOT, BF_COND, BF_KEY } from './attrs'
 
 /**
  * Reconcile a list container using HTMLElement mode (for createComponent).
@@ -52,7 +52,7 @@ export function reconcileElements<T>(
     for (let i = 0; i < items.length; i++) {
       const el = (i === 0 && firstElement) ? firstElement : renderItem(items[i], i)
       const key = getKey ? getKey(items[i], i) : String(i)
-      if (!el.dataset.key) el.setAttribute('data-key', key)
+      if (!el.dataset.key) el.setAttribute(BF_KEY, key)
       fragment.appendChild(el)
     }
     container.innerHTML = ''
@@ -103,7 +103,7 @@ export function reconcileElements<T>(
         // For SSR elements, create new element with proper initialization
         const newEl = createEl()
         if (!newEl.dataset.key) {
-          newEl.setAttribute('data-key', key)
+          newEl.setAttribute(BF_KEY, key)
         }
         fragment.appendChild(newEl)
       } else {
@@ -124,7 +124,7 @@ export function reconcileElements<T>(
           // No focus to preserve - use the temp element directly
           const tempEl = createEl()
           if (!tempEl.dataset.key) {
-            tempEl.setAttribute('data-key', key)
+            tempEl.setAttribute(BF_KEY, key)
           }
           fragment.appendChild(tempEl)
         }
@@ -133,7 +133,7 @@ export function reconcileElements<T>(
       // Create new element via renderItem (which calls createComponent)
       const el = createEl()
       if (!el.dataset.key) {
-        el.setAttribute('data-key', key)
+        el.setAttribute(BF_KEY, key)
       }
       fragment.appendChild(el)
     }

--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Compiler-Runtime Contract Tests
+ *
+ * Verifies that compiler-generated code uses conventions that the runtime
+ * expects. These tests catch mismatches between the two layers that would
+ * otherwise fail silently at runtime.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '..'
+import { HonoAdapter } from '../../../hono/src/adapter/hono-adapter'
+
+const adapter = new HonoAdapter()
+function compileClient(source: string, filename = 'Test.tsx') {
+  const result = compileJSXSync(source, filename, { adapter })
+  return result.files.find(f => f.type === 'clientJs')?.content ?? ''
+}
+
+describe('Compiler-Runtime Contract', () => {
+  describe('event names are lowercase', () => {
+    test('onClick generates lowercase click', () => {
+      const js = compileClient(`
+        "use client"
+        export function Test() {
+          return <button onClick={() => {}}>click</button>
+        }
+      `)
+      // All addEventListener calls should use lowercase event names
+      const eventMatches = js.match(/addEventListener\('([^']+)'/g) ?? []
+      for (const match of eventMatches) {
+        const eventName = match.match(/addEventListener\('([^']+)'/)?.[1]
+        if (eventName) {
+          expect(eventName).toBe(eventName.toLowerCase())
+        }
+      }
+    })
+
+    test('onKeyDown generates lowercase keydown', () => {
+      const js = compileClient(`
+        "use client"
+        export function Test() {
+          return <input onKeyDown={() => {}} />
+        }
+      `)
+      expect(js).toContain("'keydown'")
+      expect(js).not.toContain("'keyDown'")
+    })
+
+    test('onDoubleClick generates dblclick', () => {
+      const js = compileClient(`
+        "use client"
+        export function Test() {
+          return <div onDoubleClick={() => {}}>dbl</div>
+        }
+      `)
+      expect(js).toContain("'dblclick'")
+      expect(js).not.toContain("'doubleclick'")
+    })
+  })
+
+  describe('scope ID patterns', () => {
+    test('hydrate uses ComponentName_ prefix', () => {
+      const js = compileClient(`
+        "use client"
+        export function MyWidget() {
+          return <div>hello</div>
+        }
+      `)
+      expect(js).toContain("hydrate('MyWidget'")
+      expect(js).toContain('function initMyWidget(')
+    })
+
+    test('child components use slot suffix in renderChild', () => {
+      const js = compileClient(`
+        "use client"
+        import { Button } from './Button'
+        export function Test() {
+          return <Button>click</Button>
+        }
+      `)
+      // renderChild should pass a slot suffix like 's0', 's1', etc.
+      expect(js).toMatch(/renderChild\('Button',\s*\{[^}]*\},\s*undefined,\s*'s\d+'\)/)
+    })
+  })
+
+  describe('attribute constants consistency', () => {
+    test('data-key attribute in loop hydration', () => {
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        export function Test() {
+          const [items] = createSignal([{id: 1}])
+          return <ul>{items().map(item => <li key={item.id}>{item.id}</li>)}</ul>
+        }
+      `)
+      // Should use data-key for key attribute
+      expect(js).toContain("data-key")
+      // Should not use any other key attribute pattern
+      expect(js).not.toContain("data-item-key")
+    })
+  })
+
+  describe('variable name safety', () => {
+    test('parent-owned slot IDs do not contain ^ in variable names', () => {
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        import { Button } from './Button'
+        export function Test() {
+          const [items] = createSignal(['a', 'b'])
+          return <div>{items().map(item => (
+            <div key={item}>
+              <Button onClick={() => {}}>{item}</Button>
+            </div>
+          ))}</div>
+        }
+      `)
+      // ^ should never appear in variable names (would cause syntax error)
+      const varDecls = js.match(/const __\w+/g) ?? []
+      for (const decl of varDecls) {
+        expect(decl).not.toContain('^')
+      }
+    })
+  })
+
+  describe('module-level functions', () => {
+    test('module-level function without component deps emits at module scope', () => {
+      // Uses the existing test from client-js-generation.test.ts (module-level function scope isolation)
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        function computeError(field: { value: string }, allFields: { id: number; value: string }[]) {
+          const basicError = field.value === '' ? 'Required' : ''
+          const isDuplicate = allFields.some(f => f.id !== 0 && f.value === field.value)
+          return isDuplicate ? 'Duplicate' : basicError
+        }
+        export function MyComponent() {
+          const [items, setItems] = createSignal([{ id: 1, value: '' }])
+          const error = computeError(items()[0], items())
+          return <div>{error}</div>
+        }
+      `)
+      // Module-level function should appear before init function using var ?? pattern
+      expect(js).toContain('var computeError = computeError ?? function(')
+      const helperPos = js.indexOf('var computeError')
+      const initPos = js.indexOf('export function initMyComponent(')
+      expect(helperPos).toBeGreaterThan(-1)
+      expect(helperPos).toBeLessThan(initPos)
+    })
+
+    test('component-level function referencing signals stays inside init', () => {
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        export function Test() {
+          const [count, setCount] = createSignal(0)
+          function increment() { setCount(c => c + 1) }
+          return <button onClick={increment}>{count()}</button>
+        }
+      `)
+      // Component-level function should be inside init (as arrow function const)
+      const initPos = js.indexOf('export function initTest(')
+      const fnPos = js.indexOf('const increment')
+      expect(fnPos).toBeGreaterThan(initPos)
+    })
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopElement } from './types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
@@ -235,14 +235,14 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
         lines.push(`    const __renderItem = (${elem.param}, ${indexParamTemplate}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) }`)
       }
       // Hydration: preserve SSR elements, tag with data-key, track signals
-      lines.push(`    if (_${vLoop} && _${vLoop}.children.length > 0 && !_${vLoop}.firstElementChild?.hasAttribute('data-key')) {`)
+      lines.push(`    if (_${vLoop} && _${vLoop}.children.length > 0 && !_${vLoop}.firstElementChild?.hasAttribute('${DATA_KEY}')) {`)
       lines.push(`      Array.from(_${vLoop}.children).forEach((__hChild, ${indexParamTemplate}) => {`)
       lines.push(`        if (${indexParamTemplate} >= __arr.length) return`)
       lines.push(`        const ${elem.param} = __arr[${indexParamTemplate}]`)
       if (elem.key) {
-        lines.push(`        __hChild.setAttribute('data-key', String(${elem.key}))`)
+        lines.push(`        __hChild.setAttribute('${DATA_KEY}', String(${elem.key}))`)
       } else {
-        lines.push(`        __hChild.setAttribute('data-key', String(${indexParamTemplate}))`)
+        lines.push(`        __hChild.setAttribute('${DATA_KEY}', String(${indexParamTemplate}))`)
       }
       lines.push(`      })`)
       lines.push(`      if (__arr.length > 0) __renderItem(__arr[0], 0)`)
@@ -260,9 +260,9 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
         emitLoopEventDelegation(lines, `_${vLoop}`, elem.childEvents, (ls, ev, handlerCall) => {
           if (ev.nestedLoops.length === 0) {
             // Direct child of outer loop — single-level lookup
-            ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[data-key]')`)
+            ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
             ls.push(`      if (li) {`)
-            ls.push(`        const key = li.getAttribute('data-key')`)
+            ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
             ls.push(`        const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
             ls.push(`        if (${elem.param}) ${handlerCall}`)
             ls.push(`      }`)
@@ -271,13 +271,13 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
             const evVar = varSlotId(ev.childSlotId)
             // Resolve inner loop keys (innermost first)
             for (const nested of ev.nestedLoops) {
-              const dataAttr = `data-key-${nested.depth}`
+              const dataAttr = `${DATA_KEY_PREFIX}${nested.depth}`
               ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
               ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
             }
             // Resolve outer loop key
-            ls.push(`      const outerLi = ${evVar}El.closest('[data-key]')`)
-            ls.push(`      const outerKey = outerLi?.getAttribute('data-key')`)
+            ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
+            ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
             // Resolve outer loop variable
             ls.push(`      const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
             // Resolve inner loop variables via the outer param's nested array
@@ -383,7 +383,7 @@ function emitCompositeElementReconciliation(
       const propsExpr = buildPropsExpr(comp)
       const keyProp = comp.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${keyProp.value}` : ''
-      ls.push(`${indent}{ const __ph = __el.querySelector('[data-bf-ph="${phId}"]'); if (__ph) __ph.replaceWith(createComponent('${comp.name}', ${propsExpr}${keyArg})) }`)
+      ls.push(`${indent}{ const __ph = __el.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) __ph.replaceWith(createComponent('${comp.name}', ${propsExpr}${keyArg})) }`)
     }
 
     // Set up outer-level events
@@ -397,7 +397,7 @@ function emitCompositeElementReconciliation(
       ls.push(`${indent}// Initialize inner loop components and events`)
       ls.push(`${indent}${inner.array}.forEach((${inner.param}) => {`)
       if (inner.key) {
-        ls.push(`${indent}  const __innerEl = __el.querySelector('[data-key-${inner.depth}="' + ${inner.key} + '"]')`)
+        ls.push(`${indent}  const __innerEl = __el.querySelector('[${DATA_KEY_PREFIX}${inner.depth}="' + ${inner.key} + '"]')`)
       } else {
         ls.push(`${indent}  const __innerEl = null`)
       }
@@ -407,7 +407,7 @@ function emitCompositeElementReconciliation(
         const propsExpr = buildPropsExpr(comp)
         const keyProp = comp.props.find(p => p.name === 'key')
         const keyArg = keyProp ? `, ${keyProp.value}` : ''
-        ls.push(`${indent}  { const __ph = __innerEl.querySelector('[data-bf-ph="${phId}"]'); if (__ph) __ph.replaceWith(createComponent('${comp.name}', ${propsExpr}${keyArg})) }`)
+        ls.push(`${indent}  { const __ph = __innerEl.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) __ph.replaceWith(createComponent('${comp.name}', ${propsExpr}${keyArg})) }`)
       }
       for (const ev of innerEvents) {
         emitEventSetup(ls, `${indent}  `, '__innerEl', ev)
@@ -428,14 +428,14 @@ function emitCompositeElementReconciliation(
   lines.push(`    }`)
   lines.push('')
   lines.push(`    // Hydration: preserve SSR elements, init components/events, track signals`)
-  lines.push(`    if (_${vLoop} && _${vLoop}.children.length > 0 && !_${vLoop}.firstElementChild?.hasAttribute('data-key')) {`)
+  lines.push(`    if (_${vLoop} && _${vLoop}.children.length > 0 && !_${vLoop}.firstElementChild?.hasAttribute('${DATA_KEY}')) {`)
   lines.push(`      Array.from(_${vLoop}.children).forEach((__hChild, ${indexParam}) => {`)
   lines.push(`        if (${indexParam} >= __arr.length) return`)
   lines.push(`        const ${elem.param} = __arr[${indexParam}]`)
   if (elem.key) {
-    lines.push(`        __hChild.setAttribute('data-key', String(${elem.key}))`)
+    lines.push(`        __hChild.setAttribute('${DATA_KEY}', String(${elem.key}))`)
   } else {
-    lines.push(`        __hChild.setAttribute('data-key', String(${indexParam}))`)
+    lines.push(`        __hChild.setAttribute('${DATA_KEY}', String(${indexParam}))`)
   }
   // Initialize outer-level child components in SSR markup
   // Use both suffix match (for components with slotSuffix in bf-s, e.g. ~Badge_hash_s2)
@@ -463,7 +463,7 @@ function emitCompositeElementReconciliation(
     lines.push(`          const __innerEl = __ic.children[__innerIdx]`)
     lines.push(`          if (!__innerEl) return`)
     if (inner.key) {
-      lines.push(`          __innerEl.setAttribute('data-key-${inner.depth}', String(${inner.key}))`)
+      lines.push(`          __innerEl.setAttribute('${DATA_KEY_PREFIX}${inner.depth}', String(${inner.key}))`)
     }
     for (const comp of innerComps) {
       const selector = comp.slotId

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH } from './utils'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -71,7 +71,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           }
           // Convert JSX `key` to `data-key` (or `data-key-N` for nested loops)
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `data-key-${loopDepth}` : 'data-key')
+            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           // Resolve IRTemplateLiteral to string expression for use in template literals
@@ -194,7 +194,7 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
             return `\${spreadAttrs(${spreadValue})}`
           }
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `data-key-${loopDepth}` : 'data-key')
+            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
@@ -244,7 +244,7 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       }
       // Emit a placeholder div that will be replaced with createComponent() at runtime
       const phId = node.slotId || node.name
-      return `<div data-bf-ph="${phId}"></div>`
+      return `<div ${DATA_BF_PH}="${phId}"></div>`
     }
 
     case 'loop': {
@@ -437,8 +437,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           if (a.name === 'key') {
             if (loopDepth === 0) return ''  // outer loop: skip (runtime handles it)
             const valStr = attrValueToString(a.value)
-            if (valStr && a.dynamic) return templateAttrExpr(`data-key-${loopDepth}`, transformExpr(valStr), a)
-            if (valStr) return `data-key-${loopDepth}="${valStr}"`
+            if (valStr && a.dynamic) return templateAttrExpr(`${DATA_KEY_PREFIX}${loopDepth}`, transformExpr(valStr), a)
+            if (valStr) return `${DATA_KEY_PREFIX}${loopDepth}="${valStr}"`
             return ''
           }
           const attrName = toHtmlAttrName(a.name)
@@ -731,7 +731,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
             return `\${spreadAttrs(${transformExpr(spreadValue)})}`
           }
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `data-key-${loopDepth}` : 'data-key')
+            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valueStr = attrValueToString(a.value)

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -13,8 +13,12 @@ import type { LoopElement } from './types'
 export const PROPS_PARAM = '_p'
 
 /**
- * HTML attribute constants for generated code.
- * Values must match packages/dom/src/attrs.ts (runtime).
+ * HTML attribute constants for compiler-generated code.
+ * These are the same values as the runtime constants in packages/dom/src/attrs.ts
+ * (BF_KEY, BF_KEY_PREFIX, BF_PLACEHOLDER). Duplicated here because the compiler
+ * package cannot depend on the runtime package.
+ *
+ * @see packages/dom/src/attrs.ts — runtime-side definitions
  */
 export const DATA_KEY = 'data-key'
 export const DATA_KEY_PREFIX = 'data-key-'

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -13,6 +13,14 @@ import type { LoopElement } from './types'
 export const PROPS_PARAM = '_p'
 
 /**
+ * HTML attribute constants for generated code.
+ * Values must match packages/dom/src/attrs.ts (runtime).
+ */
+export const DATA_KEY = 'data-key'
+export const DATA_KEY_PREFIX = 'data-key-'
+export const DATA_BF_PH = 'data-bf-ph'
+
+/**
  * Strip ^ prefix from slot ID for use as JavaScript variable name.
  * `^s3` → `s3` (since `_^s3` is not a valid identifier)
  */


### PR DESCRIPTION
## Summary

### 1. Centralize magic string constants

Replace scattered `'data-key'`, `'data-key-N'`, `'data-bf-ph'` string literals with named constants.

| Layer | Constants | File |
|-------|----------|------|
| Runtime | `BF_KEY`, `BF_KEY_PREFIX`, `BF_PLACEHOLDER` | `packages/dom/src/attrs.ts` |
| Compiler | `DATA_KEY`, `DATA_KEY_PREFIX`, `DATA_BF_PH` | `packages/jsx/src/ir-to-client-js/utils.ts` |

Applied to: `reconcile-elements.ts`, `component.ts`, `emit-control-flow.ts`, `html-template.ts`

### 2. Compiler-runtime contract tests (9 tests)

Automated verification that compiler output matches runtime expectations:

- **Event names**: always lowercase (`keydown`, not `keyDown`), special mappings (`dblclick`)
- **Scope IDs**: `hydrate('ComponentName', ...)` pattern
- **Child components**: `renderChild` uses slot suffix
- **Key attributes**: `data-key` used consistently
- **Variable safety**: no `^` in generated variable names
- **Module-level functions**: correct scope placement

These tests catch the exact bugs fixed in PRs #700-#703 and prevent recurrence.

## Test plan

- [x] 1143 package tests pass (9 new contract tests)
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)