### PR TITLE
Fix createSignal partial destructuring (getter-only)

### DIFF
--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -770,7 +770,7 @@ export class GoTemplateAdapter extends BaseAdapter {
    */
   private resolveDynamicPropValue(
     expr: string,
-    signals: { getter: string; setter: string; initialValue: string; type: TypeInfo }[],
+    signals: { getter: string; setter: string | null; initialValue: string; type: TypeInfo }[],
     memos: { name: string; computation: string; deps: string[] }[],
     propsParams: { name: string }[]
   ): string | null {

--- a/packages/jsx/src/__tests__/analyzer.test.ts
+++ b/packages/jsx/src/__tests__/analyzer.test.ts
@@ -225,4 +225,23 @@ describe('analyzeComponent', () => {
     expect(letConstant!.declarationKind).toBe('let')
     expect(letConstant!.value).toBeUndefined()
   })
+
+  test('extracts signal with getter only (no setter)', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function ReadOnlyList() {
+          const [items] = createSignal([1, 2, 3])
+          return <div>{items().length}</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'ReadOnlyList.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('items')
+    expect(ctx.signals[0].setter).toBeNull()
+    expect(ctx.signals[0].initialValue).toBe('[1, 2, 3]')
+  })
 })

--- a/packages/jsx/src/__tests__/signal-partial-destructure.test.ts
+++ b/packages/jsx/src/__tests__/signal-partial-destructure.test.ts
@@ -1,0 +1,95 @@
+/**
+ * BarefootJS Compiler - Partial signal destructuring (getter only, no setter)
+ *
+ * const [items] = createSignal(...) should compile without errors
+ * and produce correct SSR + client JS output.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('signal partial destructuring (getter only)', () => {
+  test('compiles without errors', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function ReadOnlyList() {
+        const [items] = createSignal([{ id: 1, name: 'A' }])
+        return (
+          <div>
+            {items().map(item => (
+              <p key={item.id}>{item.name}</p>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'ReadOnlyList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+  })
+
+  test('client JS declares getter without setter', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Counter() {
+        const [count] = createSignal(42)
+        return <div>{count()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Should declare [count] (not [count, setCount])
+    expect(js).toContain('[count] = createSignal(')
+    expect(js).not.toContain('setCount')
+  })
+
+  test('SSR template references getter correctly', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      export function Display() {
+        const [label] = createSignal('hello')
+        return <span>{label()}</span>
+      }
+    `
+    const result = compileJSXSync(source, 'Display.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    // SSR should inline the initial value
+    expect(template!.content).toContain('hello')
+  })
+
+  test('getter-only signal works with createMemo dependency', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/dom'
+
+      export function Summary() {
+        const [items] = createSignal([1, 2, 3])
+        const total = createMemo(() => items().reduce((a, b) => a + b, 0))
+        return <div>{total()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Summary.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('[items] = createSignal(')
+    expect(clientJs!.content).toContain('createMemo(')
+  })
+})

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -183,7 +183,7 @@ export class TestAdapter extends BaseAdapter {
     for (const signal of ir.metadata.signals) {
       const initialValue = signal.initialValue.trim().startsWith('{') ? `(${signal.initialValue})` : signal.initialValue
       lines.push(`  const ${signal.getter} = () => ${initialValue}`)
-      lines.push(`  const ${signal.setter} = () => {}`)
+      if (signal.setter) lines.push(`  const ${signal.setter} = () => {}`)
     }
 
     for (const memo of ir.metadata.memos) {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -499,17 +499,24 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
 
   const elements = pattern.elements
   if (
-    elements.length !== 2 ||
+    elements.length < 1 || elements.length > 2 ||
     !ts.isBindingElement(elements[0]) ||
-    !ts.isBindingElement(elements[1]) ||
-    !ts.isIdentifier(elements[0].name) ||
-    !ts.isIdentifier(elements[1].name)
+    !ts.isIdentifier(elements[0].name)
   ) {
+    return
+  }
+  // Validate second element if present
+  if (elements.length === 2 && (
+    !ts.isBindingElement(elements[1]) ||
+    !ts.isIdentifier(elements[1].name)
+  )) {
     return
   }
 
   const getter = elements[0].name.text
-  const setter = elements[1].name.text
+  const setter = elements.length === 2 && ts.isBindingElement(elements[1]) && ts.isIdentifier(elements[1].name)
+    ? elements[1].name.text
+    : null
   const initialValue = callExpr.arguments[0] ? ctx.getJS(callExpr.arguments[0]) : ''
 
   // Try to infer type from initial value or type argument

--- a/packages/jsx/src/ir-to-client-js/declaration-sort.ts
+++ b/packages/jsx/src/ir-to-client-js/declaration-sort.ts
@@ -29,7 +29,7 @@ export function providedNames(decl: Declaration): string[] {
     case 'constant':
       return [decl.info.name]
     case 'signal':
-      return [decl.info.getter, decl.info.setter]
+      return decl.info.setter ? [decl.info.getter, decl.info.setter] : [decl.info.getter]
     case 'memo':
       return [decl.info.name]
     case 'function':

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -136,7 +136,11 @@ export function emitDeclaration(
         }
       }
 
-      lines.push(`  const [${signal.getter}, ${signal.setter}] = createSignal(${initialValue})`)
+      if (signal.setter) {
+        lines.push(`  const [${signal.getter}, ${signal.setter}] = createSignal(${initialValue})`)
+      } else {
+        lines.push(`  const [${signal.getter}] = createSignal(${initialValue})`)
+      }
       break
     }
     case 'memo': {
@@ -163,6 +167,7 @@ export function emitControlledSignalEffect(
   const accessor = prop?.defaultValue
     ? `(${PROPS_PARAM}.${propName} ?? ${prop.defaultValue})`
     : `${PROPS_PARAM}.${propName}`
+  if (!signal.setter) return // read-only signal, no controlled sync needed
   lines.push(`  createEffect(() => {`)
   lines.push(`    const __val = ${accessor}`)
   lines.push(`    if (__val !== undefined) ${signal.setter}(__val)`)

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -105,12 +105,12 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
   const unsafeLocalNames = new Set<string>()
 
   const signalGetters = new Set(ctx.signals.map(s => s.getter))
-  const signalSetters = new Set(ctx.signals.map(s => s.setter))
+  const signalSetters = new Set(ctx.signals.filter(s => s.setter).map(s => s.setter!))
   const memoNames = new Set(ctx.memos.map(m => m.name))
 
   const componentScopeNames = new Set<string>()
   for (const c of ctx.localConstants) componentScopeNames.add(c.name)
-  for (const s of ctx.signals) { componentScopeNames.add(s.getter); componentScopeNames.add(s.setter) }
+  for (const s of ctx.signals) { componentScopeNames.add(s.getter); if (s.setter) componentScopeNames.add(s.setter) }
   for (const m of ctx.memos) componentScopeNames.add(m.name)
   for (const f of ctx.localFunctions) componentScopeNames.add(f.name)
   for (const p of ctx.propsParams) componentScopeNames.add(p.name)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -171,7 +171,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   const componentScopeNames = new Set<string>()
   for (const s of ctx.signals) {
     componentScopeNames.add(s.getter)
-    componentScopeNames.add(s.setter)
+    if (s.setter) componentScopeNames.add(s.setter)
   }
   for (const m of ctx.memos) componentScopeNames.add(m.name)
   for (const c of ctx.localConstants) componentScopeNames.add(c.name)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -353,7 +353,7 @@ export interface IRProp extends AttrMeta {
 
 export interface SignalInfo {
   getter: string
-  setter: string
+  setter: string | null
   initialValue: string
   type: TypeInfo
   loc: SourceLocation

--- a/site/ui/components/checkout-demo.tsx
+++ b/site/ui/components/checkout-demo.tsx
@@ -1,0 +1,418 @@
+"use client"
+/**
+ * CheckoutDemo Component
+ *
+ * 3-step checkout flow: Shipping → Payment → Review & Confirm.
+ * Exercises: multi-branch conditional rendering, composite loop inside
+ * conditional (#724), controlled RadioGroup/Select, shared signals across
+ * branches, derived validation memos, conditional inside loop.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
+import { Label } from '@ui/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
+import { Separator } from '@ui/components/ui/separator'
+
+type OrderItem = {
+  id: number
+  name: string
+  price: number
+  quantity: number
+}
+
+const formatPrice = (cents: number): string =>
+  `$${(cents / 100).toFixed(2)}`
+
+const initialItems: OrderItem[] = [
+  { id: 1, name: 'Wireless Headphones', price: 7999, quantity: 1 },
+  { id: 2, name: 'USB-C Hub Adapter', price: 3499, quantity: 2 },
+  { id: 3, name: 'Mechanical Keyboard', price: 12999, quantity: 1 },
+]
+
+const SHIPPING_STANDARD = 599
+const SHIPPING_EXPRESS = 1499
+const FREE_SHIPPING_THRESHOLD = 15000
+const TAX_RATE = 0.08
+
+const steps = [
+  { id: 1, title: 'Shipping' },
+  { id: 2, title: 'Payment' },
+  { id: 3, title: 'Confirm' },
+]
+
+/**
+ * Multi-step checkout — compiler stress test
+ *
+ * Stress points:
+ * - Multi-branch conditional: 3 steps via nested ternary
+ * - Composite loop inside conditional: order items with Badge in review step
+ * - Shared signals across branches: form state persists across step switches
+ * - Derived validation memos: shippingValid, paymentValid
+ * - Controlled RadioGroup: payment method selection
+ * - Controlled Select: country picker
+ * - Conditional inside loop: quantity badge when > 1
+ */
+export function CheckoutDemo() {
+  const [step, setStep] = createSignal(1)
+  const [orderPlaced, setOrderPlaced] = createSignal(false)
+
+  // Shipping form
+  const [name, setName] = createSignal('')
+  const [email, setEmail] = createSignal('')
+  const [address, setAddress] = createSignal('')
+  const [city, setCity] = createSignal('')
+  const [zip, setZip] = createSignal('')
+  const [country, setCountry] = createSignal('')
+  const [shippingMethod, setShippingMethod] = createSignal('standard')
+
+  // Payment form
+  const [paymentMethod, setPaymentMethod] = createSignal('credit-card')
+  const [cardNumber, setCardNumber] = createSignal('')
+  const [cardExpiry, setCardExpiry] = createSignal('')
+  const [cardCvc, setCardCvc] = createSignal('')
+
+  // Order items (from Cart, can be modified during checkout)
+  const [items, setItems] = createSignal<OrderItem[]>(initialItems)
+
+  // Validation memos
+  const emailValid = createMemo(() => {
+    const v = email()
+    return v.length > 0 && v.includes('@') && v.includes('.')
+  })
+
+  const shippingValid = createMemo(() =>
+    name().length > 0
+    && emailValid()
+    && address().length > 0
+    && city().length > 0
+    && zip().length > 0
+    && country().length > 0
+  )
+
+  const cardValid = createMemo(() =>
+    cardNumber().replace(/\s/g, '').length >= 13
+    && cardExpiry().length >= 4
+    && cardCvc().length >= 3
+  )
+
+  const paymentValid = createMemo(() =>
+    paymentMethod() === 'paypal' || cardValid()
+  )
+
+  // Price memos
+  const subtotal = createMemo(() =>
+    items().reduce((sum, item) => sum + item.price * item.quantity, 0)
+  )
+
+  const shippingCost = createMemo(() => {
+    if (subtotal() >= FREE_SHIPPING_THRESHOLD) return 0
+    return shippingMethod() === 'express' ? SHIPPING_EXPRESS : SHIPPING_STANDARD
+  })
+
+  const tax = createMemo(() => Math.round(subtotal() * TAX_RATE))
+
+  const total = createMemo(() => subtotal() + shippingCost() + tax())
+
+  const removeItem = (id: number) => {
+    setItems(prev => prev.filter(item => item.id !== id))
+  }
+
+  const handlePlaceOrder = () => {
+    setOrderPlaced(true)
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      {/* Step indicator */}
+      <div className="flex items-center gap-2">
+        {steps.map((s, i) => (
+          <div key={s.id} className="flex items-center gap-2">
+            {i > 0 ? (
+              <div className="h-px w-6 bg-border" />
+            ) : null}
+            <button
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors ${step() >= s.id ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+              onClick={() => { if (s.id < step()) setStep(s.id) }}
+            >
+              {s.id}
+            </button>
+            <span className={`text-sm ${step() === s.id ? 'font-medium' : 'text-muted-foreground'}`}>
+              {s.title}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* Step content — multi-branch conditional */}
+      {orderPlaced() ? (
+        <div className="rounded-lg border p-8 text-center space-y-3">
+          <p className="text-3xl">🎉</p>
+          <p className="text-lg font-semibold">Order Placed!</p>
+          <p className="text-sm text-muted-foreground">
+            Confirmation sent to {email()}
+          </p>
+          <p className="text-sm font-medium">Total: {formatPrice(total())}</p>
+          <Button variant="outline" onClick={() => { setOrderPlaced(false); setStep(1) }}>
+            Start New Order
+          </Button>
+        </div>
+      ) : step() === 1 ? (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Shipping Information</h3>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Full Name</Label>
+              <Input
+                placeholder="John Doe"
+                value={name()}
+                onInput={(e: Event) => setName((e.target as HTMLInputElement).value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Email</Label>
+              <Input
+                placeholder="john@example.com"
+                value={email()}
+                onInput={(e: Event) => setEmail((e.target as HTMLInputElement).value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Address</Label>
+            <Input
+              placeholder="123 Main St"
+              value={address()}
+              onInput={(e: Event) => setAddress((e.target as HTMLInputElement).value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-2">
+              <Label>City</Label>
+              <Input
+                placeholder="New York"
+                value={city()}
+                onInput={(e: Event) => setCity((e.target as HTMLInputElement).value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>ZIP Code</Label>
+              <Input
+                placeholder="10001"
+                value={zip()}
+                onInput={(e: Event) => setZip((e.target as HTMLInputElement).value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Country</Label>
+              <select
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                value={country()}
+                onChange={(e: Event) => setCountry((e.target as HTMLSelectElement).value)}
+              >
+                <option value="">Select...</option>
+                <option value="us">United States</option>
+                <option value="ca">Canada</option>
+                <option value="uk">United Kingdom</option>
+                <option value="de">Germany</option>
+                <option value="jp">Japan</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <Label>Shipping Method</Label>
+            <RadioGroup value={shippingMethod()} onValueChange={setShippingMethod}>
+              <div className="flex items-center gap-3">
+                <RadioGroupItem value="standard" />
+                <div>
+                  <p className="text-sm font-medium">Standard</p>
+                  <p className="text-xs text-muted-foreground">
+                    {subtotal() >= FREE_SHIPPING_THRESHOLD ? 'Free' : formatPrice(SHIPPING_STANDARD)} · 5-7 business days
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <RadioGroupItem value="express" />
+                <div>
+                  <p className="text-sm font-medium">Express</p>
+                  <p className="text-xs text-muted-foreground">
+                    {subtotal() >= FREE_SHIPPING_THRESHOLD ? 'Free' : formatPrice(SHIPPING_EXPRESS)} · 2-3 business days
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+          </div>
+
+          <div className="flex justify-end">
+            <Button disabled={!shippingValid()} onClick={() => setStep(2)}>
+              Continue to Payment
+            </Button>
+          </div>
+        </div>
+      ) : step() === 2 ? (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Payment Method</h3>
+
+          <RadioGroup value={paymentMethod()} onValueChange={setPaymentMethod}>
+            <div className="flex items-center gap-3 rounded-lg border p-3">
+              <RadioGroupItem value="credit-card" />
+              <div>
+                <p className="text-sm font-medium">Credit Card</p>
+                <p className="text-xs text-muted-foreground">Visa, Mastercard, Amex</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-lg border p-3">
+              <RadioGroupItem value="paypal" />
+              <div>
+                <p className="text-sm font-medium">PayPal</p>
+                <p className="text-xs text-muted-foreground">Pay with your PayPal account</p>
+              </div>
+            </div>
+          </RadioGroup>
+
+          {/* Conditional card form — only shown when credit-card selected */}
+          {paymentMethod() === 'credit-card' ? (
+            <div className="space-y-4 rounded-lg border p-4">
+              <div className="space-y-2">
+                <Label>Card Number</Label>
+                <Input
+                  placeholder="4242 4242 4242 4242"
+                  value={cardNumber()}
+                  onInput={(e: Event) => setCardNumber((e.target as HTMLInputElement).value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>Expiry</Label>
+                  <Input
+                    placeholder="MM/YY"
+                    value={cardExpiry()}
+                    onInput={(e: Event) => setCardExpiry((e.target as HTMLInputElement).value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>CVC</Label>
+                  <Input
+                    placeholder="123"
+                    value={cardCvc()}
+                    onInput={(e: Event) => setCardCvc((e.target as HTMLInputElement).value)}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border p-4 text-center">
+              <p className="text-sm text-muted-foreground">
+                You will be redirected to PayPal after confirmation.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={() => setStep(1)}>
+              Back
+            </Button>
+            <Button disabled={!paymentValid()} onClick={() => setStep(3)}>
+              Review Order
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Review Order</h3>
+
+          {/* Order items — composite loop inside conditional (validates #724) */}
+          {items().length > 0 ? (
+            <div className="rounded-lg border divide-y">
+              {items().map(item => (
+                <div key={item.id} className="flex items-center justify-between p-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{item.name}</span>
+                    {item.quantity > 1 ? (
+                      <Badge variant="secondary">×{item.quantity}</Badge>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">
+                      {formatPrice(item.price * item.quantity)}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => removeItem(item.id)}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No items</p>
+          )}
+
+          {/* Shipping summary */}
+          <div className="rounded-lg border p-4 space-y-2">
+            <p className="text-sm font-medium">Ship to</p>
+            <p className="text-sm text-muted-foreground">
+              {name()}, {address()}, {city()} {zip()}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {shippingMethod() === 'express' ? 'Express' : 'Standard'} shipping
+              {email() ? ` · ${email()}` : ''}
+            </p>
+          </div>
+
+          {/* Payment summary */}
+          <div className="rounded-lg border p-4 space-y-2">
+            <p className="text-sm font-medium">Pay with</p>
+            <p className="text-sm text-muted-foreground">
+              {paymentMethod() === 'credit-card'
+                ? `Card ending in ${cardNumber().slice(-4) || '····'}`
+                : 'PayPal'}
+            </p>
+          </div>
+
+          {/* Price breakdown */}
+          <div className="rounded-lg border p-4 space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="text-muted-foreground">Subtotal</span>
+              <span>{formatPrice(subtotal())}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-muted-foreground">Shipping</span>
+              <span>{shippingCost() === 0 ? 'Free' : formatPrice(shippingCost())}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-muted-foreground">Tax</span>
+              <span>{formatPrice(tax())}</span>
+            </div>
+            <Separator />
+            <div className="flex justify-between font-semibold">
+              <span>Total</span>
+              <span>{formatPrice(total())}</span>
+            </div>
+          </div>
+
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={() => setStep(2)}>
+              Back
+            </Button>
+            <Button onClick={handlePlaceOrder}>
+              Place Order — {formatPrice(total())}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -116,6 +116,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'social-feed', title: 'Social Feed', description: 'Feed with posts, comments, replies — deeply nested loops and conditionals' },
   { slug: 'file-browser', title: 'File Browser', description: 'Tree-structured file browser with expand/collapse, multi-select, and CRUD' },
   { slug: 'cart', title: 'Cart', description: 'Shopping cart with inline quantity editing, discount, and derived pricing chain' },
+  { slug: 'checkout', title: 'Checkout', description: 'Multi-step checkout with shipping, payment, and order review' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/checkout.spec.ts
+++ b/site/ui/e2e/checkout.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Locator } from '@playwright/test'
+
+/** Fill shipping form fields and select country. */
+async function fillShipping(
+  section: Locator,
+  data: { name: string; email: string; address: string; city: string; zip: string; country: string }
+) {
+  const inputs = section.locator('input')
+  await inputs.nth(0).fill(data.name)
+  await inputs.nth(1).fill(data.email)
+  await inputs.nth(2).fill(data.address)
+  await inputs.nth(3).fill(data.city)
+  await inputs.nth(4).fill(data.zip)
+
+  // Select country from native <select>
+  await section.locator('select').selectOption({ label: data.country })
+}
+
+test.describe('Checkout Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/checkout')
+  })
+
+  test('renders step 1 with disabled Continue button', async ({ page }) => {
+    const section = page.locator('[bf-s^="CheckoutDemo_"]:not([data-slot])').first()
+    await expect(section.locator('h3:has-text("Shipping Information")')).toBeVisible()
+    await expect(section.locator('button:has-text("Continue to Payment")')).toBeDisabled()
+  })
+
+  test('filling shipping form enables Continue and navigates to Payment', async ({ page }) => {
+    const section = page.locator('[bf-s^="CheckoutDemo_"]:not([data-slot])').first()
+
+    await fillShipping(section, {
+      name: 'John Doe', email: 'john@example.com',
+      address: '123 Main St', city: 'New York', zip: '10001', country: 'United States',
+    })
+
+    const continueBtn = section.locator('button:has-text("Continue to Payment")')
+    await expect(continueBtn).toBeEnabled()
+
+    await continueBtn.click()
+    await expect(section.locator('h3:has-text("Payment Method")')).toBeVisible()
+  })
+
+  test('payment: PayPal hides card form', async ({ page }) => {
+    const section = page.locator('[bf-s^="CheckoutDemo_"]:not([data-slot])').first()
+
+    await fillShipping(section, {
+      name: 'Jane', email: 'j@e.co',
+      address: '456 Oak Ave', city: 'LA', zip: '90001', country: 'Canada',
+    })
+    await section.locator('button:has-text("Continue to Payment")').click()
+    await expect(section.locator('h3:has-text("Payment Method")')).toBeVisible()
+
+    // Credit card form visible by default
+    await expect(section.locator('input[placeholder="4242 4242 4242 4242"]')).toBeVisible()
+
+    // Switch to PayPal — find the radio button adjacent to "PayPal" text
+    await section.locator('.rounded-lg.border.p-3:has-text("PayPal") button[role="radio"]').click()
+    await expect(section.locator('input[placeholder="4242 4242 4242 4242"]')).not.toBeVisible()
+    await expect(section.locator('text=redirected to PayPal')).toBeVisible()
+  })
+
+  test('full flow: shipping → payment → review → place order', async ({ page }) => {
+    const section = page.locator('[bf-s^="CheckoutDemo_"]:not([data-slot])').first()
+
+    // Step 1: Shipping
+    await fillShipping(section, {
+      name: 'Alice Smith', email: 'alice@test.com',
+      address: '789 Pine Rd', city: 'Chicago', zip: '60601', country: 'United States',
+    })
+    await section.locator('button:has-text("Continue to Payment")').click()
+    await expect(section.locator('h3:has-text("Payment Method")')).toBeVisible()
+
+    // Step 2: Payment (PayPal)
+    await section.locator('.rounded-lg.border.p-3:has-text("PayPal") button[role="radio"]').click()
+    await section.locator('button:has-text("Review Order")').click()
+
+    // Step 3: Review — composite loop inside conditional
+    await expect(section.locator('h3:has-text("Review Order")')).toBeVisible()
+    await expect(section.locator('text=Wireless Headphones')).toBeVisible()
+    await expect(section.locator('text=USB-C Hub Adapter')).toBeVisible()
+    await expect(section.locator('text=Mechanical Keyboard')).toBeVisible()
+    // Shipping summary
+    await expect(section.locator('text=Alice Smith')).toBeVisible()
+
+    // Place order
+    await section.locator('button:has-text("Place Order")').click()
+    await expect(section.locator('text=Order Placed!')).toBeVisible()
+    await expect(section.locator('text=alice@test.com')).toBeVisible()
+  })
+
+  test('back button preserves form data', async ({ page }) => {
+    const section = page.locator('[bf-s^="CheckoutDemo_"]:not([data-slot])').first()
+
+    await fillShipping(section, {
+      name: 'Bob', email: 'b@b.co',
+      address: '1 Elm St', city: 'SF', zip: '94102', country: 'Japan',
+    })
+    await section.locator('button:has-text("Continue to Payment")').click()
+    await section.locator('button:has-text("Back")').click()
+
+    await expect(section.locator('h3:has-text("Shipping Information")')).toBeVisible()
+    await expect(section.locator('input').nth(0)).toHaveValue('Bob')
+  })
+})

--- a/site/ui/pages/components/checkout.tsx
+++ b/site/ui/pages/components/checkout.tsx
@@ -1,0 +1,72 @@
+/**
+ * Checkout Reference Page (/components/checkout)
+ */
+
+import { CheckoutDemo } from '@/components/checkout-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+
+function Checkout() {
+  const [step, setStep] = createSignal(1)
+  const [name, setName] = createSignal('')
+  const [paymentMethod, setPaymentMethod] = createSignal('credit-card')
+
+  const shippingValid = createMemo(() => name().length > 0 && ...)
+  const total = createMemo(() => subtotal() + shippingCost() + tax())
+
+  return (
+    <div>
+      {step() === 1 ? (
+        <ShippingForm />
+      ) : step() === 2 ? (
+        <PaymentForm />
+      ) : (
+        <ReviewOrder items={items()} total={total()} />
+      )}
+    </div>
+  )
+}`
+
+export function CheckoutRefPage() {
+  return (
+    <DocPage slug="checkout" toc={tocItems}>
+      <PageHeader
+        title="Checkout"
+        description="A multi-step checkout flow with shipping address, payment method selection, and order review. Demonstrates composite loops inside conditionals, controlled RadioGroup/Select, and derived validation."
+      />
+
+      <Section id="preview" title="Preview">
+        <Example code={previewCode}>
+          <CheckoutDemo />
+        </Example>
+      </Section>
+
+      <Section id="features" title="Features">
+        <ul className="list-disc pl-6 space-y-2 text-sm text-muted-foreground">
+          <li><strong>Multi-step flow:</strong> 3-step wizard (Shipping → Payment → Review) via nested ternary</li>
+          <li><strong>Form validation:</strong> Per-step validation memos disable the Continue button until all fields are valid</li>
+          <li><strong>Controlled Select:</strong> Country picker with signal binding</li>
+          <li><strong>Controlled RadioGroup:</strong> Shipping method and payment method selection</li>
+          <li><strong>Conditional card form:</strong> Credit card fields appear/hide based on payment method</li>
+          <li><strong>Composite loop in conditional:</strong> Order items with Badge components inside the review step (#724)</li>
+          <li><strong>Derived pricing chain:</strong> subtotal → shipping → tax → total via chained createMemo</li>
+          <li><strong>Cross-step state:</strong> Form data persists when navigating between steps</li>
+        </ul>
+      </Section>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -71,6 +71,7 @@ import { TasksTableRefPage } from './pages/components/tasks-table'
 import { SocialFeedRefPage } from './pages/components/social-feed'
 import { FileBrowserRefPage } from './pages/components/file-browser'
 import { CartRefPage } from './pages/components/cart'
+import { CheckoutRefPage } from './pages/components/checkout'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -492,6 +493,11 @@ export function createApp() {
   // Cart block page
   app.get('/components/cart', (c) => {
     return c.render(<CartRefPage />)
+  })
+
+  // Checkout block page
+  app.get('/components/checkout', (c) => {
+    return c.render(<CheckoutRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

- Fix `const [items] = createSignal(...)` (setter omitted) causing `ReferenceError` in SSR templates
- Root cause: `analyzer.ts` `collectSignal()` rejected `elements.length !== 2`, silently dropping the signal from `ctx.signals` — downstream SSR template generation never declared the getter variable

## Changes

- `analyzer.ts`: Allow `elements.length === 1` in `collectSignal()`, set `setter: null`
- `types.ts`: `SignalInfo.setter` is now `string | null`
- `emit-init-sections.ts`: Emit `const [getter] = createSignal(...)` when setter is null
- 5 additional files: null guards for `signal.setter` references
- 5 new tests: analyzer + full compilation for partial destructuring

## Test plan

- [x] 1236 package tests pass (5 new, 0 fail)
- [x] 9 E2E tests pass (Cart + Checkout)
- [x] Full build succeeds (including go-template adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)