### PR TITLE
Fix static array compiler bugs: siblingOffset + nested loop scope

### DIFF
--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -647,4 +647,86 @@ describe('child components inside .map() (#344)', () => {
     expect(content).toContain(".addEventListener('click', (e) => {")
     expect(content).toContain('handleClick(item.id)')
   })
+
+  test('static array with preceding siblings uses siblingOffset (#810)', () => {
+    const source = `
+      'use client'
+
+      export function Header() {
+        const roles = [{ id: 'a', label: 'A' }, { id: 'b', label: 'B' }]
+        return (
+          <tr>
+            <th>Name</th>
+            {roles.map(role => (
+              <th>{role.label}</th>
+            ))}
+          </tr>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Header.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Should use offset to skip the preceding <th>Name</th>
+    expect(content).toContain('children[__idx + 1]')
+  })
+
+  test('static array event delegation with preceding siblings uses offset (#810)', () => {
+    const source = `
+      'use client'
+
+      export function Header() {
+        const roles = [{ id: 'a', label: 'A' }, { id: 'b', label: 'B' }]
+        const select = (id: string) => console.log(id)
+        return (
+          <tr>
+            <th>Name</th>
+            {roles.map(role => (
+              <th><button onClick={() => select(role.id)}>{role.label}</button></th>
+            ))}
+          </tr>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Header.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Event delegation indexOf should subtract offset
+    expect(content).toContain('.indexOf(__el) - 1')
+  })
+
+  test('static array without preceding siblings has no offset', () => {
+    const source = `
+      'use client'
+
+      export function List() {
+        const items = [{ id: '1', label: 'A' }, { id: '2', label: 'B' }]
+        return (
+          <ul>
+            {items.map(item => (
+              <li>{item.label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // No offset needed — children[__idx] should be used directly
+    expect(content).toContain('children[__idx]')
+    expect(content).not.toContain('children[__idx + ')
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -10,6 +10,20 @@ import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from '.
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 
 /**
+ * WeakMap to store the number of non-loop DOM siblings before each loop node
+ * in its parent element. Populated during collectElements element traversal,
+ * read when constructing LoopElements.
+ */
+const loopSiblingOffsets = new WeakMap<IRNode, number>()
+
+/** Check if an IR node produces a DOM child element (for sibling offset counting). */
+function producesDomChild(node: IRNode): boolean {
+  return node.type === 'element' || node.type === 'component' || node.type === 'provider'
+    || node.type === 'text' || (node.type === 'expression' && !node.reactive)
+    || node.type === 'conditional'
+}
+
+/**
  * Collect inner loop metadata from an IR subtree.
  * Returns NestedLoopInfo for each loop node found within the tree,
  * tracking the nearest ancestor element's slotId as container.
@@ -17,16 +31,25 @@ import { expandDynamicPropValue, expandConstantForReactivity } from './prop-hand
 function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: ClientJsContext): NestedLoopInfo[] {
   const result: NestedLoopInfo[] = []
   let depth = 0
-  let lastSlotId: string | null = null
   let insideCond = false
 
-  function walk(n: IRNode): void {
+  function walk(n: IRNode, parentSlotId: string | null): void {
     switch (n.type) {
-      case 'element':
-        if (n.slotId) lastSlotId = n.slotId
-        for (const child of n.children) walk(child)
+      case 'element': {
+        const mySlotId = n.slotId ?? parentSlotId
+        // Count non-loop siblings for inner loop offset
+        let nonLoopCount = 0
+        for (const child of n.children) {
+          if (child.type === 'loop') {
+            if (nonLoopCount > 0) loopSiblingOffsets.set(child, nonLoopCount)
+          } else if (producesDomChild(child)) {
+            nonLoopCount++
+          }
+        }
+        for (const child of n.children) walk(child, mySlotId)
         break
-      case 'loop':
+      }
+      case 'loop': {
         depth++
         // Generate item template for CSR rendering in mapArray.
         // Pass loopParams so expressions are wrapped at generation time (not post-hoc regex).
@@ -48,32 +71,34 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
           array: n.array,
           param: n.param,
           key: n.key ?? '',
-          containerSlotId: lastSlotId,
+          containerSlotId: parentSlotId,
           itemTemplate,
           refsOuterParam: refsOuter,
           reactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
           insideConditional: insideCond || undefined,
+          siblingOffset: loopSiblingOffsets.get(n) || undefined,
         })
-        for (const child of n.children) walk(child)
+        for (const child of n.children) walk(child, parentSlotId)
         depth--
         break
+      }
       case 'fragment':
       case 'component':
       case 'provider':
-        for (const child of n.children) walk(child)
+        for (const child of n.children) walk(child, parentSlotId)
         break
       case 'conditional': {
         const prev = insideCond
         insideCond = true
-        walk(n.whenTrue)
-        walk(n.whenFalse)
+        walk(n.whenTrue, parentSlotId)
+        walk(n.whenFalse, parentSlotId)
         insideCond = prev
         break
       }
     }
   }
 
-  nodes.forEach(walk)
+  nodes.forEach(n => walk(n, null))
   return result
 }
 
@@ -162,6 +187,17 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
   switch (node.type) {
     case 'element':
       collectFromElement(node, ctx, insideConditional)
+      // Pre-compute sibling offsets for any loop children in this element
+      {
+        let nonLoopCount = 0
+        for (const child of node.children) {
+          if (child.type === 'loop') {
+            if (nonLoopCount > 0) loopSiblingOffsets.set(child, nonLoopCount)
+          } else if (producesDomChild(child)) {
+            nonLoopCount++
+          }
+        }
+      }
       for (const child of node.children) {
         collectElements(child, ctx, insideConditional)
       }
@@ -231,7 +267,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         // Use element reconciliation when the loop body has nested components,
         // or when inner loops need their own mapArray for events/reactive text.
         const hasNestedComps = (node.nestedComponents?.length ?? 0) > 0
-        const innerLoops = !node.childComponent && !node.isStaticArray
+        const innerLoops = !node.childComponent
           ? collectInnerLoops(node.children, node.param, ctx)
           : undefined
         const hasInnerLoops = (innerLoops?.length ?? 0) > 0
@@ -266,7 +302,8 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           nestedComponents: node.nestedComponents,
           isStaticArray: node.isStaticArray,
           useElementReconciliation,
-          innerLoops: useElementReconciliation ? innerLoops : undefined,
+          innerLoops: (useElementReconciliation || (node.isStaticArray && innerLoops?.length)) ? innerLoops : undefined,
+          siblingOffset: loopSiblingOffsets.get(node) || undefined,
           filterPredicate: node.filterPredicate ? {
             param: node.filterPredicate.param,
             raw: node.filterPredicate.raw,

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -466,8 +466,9 @@ function emitStaticArrayUpdates(lines: string[], elem: LoopElement): void {
     lines.push(`  // Reactive attributes in static array children`)
     lines.push(`  if (_${v}) {`)
     const indexParam = elem.index || '__idx'
+    const offsetExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
     lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = _${v}.children[${indexParam}]`)
+    lines.push(`      const __iterEl = _${v}.children[${offsetExpr}]`)
     lines.push(`      if (__iterEl) {`)
     // Group attrs by childSlotId to avoid duplicate const declarations
     const attrsBySlot = new Map<string, typeof elem.childReactiveAttrs>()
@@ -504,8 +505,9 @@ function emitStaticArrayUpdates(lines: string[], elem: LoopElement): void {
     lines.push(`  // Reactive texts in static array children`)
     lines.push(`  if (_${v}) {`)
     const indexParam = elem.index || '__idx'
+    const offsetExpr2 = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
     lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = _${v}.children[${indexParam}]`)
+    lines.push(`      const __iterEl = _${v}.children[${offsetExpr2}]`)
     lines.push(`      if (__iterEl) {`)
     for (const text of elem.childReactiveTexts) {
       const vn = `__rt_${varSlotId(text.slotId)}`
@@ -527,7 +529,8 @@ function emitStaticArrayUpdates(lines: string[], elem: LoopElement): void {
       ls.push(`      let __el = ${varSlotId(ev.childSlotId)}El`)
       ls.push(`      while (__el.parentElement && __el.parentElement !== ${cVar}) __el = __el.parentElement`)
       ls.push(`      if (__el.parentElement === ${cVar}) {`)
-      ls.push(`        const __idx = Array.from(${cVar}.children).indexOf(__el)`)
+      const idxOffset = elem.siblingOffset ? ` - ${elem.siblingOffset}` : ''
+      ls.push(`        const __idx = Array.from(${cVar}.children).indexOf(__el)${idxOffset}`)
       ls.push(`        const ${elem.param} = ${elem.array}[__idx]`)
       ls.push(`        if (${elem.param}) ${handlerCall}`)
       ls.push(`      }`)

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -325,7 +325,10 @@ export function emitStaticArrayChildInits(lines: string[], ctx: ClientJsContext)
 
     if (elem.nestedComponents && elem.nestedComponents.length > 0) {
       const v = varSlotId(elem.slotId)
-      for (const comp of elem.nestedComponents) {
+
+      // Outer-level components (loopDepth === 0 or undefined)
+      const outerComps = elem.nestedComponents.filter(c => !c.loopDepth)
+      for (const comp of outerComps) {
         const propsEntries = comp.props.map((p) => {
           if (p.isEventHandler) {
             return `${quotePropName(p.name)}: ${p.value}`
@@ -344,8 +347,9 @@ export function emitStaticArrayChildInits(lines: string[], ctx: ClientJsContext)
         lines.push(`  // Initialize nested ${comp.name} in static array`)
         lines.push(`  if (_${v}) {`)
         const indexParam = elem.index || '__idx'
+        const offsetExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
         lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-        lines.push(`      const __iterEl = _${v}.children[${indexParam}]`)
+        lines.push(`      const __iterEl = _${v}.children[${offsetExpr}]`)
         lines.push(`      if (__iterEl) {`)
         lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
         lines.push(`        if (__compEl) initChild('${comp.name}', __compEl, ${propsExpr})`)
@@ -353,6 +357,56 @@ export function emitStaticArrayChildInits(lines: string[], ctx: ClientJsContext)
         lines.push(`    })`)
         lines.push(`  }`)
         lines.push('')
+      }
+
+      // Inner-loop components (loopDepth > 0): iterate outer then inner loop
+      if (elem.innerLoops) {
+        for (const innerLoop of elem.innerLoops) {
+          const innerComps = elem.nestedComponents.filter(c =>
+            (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array
+          )
+          if (innerComps.length === 0) continue
+
+          lines.push(`  // Initialize inner-loop components in static array (depth ${innerLoop.depth})`)
+          lines.push(`  if (_${v}) {`)
+          const outerIdx = elem.index || '__idx'
+          const outerOffset = elem.siblingOffset ? `${outerIdx} + ${elem.siblingOffset}` : outerIdx
+          lines.push(`    ${elem.array}.forEach((${elem.param}, ${outerIdx}) => {`)
+          lines.push(`      const __outerEl = _${v}.children[${outerOffset}]`)
+          lines.push(`      if (!__outerEl) return`)
+          if (innerLoop.containerSlotId) {
+            lines.push(`      const __ic = __outerEl.querySelector('[bf="${innerLoop.containerSlotId}"]') || __outerEl`)
+          } else {
+            lines.push(`      const __ic = __outerEl`)
+          }
+          const innerOffset = innerLoop.siblingOffset ? `__innerIdx + ${innerLoop.siblingOffset}` : '__innerIdx'
+          lines.push(`      ${innerLoop.array}.forEach((${innerLoop.param}, __innerIdx) => {`)
+          lines.push(`        const __innerEl = __ic.children[${innerOffset}]`)
+          lines.push(`        if (!__innerEl) return`)
+
+          for (const comp of innerComps) {
+            const propsEntries = comp.props.map((p) => {
+              if (p.isEventHandler) {
+                return `${quotePropName(p.name)}: ${p.value}`
+              } else if (p.isLiteral) {
+                return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
+              } else {
+                return `get ${quotePropName(p.name)}() { return ${p.value} }`
+              }
+            })
+            const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
+            const selector = comp.slotId
+              ? `[bf-s$="_${comp.slotId}"]`
+              : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
+            lines.push(`        const __compEl = __innerEl.querySelector('${selector}')`)
+            lines.push(`        if (__compEl) initChild('${comp.name}', __compEl, ${propsExpr})`)
+          }
+
+          lines.push(`      })`)
+          lines.push(`    })`)
+          lines.push(`  }`)
+          lines.push('')
+        }
       }
     }
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -163,6 +163,8 @@ export interface NestedLoopInfo {
   childEvents?: LoopChildEvent[]
   /** True when this loop is inside a conditional branch (handled by insert() bindEvents instead) */
   insideConditional?: boolean
+  /** Number of non-loop DOM siblings before this loop in its container element */
+  siblingOffset?: number
 }
 
 export interface LoopChildEvent {
@@ -217,6 +219,8 @@ export interface LoopElement {
   useElementReconciliation?: boolean // True: reconcileElements + composite rendering (native root with child components)
   /** Inner loop metadata for composite element reconciliation (array, param, key, container) */
   innerLoops?: NestedLoopInfo[]
+  /** Number of non-loop DOM siblings before this loop in its parent element. Used to offset children[idx] access. */
+  siblingOffset?: number
   filterPredicate?: {
     param: string
     raw: string  // Original filter predicate expression or block body

--- a/site/ui/components/permission-matrix-demo.tsx
+++ b/site/ui/components/permission-matrix-demo.tsx
@@ -8,21 +8,17 @@
  * Compiler stress targets:
  * - Diamond memo dependency: directGrants → effectivePerms → cellStates + roleStats
  *   (multiple memos reading from shared signals, forming a diamond DAG)
- * - Static array loop with per-item reactive props (ALL_PERMISSIONS.map)
- * - Per-cell derived state: each cell's checked/disabled/inherited status from memo chain
- * - Bulk toggle: column/row bulk operations triggering cascading memo updates
- * - Reactive text in loop: per-role permission count badges update reactively
- * - Many reactive attribute bindings per loop iteration (4 cells × 3 attrs each = 12 per row)
- *
- * Known compiler limitations found during development:
- * - Ternary inside .map() callback emits raw JSX
- * - 3-level nested static array loses inner variable scope in event delegation
- * - 2-level nested static array: inner loop component init uses wrong scope
- * - Workaround: explicit cells per role (no inner loop)
+ * - 2D nested loop: ALL_PERMISSIONS.map(perm => ROLES.map(role => <Checkbox>))
+ * - Per-cell derived state: each cell's checked/disabled/inherited from memo chain
+ * - Bulk toggle: column/row bulk ops triggering cascading memo updates
+ * - Reactive text in loop: per-role count badges update reactively
+ * - Static array with preceding siblings (tests siblingOffset)
+ * - Nested static array component initialization (inner loop Checkbox)
  */
 
 import { createSignal, createMemo } from '@barefootjs/client'
 import { Badge } from '@ui/components/ui/badge'
+import { Checkbox } from '@ui/components/ui/checkbox'
 
 // --- Types ---
 
@@ -72,24 +68,9 @@ function hasDirectGrant(grants: Record<string, string[]>, roleId: string, permId
   return roleGrants.indexOf(permId) !== -1
 }
 
-// Checkbox base styles (matching @ui/checkbox appearance)
-const CB_BASE = 'perm-check inline-flex items-center justify-center h-4 w-4 shrink-0 rounded-[4px] border border-primary shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-ring'
-const CB_CHECKED = 'bg-primary text-primary-foreground'
-const CB_UNCHECKED = 'bg-background'
-const CB_DISABLED = 'cursor-not-allowed'
-
-function cbClass(state: CellState): string {
-  const base = CB_BASE
-  const check = state.checked ? CB_CHECKED : CB_UNCHECKED
-  const dis = state.disabled ? CB_DISABLED : 'cursor-pointer'
-  const inh = state.inherited ? 'inherited-badge opacity-50' : ''
-  return `${base} ${check} ${dis} ${inh}`
-}
-
 // --- Component ---
 
 export function PermissionMatrixDemo() {
-  // Signal: direct grants per role
   const [directGrants, setDirectGrants] = createSignal<Record<string, string[]>>(buildInitialGrants())
 
   // Diamond memo node 1: effective permissions per role (direct + inherited)
@@ -123,9 +104,6 @@ export function PermissionMatrixDemo() {
       for (const perm of ALL_PERMISSIONS) {
         const key = `${role.id}:${perm.id}`
         const isEffective = effectiveList.indexOf(perm.id) !== -1
-        // Inherited = a lower-authority role (higher rank number) has this permission directly.
-        // Even if this role also has a direct grant, the lower role's grant takes precedence
-        // and this role's cell shows as inherited (disabled).
         let inheritedFromBelow = false
         for (const otherRole of ROLES) {
           if (otherRole.rank > role.rank && hasDirectGrant(grants, otherRole.id, perm.id)) {
@@ -144,7 +122,7 @@ export function PermissionMatrixDemo() {
     return states
   })
 
-  // Diamond memo node 3: stats per role (reads effectivePerms + directGrants — converges)
+  // Diamond memo node 3: stats per role (reads effectivePerms + cellStates — converges)
   const roleStats = createMemo(() => {
     const effective = effectivePerms()
     const states = cellStates()
@@ -269,49 +247,34 @@ export function PermissionMatrixDemo() {
         ))}
       </div>
 
-      {/* Grid — ALL_PERMISSIONS.map with explicit role cells (4 per row) */}
+      {/* Grid — 2D nested static array: ALL_PERMISSIONS.map → ROLES.map */}
       <div className="rounded-lg border overflow-hidden">
         <table className="w-full text-sm border-collapse">
           <thead>
+            {/* Static "Permission" th + ROLES.map: tests siblingOffset */}
             <tr className="bg-muted/50">
               <th className="text-left p-3 font-medium border-r min-w-[180px]">Permission</th>
-              {/* Explicit role headers (avoids static-array off-by-one with preceding sibling) */}
-              <th className="role-header p-2 text-center font-medium border-r min-w-[100px]">
-                <div className="flex flex-col items-center gap-1">
-                  <span>Viewer</span>
-                  <div className="flex gap-1">
-                    <button className="role-toggle grant-all-btn grant-all-viewer text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => grantAllForRole('viewer')}>All</button>
-                    <button className="role-toggle revoke-all-btn revoke-all-viewer text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => revokeAllForRole('viewer')}>None</button>
+              {ROLES.map(role => (
+                <th key={role.id} className="role-header p-2 text-center font-medium border-r last:border-r-0 min-w-[100px]">
+                  <div className="flex flex-col items-center gap-1">
+                    <span>{role.label}</span>
+                    <div className="flex gap-1">
+                      <button
+                        className={`role-toggle grant-all-btn grant-all-${role.id} text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors`}
+                        onClick={() => grantAllForRole(role.id)}
+                      >
+                        All
+                      </button>
+                      <button
+                        className={`role-toggle revoke-all-btn revoke-all-${role.id} text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors`}
+                        onClick={() => revokeAllForRole(role.id)}
+                      >
+                        None
+                      </button>
+                    </div>
                   </div>
-                </div>
-              </th>
-              <th className="role-header p-2 text-center font-medium border-r min-w-[100px]">
-                <div className="flex flex-col items-center gap-1">
-                  <span>Editor</span>
-                  <div className="flex gap-1">
-                    <button className="role-toggle grant-all-btn grant-all-editor text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => grantAllForRole('editor')}>All</button>
-                    <button className="role-toggle revoke-all-btn revoke-all-editor text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => revokeAllForRole('editor')}>None</button>
-                  </div>
-                </div>
-              </th>
-              <th className="role-header p-2 text-center font-medium border-r min-w-[100px]">
-                <div className="flex flex-col items-center gap-1">
-                  <span>Admin</span>
-                  <div className="flex gap-1">
-                    <button className="role-toggle grant-all-btn grant-all-admin text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => grantAllForRole('admin')}>All</button>
-                    <button className="role-toggle revoke-all-btn revoke-all-admin text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => revokeAllForRole('admin')}>None</button>
-                  </div>
-                </div>
-              </th>
-              <th className="role-header p-2 text-center font-medium border-r-0 min-w-[100px]">
-                <div className="flex flex-col items-center gap-1">
-                  <span>Owner</span>
-                  <div className="flex gap-1">
-                    <button className="role-toggle grant-all-btn grant-all-owner text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => grantAllForRole('owner')}>All</button>
-                    <button className="role-toggle revoke-all-btn revoke-all-owner text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-accent transition-colors" onClick={() => revokeAllForRole('owner')}>None</button>
-                  </div>
-                </div>
-              </th>
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -339,63 +302,19 @@ export function PermissionMatrixDemo() {
                     </div>
                   </div>
                 </td>
-                {/* Explicit role cells (avoids nested static array compiler bug) */}
-                <td className="perm-cell border-r text-center p-2">
-                  <div className="flex items-center justify-center">
-                    <button
-                      role="checkbox"
-                      aria-checked={cellStates()['viewer:' + perm.id].checked ? 'true' : 'false'}
-                      data-state={cellStates()['viewer:' + perm.id].checked ? 'checked' : 'unchecked'}
-                      disabled={cellStates()['viewer:' + perm.id].disabled}
-                      className={cbClass(cellStates()['viewer:' + perm.id])}
-                      onClick={() => togglePermission('viewer', perm.id)}
-                    >
-                      <svg className={`h-3 w-3 ${cellStates()['viewer:' + perm.id].checked ? '' : 'hidden'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
-                    </button>
-                  </div>
-                </td>
-                <td className="perm-cell border-r text-center p-2">
-                  <div className="flex items-center justify-center">
-                    <button
-                      role="checkbox"
-                      aria-checked={cellStates()['editor:' + perm.id].checked ? 'true' : 'false'}
-                      data-state={cellStates()['editor:' + perm.id].checked ? 'checked' : 'unchecked'}
-                      disabled={cellStates()['editor:' + perm.id].disabled}
-                      className={cbClass(cellStates()['editor:' + perm.id])}
-                      onClick={() => togglePermission('editor', perm.id)}
-                    >
-                      <svg className={`h-3 w-3 ${cellStates()['editor:' + perm.id].checked ? '' : 'hidden'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
-                    </button>
-                  </div>
-                </td>
-                <td className="perm-cell border-r text-center p-2">
-                  <div className="flex items-center justify-center">
-                    <button
-                      role="checkbox"
-                      aria-checked={cellStates()['admin:' + perm.id].checked ? 'true' : 'false'}
-                      data-state={cellStates()['admin:' + perm.id].checked ? 'checked' : 'unchecked'}
-                      disabled={cellStates()['admin:' + perm.id].disabled}
-                      className={cbClass(cellStates()['admin:' + perm.id])}
-                      onClick={() => togglePermission('admin', perm.id)}
-                    >
-                      <svg className={`h-3 w-3 ${cellStates()['admin:' + perm.id].checked ? '' : 'hidden'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
-                    </button>
-                  </div>
-                </td>
-                <td className="perm-cell border-r-0 text-center p-2">
-                  <div className="flex items-center justify-center">
-                    <button
-                      role="checkbox"
-                      aria-checked={cellStates()['owner:' + perm.id].checked ? 'true' : 'false'}
-                      data-state={cellStates()['owner:' + perm.id].checked ? 'checked' : 'unchecked'}
-                      disabled={cellStates()['owner:' + perm.id].disabled}
-                      className={cbClass(cellStates()['owner:' + perm.id])}
-                      onClick={() => togglePermission('owner', perm.id)}
-                    >
-                      <svg className={`h-3 w-3 ${cellStates()['owner:' + perm.id].checked ? '' : 'hidden'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
-                    </button>
-                  </div>
-                </td>
+                {/* Inner ROLES.map: tests nested static array component init */}
+                {ROLES.map(role => (
+                  <td key={role.id} className="perm-cell border-r last:border-r-0 text-center p-2">
+                    <div className="flex items-center justify-center">
+                      <Checkbox
+                        checked={cellStates()[`${role.id}:${perm.id}`].checked}
+                        disabled={cellStates()[`${role.id}:${perm.id}`].disabled}
+                        onCheckedChange={() => togglePermission(role.id, perm.id)}
+                        className={cellStates()[`${role.id}:${perm.id}`].inherited ? 'inherited-badge opacity-50' : ''}
+                      />
+                    </div>
+                  </td>
+                ))}
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary

Closes #810

Fixes two compiler bugs in static array handling that were discovered during Permission Matrix block development.

### Bug 1: Off-by-one with preceding siblings

When a static array `.map()` has non-loop siblings before it (e.g., `<th>Permission</th>` before `{ROLES.map(...)}`), the hydration code `parent.children[idx]` incorrectly includes the non-loop siblings, causing an off-by-one.

**Fix**: Compute `siblingOffset` at compile time by counting non-loop DOM siblings before each loop in its parent element's IR children. Emit `children[idx + offset]` and `indexOf(__el) - offset`. No runtime dependency changes.

### Bug 2: Nested static array component init scope loss

When a static array has nested inner loops with components (e.g., `PERMS.map(perm => ROLES.map(role => <Checkbox>))`), the `initChild` code only iterated the outer loop, leaving inner loop variables undefined.

**Fix**:
- Remove `!isStaticArray` gate from `collectInnerLoops` call
- Fix `parentSlotId` tracking in `collectInnerLoops` (tree traversal instead of flat `lastSlotId`)
- Add nested `forEach` emission in `emitStaticArrayChildInits` with `loopDepth` filtering

### Validation

Permission Matrix updated from workaround (explicit cells) to loop version using `ROLES.map()` + `Checkbox` component, exercising both fixes:
- Header row: `<th>Permission</th>` + `{ROLES.map(...)}` → siblingOffset = 1
- Cell grid: `ALL_PERMISSIONS.map(perm => ROLES.map(role => <Checkbox>))` → nested scope

## Test plan

- [x] 553 compiler unit tests pass (+3 new for siblingOffset)
- [x] 18 Permission Matrix E2E tests pass (loop version, no workarounds)
- [x] 23 Inventory Manager E2E tests pass (no regression)
- [x] 11 Carousel E2E tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)