### PR TITLE
Fix strict TypeScript errors in compiled marked templates

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -71,8 +71,8 @@ export class HonoAdapter implements TemplateAdapter {
     this.isClientComponent = ir.metadata.isClientComponent
 
     const imports = this.generateImports(ir)
-    const types = this.generateTypes(ir)
     const component = this.generateComponent(ir)
+    const types = this.generateTypes(ir, component)
 
     const defaultExport = ir.metadata.hasDefaultExport
       ? `\nexport default ${this.componentName}`
@@ -156,12 +156,42 @@ export class HonoAdapter implements TemplateAdapter {
   // Types Generation
   // ===========================================================================
 
-  generateTypes(ir: ComponentIR): string | null {
+  generateTypes(ir: ComponentIR, componentBody?: string): string | null {
     const lines: string[] = []
 
-    // Include original type definitions
-    for (const typeDef of ir.metadata.typeDefinitions) {
-      lines.push(typeDef.definition)
+    // Include original type definitions — only those referenced in the component body
+    // or transitively referenced by other included type definitions
+    if (componentBody && ir.metadata.typeDefinitions.length > 0) {
+      const included = new Set<string>()
+      // First pass: include types directly referenced in the component body
+      for (const typeDef of ir.metadata.typeDefinitions) {
+        if (new RegExp(`\\b${typeDef.name}\\b`).test(componentBody)) {
+          included.add(typeDef.name)
+        }
+      }
+      // Transitive pass: include types referenced by already-included types
+      let changed = true
+      while (changed) {
+        changed = false
+        for (const typeDef of ir.metadata.typeDefinitions) {
+          if (included.has(typeDef.name)) continue
+          for (const name of included) {
+            const includedDef = ir.metadata.typeDefinitions.find(t => t.name === name)
+            if (includedDef && new RegExp(`\\b${typeDef.name}\\b`).test(includedDef.definition)) {
+              included.add(typeDef.name)
+              changed = true
+              break
+            }
+          }
+        }
+      }
+      for (const typeDef of ir.metadata.typeDefinitions) {
+        if (included.has(typeDef.name)) lines.push(typeDef.definition)
+      }
+    } else {
+      for (const typeDef of ir.metadata.typeDefinitions) {
+        lines.push(typeDef.definition)
+      }
     }
 
     // Generate hydration props type (only when destructured-props pattern uses it;
@@ -421,17 +451,21 @@ export class HonoAdapter implements TemplateAdapter {
 
     for (const signal of ir.metadata.signals) {
       // Create a getter that returns the initial value for SSR
-      const initialValue = signal.initialValue.trim().startsWith('{') ? `(${signal.initialValue})` : signal.initialValue
+      // Use typed version when available to preserve type annotations in .tsx output
+      const rawInitialValue = signal.typedInitialValue ?? signal.initialValue
+      const initialValue = rawInitialValue.trim().startsWith('{') ? `(${rawInitialValue})` : rawInitialValue
       lines.push(`  const ${signal.getter} = () => ${initialValue}`)
-      // Create a no-op setter for SSR — prefix with _ if not referenced anywhere
+      // Create a no-op setter for SSR — omit entirely if not referenced anywhere
       const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
-      const setterName = setterUsed ? signal.setter : `_${signal.setter}`
-      lines.push(`  const ${setterName} = (..._args: any[]) => {}`)
+      if (setterUsed) {
+        lines.push(`  const ${signal.setter} = (..._args: any[]) => {}`)
+      }
     }
 
     for (const memo of ir.metadata.memos) {
       // Evaluate memo computation at SSR time
-      lines.push(`  const ${memo.name} = ${memo.computation}`)
+      // Use typed version when available to preserve type annotations in .tsx output
+      lines.push(`  const ${memo.name} = ${memo.typedComputation ?? memo.computation}`)
     }
 
     // Include local constants — skip unreachable ones (only used in event handlers)
@@ -451,14 +485,16 @@ export class HonoAdapter implements TemplateAdapter {
       // Skip unreachable constants (only used in event handler code paths)
       if (!reachable.has(constant.name)) continue
 
-      lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
+      // Use typed version when available to preserve type annotations in .tsx output
+      lines.push(`  ${keyword} ${constant.name} = ${constant.typedValue ?? constant.value}`)
     }
 
     // Include local functions — skip unreachable ones (only used in event handlers)
     for (const func of localFunctions) {
       if (!reachable.has(func.name)) continue
       const params = func.params.map(formatParamWithType).join(', ')
-      lines.push(`  function ${func.name}(${params}) ${func.body}`)
+      // Use typed version when available to preserve type annotations in .tsx output
+      lines.push(`  function ${func.name}(${params}) ${func.typedBody ?? func.body}`)
     }
 
     return lines.join('\n')
@@ -629,7 +665,10 @@ export class HonoAdapter implements TemplateAdapter {
       return ''
     }
 
-    const indexParam = loop.index ? `, ${loop.index}` : ''
+    // Preserve type annotations for loop params in .tsx output
+    const paramAnnotation = loop.paramType ? `: ${loop.paramType}` : ''
+    const indexAnnotation = loop.indexType ? `: ${loop.indexType}` : ''
+    const indexParam = loop.index ? `, ${loop.index}${indexAnnotation}` : ''
     // Push loop key info for data-key attribute generation on loop items
     this.loopKeyStack.push({ key: loop.key, param: loop.param })
     // Render children with isInsideLoop flag so components generate their own scope IDs
@@ -637,10 +676,12 @@ export class HonoAdapter implements TemplateAdapter {
     this.loopKeyStack.pop()
 
     let mapExpr: string
-    if (loop.mapPreamble) {
-      mapExpr = `{${loop.array}.map((${loop.param}${indexParam}) => { ${loop.mapPreamble} return ${children} })}`
+    // Use typed mapPreamble when available to preserve type annotations in .tsx output
+    const preamble = loop.typedMapPreamble ?? loop.mapPreamble
+    if (preamble) {
+      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => { ${preamble} return ${children} })}`
     } else {
-      mapExpr = `{${loop.array}.map((${loop.param}${indexParam}) => ${children})}`
+      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => ${children})}`
     }
     // Wrap with loop boundary markers so reconciliation doesn't affect siblings.
     // bfComment is a helper that renders an HTML comment in JSX.
@@ -800,7 +841,7 @@ export class HonoAdapter implements TemplateAdapter {
 
     // Add event handlers (as no-op for SSR)
     for (const event of element.events) {
-      const handlerName = `on${event.name.charAt(0).toUpperCase()}${event.name.slice(1)}`
+      const handlerName = event.originalAttr ?? `on${event.name.charAt(0).toUpperCase()}${event.name.slice(1)}`
       parts.push(`${handlerName}={() => {}}`)
     }
 

--- a/packages/jsx/src/__tests__/adapter-output.test.ts
+++ b/packages/jsx/src/__tests__/adapter-output.test.ts
@@ -347,9 +347,8 @@ describe('Adapter output', () => {
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
-      // No-op setter must accept arguments
-      expect(template.content).toContain('(..._args: any[]) => {}')
-      expect(template.content).not.toMatch(/const \w+ = \(\) => \{\}/)
+      // Unused setter (only used in event handler) should be omitted entirely
+      expect(template.content).not.toContain('setCount')
     })
 
     test('signal setter accepts arguments in generated SSR template (TestAdapter)', () => {
@@ -366,7 +365,8 @@ describe('Adapter output', () => {
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
-      expect(template.content).toContain('(..._args: any[]) => {}')
+      // Unused setter (only used in event handler) should be omitted entirely
+      expect(template.content).not.toContain('setCount')
     })
 
     test('local function parameters preserve type annotations', () => {
@@ -430,7 +430,7 @@ describe('Adapter output', () => {
       expect(template.content).not.toContain('CounterPropsWithHydration')
     })
 
-    test('unused signal setter is prefixed with _ when only used in event handlers', () => {
+    test('unused signal setter is omitted when only used in event handlers', () => {
       const honoAdapter = new HonoAdapter()
       const source = `
         'use client'
@@ -445,9 +445,9 @@ describe('Adapter output', () => {
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
-      // setCount is only used in onClick which becomes () => {} in SSR
-      expect(template.content).toContain('_setCount')
-      expect(template.content).not.toMatch(/\bconst setCount\b/)
+      // setCount is only used in onClick which becomes () => {} in SSR — omit entirely
+      expect(template.content).not.toContain('setCount')
+      expect(template.content).not.toContain('_setCount')
     })
 
     test('event handler functions not emitted when only used in event handlers', () => {

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -222,8 +222,9 @@ export class TestAdapter extends BaseAdapter {
       lines.push(`  const ${signal.getter} = () => ${initialValue}`)
       if (signal.setter) {
         const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
-        const setterName = setterUsed ? signal.setter : `_${signal.setter}`
-        lines.push(`  const ${setterName} = (..._args: any[]) => {}`)
+        if (setterUsed) {
+          lines.push(`  const ${signal.setter} = (..._args: any[]) => {}`)
+        }
       }
     }
 
@@ -372,7 +373,7 @@ export class TestAdapter extends BaseAdapter {
     }
 
     for (const event of element.events) {
-      const handlerName = `on${event.name.charAt(0).toUpperCase()}${event.name.slice(1)}`
+      const handlerName = event.originalAttr ?? `on${event.name.charAt(0).toUpperCase()}${event.name.slice(1)}`
       parts.push(`${handlerName}={() => {}}`)
     }
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -530,6 +530,7 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     ? elements[1].name.text
     : null
   const initialValue = callExpr.arguments[0] ? ctx.getJS(callExpr.arguments[0]) : ''
+  const typedInitialValue = callExpr.arguments[0] ? callExpr.arguments[0].getText(ctx.sourceFile) : undefined
 
   // Try to infer type from initial value or type argument
   let type: TypeInfo = { kind: 'unknown', raw: 'unknown' }
@@ -546,6 +547,7 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     getter,
     setter,
     initialValue,
+    typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
@@ -570,6 +572,7 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
   const name = (node.name as ts.Identifier).text
   const callExpr = node.initializer as ts.CallExpression
   const computation = callExpr.arguments[0] ? ctx.getJS(callExpr.arguments[0]) : ''
+  const typedComputation = callExpr.arguments[0] ? callExpr.arguments[0].getText(ctx.sourceFile) : undefined
 
   // Extract dependencies from computation
   const deps = extractDependencies(computation, ctx)
@@ -583,6 +586,7 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
   ctx.memos.push({
     name,
     computation,
+    typedComputation: typedComputation !== computation ? typedComputation : undefined,
     type,
     deps,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
@@ -805,6 +809,7 @@ function collectFunction(
     defaultValue: p.initializer ? ctx.getJS(p.initializer) : undefined,
   }))
   const body = node.body ? ctx.getJS(node.body) : ''
+  const typedBody = node.body ? node.body.getText(ctx.sourceFile) : undefined
   const returnType = typeNodeToTypeInfo(node.type, ctx.sourceFile)
 
   // Check if function contains JSX
@@ -827,6 +832,7 @@ function collectFunction(
     name,
     params,
     body,
+    typedBody: typedBody !== body ? typedBody : undefined,
     returnType,
     containsJsx,
     isExported,
@@ -936,6 +942,9 @@ function collectConstant(
   const value = node.initializer
     ? ctx.getJS(node.initializer)
     : undefined
+  const typedValue = node.initializer
+    ? node.initializer.getText(ctx.sourceFile)
+    : undefined
 
   // Detect JSX initializers and store AST nodes for IR-level inlining (#547)
   let isJsx = false
@@ -1004,6 +1013,7 @@ function collectConstant(
   ctx.localConstants.push({
     name,
     value,
+    typedValue: typedValue !== value ? typedValue : undefined,
     valueBranches,
     declarationKind,
     isExported,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1197,6 +1197,7 @@ function transformMapCall(
   let sortComparator: SortComparatorResult | undefined
   let chainOrder: 'filter-sort' | 'sort-filter' | undefined
   let mapPreamble: string | undefined
+  let typedMapPreamble: string | undefined
 
   const filterInfo = isFilterCall(mapSource)
   const sortInfo = isSortCall(mapSource)
@@ -1319,18 +1320,26 @@ function transformMapCall(
   // Get callback function
   const callback = node.arguments[0]
   let param = 'item'
+  let paramType: string | undefined
   let index: string | null = null
+  let indexType: string | undefined
   let children: IRNode[] = []
 
   if (ts.isArrowFunction(callback)) {
-    // Extract parameter names
+    // Extract parameter names and type annotations
     if (callback.parameters.length > 0) {
       const firstParam = callback.parameters[0]
       param = firstParam.name.getText(ctx.sourceFile)
+      if (firstParam.type) {
+        paramType = firstParam.type.getText(ctx.sourceFile)
+      }
     }
     if (callback.parameters.length > 1) {
       const secondParam = callback.parameters[1]
       index = secondParam.name.getText(ctx.sourceFile)
+      if (secondParam.type) {
+        indexType = secondParam.type.getText(ctx.sourceFile)
+      }
     }
 
     // Register loop params so expressions referencing them get slotId
@@ -1369,13 +1378,21 @@ function transformMapCall(
           }
         }
         const preambleStmts: string[] = []
+        const typedPreambleStmts: string[] = []
+        let hasTypeDiff = false
         for (const stmt of body.statements) {
           if (stmt === returnStmt) break
           const js = ctx.getJS(stmt)
+          const ts = stmt.getText(ctx.sourceFile)
           preambleStmts.push(js.endsWith(';') ? js : js + ';')
+          typedPreambleStmts.push(ts.endsWith(';') ? ts : ts + ';')
+          if (js !== ts) hasTypeDiff = true
         }
         if (preambleStmts.length > 0) {
           mapPreamble = preambleStmts.join(' ')
+          if (hasTypeDiff) {
+            typedMapPreamble = typedPreambleStmts.join(' ')
+          }
         }
       }
     }
@@ -1458,6 +1475,9 @@ function transformMapCall(
     chainOrder,
     clientOnly: isClientOnly || undefined,
     mapPreamble,
+    paramType,
+    indexType,
+    typedMapPreamble,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -1580,6 +1600,7 @@ function processAttributes(
         const eventName = name.slice(2).toLowerCase()
         events.push({
           name: eventName,
+          originalAttr: name,
           handler: ctx.getJS(attr.initializer.expression),
           loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
         })

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -233,6 +233,13 @@ export interface IRLoop {
    * stores "const label = item.name.toUpperCase();" as mapPreamble.
    */
   mapPreamble?: string
+
+  /** Type annotation for loop param (e.g., 'Desk'), preserved for .tsx output */
+  paramType?: string
+  /** Type annotation for loop index param (e.g., 'number'), preserved for .tsx output */
+  indexType?: string
+  /** mapPreamble with TypeScript type annotations preserved, for .tsx output */
+  typedMapPreamble?: string
 }
 
 export interface IRComponent {
@@ -334,6 +341,7 @@ export interface IRAttribute extends AttrMeta {
 
 export interface IREvent {
   name: string // 'click', 'input', 'keydown'
+  originalAttr?: string // Original JSX attribute name: 'onClick', 'onKeyDown'
   handler: string // JS expression: '() => setCount(n => n + 1)'
   loc: SourceLocation
 }
@@ -356,6 +364,8 @@ export interface SignalInfo {
   getter: string
   setter: string | null
   initialValue: string
+  /** Initial value with TypeScript type annotations preserved, for .tsx output */
+  typedInitialValue?: string
   type: TypeInfo
   loc: SourceLocation
 }
@@ -363,6 +373,8 @@ export interface SignalInfo {
 export interface MemoInfo {
   name: string
   computation: string
+  /** Computation with TypeScript type annotations preserved, for .tsx output */
+  typedComputation?: string
   type: TypeInfo
   deps: string[]
   loc: SourceLocation
@@ -397,6 +409,8 @@ export interface FunctionInfo {
   name: string
   params: ParamInfo[]
   body: string
+  /** Body with TypeScript type annotations preserved, for .tsx output */
+  typedBody?: string
   returnType: TypeInfo | null
   containsJsx: boolean
   isExported?: boolean
@@ -410,6 +424,8 @@ export interface FunctionInfo {
 export interface ConstantInfo {
   name: string
   value?: string
+  /** Value with TypeScript type annotations preserved, for .tsx output */
+  typedValue?: string
   valueBranches?: string[]
   declarationKind: 'const' | 'let'
   isExported?: boolean


### PR DESCRIPTION
## Summary

Fixes three categories of strict TypeScript errors in compiled marked templates (Hono adapter `.tsx` output) that previously required `// @ts-nocheck`:

- **Unused variables (`noUnusedLocals`)**: Omit unused signal setters entirely instead of prefixing with `_`. Filter type definitions to only include those referenced in the component body.
- **Event handler casing**: Store original JSX attribute name (`onKeyDown`) in `IREvent.originalAttr` so adapters emit correct camelCase instead of reconstructing `onKeydown` from the lowercase DOM event name.
- **Implicit `any` (`noImplicitAny`)**: Preserve TypeScript type annotations alongside type-stripped code in IR metadata (`typedValue`, `typedBody`, `typedComputation`, `typedInitialValue`, `typedMapPreamble`, `paramType`, `indexType`). Hono adapter uses typed versions for `.tsx` output while client JS generator continues using untyped versions.

Closes #779

## Test plan

- [x] All 1290 existing tests pass (compiler, adapter conformance, Hono adapter, CSR, runtime)
- [x] Updated existing tests for new unused-setter behavior (omit vs `_` prefix)
- [ ] Verify with piconic desk that `// @ts-nocheck` can be removed from compiled templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)