### PR TITLE
Fix reactive props.xxx not tracked in Phase 2 client JS generation

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2332,4 +2332,46 @@ describe('Client JS generation', () => {
       expect(content).toMatch(/initChild\('Alert'/)
     })
   })
+
+  describe('reactive props.xxx detection (#789)', () => {
+    test('generates createEffect for props.xxx with inherited type props', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        interface BaseProps {
+          disabled?: boolean
+          className?: string
+        }
+        interface MyButtonProps extends BaseProps {
+          label: string
+        }
+
+        export function MyButton(props: MyButtonProps) {
+          const [count, setCount] = createSignal(0)
+          return <button disabled={props.disabled ?? false} className={props.className ?? ''}>{count()}</button>
+        }
+      `
+      const result = compileJSXSync(source, 'MyButton.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // props.disabled and props.className should trigger createEffect wrapping
+      expect(clientJs!.content).toContain('createEffect')
+    })
+
+    test('does not wrap props.children in createEffect', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function Wrapper(props: { children?: any }) {
+          const [count, setCount] = createSignal(0)
+          return <div>{count()}</div>
+        }
+      `
+      const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+    })
+  })
 })

--- a/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { needsEffectWrapper } from '../../ir-to-client-js/reactivity'
+import { valueReferencesReactiveData } from '../../ir-to-client-js/prop-handling'
 import type { ClientJsContext } from '../../ir-to-client-js/types'
 
 const dummyLoc = { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
@@ -99,5 +100,34 @@ describe('needsEffectWrapper', () => {
       const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
       expect(needsEffectWrapper('"static string"', ctx)).toBe(false)
     })
+  })
+})
+
+describe('valueReferencesReactiveData', () => {
+  test('extracts inherited props not in propsParams via pattern fallback', () => {
+    const ctx = makeContext({
+      propsObjectName: 'props',
+      propsParams: [{ name: 'checked', type: { kind: 'unknown', raw: 'boolean' }, optional: true }],
+    })
+    const result = valueReferencesReactiveData('props.checked || props.disabled', ctx)
+    expect(result.usesProps).toBe(true)
+    expect(result.usedProps).toContain('checked')
+    expect(result.usedProps).toContain('disabled')
+  })
+
+  test('does not duplicate props already found by propsParams loop', () => {
+    const ctx = makeContext({
+      propsObjectName: 'props',
+      propsParams: [{ name: 'disabled', type: { kind: 'unknown', raw: 'boolean' }, optional: true }],
+    })
+    const result = valueReferencesReactiveData('props.disabled', ctx)
+    expect(result.usedProps).toEqual(['disabled'])
+  })
+
+  test('excludes props.children from extraction', () => {
+    const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+    const result = valueReferencesReactiveData('props.children', ctx)
+    expect(result.usedProps).toEqual([])
+    expect(result.usesProps).toBe(false)
   })
 })

