### PR TITLE
Fix component selector disambiguation for siblings of same type (#730)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -268,11 +268,10 @@ function emitBranchChildComponentInits(
 ): void {
   const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr
   for (const comp of components) {
-    // Use slotId suffix match + child prefix (~) match only.
-    // Exclude non-child prefix match ([bf-s^="Name_"]) to avoid matching
-    // createComponent-rendered siblings that share the same component name.
+    // Use slotId suffix match only when available to avoid matching
+    // siblings of the same component type (e.g. two Buttons with different slotIds).
     const selector = comp.slotId
-      ? `[bf-s$="_${comp.slotId}"], [bf-s^="~${comp.name}_"]`
+      ? `[bf-s$="_${comp.slotId}"]`
       : `[bf-s^="~${comp.name}_"]`
     const propsEntries = comp.props
       .filter(p => p.name !== 'key')
@@ -665,8 +664,11 @@ function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChi
 
 /** Build the component-finder CSS selector for SSR hydration initChild. */
 function buildCompSelector(comp: { slotId?: string | null; name: string }): string {
+  // When slotId is available, use suffix-only selector. It is unique within
+  // the parent scope and avoids matching siblings of the same component type
+  // (e.g. two Buttons with different slotIds).
   return comp.slotId
-    ? `[bf-s$="_${comp.slotId}"], [bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
+    ? `[bf-s$="_${comp.slotId}"]`
     : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
 }
 

--- a/site/ui/e2e/comments.spec.ts
+++ b/site/ui/e2e/comments.spec.ts
@@ -70,8 +70,7 @@ test.describe('Comments Block', () => {
     await expect(popularText).toContainText('composite loop pattern')
   })
 
-  // TODO(#730): per-item signals — pending deeper loop reactivity fixes
-  test.skip('inline edit mode toggles and saves', async ({ page }) => {
+  test('inline edit mode toggles and saves', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
     const firstComment = section.locator('.comment-item').first()
 
@@ -90,7 +89,6 @@ test.describe('Comments Block', () => {
     await expect(firstComment.locator('button:has-text("Edit")')).toBeVisible()
   })
 
-  // TODO(#730): per-item signals — pending deeper loop reactivity fixes
   test.skip('toggle reaction updates count', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
     const firstComment = section.locator('.comment-item').first()
@@ -122,7 +120,6 @@ test.describe('Comments Block', () => {
     await expect(replies).toHaveCount(3)
   })
 
-  // TODO(#730): per-item signals — pending deeper loop reactivity fixes
   test.skip('add reply via input inside nested loop', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
 
@@ -138,7 +135,6 @@ test.describe('Comments Block', () => {
     await expect(frankComment.locator('text=Great explanation!')).toBeVisible()
   })
 
-  // TODO(#730): per-item signals — pending deeper loop reactivity fixes
   test.skip('delete reply removes from nested list', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
 


### PR DESCRIPTION
## Summary

Fixes a bug where `buildCompSelector` and `emitBranchChildComponentInits` generated CSS selectors with a fallback `[bf-s^="~Button_"]` that matched ANY Button component. When multiple Buttons exist as siblings (e.g., Save and Cancel in a conditional branch), `querySelector` returns the first match, causing event handlers to be attached to the wrong element.

**Root cause:** The Cancel button's `onClick: () => cancelEditing(...)` was being attached to the Save button. Clicking Cancel did nothing because the Save button had the Cancel handler overwritten by its own handler (or vice versa).

## Changes

| File | Change |
|------|--------|
| `packages/jsx/src/ir-to-client-js/emit-control-flow.ts` | `buildCompSelector`: use only `[bf-s$="_sN"]` suffix when slotId available |
| `packages/jsx/src/ir-to-client-js/emit-control-flow.ts` | `emitBranchChildComponentInits`: same fix for conditional branch component init |
| `packages/dom/src/insert.ts` | Remove debug console.log |
| `site/ui/e2e/comments.spec.ts` | Unskip inline edit test + remove TODO comments |

## Progress

| Metric | Before | After |
|--------|--------|-------|
| E2E passed | 1002 | 1003 |
| E2E skipped | 8 | 7 |

Remaining 7 skipped: comments (3: reaction toggle, add/delete reply — inner loop reactivity) + todo-app (5 — separate suite).

## Test plan

- [x] 1247 package unit tests pass
- [x] 1003 E2E tests pass, 7 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)