### PR TITLE
Unify key pipeline: keyAttrName helper + contract tests

### DIFF
--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -83,8 +83,8 @@ describe('Compiler-Runtime Contract', () => {
     })
   })
 
-  describe('attribute constants consistency', () => {
-    test('data-key attribute in loop hydration', () => {
+  describe('key pipeline', () => {
+    test('outer loop uses data-key attribute', () => {
       const js = compileClient(`
         "use client"
         import { createSignal } from '@barefootjs/dom'
@@ -93,10 +93,43 @@ describe('Compiler-Runtime Contract', () => {
           return <ul>{items().map(item => <li key={item.id}>{item.id}</li>)}</ul>
         }
       `)
-      // Should use data-key for key attribute
       expect(js).toContain("data-key")
-      // Should not use any other key attribute pattern
       expect(js).not.toContain("data-item-key")
+    })
+
+    test('nested loop uses data-key-N for inner levels', () => {
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        export function Test() {
+          const [groups] = createSignal([{id: 'g1', items: [{id: 'i1'}]}])
+          return <div>{groups().map(group => (
+            <div key={group.id}>
+              {group.items.map(item => <span key={item.id}>{item.id}</span>)}
+            </div>
+          ))}</div>
+        }
+      `)
+      // Outer loop: data-key
+      expect(js).toContain('data-key')
+      // Inner loop: data-key-1 (depth 1)
+      expect(js).toContain('data-key-1')
+      // Should not have data-key-0 (depth 0 uses data-key, not data-key-0)
+      expect(js).not.toContain('data-key-0')
+    })
+
+    test('key in HTML template uses data-key attribute name', () => {
+      const result = compileJSXSync(`
+        "use client"
+        import { createSignal } from '@barefootjs/dom'
+        export function Test() {
+          const [items] = createSignal([{id: 1}])
+          return <ul>{items().map(item => <li key={item.id}>{item.id}</li>)}</ul>
+        }
+      `, 'Test.tsx', { adapter })
+      const template = result.files.find(f => f.type === 'markedTemplate')?.content ?? ''
+      // Template should have data-key attribute for loop items
+      expect(template).toContain('data-key')
     })
   })
 

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopElement } from './types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
@@ -271,7 +271,7 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
             const evVar = varSlotId(ev.childSlotId)
             // Resolve inner loop keys (innermost first)
             for (const nested of ev.nestedLoops) {
-              const dataAttr = `${DATA_KEY_PREFIX}${nested.depth}`
+              const dataAttr = keyAttrName(nested.depth)
               ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
               ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
             }
@@ -397,7 +397,7 @@ function emitCompositeElementReconciliation(
       ls.push(`${indent}// Initialize inner loop components and events`)
       ls.push(`${indent}${inner.array}.forEach((${inner.param}) => {`)
       if (inner.key) {
-        ls.push(`${indent}  const __innerEl = __el.querySelector('[${DATA_KEY_PREFIX}${inner.depth}="' + ${inner.key} + '"]')`)
+        ls.push(`${indent}  const __innerEl = __el.querySelector('[${keyAttrName(inner.depth)}="' + ${inner.key} + '"]')`)
       } else {
         ls.push(`${indent}  const __innerEl = null`)
       }
@@ -463,7 +463,7 @@ function emitCompositeElementReconciliation(
     lines.push(`          const __innerEl = __ic.children[__innerIdx]`)
     lines.push(`          if (!__innerEl) return`)
     if (inner.key) {
-      lines.push(`          __innerEl.setAttribute('${DATA_KEY_PREFIX}${inner.depth}', String(${inner.key}))`)
+      lines.push(`          __innerEl.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
     }
     for (const comp of innerComps) {
       const selector = comp.slotId

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName } from './utils'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -71,7 +71,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           }
           // Convert JSX `key` to `data-key` (or `data-key-N` for nested loops)
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
+            ? keyAttrName(loopDepth)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           // Resolve IRTemplateLiteral to string expression for use in template literals
@@ -194,7 +194,7 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
             return `\${spreadAttrs(${spreadValue})}`
           }
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
+            ? keyAttrName(loopDepth)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
@@ -437,8 +437,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           if (a.name === 'key') {
             if (loopDepth === 0) return ''  // outer loop: skip (runtime handles it)
             const valStr = attrValueToString(a.value)
-            if (valStr && a.dynamic) return templateAttrExpr(`${DATA_KEY_PREFIX}${loopDepth}`, transformExpr(valStr), a)
-            if (valStr) return `${DATA_KEY_PREFIX}${loopDepth}="${valStr}"`
+            if (valStr && a.dynamic) return templateAttrExpr(keyAttrName(loopDepth), transformExpr(valStr), a)
+            if (valStr) return `${keyAttrName(loopDepth)}="${valStr}"`
             return ''
           }
           const attrName = toHtmlAttrName(a.name)
@@ -731,7 +731,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
             return `\${spreadAttrs(${transformExpr(spreadValue)})}`
           }
           const attrName = a.name === 'key'
-            ? (loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY)
+            ? keyAttrName(loopDepth)
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valueStr = attrValueToString(a.value)

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -25,6 +25,15 @@ export const DATA_KEY_PREFIX = 'data-key-'
 export const DATA_BF_PH = 'data-bf-ph'
 
 /**
+ * Get the data-key attribute name for a given loop depth.
+ * Outer loop (depth 0): 'data-key'
+ * Nested loops (depth N): 'data-key-N'
+ */
+export function keyAttrName(loopDepth: number): string {
+  return loopDepth > 0 ? `${DATA_KEY_PREFIX}${loopDepth}` : DATA_KEY
+}
+
+/**
  * Strip ^ prefix from slot ID for use as JavaScript variable name.
  * `^s3` → `s3` (since `_^s3` is not a valid identifier)
  */


### PR DESCRIPTION
## Summary
- Extract `keyAttrName(loopDepth)` helper to centralize key → data-key attribute name mapping
- Replace 5 duplicated inline expressions across `html-template.ts` and `emit-control-flow.ts`
- Add 3 key pipeline contract tests (outer loop, nested loop, template output)

## Motivation
Key attribute name resolution (`data-key` for depth 0, `data-key-N` for depth N) was duplicated in 5 locations. Changes to the naming convention required updating all 5, with no test to catch mismatches. The new `keyAttrName()` helper is the single source of truth.

## Test plan
- [x] 492 compiler tests pass (+2 new contract tests)
- [x] 69 adapter conformance tests pass
- [x] dom package builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)