### PR TITLE
Keep className in Hono adapter JSX output instead of converting to class

### DIFF
--- a/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
+++ b/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
@@ -149,6 +149,39 @@ describe('SSR-Hydration Contract', () => {
     }
   })
 
+  describe('className preserved in marked template JSX output (#773)', () => {
+    test('static className remains className (not class) in marked template', () => {
+      const source = `
+export function Test() {
+  return <div className="container"><span className="label">Text</span></div>
+}
+`
+      const result = compileJSXSync(source, 'Test.tsx', { adapter })
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+
+      expect(template.content).toContain('className="container"')
+      expect(template.content).toContain('className="label"')
+      expect(template.content).not.toContain('class="container"')
+      expect(template.content).not.toContain('class="label"')
+    })
+
+    test('dynamic className remains className in marked template', () => {
+      const source = `
+'use client'
+import { createSignal } from '@barefootjs/dom'
+export function Test() {
+  const [active, setActive] = createSignal(false)
+  return <div className={active() ? 'on' : 'off'}>Toggle</div>
+}
+`
+      const result = compileJSXSync(source, 'Test.tsx', { adapter })
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+
+      expect(template.content).toContain('className=')
+      expect(template.content).not.toMatch(/\bclass=/)
+    })
+  })
+
   describe('key attribute: data-key in client JS ↔ .map() in source', () => {
     for (const fixture of jsxFixtures) {
       if (statelessFixtures.has(fixture.id)) continue

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -771,8 +771,7 @@ export class HonoAdapter implements TemplateAdapter {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
-      // Convert JSX className to HTML class attribute
-      const attrName = attr.name === 'className' ? 'class' : attr.name
+      const attrName = attr.name
 
       if (attr.name === '...') {
         // Spread attribute


### PR DESCRIPTION
## Summary

- Remove `className` → `class` conversion in Hono adapter's `renderAttributes()` method
- The adapter outputs `.tsx` (JSX) files, but `HTMLBaseAttributes` defines `class?: never` — using `class` caused TypeScript errors in strict mode
- Hono's JSX runtime already handles `className` → `class` conversion at render time, so the adapter should preserve `className` as-is
- Add regression tests verifying both static and dynamic `className` are preserved in marked template output

Closes #773

## Test plan

- [x] New tests: static and dynamic `className` preserved in marked template output
- [x] Existing adapter conformance tests pass (Hono runtime still produces correct `class` in HTML)
- [x] All 1288 tests pass across 74 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)