### PR TITLE
Fix Bun.Transpiler re-introducing jsxDEV calls during minification

### DIFF
--- a/examples/echo/build.ts
+++ b/examples/echo/build.ts
@@ -463,7 +463,7 @@ combineClientJsFiles()
 // Minify client JS (after combine so all files are final)
 if (config.minify) {
   // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
-  const transpiler = new Bun.Transpiler({ minifyWhitespace: true, minifySyntax: true })
+  const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
   const clientFiles = readdirSync(clientDir).filter(f => f.endsWith('.js'))
   for (const file of clientFiles) {
     const filePath = resolve(clientDir, file)

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -156,3 +156,31 @@ describe('resolveBuildConfigFromTs', () => {
     expect(config.outDir).toBe('/test/project/build/output')
   })
 })
+
+// ── minification ────────────────────────────────────────────────────────
+
+describe('minification does not re-introduce jsxDEV', () => {
+  test('Bun.Transpiler with loader: js preserves HTML in template literals', () => {
+    const transpiler = new Bun.Transpiler({
+      loader: 'js',
+      minifyWhitespace: true,
+      minifySyntax: true,
+    })
+
+    const clientJs = `
+import { createSignal, createEffect } from '@barefootjs/client-runtime'
+export function __bf_init_Counter(el, props) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
+  const __tpl = document.createElement('template')
+  __tpl.innerHTML = \`<div class="counter"><p>\${count()}</p><button>+1</button></div>\`
+  el.appendChild(__tpl.content.cloneNode(true))
+}
+`
+    const result = transpiler.transformSync(clientJs)
+
+    expect(result).not.toContain('jsxDEV')
+    expect(result).not.toContain('jsx(')
+    expect(result).toContain('innerHTML')
+    expect(result).toContain('counter')
+  })
+})

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -302,7 +302,7 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
   // 7. Minify client JS (after combine so all files are final)
   if (config.minify) {
     // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
-    const transpiler = new Bun.Transpiler({ minifyWhitespace: true, minifySyntax: true })
+    const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
     for (const [, entry] of Object.entries(manifest)) {
       if (!entry.clientJs) continue
       const filePath = resolve(config.outDir, entry.clientJs)


### PR DESCRIPTION
## Summary

- Add `loader: 'js'` to `Bun.Transpiler` options in the minification step so it treats compiled client JS as plain JavaScript
- This prevents `minifySyntax` from converting HTML template literals back into `jsxDEV()` calls that don't exist at runtime
- Add regression test verifying minified output doesn't contain `jsxDEV`

## Root cause

`Bun.Transpiler` without an explicit `loader` auto-detects the file format. When compiled client JS contains HTML inside template literals (e.g., `__tpl.innerHTML = \`<div>...</div>\``), the transpiler misinterprets it as JSX and applies JSX transformation with `minifySyntax: true`.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/lib/build.ts` | Add `loader: 'js'` to Transpiler options |
| `examples/echo/build.ts` | Same fix |
| `packages/cli/src/__tests__/build.test.ts` | Regression test |

## Test plan

- [x] `bun test` in `packages/cli/` — 263 tests pass
- [ ] CI passes

Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)