### PR TITLE
Fix const-captured props losing reactivity in 8 UI components

### DIFF
--- a/ui/components/ui/accordion/index.tsx
+++ b/ui/components/ui/accordion/index.tsx
@@ -23,7 +23,7 @@
  */
 
 import type { ButtonHTMLAttributes, HTMLBaseAttributes } from '@barefootjs/jsx'
-import { createContext, useContext, createEffect } from '@barefootjs/client-runtime'
+import { createContext, useContext, createMemo, createEffect } from '@barefootjs/client-runtime'
 import type { Child } from '../../../types'
 import { ChevronDownIcon } from '../icon'
 
@@ -272,7 +272,7 @@ function AccordionContent(props: AccordionContentProps) {
     })
   }
 
-  const className = props.className ?? ''
+  const className = createMemo(() => props.className ?? '')
 
   return (
     <div
@@ -284,7 +284,7 @@ function AccordionContent(props: AccordionContentProps) {
       ref={handleMount}
     >
       <div className={accordionContentInnerClasses}>
-        <div className={`pt-0 pb-4 ${className}`}>
+        <div className={`pt-0 pb-4 ${className()}`}>
           {props.children}
         </div>
       </div>

--- a/ui/components/ui/command/index.tsx
+++ b/ui/components/ui/command/index.tsx
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect } from '@barefootjs/client-runtime'
 import {
   Dialog,
   DialogOverlay,
@@ -146,10 +146,10 @@ function Command(props: CommandProps) {
   const [selectedValue, setSelectedValue] = createSignal('')
   const items = new Set<HTMLElement>()
 
-  const filterFn = props.filter ?? ((value: string, search: string) => {
+  const filterFn = createMemo(() => props.filter ?? ((value: string, search: string) => {
     if (!search) return true
     return value.toLowerCase().includes(search.toLowerCase())
-  })
+  }))
 
   const handleMount = (el: HTMLElement) => {
     // Auto-select first visible item when search changes
@@ -215,7 +215,7 @@ function Command(props: CommandProps) {
       },
       registerItem: (el: HTMLElement) => items.add(el),
       unregisterItem: (el: HTMLElement) => items.delete(el),
-      filter: filterFn,
+      filter: filterFn(),
     }}>
       <div
         data-slot="command"
@@ -407,14 +407,14 @@ function CommandItem(props: CommandItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
       data-slot="command-item"
       id={props.id}
       role="option"
-      data-disabled={isDisabled || undefined}
+      data-disabled={isDisabled() || undefined}
       data-selected="false"
       className={`${commandItemClasses} ${props.className ?? ''}`}
       ref={handleMount}

--- a/ui/components/ui/context-menu/index.tsx
+++ b/ui/components/ui/context-menu/index.tsx
@@ -35,7 +35,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { CheckIcon, ChevronRightIcon } from '../icon'
@@ -391,22 +391,22 @@ function ContextMenuItem(props: ContextMenuItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
-  const isDestructive = props.variant === 'destructive'
-  const stateClasses = isDisabled
+  const isDisabled = createMemo(() => props.disabled ?? false)
+  const isDestructive = createMemo(() => props.variant === 'destructive')
+  const stateClasses = createMemo(() => isDisabled()
     ? contextMenuItemDisabledClasses
-    : isDestructive
+    : isDestructive()
       ? contextMenuItemDestructiveClasses
-      : contextMenuItemDefaultClasses
+      : contextMenuItemDefaultClasses)
 
   return (
     <div
       data-slot="context-menu-item"
       role="menuitem"
       id={props.id}
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${contextMenuItemBaseClasses} ${stateClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${contextMenuItemBaseClasses} ${stateClasses()} ${props.className ?? ''}`}
       ref={handleMount}
     >
       {props.children}
@@ -444,7 +444,7 @@ function ContextMenuCheckboxItem(props: ContextMenuCheckboxItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -452,9 +452,9 @@ function ContextMenuCheckboxItem(props: ContextMenuCheckboxItemProps) {
       role="menuitemcheckbox"
       id={props.id}
       aria-checked={String(props.checked ?? false)}
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${contextMenuCheckableItemClasses} ${isDisabled ? contextMenuItemDisabledClasses : contextMenuItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${contextMenuCheckableItemClasses} ${isDisabled() ? contextMenuItemDisabledClasses : contextMenuItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={contextMenuIndicatorClasses}>
@@ -525,7 +525,7 @@ function ContextMenuRadioItem(props: ContextMenuRadioItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -533,9 +533,9 @@ function ContextMenuRadioItem(props: ContextMenuRadioItemProps) {
       role="menuitemradio"
       id={props.id}
       aria-checked="false"
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${contextMenuCheckableItemClasses} ${isDisabled ? contextMenuItemDisabledClasses : contextMenuItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${contextMenuCheckableItemClasses} ${isDisabled() ? contextMenuItemDisabledClasses : contextMenuItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={contextMenuIndicatorClasses} data-slot="context-menu-radio-indicator">

--- a/ui/components/ui/dropdown-menu/index.tsx
+++ b/ui/components/ui/dropdown-menu/index.tsx
@@ -36,7 +36,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
 import type { ButtonHTMLAttributes, HTMLBaseAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { CheckIcon, ChevronRightIcon } from '../icon'
@@ -418,22 +418,22 @@ function DropdownMenuItem(props: DropdownMenuItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
-  const isDestructive = props.variant === 'destructive'
-  const stateClasses = isDisabled
+  const isDisabled = createMemo(() => props.disabled ?? false)
+  const isDestructive = createMemo(() => props.variant === 'destructive')
+  const stateClasses = createMemo(() => isDisabled()
     ? dropdownMenuItemDisabledClasses
-    : isDestructive
+    : isDestructive()
       ? dropdownMenuItemDestructiveClasses
-      : dropdownMenuItemDefaultClasses
+      : dropdownMenuItemDefaultClasses)
 
   return (
     <div
       data-slot="dropdown-menu-item"
       role="menuitem"
       id={props.id}
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${dropdownMenuItemBaseClasses} ${stateClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${dropdownMenuItemBaseClasses} ${stateClasses()} ${props.className ?? ''}`}
       ref={handleMount}
     >
       {props.children}
@@ -471,7 +471,7 @@ function DropdownMenuCheckboxItem(props: DropdownMenuCheckboxItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -479,9 +479,9 @@ function DropdownMenuCheckboxItem(props: DropdownMenuCheckboxItemProps) {
       role="menuitemcheckbox"
       id={props.id}
       aria-checked={String(props.checked ?? false)}
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${dropdownMenuCheckableItemClasses} ${isDisabled ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={dropdownMenuIndicatorClasses}>
@@ -552,7 +552,7 @@ function DropdownMenuRadioItem(props: DropdownMenuRadioItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -560,9 +560,9 @@ function DropdownMenuRadioItem(props: DropdownMenuRadioItemProps) {
       role="menuitemradio"
       id={props.id}
       aria-checked="false"
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${dropdownMenuCheckableItemClasses} ${isDisabled ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={dropdownMenuIndicatorClasses} data-slot="dropdown-menu-radio-indicator">

--- a/ui/components/ui/input-otp/index.tsx
+++ b/ui/components/ui/input-otp/index.tsx
@@ -29,7 +29,7 @@
  */
 
 import type { HTMLBaseAttributes } from '@barefootjs/jsx'
-import { createSignal, createContext, useContext, createEffect } from '@barefootjs/client-runtime'
+import { createSignal, createMemo, createContext, useContext, createEffect } from '@barefootjs/client-runtime'
 import type { Child } from '../../../types'
 import { MinusIcon } from '../icon'
 
@@ -117,7 +117,7 @@ function InputOTP(props: InputOTPProps) {
   const [isFocused, setIsFocused] = createSignal(false)
 
   const getValue = () => props.value !== undefined ? (props.value ?? '') : internalValue()
-  const pattern = resolvePattern(props.pattern)
+  const pattern = createMemo(() => resolvePattern(props.pattern))
 
   const updateValue = (newValue: string) => {
     const truncated = newValue.slice(0, props.maxLength)
@@ -153,7 +153,7 @@ function InputOTP(props: InputOTPProps) {
       // Filter by pattern character-by-character
       let filtered = ''
       for (const ch of raw) {
-        if (pattern.test(ch)) {
+        if (pattern().test(ch)) {
           filtered += ch
         }
       }
@@ -188,7 +188,7 @@ function InputOTP(props: InputOTPProps) {
       const pasted = e.clipboardData?.getData('text') ?? ''
       let filtered = ''
       for (const ch of pasted) {
-        if (pattern.test(ch)) {
+        if (pattern().test(ch)) {
           filtered += ch
         }
       }
@@ -314,14 +314,13 @@ function InputOTPSlot(props: InputOTPSlotProps) {
     })
   }
 
-  const className = props.className ?? ''
-  const classes = `${slotBaseClasses} ${slotActiveClasses} ${className}`
+  const className = createMemo(() => props.className ?? '')
 
   return (
     <div
       data-slot="input-otp-slot"
       data-active="false"
-      className={classes}
+      className={`${slotBaseClasses} ${slotActiveClasses} ${className()}`}
       ref={handleMount}
     >
       <span data-otp-char></span>

--- a/ui/components/ui/menubar/index.tsx
+++ b/ui/components/ui/menubar/index.tsx
@@ -39,7 +39,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { CheckIcon, ChevronRightIcon } from '../icon'
@@ -521,7 +521,7 @@ function MenubarCheckboxItem(props: MenubarCheckboxItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -529,9 +529,9 @@ function MenubarCheckboxItem(props: MenubarCheckboxItemProps) {
       role="menuitemcheckbox"
       id={props.id}
       aria-checked={String(props.checked ?? false)}
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${menubarCheckableItemClasses} ${isDisabled ? menubarItemDisabledClasses : menubarItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${menubarCheckableItemClasses} ${isDisabled() ? menubarItemDisabledClasses : menubarItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={menubarIndicatorClasses}>
@@ -599,7 +599,7 @@ function MenubarRadioItem(props: MenubarRadioItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
+  const isDisabled = createMemo(() => props.disabled ?? false)
 
   return (
     <div
@@ -607,9 +607,9 @@ function MenubarRadioItem(props: MenubarRadioItemProps) {
       role="menuitemradio"
       id={props.id}
       aria-checked="false"
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${menubarCheckableItemClasses} ${isDisabled ? menubarItemDisabledClasses : menubarItemDefaultClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${menubarCheckableItemClasses} ${isDisabled() ? menubarItemDisabledClasses : menubarItemDefaultClasses} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span className={menubarIndicatorClasses} data-slot="menubar-radio-indicator">

--- a/ui/components/ui/navigation-menu/index.tsx
+++ b/ui/components/ui/navigation-menu/index.tsx
@@ -35,7 +35,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { ChevronDownIcon } from '../icon'
@@ -450,19 +450,18 @@ interface NavigationMenuLinkProps extends HTMLBaseAttributes {
  * Navigation link element. Stateless.
  * When active, renders with aria-current="page" and data-active.
  */
-function NavigationMenuLink({ children, className = '', ...props }: NavigationMenuLinkProps) {
-  const isActive = props.active ?? false
+function NavigationMenuLink(props: NavigationMenuLinkProps) {
+  const isActive = createMemo(() => props.active ?? false)
 
   return (
     <a
       data-slot="navigation-menu-link"
       href={props.href}
-      aria-current={isActive ? 'page' : undefined}
-      data-active={isActive || undefined}
-      className={`${navigationMenuLinkBaseClasses} ${isActive ? navigationMenuLinkActiveClasses : ''} ${className}`}
-      {...props}
+      aria-current={isActive() ? 'page' : undefined}
+      data-active={isActive() || undefined}
+      className={`${navigationMenuLinkBaseClasses} ${isActive() ? navigationMenuLinkActiveClasses : ''} ${props.className ?? ''}`}
     >
-      {children}
+      {props.children}
     </a>
   )
 }

--- a/ui/components/ui/select/index.tsx
+++ b/ui/components/ui/select/index.tsx
@@ -34,7 +34,7 @@
  * ```
  */
 
-import { createContext, useContext, createSignal, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
+import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client-runtime'
 import type { HTMLBaseAttributes, ButtonHTMLAttributes } from '@barefootjs/jsx'
 import type { Child } from '../../../types'
 import { CheckIcon, ChevronDownIcon } from '../icon'
@@ -107,15 +107,15 @@ function Select(props: SelectProps) {
   const [open, setOpen] = createSignal(false)
   // Internal state for uncontrolled mode (when value prop is not provided)
   const [internalValue, setInternalValue] = createSignal(props.value ?? '')
-  const isControlled = props.value !== undefined
+  const isControlled = createMemo(() => props.value !== undefined)
 
   return (
     <SelectContext.Provider value={{
       open,
       onOpenChange: (v) => { setOpen(v); props.onOpenChange?.(v) },
-      value: () => isControlled ? (props.value ?? '') : internalValue(),
+      value: () => isControlled() ? (props.value ?? '') : internalValue(),
       onValueChange: (v: string) => {
-        if (!isControlled) setInternalValue(v)
+        if (!isControlled()) setInternalValue(v)
         if (props.onValueChange) props.onValueChange(v)
       },
       disabled: () => props.disabled ?? false,
@@ -458,8 +458,8 @@ function SelectItem(props: SelectItemProps) {
     })
   }
 
-  const isDisabled = props.disabled ?? false
-  const stateClasses = isDisabled ? selectItemDisabledClasses : selectItemDefaultClasses
+  const isDisabled = createMemo(() => props.disabled ?? false)
+  const stateClasses = createMemo(() => isDisabled() ? selectItemDisabledClasses : selectItemDefaultClasses)
 
   return (
     <div
@@ -469,9 +469,9 @@ function SelectItem(props: SelectItemProps) {
       role="option"
       id={props.id}
       aria-selected="false"
-      aria-disabled={isDisabled || undefined}
-      tabindex={isDisabled ? -1 : 0}
-      className={`${selectItemBaseClasses} ${stateClasses} ${props.className ?? ''}`}
+      aria-disabled={isDisabled() || undefined}
+      tabindex={isDisabled() ? -1 : 0}
+      className={`${selectItemBaseClasses} ${stateClasses()} ${props.className ?? ''}`}
       ref={handleMount}
     >
       <span data-slot="select-item-indicator" className={selectIndicatorClasses} style="display:none">


### PR DESCRIPTION
## Summary

Closes #792

Follow-up to #789 / PR #790. Wraps `props.xxx` captured into plain `const` variables with `createMemo()` to maintain SolidJS-style reactivity. Without this, prop changes from the parent are silently ignored after initial render.

### Components fixed

**HIGH — disabled/variant props (a11y impact)**
- `context-menu`: ContextMenuItem (`isDisabled`, `isDestructive`, `stateClasses`), ContextMenuCheckboxItem, ContextMenuRadioItem
- `dropdown-menu`: DropdownMenuItem (`isDisabled`, `isDestructive`, `stateClasses`), DropdownMenuCheckboxItem, DropdownMenuRadioItem
- `menubar`: MenubarCheckboxItem, MenubarRadioItem (MenubarItem already reactive via createEffect)
- `select`: Select (`isControlled`), SelectItem (`isDisabled`, `stateClasses`)
- `input-otp`: InputOTP (`pattern`), InputOTPSlot (`className`)
- `command`: Command (`filterFn`), CommandItem (`isDisabled`)

**MEDIUM — class/state props**
- `accordion`: AccordionContent (`className`)
- `navigation-menu`: NavigationMenuLink (`isActive` + removed prop destructuring per compiler constraint)

### Out of scope (confirmed correct)
- hover-card/popover: `align`/`side` inside `updatePosition()` — re-evaluated each call
- scroll-area: DOM query at mount, not reactive props
- collapsible: Already uses arrow functions
- MenubarItem: Already inside createEffect

## Test plan

- [x] All 8 affected component IR tests pass (2472 unit tests, 0 failures)
- [x] Adapter conformance tests pass (161 tests)
- [x] Compiler tests pass (550 tests)
- [ ] E2E tests (require dev server — verify in CI)


🤖 Generated with [Claude Code](https://claude.com/claude-code)