### PR TITLE
Scope-based context + User Profile polish (#135)

### DIFF
--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -4,10 +4,15 @@
  * Provides createContext, useContext, and provideContext for
  * compound component patterns (DropdownMenu, Tabs, Dialog, etc.).
  *
- * Uses a global context store (Map<symbol, unknown>).
- * Since hydration is synchronous (initChild calls are sequential),
- * provideContext() before initChild() guarantees children see the correct value.
+ * Context values are stored on DOM elements (scope-based), enabling
+ * multiple providers of the same context on one page (e.g., two Select
+ * components). useContext walks DOM ancestors to find the nearest provider.
+ * Portal elements (with bf-po attribute) follow the logical owner chain.
+ *
+ * A global store is kept as fallback for non-scoped usage.
  */
+
+import { BF_PORTAL_OWNER, BF_SCOPE, BF_CHILD_PREFIX } from './attrs'
 
 export type Context<T> = {
   readonly id: symbol
@@ -18,7 +23,25 @@ export type Context<T> = {
   readonly Provider: (props: { value: T; children?: unknown }) => unknown
 }
 
+/** Global fallback store for contexts without a DOM scope. */
 const contextStore = new Map<symbol, unknown>()
+
+/** Property key for context data stored on DOM elements. */
+const CONTEXT_KEY = '__bfCtx'
+
+/** Current scope element, set by initChild during component initialization. */
+let currentScope: Element | null = null
+
+/**
+ * Set the current scope element for context operations.
+ * Called by initChild to scope provideContext/useContext to the correct element.
+ * Returns the previous scope for restoration.
+ */
+export function setCurrentScope(scope: Element | null): Element | null {
+  const prev = currentScope
+  currentScope = scope
+  return prev
+}
 
 /**
  * Create a new context with an optional default value.
@@ -40,11 +63,34 @@ export function createContext<T>(defaultValue?: T): Context<T> {
 /**
  * Read the current value of a context.
  *
- * Returns the provided value if provideContext() was called,
- * falls back to the context's default value,
- * or throws if neither exists.
+ * Walks up the DOM tree from the current scope element to find
+ * the nearest ancestor that provided this context. Falls back to
+ * the global store, then to the context's default value.
  */
 export function useContext<T>(context: Context<T>): T {
+  // Walk DOM ancestors from current scope to find nearest provider.
+  // For portal elements (bf-po attribute), follow the logical owner
+  // chain back to the original parent scope.
+  if (currentScope) {
+    let el: Element | null = currentScope
+    while (el) {
+      const ctxMap = (el as any)[CONTEXT_KEY] as Map<symbol, unknown> | undefined
+      if (ctxMap?.has(context.id)) {
+        return ctxMap.get(context.id) as T
+      }
+      // Follow portal owner chain: if this element has bf-po, jump to the owner scope
+      const portalOwnerId: string | null = el.getAttribute(BF_PORTAL_OWNER)
+      if (portalOwnerId) {
+        const ownerEl: Element | null = document.querySelector(`[${BF_SCOPE}="${BF_CHILD_PREFIX}${portalOwnerId}"], [${BF_SCOPE}="${portalOwnerId}"]`)
+        if (ownerEl && ownerEl !== el) {
+          el = ownerEl
+          continue
+        }
+      }
+      el = el.parentElement
+    }
+  }
+  // Fallback to global store
   if (contextStore.has(context.id)) {
     return contextStore.get(context.id) as T
   }
@@ -57,9 +103,34 @@ export function useContext<T>(context: Context<T>): T {
 /**
  * Provide a value for a context.
  *
- * Must be called before initChild() so child components
- * can access the value via useContext().
+ * Stores the value on the current scope DOM element so that child
+ * components can find it via useContext's DOM ancestor walk.
+ * Also sets the global store as fallback.
  */
 export function provideContext<T>(context: Context<T>, value: T): void {
+  if (currentScope) {
+    let ctxMap = (currentScope as any)[CONTEXT_KEY] as Map<symbol, unknown> | undefined
+    if (!ctxMap) {
+      ctxMap = new Map()
+      ;(currentScope as any)[CONTEXT_KEY] = ctxMap
+    }
+    ctxMap.set(context.id, value)
+
+    // Propagate context to child scope elements so portal-moved children
+    // can find it via DOM ancestor walk. At provideContext time, children
+    // are still in their original SSR positions (portals haven't moved them yet).
+    const childScopes = currentScope.querySelectorAll(`[${BF_SCOPE}]`)
+    for (const child of childScopes) {
+      let childCtxMap = (child as any)[CONTEXT_KEY] as Map<symbol, unknown> | undefined
+      if (!childCtxMap) {
+        childCtxMap = new Map()
+        ;(child as any)[CONTEXT_KEY] = childCtxMap
+      }
+      // Only set if not already provided (don't override nested providers)
+      if (!childCtxMap.has(context.id)) {
+        childCtxMap.set(context.id, value)
+      }
+    }
+  }
   contextStore.set(context.id, value)
 }

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -42,7 +42,7 @@ export { reconcileList, type RenderItemFn } from './list'
 export { reconcileElements, getLoopChildren } from './reconcile-elements'
 export { mapArray } from './map-array'
 
-export { createContext, useContext, provideContext, type Context } from './context'
+export { createContext, useContext, provideContext, setCurrentScope, type Context } from './context'
 
 // Template registry for client-side component creation
 export { registerTemplate, getTemplate, hasTemplate, type TemplateFn } from './template'

--- a/packages/dom/src/registry.ts
+++ b/packages/dom/src/registry.ts
@@ -7,6 +7,7 @@
 
 import { BF_SCOPE, BF_CHILD_PREFIX } from './attrs'
 import { hydratedScopes } from './hydration-state'
+import { setCurrentScope } from './context'
 import type { InitFn } from './types'
 
 /**
@@ -93,5 +94,7 @@ export function initChild(
   if (hydratedScopes.has(childScope) && childScope.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) {
     return
   }
+  const prevScope = setCurrentScope(childScope)
   init(childScope, props)
+  setCurrentScope(prevScope)
 }

--- a/site/ui/e2e/user-profile.spec.ts
+++ b/site/ui/e2e/user-profile.spec.ts
@@ -147,6 +147,20 @@ test.describe('User Profile Block', () => {
       await expect(s.locator('.repo-empty')).toBeVisible()
     })
 
+    test('language filter select updates check indicator', async ({ page }) => {
+      const s = section(page)
+      // Open language filter and select TypeScript
+      await s.locator('.repo-language-filter').click()
+      await page.locator('[data-slot="select-item"]:has-text("TypeScript")').click()
+
+      // Reopen and verify check indicators
+      await s.locator('.repo-language-filter').click()
+      const allItem = page.locator('[data-slot="select-item"]:has-text("All Languages")')
+      const tsItem = page.locator('[data-slot="select-item"]:has-text("TypeScript")')
+      await expect(allItem).toHaveAttribute('data-state', 'unchecked')
+      await expect(tsItem).toHaveAttribute('data-state', 'checked')
+    })
+
     test('star toggle changes button text', async ({ page }) => {
       const s = section(page)
       const firstStarBtn = s.locator('.star-button').first()

--- a/site/ui/pages/components/user-profile.tsx
+++ b/site/ui/pages/components/user-profile.tsx
@@ -15,6 +15,83 @@ import {
   type TocItem,
 } from '../../components/shared/docs'
 
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+
+export function UserProfile() {
+  const [profile, setProfile] = createSignal(initialProfile)
+  const [activeTab, setActiveTab] = createSignal('overview')
+  const [editingField, setEditingField] = createSignal(null)
+  const [repoFilter, setRepoFilter] = createSignal('all')
+  const [repoSort, setRepoSort] = createSignal('stars')
+  const [repoSearch, setRepoSearch] = createSignal('')
+
+  const totalStars = createMemo(() => profile().repos.reduce((s, r) => s + r.stars, 0))
+  const filteredRepos = createMemo(() => {
+    let repos = profile().repos
+    if (repoFilter() !== 'all') repos = repos.filter(r => r.language === repoFilter())
+    const q = repoSearch().toLowerCase()
+    if (q) repos = repos.filter(r => r.name.includes(q))
+    return repos
+  })
+  const sortedRepos = createMemo(() => {
+    const items = [...filteredRepos()]
+    if (repoSort() === 'stars') return items.sort((a, b) => b.stars - a.stars)
+    return items.sort((a, b) => a.name.localeCompare(b.name))
+  })
+
+  const toggleStar = (id) => {
+    setProfile(prev => ({
+      ...prev,
+      repos: prev.repos.map(r =>
+        r.id === id ? { ...r, starred: !r.starred, stars: r.starred ? r.stars - 1 : r.stars + 1 } : r
+      ),
+    }))
+  }
+
+  return (
+    <div>
+      {/* Profile header with inline editing */}
+      <Avatar><AvatarFallback>AC</AvatarFallback></Avatar>
+      <h2>{profile().displayName}</h2>
+      {profile().verified ? <Badge>Verified</Badge> : null}
+
+      {/* Stats */}
+      <span>{profile().repos.length} repos</span>
+      <span>{totalStars()} stars</span>
+
+      {/* Tabs */}
+      <Tabs value={activeTab()} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="repos">Repositories</TabsTrigger>
+        </TabsList>
+        <TabsContent value="repos">
+          <Input value={repoSearch()} onInput={e => setRepoSearch(e.target.value)} />
+          {sortedRepos().map(repo => (
+            <div key={repo.id}>
+              <span>{repo.name}</span>
+              <Badge variant="outline">{repo.language}</Badge>
+              <span>{repo.stars} stars</span>
+              <Button onClick={() => toggleStar(repo.id)}>
+                {repo.starred ? 'Unstar' : 'Star'}
+              </Button>
+            </div>
+          ))}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}`
+
 const tocItems: TocItem[] = [
   { id: 'preview', title: 'Preview' },
   { id: 'features', title: 'Features' },
@@ -33,7 +110,7 @@ export function UserProfileRefPage() {
       />
 
       <Section id="preview" title="Preview">
-        <Example code="">
+        <Example code={previewCode}>
           <UserProfileDemo />
         </Example>
       </Section>


### PR DESCRIPTION
## Summary

Two changes: scope-based context for multiple providers, and User Profile page code example.

### Scope-based Context (runtime bug fix)

The global Map-based context store caused providers of the same context (e.g., two Select components on one page) to overwrite each other. The last provideContext call won, making earlier providers' children read the wrong value.

**Fix:** Store context values on DOM elements and walk ancestors during useContext.

- initChild sets currentScope before component init
- provideContext stores on currentScope element + propagates to child scopes (for portaled children)
- useContext walks DOM ancestors, following portal owner chain (bf-po)
- Global store kept as fallback
- **No changes to component source code or compiler**

### User Profile code example

Add previewCode to the User Profile reference page.

## Results

- 1051 E2E pass, 0 fail
- 1247 package tests pass
- New E2E test: Select checkbox indicator updates correctly after filter change