### PR TITLE
Sort event delegation checks by DOM depth (deepest-first)

### DIFF
--- a/packages/jsx/src/__tests__/event-delegation-depth-order.test.ts
+++ b/packages/jsx/src/__tests__/event-delegation-depth-order.test.ts
@@ -1,0 +1,101 @@
+/**
+ * BarefootJS Compiler - Event delegation depth ordering (#774)
+ *
+ * When parent and child elements both handle the same event inside a .map() loop,
+ * the delegation handler must check child (deeper) elements before parent (shallower)
+ * elements. Otherwise target.closest() for the parent always matches first, preventing
+ * the child handler from ever executing.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('event delegation depth ordering (#774)', () => {
+  test('child onClick is checked before parent onClick in keyed dynamic loop', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/dom'
+
+      interface Row { id: string; name: string }
+
+      export function Table() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        const handleRowClick = (row: Row) => console.log('row', row.id)
+        const handleDelete = (row: Row) => setRows(r => r.filter(x => x.id !== row.id))
+
+        return (
+          <table>
+            <tbody>
+              {rows().map(row => (
+                <tr key={row.id} onClick={() => handleRowClick(row)}>
+                  <td>{row.name}</td>
+                  <td><button onClick={() => handleDelete(row)}>Delete</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Table.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Should have event delegation with closest checks
+    expect(content).toContain(".addEventListener('click', (e) => {")
+    expect(content).toContain('target.closest')
+
+    // Child handler (handleDelete / button) must appear before parent handler
+    // (handleRowClick / tr) in the delegation handler.
+    const deletePos = content.indexOf('handleDelete(row)')
+    const rowClickPos = content.indexOf('handleRowClick(row)')
+    expect(deletePos).not.toBe(-1)
+    expect(rowClickPos).not.toBe(-1)
+    expect(deletePos).toBeLessThan(rowClickPos)
+  })
+
+  test('child onClick is checked before parent onClick in static array loop', () => {
+    const source = `
+      'use client'
+
+      export function List() {
+        const items = [{ id: '1', label: 'A' }, { id: '2', label: 'B' }]
+        const handleItemClick = (id: string) => console.log('item', id)
+        const handleAction = (id: string) => console.log('action', id)
+
+        return (
+          <ul>
+            {items.map(item => (
+              <li onClick={() => handleItemClick(item.id)}>
+                <span>{item.label}</span>
+                <button onClick={() => handleAction(item.id)}>Action</button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('click', (e) => {")
+
+    // Child handler (handleAction / button) must appear before parent handler
+    // (handleItemClick / li) in the delegation handler.
+    const actionPos = content.indexOf('handleAction(item.id)')
+    const itemClickPos = content.indexOf('handleItemClick(item.id)')
+    expect(actionPos).not.toBe(-1)
+    expect(itemClickPos).not.toBe(-1)
+    expect(actionPos).toBeLessThan(itemClickPos)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -1169,6 +1169,8 @@ function emitLoopEventDelegation(
   }
 
   for (const [eventName, events] of eventsByName) {
+    // Sort deepest-first so child elements are checked before parents (#774)
+    events.sort((a, b) => b.domDepth - a.domDepth)
     const useCapture = NON_BUBBLING_EVENTS.has(eventName)
     if (useCapture) {
       lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${eventName}', (e) => {`)

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -115,29 +115,29 @@ export function collectEventHandlersFromIR(node: IRNode): string[] {
  * Shared by collectConditionalBranchEvents, collectConditionalBranchRefs,
  * and collectLoopChildEvents to avoid duplicating the traversal logic.
  */
