### PR TITLE
Add Product Cards block + fix loop template wrapping (#135)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -236,10 +236,12 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         let template = ''
         if (node.childComponent) {
           template = '' // childComponent path uses createComponent directly
-        } else if (useElementReconciliation && node.children[0]) {
-          template = irToPlaceholderTemplate(node.children[0], buildRestSpreadNames(ctx))
         } else if (node.children[0]) {
-          template = irToHtmlTemplate(node.children[0], buildRestSpreadNames(ctx))
+          // Pass loopParams so expressions are wrapped at generation time,
+          // avoiding post-hoc regex wrapping that corrupts literal attribute values.
+          template = useElementReconciliation
+            ? irToPlaceholderTemplate(node.children[0], buildRestSpreadNames(ctx), 0, [node.param])
+            : irToHtmlTemplate(node.children[0], buildRestSpreadNames(ctx), 0, [node.param])
         }
 
         ctx.loopElements.push({

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -616,16 +616,17 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: LoopElement, 
 
   if (!hasReactiveEffects) {
     // Simple case: no reactive effects
-    const tpl = wrap(elem.template)
+    // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
     const preamble = elem.mapPreamble ? `${wrap(elem.mapPreamble)}; ` : ''
-    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => { ${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${tpl}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => { ${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
   } else {
     // Multi-line renderItem with fine-grained effects (shared for CSR and SSR)
     lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => {`)
     if (elem.mapPreamble) {
       lines.push(`    ${wrap(elem.mapPreamble)}`)
     }
-    lines.push(`    const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${wrap(elem.template)}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
+    // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
+    lines.push(`    const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
     emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts, elem.childConditionals, elem.param)
     lines.push(`    return __el`)
     lines.push(`  })`)
@@ -812,7 +813,8 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
     ls.push(`${indent}  ${wrap(ctx.elem.mapPreamble)}`)
   }
   ls.push(`${indent}  const __tpl = document.createElement('template')`)
-  ls.push(`${indent}  __tpl.innerHTML = \`${wrap(ctx.elem.template)}\``)
+  // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
+  ls.push(`${indent}  __tpl.innerHTML = \`${ctx.elem.template}\``)
   ls.push(`${indent}  __el = __tpl.content.firstElementChild.cloneNode(true)`)
   emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'csr', param)
   // CSR: inner loop initialization

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -56,8 +56,14 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
  *  @param loopDepth - Current nesting depth inside inner loops. 0 = outer loop level.
  *    When > 0, `key` attributes are converted to `data-key-{depth}` instead of `data-key`.
  */
-export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0): string {
-  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth)
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: string[]): string {
+  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams)
+  const wrapExpr = (expr: string): string => {
+    if (!loopParams) return expr
+    let result = expr
+    for (const p of loopParams) result = wrapLoopParamAsAccessor(result, p)
+    return result
+  }
 
   switch (node.type) {
     case 'element': {
@@ -76,7 +82,10 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           if (a.value === null) return attrName
           // Resolve IRTemplateLiteral to string expression for use in template literals
           const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
-          if (a.dynamic) return templateAttrExpr(attrName, valExpr, a)
+          if (a.dynamic) {
+            const wrappedVal = wrapExpr(valExpr)
+            return templateAttrExpr(attrName, wrappedVal, a)
+          }
           return `${attrName}="${valExpr}"`
         })
         .filter(Boolean)
@@ -101,16 +110,16 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
       if (node.slotId) {
-        return `<!--bf:${node.slotId}-->\${${node.expr}}<!--/-->`
+        return `<!--bf:${node.slotId}-->\${${wrapExpr(node.expr)}}<!--/-->`
       }
-      return `\${${node.expr}}`
+      return `\${${wrapExpr(node.expr)}}`
 
     case 'conditional': {
       const trueBranch = recurse(node.whenTrue)
       const falseBranch = recurse(node.whenFalse)
       const trueHtml = node.slotId ? addCondAttrToTemplate(trueBranch, node.slotId) : trueBranch
       const falseHtml = node.slotId ? addCondAttrToTemplate(falseBranch, node.slotId) : falseBranch
-      return `\${${node.condition} ? \`${trueHtml}\` : \`${falseHtml}\`}`
+      return `\${${wrapExpr(node.condition)} ? \`${trueHtml}\` : \`${falseHtml}\`}`
     }
 
     case 'fragment':
@@ -154,14 +163,17 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     case 'loop': {
       // Generate inline .map().join('') so loop variables are properly scoped
       // Increment loopDepth so inner key attrs become data-key-N
+      // Don't pass loopParams to inner loop children — the inner loop's own param is
+      // received as a .map() callback argument, not a signal accessor.
       const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1)
       const childTemplate = node.children.map(innerRecurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
+      const wrappedArray = wrapExpr(node.array)
       let mapExpr: string
       if (node.mapPreamble) {
-        mapExpr = `\${${node.array}.map((${node.param}${indexParam}) => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
+        mapExpr = `\${${wrappedArray}.map((${node.param}${indexParam}) => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
       } else {
-        mapExpr = `\${${node.array}.map((${node.param}${indexParam}) => \`${childTemplate}\`).join('')}`
+        mapExpr = `\${${wrappedArray}.map((${node.param}${indexParam}) => \`${childTemplate}\`).join('')}`
       }
       // Wrap with loop boundary markers so reconciliation doesn't affect siblings
       return `<!--${BF_LOOP_START}-->${mapExpr}<!--${BF_LOOP_END}-->`
@@ -209,7 +221,12 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
             : toHtmlAttrName(a.name)
           if (a.value === null) return attrName
           const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
-          if (a.dynamic) return templateAttrExpr(attrName, wrapExpr(valExpr), a)
+          // Only wrap dynamic expression values, not string literals that happen
+          // to be marked dynamic (e.g., className="cart-item" where "item" matches a loop param)
+          if (a.dynamic) {
+            const wrappedVal = wrapExpr(valExpr)
+            return templateAttrExpr(attrName, wrappedVal, a)
+          }
           return `${attrName}="${valExpr}"`
         })
         .filter(Boolean)
@@ -264,11 +281,12 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       const innerRecurse = (n: IRNode): string => irToPlaceholderTemplate(n, restSpreadNames, loopDepth + 1)
       const childTemplate = node.children.map(innerRecurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
+      const wrappedArray = wrapExpr(node.array)
       let mapExpr: string
       if (node.mapPreamble) {
-        mapExpr = `\${${node.array}.map((${node.param}${indexParam}) => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
+        mapExpr = `\${${wrappedArray}.map((${node.param}${indexParam}) => { ${node.mapPreamble} return \`${childTemplate}\` }).join('')}`
       } else {
-        mapExpr = `\${${node.array}.map((${node.param}${indexParam}) => \`${childTemplate}\`).join('')}`
+        mapExpr = `\${${wrappedArray}.map((${node.param}${indexParam}) => \`${childTemplate}\`).join('')}`
       }
       return `<!--${BF_LOOP_START}-->${mapExpr}<!--${BF_LOOP_END}-->`
     }

--- a/site/ui/components/product-cards-demo.tsx
+++ b/site/ui/components/product-cards-demo.tsx
@@ -1,0 +1,319 @@
+"use client"
+/**
+ * ProductCardsDemo
+ *
+ * E-commerce product grid with multi-signal filtering, cart state,
+ * view mode toggle, quick-view dialog, and toast notifications.
+ *
+ * Compiler stress targets:
+ * - Derived state from 3 signals (search + category + priceRange)
+ * - Dynamic CSS class from signal (viewMode → grid layout)
+ * - Per-item cart operations (add/remove/quantity)
+ * - Computed total from array signal (cartItems reduce)
+ * - Toast notification triggered by action
+ * - Dialog with dynamic content (selectedProduct)
+ * - Inner loops (tags.map inside products.map)
+ * - Badge variants from data (category, "Sale")
+ * - Empty state conditional
+ */
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Card, CardHeader, CardTitle, CardContent, CardDescription, CardFooter } from '@ui/components/ui/card'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Separator } from '@ui/components/ui/separator'
+import { Slider } from '@ui/components/ui/slider'
+import { ToastProvider, Toast, ToastTitle, ToastDescription, ToastClose } from '@ui/components/ui/toast'
+
+// --- Types ---
+
+type Category = 'electronics' | 'accessories' | 'wearables' | 'home'
+
+type Product = {
+  id: number
+  name: string
+  description: string
+  price: number
+  originalPrice: number
+  category: Category
+  rating: number
+  reviewCount: number
+  tags: string[]
+  image: string
+  inStock: boolean
+}
+
+type CartItem = {
+  product: Product
+  quantity: number
+}
+
+// --- Constants ---
+
+const PRICE_MAX = 300
+const FREE_SHIPPING_THRESHOLD = 10000
+
+const categoryBadgeVariant = {
+  electronics: 'default',
+  accessories: 'secondary',
+  wearables: 'outline',
+  home: 'secondary',
+} as const
+
+// --- Mock Data ---
+
+const allProducts: Product[] = [
+  { id: 1, name: 'Wireless Headphones', description: 'Premium noise-cancelling over-ear headphones', price: 19900, originalPrice: 24900, category: 'electronics', rating: 5, reviewCount: 342, tags: ['bluetooth', 'noise-cancelling'], image: '🎧', inStock: true },
+  { id: 2, name: 'Smart Watch Pro', description: 'Fitness tracker with heart rate and GPS', price: 29900, originalPrice: 29900, category: 'wearables', rating: 4, reviewCount: 215, tags: ['fitness', 'gps'], image: '⌚', inStock: true },
+  { id: 3, name: 'USB-C Hub', description: '7-in-1 multiport adapter for laptops', price: 4900, originalPrice: 5900, category: 'accessories', rating: 4, reviewCount: 178, tags: ['usb-c', 'adapter'], image: '🔌', inStock: true },
+  { id: 4, name: 'Mechanical Keyboard', description: 'RGB backlit with Cherry MX switches', price: 12900, originalPrice: 12900, category: 'electronics', rating: 5, reviewCount: 567, tags: ['rgb', 'cherry-mx'], image: '⌨️', inStock: true },
+  { id: 5, name: 'Desk Lamp', description: 'LED desk lamp with adjustable color temperature', price: 3900, originalPrice: 4900, category: 'home', rating: 4, reviewCount: 89, tags: ['led', 'adjustable'], image: '💡', inStock: true },
+  { id: 6, name: 'Phone Case', description: 'Slim protective case with MagSafe support', price: 2900, originalPrice: 2900, category: 'accessories', rating: 3, reviewCount: 445, tags: ['magsafe', 'slim'], image: '📱', inStock: true },
+  { id: 7, name: 'Fitness Band', description: 'Lightweight activity tracker with sleep monitoring', price: 7900, originalPrice: 9900, category: 'wearables', rating: 4, reviewCount: 312, tags: ['fitness', 'sleep'], image: '💪', inStock: false },
+  { id: 8, name: 'Wireless Charger', description: 'Fast wireless charging pad for Qi devices', price: 2400, originalPrice: 2400, category: 'electronics', rating: 4, reviewCount: 201, tags: ['wireless', 'fast-charge'], image: '🔋', inStock: true },
+  { id: 9, name: 'Standing Desk Mat', description: 'Anti-fatigue mat for standing desks', price: 4500, originalPrice: 5500, category: 'home', rating: 5, reviewCount: 156, tags: ['ergonomic'], image: '🧘', inStock: true },
+  { id: 10, name: 'Camera Strap', description: 'Adjustable woven camera neck strap', price: 1900, originalPrice: 1900, category: 'accessories', rating: 4, reviewCount: 67, tags: ['adjustable'], image: '📷', inStock: true },
+  { id: 11, name: 'Smart Speaker', description: 'Voice assistant with premium sound', price: 9900, originalPrice: 12900, category: 'electronics', rating: 4, reviewCount: 423, tags: ['voice', 'speaker'], image: '🔊', inStock: true },
+  { id: 12, name: 'Yoga Mat', description: 'Non-slip exercise mat with carrying strap', price: 3400, originalPrice: 3400, category: 'home', rating: 5, reviewCount: 289, tags: ['exercise', 'non-slip'], image: '🧘‍♀️', inStock: true },
+]
+
+// --- Helpers ---
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+function stars(rating: number): string {
+  return '★'.repeat(rating) + '☆'.repeat(5 - rating)
+}
+
+// --- Component ---
+
+export function ProductCardsDemo() {
+  // Signals
+  const [searchQuery, setSearchQuery] = createSignal('')
+  const [categoryFilter, setCategoryFilter] = createSignal('all')
+  const [priceRange, setPriceRange] = createSignal(PRICE_MAX)
+  const [viewMode, setViewMode] = createSignal<'grid' | 'list'>('grid')
+  const [cartItems, setCartItems] = createSignal<CartItem[]>([])
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  // 3-signal derived memo
+  const filteredProducts = createMemo(() => {
+    const query = searchQuery().toLowerCase()
+    const category = categoryFilter()
+    const maxPrice = priceRange() * 100
+    return allProducts.filter(p => {
+      if (category !== 'all' && p.category !== category) return false
+      if (p.price > maxPrice) return false
+      if (query && !p.name.toLowerCase().includes(query) && !p.tags.some(t => t.includes(query))) return false
+      return true
+    })
+  })
+
+  // Cart memos
+  const cartTotal = createMemo(() => cartItems().reduce((sum, item) => sum + item.product.price * item.quantity, 0))
+  const cartCount = createMemo(() => cartItems().reduce((sum, item) => sum + item.quantity, 0))
+
+  // Cart handlers
+  const addToCart = (product: Product) => {
+    setCartItems(prev => {
+      const existing = prev.find(item => item.product.id === product.id)
+      if (existing) {
+        return prev.map(item => item.product.id === product.id ? { ...item, quantity: item.quantity + 1 } : item)
+      }
+      return [...prev, { product, quantity: 1 }]
+    })
+    setToastMessage(`${product.name} added to cart`)
+    setToastOpen(true)
+  }
+
+  const removeFromCart = (productId: number) => {
+    setCartItems(prev => prev.filter(item => item.product.id !== productId))
+  }
+
+  const updateQuantity = (productId: number, delta: number) => {
+    setCartItems(prev => prev.map(item => {
+      if (item.product.id !== productId) return item
+      const newQty = Math.max(1, item.quantity + delta)
+      return { ...item, quantity: newQty }
+    }))
+  }
+
+  return (
+    <div className="w-full min-w-0 space-y-6">
+
+      {/* === FILTER BAR === */}
+      <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+        <Input
+          value={searchQuery()}
+          onInput={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search products..."
+          className="product-search flex-1 max-w-xs"
+        />
+        <Select value={categoryFilter()} onValueChange={setCategoryFilter}>
+          <SelectTrigger className="category-filter w-[160px]">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Categories</SelectItem>
+            <SelectItem value="electronics">Electronics</SelectItem>
+            <SelectItem value="accessories">Accessories</SelectItem>
+            <SelectItem value="wearables">Wearables</SelectItem>
+            <SelectItem value="home">Home</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground whitespace-nowrap">Max: {formatPrice(priceRange() * 100)}</span>
+          <Slider
+            value={priceRange()}
+            min={0}
+            max={PRICE_MAX}
+            onValueChange={setPriceRange}
+            className="price-slider w-32"
+          />
+        </div>
+        <Button
+          variant={viewMode() === 'list' ? 'default' : 'outline'}
+          size="sm"
+          className="view-toggle"
+          onClick={() => setViewMode(viewMode() === 'grid' ? 'list' : 'grid')}
+        >
+          {viewMode() === 'grid' ? '☰ List' : '⊞ Grid'}
+        </Button>
+      </div>
+
+      {/* Results count */}
+      <p className="product-count text-sm text-muted-foreground">{filteredProducts().length} products</p>
+
+      {/* === MAIN CONTENT === */}
+      <div className="flex flex-col lg:flex-row gap-6">
+
+        {/* --- Product Grid/List --- */}
+        <div className="flex-1 min-w-0">
+          {/* Dynamic CSS class from signal */}
+          <div className={viewMode() === 'grid'
+            ? 'product-grid grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4'
+            : 'product-grid grid grid-cols-1 gap-3'}>
+            {filteredProducts().map(product => (
+              <Card key={product.id} className="product-card">
+                <CardHeader className="pb-2">
+                  <div className="text-4xl mb-2">{product.image}</div>
+                  <div className="flex items-center gap-2">
+                    <CardTitle className="product-name text-sm">{product.name}</CardTitle>
+                    {product.originalPrice > product.price ? (
+                      <Badge variant="destructive" className="sale-badge text-xs">Sale</Badge>
+                    ) : null}
+                  </div>
+                  <CardDescription className="text-xs">{product.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="flex flex-wrap gap-1">
+                    <Badge variant={categoryBadgeVariant[product.category]} className="category-badge text-xs">{product.category}</Badge>
+                    {/* Inner loop: tags */}
+                    {product.tags.map(tag => (
+                      <Badge key={tag} variant="outline" className="tag-badge text-xs">{tag}</Badge>
+                    ))}
+                  </div>
+                  <div className="flex items-baseline gap-2">
+                    <span className="product-price font-bold">{formatPrice(product.price)}</span>
+                    {product.originalPrice > product.price ? (
+                      <span className="text-xs text-muted-foreground line-through">{formatPrice(product.originalPrice)}</span>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs">
+                    <span className="product-rating text-amber-500">{stars(product.rating)}</span>
+                    <span className="text-muted-foreground">({product.reviewCount})</span>
+                  </div>
+                </CardContent>
+                <CardFooter className="gap-2">
+                  <Button
+                    size="sm"
+                    className="add-to-cart-btn"
+                    disabled={!product.inStock}
+                    onClick={() => addToCart(product)}
+                  >
+                    {product.inStock ? 'Add to Cart' : 'Out of Stock'}
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+
+          {/* Empty state */}
+          {filteredProducts().length === 0 ? (
+            <div className="product-empty text-center py-12 text-muted-foreground">
+              <p className="text-lg">No products match your filters</p>
+              <p className="text-sm mt-1">Try adjusting your search or filters</p>
+            </div>
+          ) : null}
+        </div>
+
+        {/* --- Cart Sidebar --- */}
+        <div className="w-full lg:w-80 shrink-0">
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">Cart</CardTitle>
+                <Badge variant="secondary" className="cart-count">{cartCount()} items</Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {cartItems().length === 0 ? (
+                <p className="cart-empty text-sm text-muted-foreground text-center py-4">Your cart is empty</p>
+              ) : null}
+
+              <div className="cart-items space-y-2">
+              {cartItems().map(item => (
+                <div key={item.product.id} className="cart-item flex items-center gap-2">
+                  <span className="text-xl">{item.product.image}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="cart-item-name text-sm font-medium truncate">{item.product.name}</p>
+                    <p className="text-xs text-muted-foreground">{formatPrice(item.product.price)}</p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button variant="outline" size="sm" className="h-6 w-6 p-0 qty-minus" onClick={() => updateQuantity(item.product.id, -1)}>-</Button>
+                    <span className="cart-item-qty text-sm w-6 text-center">{item.quantity}</span>
+                    <Button variant="outline" size="sm" className="h-6 w-6 p-0 qty-plus" onClick={() => updateQuantity(item.product.id, 1)}>+</Button>
+                  </div>
+                  <Button variant="ghost" size="sm" className="h-6 px-1 text-xs text-destructive remove-btn" onClick={() => removeFromCart(item.product.id)}>×</Button>
+                </div>
+              ))}
+              </div>
+            </CardContent>
+            {cartItems().length > 0 ? (
+              <div>
+                <Separator />
+                <CardFooter className="flex-col items-stretch gap-2 pt-4">
+                  <div className="flex justify-between">
+                    <span className="text-sm font-medium">Subtotal</span>
+                    <span className="cart-total text-sm font-bold">{formatPrice(cartTotal())}</span>
+                  </div>
+                  {cartTotal() >= FREE_SHIPPING_THRESHOLD ? (
+                    <Badge variant="default" className="free-shipping self-start">Free Shipping</Badge>
+                  ) : (
+                    <p className="shipping-message text-xs text-muted-foreground">
+                      Add {formatPrice(FREE_SHIPPING_THRESHOLD - cartTotal())} more for free shipping
+                    </p>
+                  )}
+                </CardFooter>
+              </div>
+            ) : null}
+          </Card>
+        </div>
+      </div>
+
+      {/* === TOAST === */}
+      <ToastProvider position="bottom-right">
+        <Toast open={toastOpen()} onOpenChange={setToastOpen} variant="default" duration={3000}>
+          <ToastTitle>Added to Cart</ToastTitle>
+          <ToastDescription>{toastMessage()}</ToastDescription>
+          <ToastClose />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -104,6 +104,7 @@ export const componentEntries: ComponentEntry[] = [
 // Blocks — page-level composition patterns
 export const blockEntries: BlockEntry[] = [
   { slug: 'analytics-dashboard', title: 'Analytics Dashboard', description: 'Website analytics with multi-level memo chains, dynamic charts, inner loops, and controlled input' },
+  { slug: 'product-cards', title: 'Product Cards', description: 'E-commerce product grid with multi-signal filtering, cart, and view mode toggle' },
   { slug: 'user-profile', title: 'User Profile', description: 'Developer profile with inline editing, filterable repos, star toggle, and activity feed' },
   { slug: 'dashboard', title: 'Dashboard', description: 'Sales dashboard with stats, filterable orders table, and activity feed' },
   { slug: 'mail', title: 'Mail', description: 'Mail inbox with search, star toggle, bulk select, delete confirmation, and detail panel' },

--- a/site/ui/e2e/product-cards.spec.ts
+++ b/site/ui/e2e/product-cards.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Product Cards Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/product-cards')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="ProductCardsDemo_"]:not([data-slot])').first()
+
+  test.describe('Filter Bar', () => {
+    test('renders filter controls', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.product-search')).toBeVisible()
+      await expect(s.locator('.category-filter')).toBeVisible()
+      await expect(s.locator('.view-toggle')).toBeVisible()
+    })
+
+    test('search filters products by name', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.product-search').fill('headphones')
+      await expect(s.locator('.product-count')).toContainText('1 ')
+    })
+
+    test('search input retains focus', async ({ page }) => {
+      const s = section(page)
+      const search = s.locator('.product-search')
+      await search.focus()
+      await search.type('key', { delay: 30 })
+      const isFocused = await search.evaluate((el: HTMLElement) => document.activeElement === el)
+      expect(isFocused).toBe(true)
+    })
+
+    test('clearing search restores products', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.product-search').fill('headphones')
+      await s.locator('.product-search').fill('')
+      await expect(s.locator('.product-count')).toContainText('12 products')
+    })
+  })
+
+  test.describe('Empty State', () => {
+    test('shows when no products match', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.product-search').fill('nonexistent')
+      await expect(s.locator('.product-empty')).toBeVisible()
+    })
+  })
+
+  test.describe('View Mode Toggle', () => {
+    test('defaults to grid layout', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.product-grid')).toHaveClass(/grid-cols-2|grid-cols-3/)
+    })
+
+    test('toggling changes to list layout', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.view-toggle').click()
+      await expect(s.locator('.product-grid')).not.toHaveClass(/grid-cols-2/)
+    })
+  })
+
+  test.describe('Product Cards', () => {
+    test('renders product cards', async ({ page }) => {
+      const s = section(page)
+      const cards = s.locator('.product-card')
+      await expect(cards).toHaveCount(12)
+    })
+
+    test('shows Sale badge on discounted products', async ({ page }) => {
+      const s = section(page)
+      const saleBadges = s.locator('.sale-badge')
+      const count = await saleBadges.count()
+      expect(count).toBeGreaterThan(0)
+    })
+
+    test('shows category badges', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.category-badge').first()).toBeVisible()
+    })
+
+    test('shows tag badges (inner loop)', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.tag-badge').first()).toBeVisible()
+    })
+
+    test('shows rating stars', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.product-rating').first()).toBeVisible()
+    })
+
+    test('disables add-to-cart for out-of-stock', async ({ page }) => {
+      const s = section(page)
+      const outOfStock = s.locator('.add-to-cart-btn:has-text("Out of Stock")')
+      await expect(outOfStock.first()).toBeDisabled()
+    })
+  })
+
+  test.describe('Cart Sidebar', () => {
+    test('cart starts empty', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.cart-count')).toContainText('0')
+      await expect(s.locator('.cart-empty')).toBeVisible()
+    })
+
+    test('adding product shows it in cart', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-to-cart-btn').first().click()
+      await expect(s.locator('.cart-item')).toHaveCount(1)
+      await expect(s.locator('.cart-count')).toContainText('1')
+    })
+
+    test('adding same product increments quantity', async ({ page }) => {
+      const s = section(page)
+      const btn = s.locator('.add-to-cart-btn').first()
+      await btn.click()
+      await btn.click()
+      await expect(s.locator('.cart-item-qty')).toContainText('2')
+    })
+
+    test('quantity buttons work', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-to-cart-btn').first().click()
+      await s.locator('.qty-plus').first().click()
+      await expect(s.locator('.cart-item-qty')).toContainText('2')
+      await s.locator('.qty-minus').first().click()
+      await expect(s.locator('.cart-item-qty')).toContainText('1')
+    })
+
+    test('remove button removes item', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-to-cart-btn').first().click()
+      await s.locator('.remove-btn').first().click()
+      await expect(s.locator('.cart-empty')).toBeVisible()
+    })
+
+    test('subtotal updates', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-to-cart-btn').first().click()
+      await expect(s.locator('.cart-total')).toBeVisible()
+    })
+  })
+
+  test.describe('Free Shipping', () => {
+    test('shows shipping message below threshold', async ({ page }) => {
+      const s = section(page)
+      // Add a cheap item (Phone Case $29) to stay below $100 threshold
+      await s.locator('.product-card:has-text("Phone Case") .add-to-cart-btn').click()
+      await expect(s.locator('.shipping-message')).toBeVisible()
+    })
+
+    test('shows free shipping badge above threshold', async ({ page }) => {
+      const s = section(page)
+      // Add expensive items to exceed $100 threshold
+      const btns = s.locator('.add-to-cart-btn:not([disabled])')
+      await btns.nth(0).click() // Wireless Headphones $199
+      await expect(s.locator('.free-shipping')).toBeVisible()
+    })
+  })
+
+  test.describe('Toast', () => {
+    test('shows toast when item added', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-to-cart-btn').first().click()
+      await expect(page.locator('[data-slot="toast"]')).toBeVisible({ timeout: 3000 })
+    })
+  })
+})

