### PR TITLE
Add Comments block and surface nested loop event binding bug

### DIFF
--- a/site/ui/components/comments-demo.tsx
+++ b/site/ui/components/comments-demo.tsx
@@ -1,0 +1,435 @@
+"use client"
+/**
+ * CommentsDemo Component
+ *
+ * Comment thread with inline editing, sorting, reactions, and nested replies.
+ * Compiler stress: conditional swap in loop (edit mode toggle), full list
+ * reconciliation (sort order change), item removal in nested loops,
+ * object state mutation (multi-reaction map), createMemo chains (filtered +
+ * sorted view), and event handlers at every nesting level.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Avatar, AvatarFallback } from '@ui/components/ui/avatar'
+import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
+import { Separator } from '@ui/components/ui/separator'
+import { Textarea } from '@ui/components/ui/textarea'
+
+type Reaction = { emoji: string; count: number; reacted: boolean }
+
+type Reply = {
+  id: number
+  author: string
+  initials: string
+  text: string
+  time: string
+}
+
+type Comment = {
+  id: number
+  author: string
+  initials: string
+  text: string
+  time: string
+  timestamp: number
+  reactions: Reaction[]
+  replies: Reply[]
+  showReplies: boolean
+  editing: boolean
+}
+
+type SortMode = 'newest' | 'oldest' | 'popular'
+
+const reactionEmojis = ['👍', '❤️', '😂', '🎉', '🤔']
+
+const initialComments: Comment[] = [
+  {
+    id: 1, author: 'Alice Chen', initials: 'AC',
+    text: 'The new signal-based reactivity model is much cleaner than the previous approach. Fine-grained updates make a huge difference for performance.',
+    time: '2h ago', timestamp: Date.now() - 7200000,
+    reactions: [
+      { emoji: '👍', count: 12, reacted: false },
+      { emoji: '❤️', count: 3, reacted: true },
+    ],
+    replies: [
+      { id: 101, author: 'Bob Park', initials: 'BP', text: 'Agreed! The createMemo pattern especially feels natural.', time: '1h ago' },
+      { id: 102, author: 'Carol Liu', initials: 'CL', text: 'How does it compare to SolidJS signals?', time: '45m ago' },
+    ],
+    showReplies: true, editing: false,
+  },
+  {
+    id: 2, author: 'Dave Kim', initials: 'DK',
+    text: 'Found an edge case with nested loops inside conditionals — the reconciler loses track of elements when the parent branch toggles. Filing an issue now.',
+    time: '5h ago', timestamp: Date.now() - 18000000,
+    reactions: [
+      { emoji: '🤔', count: 5, reacted: false },
+      { emoji: '👍', count: 2, reacted: false },
+    ],
+    replies: [
+      { id: 201, author: 'Alice Chen', initials: 'AC', text: 'Can you share a minimal repro? I hit something similar last week.', time: '4h ago' },
+    ],
+    showReplies: false, editing: false,
+  },
+  {
+    id: 3, author: 'Eve Zhang', initials: 'EZ',
+    text: 'Just shipped a PR using the new composite loop pattern. The template generation handles child components correctly now after the latest fix.',
+    time: '1d ago', timestamp: Date.now() - 86400000,
+    reactions: [
+      { emoji: '🎉', count: 8, reacted: true },
+      { emoji: '👍', count: 15, reacted: false },
+      { emoji: '❤️', count: 6, reacted: false },
+    ],
+    replies: [],
+    showReplies: false, editing: false,
+  },
+  {
+    id: 4, author: 'Frank Lee', initials: 'FL',
+    text: 'Quick question: does createEffect automatically track all signal reads inside it, or do we need to explicitly declare dependencies?',
+    time: '3d ago', timestamp: Date.now() - 259200000,
+    reactions: [
+      { emoji: '👍', count: 1, reacted: false },
+    ],
+    replies: [
+      { id: 401, author: 'Eve Zhang', initials: 'EZ', text: 'It auto-tracks — any signal getter called during execution is registered as a dependency. No dependency array needed.', time: '3d ago' },
+      { id: 402, author: 'Alice Chen', initials: 'AC', text: 'One caveat: async code after an await breaks tracking. Keep signal reads synchronous.', time: '2d ago' },
+      { id: 403, author: 'Frank Lee', initials: 'FL', text: 'Good to know, thanks both!', time: '2d ago' },
+    ],
+    showReplies: false, editing: false,
+  },
+]
+
+let nextCommentId = 100
+let nextReplyId = 1000
+
+export function CommentsDemo() {
+  const [comments, setComments] = createSignal<Comment[]>(initialComments)
+  const [sortMode, setSortMode] = createSignal<SortMode>('newest')
+  const [newCommentText, setNewCommentText] = createSignal('')
+
+  // Memo chain stage 1: sort comments
+  const sortedComments = createMemo(() => {
+    const items = [...comments()]
+    const mode = sortMode()
+    if (mode === 'newest') return items.sort((a, b) => b.timestamp - a.timestamp)
+    if (mode === 'oldest') return items.sort((a, b) => a.timestamp - b.timestamp)
+    // popular: sum of all reaction counts
+    return items.sort((a, b) => {
+      const aTotal = a.reactions.reduce((s, r) => s + r.count, 0)
+      const bTotal = b.reactions.reduce((s, r) => s + r.count, 0)
+      return bTotal - aTotal
+    })
+  })
+
+  // Memo chain stage 2: derived stats
+  const totalComments = createMemo(() => comments().length)
+  const totalReactions = createMemo(() =>
+    comments().reduce((sum, c) => sum + c.reactions.reduce((s, r) => s + r.count, 0), 0)
+  )
+  const totalReplies = createMemo(() =>
+    comments().reduce((sum, c) => sum + c.replies.length, 0)
+  )
+
+  const addComment = () => {
+    const text = newCommentText().trim()
+    if (!text) return
+    const newComment: Comment = {
+      id: nextCommentId++,
+      author: 'You',
+      initials: 'ME',
+      text,
+      time: 'just now',
+      timestamp: Date.now(),
+      reactions: [],
+      replies: [],
+      showReplies: false,
+      editing: false,
+    }
+    setComments(prev => [newComment, ...prev])
+    setNewCommentText('')
+  }
+
+  const deleteComment = (commentId: number) => {
+    setComments(prev => prev.filter(c => c.id !== commentId))
+  }
+
+  const startEditing = (commentId: number) => {
+    setComments(prev => prev.map(c =>
+      c.id === commentId ? { ...c, editing: true } : c
+    ))
+  }
+
+  const cancelEditing = (commentId: number) => {
+    setComments(prev => prev.map(c =>
+      c.id === commentId ? { ...c, editing: false } : c
+    ))
+  }
+
+  const saveEdit = (commentId: number, newText: string) => {
+    if (!newText.trim()) return
+    setComments(prev => prev.map(c =>
+      c.id === commentId ? { ...c, text: newText.trim(), editing: false } : c
+    ))
+  }
+
+  const toggleReaction = (commentId: number, emoji: string) => {
+    setComments(prev => prev.map(c => {
+      if (c.id !== commentId) return c
+      const existing = c.reactions.find(r => r.emoji === emoji)
+      if (existing) {
+        const updated = c.reactions.map(r =>
+          r.emoji === emoji
+            ? { ...r, reacted: !r.reacted, count: r.reacted ? r.count - 1 : r.count + 1 }
+            : r
+        ).filter(r => r.count > 0)
+        return { ...c, reactions: updated }
+      }
+      return { ...c, reactions: [...c.reactions, { emoji, count: 1, reacted: true }] }
+    }))
+  }
+
+  const toggleReplies = (commentId: number) => {
+    setComments(prev => prev.map(c =>
+      c.id === commentId ? { ...c, showReplies: !c.showReplies } : c
+    ))
+  }
+
+  const addReply = (commentId: number, text: string) => {
+    if (!text.trim()) return
+    const newReply: Reply = {
+      id: nextReplyId++,
+      author: 'You',
+      initials: 'ME',
+      text: text.trim(),
+      time: 'just now',
+    }
+    setComments(prev => prev.map(c =>
+      c.id === commentId
+        ? { ...c, replies: [...c.replies, newReply], showReplies: true }
+        : c
+    ))
+  }
+
+  const deleteReply = (commentId: number, replyId: number) => {
+    setComments(prev => prev.map(c =>
+      c.id === commentId
+        ? { ...c, replies: c.replies.filter(r => r.id !== replyId) }
+        : c
+    ))
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4">
+      {/* Stats bar */}
+      <div className="flex items-center gap-4 rounded-lg border p-4">
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{totalComments()}</span> comments
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{totalReplies()}</span> replies
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{totalReactions()}</span> reactions
+        </div>
+      </div>
+
+      {/* New comment form */}
+      <div className="rounded-lg border p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <Avatar className="size-8">
+            <AvatarFallback className="text-xs">ME</AvatarFallback>
+          </Avatar>
+          <Textarea
+            placeholder="Write a comment..."
+            value={newCommentText()}
+            onInput={(e) => setNewCommentText(e.target.value)}
+            className="flex-1 min-h-[80px] text-sm"
+          />
+        </div>
+        <div className="flex justify-end">
+          <Button size="sm" onClick={addComment} disabled={!newCommentText().trim()}>
+            Post Comment
+          </Button>
+        </div>
+      </div>
+
+      {/* Sort controls — triggers full list reconciliation */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Sort by:</span>
+        <Button
+          variant={sortMode() === 'newest' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setSortMode('newest')}
+        >
+          Newest
+        </Button>
+        <Button
+          variant={sortMode() === 'oldest' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setSortMode('oldest')}
+        >
+          Oldest
+        </Button>
+        <Button
+          variant={sortMode() === 'popular' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setSortMode('popular')}
+        >
+          Popular
+        </Button>
+      </div>
+
+      {/* Comment list — sorted, each with conditional edit mode */}
+      {sortedComments().map(comment => (
+        <div key={comment.id} className="comment-item rounded-lg border">
+          <div className="p-4">
+            {/* Comment header */}
+            <div className="flex items-start gap-3">
+              <Avatar>
+                <AvatarFallback>{comment.initials}</AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-sm">{comment.author}</span>
+                    <span className="text-xs text-muted-foreground">{comment.time}</span>
+                  </div>
+                  {/* Edit/Delete buttons — only for user's own comments or all for demo */}
+                  <div className="flex items-center gap-1">
+                    {comment.editing ? null : (
+                      <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => startEditing(comment.id)}>
+                        Edit
+                      </Button>
+                    )}
+                    <Button variant="ghost" size="sm" className="h-7 px-2 text-xs text-destructive" onClick={() => deleteComment(comment.id)}>
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Conditional swap: view mode vs edit mode */}
+                {comment.editing ? (
+                  <div className="mt-2 space-y-2">
+                    <Textarea
+                      value={comment.text}
+                      className="text-sm min-h-[60px]"
+                      onInput={(e) => {
+                        const val = (e.target as HTMLTextAreaElement).value
+                        setComments(prev => prev.map(c =>
+                          c.id === comment.id ? { ...c, text: val } : c
+                        ))
+                      }}
+                    />
+                    <div className="flex gap-2">
+                      <Button size="sm" onClick={() => saveEdit(comment.id, comment.text)}>Save</Button>
+                      <Button variant="outline" size="sm" onClick={() => cancelEditing(comment.id)}>Cancel</Button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="comment-text mt-1 text-sm leading-relaxed">{comment.text}</p>
+                )}
+
+                {/* Reactions — loop of reaction badges with toggle */}
+                <div className="flex flex-wrap items-center gap-1 mt-3">
+                  {comment.reactions.map(reaction => (
+                    <button
+                      key={reaction.emoji}
+                      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors hover:bg-accent ${reaction.reacted ? 'border-primary bg-primary/10' : ''}`}
+                      onClick={() => toggleReaction(comment.id, reaction.emoji)}
+                    >
+                      {reaction.emoji} {reaction.count}
+                    </button>
+                  ))}
+                  {/* Add reaction buttons — loop of available emojis not yet used */}
+                  {reactionEmojis.filter(e => !comment.reactions.some(r => r.emoji === e)).length > 0 ? (
+                    <div className="flex items-center gap-0.5 ml-1">
+                      {reactionEmojis.filter(e => !comment.reactions.some(r => r.emoji === e)).map(emoji => (
+                        <button
+                          key={emoji}
+                          className="rounded-full px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent transition-colors opacity-40 hover:opacity-100"
+                          onClick={() => toggleReaction(comment.id, emoji)}
+                        >
+                          {emoji}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Reply section */}
+          <div className="border-t px-4 py-2">
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => toggleReplies(comment.id)}
+            >
+              {comment.showReplies ? 'Hide' : 'Show'} replies ({comment.replies.length})
+            </button>
+          </div>
+
+          {/* Replies — conditional section with nested loop */}
+          {comment.showReplies ? (
+            <div className="border-t bg-muted/30 p-4 space-y-3">
+              {comment.replies.map(reply => (
+                <div key={reply.id} className="reply-item flex items-start gap-2">
+                  <Avatar className="size-7">
+                    <AvatarFallback className="text-xs">{reply.initials}</AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <div className="rounded-lg bg-background p-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs font-semibold">{reply.author}</span>
+                          <span className="text-[10px] text-muted-foreground">{reply.time}</span>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-5 px-1 text-[10px] text-muted-foreground hover:text-destructive"
+                          onClick={() => deleteReply(comment.id, reply.id)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                      <p className="reply-text text-sm mt-1">{reply.text}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+
+              {/* Reply input */}
+              <div className="flex items-center gap-2">
+                <Avatar className="size-7">
+                  <AvatarFallback className="text-xs">ME</AvatarFallback>
+                </Avatar>
+                <Input
+                  placeholder="Write a reply..."
+                  className="flex-1 h-8 text-sm"
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === 'Enter') {
+                      const input = e.target as HTMLInputElement
+                      addReply(comment.id, input.value)
+                      input.value = ''
+                    }
+                  }}
+                />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ))}
+
+      {/* Empty state — conditional when all deleted */}
+      {comments().length === 0 ? (
+        <div className="rounded-lg border p-8 text-center text-muted-foreground">
+          <p className="text-lg font-medium">No comments yet</p>
+          <p className="text-sm mt-1">Be the first to share your thoughts.</p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -117,6 +117,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'file-browser', title: 'File Browser', description: 'Tree-structured file browser with expand/collapse, multi-select, and CRUD' },
   { slug: 'cart', title: 'Cart', description: 'Shopping cart with inline quantity editing, discount, and derived pricing chain' },
   { slug: 'checkout', title: 'Checkout', description: 'Multi-step checkout with shipping, payment, and order review' },
+  { slug: 'comments', title: 'Comments', description: 'Comment thread with inline editing, sorting, reactions, and nested replies' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/comments.spec.ts
+++ b/site/ui/e2e/comments.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Comments Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/comments')
+  })
+
+  test('renders initial comments with stats', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Should render 4 comment items
+    const items = section.locator('.comment-item')
+    await expect(items).toHaveCount(4)
+
+    // Stats bar should show counts
+    await expect(section.locator('text=4 comments')).toBeVisible()
+  })
+
+  test('add new comment updates list and stats', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Type a comment in the textarea
+    const textarea = section.locator('textarea[placeholder="Write a comment..."]')
+    await textarea.fill('This is a test comment')
+
+    // Click Post Comment
+    await section.locator('button:has-text("Post Comment")').click()
+
+    // Should have 5 comments now
+    const items = section.locator('.comment-item')
+    await expect(items).toHaveCount(5)
+    await expect(section.locator('text=5 comments')).toBeVisible()
+
+    // New comment should be visible
+    await expect(section.locator('text=This is a test comment')).toBeVisible()
+  })
+
+  test('delete comment removes from list', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Delete first comment
+    const deleteBtn = section.locator('.comment-item').first().locator('button:has-text("Delete")').first()
+    await deleteBtn.click()
+
+    // Should have 3 comments
+    const items = section.locator('.comment-item')
+    await expect(items).toHaveCount(3)
+    await expect(section.locator('text=3 comments')).toBeVisible()
+  })
+
+  test('sort buttons reorder comments', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Default is newest — first comment should be Alice's (most recent)
+    const firstText = section.locator('.comment-item').first().locator('.comment-text')
+    await expect(firstText).toContainText('signal-based reactivity')
+
+    // Switch to oldest
+    await section.locator('button:has-text("Oldest")').click()
+
+    // Oldest comment is Frank's (3d ago)
+    const oldestText = section.locator('.comment-item').first().locator('.comment-text')
+    await expect(oldestText).toContainText('Quick question')
+
+    // Switch to popular
+    await section.locator('button:has-text("Popular")').click()
+
+    // Most popular is Eve's (29 total reactions)
+    const popularText = section.locator('.comment-item').first().locator('.comment-text')
+    await expect(popularText).toContainText('composite loop pattern')
+  })
+
+  test('inline edit mode toggles and saves', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+    const firstComment = section.locator('.comment-item').first()
+
+    // Click Edit
+    await firstComment.locator('button:has-text("Edit")').click()
+
+    // Should show textarea with current text and Save/Cancel buttons
+    await expect(firstComment.locator('button:has-text("Save")')).toBeVisible()
+    await expect(firstComment.locator('button:has-text("Cancel")')).toBeVisible()
+
+    // Edit should no longer be visible
+    await expect(firstComment.locator('button:has-text("Edit")')).not.toBeVisible()
+
+    // Cancel should restore view mode
+    await firstComment.locator('button:has-text("Cancel")').click()
+    await expect(firstComment.locator('button:has-text("Edit")')).toBeVisible()
+  })
+
+  // BUG: Event handlers on elements inside nested loops (loop > loop) are not
+  // bound during hydration. The reaction buttons have bf="s22" but the click
+  // event never fires. Same issue affects Social Feed comment-level likes.
+  test.fixme('toggle reaction updates count', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+    const firstComment = section.locator('.comment-item').first()
+
+    const thumbsUp = firstComment.locator('button:has-text("👍12")')
+    await expect(thumbsUp).toBeVisible()
+
+    await thumbsUp.click()
+    await expect(firstComment.locator('button:has-text("👍13")')).toBeVisible()
+
+    await firstComment.locator('button:has-text("👍13")').click()
+    await expect(firstComment.locator('button:has-text("👍12")')).toBeVisible()
+  })
+
+  test('expand replies shows nested content', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Switch to oldest for consistent order
+    await section.locator('button:has-text("Oldest")').click()
+
+    // Frank's comment (first in oldest) has 3 replies hidden
+    const frankComment = section.locator('.comment-item').first()
+    await frankComment.locator('button:has-text("Show replies")').click()
+
+    // Should show replies
+    const replies = frankComment.locator('.reply-item')
+    await expect(replies).toHaveCount(3)
+  })
+
+  // BUG: Event handlers inside loop > conditional > inner loop are not bound.
+  // The reply Input onKeyDown and reply Delete button both fail to fire.
+  // This is the same nested loop event binding bug as reactions.
+  test.fixme('add reply via input inside nested loop', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    await section.locator('button:has-text("Oldest")').click()
+    const frankComment = section.locator('.comment-item').first()
+    await frankComment.locator('button:has-text("Show replies")').click()
+
+    const replyInput = frankComment.locator('input[placeholder="Write a reply..."]')
+    await replyInput.fill('Great explanation!')
+    await replyInput.press('Enter')
+
+    await expect(frankComment.locator('.reply-item')).toHaveCount(4)
+    await expect(frankComment.locator('text=Great explanation!')).toBeVisible()
+  })
+
+  // BUG: Same nested loop event binding issue.
+  test.fixme('delete reply removes from nested list', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    const aliceComment = section.locator('.comment-item').first()
+    const replies = aliceComment.locator('.reply-item')
+    await expect(replies).toHaveCount(2)
+
+    await replies.first().locator('button:has-text("Delete")').click()
+    await expect(aliceComment.locator('.reply-item')).toHaveCount(1)
+  })
+
+  test('delete all comments shows empty state', async ({ page }) => {
+    const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
+
+    // Delete all 4 comments
+    for (let i = 0; i < 4; i++) {
+      const deleteBtn = section.locator('.comment-item').first().locator('button:has-text("Delete")').first()
+      await deleteBtn.click()
+    }
+
+    // Should show empty state
+    await expect(section.locator('text=No comments yet')).toBeVisible()
+    await expect(section.locator('text=0 comments')).toBeVisible()
+  })
+})

--- a/site/ui/pages/components/comments.tsx
+++ b/site/ui/pages/components/comments.tsx
@@ -1,0 +1,105 @@
+/**
+ * Comments Reference Page (/components/comments)
+ *
+ * Block-level composition: inline editing (conditional swap in loop),
+ * sorting (full reconciliation), nested replies, reactions, and deletion.
+ */
+
+import { CommentsDemo } from '@/components/comments-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+function Comments() {
+  const [comments, setComments] = createSignal([...])
+  const [sortMode, setSortMode] = createSignal('newest')
+
+  // Memo chain: sorted view + derived stats
+  const sortedComments = createMemo(() => {
+    const items = [...comments()]
+    if (sortMode() === 'newest') return items.sort(...)
+    return items.sort(...)
+  })
+  const totalReactions = createMemo(() =>
+    comments().reduce((sum, c) => sum + c.reactions.length, 0)
+  )
+
+  return (
+    <div>
+      {/* Sort controls — full list reconciliation */}
+      <div>
+        <Button onClick={() => setSortMode('newest')}>Newest</Button>
+        <Button onClick={() => setSortMode('popular')}>Popular</Button>
+      </div>
+
+      {sortedComments().map(comment => (
+        <div key={comment.id}>
+          {/* Conditional swap: edit mode vs view mode */}
+          {comment.editing ? (
+            <Textarea value={comment.text} />
+          ) : (
+            <p>{comment.text}</p>
+          )}
+
+          {/* Reactions — nested loop with toggle */}
+          {comment.reactions.map(r => (
+            <button key={r.emoji}>{r.emoji} {r.count}</button>
+          ))}
+
+          {/* Replies — conditional section with loop */}
+          {comment.showReplies ? (
+            <div>
+              {comment.replies.map(reply => (
+                <div key={reply.id}>{reply.text}</div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  )
+}`
+
+export function CommentsRefPage() {
+  return (
+    <DocPage slug="comments" toc={tocItems}>
+      <PageHeader
+        title="Comments"
+        description="A comment thread with inline editing, sorting, nested replies, and emoji reactions. Exercises conditional swap in loops, full-list reconciliation on sort change, and multi-level event handling."
+      />
+
+      <Section id="preview" title="Preview">
+        <Example code={previewCode}>
+          <CommentsDemo />
+        </Example>
+      </Section>
+
+      <Section id="features" title="Features">
+        <ul className="list-disc pl-6 space-y-2 text-sm text-muted-foreground">
+          <li><strong>Inline editing:</strong> Conditional swap (view → textarea) inside a loop item, testing conditional-in-loop reconciliation</li>
+          <li><strong>Sort toggle:</strong> Newest / Oldest / Popular re-orders the entire list, triggering full reconciliation with key-based diffing</li>
+          <li><strong>Reactions:</strong> Per-comment emoji reactions with toggle — nested loop of reaction badges, dynamic add/remove</li>
+          <li><strong>Nested replies:</strong> Expandable reply thread per comment (conditional section with inner loop)</li>
+          <li><strong>Delete at every level:</strong> Remove comments and replies, exercising loop item removal reconciliation</li>
+          <li><strong>Derived stats:</strong> Total comments, replies, and reactions via createMemo chain</li>
+          <li><strong>Empty state:</strong> Conditional rendering when all comments are deleted</li>
+        </ul>
+      </Section>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -72,6 +72,7 @@ import { SocialFeedRefPage } from './pages/components/social-feed'
 import { FileBrowserRefPage } from './pages/components/file-browser'
 import { CartRefPage } from './pages/components/cart'
 import { CheckoutRefPage } from './pages/components/checkout'
+import { CommentsRefPage } from './pages/components/comments'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -498,6 +499,11 @@ export function createApp() {
   // Checkout block page
   app.get('/components/checkout', (c) => {
     return c.render(<CheckoutRefPage />)
+  })
+
+  // Comments block page
+  app.get('/components/comments', (c) => {
+    return c.render(<CommentsRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary
- Add Comments block: comment thread with inline editing, sort toggle, emoji reactions, and nested replies
- Surfaces a new **compiler bug**: event handlers on elements inside nested loops are not bound during hydration
- 7 E2E tests pass, 3 marked `fixme` pending compiler fix

## Compiler Bug: Nested Loop Event Binding

Event handlers (`onClick`, `onKeyDown`) on elements inside nested loops fail to fire:

| Pattern | Example | Status |
|---|---|---|
| loop > loop > event | Reaction toggle button | Not bound |
| loop > conditional > loop > event | Reply delete, reply input | Not bound |
| loop > event (single level) | Comment delete, edit, sort | Works |

The `bf` attribute is assigned to elements, but the click handler is never registered. Affects both native `<button>` and `Button` components. Same bug exists in Social Feed (comment-level like buttons).

## Stress Patterns Exercised

- **Inline editing**: Conditional swap (view → textarea) inside loop item
- **Sort toggle**: Newest / Oldest / Popular re-orders entire list (full reconciliation)
- **Reactions**: Per-comment emoji badges with toggle (nested loop)
- **Nested replies**: Expandable reply thread (conditional + inner loop)
- **Delete at every level**: Comment and reply removal (loop item reconciliation)
- **Derived stats**: Total comments, replies, reactions via createMemo chain
- **Empty state**: Conditional when all deleted

## Test plan
- [x] Compiler + adapter tests: 1236 pass, 0 fail
- [x] E2E (Comments): 7 pass, 3 fixme (blocked by nested loop event bug)
- [ ] Fix nested loop event binding in compiler
- [ ] Unfixme 3 E2E tests after compiler fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)