### PR TITLE
xyflow: Add edge reconnection (#799)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -886,3 +886,152 @@ test.describe('Heavy Stress Test (100 nodes)', () => {
     expect(someVisible).toBeGreaterThan(50)
   })
 })
+
+// ============================================================
+// Edge Reconnection
+// ============================================================
+test.describe('Edge Reconnection', () => {
+  test.beforeEach(async ({ page }) => {
+    // Scroll the reconnect container into view since the page is long
+    await page.evaluate(() => {
+      const el = document.getElementById('reconnect')
+      if (el && 'scrollIntoViewIfNeeded' in el) {
+        ;(el as any).scrollIntoViewIfNeeded()
+      } else if (el) {
+        el.scrollIntoView({ block: 'center' })
+      }
+    })
+    await page.waitForSelector('#reconnect .bf-flow__node[data-id="r-a"]')
+    await page.waitForSelector('#reconnect .bf-flow__node[data-id="r-b"]')
+    await page.waitForSelector('#reconnect .bf-flow__node[data-id="r-c"]')
+  })
+
+  test('reconnect endpoint handles are visible on reconnectable edges', async ({ page }) => {
+    // Reconnection handles (SVG circles) should exist for the edge
+    const handles = await page.locator('#reconnect .bf-flow__edge-reconnect').count()
+    // 1 edge with 2 endpoints (source + target)
+    expect(handles).toBe(2)
+  })
+
+  test('reconnecting edge to a different node updates the edge', async ({ page }) => {
+    // Edge r-ab connects r-a → r-b. Drag the target endpoint to r-c.
+    const result = await page.evaluate(async () => {
+      const container = document.getElementById('reconnect')!
+
+      // Find the target reconnect handle (the one at the target end of r-ab)
+      const tgtHandle = container.querySelector('.bf-flow__edge-reconnect--target') as SVGCircleElement
+      if (!tgtHandle) return { error: 'No target reconnect handle found' }
+
+      // Get the target handle position in page coordinates
+      const svg = container.querySelector('.bf-flow__edges') as SVGSVGElement
+      const viewport = container.querySelector('.bf-flow__viewport') as HTMLElement
+      const ctm = svg.getScreenCTM()
+      if (!ctm) return { error: 'No CTM' }
+
+      const cx = parseFloat(tgtHandle.getAttribute('cx') || '0')
+      const cy = parseFloat(tgtHandle.getAttribute('cy') || '0')
+
+      // Transform SVG coords to screen coords
+      const pt = svg.createSVGPoint()
+      pt.x = cx
+      pt.y = cy
+      const screenPt = pt.matrixTransform(ctm)
+
+      // Find the target handle (r-c's target handle at the top)
+      const rCHandleTarget = container.querySelector('[data-id="r-c"] .bf-flow__handle--target') as HTMLElement
+      if (!rCHandleTarget) return { error: 'No r-c target handle' }
+      const targetRect = rCHandleTarget.getBoundingClientRect()
+      const targetX = targetRect.left + targetRect.width / 2
+      const targetY = targetRect.top + targetRect.height / 2
+
+      // Dispatch drag from reconnect handle to r-c's handle
+      tgtHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: screenPt.x, clientY: screenPt.y, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: targetX, clientY: targetY, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: targetX, clientY: targetY, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 200))
+
+      // Check onReconnect was called
+      const log = (window as any).__reconnectLog || []
+      return {
+        reconnectCalled: log.length > 0,
+        oldEdgeId: log[0]?.oldEdge?.id,
+        newTarget: log[0]?.newConnection?.target,
+        edgeCount: container.querySelectorAll('.bf-flow__edge').length,
+      }
+    })
+
+    expect(result.reconnectCalled).toBe(true)
+    expect(result.oldEdgeId).toBe('r-ab')
+    expect(result.newTarget).toBe('r-c')
+    // Edge count should still be 1 (reconnected, not added)
+    expect(result.edgeCount).toBe(1)
+  })
+
+  test('dropping on empty space reverts the edge', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const container = document.getElementById('reconnect')!
+
+      const edgeBefore = container.querySelector('.bf-flow__edge[data-id="r-ab"]')
+      const pathBefore = edgeBefore?.getAttribute('d')
+
+      // Find the target reconnect handle
+      const tgtHandle = container.querySelector('.bf-flow__edge-reconnect--target') as SVGCircleElement
+      if (!tgtHandle) return { error: 'No target reconnect handle' }
+
+      const svg = container.querySelector('.bf-flow__edges') as SVGSVGElement
+      const ctm = svg.getScreenCTM()
+      if (!ctm) return { error: 'No CTM' }
+
+      const cx = parseFloat(tgtHandle.getAttribute('cx') || '0')
+      const cy = parseFloat(tgtHandle.getAttribute('cy') || '0')
+      const pt = svg.createSVGPoint()
+      pt.x = cx
+      pt.y = cy
+      const screenPt = pt.matrixTransform(ctm)
+
+      // Drag to empty space (far away from any node)
+      const containerRect = container.getBoundingClientRect()
+      const emptyX = containerRect.left + containerRect.width - 10
+      const emptyY = containerRect.top + containerRect.height - 10
+
+      tgtHandle.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: screenPt.x, clientY: screenPt.y, button: 0, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: emptyX, clientY: emptyY, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: emptyX, clientY: emptyY, bubbles: true, view: window,
+      }))
+      await new Promise(r => setTimeout(r, 200))
+
+      // Edge should still exist with the same path (reverted)
+      const edgeAfter = container.querySelector('.bf-flow__edge[data-id="r-ab"]')
+      const pathAfter = edgeAfter?.getAttribute('d')
+
+      return {
+        edgeExists: !!edgeAfter,
+        edgeCount: container.querySelectorAll('.bf-flow__edge').length,
+        pathPreserved: pathBefore === pathAfter,
+      }
+    })
+
+    expect(result.edgeExists).toBe(true)
+    expect(result.edgeCount).toBe(1)
+    expect(result.pathPreserved).toBe(true)
+  })
+})

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -36,6 +36,9 @@
 <h2>Connection Validation</h2>
 <div id="validation" class="test-container"></div>
 
