### PR TITLE
xyflow: Add edge labels and edge toolbar (#802)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -155,6 +155,136 @@ test.describe('Edge Rendering', () => {
 })
 
 // ============================================================
+// Edge Labels
+// ============================================================
+test.describe('Edge Labels', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      document.getElementById('edge-labels')?.scrollIntoView({ block: 'center' })
+    })
+  })
+
+  test('renders edge labels with correct text', async ({ page }) => {
+    const labels = page.locator('#edge-labels .bf-flow__edge-label')
+    await expect(labels).toHaveCount(2)
+    await expect(labels.nth(0)).toHaveText('connection 1')
+    await expect(labels.nth(1)).toHaveText('connection 2')
+  })
+
+  test('edge labels have data-edge-id attribute', async ({ page }) => {
+    await expect(
+      page.locator('#edge-labels .bf-flow__edge-label[data-edge-id="el-ab"]'),
+    ).toBeAttached()
+    await expect(
+      page.locator('#edge-labels .bf-flow__edge-label[data-edge-id="el-ac"]'),
+    ).toBeAttached()
+  })
+
+  test('edges without label do not render label element', async ({ page }) => {
+    await expect(
+      page.locator('#edge-labels .bf-flow__edge-label[data-edge-id="el-bc"]'),
+    ).not.toBeAttached()
+  })
+
+  test('edge labels are positioned with transform', async ({ page }) => {
+    const label = page.locator('#edge-labels .bf-flow__edge-label').first()
+    const style = await label.getAttribute('style')
+    expect(style).toContain('translate')
+  })
+
+  test('edge toolbar appears on edge selection', async ({ page }) => {
+    // Initially toolbar is hidden
+    await page.waitForSelector('#edge-labels .bf-flow__edge')
+
+    // Click on edge hit area to select it
+    await page.evaluate(() => {
+      const hitPath = document.querySelector('#edge-labels path[stroke="transparent"]')!
+      hitPath.dispatchEvent(
+        new MouseEvent('mousedown', { button: 0, bubbles: true, view: window }),
+      )
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, view: window }))
+    })
+    await page.waitForTimeout(100)
+
+    // Toolbar should be visible
+    const toolbar = page.locator('#edge-labels .bf-flow__edge-toolbar')
+    await expect(toolbar).toBeVisible()
+  })
+
+  test('edge toolbar delete button removes selected edge', async ({ page }) => {
+    await page.waitForSelector('#edge-labels .bf-flow__edge')
+    const beforeCount = await page.locator('#edge-labels .bf-flow__edge').count()
+
+    // Select first edge
+    await page.evaluate(() => {
+      const hitPath = document.querySelector('#edge-labels path[stroke="transparent"]')!
+      hitPath.dispatchEvent(
+        new MouseEvent('mousedown', { button: 0, bubbles: true, view: window }),
+      )
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, view: window }))
+    })
+    await page.waitForTimeout(100)
+
+    // Click delete button on toolbar
+    await page.evaluate(() => {
+      const btn = document.querySelector(
+        '#edge-labels .bf-flow__edge-toolbar-button',
+      )!
+      btn.dispatchEvent(
+        new MouseEvent('mousedown', { button: 0, bubbles: true, view: window }),
+      )
+    })
+    await page.waitForTimeout(100)
+
+    const afterCount = await page.locator('#edge-labels .bf-flow__edge').count()
+    expect(afterCount).toBeLessThan(beforeCount)
+  })
+
+  test('edge labels update position when node is dragged', async ({ page }) => {
+    await page.waitForSelector('#edge-labels .bf-flow__edge-label')
+
+    const result = await page.evaluate(async () => {
+      const label = document.querySelector('#edge-labels .bf-flow__edge-label')! as HTMLElement
+      const before = label.style.transform
+
+      // Drag source node
+      const node = document.querySelector('#edge-labels [data-id="el1"]')!
+      const rect = node.getBoundingClientRect()
+      const cx = rect.left + rect.width / 2
+      const cy = rect.top + rect.height / 2
+
+      node.dispatchEvent(
+        new MouseEvent('mousedown', {
+          clientX: cx,
+          clientY: cy,
+          button: 0,
+          bubbles: true,
+          view: window,
+        }),
+      )
+      for (let i = 1; i <= 5; i++) {
+        document.dispatchEvent(
+          new MouseEvent('mousemove', {
+            clientX: cx + i * 20,
+            clientY: cy,
+            bubbles: true,
+            view: window,
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 16))
+      }
+      document.dispatchEvent(
+        new MouseEvent('mouseup', { bubbles: true, view: window }),
+      )
+      await new Promise((r) => setTimeout(r, 100))
+
+      return { before, after: label.style.transform }
+    })
+    expect(result.after).not.toBe(result.before)
+  })
+})
+
+// ============================================================
 // Edge Properties (hidden, animated)
 // ============================================================
 test.describe('Edge Properties', () => {

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -30,6 +30,9 @@
 <h2>Stress Test (20 nodes)</h2>
 <div id="stress" class="test-container" style="height:500px"></div>
 
+<h2>Edge Labels</h2>
+<div id="edge-labels" class="test-container"></div>
+
 <h2>Heavy Stress Test (100 nodes)</h2>
 <div id="heavy-stress" class="test-container" style="height:600px"></div>
 
@@ -104,6 +107,22 @@ createRoot(() => {
     edges: [
       { id: 'e-drag', source: 'drag1', target: 'drag2' },
       { id: 'e-fixed', source: 'drag1', target: 'fixed' },
+    ],
+  })
+})
+
+// Edge labels test — labels on edges, toolbar on selection
+createRoot(() => {
+  initFlow(document.getElementById('edge-labels'), {
+    nodes: [
+      { id: 'el1', position: { x: 50, y: 50 }, data: { label: 'Source' } },
+      { id: 'el2', position: { x: 300, y: 50 }, data: { label: 'Target A' } },
+      { id: 'el3', position: { x: 300, y: 200 }, data: { label: 'Target B' } },
+    ],
+    edges: [
+      { id: 'el-ab', source: 'el1', target: 'el2', label: 'connection 1' },
+      { id: 'el-ac', source: 'el1', target: 'el3', label: 'connection 2' },
+      { id: 'el-bc', source: 'el2', target: 'el3' },
     ],
   })
 })

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -7,6 +7,7 @@ import {
   getSmoothStepPath,
   getStraightPath,
   getEdgePosition,
+  getEdgeToolbarTransform,
   ConnectionMode,
   Position,
 } from '@xyflow/system'
