### PR TITLE
Add bf/bf-s/bf-c/bf-p hydration attributes to JSX type definitions

### DIFF
--- a/packages/jsx/src/html-types.ts
+++ b/packages/jsx/src/html-types.ts
@@ -133,6 +133,12 @@ export interface HTMLBaseAttributes extends BaseEventAttributes {
   dangerouslySetInnerHTML?: { __html: string }
   children?: unknown
   key?: string | number | bigint | null
+
+  // Hydration attributes (used by compiled marked templates)
+  bf?: string
+  'bf-s'?: string
+  'bf-c'?: string
+  'bf-p'?: string
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `bf`, `bf-s`, `bf-c`, `bf-p` optional string properties to `HTMLBaseAttributes` in `packages/jsx/src/html-types.ts`
- These hydration attributes are emitted by compiled marked templates but were missing from JSX type definitions, causing TypeScript errors in strict mode

Closes #777

## Test plan

- [x] Verified build errors and test failures are pre-existing (identical on `main`)
- [ ] Downstream project (piconic desk) can remove `@ts-nocheck` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)