### PR TITLE
Generate strict TypeScript-safe marked templates

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -277,8 +277,14 @@ export class HonoAdapter implements TemplateAdapter {
       jsxBody = `<>{bfComment(\`scope:${scopeExpr}${propsExpr}\`)}${jsxBody}</>`
     }
 
+    // For if-statement roots, render branches early so they're included in reference analysis
+    const ifCode = isIfStatement
+      ? this.renderIfStatement(ir.root as IRIfStatement, { isRootOfClientComponent: true })
+      : ''
+
     // Generate signal initializers with unused-aware prefixing (needs jsxBody for reference analysis)
-    const signalInits = this.generateSignalInitializers(ir, jsxBody)
+    const fullBodyText = jsxBody + '\n' + ifCode
+    const signalInits = this.generateSignalInitializers(ir, fullBodyText)
 
     // Determine which hydration params are actually used in the generated body
     // Include scopeId line content for accurate reference checking
@@ -286,7 +292,7 @@ export class HonoAdapter implements TemplateAdapter {
       ? `__instanceId`
       : `__bfScope || __instanceId`
     const bodyRefText = [
-      jsxBody,
+      fullBodyText,
       signalInits,
       scopeIdLine,
       // Props serialization references __bfParentProps
@@ -366,7 +372,6 @@ export class HonoAdapter implements TemplateAdapter {
 
     // Handle if-statement roots (early return pattern)
     if (isIfStatement) {
-      const ifCode = this.renderIfStatement(ir.root as IRIfStatement, { isRootOfClientComponent: true })
       lines.push(ifCode)
       lines.push(`}`)
       return lines.join('\n')

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -22,6 +22,8 @@ import {
   type TemplateSections,
   type TemplateAdapter,
   isBooleanAttr,
+  formatParamWithType,
+  findReachableNames,
 } from '@barefootjs/jsx'
 
 export interface HonoAdapterOptions {
@@ -162,9 +164,10 @@ export class HonoAdapter implements TemplateAdapter {
       lines.push(typeDef.definition)
     }
 
-    // Generate hydration props type
+    // Generate hydration props type (only when destructured-props pattern uses it;
+    // SolidJS-style props use inline type annotation instead)
     const propsTypeName = this.getPropsTypeName(ir)
-    if (propsTypeName) {
+    if (propsTypeName && !ir.metadata.propsObjectName) {
       lines.push('')
       lines.push(`type ${this.componentName}PropsWithHydration = ${propsTypeName} & {`)
       lines.push('  __instanceId?: string')
@@ -228,40 +231,14 @@ export class HonoAdapter implements TemplateAdapter {
       typeAnnotation = propsTypeName
         ? `: ${propsTypeName} & { __instanceId?: string; __bfScope?: string; __bfChild?: boolean; __bfParentProps?: string; "data-key"?: string | number }`
         : `: Record<string, unknown> & { __instanceId?: string; __bfScope?: string; __bfChild?: boolean; __bfParentProps?: string; "data-key"?: string | number }`
-      // Extract hydration props and create the props object for component use
-      propsExtraction = `  const { __instanceId, __bfScope, __bfChild, __bfParentProps, "data-key": __dataKey, ...${propsObjectName} } = __allProps`
+      // propsExtraction is rebuilt after jsxBody generation with unused-aware aliases
     } else {
-      // Destructured props pattern (current behavior)
-      // Convert 'class' to 'className' (React convention, avoids JS reserved word)
-      const propsParams = ir.metadata.propsParams
-        .map((p: ParamInfo) => {
-          const paramName = p.name === 'class' ? 'className' : p.name
-          return p.defaultValue ? `${paramName} = ${p.defaultValue}` : paramName
-        })
-        .join(', ')
-
-      const restPropsName = ir.metadata.restPropsName
-
-      // Build full destructure with hydration props
-      // Rest props must be at the end in TypeScript
-      const hydrationProps = '__instanceId, __bfScope, __bfChild, __bfParentProps, "data-key": __dataKey'
-      const parts: string[] = []
-      if (propsParams) {
-        parts.push(propsParams)
-      }
-      parts.push(hydrationProps)
-      if (restPropsName) {
-        parts.push(`...${restPropsName}`)
-      }
-      fullPropsDestructure = `{ ${parts.join(', ')} }`
-
+      // Destructured props pattern — fullPropsDestructure rebuilt after jsxBody with unused-aware aliases
+      fullPropsDestructure = '' // placeholder, rebuilt below
       typeAnnotation = propsTypeName
         ? `: ${name}PropsWithHydration`
         : ': { __instanceId?: string; __bfScope?: string; __bfChild?: boolean }'
     }
-
-    // Generate signal initializers for SSR
-    const signalInits = this.generateSignalInitializers(ir)
 
     // Generate props serialization for hydration (for components with props)
     // Only serialize props that the client JS init function actually reads
@@ -298,6 +275,50 @@ export class HonoAdapter implements TemplateAdapter {
         ? '${__bfPropsJson ? `|${__bfPropsJson}` : ""}'
         : ''
       jsxBody = `<>{bfComment(\`scope:${scopeExpr}${propsExpr}\`)}${jsxBody}</>`
+    }
+
+    // Generate signal initializers with unused-aware prefixing (needs jsxBody for reference analysis)
+    const signalInits = this.generateSignalInitializers(ir, jsxBody)
+
+    // Determine which hydration params are actually used in the generated body
+    // Include scopeId line content for accurate reference checking
+    const scopeIdLine = hasClientInteractivity
+      ? `__instanceId`
+      : `__bfScope || __instanceId`
+    const bodyRefText = [
+      jsxBody,
+      signalInits,
+      scopeIdLine,
+      // Props serialization references __bfParentProps
+      (hasPropsToSerialize || (hasClientInteractivity && isRootComponent)) ? '__bfParentProps' : '',
+    ].join('\n')
+
+    // Rebuild hydration props with _ prefix for unused ones
+    const bfScopeAlias = /\b__bfScope\b/.test(bodyRefText) ? '__bfScope' : '__bfScope: _bfScope'
+    const bfChildAlias = /\b__bfChild\b/.test(bodyRefText) ? '__bfChild' : '__bfChild: _bfChild'
+    const bfParentPropsAlias = /\b__bfParentProps\b/.test(bodyRefText) ? '__bfParentProps' : '__bfParentProps: _bfParentProps'
+    const dataKeyAlias = /\b__dataKey\b/.test(bodyRefText) ? '"data-key": __dataKey' : '"data-key": _dataKey'
+
+    if (propsObjectName) {
+      propsExtraction = `  const { __instanceId, ${bfScopeAlias}, ${bfChildAlias}, ${bfParentPropsAlias}, ${dataKeyAlias}, ...${propsObjectName} } = __allProps`
+    } else {
+      const hydrationProps = `__instanceId, ${bfScopeAlias}, ${bfChildAlias}, ${bfParentPropsAlias}, ${dataKeyAlias}`
+      const parts: string[] = []
+      const propsParams = ir.metadata.propsParams
+        .map((p: ParamInfo) => {
+          const paramName = p.name === 'class' ? 'className' : p.name
+          return p.defaultValue ? `${paramName} = ${p.defaultValue}` : paramName
+        })
+        .join(', ')
+      if (propsParams) {
+        parts.push(propsParams)
+      }
+      parts.push(hydrationProps)
+      const restPropsName = ir.metadata.restPropsName
+      if (restPropsName) {
+        parts.push(`...${restPropsName}`)
+      }
+      fullPropsDestructure = `{ ${parts.join(', ')} }`
     }
 
     const lines: string[] = []
@@ -359,15 +380,48 @@ export class HonoAdapter implements TemplateAdapter {
     return lines.join('\n')
   }
 
-  private generateSignalInitializers(ir: ComponentIR): string {
+  private generateSignalInitializers(ir: ComponentIR, jsxBody: string): string {
     const lines: string[] = []
+
+    // Build primary reference text for reachability analysis:
+    // jsxBody + signal initial values + memo computations (these are the "consumers")
+    const primaryRefs = [jsxBody]
+    for (const signal of ir.metadata.signals) {
+      primaryRefs.push(signal.initialValue)
+    }
+    for (const memo of ir.metadata.memos) {
+      primaryRefs.push(memo.computation)
+    }
+    const primaryRefText = primaryRefs.join('\n')
+
+    // Collect local declarations and their bodies for dependency analysis
+    const localFunctions = ir.metadata.localFunctions.filter(f => !f.isExported)
+    const localConstants = ir.metadata.localConstants.filter(c => !c.isExported && c.value)
+    const declarations = [
+      ...localFunctions.map(f => ({ name: f.name, body: f.body })),
+      ...localConstants.map(c => ({ name: c.name, body: c.value! })),
+    ]
+
+    // Find reachable declarations via transitive dependency analysis
+    const reachable = findReachableNames(primaryRefText, declarations)
+
+    // Also check which signal setters are referenced
+    const reachableBodies = [...reachable].map(name => {
+      const func = localFunctions.find(f => f.name === name)
+      if (func) return func.body
+      const constant = localConstants.find(c => c.name === name)
+      return constant?.value ?? ''
+    }).join('\n')
+    const setterRefText = primaryRefText + '\n' + reachableBodies
 
     for (const signal of ir.metadata.signals) {
       // Create a getter that returns the initial value for SSR
       const initialValue = signal.initialValue.trim().startsWith('{') ? `(${signal.initialValue})` : signal.initialValue
       lines.push(`  const ${signal.getter} = () => ${initialValue}`)
-      // Create a no-op setter for SSR (in case it's passed to child components)
-      lines.push(`  const ${signal.setter} = () => {}`)
+      // Create a no-op setter for SSR — prefix with _ if not referenced anywhere
+      const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
+      const setterName = setterUsed ? signal.setter : `_${signal.setter}`
+      lines.push(`  const ${setterName} = (..._args: any[]) => {}`)
     }
 
     for (const memo of ir.metadata.memos) {
@@ -392,10 +446,10 @@ export class HonoAdapter implements TemplateAdapter {
       lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }
 
-    // Include local functions (skip exported ones — they are at module level)
-    for (const func of ir.metadata.localFunctions) {
-      if (func.isExported) continue
-      const params = func.params.map((p) => p.name).join(', ')
+    // Include local functions — skip unreachable ones (only used in event handlers)
+    for (const func of localFunctions) {
+      if (!reachable.has(func.name)) continue
+      const params = func.params.map(formatParamWithType).join(', ')
       lines.push(`  function ${func.name}(${params}) ${func.body}`)
     }
 

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -434,7 +434,7 @@ export class HonoAdapter implements TemplateAdapter {
       lines.push(`  const ${memo.name} = ${memo.computation}`)
     }
 
-    // Include local constants (skip exported ones — they are at module level)
+    // Include local constants — skip unreachable ones (only used in event handlers)
     for (const constant of ir.metadata.localConstants) {
       if (constant.isExported) continue
       const keyword = constant.declarationKind ?? 'const'
@@ -447,6 +447,9 @@ export class HonoAdapter implements TemplateAdapter {
       // - createContext() — only used client-side via provideContext/useContext
       // - new WeakMap() — client-side cross-component shared state
       if (/^createContext\b/.test(value) || /^new WeakMap\b/.test(value)) continue
+
+      // Skip unreachable constants (only used in event handler code paths)
+      if (!reachable.has(constant.name)) continue
 
       lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }

--- a/packages/jsx/src/__tests__/adapter-output.test.ts
+++ b/packages/jsx/src/__tests__/adapter-output.test.ts
@@ -228,7 +228,7 @@ describe('Adapter output', () => {
       const content = template.content
 
       // Exported helper function should be at module level
-      expect(content).toContain('export function helperFn(x)')
+      expect(content).toContain('export function helperFn(x: number)')
 
       // It should appear before the component
       const helperIndex = content.indexOf('export function helperFn')
@@ -328,6 +328,210 @@ describe('Adapter output', () => {
       const template = result.files.find(f => f.type === 'markedTemplate')!
       expect(template).toBeDefined()
       expect(template.content).toContain("export const formatDate = (d) => d.toISOString().split('T')[0]")
+    })
+  })
+
+  describe('strict TypeScript compliance (#762)', () => {
+    test('signal setter accepts arguments in generated SSR template (HonoAdapter)', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // No-op setter must accept arguments
+      expect(template.content).toContain('(..._args: any[]) => {}')
+      expect(template.content).not.toMatch(/const \w+ = \(\) => \{\}/)
+    })
+
+    test('signal setter accepts arguments in generated SSR template (TestAdapter)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template.content).toContain('(..._args: any[]) => {}')
+    })
+
+    test('local function parameters preserve type annotations', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        function formatNum(n: number): string { return n.toFixed(2) }
+
+        export function Display() {
+          const [val, setVal] = createSignal(0)
+          return <span>{formatNum(val())}</span>
+        }
+      `
+      const result = compileJSXSync(source, 'Display.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template.content).toContain('function formatNum(n: number)')
+    })
+
+    test('exported function parameters preserve type annotations in module exports', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function helperFn(x: number, label: string) { return label + x }
+
+        export function MyComponent() {
+          const [val, setVal] = createSignal(0)
+          return <div>{helperFn(val(), 'value: ')}</div>
+        }
+      `
+      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template.content).toContain('export function helperFn(x: number, label: string)')
+    })
+
+    test('SolidJS-style props do not generate unused PropsWithHydration type', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        interface CounterProps { initial?: number }
+
+        export function Counter(props: CounterProps) {
+          const [count, setCount] = createSignal(props.initial ?? 0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // SolidJS-style uses inline type, should not generate PropsWithHydration
+      expect(template.content).not.toContain('CounterPropsWithHydration')
+    })
+
+    test('unused signal setter is prefixed with _ when only used in event handlers', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // setCount is only used in onClick which becomes () => {} in SSR
+      expect(template.content).toContain('_setCount')
+      expect(template.content).not.toMatch(/\bconst setCount\b/)
+    })
+
+    test('event handler functions not emitted when only used in event handlers', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function MembersPanel() {
+          const [members, setMembers] = createSignal<string[]>([])
+
+          function handleGrant(id: string) {
+            setMembers(prev => [...prev, id])
+          }
+
+          function handleRevoke(id: string) {
+            setMembers(prev => prev.filter(m => m !== id))
+          }
+
+          return (
+            <div>
+              <button onClick={() => handleGrant('user1')}>Grant</button>
+              <button onClick={() => handleRevoke('user1')}>Revoke</button>
+              <span>{members().length}</span>
+            </div>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'MembersPanel.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Functions only used in event handlers should not be emitted
+      expect(template.content).not.toContain('function handleGrant')
+      expect(template.content).not.toContain('function handleRevoke')
+    })
+
+    test('function used in JSX body is preserved even if also used in events', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Display() {
+          const [val, setVal] = createSignal(0)
+
+          function formatVal(n: number): string { return n.toFixed(2) }
+
+          return (
+            <div>
+              <span>{formatVal(val())}</span>
+              <button onClick={() => setVal(v => v + 1)}>Inc</button>
+            </div>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'Display.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // formatVal is used in JSX body, must be preserved
+      expect(template.content).toContain('function formatVal(n: number)')
+    })
+
+    test('unused hydration params get _ prefix (Hono interactive component)', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Hono interactive components don't use __bfScope in their scopeId generation
+      // so it should be aliased with _ prefix
+      expect(template.content).toContain('__bfScope: _bfScope')
+      // __bfParentProps should also be aliased (no props to serialize)
+      expect(template.content).toContain('__bfParentProps: _bfParentProps')
     })
   })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -18,6 +18,7 @@ import type {
   ParamInfo,
 } from '../types'
 import { type AdapterOutput, type TemplateSections, BaseAdapter } from './interface'
+import { formatParamWithType, findReachableNames } from '../module-exports'
 
 export class TestAdapter extends BaseAdapter {
   name = 'test'
@@ -109,8 +110,9 @@ export class TestAdapter extends BaseAdapter {
       lines.push(typeDef.definition)
     }
 
+    // Only generate PropsWithHydration when destructured-props pattern uses it
     const propsTypeName = ir.metadata.propsType?.raw
-    if (propsTypeName) {
+    if (propsTypeName && !ir.metadata.propsObjectName) {
       lines.push('')
       lines.push(`type ${this.componentName}PropsWithHydration = ${propsTypeName} & {`)
       lines.push('  __instanceId?: string')
@@ -127,13 +129,27 @@ export class TestAdapter extends BaseAdapter {
     const hasClientInteractivity = ir.metadata.signals.length > 0 ||
       ir.metadata.memos.length > 0
 
+    const typeAnnotation = propsTypeName
+      ? `: ${name}PropsWithHydration`
+      : ': { __instanceId?: string; __bfScope?: string }'
+
+    const jsxBody = this.renderNode(ir.root)
+    const signalInits = this.generateSignalInitializers(ir, jsxBody)
+
+    // Determine which hydration params are used in the generated body
+    // Include the scopeId line content for accurate reference checking
+    const scopeIdLine = hasClientInteractivity
+      ? `(/_s\\d/.test(__bfScope || '') ? __bfScope : null) || __instanceId`
+      : `__bfScope || __instanceId`
+    const bodyRefText = [jsxBody, signalInits, scopeIdLine].join('\n')
+    const bfScopeAlias = /\b__bfScope\b/.test(bodyRefText) ? '__bfScope' : '__bfScope: _bfScope'
+
     const propsParams = ir.metadata.propsParams
       .map((p: ParamInfo) => (p.defaultValue ? `${p.name} = ${p.defaultValue}` : p.name))
       .join(', ')
 
     const restPropsName = ir.metadata.restPropsName
-
-    const hydrationProps = '__instanceId, __bfScope'
+    const hydrationProps = `__instanceId, ${bfScopeAlias}`
     const parts: string[] = []
     if (propsParams) {
       parts.push(propsParams)
@@ -143,13 +159,6 @@ export class TestAdapter extends BaseAdapter {
       parts.push(`...${restPropsName}`)
     }
     const fullPropsDestructure = `{ ${parts.join(', ')} }`
-
-    const typeAnnotation = propsTypeName
-      ? `: ${name}PropsWithHydration`
-      : ': { __instanceId?: string; __bfScope?: string }'
-
-    const signalInits = this.generateSignalInitializers(ir)
-    const jsxBody = this.renderNode(ir.root)
 
     const lines: string[] = []
     lines.push(`export function ${name}(${fullPropsDestructure}${typeAnnotation}) {`)
@@ -177,13 +186,45 @@ export class TestAdapter extends BaseAdapter {
     return lines.join('\n')
   }
 
-  private generateSignalInitializers(ir: ComponentIR): string {
+  private generateSignalInitializers(ir: ComponentIR, jsxBody: string): string {
     const lines: string[] = []
+
+    // Build primary reference text for reachability analysis
+    const primaryRefs = [jsxBody]
+    for (const signal of ir.metadata.signals) {
+      primaryRefs.push(signal.initialValue)
+    }
+    for (const memo of ir.metadata.memos) {
+      primaryRefs.push(memo.computation)
+    }
+    const primaryRefText = primaryRefs.join('\n')
+
+    // Collect local declarations for dependency analysis
+    const localFunctions = ir.metadata.localFunctions.filter(f => !f.isExported)
+    const localConstants = ir.metadata.localConstants.filter(c => !c.isExported && c.value)
+    const declarations = [
+      ...localFunctions.map(f => ({ name: f.name, body: f.body })),
+      ...localConstants.map(c => ({ name: c.name, body: c.value! })),
+    ]
+    const reachable = findReachableNames(primaryRefText, declarations)
+
+    // Build text for setter reference checking
+    const reachableBodies = [...reachable].map(name => {
+      const func = localFunctions.find(f => f.name === name)
+      if (func) return func.body
+      const constant = localConstants.find(c => c.name === name)
+      return constant?.value ?? ''
+    }).join('\n')
+    const setterRefText = primaryRefText + '\n' + reachableBodies
 
     for (const signal of ir.metadata.signals) {
       const initialValue = signal.initialValue.trim().startsWith('{') ? `(${signal.initialValue})` : signal.initialValue
       lines.push(`  const ${signal.getter} = () => ${initialValue}`)
-      if (signal.setter) lines.push(`  const ${signal.setter} = () => {}`)
+      if (signal.setter) {
+        const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
+        const setterName = setterUsed ? signal.setter : `_${signal.setter}`
+        lines.push(`  const ${setterName} = (..._args: any[]) => {}`)
+      }
     }
 
     for (const memo of ir.metadata.memos) {
@@ -200,10 +241,10 @@ export class TestAdapter extends BaseAdapter {
       lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }
 
-    // Include local functions (skip exported ones — they are at module level)
-    for (const func of ir.metadata.localFunctions) {
-      if (func.isExported) continue
-      const params = func.params.map((p) => p.name).join(', ')
+    // Include local functions — skip unreachable ones (only used in event handlers)
+    for (const func of localFunctions) {
+      if (!reachable.has(func.name)) continue
+      const params = func.params.map(formatParamWithType).join(', ')
       lines.push(`  function ${func.name}(${params}) ${func.body}`)
     }
 

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -238,6 +238,8 @@ export class TestAdapter extends BaseAdapter {
         lines.push(`  ${keyword} ${constant.name}`)
         continue
       }
+      // Skip unreachable constants (only used in event handler code paths)
+      if (!reachable.has(constant.name)) continue
       lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
     }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -40,7 +40,7 @@ export { analyzeComponent, listExportedComponents, type AnalyzerContext } from '
 export { jsxToIR } from './jsx-to-ir'
 
 // Module exports generation (compiler layer)
-export { generateModuleExports, extractFunctionParams } from './module-exports'
+export { generateModuleExports, extractFunctionParams, formatParamWithType, findReachableNames } from './module-exports'
 
 // Adapters
 export { BaseAdapter } from './adapters/interface'

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -5,7 +5,7 @@
  * This is a compiler-layer concern, not adapter-specific.
  */
 
-import type { ComponentIR } from './types'
+import type { ComponentIR, ParamInfo } from './types'
 
 /**
  * Generate module-level export statements for constants and functions.
@@ -30,11 +30,53 @@ export function generateModuleExports(ir: ComponentIR): string | null {
 
   for (const func of ir.metadata.localFunctions) {
     if (!func.isExported) continue
-    const params = func.params.map((p) => p.name).join(', ')
+    const params = func.params.map(formatParamWithType).join(', ')
     lines.push(`export function ${func.name}(${params}) ${func.body}`)
   }
 
   return lines.length > 0 ? lines.join('\n') : null
+}
+
+/**
+ * Format a ParamInfo for .tsx output, preserving type annotations when available.
+ */
+export function formatParamWithType(p: ParamInfo): string {
+  const typeAnnotation = p.type?.raw && p.type.raw !== 'unknown' ? `: ${p.type.raw}` : ''
+  return `${p.name}${typeAnnotation}`
+}
+
+/**
+ * Find names reachable from primary reference text via transitive dependency analysis.
+ * Used to determine which SSR declarations are actually needed (vs. only used in event handlers).
+ */
+export function findReachableNames(
+  primaryRefs: string,
+  declarations: { name: string; body: string }[],
+): Set<string> {
+  const allNames = new Set(declarations.map(d => d.name))
+  const bodyMap = new Map(declarations.map(d => [d.name, d.body]))
+  const reachable = new Set<string>()
+  const queue: string[] = []
+
+  for (const name of allNames) {
+    if (new RegExp(`\\b${name}\\b`).test(primaryRefs)) {
+      reachable.add(name)
+      queue.push(name)
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    const body = bodyMap.get(current) || ''
+    for (const name of allNames) {
+      if (!reachable.has(name) && new RegExp(`\\b${name}\\b`).test(body)) {
+        reachable.add(name)
+        queue.push(name)
+      }
+    }
+  }
+
+  return reachable
 }
 
 /**


### PR DESCRIPTION
## Summary

Make compiled `.tsx` marked templates pass `tsc --strict` and `noUnusedLocals`/`noUnusedParameters` by fixing 4 root causes in the adapter codegen:

- **Signal setter type mismatch**: SSR no-op setters `() => {}` now become `(..._args: any[]) => {}` to accept arguments matching the real setter contract
- **Function param types lost**: New `formatParamWithType()` utility preserves type annotations from `ParamInfo` when generating `.tsx` output (local + exported functions)
- **Unused `PropsWithHydration` type**: Only generated when the destructured-props pattern references it; skipped for SolidJS-style props
- **Unused declarations**: Transitive reachability analysis (`findReachableNames`) skips SSR emission of functions only used in event handlers, prefixes unreferenced signal setters with `_`, and aliases unused hydration params

Closes #762

## Test plan

- [x] 9 new test cases in `adapter-output.test.ts` covering all 4 fix areas
- [x] Updated existing test expectation (`helperFn(x)` → `helperFn(x: number)`)
- [x] All 1277 package tests pass (0 failures)
- [x] All 159 adapter conformance tests pass
- [x] All 1148 UI component IR tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)