### PR TITLE
Document and rename isReactiveExpression Phase 1/Phase 2

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,7 +5,7 @@
 import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopChildReactiveAttr, NestedLoopInfo } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
-import { isReactiveExpression, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs } from './reactivity'
+import { needsEffectWrapper, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 
@@ -349,7 +349,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
 
           const hasPropsRef = expandedValue.includes('props.')
-          const hasReactiveExpr = isReactiveExpression(expandedValue, ctx)
+          const hasReactiveExpr = needsEffectWrapper(expandedValue, ctx)
           if (hasPropsRef || hasReactiveExpr) {
             const attrName = prop.name === 'className' ? 'class' : prop.name
             ctx.reactiveChildProps.push({
@@ -469,7 +469,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
         // e.g., `classes` → `` `${baseClasses} ${variantClasses[variant]} ${className}` ``
         const expandedValueStr = expandConstantForReactivity(valueStr, ctx)
 
-        if (isReactiveExpression(expandedValueStr, ctx)) {
+        if (needsEffectWrapper(expandedValueStr, ctx)) {
           ctx.reactiveAttrs.push({
             slotId: element.slotId,
             attrName: attr.name,

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -15,13 +15,19 @@ import { attrValueToString } from './utils'
 import { expandConstantForReactivity } from './prop-handling'
 
 /**
- * Check if an expression directly references signal getters, memos, or props.
+ * Phase 2 reactivity detection: determines if a code expression needs `createEffect`
+ * wrapping during IR → Client JS generation.
  *
- * Note: This function does NOT follow local constants — constant taint analysis
- * is handled in Phase 1 (jsx-to-ir.ts) when marking IR nodes as reactive.
- * Phase 2 only checks direct references in the expression string.
+ * This operates on string expressions (already extracted from IR), using regex matching
+ * against known signal getters, memo names, and prop parameter names.
+ *
+ * Unlike Phase 1's `isReactiveExpression` (in jsx-to-ir.ts), this function:
+ * - Has NO access to TypeChecker or AST — works purely on expression strings
+ * - Does NOT follow local constants (constant taint analysis is Phase 1's job)
+ * - Skips `children` props because children are server-rendered and should not
+ *   trigger `createEffect` wrapping on the client
  */
-export function isReactiveExpression(expr: string, ctx: ClientJsContext): boolean {
+export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean {
   for (const signal of ctx.signals) {
     if (new RegExp(`\\b${signal.getter}\\s*\\(`).test(expr)) {
       return true
@@ -34,7 +40,8 @@ export function isReactiveExpression(expr: string, ctx: ClientJsContext): boolea
     }
   }
 
-  // Check individual prop names (excluding children which is server-rendered)
+  // Check individual prop names (excluding children which is server-rendered
+  // and should not trigger effect wrapping on the client)
   for (const prop of ctx.propsParams) {
     if (prop.name === 'children') continue
     if (new RegExp(`\\b${prop.name}\\b`).test(expr)) {
@@ -323,7 +330,7 @@ export function collectLoopChildReactiveAttrs(
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx)
-        if (isReactiveExpression(expanded, ctx)) {
+        if (needsEffectWrapper(expanded, ctx)) {
           attrs.push({
             childSlotId: el.slotId,
             attrName: attr.name,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1910,7 +1910,17 @@ function isSignalOrMemoArray(array: string, ctx: TransformContext): boolean {
 }
 
 /**
- * Check if an expression is reactive.
+ * Phase 1 reactivity detection: determines the `reactive: boolean` flag on IR nodes
+ * during JSX → IR transformation.
+ *
+ * This operates on TypeScript AST nodes and source text, using the TypeChecker when
+ * available for precise Reactive<T> branded-type detection, with regex fallbacks.
+ *
+ * Unlike Phase 2's `needsEffectWrapper` (in ir-to-client-js/reactivity.ts), this function:
+ * - Has access to the TypeChecker and full AST for type-level analysis
+ * - Follows local constant references transitively (e.g., `const x = count()`)
+ * - Does NOT need a `children` skip because children are processed as child JSX nodes
+ *   in the AST, not as named props — they never appear as `props.children` expressions here
  *
  * Detection strategy:
  * 1. TypeChecker: walk AST to find Reactive<T> branded types (signals, memos, FieldReturn, etc.)


### PR DESCRIPTION
## Summary
- Rename Phase 2 `isReactiveExpression` → `needsEffectWrapper` to distinguish from Phase 1
- Add JSDoc to both functions explaining their distinct roles:
  - Phase 1 (jsx-to-ir.ts): determines `reactive: boolean` on IR nodes using TypeChecker + AST
  - Phase 2 (reactivity.ts → `needsEffectWrapper`): determines if string expressions need `createEffect` wrapping using regex
- Document why children skip exists in Phase 2 but not Phase 1

## Motivation
Two same-named functions with different logic was confusing. Phase 1 operates on AST nodes and doesn't need a children skip (children are JSX child nodes, not named props). Phase 2 operates on string expressions and skips `children` because it's server-rendered.

## Test plan
- [x] 492 compiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)