--- a/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from 'bun:test'
+import { needsEffectWrapper } from '../../ir-to-client-js/reactivity'
+import type { ClientJsContext } from '../../ir-to-client-js/types'
+
+const dummyLoc = { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
+
+function makeContext(overrides: Partial<ClientJsContext> = {}): ClientJsContext {
+  return {
+    componentName: 'Test',
+    signals: [],
+    memos: [],
+    effects: [],
+    onMounts: [],
+    localFunctions: [],
+    localConstants: [],
+    propsParams: [],
+    propsObjectName: null,
+    restPropsName: null,
+    interactiveElements: [],
+    dynamicElements: [],
+    conditionalElements: [],
+    loopElements: [],
+    refElements: [],
+    childInits: [],
+    reactiveProps: [],
+    reactiveChildProps: [],
+    reactiveAttrs: [],
+    clientOnlyElements: [],
+    clientOnlyConditionals: [],
+    providerSetups: [],
+    restAttrElements: [],
+    warnings: [],
+    ...overrides,
+  }
+}
+
+describe('needsEffectWrapper', () => {
+  describe('signal detection', () => {
+    test('detects signal getter call', () => {
+      const ctx = makeContext({ signals: [{ getter: 'count', setter: 'setCount', initialValue: '0', type: { kind: 'unknown', raw: 'number' }, loc: dummyLoc }] })
+      expect(needsEffectWrapper('count()', ctx)).toBe(true)
+    })
+
+    test('does not match signal name without call', () => {
+      const ctx = makeContext({ signals: [{ getter: 'count', setter: 'setCount', initialValue: '0', type: { kind: 'unknown', raw: 'number' }, loc: dummyLoc }] })
+      expect(needsEffectWrapper('count', ctx)).toBe(false)
+    })
+  })
+
+  describe('memo detection', () => {
+    test('detects memo call', () => {
+      const ctx = makeContext({ memos: [{ name: 'doubled', computation: 'count() * 2', type: { kind: 'unknown', raw: 'number' }, deps: [], loc: dummyLoc }] })
+      expect(needsEffectWrapper('doubled()', ctx)).toBe(true)
+    })
+  })
+
+  describe('props.xxx pattern detection', () => {
+    test('detects props.xxx when propsParams is empty but propsObjectName is set', () => {
+      const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+      expect(needsEffectWrapper('props.disabled ?? false', ctx)).toBe(true)
+    })
+
+    test('detects props.xxx in template literal', () => {
+      const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+      expect(needsEffectWrapper('`${props.className ?? ""} extra`', ctx)).toBe(true)
+    })
+
+    test('detects props.xxx with custom props object name', () => {
+      const ctx = makeContext({ propsObjectName: 'p', propsParams: [] })
+      expect(needsEffectWrapper('p.disabled', ctx)).toBe(true)
+    })
+
+    test('excludes props.children', () => {
+      const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+      expect(needsEffectWrapper('props.children', ctx)).toBe(false)
+    })
+
+    test('detects props.xxx even when props.children is also present', () => {
+      const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+      expect(needsEffectWrapper('props.disabled || props.children', ctx)).toBe(true)
+    })
+
+    test('works alongside populated propsParams', () => {
+      const ctx = makeContext({
+        propsObjectName: 'props',
+        propsParams: [{ name: 'checked', type: { kind: 'unknown', raw: 'boolean' }, optional: true }],
+      })
+      // 'checked' matched via propsParams, 'disabled' matched via fallback pattern
+      expect(needsEffectWrapper('props.checked', ctx)).toBe(true)
+      expect(needsEffectWrapper('props.disabled', ctx)).toBe(true)
+    })
+
+    test('does not match when propsObjectName is null (destructured)', () => {
+      const ctx = makeContext({ propsObjectName: null, propsParams: [] })
+      expect(needsEffectWrapper('props.disabled', ctx)).toBe(false)
+    })
+
+    test('does not match unrelated identifiers', () => {
+      const ctx = makeContext({ propsObjectName: 'props', propsParams: [] })
+      expect(needsEffectWrapper('"static string"', ctx)).toBe(false)
+    })
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -54,13 +54,15 @@ export function valueReferencesReactiveData(
     }
   }
 
-  // Fallback: extract prop names from props.xxx pattern when propsParams is incomplete
-  // (e.g., inherited props from extended interfaces not resolved by extractPropsFromType)
-  if (ctx.propsObjectName && usedProps.length === 0) {
+  // Also extract prop names from props.xxx pattern directly.
+  // propsParams may be incomplete when extractPropsFromType couldn't resolve inherited
+  // props (e.g., CheckboxProps extends ButtonHTMLAttributes → 'disabled' not extracted).
+  // Always run this to catch props missed by the propsParams loop above.
+  if (ctx.propsObjectName) {
     const propsAccess = new RegExp(`\\b${ctx.propsObjectName}\\.(\\w+)`, 'g')
     let match: RegExpExecArray | null
     while ((match = propsAccess.exec(value)) !== null) {
-      if (match[1] !== 'children') {
+      if (match[1] !== 'children' && !usedProps.includes(match[1])) {
         usedProps.push(match[1])
       }
     }

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -54,6 +54,18 @@ export function valueReferencesReactiveData(
     }
   }
 
+  // Fallback: extract prop names from props.xxx pattern when propsParams is incomplete
+  // (e.g., inherited props from extended interfaces not resolved by extractPropsFromType)
+  if (ctx.propsObjectName && usedProps.length === 0) {
+    const propsAccess = new RegExp(`\\b${ctx.propsObjectName}\\.(\\w+)`, 'g')
+    let match: RegExpExecArray | null
+    while ((match = propsAccess.exec(value)) !== null) {
+      if (match[1] !== 'children') {
+        usedProps.push(match[1])
+      }
+    }
+  }
+
   for (const signal of ctx.signals) {
     if (new RegExp(`\\b${signal.getter}\\s*\\(`).test(value)) {
       usesSignals = true

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -51,6 +51,14 @@ export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean 
     }
   }
 
+  // Fallback: detect props.xxx pattern directly when propsObjectName is known.
+  // Catches cases where extractPropsFromType couldn't resolve inherited props
+  // (e.g., CheckboxProps extends ButtonHTMLAttributes → 'disabled' not in propsParams).
+  if (ctx.propsObjectName) {
+    const propsAccess = new RegExp(`\\b${ctx.propsObjectName}\\.(?!children\\b)\\w+`)
+    if (propsAccess.test(expr)) return true
+  }
+
   return false
 }
 

--- a/ui/components/ui/carousel/index.tsx
+++ b/ui/components/ui/carousel/index.tsx
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, onCleanup } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, onCleanup } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes, ButtonHTMLAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { ChevronLeftIcon, ChevronRightIcon } from '../icon'
@@ -76,7 +76,7 @@ interface CarouselProps extends HTMLBaseAttributes {
 }
 
 function Carousel(props: CarouselProps) {
-  const orientation = props.orientation ?? 'horizontal'
+  const orientation = createMemo(() => props.orientation ?? 'horizontal')
   const [canScrollPrev, setCanScrollPrev] = createSignal(false)
   const [canScrollNext, setCanScrollNext] = createSignal(false)
   let emblaApi: EmblaCarouselType | undefined
@@ -86,7 +86,7 @@ function Carousel(props: CarouselProps) {
 
   const handleMount = (el: HTMLElement) => {
     el.addEventListener('keydown', (e: KeyboardEvent) => {
-      if (orientation === 'horizontal') {
+      if (orientation() === 'horizontal') {
         if (e.key === 'ArrowLeft') { e.preventDefault(); scrollPrev() }
         else if (e.key === 'ArrowRight') { e.preventDefault(); scrollNext() }
       } else {
@@ -98,7 +98,7 @@ function Carousel(props: CarouselProps) {
 
   return (
     <CarouselContext.Provider value={{
-      orientation,
+      orientation: orientation(),
       scrollPrev,
       scrollNext,
       canScrollPrev,
@@ -114,7 +114,7 @@ function Carousel(props: CarouselProps) {
         className={`${carouselClasses} ${props.className ?? ''}`}
         tabindex={0}
         ref={handleMount}
-        data-orientation={orientation}
+        data-orientation={orientation()}
         data-opts={props.opts ? JSON.stringify(props.opts) : undefined}
       >
         {props.children}
@@ -131,7 +131,7 @@ interface CarouselContentProps extends HTMLBaseAttributes {
 }
 
 function CarouselContent(props: CarouselContentProps) {
-  const orientation = props.orientation ?? 'horizontal'
+  const orientation = createMemo(() => props.orientation ?? 'horizontal')
 
   const handleMount = (el: HTMLElement) => {
     const ctx = useContext(CarouselContext)
@@ -171,13 +171,13 @@ function CarouselContent(props: CarouselContentProps) {
     })
   }
 
-  const directionClasses = orientation === 'vertical' ? 'flex-col -mt-4' : 'flex -ml-4'
+  const directionClasses = createMemo(() => orientation() === 'vertical' ? 'flex-col -mt-4' : 'flex -ml-4')
 
   return (
     <div data-slot="carousel-viewport" className="overflow-hidden">
       <div
         data-slot="carousel-content"
-        className={`${directionClasses} ${props.className ?? ''}`}
+        className={`${directionClasses()} ${props.className ?? ''}`}
         ref={handleMount}
       >
         {props.children}
@@ -194,14 +194,14 @@ interface CarouselItemProps extends HTMLBaseAttributes {
 }
 
 function CarouselItem(props: CarouselItemProps) {
-  const paddingClass = (props.orientation ?? 'horizontal') === 'vertical' ? 'pt-4' : 'pl-4'
+  const paddingClass = createMemo(() => (props.orientation ?? 'horizontal') === 'vertical' ? 'pt-4' : 'pl-4')
 
   return (
     <div
       data-slot="carousel-item"
       role="group"
       aria-roledescription="slide"
-      className={`${carouselItemClasses} ${paddingClass} ${props.className ?? ''}`}
+      className={`${carouselItemClasses} ${paddingClass()} ${props.className ?? ''}`}
     >
       {props.children}
     </div>
@@ -219,8 +219,8 @@ const prevHorizontalClasses = '-left-12 top-1/2 -translate-y-1/2'
 const prevVerticalClasses = '-top-12 left-1/2 -translate-x-1/2 rotate-90'
 
 function CarouselPrevious(props: CarouselPreviousProps) {
-  const orientation = props.orientation ?? 'horizontal'
-  const positionClasses = orientation === 'vertical' ? prevVerticalClasses : prevHorizontalClasses
+  const orientation = createMemo(() => props.orientation ?? 'horizontal')
+  const positionClasses = createMemo(() => orientation() === 'vertical' ? prevVerticalClasses : prevHorizontalClasses)
 
   const handleMount = (el: HTMLElement) => {
     const ctx = useContext(CarouselContext)
@@ -240,7 +240,7 @@ function CarouselPrevious(props: CarouselPreviousProps) {
     <button
       data-slot="carousel-previous"
       type="button"
-      className={`${carouselButtonBaseClasses} ${positionClasses} ${props.className ?? ''}`}
+      className={`${carouselButtonBaseClasses} ${positionClasses()} ${props.className ?? ''}`}
       disabled
       aria-label="Previous slide"
       ref={handleMount}
@@ -262,8 +262,8 @@ const nextHorizontalClasses = '-right-12 top-1/2 -translate-y-1/2'
 const nextVerticalClasses = '-bottom-12 left-1/2 -translate-x-1/2 rotate-90'
 
 function CarouselNext(props: CarouselNextProps) {
-  const orientation = props.orientation ?? 'horizontal'
-  const positionClasses = orientation === 'vertical' ? nextVerticalClasses : nextHorizontalClasses
+  const orientation = createMemo(() => props.orientation ?? 'horizontal')
+  const positionClasses = createMemo(() => orientation() === 'vertical' ? nextVerticalClasses : nextHorizontalClasses)
 
   const handleMount = (el: HTMLElement) => {
     const ctx = useContext(CarouselContext)
@@ -283,7 +283,7 @@ function CarouselNext(props: CarouselNextProps) {
     <button
       data-slot="carousel-next"
       type="button"
-      className={`${carouselButtonBaseClasses} ${positionClasses} ${props.className ?? ''}`}
+      className={`${carouselButtonBaseClasses} ${positionClasses()} ${props.className ?? ''}`}
       disabled
       aria-label="Next slide"
       ref={handleMount}

--- a/ui/components/ui/checkbox/index.tsx
+++ b/ui/components/ui/checkbox/index.tsx
@@ -109,7 +109,9 @@ function Checkbox(props: CheckboxProps) {
   const isChecked = createMemo(() => isControlled() ? controlledChecked() : internalChecked())
 
   // Classes - state styling handled by data-state attribute selectors
-  const classes = `${baseClasses} ${focusClasses} ${errorClasses} ${stateClasses} ${props.className ?? ''} grid place-content-center`
+  const classes = createMemo(() =>
+    `${baseClasses} ${focusClasses} ${errorClasses} ${stateClasses} ${props.className ?? ''} grid place-content-center`
+  )
 
   // Click handler — only updates signals; the compiler's reactivity handles
   // data-state, aria-checked, and conditional SVG via insert().
@@ -134,7 +136,7 @@ function Checkbox(props: CheckboxProps) {
       aria-checked={isChecked()}
       aria-invalid={props.error || undefined}
       disabled={props.disabled ?? false}
-      className={classes}
+      className={classes()}
       onClick={handleClick}
     >
       {isChecked() && (

--- a/ui/components/ui/combobox/index.tsx
+++ b/ui/components/ui/combobox/index.tsx
@@ -38,7 +38,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes, ButtonHTMLAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { CheckIcon, ChevronDownIcon, SearchIcon } from '../icon'
@@ -166,12 +166,12 @@ function Combobox(props: ComboboxProps) {
   const [search, setSearch] = createSignal('')
   // Internal state for uncontrolled mode (when value prop is not provided)
   const [internalValue, setInternalValue] = createSignal(props.value ?? '')
-  const isControlled = props.value !== undefined
+  const isControlled = createMemo(() => props.value !== undefined)
 
-  const filterFn = props.filter ?? ((value: string, search: string) => {
+  const filterFn = createMemo(() => props.filter ?? ((value: string, search: string) => {
     if (!search) return true
     return value.toLowerCase().includes(search.toLowerCase())
-  })
+  }))
 
   return (
     <ComboboxContext.Provider value={{
@@ -181,14 +181,14 @@ function Combobox(props: ComboboxProps) {
         // Clear search when closing
         if (!v) setSearch('')
       },
-      value: () => isControlled ? (props.value ?? '') : internalValue(),
+      value: () => isControlled() ? (props.value ?? '') : internalValue(),
       onValueChange: (v: string) => {
-        if (!isControlled) setInternalValue(v)
+        if (!isControlled()) setInternalValue(v)
         if (props.onValueChange) props.onValueChange(v)
       },
       search,
       onSearchChange: setSearch,
-      filter: filterFn,
+      filter: filterFn(),
     }}>
       <div data-slot="combobox" id={props.id} className={`relative inline-block ${props.className ?? ''}`}>
         {props.children}
@@ -568,8 +568,8 @@ function ComboboxItem(props: ComboboxItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
-  const stateClasses = isDisabled ? itemDisabledClasses : itemDefaultClasses
+  const isDisabled = createMemo(() => props.disabled ?? false)
+  const stateClasses = createMemo(() => isDisabled() ? itemDisabledClasses : itemDefaultClasses)
 
   return (
     <div
@@ -580,9 +580,9 @@ function ComboboxItem(props: ComboboxItemProps) {
       role="option"
       id={props.id}
       aria-selected="false"
-      aria-disabled={isDisabled || undefined}
+      aria-disabled={isDisabled() || undefined}
       tabindex={-1}
-      className={`${itemBaseClasses} ${stateClasses} ${props.className ?? ''}`}
+      className={`${itemBaseClasses} ${stateClasses()} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span data-slot="combobox-item-indicator" className={indicatorClasses} style="display:none">

--- a/ui/components/ui/pagination/index.tsx
+++ b/ui/components/ui/pagination/index.tsx
@@ -31,6 +31,7 @@
  */
 
 import type { AnchorHTMLAttributes, HTMLBaseAttributes } from '@barefootjs/jsx'
+import { createMemo } from '@barefootjs/client'
 import type { Child } from '../../../types'
 import { ChevronLeftIcon, ChevronRightIcon, EllipsisIcon } from '../icon'
 
@@ -96,14 +97,14 @@ interface PaginationLinkProps extends AnchorHTMLAttributes {
 }
 
 function PaginationLink(props: PaginationLinkProps) {
-  const size = props.size ?? 'icon'
+  const size = createMemo(() => props.size ?? 'icon')
   return (
     <a
       aria-current={props.isActive ? 'page' : undefined}
       data-slot="pagination-link"
       data-active={props.isActive}
       id={props.id}
-      className={`${buttonBaseClasses} ${props.isActive ? variantClasses.outline : variantClasses.ghost} ${sizeClasses[size]} ${props.className ?? ''}`}
+      className={`${buttonBaseClasses} ${props.isActive ? variantClasses.outline : variantClasses.ghost} ${sizeClasses[size()]} ${props.className ?? ''}`}
       href={props.href}
       onClick={props.onClick}
     >

--- a/ui/components/ui/progress/index.tsx
+++ b/ui/components/ui/progress/index.tsx
@@ -51,22 +51,22 @@ interface ProgressProps extends HTMLBaseAttributes {
  * Progress component for displaying task completion.
  */
 function Progress(props: ProgressProps) {
-  const max = props.max ?? 100
+  const max = createMemo(() => props.max ?? 100)
 
   // Track the value reactively
   const [currentValue, setCurrentValue] = createSignal(props.value ?? 0)
 
   // Compute percentage clamped to [0, 100]
   const percentage = createMemo(() => {
-    if (max <= 0) return 0
-    return Math.max(0, Math.min(100, (currentValue() / max) * 100))
+    if (max() <= 0) return 0
+    return Math.max(0, Math.min(100, (currentValue() / max()) * 100))
   })
 
   // Compute data-state: "complete" when value >= max, otherwise "loading"
-  const dataState = createMemo(() => currentValue() >= max ? 'complete' : 'loading')
+  const dataState = createMemo(() => currentValue() >= max() ? 'complete' : 'loading')
 
-  const rootClasses = `${rootBaseClasses} ${props.className ?? ''}`
-  const indicatorClasses = `${indicatorBaseClasses} ${props.indicatorClassName ?? ''}`
+  const rootClasses = createMemo(() => `${rootBaseClasses} ${props.className ?? ''}`)
+  const indicatorClasses = createMemo(() => `${indicatorBaseClasses} ${props.indicatorClassName ?? ''}`)
 
   return (
     <div
@@ -75,14 +75,14 @@ function Progress(props: ProgressProps) {
       role="progressbar"
       aria-valuenow={currentValue()}
       aria-valuemin={0}
-      aria-valuemax={max}
+      aria-valuemax={max()}
       data-state={dataState()}
-      className={rootClasses}
+      className={rootClasses()}
     >
       <div
         data-slot="progress-indicator"
         data-state={dataState()}
-        className={indicatorClasses}
+        className={indicatorClasses()}
         style={`transform: translateX(-${100 - percentage()}%)`}
       />
     </div>

--- a/ui/components/ui/sidebar/index.tsx
+++ b/ui/components/ui/sidebar/index.tsx
@@ -35,6 +35,7 @@
 
 import {
   createSignal,
+  createMemo,
   createEffect,
   onCleanup,
 } from '@barefootjs/client'
@@ -166,11 +167,11 @@ interface SidebarProps extends HTMLBaseAttributes {
 }
 
 function Sidebar(props: SidebarProps) {
-  const side = props.side ?? 'left'
-  const variant = props.variant ?? 'sidebar'
-  const collapsible = props.collapsible ?? 'offcanvas'
+  const side = createMemo(() => props.side ?? 'left')
+  const variant = createMemo(() => props.variant ?? 'sidebar')
+  const collapsible = createMemo(() => props.collapsible ?? 'offcanvas')
 
-  if (collapsible === 'none') {
+  if (collapsible() === 'none') {
     return (
       <div
         data-slot="sidebar"
@@ -190,44 +191,52 @@ function Sidebar(props: SidebarProps) {
     createEffect(() => {
       const s = ctx.state()
       el.dataset.state = s
-      el.dataset.collapsible = s === 'collapsed' ? collapsible : ''
+      el.dataset.collapsible = s === 'collapsed' ? collapsible() : ''
       el.style.display = ctx.isMobile() ? 'none' : ''
     })
   }
 
   // Gap width classes
-  const gapFloatingOrInset = variant === 'floating' || variant === 'inset'
-  const gapClasses = `relative w-[var(--sidebar-width)] bg-transparent transition-[width] duration-200 ease-linear group-data-[collapsible=offcanvas]:w-0 ${side === 'right' ? 'rotate-180' : ''} ${gapFloatingOrInset ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem)]' : 'group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)]'}`
+  const gapClasses = createMemo(() => {
+    const gapFloatingOrInset = variant() === 'floating' || variant() === 'inset'
+    return `relative w-[var(--sidebar-width)] bg-transparent transition-[width] duration-200 ease-linear group-data-[collapsible=offcanvas]:w-0 ${side() === 'right' ? 'rotate-180' : ''} ${gapFloatingOrInset ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem)]' : 'group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)]'}`
+  })
 
   // Container classes
-  const containerBase = `absolute inset-y-0 z-10 hidden h-full w-[var(--sidebar-width)] transition-[left,right,width] duration-200 ease-linear md:flex`
-  const containerSide = side === 'left'
-    ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-    : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]'
-  const containerVariant = gapFloatingOrInset
-    ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]'
-    : `group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)] ${side === 'left' ? 'border-r' : 'border-l'}`
+  const containerClasses = createMemo(() => {
+    const gapFloatingOrInset = variant() === 'floating' || variant() === 'inset'
+    const base = `absolute inset-y-0 z-10 hidden h-full w-[var(--sidebar-width)] transition-[left,right,width] duration-200 ease-linear md:flex`
+    const sideClass = side() === 'left'
+      ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+      : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]'
+    const variantClass = gapFloatingOrInset
+      ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]'
+      : `group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)] ${side() === 'left' ? 'border-r' : 'border-l'}`
+    return `${base} ${sideClass} ${variantClass}`
+  })
 
   // Inner classes
-  const innerClasses = `bg-background flex size-full flex-col ${variant === 'floating' ? 'rounded-lg shadow-sm ring-1 ring-border' : ''}`
+  const innerClasses = createMemo(() =>
+    `bg-background flex size-full flex-col ${variant() === 'floating' ? 'rounded-lg shadow-sm ring-1 ring-border' : ''}`
+  )
 
   return (
     <div
       className="group peer text-foreground hidden md:block"
       data-state="expanded"
       data-collapsible=""
-      data-variant={variant}
-      data-side={side}
+      data-variant={variant()}
+      data-side={side()}
       data-slot="sidebar"
       ref={handleDesktopMount}
     >
-      <div data-slot="sidebar-gap" className={gapClasses} />
+      <div data-slot="sidebar-gap" className={gapClasses()} />
       <div
         data-slot="sidebar-container"
-        data-side={side}
-        className={`${containerBase} ${containerSide} ${containerVariant} ${props.className ?? ''}`}
+        data-side={side()}
+        className={`${containerClasses()} ${props.className ?? ''}`}
       >
-        <div data-sidebar="sidebar" data-slot="sidebar-inner" className={innerClasses}>
+        <div data-sidebar="sidebar" data-slot="sidebar-inner" className={innerClasses()}>
           {props.children}
         </div>
       </div>
@@ -526,14 +535,16 @@ interface SidebarMenuButtonProps extends ButtonHTMLAttributes {
 }
 
 function SidebarMenuButton(props: SidebarMenuButtonProps) {
-  const variant = props.variant ?? 'default'
-  const size = props.size ?? 'default'
-  const isActive = props.isActive ?? false
+  const variant = createMemo(() => props.variant ?? 'default')
+  const size = createMemo(() => props.size ?? 'default')
+  const isActive = createMemo(() => props.isActive ?? false)
 
-  const classes = `${menuButtonBaseClasses} ${menuButtonVariantClasses[variant]} ${menuButtonSizeClasses[size]} ${props.className ?? ''}`
+  const classes = createMemo(() =>
+    `${menuButtonBaseClasses} ${menuButtonVariantClasses[variant()]} ${menuButtonSizeClasses[size()]} ${props.className ?? ''}`
+  )
 
   const handleMount = (el: HTMLElement) => {
-    if (isActive) {
+    if (isActive()) {
       el.dataset.active = 'true'
     }
   }
@@ -541,10 +552,10 @@ function SidebarMenuButton(props: SidebarMenuButtonProps) {
   return (
     <button
       data-slot="sidebar-menu-button"
-      data-size={size}
-      data-active={isActive || undefined}
+      data-size={size()}
+      data-active={isActive() || undefined}
       type="button"
-      className={classes}
+      className={classes()}
       ref={handleMount}
     >
       {props.children}

--- a/ui/components/ui/slider/index.tsx
+++ b/ui/components/ui/slider/index.tsx
@@ -83,12 +83,12 @@ interface SliderProps extends HTMLBaseAttributes {
  * Supports both controlled and uncontrolled modes.
  */
 function Slider(props: SliderProps) {
-  const min = props.min ?? 0
-  const max = props.max ?? 100
-  const step = props.step ?? 1
+  const min = createMemo(() => props.min ?? 0)
+  const max = createMemo(() => props.max ?? 100)
+  const step = createMemo(() => props.step ?? 1)
 
   // Internal state for uncontrolled mode
-  const [internalValue, setInternalValue] = createSignal(props.defaultValue ?? min)
+  const [internalValue, setInternalValue] = createSignal(props.defaultValue ?? min())
 
   // Controlled state - synced from parent via DOM attribute
   // When parent passes value={signal()}, the compiler generates a sync effect
@@ -103,29 +103,29 @@ function Slider(props: SliderProps) {
 
   // Compute percentage for positioning
   const percentage = createMemo(() => {
-    if (max <= min) return 0
-    return Math.max(0, Math.min(100, ((currentValue() - min) / (max - min)) * 100))
+    if (max() <= min()) return 0
+    return Math.max(0, Math.min(100, ((currentValue() - min()) / (max() - min())) * 100))
   })
 
   // Snap a raw value to the nearest step
   const snapToStep = (rawValue: number): number => {
-    const stepped = Math.round((rawValue - min) / step) * step + min
+    const stepped = Math.round((rawValue - min()) / step()) * step() + min()
     // Round to avoid floating point issues
-    const decimals = (step.toString().split('.')[1] || '').length
+    const decimals = (step().toString().split('.')[1] || '').length
     const rounded = parseFloat(stepped.toFixed(decimals))
-    return Math.max(min, Math.min(max, rounded))
+    return Math.max(min(), Math.min(max(), rounded))
   }
 
   // Calculate value from pointer position relative to track
   const getValueFromPointer = (clientX: number, trackRect: DOMRect): number => {
     const pct = (clientX - trackRect.left) / trackRect.width
-    const rawValue = min + pct * (max - min)
+    const rawValue = min() + pct * (max() - min())
     return snapToStep(rawValue)
   }
 
   // Update DOM elements to reflect current value
   const updateSliderUI = (root: HTMLElement, value: number) => {
-    const pct = ((value - min) / (max - min)) * 100
+    const pct = ((value - min()) / (max() - min())) * 100
     const thumb = root.querySelector('[data-slot="slider-thumb"]') as HTMLElement
     const range = root.querySelector('[data-slot="slider-range"]') as HTMLElement
 
@@ -199,17 +199,17 @@ function Slider(props: SliderProps) {
     switch (e.key) {
       case 'ArrowRight':
       case 'ArrowUp':
-        newValue = snapToStep(current + step)
+        newValue = snapToStep(current + step())
         break
       case 'ArrowLeft':
       case 'ArrowDown':
-        newValue = snapToStep(current - step)
+        newValue = snapToStep(current - step())
         break
       case 'Home':
-        newValue = min
+        newValue = min()
         break
       case 'End':
-        newValue = max
+        newValue = max()
         break
       default:
         return
@@ -243,8 +243,8 @@ function Slider(props: SliderProps) {
       <span
         data-slot="slider-thumb"
         role="slider"
-        aria-valuemin={min}
-        aria-valuemax={max}
+        aria-valuemin={min()}
+        aria-valuemax={max()}
         aria-valuenow={currentValue()}
         tabindex={props.disabled ? -1 : 0}
         className={thumbClasses}


### PR DESCRIPTION
## Summary

Fixes #789 — Two-part fix for reactive props not updating after hydration.

### Part 1: Compiler — `needsEffectWrapper()` misses `props.xxx` pattern

- **Root cause**: `extractPropsFromType()` only extracts directly declared interface members, not inherited ones (e.g., `disabled` from `ButtonHTMLAttributes`). When `propsParams` is incomplete, `needsEffectWrapper()` fails to detect `props.xxx` as reactive.
- **Fix**: Added `props.xxx` pattern detection as a fallback in both `needsEffectWrapper()` (reactivity.ts) and `valueReferencesReactiveData()` (prop-handling.ts). Uses `propsObjectName` to match any `props.xxx` access (excluding `props.children`).

### Part 2: UI Components — `const` captures losing reactivity

Replaced `const x = props.xxx` with `const x = createMemo(() => props.xxx)` in 7 components:

| Component | Props memoized |
|-----------|---------------|
| checkbox | `classes` (className) |
| slider | `min`, `max`, `step` |
| progress | `max`, `rootClasses`, `indicatorClasses` |
| carousel | `orientation` (×5), `paddingClass`, `directionClasses`, `positionClasses` (×2) |
| sidebar | `side`, `variant`, `collapsible`, `gapClasses`, `containerClasses`, `innerClasses`, MenuButton `variant`/`size`/`isActive`/`classes` |
| pagination | `size` |
| combobox | `isControlled`, `filterFn`, `isDisabled`, `stateClasses` |

drawer and scroll-area skipped (LOW severity — reads already inside `createEffect` callbacks).

## Test plan

- [x] New unit tests for `needsEffectWrapper()` with empty `propsParams` + `propsObjectName` set (11 tests)
- [x] Integration test: component with inherited type props generates `createEffect`
- [x] Full compiler test suite passes (547 tests, 0 failures)
- [ ] E2E tests for affected components (checkbox, slider, etc.)

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)