### PR TITLE
Fix XSS vulnerability in chart tooltip components

### DIFF
--- a/packages/chart/src/area-tooltip.ts
+++ b/packages/chart/src/area-tooltip.ts
@@ -1,5 +1,6 @@
 import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
 import { AreaChartContext } from './context'
+import { escapeHtml } from './utils/escape-html'
 
 /**
  * Init function for ChartTooltip in AreaChart context.
@@ -62,16 +63,16 @@ export function initAreaChartTooltip(_scope: Element, props: Record<string, unkn
 
       const label = labelFormatter ? labelFormatter(xValue) : xValue
 
-      let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
+      let html = `<div style="font-weight:500;margin-bottom:4px">${escapeHtml(label)}</div>`
       for (const area of areas) {
         const value = datum[area.dataKey]
         const configEntry = config[area.dataKey]
         const color = area.stroke ?? configEntry?.color ?? 'currentColor'
         const entryLabel = configEntry?.label ?? area.dataKey
         html += `<div style="display:flex;align-items:center;gap:8px">`
-        html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
-        html += `<span>${entryLabel}</span>`
-        html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+        html += `<span style="width:8px;height:8px;border-radius:2px;background:${escapeHtml(color)};display:inline-block"></span>`
+        html += `<span>${escapeHtml(entryLabel)}</span>`
+        html += `<span style="font-weight:500;margin-left:auto">${escapeHtml(value)}</span>`
         html += `</div>`
       }
       currentTooltip.innerHTML = html

--- a/packages/chart/src/pie-tooltip.ts
+++ b/packages/chart/src/pie-tooltip.ts
@@ -1,5 +1,6 @@
 import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
 import { PieChartContext } from './context'
+import { escapeHtml } from './utils/escape-html'
 
 /**
  * Init function for PieTooltip component.
@@ -60,9 +61,9 @@ export function initPieTooltip(_scope: Element, props: Record<string, unknown>):
       const label = labelFormatter ? labelFormatter(name) : entryLabel
 
       let html = `<div style="display:flex;align-items:center;gap:8px">`
-      html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
-      html += `<span>${label}</span>`
-      html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+      html += `<span style="width:8px;height:8px;border-radius:2px;background:${escapeHtml(color)};display:inline-block"></span>`
+      html += `<span>${escapeHtml(label)}</span>`
+      html += `<span style="font-weight:500;margin-left:auto">${escapeHtml(value)}</span>`
       html += `</div>`
       currentTooltip.innerHTML = html
       currentTooltip.style.opacity = '1'

--- a/packages/chart/src/radar-tooltip.ts
+++ b/packages/chart/src/radar-tooltip.ts
@@ -1,5 +1,6 @@
 import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
 import { RadarChartContext } from './context'
+import { escapeHtml } from './utils/escape-html'
 
 /**
  * Init function for RadarTooltip component.
@@ -61,16 +62,16 @@ export function initRadarTooltip(_scope: Element, props: Record<string, unknown>
 
       const label = labelFormatter ? labelFormatter(axisValue) : axisValue
 
-      let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
+      let html = `<div style="font-weight:500;margin-bottom:4px">${escapeHtml(label)}</div>`
       for (const radar of radars) {
         const value = datum[radar.dataKey]
         const configEntry = config[radar.dataKey]
         const color = radar.fill ?? configEntry?.color ?? 'currentColor'
         const entryLabel = configEntry?.label ?? radar.dataKey
         html += `<div style="display:flex;align-items:center;gap:8px">`
-        html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
-        html += `<span>${entryLabel}</span>`
-        html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+        html += `<span style="width:8px;height:8px;border-radius:2px;background:${escapeHtml(color)};display:inline-block"></span>`
+        html += `<span>${escapeHtml(entryLabel)}</span>`
+        html += `<span style="font-weight:500;margin-left:auto">${escapeHtml(value)}</span>`
         html += `</div>`
       }
       currentTooltip.innerHTML = html

--- a/packages/chart/src/tooltip.ts
+++ b/packages/chart/src/tooltip.ts
@@ -1,5 +1,6 @@
 import { useContext, createEffect, onCleanup } from '@barefootjs/dom'
 import { BarChartContext } from './context'
+import { escapeHtml } from './utils/escape-html'
 
 /**
  * Init function for ChartTooltip component.
@@ -62,16 +63,16 @@ export function initChartTooltip(_scope: Element, props: Record<string, unknown>
 
       const label = labelFormatter ? labelFormatter(xValue) : xValue
 
-      let html = `<div style="font-weight:500;margin-bottom:4px">${label}</div>`
+      let html = `<div style="font-weight:500;margin-bottom:4px">${escapeHtml(label)}</div>`
       for (const bar of bars) {
         const value = datum[bar.dataKey]
         const configEntry = config[bar.dataKey]
         const color = bar.fill ?? configEntry?.color ?? 'currentColor'
         const entryLabel = configEntry?.label ?? bar.dataKey
         html += `<div style="display:flex;align-items:center;gap:8px">`
-        html += `<span style="width:8px;height:8px;border-radius:2px;background:${color};display:inline-block"></span>`
-        html += `<span>${entryLabel}</span>`
-        html += `<span style="font-weight:500;margin-left:auto">${value}</span>`
+        html += `<span style="width:8px;height:8px;border-radius:2px;background:${escapeHtml(color)};display:inline-block"></span>`
+        html += `<span>${escapeHtml(entryLabel)}</span>`
+        html += `<span style="font-weight:500;margin-left:auto">${escapeHtml(value)}</span>`
         html += `</div>`
       }
       currentTooltip.innerHTML = html

--- a/packages/chart/src/utils/escape-html.ts
+++ b/packages/chart/src/utils/escape-html.ts
@@ -1,0 +1,13 @@
+/**
+ * Escape special HTML characters to prevent XSS when interpolating
+ * user-supplied values into innerHTML strings.
+ */
+export function escapeHtml(value: unknown): string {
+  const str = String(value ?? '')
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}


### PR DESCRIPTION
## Summary

- Add `escapeHtml()` utility to escape `& < > " '` in dynamic values before innerHTML interpolation
- Apply escaping to all 4 tooltip components: bar chart, area chart, pie chart, radar chart
- Prevents XSS when `label`, `color`, `entryLabel`, or `value` contain user-supplied data

## Affected files

- `packages/chart/src/utils/escape-html.ts` (new)
- `packages/chart/src/tooltip.ts`
- `packages/chart/src/area-tooltip.ts`
- `packages/chart/src/pie-tooltip.ts`
- `packages/chart/src/radar-tooltip.ts`

## Test plan

- [x] `bun run build` passes for `@barefootjs/chart`
- [x] All 9 existing chart tests pass
- [ ] Visual verification: tooltip rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)