+<h2>Edge Reconnection</h2>
+<div id="reconnect" class="test-container"></div>
+
 <script type="module">
 import { createRoot } from '@barefootjs/client'
 import { initFlow, initBackground, initControls } from '@barefootjs/xyflow'
@@ -167,6 +170,26 @@ createRoot(() => {
 
   initFlow(el, { nodes, edges, fitView: true })
   initControls(el, { position: 'top-right' })
+})
+
+// Edge Reconnection — edges can be reconnected by dragging endpoints
+createRoot(() => {
+  const reconnectEl = document.getElementById('reconnect')
+  window.__reconnectLog = []
+  initFlow(reconnectEl, {
+    nodes: [
+      { id: 'r-a', position: { x: 50, y: 100 }, data: { label: 'Node A' } },
+      { id: 'r-b', position: { x: 300, y: 50 }, data: { label: 'Node B' } },
+      { id: 'r-c', position: { x: 300, y: 200 }, data: { label: 'Node C' } },
+    ],
+    edges: [
+      { id: 'r-ab', source: 'r-a', target: 'r-b' },
+    ],
+    edgesReconnectable: true,
+    onReconnect: (oldEdge, newConnection) => {
+      window.__reconnectLog.push({ oldEdge, newConnection })
+    },
+  })
 })
 
 // Connection Validation — only allow connections to "v-allowed"

--- a/packages/xyflow/src/connection.ts
+++ b/packages/xyflow/src/connection.ts
@@ -1,6 +1,6 @@
 import { untrack } from '@barefootjs/client'
