### PR TITLE
Reactive inner loops via mapArray for per-item signal updates (#730)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -14,7 +14,7 @@ import { expandDynamicPropValue, expandConstantForReactivity } from './prop-hand
  * Returns NestedLoopInfo for each loop node found within the tree,
  * tracking the nearest ancestor element's slotId as container.
  */
-function collectInnerLoops(nodes: IRNode[]): NestedLoopInfo[] {
+function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: ClientJsContext): NestedLoopInfo[] {
   const result: NestedLoopInfo[] = []
   let depth = 0
   let lastSlotId: string | null = null
@@ -27,12 +27,28 @@ function collectInnerLoops(nodes: IRNode[]): NestedLoopInfo[] {
         break
       case 'loop':
         depth++
+        // Generate item template for CSR rendering in mapArray
+        const itemTemplate = n.children.map(c => irToPlaceholderTemplate(c, undefined, depth)).join('')
+        // Check if array expression references the outer loop param
+        const refsOuter = outerLoopParam
+          ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
+          : false
+        // Collect reactive text expressions inside inner loop items
+        const innerReactiveTexts: Array<{ slotId: string; expression: string }> = []
+        if (refsOuter && ctx) {
+          for (const child of n.children) {
+            innerReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
+          }
+        }
         result.push({
           depth,
           array: n.array,
           param: n.param,
           key: n.key ?? '',
           containerSlotId: lastSlotId,
+          itemTemplate,
+          refsOuterParam: refsOuter,
+          reactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
         })
         for (const child of n.children) walk(child)
         depth--
@@ -234,7 +250,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           nestedComponents: node.nestedComponents,
           isStaticArray: node.isStaticArray,
           useElementReconciliation,
-          innerLoops: useElementReconciliation ? collectInnerLoops(node.children) : undefined,
+          innerLoops: useElementReconciliation ? collectInnerLoops(node.children, node.param, ctx) : undefined,
           filterPredicate: node.filterPredicate ? {
             param: node.filterPredicate.param,
             raw: node.filterPredicate.raw,
@@ -550,7 +566,7 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           childReactiveTexts: useElementReconciliation ? childReactiveTexts : undefined,
           childReactiveAttrs: useElementReconciliation ? childReactiveAttrs : undefined,
           childConditionals: useElementReconciliation ? childConditionals : undefined,
-          innerLoops: useElementReconciliation ? collectInnerLoops(n.children) : undefined,
+          innerLoops: useElementReconciliation ? collectInnerLoops(n.children, n.param) : undefined,
           useElementReconciliation: useElementReconciliation || undefined,
         })
         // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -617,7 +617,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
 interface DepthLevel {
   comps: (LoopElement['nestedComponents'] & {})[number][]
   events: LoopChildEvent[]
-  loopInfo: { array: string; param: string; key: string; depth: number; containerSlotId?: string | null } | null
+  loopInfo: { array: string; param: string; key: string; depth: number; containerSlotId?: string | null; itemTemplate?: string; refsOuterParam?: boolean; reactiveTexts?: Array<{ slotId: string; expression: string }> } | null
 }
 
 /**
@@ -791,21 +791,76 @@ function emitInnerLoopSetup(
     const uid = `${inner.depth}_${i}`
     const arrayExpr = wrapOuter(inner.array)
     const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
-    ls.push(`${indent}// Initialize ${inner.array} loop components and events`)
-    ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `${parentElVar}.querySelector(${containerSelector})` : parentElVar}`)
-    // Guard: inner loop array may be undefined when inside a conditional branch
-    ls.push(`${indent}if (__ic${uid} && ${arrayExpr}) ${arrayExpr}.forEach((${inner.param}, __innerIdx${uid}) => {`)
-    ls.push(`${indent}  const __innerEl${uid} = __ic${uid}.children[__innerIdx${uid}]`)
-    ls.push(`${indent}  if (!__innerEl${uid}) return`)
-    if (inner.key) {
-      ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
+
+    // Use reactive mapArray only for inner loops that:
+    // 1. Reference the outer loop param (need reactivity)
+    // 2. Have an item template (for CSR element creation)
+    // 3. Don't contain child components (components need initChild which is complex to re-run)
+    const hasComps = level.comps.length > 0
+    if (inner.refsOuterParam && inner.itemTemplate && outerLoopParam && !hasComps) {
+      // Reactive inner loop: use mapArray for proper add/remove/update
+      // Key function receives plain item value (not accessor) per mapArray contract
+      const keyFn = inner.key
+        ? `(${inner.param}) => String(${inner.key})`
+        : 'null'
+      // Template and key inside renderItem use accessor: wrap both outer and inner params
+      const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
+      const wrappedTemplate = wrapBoth(inner.itemTemplate!)
+      ls.push(`${indent}// Reactive inner loop: ${inner.array}`)
+      ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `${parentElVar}.querySelector(${containerSelector})` : parentElVar}`)
+      ls.push(`${indent}if (__ic${uid}) mapArray(() => ${arrayExpr} || [], __ic${uid}, ${keyFn}, (${inner.param}, __innerIdx${uid}, __existing) => {`)
+      // SSR/CSR branch
+      ls.push(`${indent}  const __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
+      if (inner.key) {
+        // Inside renderItem, inner.param is an accessor
+        const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
+        ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${wrappedKey}))`)
+      }
+      // Set up events — wrap both outer and inner loop params as accessors
+      if (level.events.length > 0) {
+        // Pre-wrap event handlers with inner loop param before passing to emitEventSetup
+        const wrappedEvents = level.events.map(ev => ({
+          ...ev,
+          handler: wrapLoopParamAsAccessor(ev.handler, inner.param),
+        }))
+        ls.push(`${indent}  if (!__existing) {`)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, [], wrappedEvents, 'csr', outerLoopParam)
+        ls.push(`${indent}  } else {`)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, [], wrappedEvents, 'ssr', outerLoopParam)
+        ls.push(`${indent}  }`)
+      }
+      // Recurse for child levels
+      if (childLevels.length > 0) {
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
+      }
+      // Reactive text effects for inner loop items
+      if (inner.reactiveTexts && inner.reactiveTexts.length > 0) {
+        for (const text of inner.reactiveTexts) {
+          const wrappedExpr = wrapLoopParamAsAccessor(wrapOuter(text.expression), inner.param)
+          ls.push(`${indent}  { const [__rt] = $t(__innerEl${uid}, '${text.slotId}')`)
+          ls.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${wrappedExpr}) }) }`)
+        }
+      }
+      ls.push(`${indent}  return __innerEl${uid}`)
+      ls.push(`${indent}}) }`)
+    } else {
+      // Static inner loop: use forEach for initial setup only
+      ls.push(`${indent}// Initialize ${inner.array} loop components and events`)
+      ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `${parentElVar}.querySelector(${containerSelector})` : parentElVar}`)
+      // Guard: inner loop array may be undefined when inside a conditional branch
+      ls.push(`${indent}if (__ic${uid} && ${arrayExpr}) ${arrayExpr}.forEach((${inner.param}, __innerIdx${uid}) => {`)
+      ls.push(`${indent}  const __innerEl${uid} = __ic${uid}.children[__innerIdx${uid}]`)
+      ls.push(`${indent}  if (!__innerEl${uid}) return`)
+      if (inner.key) {
+        ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
+      }
+      emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam)
+      // Recurse for child levels (nested deeper loops)
+      if (childLevels.length > 0) {
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
+      }
+      ls.push(`${indent}}) }`)
     }
-    emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam)
-    // Recurse for child levels (nested deeper loops)
-    if (childLevels.length > 0) {
-      emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
-    }
-    ls.push(`${indent}}) }`)
 
     i = j // skip past this level + its children
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -151,6 +151,12 @@ export interface NestedLoopInfo {
   param: string    // Inner loop parameter name (e.g., 'task')
   key: string      // Inner loop key expression (e.g., 'task.id')
   containerSlotId: string | null // Slot ID of the parent element containing the loop (for hydration)
+  /** HTML template for a single inner loop item (for mapArray CSR rendering) */
+  itemTemplate?: string
+  /** Whether the inner array references the outer loop param (needs reactive mapArray) */
+  refsOuterParam?: boolean
+  /** Reactive text expressions inside inner loop items (slotId → expression) */
+  reactiveTexts?: Array<{ slotId: string; expression: string }>
 }
 
 export interface LoopChildEvent {

--- a/site/ui/e2e/comments.spec.ts
+++ b/site/ui/e2e/comments.spec.ts
@@ -89,7 +89,7 @@ test.describe('Comments Block', () => {
     await expect(firstComment.locator('button:has-text("Edit")')).toBeVisible()
   })
 
-  test.skip('toggle reaction updates count', async ({ page }) => {
+  test('toggle reaction updates count', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
     const firstComment = section.locator('.comment-item').first()
 


### PR DESCRIPTION
## Summary

Inner loops inside composite outer `mapArray` loops (e.g., `comment.reactions.map(...)` inside `sortedComments().map(...)`) now use `mapArray` for reactive rendering. Previously, they used `forEach` for one-time initialization only, so changes to nested arrays were not reflected in the DOM.

## Root cause

When the outer per-item signal changes (e.g., reaction count increments), `mapArray` calls `setItem(newComment)` which updates the per-item signal. Inner loops using `forEach` never re-run, so:
- Text updates (👍12 → 👍13) don't appear
- Added items don't appear in the DOM
- Removed items stay in the DOM

## Approach

Replace `forEach` with `mapArray` for inner loops that:
1. Reference the outer loop parameter (need reactivity)
2. Have a generated item template (for CSR element creation)
3. **Don't contain child components** (components need `initChild` which is complex to re-run in mapArray context — guarded for now)

The inner `mapArray` provides per-item signals for inner loop items, enabling fine-grained reactive text updates.

## Changes

| File | Change |
|------|--------|
| `packages/jsx/src/ir-to-client-js/types.ts` | Extend `NestedLoopInfo` with `itemTemplate`, `refsOuterParam`, `reactiveTexts` |
| `packages/jsx/src/ir-to-client-js/collect-elements.ts` | Generate item template, collect reactive texts per inner loop |
| `packages/jsx/src/ir-to-client-js/emit-control-flow.ts` | `emitInnerLoopSetup`: generate `mapArray` for reactive inner loops |
| `site/ui/e2e/comments.spec.ts` | Unskip reaction toggle test |

## Progress

| Metric | Before | After |
|--------|--------|-------|
| E2E passed | 1003 | 1004 |
| E2E skipped | 7 | 6 |

Remaining 6 skipped:
- comments: 2 (add/delete reply — inner loop with components, needs component-aware mapArray)
- todo-app: 5 (separate test suite, similar inner loop issues)

## Test plan

- [x] 1247 package unit tests pass
- [x] 1004 E2E tests pass, 6 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)