### PR TITLE
Create @barefootjs/shared for marker constants

### DIFF
--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -34,6 +34,9 @@
     "url": "https://github.com/kfly8/barefootjs",
     "directory": "packages/client-runtime"
   },
+  "dependencies": {
+    "@barefootjs/shared": "workspace:*"
+  },
   "peerDependencies": {
     "@barefootjs/client": ">=0.0.1"
   },

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -41,6 +41,9 @@
     "url": "https://github.com/kfly8/barefootjs",
     "directory": "packages/jsx"
   },
+  "dependencies": {
+    "@barefootjs/shared": "workspace:*"
+  },
   "peerDependencies": {
     "@barefootjs/client-runtime": "workspace:*"
   },

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -10,6 +10,7 @@ import type {
   IRNode,
   ImportSpecifier,
 } from '../types'
+import { BF_SCOPE, BF_SLOT, BF_COND } from '@barefootjs/shared'
 import { BaseAdapter } from './interface'
 import { formatParamWithType, findReachableNames } from '../module-exports'
 
@@ -189,14 +190,14 @@ export abstract class JsxAdapter extends BaseAdapter {
   // ===========================================================================
 
   renderScopeMarker(instanceIdExpr: string): string {
-    return `bf-s={${instanceIdExpr}}`
+    return `${BF_SCOPE}={${instanceIdExpr}}`
   }
 
   renderSlotMarker(slotId: string): string {
-    return `bf="${slotId}"`
+    return `${BF_SLOT}="${slotId}"`
   }
 
   renderCondMarker(condId: string): string {
-    return `bf-c="${condId}"`
+    return `${BF_COND}="${condId}"`
   }
 }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -5,31 +5,21 @@
 
 import type { IRTemplateLiteral } from '../types'
 import type { LoopElement } from './types'
+import {
+  BF_KEY as DATA_KEY,
+  BF_KEY_PREFIX as DATA_KEY_PREFIX,
+  BF_PLACEHOLDER as DATA_BF_PH,
+  BF_LOOP_START,
+  BF_LOOP_END,
+} from '@barefootjs/shared'
+
+export { DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH, BF_LOOP_START, BF_LOOP_END }
 
 /**
  * Parameter name for the props object in generated init/template functions.
  * Short name to minimize client JS bundle size.
  */
 export const PROPS_PARAM = '_p'
-
-/**
- * HTML attribute constants for compiler-generated code.
- * These are the same values as the runtime constants in packages/dom/src/attrs.ts
- * (BF_KEY, BF_KEY_PREFIX, BF_PLACEHOLDER). Duplicated here because the compiler
- * package cannot depend on the runtime package.
- *
- * @see packages/dom/src/attrs.ts — runtime-side definitions
- */
-export const DATA_KEY = 'data-key'
-export const DATA_KEY_PREFIX = 'data-key-'
-export const DATA_BF_PH = 'data-bf-ph'
-
-/**
- * Loop boundary comment markers.
- * @see packages/dom/src/attrs.ts — BF_LOOP_START, BF_LOOP_END (runtime-side mirror)
- */
-export const BF_LOOP_START = 'bf-loop'
-export const BF_LOOP_END = 'bf-/loop'
 
 /**
  * Get the data-key attribute name for a given loop depth.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@barefootjs/shared",
+  "version": "0.0.1",
+  "description": "Shared constants for BarefootJS compiler and runtime",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "keywords": [
+    "barefoot",
+    "shared"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kfly8/barefootjs",
+    "directory": "packages/shared"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,23 +1,18 @@
-/**
- * BarefootJS - HTML Attribute Constants
- *
- * Re-exported from @barefootjs/shared (single source of truth).
- */
 export {
   BF_SCOPE,
   BF_SLOT,
   BF_PROPS,
   BF_COND,
+  BF_ITEM,
   BF_PORTAL_OWNER,
   BF_PORTAL_ID,
   BF_PORTAL_PLACEHOLDER,
-  BF_ITEM,
   BF_CHILD_PREFIX,
   BF_PARENT_OWNED_PREFIX,
   BF_SCOPE_COMMENT_PREFIX,
+  BF_LOOP_START,
+  BF_LOOP_END,
   BF_KEY,
   BF_KEY_PREFIX,
   BF_PLACEHOLDER,
-  BF_LOOP_START,
-  BF_LOOP_END,
-} from '@barefootjs/shared'
+} from './markers'