--- a/site/ui/pages/components/product-cards.tsx
+++ b/site/ui/pages/components/product-cards.tsx
@@ -1,0 +1,135 @@
+/**
+ * Product Cards Reference Page (/components/product-cards)
+ */
+
+import { ProductCardsDemo } from '@/components/product-cards-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/dom'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+
+export function ProductCards() {
+  const [search, setSearch] = createSignal('')
+  const [category, setCategory] = createSignal('all')
+  const [cart, setCart] = createSignal([])
+
+  const filtered = createMemo(() => {
+    return products.filter(p => {
+      if (category() !== 'all' && p.category !== category()) return false
+      if (search() && !p.name.toLowerCase().includes(search().toLowerCase())) return false
+      return true
+    })
+  })
+  const cartTotal = createMemo(() => cart().reduce((s, i) => s + i.product.price * i.quantity, 0))
+
+  const addToCart = (product) => {
+    setCart(prev => {
+      const existing = prev.find(i => i.product.id === product.id)
+      if (existing) return prev.map(i => i.product.id === product.id ? { ...i, quantity: i.quantity + 1 } : i)
+      return [...prev, { product, quantity: 1 }]
+    })
+  }
+
+  return (
+    <div className="flex gap-6">
+      <div className="flex-1">
+        <Input value={search()} onInput={e => setSearch(e.target.value)} placeholder="Search..." />
+        <div className="grid grid-cols-3 gap-4">
+          {filtered().map(product => (
+            <Card key={product.id}>
+              <CardHeader><CardTitle>{product.name}</CardTitle></CardHeader>
+              <CardContent>
+                <Badge variant="outline">{product.category}</Badge>
+                <span>{formatPrice(product.price)}</span>
+              </CardContent>
+              <CardFooter>
+                <Button onClick={() => addToCart(product)}>Add to Cart</Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </div>
+      <div className="w-80">
+        <Card>
+          <CardHeader><CardTitle>Cart ({cart().length})</CardTitle></CardHeader>
+          <CardContent>
+            {cart().map(item => (
+              <div key={item.product.id}>{item.product.name} × {item.quantity}</div>
+            ))}
+          </CardContent>
+          <CardFooter>Subtotal: {formatPrice(cartTotal())}</CardFooter>
+        </Card>
+      </div>
+    </div>
+  )
+}`
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+  { id: 'filters', title: 'Multi-Signal Filtering', branch: 'start' },
+  { id: 'cart', title: 'Cart Operations', branch: 'child' },
+  { id: 'view-mode', title: 'View Mode Toggle', branch: 'end' },
+]
+
+export function ProductCardsRefPage() {
+  return (
+    <DocPage slug="product-cards" toc={tocItems}>
+      <PageHeader
+        title="Product Cards"
+        description="E-commerce product grid with multi-signal filtering, cart management, and view mode toggle."
+      />
+
+      <Section id="preview" title="Preview">
+        <Example code={previewCode}>
+          <ProductCardsDemo />
+        </Example>
+      </Section>
+
+      <Section id="features" title="Features">
+        <ul className="list-disc pl-6 space-y-1 text-sm text-muted-foreground">
+          <li>3-signal derived memo (search + category + price range)</li>
+          <li>Dynamic CSS class from signal (grid vs list layout)</li>
+          <li>Per-item cart operations (add, remove, quantity)</li>
+          <li>Computed total from array signal</li>
+          <li>Free shipping threshold with reactive badge</li>
+          <li>Toast notification on add-to-cart</li>
+          <li>Inner tag loops inside product cards</li>
+          <li>Sale badge and category badge variants</li>
+        </ul>
+      </Section>
+
+      <Section id="filters" title="Multi-Signal Filtering">
+        <p className="text-sm text-muted-foreground">
+          Search, category dropdown, and price slider drive a single <code>filteredProducts</code> memo
+          from three independent signals.
+        </p>
+      </Section>
+
+      <Section id="cart" title="Cart Operations">
+        <p className="text-sm text-muted-foreground">
+          Cart sidebar with quantity controls. Subtotal computed via <code>cartItems().reduce()</code>.
+          Free shipping badge appears when total exceeds threshold.
+        </p>
+      </Section>
+
+      <Section id="view-mode" title="View Mode Toggle">
+        <p className="text-sm text-muted-foreground">
+          Toggle between grid and list layouts. CSS class changes reactively based on <code>viewMode()</code> signal.
+        </p>
+      </Section>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -61,6 +61,7 @@ import { SheetRefPage } from './pages/components/sheet'
 import { DashboardRefPage } from './pages/components/dashboard'
 import { AnalyticsDashboardRefPage } from './pages/components/analytics-dashboard'
 import { UserProfileRefPage } from './pages/components/user-profile'
+import { ProductCardsRefPage } from './pages/components/product-cards'
 import { MailRefPage } from './pages/components/mail'
 import { KanbanRefPage } from './pages/components/kanban'
 import { LoginRefPage } from './pages/components/login'
@@ -446,6 +447,11 @@ export function createApp() {
   // User Profile block page
   app.get('/components/user-profile', (c) => {
     return c.render(<UserProfileRefPage />)
+  })
+
+  // Product Cards block page
+  app.get('/components/product-cards', (c) => {
+    return c.render(<ProductCardsRefPage />)
   })
 
   // Mail block page


### PR DESCRIPTION
## Summary

New Product Cards block + compiler fix for loop template literal wrapping.

### Compiler fix: IR-aware wrapping for all loop template paths

Extended loopParams-based wrapping (introduced in PR #748 for irToPlaceholderTemplate) to:
- irToHtmlTemplate (plain loops) — new loopParams parameter
- All 3 CSR template emission paths in emit-control-flow.ts — remove post-hoc wrap()

Also fix attribute value wrap guard: use wrapExpr on all dynamic attrs instead of checking typeof a.value === 'string' (string-typed attr values can be either literals or expressions in the IR).

Found during development: className="cart-item" was corrupted to "cart-item()" because the loop param "item" matched inside the literal class name.

### Product Cards block

- 3-signal derived memo (search + category + price range)
- Dynamic CSS class from signal (grid vs list layout)
- Cart sidebar with per-item quantity controls
- Computed total from array signal (cartItems.reduce)
- Free shipping threshold with reactive badge
- Toast notification on add-to-cart
- Inner tag loops inside product cards
- 22 E2E tests, all passing

### Known pre-existing failures (on main)

- comments: add new comment (1 fail)
- calendar: month navigation (1 fail, flaky)

## Results

- 1072 E2E pass, 2 fail (pre-existing on main)
- 1247 package tests pass