### PR TITLE
xyflow: Add interactive pan/zoom to MiniMap (#797)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -707,3 +707,124 @@ test.describe('Heavy Stress Test (100 nodes)', () => {
     expect(someVisible).toBeGreaterThan(50)
   })
 })
+
+// ============================================================
+// MiniMap Plugin
+// ============================================================
+test.describe('MiniMap Plugin', () => {
+  test.beforeEach(async ({ page }) => {
+    // Scroll minimap section into viewport so page.mouse can reach it
+    await page.locator('#minimap-test').scrollIntoViewIfNeeded()
+    await page.waitForTimeout(200)
+  })
+
+  test('renders minimap container', async ({ page }) => {
+    await expect(page.locator('#minimap-test .bf-flow__minimap')).toBeVisible()
+  })
+
+  test('minimap contains SVG element', async ({ page }) => {
+    const svg = page.locator('#minimap-test .bf-flow__minimap svg')
+    await expect(svg).toBeAttached()
+    expect(Number(await svg.getAttribute('width'))).toBe(200)
+    expect(Number(await svg.getAttribute('height'))).toBe(150)
+  })
+
+  test('minimap renders node rectangles', async ({ page }) => {
+    // Wait for nodes to be measured and minimap to render
+    await page.waitForTimeout(500)
+    const rects = page.locator('#minimap-test .bf-flow__minimap svg g rect')
+    const count = await rects.count()
+    expect(count).toBe(4)
+  })
+
+  test('minimap has viewport mask path', async ({ page }) => {
+    await page.waitForTimeout(500)
+    const mask = page.locator('#minimap-test .bf-flow__minimap-mask')
+    await expect(mask).toBeAttached()
+    const d = await mask.getAttribute('d')
+    expect(d).toBeTruthy()
+    // Mask uses evenodd fill rule with two sub-paths
+    expect(await mask.getAttribute('fill-rule')).toBe('evenodd')
+  })
+
+  test('minimap SVG has viewBox attribute', async ({ page }) => {
+    await page.waitForTimeout(500)
+    const svg = page.locator('#minimap-test .bf-flow__minimap svg')
+    const viewBox = await svg.getAttribute('viewBox')
+    expect(viewBox).toBeTruthy()
+    // viewBox should have 4 numbers
+    expect(viewBox!.split(' ').length).toBe(4)
+  })
+
+  test('minimap has interactive cursor', async ({ page }) => {
+    const svg = page.locator('#minimap-test .bf-flow__minimap svg')
+    const cursor = await svg.evaluate((el: SVGSVGElement) => el.style.cursor)
+    expect(cursor).toBe('grab')
+  })
+
+  test('dragging on minimap pans the main viewport', async ({ page }) => {
+    await page.waitForTimeout(500)
+    const container = page.locator('#minimap-test')
+    const viewport = container.locator('.bf-flow__viewport')
+    const minimapSvg = container.locator('.bf-flow__minimap svg')
+
+    const transformBefore = await viewport.evaluate((el: HTMLElement) => el.style.transform)
+
+    // Drag on the minimap SVG
+    const box = await minimapSvg.boundingBox()
+    if (!box) throw new Error('minimap SVG not found')
+
+    const startX = box.x + box.width / 2
+    const startY = box.y + box.height / 2
+
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.mouse.move(startX + 30, startY + 20, { steps: 5 })
+    await page.mouse.up()
+    await page.waitForTimeout(300)
+
+    const transformAfter = await viewport.evaluate((el: HTMLElement) => el.style.transform)
+    expect(transformAfter).not.toBe(transformBefore)
+  })
+
+  test('minimap viewport indicator updates after main viewport pan', async ({ page }) => {
+    await page.waitForTimeout(500)
+    const container = page.locator('#minimap-test')
+    const mask = container.locator('.bf-flow__minimap-mask')
+
+    const maskBefore = await mask.getAttribute('d')
+
+    // Pan the main viewport by dragging on empty area (top-left to avoid minimap)
+    const mainBox = await container.boundingBox()
+    if (!mainBox) throw new Error('container not found')
+
+    const startX = mainBox.x + 50
+    const startY = mainBox.y + 50
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.mouse.move(startX - 100, startY - 80, { steps: 10 })
+    await page.mouse.up()
+    await page.waitForTimeout(500)
+
+    const maskAfter = await mask.getAttribute('d')
+    expect(maskAfter).not.toBe(maskBefore)
+  })
+
+  test('minimap zoom via scroll wheel changes main viewport zoom', async ({ page }) => {
+    await page.waitForTimeout(500)
+    const container = page.locator('#minimap-test')
+    const viewport = container.locator('.bf-flow__viewport')
+    const minimapSvg = container.locator('.bf-flow__minimap svg')
+
+    const before = await getTransform(viewport)
+    const box = await minimapSvg.boundingBox()
+    if (!box) throw new Error('minimap SVG not found')
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(0, -300)
+    await page.waitForTimeout(500)
+
+    const after = await getTransform(viewport)
+    expect(after.scale).not.toBeCloseTo(before.scale, 1)
+  })
+})

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -33,9 +33,12 @@
 <h2>Heavy Stress Test (100 nodes)</h2>
 <div id="heavy-stress" class="test-container" style="height:600px"></div>
 
