### PR TITLE
Clean up Hono adapter: remove redundant key prop output

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -738,8 +738,9 @@ export class HonoAdapter implements TemplateAdapter {
       if (prop.name === '...') {
         parts.push(`{...${prop.value}}`)
       } else if (prop.name === 'key') {
-        // JSX key prop - also add data-key for reconciliation
-        parts.push(`${prop.name}={${prop.value}}`)
+        // JSX key → data-key only. Hono JSX strips `key` from HTML output
+        // (delete props["key"]), so emitting key={} is a no-op. We only need
+        // data-key which the BarefootJS client runtime uses for reconciliation.
         keyValue = prop.value
       } else if (prop.dynamic) {
         parts.push(`${prop.name}={${prop.value}}`)


### PR DESCRIPTION
## Summary
Remove redundant `key={value}` JSX prop output from Hono adapter's `renderComponentProps`. Only `data-key={value}` is needed — Hono JSX runtime strips `key` from props via `delete props["key"]`, so it never reaches HTML output.

## Changes
- Remove `parts.push(\`\${prop.name}={\${prop.value}}\`)` for key props (1 line)
- Add comment explaining the key → data-key conversion

## Test plan
- [x] 46 Hono adapter tests pass
- [x] 490 compiler tests pass
- [x] 69 adapter conformance tests pass
- [x] Hono package builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)