--- a/packages/shared/src/markers.ts
+++ b/packages/shared/src/markers.ts
@@ -1,0 +1,76 @@
+/**
+ * BarefootJS - Hydration Marker Constants
+ *
+ * Single source of truth for HTML attribute names used as hydration markers.
+ * Referenced by both the compiler (@barefootjs/jsx) and runtime (@barefootjs/client-runtime).
+ *
+ * These are not data-* attributes (like Angular's ng-, Vue's v-, Alpine's x-).
+ */
+
+// ---------------------------------------------------------------------------
+// Element attributes
+// ---------------------------------------------------------------------------
+
+/** Component scope boundary: `bf-s="Toggle_h1rn0a"` */
+export const BF_SCOPE = 'bf-s'
+
+/** Slot ID (most common): `bf="s1"` */
+export const BF_SLOT = 'bf'
+
+/** Serialized props JSON: `bf-p="..."` */
+export const BF_PROPS = 'bf-p'
+
+/** Conditional marker: `bf-c="s0"` */
+export const BF_COND = 'bf-c'
+
+/** List item marker: `bf-i` */
+export const BF_ITEM = 'bf-i'
+
+// ---------------------------------------------------------------------------
+// Portal attributes
+// ---------------------------------------------------------------------------
+
+/** Portal ownership: `bf-po="Toggle_h1rn0a"` */
+export const BF_PORTAL_OWNER = 'bf-po'
+
+/** Portal ID: `bf-pi="bf-portal-1"` */
+export const BF_PORTAL_ID = 'bf-pi'
+
+/** Portal placeholder: `bf-pp="bf-portal-1"` */
+export const BF_PORTAL_PLACEHOLDER = 'bf-pp'
+
+// ---------------------------------------------------------------------------
+// Value prefixes
+// ---------------------------------------------------------------------------
+
+/** Child component prefix in scope value: `~ToggleItem_abc` */
+export const BF_CHILD_PREFIX = '~'
+
+/** Parent-owned slot prefix in bf value: `bf="^s3"` */
+export const BF_PARENT_OWNED_PREFIX = '^'
+
+// ---------------------------------------------------------------------------
+// Comment markers
+// ---------------------------------------------------------------------------
+
+/** Comment-based scope marker prefix: `<!--bf-scope:ComponentName_abc123-->` */
+export const BF_SCOPE_COMMENT_PREFIX = 'bf-scope:'
+
+/** Loop boundary start: `<!--bf-loop-->` */
+export const BF_LOOP_START = 'bf-loop'
+
+/** Loop boundary end: `<!--bf-/loop-->` */
+export const BF_LOOP_END = 'bf-/loop'
+
+// ---------------------------------------------------------------------------
+// Data attributes
+// ---------------------------------------------------------------------------
+
+/** Key attribute for list reconciliation: `data-key="1"` */
+export const BF_KEY = 'data-key'
+
+/** Nested loop key attribute prefix: `data-key-1`, `data-key-2` */
+export const BF_KEY_PREFIX = 'data-key-'
+
+/** Component placeholder in loop templates: `data-bf-ph="s5"` */
+export const BF_PLACEHOLDER = 'data-bf-ph'


### PR DESCRIPTION
## Summary

- Create `@barefootjs/shared` package with all 16 hydration marker constants (`BF_SCOPE`, `BF_SLOT`, `BF_COND`, etc.)
- `client-runtime/src/attrs.ts` now re-exports from `@barefootjs/shared` instead of defining constants
- `jsx/src/ir-to-client-js/utils.ts` imports from `@barefootjs/shared` instead of duplicating constants
- `JsxAdapter` marker methods use shared constants instead of hardcoded strings

Previously, marker constants were defined in `client-runtime` and duplicated in the `jsx` compiler package. Changing a marker name required updating both packages manually. Now there's a single source of truth.

## Test plan

- [x] All 1965 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)