### PR TITLE
Add scriptBasePath option to make addScriptCollection base path configurable

### DIFF
--- a/packages/hono/src/__tests__/build.test.ts
+++ b/packages/hono/src/__tests__/build.test.ts
@@ -28,6 +28,31 @@ export function Counter(props: CounterProps) {
     expect(result).toBeDefined()
   })
 
+  test('uses custom scriptBasePath', () => {
+    const input = `import { jsx } from 'hono/jsx'
+
+export function Counter() {
+  return (<div>hello</div>)
+}`
+
+    const result = addScriptCollection(input, 'Counter', 'Counter.client.js', '/assets/js/')
+    expect(result).toContain('/assets/js/barefoot.js')
+    expect(result).toContain('/assets/js/Counter.client.js')
+    expect(result).not.toContain('/static/components/')
+  })
+
+  test('normalizes scriptBasePath without trailing slash', () => {
+    const input = `import { jsx } from 'hono/jsx'
+
+export function Counter() {
+  return (<div>hello</div>)
+}`
+
+    const result = addScriptCollection(input, 'Counter', 'Counter.client.js', '/assets/js')
+    expect(result).toContain('/assets/js/barefoot.js')
+    expect(result).toContain('/assets/js/Counter.client.js')
+  })
+
   test('handles destructured params with arrow function defaults', () => {
     const input = `import { jsx } from 'hono/jsx'
 
@@ -63,12 +88,37 @@ describe('createConfig()', () => {
 
   test('sets transformMarkedTemplate by default', () => {
     const config = createConfig()
-    expect(config.transformMarkedTemplate).toBe(addScriptCollection)
+    expect(typeof config.transformMarkedTemplate).toBe('function')
   })
 
   test('disables transformMarkedTemplate when scriptCollection is false', () => {
     const config = createConfig({ scriptCollection: false })
     expect(config.transformMarkedTemplate).toBeUndefined()
+  })
+
+  test('uses custom scriptBasePath in transformMarkedTemplate', () => {
+    const config = createConfig({ scriptBasePath: '/assets/js/' })
+    const input = `import { jsx } from 'hono/jsx'
+
+export function Counter() {
+  return (<div>hello</div>)
+}`
+    const result = config.transformMarkedTemplate!(input, 'Counter', 'Counter.client.js')
+    expect(result).toContain('/assets/js/barefoot.js')
+    expect(result).toContain('/assets/js/Counter.client.js')
+    expect(result).not.toContain('/static/components/')
+  })
+
+  test('uses default scriptBasePath in transformMarkedTemplate', () => {
+    const config = createConfig()
+    const input = `import { jsx } from 'hono/jsx'
+
+export function Counter() {
+  return (<div>hello</div>)
+}`
+    const result = config.transformMarkedTemplate!(input, 'Counter', 'Counter.client.js')
+    expect(result).toContain('/static/components/barefoot.js')
+    expect(result).toContain('/static/components/Counter.client.js')
   })
 
   test('passes through build options', () => {

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -7,6 +7,8 @@ import type { HonoAdapterOptions } from './adapter'
 export interface HonoBuildOptions extends BuildOptions {
   /** Inject Hono script collection wrapper (default: true) */
   scriptCollection?: boolean
+  /** Base path for client JS script URLs (default: '/static/components/') */
+  scriptBasePath?: string
   /** Adapter-specific options passed to HonoAdapter */
   adapterOptions?: HonoAdapterOptions
 }
@@ -27,7 +29,10 @@ export function createConfig(options: HonoBuildOptions = {}) {
     minify: options.minify,
     contentHash: options.contentHash,
     clientOnly: options.clientOnly,
-    transformMarkedTemplate: useScriptCollection ? addScriptCollection : undefined,
+    transformMarkedTemplate: useScriptCollection
+      ? (content: string, componentId: string, clientJsPath: string) =>
+          addScriptCollection(content, componentId, clientJsPath, options.scriptBasePath)
+      : undefined,
   }
 }
 
@@ -36,7 +41,8 @@ export function createConfig(options: HonoBuildOptions = {}) {
  * Injects imports, a helper function, and script collector into each
  * exported component function.
  */
-export function addScriptCollection(content: string, componentId: string, clientJsPath: string): string {
+export function addScriptCollection(content: string, componentId: string, clientJsPath: string, scriptBasePath: string = '/static/components/'): string {
+  const basePath = scriptBasePath.endsWith('/') ? scriptBasePath : scriptBasePath + '/'
   const importStatement = "import { useRequestContext } from 'hono/jsx-renderer'\nimport { Fragment } from 'hono/jsx'\n"
 
   // Find the last import statement and add our import after it
@@ -70,13 +76,13 @@ function __bfWrap(jsx: any, scripts: string[]) {
     const __bfRendered = __c.get('bfScriptsRendered')
     if (!__outputScripts.has('__barefoot__')) {
       __outputScripts.add('__barefoot__')
-      if (__bfRendered) __bfInlineScripts.push('/static/components/barefoot.js')
-      else __scripts.push({ src: '/static/components/barefoot.js' })
+      if (__bfRendered) __bfInlineScripts.push('${basePath}barefoot.js')
+      else __scripts.push({ src: '${basePath}barefoot.js' })
     }
     if (!__outputScripts.has('${componentId}')) {
       __outputScripts.add('${componentId}')
-      if (__bfRendered) __bfInlineScripts.push('/static/components/${clientJsPath}')
-      else __scripts.push({ src: '/static/components/${clientJsPath}' })
+      if (__bfRendered) __bfInlineScripts.push('${basePath}${clientJsPath}')
+      else __scripts.push({ src: '${basePath}${clientJsPath}' })
     }
     __c.set('bfCollectedScripts', __scripts)
     __c.set('bfOutputScripts', __outputScripts)


### PR DESCRIPTION
## Summary

- Add `scriptBasePath` option to `HonoBuildOptions` and `createConfig()` so consumers can customize the URL base path for client JS scripts
- Replace hardcoded `/static/components/` in `addScriptCollection` with the configurable parameter (default unchanged)
- Normalize the path to ensure a trailing slash

### Usage

```typescript
export default createConfig({
  components: ['worker/components'],
  outDir: 'dist/static',
  scriptBasePath: '/assets/bf/',  // default: '/static/components/'
  minify: true,
})
```

Direct callers can also pass the optional 4th parameter:
```typescript
addScriptCollection(content, 'Counter', 'Counter.client.js', '/assets/bf/')
```

Closes #765

## Test plan

- [x] Existing tests pass with default path (backward compatible)
- [x] New test: custom `scriptBasePath` via `addScriptCollection` directly
- [x] New test: custom `scriptBasePath` via `createConfig`
- [x] New test: trailing slash normalization
- [x] All 53 hono package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)