@@ -37,6 +38,10 @@ export function createEdgeRenderer<
   // Track edge path elements and hit areas by edge id
   const edgeElements = new Map<string, SVGPathElement>()
   const hitElements = new Map<string, SVGPathElement>()
+
+  // Expose label positions so the edge label renderer can read them
+  const labelPositions = new Map<string, { x: number; y: number }>()
+  ;(store as any)._edgeLabelPositions = labelPositions
 
   createEffect(() => {
     const edges = store.edges()
@@ -89,7 +94,10 @@ export function createEdgeRenderer<
       const pathData = getEdgePath(edge, edgePos)
       if (!pathData) continue
 
-      const [path] = pathData
+      const [path, labelX, labelY] = pathData
+
+      // Store label position for the edge label renderer
+      labelPositions.set(edge.id, { x: labelX, y: labelY })
 
       let pathEl = edgeElements.get(edge.id)
       if (!pathEl) {
@@ -140,6 +148,7 @@ export function createEdgeRenderer<
       if (el) { el.remove(); edgeElements.delete(removedId) }
       const hit = hitElements.get(removedId)
       if (hit) { hit.remove(); hitElements.delete(removedId) }
+      labelPositions.delete(removedId)
     }
   })
 
@@ -147,6 +156,161 @@ export function createEdgeRenderer<
     edgeGroup.remove()
     edgeElements.clear()
     hitElements.clear()