-import { getBezierPath, Position } from '@xyflow/system'
-import type { FlowStore, NodeBase, EdgeBase } from './types'
+import { getBezierPath, Position, reconnectEdge as reconnectEdgeUtil } from '@xyflow/system'
+import type { FlowStore, NodeBase, EdgeBase, Connection } from './types'
 import { SVG_NS } from './constants'
 
 /**
@@ -162,6 +162,172 @@ export function attachConnectionHandler<
       }
 
       // Remove connection line
+      connectionLine.remove()
+    }
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  })
+}
+
+/**
+ * Attach a reconnection drag handler to an edge endpoint handle.
+ * Dragging this handle detaches the edge from its source/target and allows
+ * reconnecting to a different handle.
+ *
+ * @param handleEl - The SVG circle element acting as the reconnection grip
+ * @param edge - The edge being reconnected
+ * @param endpointType - Which endpoint of the edge is being dragged ('source' | 'target')
+ * @param container - The flow container element
+ * @param edgesSvg - The SVG element containing edge paths
+ * @param store - The flow store
+ */
+export function attachReconnectionHandler<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+>(
+  handleEl: SVGCircleElement,
+  edge: EdgeType,
+  endpointType: 'source' | 'target',
+  container: HTMLElement,
+  edgesSvg: SVGSVGElement,
+  store: FlowStore<NodeType, EdgeType>,
+): void {
+  handleEl.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return
+    e.stopPropagation()
+    e.preventDefault()
+
+    // The fixed anchor is the opposite endpoint of the edge
+    const anchorNodeId = endpointType === 'source' ? edge.target : edge.source
+
+    // Determine anchor position from the node
+    const nodeLookup = untrack(store.nodeLookup)
+    const anchorNode = nodeLookup.get(anchorNodeId)
+    if (!anchorNode) return
+
+    const anchorW = anchorNode.measured.width ?? 150
+    const anchorH = anchorNode.measured.height ?? 40
+    const anchorPos = anchorNode.internals.positionAbsolute
+
+    // For the anchor, use the handle position appropriate for the fixed end:
+    // If we're dragging the "source" end, the fixed anchor is the "target" end
+    // (which has a handle at the top). If dragging "target", anchor is "source" (bottom).
+    const anchorX = anchorPos.x + anchorW / 2
+    const anchorY = endpointType === 'source'
+      ? anchorPos.y          // target handle is at top
+      : anchorPos.y + anchorH // source handle is at bottom
+
+    // Hide the original edge path while reconnecting
+    const edgePathEl = edgesSvg.querySelector(`.bf-flow__edge[data-id="${edge.id}"]`) as SVGPathElement | null
+    const hitPathEl = edgesSvg.querySelector(`path[data-hit-id="${edge.id}"]`) as SVGPathElement | null
+    if (edgePathEl) edgePathEl.style.opacity = '0.2'
+    if (hitPathEl) hitPathEl.style.display = 'none'
+
+    // Create temporary connection line from anchor to cursor
+    const connectionLine = document.createElementNS(SVG_NS, 'path')
+    connectionLine.setAttribute('fill', 'none')
+    connectionLine.setAttribute('stroke', '#b1b1b7')
+    connectionLine.setAttribute('stroke-width', '1')
+    connectionLine.setAttribute('stroke-dasharray', '5')
+    edgesSvg.appendChild(connectionLine)
+
+    let lastHoveredHandle: HTMLElement | null = null
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const containerRect = container.getBoundingClientRect()
+      const [, , scale] = store.getTransform()
+      const vp = untrack(store.viewport)
+
+      const cursorX = (ev.clientX - containerRect.left - vp.x) / scale
+      const cursorY = (ev.clientY - containerRect.top - vp.y) / scale
+
+      // Draw bezier from anchor to cursor
+      // sourcePosition/targetPosition depends on which endpoint is the anchor
+      const sourcePosition = endpointType === 'source' ? Position.Top : Position.Bottom
+      const targetPosition = endpointType === 'source' ? Position.Bottom : Position.Top
+
+      const [path] = getBezierPath({
+        sourceX: anchorX,
+        sourceY: anchorY,
+        sourcePosition,
+        targetX: cursorX,
+        targetY: cursorY,
+        targetPosition,
+      })
+
+      connectionLine.setAttribute('d', path)
+
+      // Validate on hover over handles
+      const hoverEl = document.elementFromPoint(ev.clientX, ev.clientY)
+      const hoveredHandle = hoverEl?.closest?.('.bf-flow__handle') as HTMLElement | null
+
+      if (lastHoveredHandle && lastHoveredHandle !== hoveredHandle) {
+        lastHoveredHandle.classList.remove('valid', 'invalid')
+      }
+
+      if (
+        hoveredHandle &&
+        hoveredHandle.dataset.nodeId &&
+        hoveredHandle.dataset.nodeId !== anchorNodeId
+      ) {
+        // Build connection: anchor is the fixed end, hovered node is the new end
+        const hoveredNodeId = hoveredHandle.dataset.nodeId
+        const conn: Connection = endpointType === 'source'
+          ? { source: hoveredNodeId, target: anchorNodeId, sourceHandle: null, targetHandle: null }
+          : { source: anchorNodeId, target: hoveredNodeId, sourceHandle: null, targetHandle: null }
+
+        const isValid = checkConnectionValidity(store, conn)
+        hoveredHandle.classList.remove('valid', 'invalid')
+        hoveredHandle.classList.add(isValid ? 'valid' : 'invalid')
+        lastHoveredHandle = hoveredHandle
+      } else {
+        lastHoveredHandle = null
+      }
+    }
+
+    const onMouseUp = (ev: MouseEvent) => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+
+      if (lastHoveredHandle) {
+        lastHoveredHandle.classList.remove('valid', 'invalid')
+      }
+
+      // Restore the original edge appearance
+      if (edgePathEl) edgePathEl.style.opacity = ''
+      if (hitPathEl) hitPathEl.style.display = ''
+
+      // Check if released on a valid handle
+      const targetEl = document.elementFromPoint(ev.clientX, ev.clientY)
+      const droppedHandle = targetEl?.closest?.('.bf-flow__handle') as HTMLElement | null
+
+      if (
+        droppedHandle &&
+        droppedHandle.dataset.nodeId &&
+        droppedHandle.dataset.nodeId !== anchorNodeId
+      ) {
+        const droppedNodeId = droppedHandle.dataset.nodeId
+        const newConnection: Connection = endpointType === 'source'
+          ? { source: droppedNodeId, target: anchorNodeId, sourceHandle: null, targetHandle: null }
+          : { source: anchorNodeId, target: droppedNodeId, sourceHandle: null, targetHandle: null }
+
+        const isValid = checkConnectionValidity(store, newConnection)
+
+        if (isValid) {
+          // Fire onReconnect callback
+          if (store.onReconnect) {
+            store.onReconnect(edge, newConnection)
+          }
+
+          // Update edges using reconnectEdge utility
+          const currentEdges = untrack(store.edges)
+          const updatedEdges = reconnectEdgeUtil(edge, newConnection, currentEdges)
+          store.setEdges(updatedEdges as EdgeType[])
+        }
+      }
+      // If not dropped on a valid handle, the edge reverts (appearance already restored)
+
       connectionLine.remove()
     }
 

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -17,6 +17,7 @@ import type {
 } from '@xyflow/system'
 import type { FlowStore } from './types'
 import { SVG_NS } from './constants'
