### PR TITLE
Fix unused imports and type inference gaps in compiled marked templates

### DIFF
--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -70,9 +70,11 @@ export class HonoAdapter implements TemplateAdapter {
     this.componentName = ir.metadata.componentName
     this.isClientComponent = ir.metadata.isClientComponent
 
-    const imports = this.generateImports(ir)
+    // Generate component body FIRST so we can scan it for used imports
     const component = this.generateComponent(ir)
     const types = this.generateTypes(ir, component)
+    const componentCode = [types, component].filter(Boolean).join('\n')
+    const imports = this.generateImports(ir, componentCode)
 
     const defaultExport = ir.metadata.hasDefaultExport
       ? `\nexport default ${this.componentName}`
@@ -100,15 +102,29 @@ export class HonoAdapter implements TemplateAdapter {
   // Imports Generation
   // ===========================================================================
 
-  private generateImports(ir: ComponentIR): string {
+  private generateImports(ir: ComponentIR, componentCode: string): string {
     const lines: string[] = []
 
-    // Add bfComment/bfText for hydration markers
-    lines.push("import { bfComment, bfText, bfTextEnd } from '@barefootjs/hono/utils'")
+    // Only import bfComment/bfText/bfTextEnd utilities that are actually used
+    const utilImports: string[] = []
+    for (const util of ['bfComment', 'bfText', 'bfTextEnd']) {
+      if (new RegExp(`\\b${util}\\b`).test(componentCode)) {
+        utilImports.push(util)
+      }
+    }
+    if (utilImports.length > 0) {
+      lines.push(`import { ${utilImports.join(', ')} } from '@barefootjs/hono/utils'`)
+    }
 
-    // Re-export original imports (excluding @barefootjs/client-runtime)
+    // Re-export original imports, skipping all barefootjs client-side modules
+    // (their exports are replaced by SSR no-ops in generateSignalInitializers)
+    const ssrSkippedSources = new Set([
+      '@barefootjs/client-runtime',
+      '@barefootjs/dom',
+      '@barefootjs/client',
+    ])
     for (const imp of ir.metadata.imports) {
-      if (imp.source === '@barefootjs/client-runtime') continue
+      if (ssrSkippedSources.has(imp.source)) continue
       if (imp.specifiers.length === 0) {
         if (!imp.isTypeOnly) {
           lines.push(`import '${imp.source}'`)
@@ -454,7 +470,17 @@ export class HonoAdapter implements TemplateAdapter {
       // Use typed version when available to preserve type annotations in .tsx output
       const rawInitialValue = signal.typedInitialValue ?? signal.initialValue
       const initialValue = rawInitialValue.trim().startsWith('{') ? `(${rawInitialValue})` : rawInitialValue
-      lines.push(`  const ${signal.getter} = () => ${initialValue}`)
+      // When typedInitialValue is absent but signal.type has a meaningful type from a generic
+      // parameter (e.g. createSignal<string[]>([])), add a type assertion to prevent TS
+      // from inferring never[] / {} / null etc.
+      const needsTypeAssertion = !signal.typedInitialValue
+        && signal.type.raw !== 'unknown'
+        && signal.type.raw !== signal.initialValue
+      if (needsTypeAssertion) {
+        lines.push(`  const ${signal.getter} = () => ${initialValue} as ${signal.type.raw}`)
+      } else {
+        lines.push(`  const ${signal.getter} = () => ${initialValue}`)
+      }
       // Create a no-op setter for SSR — omit entirely if not referenced anywhere
       const setterUsed = new RegExp(`\\b${signal.setter}\\b`).test(setterRefText)
       if (setterUsed) {

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -474,8 +474,8 @@ export class HonoAdapter implements TemplateAdapter {
       // parameter (e.g. createSignal<string[]>([])), add a type assertion to prevent TS
       // from inferring never[] / {} / null etc.
       const needsTypeAssertion = !signal.typedInitialValue
-        && signal.type.raw !== 'unknown'
-        && signal.type.raw !== signal.initialValue
+        && signal.type.kind !== 'unknown'
+        && signal.type.kind !== 'primitive'
       if (needsTypeAssertion) {
         lines.push(`  const ${signal.getter} = () => ${initialValue} as ${signal.type.raw}`)
       } else {

--- a/packages/jsx/src/__tests__/adapter-output.test.ts
+++ b/packages/jsx/src/__tests__/adapter-output.test.ts
@@ -534,4 +534,126 @@ describe('Adapter output', () => {
       expect(template.content).toContain('__bfParentProps: _bfParentProps')
     })
   })
+
+  describe('unused imports and type inference (#782)', () => {
+    test('static component omits bfComment/bfText/bfTextEnd imports', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        export function Logo() {
+          return <div class="logo">BarefootJS</div>
+        }
+      `
+      const result = compileJSXSync(source, 'Logo.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template.content).not.toContain("from '@barefootjs/hono/utils'")
+    })
+
+    test('interactive component only imports used hono utilities', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Should have bfComment (for hydration markers) but only the ones actually used
+      const importLine = template.content.split('\n').find(l => l.includes("from '@barefootjs/hono/utils'"))
+      if (importLine) {
+        // Each imported name should actually appear in the component body
+        const importedNames = importLine.match(/\b(bfComment|bfText|bfTextEnd)\b/g) ?? []
+        const componentBody = template.content.slice(template.content.indexOf('export function'))
+        for (const name of importedNames) {
+          expect(componentBody).toContain(name)
+        }
+      }
+    })
+
+    test('@barefootjs/client-runtime imports are skipped in SSR output', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      expect(template.content).not.toContain("from '@barefootjs/client-runtime'")
+      expect(template.content).not.toContain("from '@barefootjs/dom'")
+      expect(template.content).not.toContain("from '@barefootjs/client'")
+    })
+
+    test('signal with generic type parameter emits type assertion in SSR getter', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function TodoList() {
+          const [items, setItems] = createSignal<string[]>([])
+          return <span>{items().length}</span>
+        }
+      `
+      const result = compileJSXSync(source, 'TodoList.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Should emit typed assertion: [] as string[] instead of bare []
+      expect(template.content).toMatch(/items\s*=\s*\(\)\s*=>\s*\[\]\s+as\s+string\[\]/)
+    })
+
+    test('signal with inline type annotation preserves it without duplication', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function Panel() {
+          const [ids, setIds] = createSignal([] as string[])
+          return <span>{ids().length}</span>
+        }
+      `
+      const result = compileJSXSync(source, 'Panel.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Should preserve the inline annotation, not add a duplicate
+      expect(template.content).toContain('[] as string[]')
+      // Should NOT have double assertion: [] as string[] as string[]
+      expect(template.content).not.toContain('as string[] as string[]')
+    })
+
+    test('signal with primitive type does not emit redundant assertion', () => {
+      const honoAdapter = new HonoAdapter()
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function Counter() {
+          const [count, setCount] = createSignal(0)
+          return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      // Primitive initial value should NOT have redundant `as number`
+      expect(template.content).not.toMatch(/\b0\s+as\s+number\b/)
+    })
+  })
 })

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -229,7 +229,21 @@ function compileMultipleComponentsSync(
     return { files, errors }
   }
 
-  // Use imports from first component (they should be similar)
+  // Merge imports from all components, deduplicating by line
+  const seenImportLines = new Set<string>()
+  const uniqueImports: string[] = []
+  for (const output of allOutputs) {
+    if (output.imports) {
+      for (const line of output.imports.split('\n')) {
+        if (line.trim() && !seenImportLines.has(line)) {
+          seenImportLines.add(line)
+          uniqueImports.push(line)
+        }
+      }
+    }
+  }
+  const mergedImports = uniqueImports.join('\n')
+
   // Combine unique type definitions
   const seenTypes = new Set<string>()
   const uniqueTypes: string[] = []
@@ -256,7 +270,7 @@ function compileMultipleComponentsSync(
 
   // Combine all components
   const combinedTemplate = [
-    allOutputs[0].imports,
+    mergedImports,
     uniqueTypes.join('\n\n'),
     uniqueModuleExports.length > 0 ? uniqueModuleExports.join('\n') : '',
     ...allOutputs.map(o => o.component),


### PR DESCRIPTION
## Summary

Closes #782

- Only emit `bfComment`/`bfText`/`bfTextEnd` imports when actually used in the generated component (fixes TS6192 unused import errors)
- Skip `@barefootjs/dom` and `@barefootjs/client` imports in SSR output, matching the existing pattern in test-adapter and client JS codegen (fixes TS6133 `createSignal` unused errors)
- Add type assertion for signal SSR no-ops when the type comes from a generic parameter (e.g. `createSignal<string[]>([])` → `() => [] as string[]` instead of `() => []` which infers `never[]`)

## Test plan

- [x] adapter-tests: 161 pass
- [x] hono adapter tests: 53 pass
- [x] compiler unit tests: 519 pass
- [x] `bun run build` in `packages/hono` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)