### PR TITLE
Preserve focus for controlled inputs in loops (#730)

### DIFF
--- a/packages/dom/src/map-array.ts
+++ b/packages/dom/src/map-array.ts
@@ -190,9 +190,21 @@ export function mapArray<T>(
       }
     }
 
-    // Reconcile DOM order: insertBefore moves already-connected elements
+    // Reconcile DOM order: skip insertBefore entirely when order is unchanged.
+    // Moving elements via insertBefore causes detach/reattach which makes
+    // focused inputs lose focus (controlled input flicker).
+    let inOrder = true
+    let checkNode: Node | null = startMarker ? startMarker.nextSibling : container.firstChild
     for (const { element } of desiredOrder) {
-      container.insertBefore(element, anchor)
+      // Skip non-element nodes (comments, text)
+      while (checkNode && checkNode.nodeType !== Node.ELEMENT_NODE) checkNode = checkNode.nextSibling
+      if (checkNode !== element) { inOrder = false; break }
+      checkNode = checkNode.nextSibling
+    }
+    if (!inOrder) {
+      for (const { element } of desiredOrder) {
+        container.insertBefore(element, anchor)
+      }
     }
   })
 }

--- a/site/ui/e2e/controlled-input-focus.spec.ts
+++ b/site/ui/e2e/controlled-input-focus.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Controlled input focus preservation in loops', () => {
+  test('field-arrays: typing preserves focus and value', async ({ page }) => {
+    await page.goto('/docs/forms/field-arrays')
+    await page.waitForLoadState('networkidle')
+
+    const demo = page.locator('[bf-s^="BasicFieldArrayDemo_"]')
+    const input = demo.locator('input').first()
+
+    await input.focus()
+    await input.type('test@example.com', { delay: 30 })
+
+    // Focus must be preserved
+    const isFocused = await input.evaluate(el => document.activeElement === el)
+    expect(isFocused).toBe(true)
+    await expect(input).toHaveValue('test@example.com')
+  })
+
+  test('field-arrays: typing in added field preserves focus', async ({ page }) => {
+    await page.goto('/docs/forms/field-arrays')
+    await page.waitForLoadState('networkidle')
+
+    const demo = page.locator('[bf-s^="BasicFieldArrayDemo_"]')
+    await demo.locator('button:has-text("+ Add Email")').click()
+    const secondInput = demo.locator('input').nth(1)
+
+    await secondInput.focus()
+    await secondInput.type('user@test.com', { delay: 30 })
+
+    const isFocused = await secondInput.evaluate(el => document.activeElement === el)
+    expect(isFocused).toBe(true)
+    await expect(secondInput).toHaveValue('user@test.com')
+  })
+
+  test('comments: editing textarea preserves focus', async ({ page }) => {
+    await page.goto('/components/comments')
+    await page.waitForLoadState('networkidle')
+
+    const firstComment = page.locator('[bf-s^="CommentsDemo_"]:not([data-slot])').first().locator('.comment-item').first()
+    await firstComment.locator('button:has-text("Edit")').click()
+
+    const textarea = firstComment.locator('textarea')
+    await textarea.fill('')
+    await textarea.type('Updated text', { delay: 30 })
+
+    const isFocused = await textarea.evaluate(el => document.activeElement === el)
+    expect(isFocused).toBe(true)
+    await expect(textarea).toHaveValue('Updated text')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the last remaining item in #730: **controlled inputs in loops lose focus when typing**.

## Root cause

`mapArray`'s DOM reconciliation called `container.insertBefore(element, anchor)` for **every element on every update**, even when the order hadn't changed. `insertBefore` detaches and reattaches the element, which causes the browser to blur any focused input inside.

For controlled inputs (e.g., `<input value={field.value} onInput={...} />`), each keystroke triggers:
1. `onInput` → `setFields(...)` → signal update
2. `mapArray` effect re-runs → same keys → `setItem()` (correct, no re-render)
3. But then the reconciliation loop moves every element → focus lost

## Fix

Before calling `insertBefore`, check if the DOM order already matches the desired order. When unchanged (the common case for per-item signal updates), skip all moves entirely.

```typescript
let inOrder = true
let checkNode = startMarker ? startMarker.nextSibling : container.firstChild
for (const { element } of desiredOrder) {
  while (checkNode && checkNode.nodeType !== Node.ELEMENT_NODE) checkNode = checkNode.nextSibling
  if (checkNode !== element) { inOrder = false; break }
  checkNode = checkNode.nextSibling
}
if (!inOrder) {
  for (const { element } of desiredOrder) {
    container.insertBefore(element, anchor)
  }
}
```

## Test plan

- [x] 1247 package unit tests pass (including mapArray reorder test)
- [x] 1014 E2E tests pass, 0 skipped
- [x] New E2E tests: field-arrays typing focus, added field focus, comments textarea focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)