### PR TITLE
Support reactive composite loops inside conditional branches

### DIFF
--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -1,0 +1,145 @@
+/**
+ * BarefootJS Compiler - Composite loops inside conditional branches (#724)
+ *
+ * Verifies that loops with child components inside ternary conditionals
+ * generate reconcileElements with createComponent in the branch's bindEvents.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('composite loops inside conditional branches (#724)', () => {
+  test('loop with child component inside ternary generates composite reconciliation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function CartDemo() {
+        const [items, setItems] = createSignal([
+          { id: 1, name: 'Item A' },
+          { id: 2, name: 'Item B' },
+        ])
+
+        const removeItem = (id: number) => {
+          setItems(prev => prev.filter(item => item.id !== id))
+        }
+
+        return (
+          <div>
+            {items().length > 0 ? (
+              <ul>
+                {items().map(item => (
+                  <li key={item.id}>
+                    <span>{item.name}</span>
+                    <Button onClick={() => removeItem(item.id)}>Remove</Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>Empty</p>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CartDemo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Should use reconcileElements inside the branch's bindEvents
+    expect(js).toContain('reconcileElements(')
+
+    // Should use createComponent for Button inside renderItem (CSR path)
+    expect(js).toContain("createComponent('Button'")
+
+    // Should use createDisposableEffect for branch-scoped disposal
+    expect(js).toContain('createDisposableEffect(')
+
+    // Should use placeholder template (data-bf-ph) instead of inline renderChild
+    expect(js).toContain('data-bf-ph')
+  })
+
+  test('simple loop inside ternary (no components) uses basic reconciliation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function SimpleList() {
+        const [items, setItems] = createSignal(['a', 'b', 'c'])
+        return (
+          <div>
+            {items().length > 0 ? (
+              <ul>
+                {items().map((item, i) => (
+                  <li key={i}>{item}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>Empty</p>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'SimpleList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Should still use reconcileElements for simple loop
+    expect(js).toContain('reconcileElements(')
+    expect(js).toContain('createDisposableEffect(')
+
+    // Should NOT use createComponent (no child components)
+    expect(js).not.toContain('createComponent(')
+  })
+
+  test('SSR hydration: composite branch loop initializes child components via initChild', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function TodoList() {
+        const [todos, setTodos] = createSignal([
+          { id: 1, text: 'Learn' },
+        ])
+
+        return (
+          <div>
+            {todos().length > 0 ? (
+              <div>
+                {todos().map(todo => (
+                  <div key={todo.id}>
+                    <Badge>{todo.text}</Badge>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p>No todos</p>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'TodoList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // SSR hydration should call initChild for existing elements
+    expect(js).toContain("initChild('Badge'")
+
+    // CSR path should call createComponent for new elements
+    expect(js).toContain("createComponent('Badge'")
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -182,8 +182,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseChildComponents,
           whenTrueTextEffects: collectBranchTextEffects(node.whenTrue),
           whenFalseTextEffects: collectBranchTextEffects(node.whenFalse),
-          whenTrueLoops: collectBranchLoops(node.whenTrue),
-          whenFalseLoops: collectBranchLoops(node.whenFalse),
+          whenTrueLoops: collectBranchLoops(node.whenTrue, ctx),
+          whenFalseLoops: collectBranchLoops(node.whenFalse, ctx),
         })
       } else if (node.reactive && node.slotId) {
         const whenTrueEvents = collectConditionalBranchEvents(node.whenTrue)
@@ -209,8 +209,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           whenFalseChildComponents,
           whenTrueTextEffects,
           whenFalseTextEffects,
-          whenTrueLoops: collectBranchLoops(node.whenTrue),
-          whenFalseLoops: collectBranchLoops(node.whenFalse),
+          whenTrueLoops: collectBranchLoops(node.whenTrue, ctx),
+          whenFalseLoops: collectBranchLoops(node.whenFalse, ctx),
         })
       }
       // Recurse into conditional branches with insideConditional = true
@@ -527,10 +527,12 @@ function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
  * Collect loop info from a conditional branch for reactive reconciliation.
  * Finds IRLoop nodes in the branch and extracts their metadata.
  * Only collects top-level loops (not nested loops inside other loops).
+ * Detects composite loops (with child components) and collects extra metadata.
  */