+<h2>MiniMap Interactive</h2>
+<div id="minimap-test" class="test-container"></div>
+
 <script type="module">
 import { createRoot } from '@barefootjs/client'
-import { initFlow, initBackground, initControls } from '@barefootjs/xyflow'
+import { initFlow, initBackground, initControls, initMiniMap } from '@barefootjs/xyflow'
 
 // Debug: trace mousedown → D3 drag flow
 document.addEventListener('mousedown', (e) => {
@@ -164,6 +167,26 @@ createRoot(() => {
 
   initFlow(el, { nodes, edges, fitView: true })
   initControls(el, { position: 'top-right' })
+})
+
+// MiniMap interactive test
+createRoot(() => {
+  const el = document.getElementById('minimap-test')
+  initFlow(el, {
+    nodes: [
+      { id: 'm1', position: { x: 0, y: 0 }, data: { label: 'Alpha' } },
+      { id: 'm2', position: { x: 250, y: 0 }, data: { label: 'Beta' } },
+      { id: 'm3', position: { x: 125, y: 150 }, data: { label: 'Gamma' } },
+      { id: 'm4', position: { x: 500, y: 100 }, data: { label: 'Delta' } },
+    ],
+    edges: [
+      { id: 'em1-2', source: 'm1', target: 'm2' },
+      { id: 'em1-3', source: 'm1', target: 'm3' },
+      { id: 'em2-4', source: 'm2', target: 'm4' },
+      { id: 'em3-4', source: 'm3', target: 'm4' },
+    ],
+  })
+  initMiniMap(el, { pannable: true, zoomable: true })
 })
 </script>
 </body>

--- a/packages/xyflow/src/minimap.ts
+++ b/packages/xyflow/src/minimap.ts
@@ -1,5 +1,4 @@
 import { createEffect, onCleanup, untrack } from '@barefootjs/client-runtime'
-import { XYMinimap } from '@xyflow/system'
 import { useFlow } from './hooks'
 import { SVG_NS, INFINITE_EXTENT } from './constants'
 import { applyPositionStyle } from './utils'
@@ -9,13 +8,53 @@ export type MiniMapProps = {
   width?: number
   height?: number
   nodeColor?: string | ((node: any) => string)
+  maskColor?: string
+  maskStrokeColor?: string
+  maskStrokeWidth?: number
   pannable?: boolean
   zoomable?: boolean
+  zoomStep?: number
+  inversePan?: boolean
+  offsetScale?: number
+}
+
+/**
+ * Calculate the bounding rect of all nodes in the node lookup.
+ */
+function getNodeBoundingRect(nodeLookup: Map<string, any>): {
+  x: number
+  y: number
+  width: number
+  height: number
+} | null {
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity
+
+  for (const [, node] of nodeLookup) {
+    const pos = node.internals.positionAbsolute
+    const nw = node.measured.width ?? 150
+    const nh = node.measured.height ?? 40
+    minX = Math.min(minX, pos.x)
+    minY = Math.min(minY, pos.y)
+    maxX = Math.max(maxX, pos.x + nw)
+    maxY = Math.max(maxY, pos.y + nh)
+  }
+
+  if (!isFinite(minX)) return null
+
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
 }
 
 /**
  * Init function for MiniMap component.
  * Renders a small overview of the graph with interactive pan/zoom.
+ *
+ * Pan and zoom are implemented with direct pointer/wheel event handlers
+ * rather than XYMinimap from @xyflow/system, because XYMinimap's D3 zoom
+ * pan handlers check for 'mousemove'/'mousedown' event types but D3 zoom v3
+ * dispatches PointerEvents ('pointermove'/'pointerdown'), making pan a no-op.
  */
 export function initMiniMap(scope: Element, props: Record<string, unknown>): void {
   const store = useFlow()
@@ -25,12 +64,22 @@ export function initMiniMap(scope: Element, props: Record<string, unknown>): voi
   const mapWidth = (props.width as number) ?? 200
   const mapHeight = (props.height as number) ?? 150
   const nodeColor = (props.nodeColor as string) ?? '#e2e2e2'
+  const maskColor = (props.maskColor as string) ?? 'rgba(200, 200, 200, 0.6)'
+  const maskStrokeColor = (props.maskStrokeColor as string) ?? 'none'
+  const maskStrokeWidth = (props.maskStrokeWidth as number) ?? 0
   const pannable = (props.pannable as boolean) ?? true
   const zoomable = (props.zoomable as boolean) ?? true
+  const zoomStep = (props.zoomStep as number) ?? 1
+  const inversePan = (props.inversePan as boolean) ?? false
+  const offsetScale = (props.offsetScale as number) ?? 5
 
-  // Container
+  // Track the current viewScale for pan calculations.
+  let currentViewScale = 1
+
+  // Container — nopan/nowheel/nodrag classes prevent the main flow's D3 zoom
+  // from intercepting events on the minimap.
   const container = document.createElement('div')
-  container.className = 'bf-flow__minimap'
+  container.className = 'bf-flow__minimap nopan nowheel nodrag'
   container.style.position = 'absolute'
   container.style.zIndex = '5'
   container.style.overflow = 'hidden'
@@ -38,80 +87,141 @@ export function initMiniMap(scope: Element, props: Record<string, unknown>): voi
   container.style.boxShadow = '0 1px 4px rgba(0,0,0,0.15)'
   container.style.backgroundColor = '#fff'
 
+  // Stop event propagation so the main flow's D3 zoom doesn't interfere.
+  for (const evt of [
+    'mousedown', 'mousemove', 'mouseup',
+    'pointerdown', 'pointermove', 'pointerup',
+    'wheel', 'touchstart', 'touchmove', 'touchend', 'dblclick',
+  ] as const) {
+    container.addEventListener(evt, (e) => e.stopPropagation())
+  }
+
   applyPositionStyle(container, position)
 
-  // SVG for minimap
+  // SVG for minimap with viewBox (set reactively)
   const svg = document.createElementNS(SVG_NS, 'svg')
   svg.setAttribute('width', String(mapWidth))
   svg.setAttribute('height', String(mapHeight))
   svg.style.display = 'block'
+  if (pannable) {
+    svg.style.cursor = 'grab'
+  }
   container.appendChild(svg)
 
   el.appendChild(container)
 
-  // Initialize XYMinimap for pan/zoom interaction on minimap
-  const pz = untrack(store.panZoom)
-  if (pz) {
-    const minimapInstance = XYMinimap({
-      panZoom: pz,
-      domNode: svg,
-      getTransform: store.getTransform,
-      getViewScale: () => untrack(store.viewport).zoom,
-    })
-
-    minimapInstance.update({
-      translateExtent: INFINITE_EXTENT,
-      width: mapWidth,
-      height: mapHeight,
-      pannable,
-      zoomable,
-    })
-
-    onCleanup(() => minimapInstance.destroy())
-  }
-
-  // Reactively render node rectangles in the minimap
+  // Node rectangles group
   const nodesGroup = document.createElementNS(SVG_NS, 'g')
   svg.appendChild(nodesGroup)
 
-  const viewportRect = document.createElementNS(SVG_NS, 'rect')
-  viewportRect.setAttribute('fill', 'none')
-  viewportRect.setAttribute('stroke', '#4a90d9')
-  viewportRect.setAttribute('stroke-width', '2')
-  svg.appendChild(viewportRect)
+  // Viewport mask: an SVG path with evenodd fill rule that masks the area
+  // outside the current viewport, matching React Flow's approach.
+  const maskPath = document.createElementNS(SVG_NS, 'path')
+  maskPath.setAttribute('class', 'bf-flow__minimap-mask')
+  maskPath.setAttribute('fill', maskColor)
+  maskPath.setAttribute('fill-rule', 'evenodd')
+  maskPath.setAttribute('stroke', maskStrokeColor)
+  maskPath.setAttribute('stroke-width', String(maskStrokeWidth))
+  maskPath.setAttribute('pointer-events', 'none')
+  svg.appendChild(maskPath)
 
+  // Interactive pan via pointer events.
+  const pz = untrack(store.panZoom)
+
+  if (pannable && pz) {
+    let isDragging = false
+    let lastPointerPos: [number, number] = [0, 0]
+
+    svg.addEventListener('pointerdown', (e) => {
+      isDragging = true
+      lastPointerPos = [e.clientX, e.clientY]
+      svg.setPointerCapture(e.pointerId)
+      svg.style.cursor = 'grabbing'
+      e.preventDefault()
+    })
+
+    svg.addEventListener('pointermove', (e) => {
+      if (!isDragging) return
+      const transform = store.getTransform()
+      const dx = e.clientX - lastPointerPos[0]
+      const dy = e.clientY - lastPointerPos[1]
+      lastPointerPos = [e.clientX, e.clientY]
+
+      const moveScale =
+        currentViewScale *
+        Math.max(transform[2], Math.log(transform[2])) *
+        (inversePan ? -1 : 1)
+      const position = {
+        x: transform[0] - dx * moveScale,
+        y: transform[1] - dy * moveScale,
+      }
+      const extent: [[number, number], [number, number]] = [
+        [0, 0],
+        [untrack(store.width), untrack(store.height)],
+      ]
+      pz.setViewportConstrained(
+        { x: position.x, y: position.y, zoom: transform[2] },
+        extent,
+        INFINITE_EXTENT,
+      )
+    })
+
+    svg.addEventListener('pointerup', () => {
+      isDragging = false
+      svg.style.cursor = 'grab'
+    })
+  }
+
+  // Interactive zoom via wheel events.
+  if (zoomable && pz) {
+    svg.addEventListener(
+      'wheel',
+      (e) => {
+        e.preventDefault()
+        const transform = store.getTransform()
+        const isMac = navigator.platform.includes('Mac')
+        const factor = e.ctrlKey && isMac ? 10 : 1
+        const pinchDelta =
+          -e.deltaY *
+          (e.deltaMode === 1 ? 0.05 : e.deltaMode ? 1 : 0.002) *
+          zoomStep
+        const nextZoom = transform[2] * Math.pow(2, pinchDelta * factor)
+        pz.scaleTo(nextZoom)
+      },
+      { passive: false },
+    )
+  }
+
+  // Reactively render the minimap: nodes, viewport mask.
   createEffect(() => {
     const nodeLookup = store.nodeLookup()
     const vp = store.viewport()
-    const w = store.width()
-    const h = store.height()
+    const flowW = store.width()
+    const flowH = store.height()
+    // Track position changes from drag
+    store.positionEpoch()
 
-    // Calculate bounds of all nodes
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
-    for (const [, node] of nodeLookup) {
-      const pos = node.internals.positionAbsolute
-      const nw = node.measured.width ?? 150
-      const nh = node.measured.height ?? 40
-      minX = Math.min(minX, pos.x)
-      minY = Math.min(minY, pos.y)
-      maxX = Math.max(maxX, pos.x + nw)
-      maxY = Math.max(maxY, pos.y + nh)
-    }
+    const bounds = getNodeBoundingRect(nodeLookup)
+    if (!bounds) return
 
-    if (!isFinite(minX)) return
+    // Compute viewBox following React Flow's approach
+    const scaledWidth = bounds.width / mapWidth
+    const scaledHeight = bounds.height / mapHeight
+    const viewScale = Math.max(scaledWidth, scaledHeight)
+    currentViewScale = viewScale
 
-    // Add padding
-    const padding = 50
-    minX -= padding
-    minY -= padding
-    maxX += padding
-    maxY += padding
+    const viewWidth = viewScale * mapWidth
+    const viewHeight = viewScale * mapHeight
+    const offset = offsetScale * viewScale
 
-    const boundsWidth = maxX - minX
-    const boundsHeight = maxY - minY
-    const scale = Math.min(mapWidth / boundsWidth, mapHeight / boundsHeight)
+    const vbX = bounds.x - (viewWidth - bounds.width) / 2 - offset
+    const vbY = bounds.y - (viewHeight - bounds.height) / 2 - offset
+    const vbW = viewWidth + offset * 2
+    const vbH = viewHeight + offset * 2
 
-    // Clear and redraw nodes
+    svg.setAttribute('viewBox', `${vbX} ${vbY} ${vbW} ${vbH}`)
+
+    // Clear and redraw node rectangles
     nodesGroup.innerHTML = ''
     for (const [, node] of nodeLookup) {
       const pos = node.internals.positionAbsolute
@@ -119,25 +229,34 @@ export function initMiniMap(scope: Element, props: Record<string, unknown>): voi
       const nh = node.measured.height ?? 40
 
       const rect = document.createElementNS(SVG_NS, 'rect')
-      rect.setAttribute('x', String((pos.x - minX) * scale))
-      rect.setAttribute('y', String((pos.y - minY) * scale))
-      rect.setAttribute('width', String(nw * scale))
-      rect.setAttribute('height', String(nh * scale))
-      const color = typeof nodeColor === 'function' ? (nodeColor as (n: any) => string)(node) : nodeColor
+      rect.setAttribute('x', String(pos.x))
+      rect.setAttribute('y', String(pos.y))
+      rect.setAttribute('width', String(nw))
+      rect.setAttribute('height', String(nh))
+      const color =
+        typeof nodeColor === 'function'
+          ? (nodeColor as (n: any) => string)(node)
+          : nodeColor
       rect.setAttribute('fill', color)
       rect.setAttribute('rx', '2')
       nodesGroup.appendChild(rect)
     }
 
-    // Update viewport rectangle
-    const vpX = (-vp.x / vp.zoom - minX) * scale
-    const vpY = (-vp.y / vp.zoom - minY) * scale
-    const vpW = (w / vp.zoom) * scale
-    const vpH = (h / vp.zoom) * scale
-    viewportRect.setAttribute('x', String(vpX))
-    viewportRect.setAttribute('y', String(vpY))
-    viewportRect.setAttribute('width', String(vpW))
-    viewportRect.setAttribute('height', String(vpH))
+    // Compute viewport bounding box in flow coordinates
+    const vpX = -vp.x / vp.zoom
+    const vpY = -vp.y / vp.zoom
+    const vpW = flowW / vp.zoom
+    const vpH = flowH / vp.zoom
+
+    // Build mask path: outer rect with inner viewport cutout (evenodd)
+    const outerX = vbX - offset
+    const outerY = vbY - offset
+    const outerW = vbW + offset * 2
+    const outerH = vbH + offset * 2
+    const d =
+      `M${outerX},${outerY}h${outerW}v${outerH}h${-outerW}z` +
+      `M${vpX},${vpY}h${vpW}v${vpH}h${-vpW}z`
+    maskPath.setAttribute('d', d)
   })
 
   onCleanup(() => container.remove())


### PR DESCRIPTION
## Summary

- Implement interactive pan/zoom on the MiniMap plugin with direct pointer/wheel event handlers
- Replace `XYMinimap`'s D3 zoom-based pan handlers which don't work with D3 zoom v3 (checks `'mousemove'` but D3 v3 dispatches `'pointermove'`)
- Add viewport mask with evenodd fill-rule matching React Flow's approach
- Use SVG `viewBox` for coordinate mapping instead of manual scale calculations

## Changes

- **`packages/xyflow/src/minimap.ts`**: Rewrite minimap with pointer event pan, wheel zoom, viewport mask, and viewBox-based rendering
- **`packages/xyflow/e2e/flow.spec.ts`**: Add 9 E2E tests for minimap (rendering + interaction)
- **`packages/xyflow/e2e/test-page.html`**: Add minimap test section

## Test plan

- [x] 29 unit tests pass
- [x] 71 E2E tests pass (9 new minimap tests)
- [ ] Compare MiniMap behavior with React Flow reference at :3199 vs :3099

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)