### PR TITLE
Add fine-grained conditional effects inside loop items (#730 Phase 3)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,7 +5,7 @@
 import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchConditional, ConditionalBranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildEvent, LoopChildReactiveAttr, NestedLoopInfo } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
-import { needsEffectWrapper, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
+import { needsEffectWrapper, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 
@@ -186,11 +186,13 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         const childEvents: LoopChildEvent[] = []
         const childReactiveAttrs: LoopChildReactiveAttr[] = []
         const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
+        const childConditionals: import('./types').LoopChildConditional[] = []
         for (const child of node.children) {
           childHandlers.push(...collectEventHandlersFromIR(child))
           childEvents.push(...collectLoopChildEventsWithNesting(child))
           childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx))
           childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx))
+          childConditionals.push(...collectLoopChildConditionals(child, ctx))
         }
 
         if (node.childComponent) {
@@ -227,6 +229,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           childEvents,
           childReactiveAttrs,
           childReactiveTexts,
+          childConditionals,
           childComponent: node.childComponent,
           nestedComponents: node.nestedComponents,
           isStaticArray: node.isStaticArray,

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -255,12 +255,35 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
  * independently when the signal it reads changes.
  * Used by both plain element and composite element dynamic loops.
  */
+/** Emit initChild calls for components inside a conditional branch. */
+function emitBranchChildComponentInits(
+  lines: string[],
+  indent: string,
+  components: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }>,
+): void {
+  for (const comp of components) {
+    const selector = comp.slotId
+      ? `[bf-s$="_${comp.slotId}"], [bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
+      : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
+    const propsEntries = comp.props
+      .filter(p => p.name !== 'key')
+      .map(p => {
+        if (p.name.startsWith('on') && p.name.length > 2) return `${quotePropName(p.name)}: ${p.value}`
+        if (p.isLiteral) return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
+        return `get ${quotePropName(p.name)}() { return ${p.value} }`
+      })
+    const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
+    lines.push(`${indent}{ const __c = __branchScope.querySelector('${selector}'); if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
+  }
+}
+
 function emitLoopChildReactiveEffects(
   lines: string[],
   indent: string,
   elVar: string,
   attrs: LoopElement['childReactiveAttrs'],
   texts: LoopElement['childReactiveTexts'],
+  conditionals?: LoopElement['childConditionals'],
 ): void {
   // Reactive attribute effects
   const attrsBySlot = new Map<string, typeof attrs>()
@@ -290,6 +313,26 @@ function emitLoopChildReactiveEffects(
     const varName = `__rt_${varSlotId(text.slotId)}`
     lines.push(`${indent}{ const ${varName} = (() => { const w = document.createTreeWalker(${elVar}, NodeFilter.SHOW_COMMENT); while (w.nextNode()) { if (w.currentNode.nodeValue === 'bf:${text.slotId}') return w.currentNode.nextSibling }; return null })()`)
     lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.expression}) }) }`)
+  }
+
+  // Reactive conditional effects
+  // Use insert() scoped to the loop item element for conditional switching
+  if (conditionals) {
+    for (const cond of conditionals) {
+      const whenTrueWithCond = addCondAttrToTemplate(cond.whenTrueHtml, cond.slotId)
+      const whenFalseWithCond = addCondAttrToTemplate(cond.whenFalseHtml, cond.slotId)
+      lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${cond.condition}, {`)
+      lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
+      lines.push(`${indent}  bindEvents: (__branchScope) => {`)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents)
+      lines.push(`${indent}  }`)
+      lines.push(`${indent}}, {`)
+      lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
+      lines.push(`${indent}  bindEvents: (__branchScope) => {`)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents)
+      lines.push(`${indent}  }`)
+      lines.push(`${indent}})`)
+    }
   }
 }
 
@@ -476,7 +519,7 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: LoopElement, 
     lines.push(`    const __tpl = document.createElement('template')`)
     lines.push(`    __tpl.innerHTML = \`${elem.template}\``)
     lines.push(`    const __el = __tpl.content.firstElementChild.cloneNode(true)`)
-    emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts)
+    emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts, elem.childConditionals)
     lines.push(`    return __el`)
     lines.push(`  })`)
   }
@@ -641,11 +684,12 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
   // Inner loop levels (depth 1, 2, ...) — each level nests inside the previous
   emitInnerLoopSetup(ls, indent, '__el', ctx.depthLevels, 'csr')
 
-  // Fine-grained effects for reactive attrs and text inside composite loop items
+  // Fine-grained effects for reactive attrs, text, and conditionals
   const reactiveAttrs = ctx.elem.childReactiveAttrs ?? []
   const reactiveTexts = ctx.elem.childReactiveTexts ?? []