-function collectBranchLoops(node: IRNode): ConditionalBranchLoop[] {
+function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBranchLoop[] {
   const loops: ConditionalBranchLoop[] = []
   let parentSlotId: string | null = null
+  const restNames = ctx ? buildRestSpreadNames(ctx) : undefined
 
   function walk(n: IRNode): void {
     switch (n.type) {
@@ -542,10 +544,29 @@ function collectBranchLoops(node: IRNode): ConditionalBranchLoop[] {
         break
       case 'loop': {
         if (!parentSlotId) break
+
+        // Detect composite: native element root + nested components
+        const hasNestedComps = (n.nestedComponents?.length ?? 0) > 0
+        const useElementReconciliation = !n.childComponent && !n.isStaticArray && hasNestedComps
+
         // Build the item template from loop children.
         // Use loopDepth=0: this loop gets its own reconcileElements (independent
         // from the conditional's template), so items use data-key (not data-key-1).
-        const childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0)).join('')
+        let childTemplate: string
+        if (useElementReconciliation && n.children[0]) {
+          childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0)
+        } else {
+          childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0)).join('')
+        }
+
+        // Collect child events for composite loops
+        const childEvents: LoopChildEvent[] = []
+        if (useElementReconciliation) {
+          for (const child of n.children) {
+            childEvents.push(...collectLoopChildEventsWithNesting(child))
+          }
+        }
+
         loops.push({
           array: n.array,
           param: n.param,
@@ -554,6 +575,10 @@ function collectBranchLoops(node: IRNode): ConditionalBranchLoop[] {
           template: childTemplate,
           containerSlotId: parentSlotId,
           mapPreamble: n.mapPreamble ?? null,
+          nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
+          childEvents: useElementReconciliation ? childEvents : undefined,
+          innerLoops: useElementReconciliation ? collectInnerLoops(n.children) : undefined,
+          useElementReconciliation: useElementReconciliation || undefined,
         })
         // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation
         break

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -88,21 +88,114 @@ function emitBranchBindings(
       lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
       // Rename SSR data-key-1 → data-key for reconcileElements compatibility
       lines.push(`      if (__loop_${cv}) getLoopChildren(__loop_${cv}).forEach(__el => { if (__el.hasAttribute('${DATA_KEY_PREFIX}1') && !__el.hasAttribute('${DATA_KEY}')) { __el.setAttribute('${DATA_KEY}', __el.getAttribute('${DATA_KEY_PREFIX}1')); __el.removeAttribute('${DATA_KEY_PREFIX}1') } })`)
-      const keyFn = loop.key
-        ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
-        : 'null'
-      const indexParam = loop.index || '__idx'
-      lines.push(`      if (__loop_${cv}) __disposers.push(createDisposableEffect(() => {`)
-      if (loop.mapPreamble) {
-        lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+
+      if (loop.useElementReconciliation && loop.nestedComponents?.length) {
+        // Composite loop: items contain child components — use createComponent in renderItem
+        emitCompositeBranchLoop(lines, loop, cv)
       } else {
-        lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+        // Simple loop: basic template clone
+        const keyFn = loop.key
+          ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
+          : 'null'
+        const indexParam = loop.index || '__idx'
+        lines.push(`      if (__loop_${cv}) __disposers.push(createDisposableEffect(() => {`)
+        if (loop.mapPreamble) {
+          lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+        } else {
+          lines.push(`        reconcileElements(__loop_${cv}, ${loop.array}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+        }
+        lines.push(`      }))`)
       }
-      lines.push(`      }))`)
     }
 
     lines.push(`      return () => __disposers.forEach(d => d())`)
   }
+}
+
+/**
+ * Emit composite loop reconciliation inside a conditional branch's bindEvents.
+ * Mirrors emitCompositeElementReconciliation but scoped to a branch with disposal.
+ * Generates: SSR hydration (initChild) + CSR renderItem (createComponent) + reconcileElements.
+ */
+function emitCompositeBranchLoop(
+  lines: string[],
+  loop: ConditionalBranchLoop,
+  cv: string,
+): void {
+  const nestedComps = loop.nestedComponents!
+  const innerLoops = loop.innerLoops ?? []
+  const childEvents = loop.childEvents ?? []
+  const indexParam = loop.index || '__idx'
+
+  // Build per-depth-level data (same pattern as emitCompositeElementReconciliation)
+  const maxDepth = Math.max(
+    ...nestedComps.map(c => c.loopDepth ?? 0),
+    ...innerLoops.map(l => l.depth),
+    0,
+  )
+  const depthLevels: DepthLevel[] = []
+  for (let d = 1; d <= maxDepth; d++) {
+    const loopInfo = innerLoops.find(l => l.depth === d) ?? null
+    depthLevels.push({
+      comps: nestedComps.filter(c => (c.loopDepth ?? 0) === d),
+      events: childEvents.filter(ev =>
+        ev.nestedLoops.length > 0 && ev.nestedLoops[ev.nestedLoops.length - 1].depth === d
+      ),
+      loopInfo,
+    })
+  }
+
+  const outerComps = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
+  const outerEvents = childEvents.filter(ev => ev.nestedLoops.length === 0)
+
+  // Build a partial LoopElement-compatible object for CompositeLoopContext
+  const pseudoElem = {
+    template: loop.template,
+    mapPreamble: loop.mapPreamble ?? undefined,
+  } as LoopElement
+
+  const ctx: CompositeLoopContext = {
+    elem: pseudoElem,
+    outerComps,
+    outerEvents,
+    depthLevels,
+  }
+
+  const keyFn = loop.key
+    ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
+    : 'null'
+
+  // Wrap everything in a disposable effect for branch cleanup
+  lines.push(`      if (__loop_${cv}) __disposers.push(createDisposableEffect(() => {`)
+  lines.push(`        const __arr = ${loop.array}`)
+  lines.push(`        const __renderItem = (${loop.param}, ${indexParam}) => {`)
+  emitCompositeRenderItemBody(lines, '          ', ctx)
+  lines.push(`        }`)
+
+  // SSR hydration: tag existing children with data-key and initialize components
+  lines.push(`        const __loopChildren = getLoopChildren(__loop_${cv})`)
+  lines.push(`        if (__loopChildren.length > 0 && !__loopChildren[0]?.hasAttribute('${DATA_KEY}')) {`)
+  lines.push(`          __loopChildren.forEach((__hChild, ${indexParam}) => {`)
+  lines.push(`            if (${indexParam} >= __arr.length) return`)
+  lines.push(`            const ${loop.param} = __arr[${indexParam}]`)
+  if (loop.key) {
+    lines.push(`            __hChild.setAttribute('${DATA_KEY}', String(${loop.key}))`)
+  } else {
+    lines.push(`            __hChild.setAttribute('${DATA_KEY}', String(${indexParam}))`)
+  }
+  // Initialize components on SSR elements (hydration)
+  emitComponentAndEventSetup(lines, '            ', '__hChild', outerComps, outerEvents, 'ssr')
+  emitInnerLoopSetup(lines, '            ', '__hChild', depthLevels, 0, 'ssr')
+  lines.push(`          })`)
+  // Pre-render first item to initialize createComponent paths
+  lines.push(`          if (__arr.length > 0) __renderItem(__arr[0], 0)`)
+  lines.push(`          return`)
+  lines.push(`        }`)
+
+  // Blur active element before reconciliation to avoid syncElementState issues
+  lines.push(`        if (__loop_${cv}?.contains(document.activeElement)) document.activeElement?.blur()`)
+  lines.push(`        reconcileElements(__loop_${cv}, __arr, ${keyFn}, __renderItem)`)
+  lines.push(`      }))`)
 }
 
 /** Emit insert() calls for server-rendered reactive conditionals with branch configs. */

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -109,6 +109,11 @@ export interface ConditionalBranchLoop {
   template: string     // HTML template for each item
   containerSlotId: string // bf slot ID of the container element (e.g., 's1' for <ul bf="s1">)
   mapPreamble: string | null
+  // Composite loop fields (loops whose body contains child components)
+  nestedComponents?: IRLoopChildComponent[]
+  childEvents?: LoopChildEvent[]
+  innerLoops?: NestedLoopInfo[]
+  useElementReconciliation?: boolean
 }
 
 export interface ConditionalElement {

--- a/site/ui/components/cart-demo.tsx
+++ b/site/ui/components/cart-demo.tsx
@@ -78,79 +78,79 @@ export function CartDemo() {
         <Badge variant="secondary">{itemCount()} items</Badge>
       </div>
 
-      {/* Cart item list — outside conditional for proper hydration of loop components */}
-      <div className="rounded-lg border divide-y">
-        {items().map(item => (
-          <div key={item.id} className="flex items-center gap-3 p-3">
-            <span className="text-2xl">{item.image}</span>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate">{item.name}</p>
-              <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
-            </div>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 w-7 p-0"
-                onClick={() => updateQuantity(item.id, -1)}
-              >
-                −
-              </Button>
-              <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 w-7 p-0"
-                onClick={() => updateQuantity(item.id, 1)}
-              >
-                +
-              </Button>
-            </div>
-            <p className="text-sm font-semibold w-16 text-right">
-              {formatPrice(item.price * item.quantity)}
-            </p>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-              onClick={() => removeItem(item.id)}
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-
-      {/* Summary — conditional on non-empty cart */}
+      {/* Cart items + summary — both inside conditional */}
       {items().length > 0 ? (
-        <div className="space-y-3">
-          <div className="rounded-lg border p-4 space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Subtotal</span>
-              <span>{formatPrice(subtotal())}</span>
-            </div>
-            {discount() > 0 ? (
-              <div className="flex justify-between text-sm text-green-600">
-                <span>Discount (10%)</span>
-                <span>−{formatPrice(discount())}</span>
+        <div className="space-y-4">
+          <div className="rounded-lg border divide-y">
+            {items().map(item => (
+              <div key={item.id} className="flex items-center gap-3 p-3">
+                <span className="text-2xl">{item.image}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{item.name}</p>
+                  <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, -1)}
+                  >
+                    −
+                  </Button>
+                  <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, 1)}
+                  >
+                    +
+                  </Button>
+                </div>
+                <p className="text-sm font-semibold w-16 text-right">
+                  {formatPrice(item.price * item.quantity)}
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => removeItem(item.id)}
+                >
+                  ✕
+                </Button>
               </div>
-            ) : null}
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Tax (8%)</span>
-              <span>{formatPrice(tax())}</span>
-            </div>
-            <Separator />
-            <div className="flex justify-between font-semibold">
-              <span>Total</span>
-              <span>{formatPrice(total())}</span>
-            </div>
-            {discount() === 0 ? (
-              <p className="text-xs text-muted-foreground">
-                Add {formatPrice(DISCOUNT_THRESHOLD - subtotal())} more for 10% off
-              </p>
-            ) : null}
+            ))}
           </div>
-          <Button className="w-full">Checkout — {formatPrice(total())}</Button>
+          <div className="space-y-3">
+            <div className="rounded-lg border p-4 space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span>{formatPrice(subtotal())}</span>
+              </div>
+              {discount() > 0 ? (
+                <div className="flex justify-between text-sm text-green-600">
+                  <span>Discount (10%)</span>
+                  <span>−{formatPrice(discount())}</span>
+                </div>
+              ) : null}
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Tax (8%)</span>
+                <span>{formatPrice(tax())}</span>
+              </div>
+              <Separator />
+              <div className="flex justify-between font-semibold">
+                <span>Total</span>
+                <span>{formatPrice(total())}</span>
+              </div>
+              {discount() === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Add {formatPrice(DISCOUNT_THRESHOLD - subtotal())} more for 10% off
+                </p>
+              ) : null}
+            </div>
+            <Button className="w-full">Checkout — {formatPrice(total())}</Button>
+          </div>
         </div>
       ) : (
         <div className="rounded-lg border p-8 text-center">

--- a/site/ui/e2e/cart.spec.ts
+++ b/site/ui/e2e/cart.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Cart Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/cart')
+  })
+
+  test('renders cart items with working buttons', async ({ page }) => {
+    const section = page.locator('[bf-s^="CartDemo_"]:not([data-slot])').first()
+
+    // Should render 4 cart items initially
+    const items = section.locator('.divide-y > div')
+    await expect(items).toHaveCount(4)
+
+    // Quantity buttons should be functional (Button components are hydrated)
+    const firstItem = items.first()
+    const minusBtn = firstItem.locator('button:has-text("−")')
+    const plusBtn = firstItem.locator('button:has-text("+")')
+    await expect(minusBtn).toBeVisible()
+    await expect(plusBtn).toBeVisible()
+  })
+
+  test('increment quantity updates item price', async ({ page }) => {
+    const section = page.locator('[bf-s^="CartDemo_"]:not([data-slot])').first()
+    const firstItem = section.locator('.divide-y > div').first()
+    const plusBtn = firstItem.locator('button:has-text("+")')
+
+    // Click + to increment quantity
+    await plusBtn.click()
+
+    // Quantity should show 2
+    const quantity = firstItem.locator('.w-8.text-center')
+    await expect(quantity).toHaveText('2')
+  })
+
+  test('remove all items shows empty cart state', async ({ page }) => {
+    const section = page.locator('[bf-s^="CartDemo_"]:not([data-slot])').first()
+
+    // Remove all 4 items
+    for (let i = 0; i < 4; i++) {
+      const removeBtn = section.locator('button:has-text("✕")').first()
+      await removeBtn.click()
+    }
+
+    // Should show empty state
+    await expect(section.locator('text=Your cart is empty')).toBeVisible()
+  })
+
+  test('remove item updates remaining item list reactively', async ({ page }) => {
+    const section = page.locator('[bf-s^="CartDemo_"]:not([data-slot])').first()
+
+    // Remove first item
+    const removeBtn = section.locator('button:has-text("✕")').first()
+    await removeBtn.click()
+
+    // Should have 3 items now
+    const items = section.locator('.divide-y > div')
+    await expect(items).toHaveCount(3)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #724.

- Loops with child components (e.g., `Button`) inside ternary conditionals now work reactively — when the array signal changes but the condition stays the same, `reconcileElements` properly creates/updates elements with `createComponent` for child components and `initChild` for SSR hydration
- Extends `ConditionalBranchLoop` type with composite fields (`nestedComponents`, `childEvents`, `innerLoops`, `useElementReconciliation`)
- Updates `collectBranchLoops()` to detect composite loops and use `irToPlaceholderTemplate()`
- Adds `emitCompositeBranchLoop()` which reuses existing `emitCompositeRenderItemBody()` and `emitComponentAndEventSetup()` helpers
- Removes Cart demo workaround — loop now lives inside the conditional as intended

## Test plan

- [x] Compiler unit tests: 3 new tests verifying composite branch loop codegen (1231 total, 0 fail)
- [x] E2E tests: 4 new tests for Cart block — item rendering, quantity increment, item removal, empty state transition
- [x] Full build passes with no errors
- [x] Verified compiled Cart demo output contains `createComponent('Button')` in renderItem and `initChild('Button')` in hydration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)