### PR TITLE
Reactive inner loops with components + conditional branch dedup (#730)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -18,6 +18,7 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
   const result: NestedLoopInfo[] = []
   let depth = 0
   let lastSlotId: string | null = null
+  let insideCond = false
 
   function walk(n: IRNode): void {
     switch (n.type) {
@@ -49,6 +50,7 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
           itemTemplate,
           refsOuterParam: refsOuter,
           reactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
+          insideConditional: insideCond || undefined,
         })
         for (const child of n.children) walk(child)
         depth--
@@ -58,10 +60,14 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
       case 'provider':
         for (const child of n.children) walk(child)
         break
-      case 'conditional':
+      case 'conditional': {
+        const prev = insideCond
+        insideCond = true
         walk(n.whenTrue)
         walk(n.whenFalse)
+        insideCond = prev
         break
+      }
     }
   }
 

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -285,6 +285,72 @@ function emitBranchChildComponentInits(
   }
 }
 
+/**
+ * Emit mapArray calls for inner loops inside a conditional branch's bindEvents.
+ * When a loop item has a conditional (e.g., showReplies ? replies : null),
+ * the inner loop container only exists when the branch is active.
+ * This sets up mapArray each time the branch activates.
+ */
+function emitBranchInnerLoops(
+  lines: string[],
+  indent: string,
+  scopeVar: string,
+  innerLoops: import('./types').NestedLoopInfo[] | undefined,
+  outerLoopParam?: string,
+): void {
+  if (!innerLoops || !outerLoopParam) return
+  const wrapOuter = (expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam)
+
+  for (let i = 0; i < innerLoops.length; i++) {
+    const inner = innerLoops[i]
+    if (!inner.refsOuterParam || !inner.itemTemplate) continue
+
+    const uid = `br_${i}`
+    const arrayExpr = wrapOuter(inner.array)
+    const keyFn = inner.key
+      ? `(${inner.param}) => String(${inner.key})`
+      : 'null'
+    const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
+    const wrappedTemplate = wrapBoth(inner.itemTemplate)
+    const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
+
+    lines.push(`${indent}{ const __bic${uid} = ${containerSelector !== 'null' ? `${scopeVar}.querySelector(${containerSelector})` : scopeVar}`)
+    lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${inner.param}, __bidx${uid}, __existing) => {`)
+    lines.push(`${indent}  const __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
+    if (inner.key) {
+      const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
+      lines.push(`${indent}  __bel${uid}.setAttribute('${keyAttrName(1)}', String(${wrappedKey}))`)
+    }
+    // Components and events inside inner loop items
+    const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
+    const comps = (inner.childComponents ?? []).map(comp => ({
+      ...comp,
+      props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+    }))
+    const events = (inner.childEvents ?? []).map(ev => ({
+      ...ev,
+      handler: wrapInner(ev.handler),
+    }))
+    if (comps.length > 0 || events.length > 0) {
+      lines.push(`${indent}  if (!__existing) {`)
+      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'csr', outerLoopParam)
+      lines.push(`${indent}  } else {`)
+      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'ssr', outerLoopParam)
+      lines.push(`${indent}  }`)
+    }
+    // Reactive text effects for inner loop items
+    if (inner.reactiveTexts && inner.reactiveTexts.length > 0) {
+      for (const text of inner.reactiveTexts) {
+        const wrappedExpr = wrapBoth(text.expression)
+        lines.push(`${indent}  { const [__rt] = $t(__bel${uid}, '${text.slotId}')`)
+        lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${wrappedExpr}) }) }`)
+      }
+    }
+    lines.push(`${indent}  return __bel${uid}`)
+    lines.push(`${indent}}) }`)
+  }
+}
+
 function emitLoopChildReactiveEffects(
   lines: string[],
   indent: string,
@@ -333,11 +399,13 @@ function emitLoopChildReactiveEffects(
       lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
       emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents, loopParam)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrueInnerLoops, loopParam)
       lines.push(`${indent}  }`)
       lines.push(`${indent}}, {`)
       lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
       emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents, loopParam)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalseInnerLoops, loopParam)
       lines.push(`${indent}  }`)
       lines.push(`${indent}})`)
     }
@@ -617,7 +685,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
 interface DepthLevel {
   comps: (LoopElement['nestedComponents'] & {})[number][]
   events: LoopChildEvent[]
-  loopInfo: { array: string; param: string; key: string; depth: number; containerSlotId?: string | null; itemTemplate?: string; refsOuterParam?: boolean; reactiveTexts?: Array<{ slotId: string; expression: string }> } | null
+  loopInfo: { array: string; param: string; key: string; depth: number; containerSlotId?: string | null; itemTemplate?: string; refsOuterParam?: boolean; reactiveTexts?: Array<{ slotId: string; expression: string }>; insideConditional?: boolean } | null
 }
 
 /**
@@ -778,6 +846,9 @@ function emitInnerLoopSetup(
     const level = levels[i]
     const inner = level.loopInfo
     if (!inner) { i++; continue }
+    // Skip loops inside conditionals — they are handled by emitBranchInnerLoops
+    // inside insert() bindEvents to avoid duplicate mapArray initialization
+    if (inner.insideConditional) { i++; continue }
 
     // Collect child levels (immediately following with depth > current)
     const childLevels: DepthLevel[] = []

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -792,12 +792,7 @@ function emitInnerLoopSetup(
     const arrayExpr = wrapOuter(inner.array)
     const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
 
-    // Use reactive mapArray only for inner loops that:
-    // 1. Reference the outer loop param (need reactivity)
-    // 2. Have an item template (for CSR element creation)
-    // 3. Don't contain child components (components need initChild which is complex to re-run)
-    const hasComps = level.comps.length > 0
-    if (inner.refsOuterParam && inner.itemTemplate && outerLoopParam && !hasComps) {
+    if (inner.refsOuterParam && inner.itemTemplate && outerLoopParam) {
       // Reactive inner loop: use mapArray for proper add/remove/update
       // Key function receives plain item value (not accessor) per mapArray contract
       const keyFn = inner.key
@@ -816,17 +811,24 @@ function emitInnerLoopSetup(
         const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
         ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${wrappedKey}))`)
       }
