### PR TITLE
Add Cart block + reactive loops inside conditionals

### DIFF
--- a/.claude/projects/-Users-kfly8-src-github-com-kfly8-barefootjs/memory/refactor-priority.md
+++ b/.claude/projects/-Users-kfly8-src-github-com-kfly8-barefootjs/memory/refactor-priority.md
@@ -1,0 +1,53 @@
+---
+name: Refactoring Priority Plan
+description: Three-phase plan to reduce compiler/runtime fragility and improve human maintainability
+type: project
+---
+
+## Motivation
+
+9 blocks implemented, 7 compiler/runtime bugs fixed. Bugs share 3 structural root causes:
+1. Same concept implemented in multiple places (unsynchronized)
+2. Implicit contracts between compiler output and runtime (not type-enforced)
+3. Mixed responsibilities in large files (emit-init-sections.ts = 1,520 lines)
+
+**Why:** The codebase is currently AI-editable but not human-maintainable.
+
+**How to apply:** Use this as a checklist when planning refactoring work.
+
+## Phase 1: Safety Guards (bug recurrence prevention)
+
+1. **Element search helper** — `querySelector` + `matches` pattern in 1 function
+   - Files: new helper in `packages/dom/src/`, used by `insert.ts`, `reconcile-elements.ts`, compiler codegen
+   - Prevents: loop root event binding bug
+
+2. **innerHTML helper** — wrapper that always applies `escapeAttrGt`
+   - Files: `packages/dom/src/component.ts`, `insert.ts`
+   - Prevents: UnoCSS `>` breaking HTML parsing
+
+3. **Event name normalization unification** — single function for compiler + runtime
+   - Files: `packages/jsx/src/ir-to-client-js/utils.ts`, `packages/dom/src/apply-rest-attrs.ts`
+   - Prevents: camelCase event name mismatch
+
+## Phase 2: Responsibility Separation (comprehensibility)
+
+4. **Split `emit-init-sections.ts`** (1,520 lines → 3-4 files)
+   - `emit-control-flow.ts` — conditionals + loops
+   - `emit-reactive-updates.ts` — attributes, text, classes
+   - `emit-events.ts` — event handlers, refs
+   - Keep `emit-init-sections.ts` for shared helpers
+
+5. **Scope search abstraction** — unify bf-s / comment / portal queries in `query.ts`
+   - Extract ScopeResolver interface
+   - Reduce `query.ts` from 657 lines
+
+## Phase 3: Contract Enforcement (structural safety)
+
+6. **Compiler-runtime contract tests**
+   - Scope ID pattern validation
+   - Event name lowercase assertion
+   - Attribute constant consistency
+
+7. **Magic string constants centralization**
+   - `data-key`, `data-key-N` → `attrs.ts`
+   - Compiler-side attribute constants → shared with runtime

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -542,8 +542,10 @@ function collectBranchLoops(node: IRNode): ConditionalBranchLoop[] {
         break
       case 'loop': {
         if (!parentSlotId) break
-        // Build the item template from loop children
-        const childTemplate = n.children.map(c => irToHtmlTemplate(c)).join('')
+        // Build the item template from loop children.
+        // Use loopDepth=0: this loop gets its own reconcileElements (independent
+        // from the conditional's template), so items use data-key (not data-key-1).
+        const childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0)).join('')
         loops.push({
           array: n.array,
           param: n.param,

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,7 +3,7 @@
  */
 
 import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopChildReactiveAttr, NestedLoopInfo } from './types'
+import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchLoop, ConditionalBranchTextEffect, LoopChildEvent, LoopChildReactiveAttr, NestedLoopInfo } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 import { needsEffectWrapper, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
@@ -182,6 +182,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseChildComponents,
           whenTrueTextEffects: collectBranchTextEffects(node.whenTrue),
           whenFalseTextEffects: collectBranchTextEffects(node.whenFalse),
+          whenTrueLoops: collectBranchLoops(node.whenTrue),
+          whenFalseLoops: collectBranchLoops(node.whenFalse),
         })
       } else if (node.reactive && node.slotId) {
         const whenTrueEvents = collectConditionalBranchEvents(node.whenTrue)
@@ -207,6 +209,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseChildComponents,
           whenTrueTextEffects,
           whenFalseTextEffects,
+          whenTrueLoops: collectBranchLoops(node.whenTrue),
+          whenFalseLoops: collectBranchLoops(node.whenFalse),
         })
       }
       // Recurse into conditional branches with insideConditional = true