+import { attachReconnectionHandler } from './connection'
 
 /**
  * Reactively renders all edges as SVG paths.
@@ -34,9 +35,11 @@ export function createEdgeRenderer<
   edgeGroup.setAttribute('class', 'bf-flow__edge-group')
   svgContainer.appendChild(edgeGroup)
 
-  // Track edge path elements and hit areas by edge id
+  // Track edge path elements, hit areas, and reconnection handles by edge id
   const edgeElements = new Map<string, SVGPathElement>()
   const hitElements = new Map<string, SVGPathElement>()
+  const reconnectSourceHandles = new Map<string, SVGCircleElement>()
+  const reconnectTargetHandles = new Map<string, SVGCircleElement>()
 
   createEffect(() => {
     const edges = store.edges()
@@ -98,6 +101,7 @@ export function createEdgeRenderer<
         hitPath.setAttribute('fill', 'none')
         hitPath.setAttribute('stroke', 'transparent')
         hitPath.setAttribute('stroke-width', '20')
+        hitPath.dataset.hitId = edge.id
         hitPath.style.cursor = 'pointer'
         hitPath.style.pointerEvents = 'stroke'
         hitPath.addEventListener('mousedown', (e) => {
@@ -132,6 +136,47 @@ export function createEdgeRenderer<
 
       pathEl.classList.toggle('bf-flow__edge--selected', !!edge.selected)
       pathEl.classList.toggle('bf-flow__edge--animated', !!edge.animated)
+
+      // Edge reconnection handles
+      const isReconnectable = store.edgesReconnectable && (edge as any).reconnectable !== false
+      if (isReconnectable) {
+        // Source reconnection handle
+        let srcHandle = reconnectSourceHandles.get(edge.id)
+        if (!srcHandle) {
+          srcHandle = document.createElementNS(SVG_NS, 'circle') as SVGCircleElement
+          srcHandle.setAttribute('class', 'bf-flow__edge-reconnect bf-flow__edge-reconnect--source')
+          srcHandle.setAttribute('r', '5')
+          srcHandle.style.cursor = 'crosshair'
+          srcHandle.style.pointerEvents = 'all'
+          edgeGroup.appendChild(srcHandle)
+          reconnectSourceHandles.set(edge.id, srcHandle)
+          // Attach reconnection handler
+          const container = store.domNode()
+          if (container) {
+            attachReconnectionHandler(srcHandle, edge, 'source', container, svgContainer, store)
+          }
+        }
+        srcHandle.setAttribute('cx', String(edgePos.sourceX))
+        srcHandle.setAttribute('cy', String(edgePos.sourceY))
+
+        // Target reconnection handle
+        let tgtHandle = reconnectTargetHandles.get(edge.id)
+        if (!tgtHandle) {
+          tgtHandle = document.createElementNS(SVG_NS, 'circle') as SVGCircleElement
+          tgtHandle.setAttribute('class', 'bf-flow__edge-reconnect bf-flow__edge-reconnect--target')
+          tgtHandle.setAttribute('r', '5')
+          tgtHandle.style.cursor = 'crosshair'
+          tgtHandle.style.pointerEvents = 'all'
+          edgeGroup.appendChild(tgtHandle)
+          reconnectTargetHandles.set(edge.id, tgtHandle)
+          const container = store.domNode()
+          if (container) {
+            attachReconnectionHandler(tgtHandle, edge, 'target', container, svgContainer, store)
+          }
+        }
+        tgtHandle.setAttribute('cx', String(edgePos.targetX))
+        tgtHandle.setAttribute('cy', String(edgePos.targetY))
+      }
     }
 
     // Remove edges that no longer exist
@@ -140,6 +185,10 @@ export function createEdgeRenderer<
       if (el) { el.remove(); edgeElements.delete(removedId) }
       const hit = hitElements.get(removedId)
       if (hit) { hit.remove(); hitElements.delete(removedId) }
+      const srcH = reconnectSourceHandles.get(removedId)
+      if (srcH) { srcH.remove(); reconnectSourceHandles.delete(removedId) }
+      const tgtH = reconnectTargetHandles.get(removedId)
+      if (tgtH) { tgtH.remove(); reconnectTargetHandles.delete(removedId) }
     }
   })
 
@@ -147,6 +196,8 @@ export function createEdgeRenderer<
     edgeGroup.remove()
     edgeElements.clear()
     hitElements.clear()
+    reconnectSourceHandles.clear()
+    reconnectTargetHandles.clear()
   })
 }
 

--- a/packages/xyflow/src/flow.ts
+++ b/packages/xyflow/src/flow.ts
@@ -41,6 +41,8 @@ export function initFlow(scope: Element, props: Record<string, unknown>): void {
     snapGrid: flowProps.snapGrid,
     onConnect: flowProps.onConnect,
     isValidConnection: flowProps.isValidConnection,
+    edgesReconnectable: flowProps.edgesReconnectable,
+    onReconnect: flowProps.onReconnect,
   })
 
   provideContext(FlowContext, store)
@@ -220,6 +222,9 @@ function injectDefaultStyles() {
     .bf-flow__edge--selected { stroke: #555; stroke-width: 2; }
     .bf-flow__edge--animated { stroke-dasharray: 5; animation: bf-dashdraw 0.5s linear infinite; }
     @keyframes bf-dashdraw { from { stroke-dashoffset: 10; } }
+    .bf-flow__edge-reconnect { fill: #b1b1b7; stroke: #fff; stroke-width: 1.5; opacity: 0; transition: opacity 0.15s; }
+    .bf-flow__edge-group:hover .bf-flow__edge-reconnect { opacity: 1; }
+    .bf-flow__edge-reconnect:hover { fill: #555; r: 7; }
     .bf-flow__controls-button:hover { background: #f4f4f4 !important; }
     .bf-flow__controls-button:last-child { border-bottom: none !important; }
   `

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -6,7 +6,7 @@ export { createNodeWrapper, createNodeRenderer } from './node-wrapper'
 export { createEdgeRenderer } from './edge-renderer'
 export { createHandle, initHandle } from './handle'
 export type { HandleType, HandleProps } from './handle'
-export { attachConnectionHandler } from './connection'
+export { attachConnectionHandler, attachReconnectionHandler } from './connection'
 export { useFlow, useViewport, useNodes, useEdges, useNodesInitialized } from './hooks'
 export { setupKeyboardHandlers, setupNodeSelection } from './selection'
 
@@ -46,6 +46,8 @@ export type {
   NodeDragItem,
   ConnectionMode,
   NodeComponentProps,
+  OnReconnect,
+  Connection,
 } from './types'
 
 // Compat layer (React Flow API shims for desk migration)

--- a/packages/xyflow/src/store.ts
+++ b/packages/xyflow/src/store.ts
@@ -47,6 +47,7 @@ export function createFlowStore<
   const nodeExtent = options.nodeExtent ?? INFINITE_EXTENT
   const snapToGrid = options.snapToGrid ?? false
   const snapGrid: SnapGrid = options.snapGrid ?? [15, 15]
+  const edgesReconnectable = options.edgesReconnectable ?? false
 
   // --- Core state signals ---
   const [nodes, setNodes] = createSignal<NodeType[]>(options.nodes ?? [])
@@ -344,6 +345,7 @@ export function createFlowStore<
     nodeExtent,
     snapToGrid,
     snapGrid,
+    edgesReconnectable,
 
     getTransform,
 
@@ -356,5 +358,6 @@ export function createFlowStore<
     onConnectStart: options.onConnectStart,
     onConnectEnd: options.onConnectEnd,
     isValidConnection: options.isValidConnection,
+    onReconnect: options.onReconnect,
   }
 }

--- a/packages/xyflow/src/types.ts
+++ b/packages/xyflow/src/types.ts
@@ -20,6 +20,7 @@ import type {
   IsValidConnection,
   NodeDragItem,
   ConnectionMode,
+  Connection,
 } from '@xyflow/system'
 import type { Signal, Memo } from '@barefootjs/client'
 import type { ComponentDef } from '@barefootjs/client-runtime'
@@ -47,7 +48,16 @@ export type {
   IsValidConnection,
   NodeDragItem,
   ConnectionMode,
+  Connection,
 }
+
+/**
+ * Callback fired when an edge is reconnected to a new handle.
+ */
+export type OnReconnect<EdgeType extends EdgeBase = EdgeBase> = (
+  oldEdge: EdgeType,
+  newConnection: Connection,
+) => void
 
 /**
  * Options for creating a flow store.
@@ -71,6 +81,10 @@ export type FlowStoreOptions<
   // Custom component types
   nodeTypes?: Record<string, ComponentDef | ((props: NodeComponentProps<NodeType>) => void)>
   edgeTypes?: Record<string, ComponentDef>
+
+  // Edge reconnection
+  edgesReconnectable?: boolean
+  onReconnect?: OnReconnect<EdgeType>
 
   // Callbacks
   onConnect?: OnConnect
@@ -155,6 +169,10 @@ export type FlowStore<
   // Custom component types
   nodeTypes?: Record<string, ComponentDef | ((props: NodeComponentProps<NodeType>) => void)>
   edgeTypes?: Record<string, ComponentDef>
+
+  // Edge reconnection
+  edgesReconnectable: boolean
+  onReconnect?: OnReconnect<EdgeType>
 
   // Callbacks
   onConnect?: OnConnect


### PR DESCRIPTION
## Summary

- Add `edgesReconnectable` prop and `onReconnect` callback to enable reconnecting existing edges by dragging endpoint handles
- Show small SVG circle handles at edge source/target endpoints (visible on hover via CSS transition)
- Dragging an endpoint handle starts reconnection mode with a dashed connection line; dropping on a valid handle updates the edge via `@xyflow/system` `reconnectEdge` utility
- Connection validation (`isValidConnection`) applies during reconnection, with visual valid/invalid feedback on target handles
- Dropping on empty space reverts the edge (no change)

## Test plan

- [x] Unit tests pass (`bun test packages/xyflow/src/__tests__/` — 29 tests)
- [x] E2E tests pass (`bunx playwright test e2e/flow.spec.ts` — 70 tests, 3 new)
- [x] New E2E: reconnect endpoint handles visible on reconnectable edges
- [x] New E2E: reconnecting edge to a different node updates edge + fires `onReconnect`
- [x] New E2E: dropping on empty space reverts edge
- [ ] Manual: compare with React Flow reference (`tmp/xyflow-react-ref/app.tsx` on :3199)

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)