### PR TITLE
Fix conditional component init inside composite loops (#730)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -678,8 +678,20 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
   ls.push(`${indent}__tpl.innerHTML = \`${ctx.elem.template}\``)
   ls.push(`${indent}const __el = __tpl.content.firstElementChild.cloneNode(true)`)
 
-  // Outer-level component + event setup
-  emitComponentAndEventSetup(ls, indent, '__el', ctx.outerComps, ctx.outerEvents, 'csr')
+  // Outer-level component + event setup.
+  // Exclude components inside reactive conditionals — they are managed by insert()
+  // via bindEvents/initChild, not createComponent/replaceWith. If we replaceWith
+  // them here, the bf-c marker element is destroyed and insert() can't find it.
+  const condCompSlotIds = new Set<string>()
+  for (const cond of ctx.elem.childConditionals ?? []) {
+    for (const comp of [...cond.whenTrueComponents, ...cond.whenFalseComponents]) {
+      if (comp.slotId) condCompSlotIds.add(comp.slotId)
+    }
+  }
+  const filteredComps = condCompSlotIds.size > 0
+    ? ctx.outerComps.filter(c => !c.slotId || !condCompSlotIds.has(c.slotId))
+    : ctx.outerComps
+  emitComponentAndEventSetup(ls, indent, '__el', filteredComps, ctx.outerEvents, 'csr')
 
   // Inner loop levels (depth 1, 2, ...) — each level nests inside the previous
   emitInnerLoopSetup(ls, indent, '__el', ctx.depthLevels, 'csr')

--- a/site/ui/e2e/chat.spec.ts
+++ b/site/ui/e2e/chat.spec.ts
@@ -52,8 +52,7 @@ test.describe('Chat Block', () => {
       await expect(messages).toHaveCount(2)
     })
 
-    // TODO(#730): conditional with component children inside component loop
-    test.skip('switching to Carol marks her messages as read', async ({ page }) => {
+    test('switching to Carol marks her messages as read', async ({ page }) => {
       const section = page.locator('[bf-s^="ChatDemo_"]:not([data-slot])').first()
 
       // Carol should have unread badge before clicking

--- a/site/ui/e2e/kanban.spec.ts
+++ b/site/ui/e2e/kanban.spec.ts
@@ -93,7 +93,7 @@ test.describe('Kanban Board Block', () => {
       await expect(column.locator('.add-task-form')).toBeVisible()
     })
 
-    // TODO(#730): insert() bindEvents needs full component init for conditional form
+    // TODO(#730): insert() bindEvents initChild not initializing Button onClick
     test.skip('adding task increases count', async ({ page }) => {
       const section = page.locator('[bf-s^="KanbanDemo_"]:not([data-slot])').first()
       const column = section.locator('.kanban-column').first()


### PR DESCRIPTION
## Summary
- Fix Chat unread badge and Kanban add-form conditional not updating when signals change
- Reduces skipped E2E tests from 2 to 1

## Root cause

When a reactive conditional inside a loop template contains child components (Badge, Button), `createComponent`'s `replaceWith` destroyed the `bf-c` marker element. This made `insert()` unable to find the marker for subsequent conditional branch switching.

```
Template: ${cond ? '<div bf-c="s4" data-bf-ph="s10"></div>' : '<!--markers-->'}
         ↓ createComponent replaces placeholder
Result:  <Badge bf-s="...">   ← bf-c="s4" marker is gone!
         ↓ insert() looks for [bf-c="s4"]
         → not found → insert() does nothing → badge never hides
```

## Fix

Exclude components that are inside reactive conditionals from the `createComponent/replaceWith` path. These components are instead initialized via `initChild` in `insert()`'s `bindEvents` callback.

## Test results
- [x] Compiler tests: 1245 pass, 0 fail
- [x] E2E: 1009 pass, 1 skipped, 0 fail
- [x] Chat "switching to Carol" — fixed (was skipped)
- [x] Kanban "clicking + shows add form" — still passes

## Remaining skip (1)
- Kanban "adding task increases count" — Button inside `insert()`'s `bindEvents` `initChild` not receiving `onClick` handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)