-  if (reactiveAttrs.length > 0 || reactiveTexts.length > 0) {
-    emitLoopChildReactiveEffects(ls, indent, '__el', reactiveAttrs, reactiveTexts)
+  const reactiveConditionals = ctx.elem.childConditionals ?? []
+  if (reactiveAttrs.length > 0 || reactiveTexts.length > 0 || reactiveConditionals.length > 0) {
+    emitLoopChildReactiveEffects(ls, indent, '__el', reactiveAttrs, reactiveTexts, reactiveConditionals)
   }
 
   ls.push(`${indent}return __el`)

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -10,6 +10,7 @@ import type {
   LoopChildEvent,
   LoopChildReactiveAttr,
   LoopChildReactiveText,
+  LoopChildConditional,
   NestedLoopInfo,
 } from './types'
 import { attrValueToString } from './utils'
@@ -346,6 +347,50 @@ export function collectLoopChildReactiveTexts(
 
   walk(node)
   return texts
+}
+
+/**
+ * Collect reactive conditionals from loop children.
+ * These are conditional nodes with a slotId that have reactive conditions,
+ * needing insert() calls for fine-grained conditional switching.
+ */
+export function collectLoopChildConditionals(
+  node: IRNode,
+  ctx: ClientJsContext,
+): LoopChildConditional[] {
+  const conditionals: LoopChildConditional[] = []
+  const { irToHtmlTemplate } = require('./html-template')
+
+  function walk(n: IRNode): void {
+    if (n.type === 'conditional' && n.slotId && n.reactive) {
+      const expanded = expandConstantForReactivity(n.condition, ctx)
+      if (needsEffectWrapper(expanded, ctx)) {
+        const whenTrueHtml = irToHtmlTemplate(n.whenTrue)
+        const whenFalseHtml = irToHtmlTemplate(n.whenFalse)
+        conditionals.push({
+          slotId: n.slotId,
+          condition: expanded,
+          whenTrueHtml,
+          whenFalseHtml,
+          whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
+          whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
+        })
+      }
+      // Don't recurse into conditional branches — nested conditionals
+      // inside branches will be handled by insert()'s own bindEvents
+      return
+    }
+    if (n.type === 'element') {
+      for (const child of n.children) walk(child)
+    }
+    if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
+      for (const child of n.children) walk(child)
+    }
+    // Don't recurse into nested loops — they have their own mapArray
+  }
+
+  walk(node)
+  return conditionals
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -169,6 +169,15 @@ export interface LoopChildReactiveText {
   expression: string // Expression that reads signals
 }
 
+export interface LoopChildConditional {
+  slotId: string       // bf-c slot ID for insert() targeting
+  condition: string    // Reactive condition expression
+  whenTrueHtml: string // HTML template for true branch
+  whenFalseHtml: string // HTML template for false branch (usually comment markers)
+  whenTrueComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }>
+  whenFalseComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }>
+}
+
 export interface LoopElement {
   slotId: string
   array: string
@@ -180,6 +189,7 @@ export interface LoopElement {
   childEvents: LoopChildEvent[] // Detailed event info for delegation
   childReactiveAttrs: LoopChildReactiveAttr[] // Reactive attributes in loop children
   childReactiveTexts: LoopChildReactiveText[] // Reactive text interpolations in loop children
+  childConditionals?: LoopChildConditional[] // Reactive conditionals in loop children
   childComponent?: IRLoopChildComponent // For createComponent-based rendering
   nestedComponents?: IRLoopChildComponent[] // For nested components in loop bodies
   isStaticArray: boolean // True if array is a static prop (not a signal)

--- a/site/ui/e2e/chat.spec.ts
+++ b/site/ui/e2e/chat.spec.ts
@@ -52,7 +52,7 @@ test.describe('Chat Block', () => {
       await expect(messages).toHaveCount(2)
     })
 
-    // TODO(#730 Phase 3): template-baked conditionals in loops not yet fine-grained
+    // TODO(#730): conditional with component children inside component loop
     test.skip('switching to Carol marks her messages as read', async ({ page }) => {
       const section = page.locator('[bf-s^="ChatDemo_"]:not([data-slot])').first()
 

--- a/site/ui/e2e/kanban.spec.ts
+++ b/site/ui/e2e/kanban.spec.ts
@@ -85,8 +85,7 @@ test.describe('Kanban Board Block', () => {
   })
 
   test.describe('Add Task', () => {
-    // TODO(#730 Phase 3): template-baked conditionals in loops not yet fine-grained
-    test.skip('clicking + shows add form', async ({ page }) => {
+    test('clicking + shows add form', async ({ page }) => {
       const section = page.locator('[bf-s^="KanbanDemo_"]:not([data-slot])').first()
       const column = section.locator('.kanban-column').first()
 
@@ -94,7 +93,7 @@ test.describe('Kanban Board Block', () => {
       await expect(column.locator('.add-task-form')).toBeVisible()
     })
 
-    // TODO(#730 Phase 3): depends on add form visibility (template-baked conditional)
+    // TODO(#730): insert() bindEvents needs full component init for conditional form
     test.skip('adding task increases count', async ({ page }) => {
       const section = page.locator('[bf-s^="KanbanDemo_"]:not([data-slot])').first()
       const column = section.locator('.kanban-column').first()


### PR DESCRIPTION
## Summary
- Compiler emits `insert()` calls for reactive conditionals inside loop renderItem bodies
- Reduces skipped E2E tests from 3 to 2

Phase 3 of #730. Builds on Phase 2 (fine-grained effects for attrs/text).

## What changed

Previously, conditionals inside loops (e.g., `{addingToColumn() === col.id ? <form> : null}`) were baked into the template string as ternary expressions. With `createRoot` Listener isolation, these ternaries were evaluated once at element creation and never updated.

Now the compiler:
1. Collects reactive `IRConditional` nodes from loop children via `collectLoopChildConditionals`
2. Emits `insert()` calls inside renderItem for each conditional
3. `insert()` handles branch switching reactively using its own `createDisposableEffect`
4. `bindEvents` initializes child components (Input, Button, Badge) via `initChild`

## Fixed
- Kanban: "clicking + shows add form" — previously skipped, now passes

## Remaining skips (2)
- **Chat**: "switching to Carol marks her messages as read" — unread badge conditional is inside a **component loop** (not composite), which uses a different codegen path
- **Kanban**: "adding task increases count" — form components inside `insert()` `bindEvents` need full event binding (not just `initChild`)

## Test Plan
- [x] Compiler + runtime tests: 1245 pass, 0 fail
- [x] E2E: 1008 pass, 2 skipped, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)