-      // Set up events — wrap both outer and inner loop params as accessors
-      if (level.events.length > 0) {
-        // Pre-wrap event handlers with inner loop param before passing to emitEventSetup
+      // Set up components and events — wrap inner loop param as accessor
+      if (level.comps.length > 0 || level.events.length > 0) {
+        // Pre-wrap both component props and event handlers with inner loop param
+        const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
+        const wrappedComps = level.comps.map(comp => ({
+          ...comp,
+          props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+          children: comp.children?.map(c => c.type === 'expression' && c.expr
+            ? { ...c, expr: wrapInner(c.expr) } : c),
+        }))
         const wrappedEvents = level.events.map(ev => ({
           ...ev,
-          handler: wrapLoopParamAsAccessor(ev.handler, inner.param),
+          handler: wrapInner(ev.handler),
         }))
         ls.push(`${indent}  if (!__existing) {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, [], wrappedEvents, 'csr', outerLoopParam)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'csr', outerLoopParam)
         ls.push(`${indent}  } else {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, [], wrappedEvents, 'ssr', outerLoopParam)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'ssr', outerLoopParam)
         ls.push(`${indent}  }`)
       }
       // Recurse for child levels

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -388,6 +388,8 @@ export function collectLoopChildConditionals(
           whenFalseHtml,
           whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
           whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
+          whenTrueInnerLoops: collectBranchInnerLoops(n.whenTrue, loopParam, ctx),
+          whenFalseInnerLoops: collectBranchInnerLoops(n.whenFalse, loopParam, ctx),
         })
       }
       // Don't recurse into conditional branches — nested conditionals
