### PR TITLE
Refactor: extract wrapExprWithLoopParams + fix conditional template wrapping

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -875,7 +875,6 @@ function emitInnerLoopSetup(
       const keyFn = inner.key
         ? `(${inner.param}) => String(${inner.key})`
         : 'null'
-      const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
       // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
       const wrappedTemplate = inner.itemTemplate!
       ls.push(`${indent}// Reactive inner loop: ${inner.array}`)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, BF_LOOP_START, BF_LOOP_END, exprReferencesIdent, wrapLoopParamAsAccessor } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, BF_LOOP_START, BF_LOOP_END, exprReferencesIdent, wrapExprWithLoopParams } from './utils'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -58,12 +58,7 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
  */
 export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: string[]): string {
   const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams)
-  const wrapExpr = (expr: string): string => {
-    if (!loopParams) return expr
-    let result = expr
-    for (const p of loopParams) result = wrapLoopParamAsAccessor(result, p)
-    return result
-  }
+  const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
 
   switch (node.type) {
     case 'element': {
@@ -198,13 +193,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
  */
 export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: string[]): string {
   const recurse = (n: IRNode): string => irToPlaceholderTemplate(n, restSpreadNames, loopDepth, loopParams)
-  // Wrap expression with loop param accessors (only for expressions, not literal text)
-  const wrapExpr = (expr: string): string => {
-    if (!loopParams) return expr
-    let result = expr
-    for (const p of loopParams) result = wrapLoopParamAsAccessor(result, p)
-    return result
-  }
+  const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
 
   switch (node.type) {
     case 'element': {

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -379,8 +379,9 @@ export function collectLoopChildConditionals(
       // needsEffectWrapper only knows about signals/memos/props, not loop params.
       if (!refsLoopParam && !needsEffectWrapper(expanded, ctx)) return
       {
-        const whenTrueHtml = irToHtmlTemplate(n.whenTrue)
-        const whenFalseHtml = irToHtmlTemplate(n.whenFalse)
+        const loopParamsForCond = loopParam ? [loopParam] : undefined
+        const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
+        const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
         conditionals.push({
           slotId: n.slotId,
           condition: expanded,

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -203,3 +203,15 @@ export function wrapLoopParamAsAccessor(expr: string, paramName: string): string
   return expr.replace(new RegExp(`\\b${escapeRegExp(paramName)}\\b(?!\\s*\\()(?!-)`, 'g'), `${paramName}()`)
 }
 
+/**
+ * Apply wrapLoopParamAsAccessor for multiple loop params.
+ * Used during template generation to wrap expression values at IR level,
+ * avoiding post-hoc regex replacement on full template strings.
+ */
+export function wrapExprWithLoopParams(expr: string, loopParams?: string[]): string {
+  if (!loopParams) return expr
+  let result = expr
+  for (const p of loopParams) result = wrapLoopParamAsAccessor(result, p)
+  return result
+}
+


### PR DESCRIPTION
## Summary

Cleanup of template loop param wrapping after Block development (PRs #748, #749, #751).

### Changes

1. **Extract `wrapExprWithLoopParams` to utils.ts** — removes duplicate inline `wrapExpr` definitions from `irToHtmlTemplate` and `irToPlaceholderTemplate`

2. **Remove unused `wrapBoth` variable** in `emitInnerLoopSetup` (was left over after template pre-wrapping migration)

3. **Fix: pass loopParams to conditional branch templates** — `collectLoopChildConditionals` in reactivity.ts was calling `irToHtmlTemplate` without `loopParams`, meaning expressions inside conditional branches of loop items were not wrapped with loop param accessors

## Test plan

- 1247 package tests pass
- 1073 E2E pass, 0 fail