@@ -517,4 +521,52 @@ function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
   }
   walk(node)
   return effects
+}
+
+/**
+ * Collect loop info from a conditional branch for reactive reconciliation.
+ * Finds IRLoop nodes in the branch and extracts their metadata.
+ * Only collects top-level loops (not nested loops inside other loops).
+ */
+function collectBranchLoops(node: IRNode): ConditionalBranchLoop[] {
+  const loops: ConditionalBranchLoop[] = []
+  let parentSlotId: string | null = null
+
+  function walk(n: IRNode): void {
+    switch (n.type) {
+      case 'element':
+        const prevSlot = parentSlotId
+        if (n.slotId) parentSlotId = n.slotId
+        for (const child of n.children) walk(child)
+        parentSlotId = prevSlot
+        break
+      case 'loop': {
+        if (!parentSlotId) break
+        // Build the item template from loop children
+        const childTemplate = n.children.map(c => irToHtmlTemplate(c)).join('')
+        loops.push({
+          array: n.array,
+          param: n.param,
+          index: n.index,
+          key: n.key,
+          template: childTemplate,
+          containerSlotId: parentSlotId,
+          mapPreamble: n.mapPreamble ?? null,
+        })
+        // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation
+        break
+      }
+      case 'fragment':
+      case 'component':
+      case 'provider':
+        for (const child of n.children) walk(child)
+        break
+      // Don't recurse into nested conditionals
+      case 'conditional':
+      case 'if-statement':
+        break
+    }
+  }
+  walk(node)
+  return loops
 }

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, ConditionalBranchLoop, LoopChildEvent, LoopElement } from './types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH, keyAttrName } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
@@ -80,9 +80,14 @@ function emitBranchBindings(
 
     // Emit loop reconciliation effects for loops inside this branch.
     // The loop's container is found via $() and updated reactively via reconcileElements.
+    // SSR templates use data-key-1 for loops inside conditionals (depth 1 in the
+    // inline template), but reconcileElements uses data-key (depth 0 for independent loops).
+    // Rename SSR attributes on hydration so reconcileElements can find them.
     for (const loop of branchLoops) {
       const cv = varSlotId(loop.containerSlotId)
       lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
+      // Rename SSR data-key-1 → data-key for reconcileElements compatibility
+      lines.push(`      if (__loop_${cv}) getLoopChildren(__loop_${cv}).forEach(__el => { if (__el.hasAttribute('${DATA_KEY_PREFIX}1') && !__el.hasAttribute('${DATA_KEY}')) { __el.setAttribute('${DATA_KEY}', __el.getAttribute('${DATA_KEY_PREFIX}1')); __el.removeAttribute('${DATA_KEY_PREFIX}1') } })`)
       const keyFn = loop.key
         ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
         : 'null'

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -4,7 +4,7 @@
  * and event delegation within loop containers.
  */
 
-import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, LoopChildEvent, LoopElement } from './types'
+import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, ConditionalBranchLoop, LoopChildEvent, LoopElement } from './types'
 import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