-function traverseElements(node: IRNode, visitor: (el: IRElement) => void): void {
+function traverseElements(node: IRNode, visitor: (el: IRElement, domDepth: number) => void, domDepth = 0): void {
   switch (node.type) {
     case 'element':
-      visitor(node)
+      visitor(node, domDepth)
       for (const child of node.children) {
-        traverseElements(child, visitor)
+        traverseElements(child, visitor, domDepth + 1)
       }
       break
     case 'fragment':
     case 'component':
     case 'provider':
       for (const child of node.children) {
-        traverseElements(child, visitor)
+        traverseElements(child, visitor, domDepth)
       }
       break
     case 'conditional':
-      traverseElements(node.whenTrue, visitor)
-      traverseElements(node.whenFalse, visitor)
+      traverseElements(node.whenTrue, visitor, domDepth)
+      traverseElements(node.whenFalse, visitor, domDepth)
       break
     case 'if-statement':
-      traverseElements(node.consequent, visitor)
+      traverseElements(node.consequent, visitor, domDepth)
       if (node.alternate) {
-        traverseElements(node.alternate, visitor)
+        traverseElements(node.alternate, visitor, domDepth)
       }
       break
     // Note: 'loop' case is intentionally omitted. Nested .map() event delegation
@@ -188,7 +188,7 @@ export function collectConditionalBranchRefs(node: IRNode): ConditionalBranchRef
  */
 export function collectLoopChildEvents(node: IRNode): LoopChildEvent[] {
   const events: LoopChildEvent[] = []
-  traverseElements(node, (el) => {
+  traverseElements(node, (el, domDepth) => {
     if (el.slotId) {
       for (const event of el.events) {
         events.push({
@@ -196,6 +196,7 @@ export function collectLoopChildEvents(node: IRNode): LoopChildEvent[] {
           childSlotId: el.slotId,
           handler: event.handler,
           nestedLoops: [],
+          domDepth,
         })
       }
     }
@@ -216,7 +217,7 @@ export function collectLoopChildEventsWithNesting(
 
   let lastElementSlotId: string | null = null
 
-  function walk(n: IRNode): void {
+  function walk(n: IRNode, domDepth = 0): void {
     switch (n.type) {
       case 'element': {
         const prevSlotId = lastElementSlotId
@@ -228,10 +229,11 @@ export function collectLoopChildEventsWithNesting(
               childSlotId: n.slotId,
               handler: event.handler,
               nestedLoops: [...nestingStack],
+              domDepth,
             })
           }
         }
-        for (const child of n.children) walk(child)
+        for (const child of n.children) walk(child, domDepth + 1)
         lastElementSlotId = prevSlotId
         break
       }
@@ -244,21 +246,21 @@ export function collectLoopChildEventsWithNesting(
           key: n.key ?? '',
           containerSlotId: lastElementSlotId,
         })
-        for (const child of n.children) walk(child)
+        for (const child of n.children) walk(child, domDepth)
         nestingStack.pop()
         break
       case 'fragment':
       case 'component':
       case 'provider':
-        for (const child of n.children) walk(child)
+        for (const child of n.children) walk(child, domDepth)
         break
       case 'conditional':
-        walk(n.whenTrue)
-        walk(n.whenFalse)
+        walk(n.whenTrue, domDepth)
+        walk(n.whenFalse, domDepth)
         break
       case 'if-statement':
-        walk(n.consequent)
-        if (n.alternate) walk(n.alternate)
+        walk(n.consequent, domDepth)
+        if (n.alternate) walk(n.alternate, domDepth)
         break
     }
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -171,6 +171,8 @@ export interface LoopChildEvent {
   handler: string // Handler expression (may reference loop param)
   /** Nesting info for events inside nested inner loops. Empty = direct child. */
   nestedLoops: NestedLoopInfo[]
+  /** DOM nesting depth (0 = loop body root). Deepest-first sorting for event delegation (#774). */
+  domDepth: number
 }
 
 export interface LoopChildReactiveAttr extends AttrMeta {


### PR DESCRIPTION
## Summary

- Track DOM nesting depth (`domDepth`) in `LoopChildEvent` during IR event collection
- Sort delegation checks deepest-first in `emitLoopEventDelegation()` so child elements are checked before parents
- Fixes all three delegation code paths: dynamic keyed/non-keyed loops, branch loops, and static arrays

When parent and child elements both handle the same event in a `.map()` loop (e.g., `<tr onClick>` containing `<button onClick>`), `target.closest()` for the parent always matches first, preventing the child handler from ever executing. Sorting by DOM depth ensures correct event bubbling behavior.

## Test plan

- [x] New compiler unit test (`event-delegation-depth-order.test.ts`) verifies child handler is checked before parent in both keyed dynamic and static array loops
- [x] All 516 existing compiler tests pass
- [x] All 159 adapter conformance tests pass

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)