### PR TITLE
Fix event handlers inside .map() within conditional branches

### DIFF
--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -98,6 +98,55 @@ describe('composite loops inside conditional branches (#724)', () => {
     expect(js).not.toContain('createComponent(')
   })
 
+  test('simple loop with onClick inside conditional generates event delegation (#766)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      interface Item { id: string; name: string }
+
+      export function ItemList(props) {
+        const [items, setItems] = createSignal(props.initialItems)
+
+        const handleDelete = (id) => {
+          setItems(items().filter(i => i.id !== id))
+        }
+
+        return (
+          <div>
+            {items().length > 0 && (
+              <div className="list">
+                {items().map(item => (
+                  <div key={item.id}>
+                    <span>{item.name}</span>
+                    <button onClick={() => handleDelete(item.id)}>Delete</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Should use mapArray for the loop
+    expect(js).toContain('mapArray(')
+
+    // Should have event delegation (addEventListener + closest pattern)
+    expect(js).toContain(".addEventListener('click', (e) => {")
+    expect(js).toContain('target.closest')
+    expect(js).toContain('handleDelete(item.id)')
+
+    // Should NOT use createComponent (no child components)
+    expect(js).not.toContain('createComponent(')
+  })
+
   test('SSR hydration: composite branch loop initializes child components via initChild', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -583,7 +583,7 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           containerSlotId: parentSlotId,
           mapPreamble: n.mapPreamble ?? null,
           nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
-          childEvents: childEvents.length > 0 ? childEvents : undefined,
+          childEvents,
           childReactiveTexts: useElementReconciliation ? childReactiveTexts : undefined,
           childReactiveAttrs: useElementReconciliation ? childReactiveAttrs : undefined,
           childConditionals: useElementReconciliation ? childConditionals : undefined,

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -555,14 +555,19 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0)).join('')
         }
 
-        // Collect child events and reactive fields for composite loops
+        // Collect child events for ALL loops (needed for event delegation).
+        // Reactive fields (texts, attrs, conditionals) are composite-only.
         const childEvents: LoopChildEvent[] = []
         const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
         const childReactiveAttrs: import('./types').LoopChildReactiveAttr[] = []
         const childConditionals: import('./types').LoopChildConditional[] = []
-        if (useElementReconciliation && ctx) {
+        if (ctx) {
           for (const child of n.children) {
             childEvents.push(...collectLoopChildEventsWithNesting(child))
+          }
+        }
+        if (useElementReconciliation && ctx) {
+          for (const child of n.children) {
             childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
             childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
             childConditionals.push(...collectLoopChildConditionals(child, ctx, n.param))
@@ -578,7 +583,7 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           containerSlotId: parentSlotId,
           mapPreamble: n.mapPreamble ?? null,
           nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
-          childEvents: useElementReconciliation ? childEvents : undefined,
+          childEvents: childEvents.length > 0 ? childEvents : undefined,
           childReactiveTexts: useElementReconciliation ? childReactiveTexts : undefined,
           childReactiveAttrs: useElementReconciliation ? childReactiveAttrs : undefined,
           childConditionals: useElementReconciliation ? childConditionals : undefined,

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -110,7 +110,7 @@ function emitBranchBindings(
           lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         }
         // Event delegation for simple branch loops (#766)
-        if (loop.childEvents?.length) {
+        if (loop.childEvents.length > 0) {
           emitBranchLoopEventDelegation(lines, loop, cv)
         }
       }
@@ -164,7 +164,7 @@ function emitCompositeBranchLoop(
 ): void {
   const nestedComps = loop.nestedComponents!
   const innerLoops = loop.innerLoops ?? []
-  const childEvents = loop.childEvents ?? []
+  const childEvents = loop.childEvents
   const indexParam = loop.index || '__idx'
 
   const depthLevels = buildDepthLevels(innerLoops, nestedComps, childEvents)
@@ -779,7 +779,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
  */
 function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchLoop, cv: string): void {
   const containerVar = `__loop_${cv}`
-  const childEvents = loop.childEvents!
+  const childEvents = loop.childEvents
 
   if (loop.key) {
     // Keyed: find item by data-key attribute

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -109,10 +109,7 @@ function emitBranchBindings(
         } else {
           lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         }
-        // Event delegation for simple branch loops (#766)
-        if (loop.childEvents.length > 0) {
-          emitBranchLoopEventDelegation(lines, loop, cv)
-        }
+        emitBranchLoopEventDelegation(lines, loop, cv)
       }
     }
 

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -109,6 +109,10 @@ function emitBranchBindings(
         } else {
           lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}) => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         }
+        // Event delegation for simple branch loops (#766)
+        if (loop.childEvents?.length) {
+          emitBranchLoopEventDelegation(lines, loop, cv)
+        }
       }
     }
 
@@ -764,6 +768,57 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
       ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
       ls.push(`        const ${elem.param} = ${elem.array}[idx]`)
       ls.push(`        if (${elem.param}) ${handlerCall}`)
+      ls.push(`      }`)
+    })
+  }
+}
+
+/**
+ * Emit event delegation for simple (non-composite) loops inside conditional branches (#766).
+ * Mirrors emitDynamicLoopEventDelegation but uses branch-scoped container variable.
+ */
+function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchLoop, cv: string): void {
+  const containerVar = `__loop_${cv}`
+  const childEvents = loop.childEvents!
+
+  if (loop.key) {
+    // Keyed: find item by data-key attribute
+    const keyWithItem = loop.key.replace(new RegExp(`\\b${loop.param}\\b`, 'g'), 'item')
+    emitLoopEventDelegation(lines, containerVar, childEvents, (ls, ev, handlerCall) => {
+      if (ev.nestedLoops.length === 0) {
+        ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
+        ls.push(`      if (li) {`)
+        ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
+        ls.push(`        const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
+        ls.push(`        if (${loop.param}) ${handlerCall}`)
+        ls.push(`      }`)
+      } else {
+        // Nested loop event — multi-level data-key-N resolution
+        const evVar = varSlotId(ev.childSlotId)
+        for (const nested of ev.nestedLoops) {
+          const dataAttr = keyAttrName(nested.depth)
+          ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
+          ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
+        }
+        ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
+        ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
+        ls.push(`      const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
+        for (const nested of ev.nestedLoops) {
+          const innerKeyExpr = nested.key.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+          ls.push(`      const ${nested.param} = ${loop.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
+        }
+        const allParams = [loop.param, ...ev.nestedLoops.map(n => n.param)]
+        ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
+      }
+    })
+  } else {
+    // Non-keyed: find item by index in parent children
+    emitLoopEventDelegation(lines, containerVar, childEvents, (ls, ev, handlerCall) => {
+      ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
+      ls.push(`      if (li && li.parentElement) {`)
+      ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
+      ls.push(`        const ${loop.param} = ${loop.array}[idx]`)
+      ls.push(`        if (${loop.param}) ${handlerCall}`)
       ls.push(`      }`)
     })
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -109,9 +109,9 @@ export interface ConditionalBranchLoop {
   template: string     // HTML template for each item
   containerSlotId: string // bf slot ID of the container element (e.g., 's1' for <ul bf="s1">)
   mapPreamble: string | null
+  childEvents: LoopChildEvent[]
   // Composite loop fields (loops whose body contains child components)
   nestedComponents?: IRLoopChildComponent[]
-  childEvents?: LoopChildEvent[]
   childReactiveTexts?: LoopChildReactiveText[]
   childReactiveAttrs?: LoopChildReactiveAttr[]
   childConditionals?: LoopChildConditional[]


### PR DESCRIPTION
## Summary

Closes #766

- **Root cause**: `collectBranchLoops()` only collected `childEvents` when `useElementReconciliation` was true (loops with child components). Simple loops with plain HTML + event handlers were completely skipped.
- **Fix**: Split event collection to run unconditionally for all branch loops, and add `emitBranchLoopEventDelegation()` to emit container-level event delegation (matching the top-level loop pattern) for simple branch loops.

## Changes

- `collect-elements.ts`: Collect `childEvents` for all branch loops, not just composite ones
- `emit-control-flow.ts`: Add `emitBranchLoopEventDelegation()` — mirrors `emitDynamicLoopEventDelegation()` for branch-scoped container variables. Supports keyed/non-keyed and nested loop events.
- `composite-branch-loop.test.ts`: Add test for the exact pattern from #766 (onClick inside .map() inside conditional `&&`)

## Test plan

- [x] New test: simple loop with `onClick` inside conditional generates `addEventListener` + `target.closest` delegation
- [x] Compiler test suite: 501 tests pass
- [x] Adapter conformance: 159 tests pass
- [ ] E2E: verify click handlers fire in a real conditional list scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)