### PR TITLE
xyflow: Add connection validation (isValidConnection) (#803)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -662,6 +662,185 @@ test.describe('Stress Test (20 nodes)', () => {
 })
 
 // ============================================================
+// Connection Validation (isValidConnection)
+// ============================================================
+test.describe('Connection Validation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Scroll the validation container into view since it's at the bottom of the page
+    await page.evaluate(() => {
+      const el = document.getElementById('validation')
+      if (el && 'scrollIntoViewIfNeeded' in el) {
+        ;(el as any).scrollIntoViewIfNeeded()
+      } else if (el) {
+        el.scrollIntoView({ block: 'center' })
+      }
+    })
+    await page.waitForSelector('#validation .bf-flow__node[data-id="v-source"]')
+    await page.waitForSelector('#validation .bf-flow__node[data-id="v-allowed"]')
+    await page.waitForSelector('#validation .bf-flow__node[data-id="v-blocked"]')
+  })
+
+  test('valid connection creates an edge', async ({ page }) => {
+    const beforeEdges = await page.locator('#validation .bf-flow__edge').count()
+
+    const created = await page.evaluate(async () => {
+      const sourceHandle = document.querySelector('#validation [data-id="v-source"] .bf-flow__handle--source')!
+      const targetHandle = document.querySelector('#validation [data-id="v-allowed"] .bf-flow__handle--target')!
+      const sr = sourceHandle.getBoundingClientRect()
+      const tr = targetHandle.getBoundingClientRect()
+
+      sourceHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: sr.left + 3, clientY: sr.top + 3, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 200))
+
+      return document.querySelectorAll('#validation .bf-flow__edge').length
+    })
+
+    expect(created).toBeGreaterThan(beforeEdges)
+  })
+
+  test('invalid connection does not create an edge', async ({ page }) => {
+    const beforeEdges = await page.locator('#validation .bf-flow__edge').count()
+
+    const afterEdges = await page.evaluate(async () => {
+      const sourceHandle = document.querySelector('#validation [data-id="v-source"] .bf-flow__handle--source')!
+      const targetHandle = document.querySelector('#validation [data-id="v-blocked"] .bf-flow__handle--target')!
+      const sr = sourceHandle.getBoundingClientRect()
+      const tr = targetHandle.getBoundingClientRect()
+
+      sourceHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: sr.left + 3, clientY: sr.top + 3, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 200))
+
+      return document.querySelectorAll('#validation .bf-flow__edge').length
+    })
+
+    expect(afterEdges).toBe(beforeEdges)
+  })
+
+  test('valid target handle shows .valid class during drag', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const sourceHandle = document.querySelector('#validation [data-id="v-source"] .bf-flow__handle--source')!
+      const targetHandle = document.querySelector('#validation [data-id="v-allowed"] .bf-flow__handle--target')!
+      const sr = sourceHandle.getBoundingClientRect()
+      const tr = targetHandle.getBoundingClientRect()
+
+      sourceHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: sr.left + 3, clientY: sr.top + 3, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Move to the target handle
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const hasValid = targetHandle.classList.contains('valid')
+      const hasInvalid = targetHandle.classList.contains('invalid')
+
+      // Clean up — release mouse
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      return { hasValid, hasInvalid }
+    })
+
+    expect(result.hasValid).toBe(true)
+    expect(result.hasInvalid).toBe(false)
+  })
+
+  test('invalid target handle shows .invalid class during drag', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const sourceHandle = document.querySelector('#validation [data-id="v-source"] .bf-flow__handle--source')!
+      const targetHandle = document.querySelector('#validation [data-id="v-blocked"] .bf-flow__handle--target')!
+      const sr = sourceHandle.getBoundingClientRect()
+      const tr = targetHandle.getBoundingClientRect()
+
+      sourceHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: sr.left + 3, clientY: sr.top + 3, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Move to the blocked target handle
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      const hasValid = targetHandle.classList.contains('valid')
+      const hasInvalid = targetHandle.classList.contains('invalid')
+
+      // Clean up — release mouse
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      return { hasValid, hasInvalid }
+    })
+
+    expect(result.hasValid).toBe(false)
+    expect(result.hasInvalid).toBe(true)
+  })
+
+  test('validation classes are cleaned up after mouse up', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const sourceHandle = document.querySelector('#validation [data-id="v-source"] .bf-flow__handle--source')!
+      const targetHandle = document.querySelector('#validation [data-id="v-blocked"] .bf-flow__handle--target')!
+      const sr = sourceHandle.getBoundingClientRect()
+      const tr = targetHandle.getBoundingClientRect()
+
+      sourceHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: sr.left + 3, clientY: sr.top + 3, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      // Verify the class is present during drag
+      const hasDuring = targetHandle.classList.contains('invalid')
+
+      // Release mouse
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: tr.left + 3, clientY: tr.top + 3, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      // Verify classes are cleaned up
+      const hasValidAfter = targetHandle.classList.contains('valid')
+      const hasInvalidAfter = targetHandle.classList.contains('invalid')
+
+      return { hasDuring, hasValidAfter, hasInvalidAfter }
+    })
+
+    expect(result.hasDuring).toBe(true)
+    expect(result.hasValidAfter).toBe(false)
+    expect(result.hasInvalidAfter).toBe(false)
+  })
+})
+
+// ============================================================
 // Heavy Stress Test (100 nodes, 10x10 grid)
 // ============================================================
 test.describe('Heavy Stress Test (100 nodes)', () => {

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -33,6 +33,9 @@
 <h2>Heavy Stress Test (100 nodes)</h2>
 <div id="heavy-stress" class="test-container" style="height:600px"></div>
 
+<h2>Connection Validation</h2>
+<div id="validation" class="test-container"></div>
+
 <script type="module">
 import { createRoot } from '@barefootjs/client'
 import { initFlow, initBackground, initControls } from '@barefootjs/xyflow'
@@ -164,6 +167,21 @@ createRoot(() => {
 
   initFlow(el, { nodes, edges, fitView: true })
   initControls(el, { position: 'top-right' })
+})
+
+// Connection Validation — only allow connections to "v-allowed"
+createRoot(() => {
+  initFlow(document.getElementById('validation'), {
+    nodes: [
+      { id: 'v-source', position: { x: 50, y: 100 }, data: { label: 'Source' } },
+      { id: 'v-allowed', position: { x: 300, y: 50 }, data: { label: 'Allowed Target' } },
+      { id: 'v-blocked', position: { x: 300, y: 200 }, data: { label: 'Blocked Target' } },
+    ],
+    edges: [],
+    isValidConnection: (connection) => {
+      return connection.target === 'v-allowed'
+    },
+  })
 })
 </script>
 </body>

--- a/packages/xyflow/src/connection.ts
+++ b/packages/xyflow/src/connection.ts
@@ -4,6 +4,39 @@ import type { FlowStore, NodeBase, EdgeBase } from './types'
 import { SVG_NS } from './constants'
 
 /**
+ * Build a connection object for the given source handle / target handle pair.
+ * Used by both validation and edge creation.
+ */
+function buildConnection(
+  sourceNodeId: string,
+  targetNodeId: string,
+  handleType: 'source' | 'target',
+): { source: string; target: string; sourceHandle: string | null; targetHandle: string | null } {
+  let source = sourceNodeId
+  let target = targetNodeId
+  if (handleType === 'target') {
+    source = targetNodeId
+    target = sourceNodeId
+  }
+  return { source, target, sourceHandle: null, targetHandle: null }
+}
+
+/**
+ * Check whether a proposed connection is valid according to the store's
+ * isValidConnection callback. Returns true when no callback is configured.
+ */
+function checkConnectionValidity<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+>(
+  store: FlowStore<NodeType, EdgeType>,
+  connection: { source: string; target: string; sourceHandle: string | null; targetHandle: string | null },
+): boolean {
+  if (!store.isValidConnection) return true
+  return store.isValidConnection(connection)
+}
+
+/**
  * Attach a connection drag handler to a handle element.
  * Called when creating each handle in node-wrapper.
  */
@@ -42,6 +75,9 @@ export function attachConnectionHandler<
     connectionLine.setAttribute('stroke-width', '1')
     edgesSvg.appendChild(connectionLine)
 
+    // Track the currently hovered handle for validation feedback
+    let lastHoveredHandle: HTMLElement | null = null
+
     const onMouseMove = (e: MouseEvent) => {
       // Read fresh viewport and container rect each move — the user
       // may pan/zoom while drawing a connection.
@@ -62,11 +98,41 @@ export function attachConnectionHandler<
       })
 
       connectionLine.setAttribute('d', path)
+
+      // Validate connection on hover over target handles
+      const hoverEl = document.elementFromPoint(e.clientX, e.clientY)
+      const hoveredHandle = hoverEl?.closest?.('.bf-flow__handle') as HTMLElement | null
+
+      // Clear previous handle's validation classes
+      if (lastHoveredHandle && lastHoveredHandle !== hoveredHandle) {
+        lastHoveredHandle.classList.remove('valid', 'invalid')
+      }
+
+      if (
+        hoveredHandle &&
+        hoveredHandle !== handleEl &&
+        hoveredHandle.dataset.nodeId &&
+        hoveredHandle.dataset.nodeId !== nodeId
+      ) {
+        const conn = buildConnection(nodeId, hoveredHandle.dataset.nodeId, handleType)
+        const isValid = checkConnectionValidity(store, conn)
+
+        hoveredHandle.classList.remove('valid', 'invalid')
+        hoveredHandle.classList.add(isValid ? 'valid' : 'invalid')
+        lastHoveredHandle = hoveredHandle
+      } else {
+        lastHoveredHandle = null
+      }
     }
 
     const onMouseUp = (e: MouseEvent) => {
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
+
+      // Clean up validation classes from any hovered handle
+      if (lastHoveredHandle) {
+        lastHoveredHandle.classList.remove('valid', 'invalid')
+      }
 
       // Check if released on a target handle
       const targetEl = document.elementFromPoint(e.clientX, e.clientY)
@@ -78,24 +144,21 @@ export function attachConnectionHandler<
         targetHandle.dataset.nodeId !== nodeId
       ) {
         const targetNodeId = targetHandle.dataset.nodeId
+        const conn = buildConnection(nodeId, targetNodeId, handleType)
 
-        // Determine source/target based on handle types
-        let source = nodeId
-        let target = targetNodeId
-        if (handleType === 'target') {
-          source = targetNodeId
-          target = nodeId
+        // Validate before creating edge
+        const isValid = checkConnectionValidity(store, conn)
+
+        if (isValid) {
+          const edgeId = `e-${conn.source}-${conn.target}-${Date.now()}`
+          const newEdge = { id: edgeId, source: conn.source, target: conn.target } as EdgeType
+
+          if (store.onConnect) {
+            store.onConnect(conn)
+          }
+
+          store.addEdge(newEdge)
         }
-
-        // Create edge
-        const edgeId = `e-${source}-${target}-${Date.now()}`
-        const newEdge = { id: edgeId, source, target } as EdgeType
-
-        if (store.onConnect) {
-          store.onConnect({ source, target, sourceHandle: null, targetHandle: null })
-        }
-
-        store.addEdge(newEdge)
       }
 
       // Remove connection line

--- a/packages/xyflow/src/flow.ts
+++ b/packages/xyflow/src/flow.ts
@@ -40,6 +40,7 @@ export function initFlow(scope: Element, props: Record<string, unknown>): void {
     snapToGrid: flowProps.snapToGrid,
     snapGrid: flowProps.snapGrid,
     onConnect: flowProps.onConnect,
+    isValidConnection: flowProps.isValidConnection,
   })
 
   provideContext(FlowContext, store)