+    labelPositions.clear()
+  })
+}
+
+/**
+ * Reactively renders edge labels and edge toolbar as HTML elements
+ * in a layer above the SVG edges.
+ *
+ * Edge labels are positioned at the midpoint of each edge using CSS transforms.
+ * When an edge is selected, a toolbar with a delete button appears near the midpoint.
+ */
+export function createEdgeLabelRenderer<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+>(
+  store: FlowStore<NodeType, EdgeType>,
+  viewportEl: HTMLElement,
+): void {
+  // Container for edge labels — positioned absolutely inside the viewport
+  const labelContainer = document.createElement('div')
+  labelContainer.className = 'bf-flow__edge-labels'
+  labelContainer.style.position = 'absolute'
+  labelContainer.style.top = '0'
+  labelContainer.style.left = '0'
+  labelContainer.style.width = '0'
+  labelContainer.style.height = '0'
+  labelContainer.style.pointerEvents = 'none'
+  viewportEl.appendChild(labelContainer)
+
+  // Track label elements by edge id
+  const labelElements = new Map<string, HTMLDivElement>()
+  // Track toolbar element (only one at a time — for the selected edge)
+  let toolbarEl: HTMLDivElement | null = null
+  let toolbarEdgeId: string | null = null
+
+  createEffect(() => {
+    const edges = store.edges()
+    store.positionEpoch()
+    store.nodes()
+    store.nodeLookup()
+
+    const labelPositions = (store as any)._edgeLabelPositions as
+      | Map<string, { x: number; y: number }>
+      | undefined
+
+    const existingIds = new Set(labelElements.keys())
+    let selectedEdgeId: string | null = null
+    let selectedLabelX = 0
+    let selectedLabelY = 0
+
+    for (const edge of edges) {
+      if (edge.hidden) continue
+
+      const pos = labelPositions?.get(edge.id)
+      if (!pos) continue
+
+      // Track selected edge for toolbar
+      if (edge.selected) {
+        selectedEdgeId = edge.id
+        selectedLabelX = pos.x
+        selectedLabelY = pos.y
+      }
+
+      // Only render label if the edge has one
+      const labelText = (edge as any).label
+      if (!labelText) {
+        // No label — remove if previously existed
+        const existing = labelElements.get(edge.id)
+        if (existing) {
+          existing.remove()
+          labelElements.delete(edge.id)
+        }
+        existingIds.delete(edge.id)
+        continue
+      }
+
+      existingIds.delete(edge.id)
+
+      let labelEl = labelElements.get(edge.id)
+      if (!labelEl) {
+        labelEl = document.createElement('div')
+        labelEl.className = 'bf-flow__edge-label'
+        labelEl.dataset.edgeId = edge.id
+        labelEl.style.pointerEvents = 'all'
+        labelContainer.appendChild(labelEl)
+        labelElements.set(edge.id, labelEl)
+      }
+
+      // Update content
+      if (labelEl.textContent !== String(labelText)) {
+        labelEl.textContent = String(labelText)
+      }
+
+      // Position at edge midpoint using transform
+      labelEl.style.transform =
+        `translate(-50%, -50%) translate(${pos.x}px, ${pos.y}px)`
+
+      labelEl.classList.toggle('bf-flow__edge-label--selected', !!edge.selected)
+    }
+
+    // Remove labels for edges that no longer exist
+    for (const removedId of existingIds) {
+      const el = labelElements.get(removedId)
+      if (el) { el.remove(); labelElements.delete(removedId) }
+    }
+
+    // Edge toolbar — show on selected edge, hide otherwise
+    if (selectedEdgeId) {
+      if (!toolbarEl) {
+        toolbarEl = document.createElement('div')
+        toolbarEl.className = 'bf-flow__edge-toolbar'
+        toolbarEl.style.pointerEvents = 'all'
+        labelContainer.appendChild(toolbarEl)
+      }
+
+      // Render delete button
+      if (toolbarEdgeId !== selectedEdgeId) {
+        toolbarEl.innerHTML = ''
+        const deleteBtn = document.createElement('button')
+        deleteBtn.className = 'bf-flow__edge-toolbar-button'
+        deleteBtn.title = 'Delete edge'
+        deleteBtn.textContent = '\u00d7' // multiplication sign
+        const edgeId = selectedEdgeId
+        deleteBtn.addEventListener('mousedown', (e) => {
+          e.stopPropagation()
+          store.setEdges((prev) => prev.filter((ed) => ed.id !== edgeId))
+        })
+        toolbarEl.appendChild(deleteBtn)
+        toolbarEdgeId = selectedEdgeId
+      }
+
+      // Position toolbar below the edge midpoint
+      const zoom = store.viewport().zoom
+      const toolbarTransform = getEdgeToolbarTransform(
+        selectedLabelX,
+        selectedLabelY,
+        zoom,
+        'center',
+        'top',
+      )
+      toolbarEl.style.transform = toolbarTransform
+      toolbarEl.style.display = ''
+    } else {
+      // Hide toolbar when no edge is selected
+      if (toolbarEl) {
+        toolbarEl.style.display = 'none'
+        toolbarEdgeId = null
+      }
+    }
+  })
+
+  onCleanup(() => {
+    labelContainer.remove()
+    labelElements.clear()
+    if (toolbarEl) { toolbarEl.remove(); toolbarEl = null }
   })
 }
 

