### PR TITLE
Fix compiler emitting raw jsxDEV calls in conditional branch with .map()

### DIFF
--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -185,3 +185,116 @@ describe('composite loops inside conditional branches (#724)', () => {
     expect(js).toContain("createComponent('Badge'")
   })
 })
+
+describe('direct map call as conditional branch (#783)', () => {
+  test('logical AND with direct .map() does not emit jsxDEV calls', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Group { key: string; label: string; items: string[] }
+
+      export function GroupList(props) {
+        const [mode, setMode] = createSignal('flat')
+        const [groups] = createSignal(props.initialGroups)
+
+        return (
+          <div>
+            <button onClick={() => setMode(mode() === 'flat' ? 'grouped' : 'flat')}>
+              Toggle
+            </button>
+            {mode() === 'grouped' &&
+              groups().map((group) => (
+                <div key={group.key} className="group">
+                  <h2>{group.label}</h2>
+                  <ul>
+                    {group.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'GroupList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Must NOT contain raw jsxDEV calls
+    expect(js).not.toMatch(/jsxDEV/)
+
+    // Template should contain inline .map() expression
+    expect(js).toContain('.map(')
+  })
+
+  test('ternary with direct .map() in true branch', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function ItemList(props) {
+        const [items] = createSignal(props.initialItems)
+
+        return (
+          <div>
+            {items().length > 0
+              ? items().map((item) => (
+                  <div key={item.id}>{item.name}</div>
+                ))
+              : <p>No items</p>
+            }
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Must NOT contain raw jsxDEV calls
+    expect(js).not.toMatch(/jsxDEV/)
+
+    // Template should contain inline .map() expression
+    expect(js).toContain('.map(')
+  })
+
+  test('parenthesized .map() in conditional branch', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function TagList(props) {
+        const [show] = createSignal(true)
+        const [tags] = createSignal(props.tags)
+
+        return (
+          <div>
+            {show() && (tags().map((tag) => (
+              <span key={tag}>{tag}</span>
+            )))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'TagList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Must NOT contain raw jsxDEV calls
+    expect(js).not.toMatch(/jsxDEV/)
+
+    // Template should contain inline .map() expression
+    expect(js).toContain('.map(')
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -966,6 +966,14 @@ function transformConditionalBranch(
     }
   }
 
+  // Map call returning JSX in conditional branch (#783)
+  if (ts.isCallExpression(node) && isMapCall(node)) {
+    const mapResult = transformMapCall(node, ctx)
+    if (mapResult) {
+      return mapResult
+    }
+  }
+
   // Regular expression (including null)
   const exprText = ctx.getJS(node)
   return {


### PR DESCRIPTION
## Summary

Closes #783

- `transformConditionalBranch()` did not handle `.map()` calls returning JSX, causing raw `jsxDEV()` function calls to leak into the compiled template string
- Added `.map()` detection in `transformConditionalBranch()`, mirroring the existing pattern in `transformExpression()` (lines 695-701)
- The downstream pipeline (template generation, element collection, branch loop collection) already handles `IRLoop` nodes in conditional branches correctly

## Root Cause

When `{condition && items.map(item => <div>...</div>)}` was compiled, `transformConditionalBranch()` checked for JSX elements, parenthesized expressions, nested ternaries, logical AND, nullish coalescing, and JSX function calls — but not `.map()` calls. The `.map()` fell through to the "Regular expression" handler, which called `ctx.getJS(node)` producing raw JavaScript with `jsxDEV()` calls that don't exist at runtime.

## Test plan

- [x] Added 3 test cases in `composite-branch-loop.test.ts`:
  - Logical AND with direct `.map()` (issue's reproduction case with nested maps)
  - Ternary with direct `.map()` in true branch
  - Parenthesized `.map()` in conditional branch
- [x] All 988 compiler unit tests pass (0 failures)