### PR TITLE
Fix analyzer to detect `export default function` pattern

### DIFF
--- a/packages/jsx/src/__tests__/analyzer.test.ts
+++ b/packages/jsx/src/__tests__/analyzer.test.ts
@@ -296,4 +296,22 @@ describe('analyzeComponent', () => {
     expect(ctx.componentName).toBe('Counter')
     expect(ctx.hasDefaultExport).toBe(false)
   })
+
+  test('hasDefaultExport is false with named export only', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+        export { Counter }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.componentName).toBe('Counter')
+    expect(ctx.hasDefaultExport).toBe(false)
+  })
 })

--- a/packages/jsx/src/__tests__/analyzer.test.ts
+++ b/packages/jsx/src/__tests__/analyzer.test.ts
@@ -244,4 +244,56 @@ describe('analyzeComponent', () => {
     expect(ctx.signals[0].setter).toBeNull()
     expect(ctx.signals[0].initialValue).toBe('[1, 2, 3]')
   })
+
+  test('detects export default function pattern', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export default function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.componentName).toBe('Counter')
+    expect(ctx.hasDefaultExport).toBe(true)
+  })
+
+  test('detects export default ComponentName pattern', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+        export default Counter
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.componentName).toBe('Counter')
+    expect(ctx.hasDefaultExport).toBe(true)
+  })
+
+  test('hasDefaultExport is false when no default export', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/dom'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.componentName).toBe('Counter')
+    expect(ctx.hasDefaultExport).toBe(false)
+  })
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -170,11 +170,19 @@ function findDefaultExportedComponent(sourceFile: ts.SourceFile): string | undef
   let defaultExportName: string | undefined
 
   function findDefaultExport(node: ts.Node): void {
-    // export default ComponentName
+    // Pattern 1: export default ComponentName
     if (ts.isExportAssignment(node) && !node.isExportEquals) {
       if (ts.isIdentifier(node.expression)) {
         defaultExportName = node.expression.text
       }
+    }
+    // Pattern 2: export default function ComponentName() { ... }
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name &&
+      node.modifiers?.some(m => m.kind === ts.SyntaxKind.DefaultKeyword)
+    ) {
+      defaultExportName = node.name.text
     }
     ts.forEachChild(node, findDefaultExport)
   }
@@ -222,6 +230,10 @@ function visit(
         ctx.componentName = node.name.text
         ctx.componentNode = node
         analyzeComponentBody(node, ctx)
+        // Detect: export default function ComponentName() { ... }
+        if (node.modifiers?.some(m => m.kind === ts.SyntaxKind.DefaultKeyword)) {
+          ctx.hasDefaultExport = true
+        }
       }
     } else {
       // Skip recursion into non-target component bodies


### PR DESCRIPTION
## Summary

- Fix analyzer to detect `export default function ComponentName()` syntax (FunctionDeclaration with DefaultKeyword modifier)
- Previously only `export default ComponentName` (ExportAssignment) was detected

## Changes

- `packages/jsx/src/analyzer.ts`: Add detection in both `findDefaultExportedComponent()` and `visit()` for the FunctionDeclaration + DefaultKeyword pattern
- `packages/jsx/src/__tests__/analyzer.test.ts`: Add 3 test cases covering both patterns and the negative case

## Test plan

- [x] `bun test packages/jsx/src/__tests__/analyzer.test.ts` — 14 tests pass
- [x] `bun test packages/jsx/src/__tests__/` — 503 tests pass
- [x] `bun test packages/adapter-tests/` — 159 tests pass

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)