@@ -19,7 +19,8 @@ function emitBranchBindings(
   refs: ConditionalBranchRef[],
   childComponents: ConditionalBranchChildComponent[],
   eventNameFn: (eventName: string) => string,
-  textEffects: ConditionalBranchTextEffect[] = []
+  textEffects: ConditionalBranchTextEffect[] = [],
+  branchLoops: ConditionalBranchLoop[] = []
 ): void {
   const allSlotIds = new Set<string>()
   for (const event of events) allSlotIds.add(event.slotId)
@@ -62,11 +63,12 @@ function emitBranchBindings(
     lines.push(`      if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
   }
 
-  // Emit disposable text effects scoped to this branch.
+  // Emit disposable effects scoped to this branch (text effects + loop reconciliation).
   // These only run while the branch is active and are disposed on branch switch.
-  // Text node is resolved once (stable while branch is active) and closed over.
-  if (textEffects.length > 0) {
+  const hasDisposables = textEffects.length > 0 || branchLoops.length > 0
+  if (hasDisposables) {
     lines.push(`      const __disposers = []`)
+
     for (const te of textEffects) {
       const v = varSlotId(te.slotId)
       lines.push(`      const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
@@ -75,6 +77,25 @@ function emitBranchBindings(
       lines.push(`        if (__el_${v} && !__val?.__isSlot) __el_${v}.nodeValue = String(__val ?? '')`)
       lines.push(`      }))`)
     }
+
+    // Emit loop reconciliation effects for loops inside this branch.
+    // The loop's container is found via $() and updated reactively via reconcileElements.
+    for (const loop of branchLoops) {
+      const cv = varSlotId(loop.containerSlotId)
+      lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
+      const keyFn = loop.key
+        ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
+        : 'null'
+      const indexParam = loop.index || '__idx'
+      lines.push(`      if (__loop_${cv}) __disposers.push(createDisposableEffect(() => {`)
+      if (loop.mapPreamble) {
+        lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+      } else {
+        lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+      }
+      lines.push(`      }))`)
+    }
+
     lines.push(`      return () => __disposers.forEach(d => d())`)
   }
 }
@@ -88,12 +109,12 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, toDomEventName, elem.whenTrueTextEffects)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, toDomEventName, elem.whenTrueTextEffects, elem.whenTrueLoops)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, toDomEventName, elem.whenFalseTextEffects)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, toDomEventName, elem.whenFalseTextEffects, elem.whenFalseLoops)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')
@@ -111,12 +132,12 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, rawEventName, elem.whenTrueTextEffects)
+    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, rawEventName, elem.whenTrueTextEffects, elem.whenTrueLoops)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, rawEventName, elem.whenFalseTextEffects)
+    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, rawEventName, elem.whenFalseTextEffects, elem.whenFalseLoops)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -100,6 +100,17 @@ export interface ConditionalBranchTextEffect {
   expression: string
 }
 