@@ -213,6 +214,8 @@ function injectDefaultStyles() {
     .bf-flow__handle--target:hover { top: -5px; }
     .bf-flow__handle--source { bottom: -3px; }
     .bf-flow__handle--source:hover { bottom: -5px; }
+    .bf-flow__handle.valid { background-color: #22c55e; border-color: #16a34a; width: 10px; height: 10px; }
+    .bf-flow__handle.invalid { background-color: #ef4444; border-color: #dc2626; width: 10px; height: 10px; }
     .bf-flow__edge { fill: none; stroke: #b1b1b7; stroke-width: 1; pointer-events: none; }
     .bf-flow__edge--selected { stroke: #555; stroke-width: 2; }
     .bf-flow__edge--animated { stroke-dasharray: 5; animation: bf-dashdraw 0.5s linear infinite; }


### PR DESCRIPTION
## Summary

- Wire `isValidConnection` callback from `FlowProps` through `createFlowStore` to the connection drag handler in `connection.ts`
- During handle drag, call `isValidConnection` when hovering over a target handle and apply `.valid` / `.invalid` CSS classes for visual feedback (green = valid, red = invalid)
- Cancel connection (skip edge creation) when validation returns `false` on drop
- Add default CSS styles for `.bf-flow__handle.valid` and `.bf-flow__handle.invalid` states
- Add 5 E2E tests covering valid/invalid connection creation and visual feedback
- Add React Flow reference demo with `isValidConnection`

## Test plan

- [x] Unit tests pass: `bun test packages/xyflow/src/__tests__/` (29 tests)
- [x] E2E tests pass: `bunx playwright test e2e/flow.spec.ts` (67 tests, 5 new)
- [ ] Manual: drag from "Source" to "Allowed Target" — edge created, green handle feedback
- [ ] Manual: drag from "Source" to "Blocked Target" — no edge created, red handle feedback
- [ ] Compare with React reference at `:3199` — behavior matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)