### PR TITLE
xyflow: Add selection rectangle (#801)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -662,6 +662,200 @@ test.describe('Stress Test (20 nodes)', () => {
 })
 
 // ============================================================
+// Selection Rectangle
+// ============================================================
+test.describe('Selection Rectangle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      document.getElementById('selection-rect')?.scrollIntoView({ block: 'center' })
+    })
+  })
+
+  test('Shift+drag on empty pane draws selection rectangle', async ({ page }) => {
+    await page.waitForSelector('#selection-rect .bf-flow__node[data-id="sr1"]')
+
+    const rectVisible = await page.evaluate(async () => {
+      const container = document.getElementById('selection-rect')!
+      const cr = container.getBoundingClientRect()
+      // Start drag on empty area (bottom-right corner where no nodes are)
+      const startX = cr.left + cr.width - 50
+      const startY = cr.top + cr.height - 50
+
+      container.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: startX, clientY: startY, button: 0,
+        shiftKey: true, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Move to create a rectangle
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: startX + 100, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Check if selection rect exists
+      const selRect = container.querySelector('.bf-flow__selection')
+      const exists = selRect !== null
+      const hasSize = selRect
+        ? (parseInt((selRect as HTMLElement).style.width) > 0)
+        : false
+
+      // Release
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: startX + 100, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      return { exists, hasSize }
+    })
+
+    expect(rectVisible.exists).toBe(true)
+    expect(rectVisible.hasSize).toBe(true)
+  })
+
+  test('releasing mouse removes selection rectangle', async ({ page }) => {
+    await page.waitForSelector('#selection-rect .bf-flow__node[data-id="sr1"]')
+
+    const afterRelease = await page.evaluate(async () => {
+      const container = document.getElementById('selection-rect')!
+      const cr = container.getBoundingClientRect()
+      const startX = cr.left + cr.width - 50
+      const startY = cr.top + cr.height - 50
+
+      container.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: startX, clientY: startY, button: 0,
+        shiftKey: true, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: startX + 100, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Release
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: startX + 100, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      // Check rect is removed
+      return container.querySelector('.bf-flow__selection') === null
+    })
+
+    expect(afterRelease).toBe(true)
+  })
+
+  test('nodes inside selection rectangle become selected', async ({ page }) => {
+    await page.waitForSelector('#selection-rect .bf-flow__node[data-id="sr1"]')
+
+    const result = await page.evaluate(async () => {
+      const container = document.getElementById('selection-rect')!
+      const cr = container.getBoundingClientRect()
+
+      // Drag from top-left to cover sr1 (50,50) and sr3 (50,200) — left column
+      const startX = cr.left + 10
+      const startY = cr.top + 10
+      const endX = cr.left + 220
+      const endY = cr.top + 280
+
+      container.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: startX, clientY: startY, button: 0,
+        shiftKey: true, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Move in steps for more reliable detection
+      for (let i = 1; i <= 5; i++) {
+        document.dispatchEvent(new MouseEvent('mousemove', {
+          clientX: startX + ((endX - startX) * i) / 5,
+          clientY: startY + ((endY - startY) * i) / 5,
+          bubbles: true, view: window,
+        }))
+        await new Promise((r) => setTimeout(r, 10))
+      }
+
+      // Release
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: endX, clientY: endY,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 100))
+
+      // Check which nodes are selected
+      const nodes = container.querySelectorAll('.bf-flow__node')
+      const selected: string[] = []
+      nodes.forEach((n) => {
+        if (n.classList.contains('bf-flow__node--selected')) {
+          selected.push(n.getAttribute('data-id')!)
+        }
+      })
+      return selected
+    })
+
+    // sr1 and sr3 are in the left column, should be selected
+    // sr5 is far right, should not be selected
+    expect(result).toContain('sr1')
+    expect(result).toContain('sr3')
+    expect(result).not.toContain('sr5')
+  })
+})
+
+// ============================================================
+// Selection on Drag
+// ============================================================
+test.describe('Selection on Drag', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      document.getElementById('selection-on-drag')?.scrollIntoView({ block: 'center' })
+    })
+  })
+
+  test('drag without Shift starts selection when selectionOnDrag is true', async ({ page }) => {
+    await page.waitForSelector('#selection-on-drag .bf-flow__node[data-id="sd1"]')
+
+    const result = await page.evaluate(async () => {
+      const container = document.getElementById('selection-on-drag')!
+      const cr = container.getBoundingClientRect()
+
+      // Drag on empty area without Shift
+      const startX = cr.left + cr.width - 50
+      const startY = cr.top + cr.height - 50
+
+      container.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: startX, clientY: startY, button: 0,
+        shiftKey: false, bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      document.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: startX + 80, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Check if selection rect appears
+      const selRect = container.querySelector('.bf-flow__selection')
+      const exists = selRect !== null
+
+      document.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: startX + 80, clientY: startY + 50,
+        bubbles: true, view: window,
+      }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      return exists
+    })
+
+    expect(result).toBe(true)
+  })
+})
+
+// ============================================================
 // Heavy Stress Test (100 nodes, 10x10 grid)
 // ============================================================
 test.describe('Heavy Stress Test (100 nodes)', () => {

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -30,6 +30,13 @@
 <h2>Stress Test (20 nodes)</h2>
 <div id="stress" class="test-container" style="height:500px"></div>
 
+<h2>Selection Rectangle (Shift+drag)</h2>
+<div id="selection-rect" class="test-container"></div>
+
+<h2>Selection on Drag (drag without Shift)</h2>
+<div id="selection-on-drag" class="test-container"></div>
+
+
 <h2>Heavy Stress Test (100 nodes)</h2>
 <div id="heavy-stress" class="test-container" style="height:600px"></div>
 
@@ -144,6 +151,37 @@ createRoot(() => {
   initFlow(el, { nodes, edges, fitView: true })
   initBackground(el, { variant: 'lines', gap: 30, color: '#f0f0f0' })
   initControls(el, { position: 'top-right' })
+})
+
+// Selection rectangle test — Shift+drag on empty pane
+createRoot(() => {
+  initFlow(document.getElementById('selection-rect'), {
+    nodes: [
+      { id: 'sr1', position: { x: 50, y: 50 }, data: { label: 'Node A' } },
+      { id: 'sr2', position: { x: 250, y: 50 }, data: { label: 'Node B' } },
+      { id: 'sr3', position: { x: 50, y: 200 }, data: { label: 'Node C' } },
+      { id: 'sr4', position: { x: 250, y: 200 }, data: { label: 'Node D' } },
+      { id: 'sr5', position: { x: 500, y: 120 }, data: { label: 'Node E' } },
+    ],
+    edges: [
+      { id: 'esr-ab', source: 'sr1', target: 'sr2' },
+      { id: 'esr-cd', source: 'sr3', target: 'sr4' },
+    ],
+  })
+})
+
+// Selection on drag test — drag without Shift starts selection
+createRoot(() => {
+  initFlow(document.getElementById('selection-on-drag'), {
+    nodes: [
+      { id: 'sd1', position: { x: 50, y: 50 }, data: { label: 'Left' } },
+      { id: 'sd2', position: { x: 250, y: 50 }, data: { label: 'Center' } },
+      { id: 'sd3', position: { x: 450, y: 50 }, data: { label: 'Right' } },
+    ],
+    edges: [],
+    selectionOnDrag: true,
+    selectionMode: 'partial',
+  })
 })
 
 // Heavy stress test — 100 nodes, 180 edges (10x10 grid)

--- a/packages/xyflow/src/flow.ts
+++ b/packages/xyflow/src/flow.ts
@@ -15,7 +15,7 @@ import { createFlowStore } from './store'
 import { FlowContext } from './context'
 import { createNodeRenderer } from './node-wrapper'
 import { createEdgeRenderer } from './edge-renderer'
-import { setupKeyboardHandlers } from './selection'
+import { setupKeyboardHandlers, setupSelectionRectangle } from './selection'
 import { INFINITE_EXTENT, SVG_NS } from './constants'
 import type { FlowProps } from './types'
 
@@ -143,6 +143,10 @@ export function initFlow(scope: Element, props: Record<string, unknown>): void {
   createNodeRenderer(store, nodesEl)
   createEdgeRenderer(store, edgesSvg)
   setupKeyboardHandlers(store, el)
+  setupSelectionRectangle(store, el, {
+    selectionOnDrag: flowProps.selectionOnDrag,
+    selectionMode: flowProps.selectionMode,
+  })
 
   el.addEventListener('click', (event) => {
     if (event.target === el || event.target === viewportEl) {
@@ -219,6 +223,12 @@ function injectDefaultStyles() {
     @keyframes bf-dashdraw { from { stroke-dashoffset: 10; } }
     .bf-flow__controls-button:hover { background: #f4f4f4 !important; }
     .bf-flow__controls-button:last-child { border-bottom: none !important; }
+    .bf-flow__selection {
+      background: rgba(0, 89, 220, 0.08);
+      border: 1px solid rgba(0, 89, 220, 0.4);
+      border-radius: 2px;
+      pointer-events: none;
+    }
   `
   document.head.appendChild(style)
 }

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -8,7 +8,8 @@ export { createHandle, initHandle } from './handle'
 export type { HandleType, HandleProps } from './handle'
 export { attachConnectionHandler } from './connection'
 export { useFlow, useViewport, useNodes, useEdges, useNodesInitialized } from './hooks'
-export { setupKeyboardHandlers, setupNodeSelection } from './selection'
+export { setupKeyboardHandlers, setupNodeSelection, setupSelectionRectangle } from './selection'
+export type { SelectionRectOptions } from './selection'
 
 // Plugins
 export { initBackground } from './background'
@@ -46,6 +47,7 @@ export type {
   NodeDragItem,
   ConnectionMode,
   NodeComponentProps,
+  SelectionMode,
 } from './types'
 
 // Compat layer (React Flow API shims for desk migration)

--- a/packages/xyflow/src/selection.ts
+++ b/packages/xyflow/src/selection.ts
@@ -1,6 +1,6 @@
 import { onCleanup, untrack } from '@barefootjs/client'
-import type { NodeBase, EdgeBase } from '@xyflow/system'
-import type { FlowStore, InternalFlowStore } from './types'
+import type { NodeBase, EdgeBase, InternalNodeBase, Transform } from '@xyflow/system'
+import type { FlowStore, InternalFlowStore, SelectionMode } from './types'
 
 /**
  * Set up keyboard handlers for the flow container.
@@ -97,5 +97,233 @@ export function setupNodeSelection<NodeType extends NodeBase>(
           : n,
       ),
     )
+  })
+}
+
+/**
+ * Simple rect type for selection calculations.
+ */
+type SelectionRect = { x: number; y: number; width: number; height: number }
+
+/**
+ * Find nodes whose absolute positions overlap a screen-space rectangle.
+ *
+ * Unlike @xyflow/system's getNodesInside, this does NOT require handleBounds
+ * to be set — it works directly with positionAbsolute and measured dimensions.
+ * This avoids the forceInitialRender fallback that returns ALL nodes.
+ */
+function findNodesInRect<NodeType extends NodeBase>(
+  nodeLookup: Map<string, InternalNodeBase<NodeType>>,
+  rect: SelectionRect,
+  [tx, ty, tScale]: Transform,
+  partially: boolean,
+): InternalNodeBase<NodeType>[] {
+  // Convert the screen-space rect to flow-space (undo viewport transform)
+  const flowRect = {
+    x: (rect.x - tx) / tScale,
+    y: (rect.y - ty) / tScale,
+    width: rect.width / tScale,
+    height: rect.height / tScale,
+  }
+
+  const result: InternalNodeBase<NodeType>[] = []
+
+  for (const node of nodeLookup.values()) {
+    if (node.hidden) continue
+
+    const nodeW = node.measured.width ?? 0
+    const nodeH = node.measured.height ?? 0
+    if (nodeW === 0 && nodeH === 0) continue
+
+    const pos = node.internals.positionAbsolute
+
+    // Calculate overlap between the flow-space selection rect and node rect
+    const overlapX = Math.max(0,
+      Math.min(flowRect.x + flowRect.width, pos.x + nodeW) -
+      Math.max(flowRect.x, pos.x),
+    )
+    const overlapY = Math.max(0,
+      Math.min(flowRect.y + flowRect.height, pos.y + nodeH) -
+      Math.max(flowRect.y, pos.y),
+    )
+    const overlapArea = overlapX * overlapY
+    const nodeArea = nodeW * nodeH
+
+    if (partially) {
+      // Partial mode: any overlap counts
+      if (overlapArea > 0) result.push(node)
+    } else {
+      // Full mode: node must be fully contained
+      if (overlapArea >= nodeArea) result.push(node)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Options for the selection rectangle behavior.
+ */
+export type SelectionRectOptions = {
+  /** When true, drag on pane starts selection without Shift key */
+  selectionOnDrag?: boolean
+  /** 'partial' selects overlapping nodes; 'full' requires full containment */
+  selectionMode?: SelectionMode
+}
+
+/**
+ * Set up selection rectangle (rubber-band / lasso) on the flow container.
+ *
+ * The rectangle is drawn when:
+ * - Shift+drag on empty pane, OR
+ * - Drag on empty pane when `selectionOnDrag` is true
+ *
+ * Nodes inside the rectangle are selected on mouse up.
+ */
+export function setupSelectionRectangle<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+>(
+  store: InternalFlowStore<NodeType, EdgeType>,
+  container: HTMLElement,
+  options: SelectionRectOptions = {},
+): void {
+  const selectionOnDrag = options.selectionOnDrag ?? false
+  const selectionMode: SelectionMode = options.selectionMode ?? 'partial'
+
+  let selectionRect: HTMLDivElement | null = null
+  let isSelecting = false
+  let startX = 0
+  let startY = 0
+
+  function handleMouseDown(event: MouseEvent) {
+    if (event.button !== 0) return
+
+    // Only start selection on the container or viewport (empty pane),
+    // not on nodes, handles, controls, etc.
+    const target = event.target as HTMLElement
+    const isPane =
+      target === container ||
+      target.classList.contains('bf-flow__viewport') ||
+      target.classList.contains('bf-flow__nodes') ||
+      target.classList.contains('bf-flow__edges')
+
+    if (!isPane) return
+
+    // Determine if selection should activate:
+    // - Shift+drag always triggers selection
+    // - Plain drag triggers selection only if selectionOnDrag is true
+    const shiftHeld = event.shiftKey
+    if (!shiftHeld && !selectionOnDrag) return
+
+    // Stop propagation so D3 pan/zoom doesn't compete with selection drag
+    event.stopPropagation()
+    event.preventDefault()
+
+    isSelecting = true
+    startX = event.clientX
+    startY = event.clientY
+
+    // Create the selection rectangle element
+    selectionRect = document.createElement('div')
+    selectionRect.className = 'bf-flow__selection'
+    selectionRect.style.position = 'absolute'
+    selectionRect.style.pointerEvents = 'none'
+    selectionRect.style.left = '0'
+    selectionRect.style.top = '0'
+    selectionRect.style.width = '0'
+    selectionRect.style.height = '0'
+    selectionRect.style.zIndex = '5'
+    container.appendChild(selectionRect)
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }
+
+  function handleMouseMove(event: MouseEvent) {
+    if (!isSelecting || !selectionRect) return
+
+    const containerRect = container.getBoundingClientRect()
+    const currentX = event.clientX
+    const currentY = event.clientY
+
+    // Calculate rectangle bounds relative to the container
+    const left = Math.min(startX, currentX) - containerRect.left
+    const top = Math.min(startY, currentY) - containerRect.top
+    const width = Math.abs(currentX - startX)
+    const height = Math.abs(currentY - startY)
+
+    selectionRect.style.left = `${left}px`
+    selectionRect.style.top = `${top}px`
+    selectionRect.style.width = `${width}px`
+    selectionRect.style.height = `${height}px`
+  }
+
+  function handleMouseUp(event: MouseEvent) {
+    if (!isSelecting) return
+
+    document.removeEventListener('mousemove', handleMouseMove)
+    document.removeEventListener('mouseup', handleMouseUp)
+
+    // Determine which nodes are inside the selection rectangle
+    const containerRect = container.getBoundingClientRect()
+    const currentX = event.clientX
+    const currentY = event.clientY
+
+    const left = Math.min(startX, currentX) - containerRect.left
+    const top = Math.min(startY, currentY) - containerRect.top
+    const width = Math.abs(currentX - startX)
+    const height = Math.abs(currentY - startY)
+
+    // Only process selection if the rectangle has meaningful size
+    // (avoid accidental clicks registering as selection)
+    if (width > 5 || height > 5) {
+      const transform = store.getTransform()
+      const nodeLookup = untrack(store.nodeLookup)
+      const partially = selectionMode === 'partial'
+
+      const nodesInside = findNodesInRect(
+        nodeLookup,
+        { x: left, y: top, width, height },
+        transform,
+        partially,
+      )
+
+      const selectedIds = new Set(nodesInside.map((n) => n.id))
+
+      if (selectedIds.size > 0) {
+        store.setNodes((prev) =>
+          prev.map((n) =>
+            selectedIds.has(n.id) ? { ...n, selected: true } : { ...n, selected: false },
+          ),
+        )
+      } else {
+        store.unselectNodesAndEdges()
+      }
+    } else {
+      // Small drag = click on empty pane, deselect all
+      store.unselectNodesAndEdges()
+    }
+
+    // Remove the selection rectangle element
+    if (selectionRect) {
+      selectionRect.remove()
+      selectionRect = null
+    }
+
+    isSelecting = false
+  }
+
+  // Use capture phase so we can intercept before D3 zoom when needed
+  container.addEventListener('mousedown', handleMouseDown, true)
+
+  onCleanup(() => {
+    container.removeEventListener('mousedown', handleMouseDown, true)
+    document.removeEventListener('mousemove', handleMouseMove)
+    document.removeEventListener('mouseup', handleMouseUp)
+    if (selectionRect) {
+      selectionRect.remove()
+      selectionRect = null
+    }
   })
 }

--- a/packages/xyflow/src/types.ts
+++ b/packages/xyflow/src/types.ts
@@ -194,6 +194,13 @@ export type NodeComponentProps<NodeType extends NodeBase = NodeBase> = {
 }
 
 /**
+ * Selection mode for rectangle selection.
+ * - 'partial': selects nodes that partially overlap the rectangle (default)
+ * - 'full': only selects nodes fully contained in the rectangle
+ */
+export type SelectionMode = 'partial' | 'full'
+
+/**
  * Props for the Flow init function.
  */
 export type FlowProps<
@@ -201,4 +208,8 @@ export type FlowProps<
   EdgeType extends EdgeBase = EdgeBase,
 > = FlowStoreOptions<NodeType, EdgeType> & {
   class?: string
+  /** When true, dragging on empty pane starts selection without Shift key */
+  selectionOnDrag?: boolean
+  /** Selection mode: 'partial' (default) or 'full' */
+  selectionMode?: SelectionMode
 }


### PR DESCRIPTION
## Summary
- Implement rubber-band selection rectangle for `@barefootjs/xyflow` — Shift+drag on empty pane draws a selection box, and nodes inside it get selected on mouse up
- Add `selectionOnDrag` prop (boolean) to enable drag-to-select without requiring the Shift key
- Add `selectionMode` prop (`'partial'` | `'full'`) controlling whether partial overlap or full containment is needed for selection
- Custom `findNodesInRect` utility that works without `handleBounds` (avoids `@xyflow/system`'s `forceInitialRender` fallback)
- CSS `.bf-flow__selection` class with semi-transparent blue overlay and `pointer-events: none`

## Test plan
- [x] Unit tests pass (29 tests)
- [x] E2E tests pass (66 tests, 4 new)
  - Shift+drag draws selection rectangle
  - Mouse release removes rectangle
  - Nodes inside rectangle become selected
  - `selectionOnDrag` enables drag without Shift

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)