--- a/packages/xyflow/src/flow.ts
+++ b/packages/xyflow/src/flow.ts
@@ -14,7 +14,7 @@ import type {
 import { createFlowStore } from './store'
 import { FlowContext } from './context'
 import { createNodeRenderer } from './node-wrapper'
-import { createEdgeRenderer } from './edge-renderer'
+import { createEdgeRenderer, createEdgeLabelRenderer } from './edge-renderer'
 import { setupKeyboardHandlers } from './selection'
 import { INFINITE_EXTENT, SVG_NS } from './constants'
 import type { FlowProps } from './types'
@@ -142,6 +142,7 @@ export function initFlow(scope: Element, props: Record<string, unknown>): void {
 
   createNodeRenderer(store, nodesEl)
   createEdgeRenderer(store, edgesSvg)
+  createEdgeLabelRenderer(store, viewportEl)
   setupKeyboardHandlers(store, el)
 
   el.addEventListener('click', (event) => {
@@ -219,6 +220,50 @@ function injectDefaultStyles() {
     @keyframes bf-dashdraw { from { stroke-dashoffset: 10; } }
     .bf-flow__controls-button:hover { background: #f4f4f4 !important; }
     .bf-flow__controls-button:last-child { border-bottom: none !important; }
+    .bf-flow__edge-label {
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: #f8f8f8;
+      border: 1px solid #e2e2e2;
+      border-radius: 4px;
+      padding: 2px 6px;
+      font-size: 11px;
+      color: #222;
+      white-space: nowrap;
+      cursor: default;
+    }
+    .bf-flow__edge-label--selected {
+      border-color: #555;
+    }
+    .bf-flow__edge-toolbar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: flex;
+      gap: 4px;
+      z-index: 10;
+    }
+    .bf-flow__edge-toolbar-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      border: 1px solid #e2e2e2;
+      background: #fff;
+      color: #666;
+      font-size: 14px;
+      line-height: 1;
+      cursor: pointer;
+      padding: 0;
+    }
+    .bf-flow__edge-toolbar-button:hover {
+      background: #fee;
+      color: #c00;
+      border-color: #c00;
+    }
   `
   document.head.appendChild(style)
 }

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -3,7 +3,7 @@ export { initFlow } from './flow'
 export { createFlowStore } from './store'
 export { FlowContext } from './context'
 export { createNodeWrapper, createNodeRenderer } from './node-wrapper'
-export { createEdgeRenderer } from './edge-renderer'
+export { createEdgeRenderer, createEdgeLabelRenderer } from './edge-renderer'
 export { createHandle, initHandle } from './handle'
 export type { HandleType, HandleProps } from './handle'
 export { attachConnectionHandler } from './connection'
@@ -61,6 +61,7 @@ export {
   getIncomers,
   getNodesBounds,
   getNodesInside,
+  getEdgeToolbarTransform,
   Position,
   ConnectionMode as ConnectionModeEnum,
   MarkerType,


### PR DESCRIPTION
## Summary

- Add `createEdgeLabelRenderer` that renders HTML labels at edge midpoints, positioned via CSS transforms using `labelX`/`labelY` from `getEdgePath`
- Add edge toolbar that appears near selected edges with a delete button, using `getEdgeToolbarTransform` from `@xyflow/system`
- Add CSS styles for `.bf-flow__edge-label`, `.bf-flow__edge-label--selected`, `.bf-flow__edge-toolbar`, and `.bf-flow__edge-toolbar-button`
- Re-export `getEdgeToolbarTransform` from the package for custom toolbar positioning

## Test plan

- [x] 7 new E2E tests covering:
  - Edge labels render with correct text content
  - Edge labels have `data-edge-id` attribute
  - Edges without `label` property do not render label elements
  - Labels are positioned via CSS transform
  - Edge toolbar appears when an edge is selected
  - Toolbar delete button removes the selected edge
  - Label positions update when nodes are dragged
- [x] All 69 existing E2E tests pass (no regressions)
- [x] React reference demo added in `tmp/xyflow-react-ref/app.tsx`

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)