### PR TITLE
Add SVG marker element to JSX type definitions

### DIFF
--- a/packages/jsx/src/jsx-runtime/index.d.ts
+++ b/packages/jsx/src/jsx-runtime/index.d.ts
@@ -196,6 +196,7 @@ export declare namespace JSX {
     use: HTMLBaseAttributes & { href?: string; x?: number | string; y?: number | string; width?: number | string; height?: number | string }
     symbol: HTMLBaseAttributes & { viewBox?: string }
     clipPath: HTMLBaseAttributes
+    marker: HTMLBaseAttributes & { viewBox?: string; refX?: number | string; refY?: number | string; markerWidth?: number | string; markerHeight?: number | string; markerUnits?: string; orient?: string | number }
     mask: HTMLBaseAttributes
     linearGradient: HTMLBaseAttributes & { x1?: number | string; y1?: number | string; x2?: number | string; y2?: number | string }
     radialGradient: HTMLBaseAttributes & { cx?: number | string; cy?: number | string; r?: number | string; fx?: number | string; fy?: number | string }


### PR DESCRIPTION
## Summary

- Add `marker` SVG element with its attributes (`viewBox`, `refX`, `refY`, `markerWidth`, `markerHeight`, `markerUnits`, `orient`) to `IntrinsicElements` JSX type definitions
- Follows the existing inline pattern used by all other SVG elements in `index.d.ts`

Closes #759

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 500 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)