+/** Loop info extracted from a conditional branch for reactive reconciliation. */
+export interface ConditionalBranchLoop {
+  array: string       // Array expression (e.g., 'items()')
+  param: string       // Loop parameter name (e.g., 'item')
+  index: string | null // Index parameter (e.g., 'i')
+  key: string | null   // Key expression (e.g., 'item.id')
+  template: string     // HTML template for each item
+  containerSlotId: string // bf slot ID of the container element (e.g., 's1' for <ul bf="s1">)
+  mapPreamble: string | null
+}
+
 export interface ConditionalElement {
   slotId: string
   condition: string
@@ -113,6 +124,8 @@ export interface ConditionalElement {
   whenFalseChildComponents: ConditionalBranchChildComponent[]
   whenTrueTextEffects: ConditionalBranchTextEffect[]
   whenFalseTextEffects: ConditionalBranchTextEffect[]
+  whenTrueLoops: ConditionalBranchLoop[]
+  whenFalseLoops: ConditionalBranchLoop[]
 }
 
 export interface NestedLoopInfo {
@@ -201,6 +214,8 @@ export interface ClientOnlyConditional {
   whenFalseChildComponents: ConditionalBranchChildComponent[]
   whenTrueTextEffects: ConditionalBranchTextEffect[]
   whenFalseTextEffects: ConditionalBranchTextEffect[]
+  whenTrueLoops: ConditionalBranchLoop[]
+  whenFalseLoops: ConditionalBranchLoop[]
 }
 
 export interface RestAttrElement {

--- a/site/ui/components/cart-demo.tsx
+++ b/site/ui/components/cart-demo.tsx
@@ -1,0 +1,163 @@
+"use client"
+/**
+ * CartDemo Component
+ *
+ * E-commerce shopping cart with inline quantity editing, item removal,
+ * and derived state chain (subtotals → total → discount → final price).
+ * Exercises: loop with inline state updates, derived state via createMemo,
+ * conditional rendering (empty cart, discount threshold), dynamic list
+ * updates (remove item → reconciliation).
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Separator } from '@ui/components/ui/separator'
+
+type CartItem = {
+  id: number
+  name: string
+  price: number
+  quantity: number
+  image: string
+}
+
+const formatPrice = (cents: number): string =>
+  `$${(cents / 100).toFixed(2)}`
+
+const initialItems: CartItem[] = [
+  { id: 1, name: 'Wireless Headphones', price: 7999, quantity: 1, image: '🎧' },
+  { id: 2, name: 'USB-C Hub Adapter', price: 3499, quantity: 2, image: '🔌' },
+  { id: 3, name: 'Mechanical Keyboard', price: 12999, quantity: 1, image: '⌨️' },
+  { id: 4, name: 'Laptop Stand', price: 4999, quantity: 1, image: '💻' },
+]
+
+const DISCOUNT_THRESHOLD = 20000  // $200 in cents
+const DISCOUNT_RATE = 0.1         // 10%
+const TAX_RATE = 0.08             // 8%
+
+export function CartDemo() {
+  const [items, setItems] = createSignal<CartItem[]>(initialItems)
+
+  // Derived state chain: subtotal → discount → tax → total
+  const subtotal = createMemo(() =>
+    items().reduce((sum, item) => sum + item.price * item.quantity, 0)
+  )
+
+  const discount = createMemo(() =>
+    subtotal() >= DISCOUNT_THRESHOLD ? Math.round(subtotal() * DISCOUNT_RATE) : 0
+  )
+
+  const taxableAmount = createMemo(() => subtotal() - discount())
+
+  const tax = createMemo(() => Math.round(taxableAmount() * TAX_RATE))
+
+  const total = createMemo(() => taxableAmount() + tax())
+
+  const itemCount = createMemo(() =>
+    items().reduce((sum, item) => sum + item.quantity, 0)
+  )
+
+  const updateQuantity = (id: number, delta: number) => {
+    setItems(prev => prev.map(item =>
+      item.id === id
+        ? { ...item, quantity: Math.max(1, item.quantity + delta) }
+        : item
+    ))
+  }
+
+  const removeItem = (id: number) => {
+    setItems(prev => prev.filter(item => item.id !== id))
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Shopping Cart</h3>
+        <Badge variant="secondary">{itemCount()} items</Badge>
+      </div>
+
+      {/* Cart item list — outside conditional so reconcileElements works */}
+      <div className="rounded-lg border divide-y">
+        {items().map(item => (
+          <div key={item.id} className="flex items-center gap-3 p-3">
+            <span className="text-2xl">{item.image}</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{item.name}</p>
+              <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => updateQuantity(item.id, -1)}
+              >
+                −
+              </Button>
+              <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => updateQuantity(item.id, 1)}
+              >
+                +
+              </Button>
+            </div>
+            <p className="text-sm font-semibold w-16 text-right">
+              {formatPrice(item.price * item.quantity)}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeItem(item.id)}
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Summary — conditional on non-empty cart */}
+      {items().length > 0 ? (
+        <div className="space-y-3">
+          <div className="rounded-lg border p-4 space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="text-muted-foreground">Subtotal</span>
+              <span>{formatPrice(subtotal())}</span>
+            </div>
+            {discount() > 0 ? (
+              <div className="flex justify-between text-sm text-green-600">
+                <span>Discount (10%)</span>
+                <span>−{formatPrice(discount())}</span>
+              </div>
+            ) : null}
+            <div className="flex justify-between text-sm">
+              <span className="text-muted-foreground">Tax (8%)</span>
+              <span>{formatPrice(tax())}</span>
+            </div>
+            <Separator />
+            <div className="flex justify-between font-semibold">
+              <span>Total</span>
+              <span>{formatPrice(total())}</span>
+            </div>
+            {discount() === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                Add {formatPrice(DISCOUNT_THRESHOLD - subtotal())} more for 10% off
+              </p>
+            ) : null}
+          </div>
+          <Button className="w-full">Checkout — {formatPrice(total())}</Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border p-8 text-center">
+          <p className="text-2xl mb-2">🛒</p>
+          <p className="text-sm text-muted-foreground">Your cart is empty</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/ui/components/cart-demo.tsx
+++ b/site/ui/components/cart-demo.tsx
@@ -78,52 +78,50 @@ export function CartDemo() {
         <Badge variant="secondary">{itemCount()} items</Badge>
       </div>
 
-      {/* Cart item list — outside conditional so reconcileElements works */}
-      <div className="rounded-lg border divide-y">
-        {items().map(item => (
-          <div key={item.id} className="flex items-center gap-3 p-3">
-            <span className="text-2xl">{item.image}</span>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate">{item.name}</p>
-              <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
-            </div>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 w-7 p-0"
-                onClick={() => updateQuantity(item.id, -1)}
-              >
-                −
-              </Button>
-              <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 w-7 p-0"
-                onClick={() => updateQuantity(item.id, 1)}
-              >
-                +
-              </Button>
-            </div>
-            <p className="text-sm font-semibold w-16 text-right">
-              {formatPrice(item.price * item.quantity)}
-            </p>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-              onClick={() => removeItem(item.id)}
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-
-      {/* Summary — conditional on non-empty cart */}
+      {/* Cart items — loop inside conditional, reactive via bindEvents reconcileElements */}
       {items().length > 0 ? (
         <div className="space-y-3">
+          <div className="rounded-lg border divide-y">
+            {items().map(item => (
+              <div key={item.id} className="flex items-center gap-3 p-3">
+                <span className="text-2xl">{item.image}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{item.name}</p>
+                  <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, -1)}
+                  >
+                    −
+                  </Button>
+                  <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, 1)}
+                  >
+                    +
+                  </Button>
+                </div>
+                <p className="text-sm font-semibold w-16 text-right">
+                  {formatPrice(item.price * item.quantity)}
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => removeItem(item.id)}
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+          </div>
           <div className="rounded-lg border p-4 space-y-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Subtotal</span>

--- a/site/ui/components/cart-demo.tsx
+++ b/site/ui/components/cart-demo.tsx
@@ -78,50 +78,52 @@ export function CartDemo() {
         <Badge variant="secondary">{itemCount()} items</Badge>
       </div>
 
-      {/* Cart items — loop inside conditional, reactive via bindEvents reconcileElements */}
+      {/* Cart item list — outside conditional for proper hydration of loop components */}
+      <div className="rounded-lg border divide-y">
+        {items().map(item => (
+          <div key={item.id} className="flex items-center gap-3 p-3">
+            <span className="text-2xl">{item.image}</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{item.name}</p>
+              <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => updateQuantity(item.id, -1)}
+              >
+                −
+              </Button>
+              <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 w-7 p-0"
+                onClick={() => updateQuantity(item.id, 1)}
+              >
+                +
+              </Button>
+            </div>
+            <p className="text-sm font-semibold w-16 text-right">
+              {formatPrice(item.price * item.quantity)}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeItem(item.id)}
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Summary — conditional on non-empty cart */}
       {items().length > 0 ? (
         <div className="space-y-3">
-          <div className="rounded-lg border divide-y">
-            {items().map(item => (
-              <div key={item.id} className="flex items-center gap-3 p-3">
-                <span className="text-2xl">{item.image}</span>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{item.name}</p>
-                  <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
-                </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-7 p-0"
-                    onClick={() => updateQuantity(item.id, -1)}
-                  >
-                    −
-                  </Button>
-                  <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-7 p-0"
-                    onClick={() => updateQuantity(item.id, 1)}
-                  >
-                    +
-                  </Button>
-                </div>
-                <p className="text-sm font-semibold w-16 text-right">
-                  {formatPrice(item.price * item.quantity)}
-                </p>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                  onClick={() => removeItem(item.id)}
-                >
-                  ✕
-                </Button>
-              </div>
-            ))}
-          </div>
           <div className="rounded-lg border p-4 space-y-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Subtotal</span>

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -115,6 +115,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'tasks-table', title: 'Tasks Table', description: 'Data table with sort, filter, pagination, and row selection' },
   { slug: 'social-feed', title: 'Social Feed', description: 'Feed with posts, comments, replies — deeply nested loops and conditionals' },
   { slug: 'file-browser', title: 'File Browser', description: 'Tree-structured file browser with expand/collapse, multi-select, and CRUD' },
+  { slug: 'cart', title: 'Cart', description: 'Shopping cart with inline quantity editing, discount, and derived pricing chain' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/pages/components/cart.tsx
+++ b/site/ui/pages/components/cart.tsx
@@ -1,0 +1,73 @@
+/**
+ * Cart Reference Page (/components/cart)
+ */
+
+import { CartDemo } from '@/components/cart-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+
+function Cart() {
+  const [items, setItems] = createSignal([...])
+
+  // Derived state chain
+  const subtotal = createMemo(() => items().reduce(...))
+  const discount = createMemo(() => subtotal() >= 200 ? ... : 0)
+  const tax = createMemo(() => (subtotal() - discount()) * 0.08)
+  const total = createMemo(() => subtotal() - discount() + tax())
+
+  return (
+    <div>
+      {items().map(item => (
+        <div key={item.id}>
+          <span>{item.name}</span>
+          <button onClick={() => updateQuantity(item.id, -1)}>−</button>
+          <span>{item.quantity}</span>
+          <button onClick={() => updateQuantity(item.id, 1)}>+</button>
+        </div>
+      ))}
+      <div>Total: {formatPrice(total())}</div>
+    </div>
+  )
+}`
+
+export function CartRefPage() {
+  return (
+    <DocPage slug="cart" toc={tocItems}>
+      <PageHeader
+        title="Cart"
+        description="A shopping cart with inline quantity editing, item removal, and a derived state chain for pricing (subtotal → discount → tax → total)."
+      />
+
+      <Section id="preview" title="Preview">
+        <Example code={previewCode}>
+          <CartDemo />
+        </Example>
+      </Section>
+
+      <Section id="features" title="Features">
+        <ul className="list-disc pl-6 space-y-2 text-sm text-muted-foreground">
+          <li><strong>Inline editing:</strong> +/− buttons update quantity per item</li>
+          <li><strong>Derived state chain:</strong> subtotal → discount → tax → total via 4 chained createMemo</li>
+          <li><strong>Conditional discount:</strong> 10% off when subtotal exceeds $200</li>
+          <li><strong>Remove item:</strong> Filters array, triggers reconciliation</li>
+          <li><strong>Empty state:</strong> Conditional rendering when all items removed</li>
+          <li><strong>Line totals:</strong> Per-item price × quantity computed in template</li>
+        </ul>
+      </Section>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -70,6 +70,7 @@ import { MultiStepFormRefPage } from './pages/components/multi-step-form'
 import { TasksTableRefPage } from './pages/components/tasks-table'
 import { SocialFeedRefPage } from './pages/components/social-feed'
 import { FileBrowserRefPage } from './pages/components/file-browser'
+import { CartRefPage } from './pages/components/cart'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -486,6 +487,11 @@ export function createApp() {
   // File Browser block page
   app.get('/components/file-browser', (c) => {
     return c.render(<FileBrowserRefPage />)
+  })
+
+  // Cart block page
+  app.get('/components/cart', (c) => {
+    return c.render(<CartRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary
Cart block with inline quantity editing + compiler infrastructure for reactive loops inside conditionals.

## Cart block
- Inline quantity +/− editing via Button components
- Item removal with reconciliation
- 4-chained createMemo: subtotal → discount → tax → total
- Conditional discount (10% over $200)
- Empty cart state

## Compiler infrastructure (partial — see #724)
- `ConditionalBranchLoop` type for loop metadata in conditional branches
- `collectBranchLoops()` extracts loop info from conditional IR
- `emitBranchBindings()` generates `createDisposableEffect` + `reconcileElements` in `bindEvents`
- data-key rename during hydration for SSR/CSR compatibility

**Known limitation**: loops inside conditionals still use the workaround (loop outside conditional) because SSR components inside the loop aren't hydrated yet. Full fix tracked in #724.

## Test plan
- [x] 492 compiler tests pass
- [x] CI all green (e2e-site-ui included)
- [x] Browser verified: quantity +/−, remove, derived state chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)