@@ -405,6 +407,79 @@ export function collectLoopChildConditionals(
 
   walk(node)
   return conditionals
+}
+
+/**
+ * Collect inner loop info from a conditional branch IR node.
+ * Used to set up mapArray inside insert() bindEvents for loops
+ * that are inside conditional branches of loop items.
+ */
+function collectBranchInnerLoops(
+  node: IRNode,
+  outerLoopParam?: string,
+  ctx?: ClientJsContext,
+): LoopChildConditional['whenTrueInnerLoops'] {
+  const { irToPlaceholderTemplate } = require('./html-template')
+  const loops: import('./types').NestedLoopInfo[] = []
+  let lastSlotId: string | null = null
+
+  function walk(n: IRNode): void {
+    if (n.type === 'element') {
+      if (n.slotId) lastSlotId = n.slotId
+      for (const child of n.children) walk(child)
+    } else if (n.type === 'loop') {
+      const itemTemplate = n.children.map((c: IRNode) => irToPlaceholderTemplate(c, undefined, 1)).join('')
+      const refsOuter = outerLoopParam
+        ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
+        : false
+      const reactiveTexts: Array<{ slotId: string; expression: string }> = []
+      if (refsOuter && ctx) {
+        for (const child of n.children) {
+          reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
+        }
+      }
+      // Collect child components and events inside inner loop items
+      // Walk loop body children (not the loop node itself, which traverseForComponents skips)
+      const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }> = []
+      for (const child of n.children) {
+        rawComps.push(...collectConditionalBranchChildComponents(child))
+      }
+      const childComponents = rawComps.map(c => ({
+        name: c.name,
+        slotId: c.slotId,
+        props: c.props.map(p => ({
+          name: p.name,
+          value: p.value,
+          dynamic: p.dynamic ?? false,
+          isLiteral: p.isLiteral ?? false,
+          isEventHandler: p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase(),
+        })),
+        children: [] as import('../types').IRNode[],
+        loopDepth: 1,
+      }))
+      const childEvents: import('./types').LoopChildEvent[] = []
+      for (const child of n.children) {
+        childEvents.push(...collectLoopChildEventsWithNesting(child))
+      }
+      loops.push({
+        depth: 1,
+        array: n.array,
+        param: n.param,
+        key: n.key ?? '',
+        containerSlotId: lastSlotId,
+        itemTemplate,
+        refsOuterParam: refsOuter,
+        reactiveTexts: reactiveTexts.length > 0 ? reactiveTexts : undefined,
+        childComponents: childComponents.length > 0 ? childComponents : undefined,
+        childEvents: childEvents.length > 0 ? childEvents : undefined,
+      })
+    } else if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
+      for (const child of n.children) walk(child)
+    }
+  }
+
+  walk(node)
+  return loops.length > 0 ? loops : undefined
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -157,6 +157,12 @@ export interface NestedLoopInfo {
   refsOuterParam?: boolean
   /** Reactive text expressions inside inner loop items (slotId → expression) */
   reactiveTexts?: Array<{ slotId: string; expression: string }>
+  /** Child components inside inner loop items (for initChild/createComponent) */
+  childComponents?: import('../types').IRLoopChildComponent[]
+  /** Event handlers inside inner loop items */
+  childEvents?: LoopChildEvent[]
+  /** True when this loop is inside a conditional branch (handled by insert() bindEvents instead) */
+  insideConditional?: boolean
 }
 
 export interface LoopChildEvent {
@@ -185,6 +191,10 @@ export interface LoopChildConditional {
   whenFalseHtml: string // HTML template for false branch (usually comment markers)
   whenTrueComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }>
   whenFalseComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }>
+  /** Inner loops inside whenTrue branch that need mapArray setup */
+  whenTrueInnerLoops?: NestedLoopInfo[]
+  /** Inner loops inside whenFalse branch that need mapArray setup */
+  whenFalseInnerLoops?: NestedLoopInfo[]
 }
 
 export interface LoopElement {

--- a/site/ui/e2e/comments.spec.ts
+++ b/site/ui/e2e/comments.spec.ts
@@ -120,7 +120,7 @@ test.describe('Comments Block', () => {
     await expect(replies).toHaveCount(3)
   })
 
-  test.skip('add reply via input inside nested loop', async ({ page }) => {
+  test('add reply via input inside nested loop', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
 
     await section.locator('button:has-text("Oldest")').click()
@@ -135,7 +135,7 @@ test.describe('Comments Block', () => {
     await expect(frankComment.locator('text=Great explanation!')).toBeVisible()
   })
 
-  test.skip('delete reply removes from nested list', async ({ page }) => {
+  test('delete reply removes from nested list', async ({ page }) => {
     const section = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first()
 
     const aliceComment = section.locator('.comment-item').first()


### PR DESCRIPTION
## Summary

Two fixes for inner loop reactivity in per-item signals (#730):

### 1. Component-containing inner loops use mapArray (kanban regression fix)

PR #744 introduced `mapArray` for reactive inner loops but guarded against component-containing ones. The guard was ineffective, causing kanban's `col.tasks` loop to use `mapArray` without proper accessor wrapping.

**Fix:** Remove the guard, properly pre-wrap component props and event handlers with inner loop param accessor (skipping literal props to avoid false matches like `"delete-task"` → `"delete-task()"`).

### 2. Deduplicate mapArray for inner loops inside conditional branches

Comments' replies loop (`comment.replies.map(...)`) is inside a conditional (`comment.showReplies ? ... : null`). The replies `mapArray` was emitted in **3 places**: SSR path, CSR path, AND `insert()` bindEvents. For initially-visible branches, the first `mapArray` adopted elements, then the second conflicted.

**Fix:**
- Add `insideConditional` flag to `NestedLoopInfo`
- `collectInnerLoops` tracks conditional nesting
- `emitInnerLoopSetup` skips `insideConditional` loops (handled exclusively by `emitBranchInnerLoops` in `insert()` bindEvents)
- Fix `collectBranchInnerLoops` to walk loop children when collecting components

## Progress

| Metric | Before (main) | After |
|--------|--------------|-------|
| E2E passed | 1004 | 1006 |
| E2E skipped | 6 | 4 |

Remaining 4 skipped: todo-app (separate test suite).

## Test plan

- [x] 1247 package unit tests pass
- [x] 1006 E2E tests pass, 4 skipped, 0 failed
- [x] All 10 comments tests pass (including add/delete reply)
- [x] All 12 kanban tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)