### PR TITLE
xyflow: Add node resize support (#804)

### DIFF
--- a/packages/xyflow/e2e/flow.spec.ts
+++ b/packages/xyflow/e2e/flow.spec.ts
@@ -1609,3 +1609,148 @@ test.describe('Custom Edge Types', () => {
     expect(defaultEdges).toBe(1)
   })
 })
+
+// ============================================================
+// Node Resize
+// ============================================================
+test.describe('Node Resize', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      const el = document.getElementById('node-resize')
+      if (el && 'scrollIntoViewIfNeeded' in el) {
+        ;(el as any).scrollIntoViewIfNeeded()
+      } else if (el) {
+        el.scrollIntoView({ block: 'center' })
+      }
+    })
+    await page.waitForSelector('#node-resize .bf-flow__node[data-id="rs1"]')
+  })
+
+  test('resizable nodes have resize handles', async ({ page }) => {
+    const node1 = page.locator('#node-resize .bf-flow__node[data-id="rs1"]')
+    const handles = node1.locator('.bf-flow__resize-handle')
+    // Handle variant: 4 corner handles (top-left, top-right, bottom-left, bottom-right)
+    await expect(handles).toHaveCount(4)
+  })
+
+  test('resize handles have correct position data attributes', async ({ page }) => {
+    const node1 = page.locator('#node-resize .bf-flow__node[data-id="rs1"]')
+    for (const pos of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
+      await expect(node1.locator(`.bf-flow__resize-handle[data-position="${pos}"]`)).toBeAttached()
+    }
+  })
+
+  test('non-resizable node does not have resize handles', async ({ page }) => {
+    const node3 = page.locator('#node-resize .bf-flow__node[data-id="rs3"]')
+    const handles = node3.locator('.bf-flow__resize-handle')
+    await expect(handles).toHaveCount(0)
+  })
+
+  test('resizable nodes have bf-flow__node--resizable class', async ({ page }) => {
+    const node1 = page.locator('#node-resize .bf-flow__node[data-id="rs1"]')
+    await expect(node1).toHaveClass(/bf-flow__node--resizable/)
+  })
+
+  test('resize container element exists', async ({ page }) => {
+    const node1 = page.locator('#node-resize .bf-flow__node[data-id="rs1"]')
+    const container = node1.locator('.bf-flow__node-resizer')
+    await expect(container).toBeAttached()
+  })
+
+  test('dragging bottom-right handle changes node dimensions', async ({ page }) => {
+    const node1 = page.locator('#node-resize .bf-flow__node[data-id="rs1"]')
+
+    // Get initial dimensions
+    const initialBox = await node1.boundingBox()
+    expect(initialBox).toBeTruthy()
+
+    const handle = node1.locator('.bf-flow__resize-handle[data-position="bottom-right"]')
+    const handleBox = await handle.boundingBox()
+    expect(handleBox).toBeTruthy()
+
+    // Drag the bottom-right handle to increase size
+    await page.evaluate(
+      async ({ handleSel, dx, dy }) => {
+        const handleEl = document.querySelector(handleSel)!
+        const rect = handleEl.getBoundingClientRect()
+        const cx = rect.left + rect.width / 2
+        const cy = rect.top + rect.height / 2
+
+        handleEl.dispatchEvent(
+          new MouseEvent('mousedown', { clientX: cx, clientY: cy, button: 0, bubbles: true, view: window }),
+        )
+        await new Promise((r) => setTimeout(r, 50))
+        for (let i = 1; i <= 5; i++) {
+          document.dispatchEvent(
+            new MouseEvent('mousemove', {
+              clientX: cx + (dx * i) / 5,
+              clientY: cy + (dy * i) / 5,
+              bubbles: true,
+              view: window,
+            }),
+          )
+          await new Promise((r) => setTimeout(r, 16))
+        }
+        document.dispatchEvent(
+          new MouseEvent('mouseup', { clientX: cx + dx, clientY: cy + dy, bubbles: true, view: window }),
+        )
+        await new Promise((r) => setTimeout(r, 100))
+      },
+      {
+        handleSel: '#node-resize .bf-flow__node[data-id="rs1"] .bf-flow__resize-handle[data-position="bottom-right"]',
+        dx: 50,
+        dy: 30,
+      },
+    )
+
+    // Verify the onResize callback was fired
+    const resizeLog = await page.evaluate(() => (window as any).__resizeLog)
+    const rs1Resizes = resizeLog.filter((r: any) => r.nodeId === 'rs1')
+    expect(rs1Resizes.length).toBeGreaterThan(0)
+  })
+
+  test('min constraints are respected during resize', async ({ page }) => {
+    // rs1 has minWidth: 80, minHeight: 50
+    // Try to make it very small by dragging bottom-right handle far to the upper-left
+    await page.evaluate(
+      async ({ handleSel, dx, dy }) => {
+        const handleEl = document.querySelector(handleSel)!
+        const rect = handleEl.getBoundingClientRect()
+        const cx = rect.left + rect.width / 2
+        const cy = rect.top + rect.height / 2
+
+        handleEl.dispatchEvent(
+          new MouseEvent('mousedown', { clientX: cx, clientY: cy, button: 0, bubbles: true, view: window }),
+        )
+        await new Promise((r) => setTimeout(r, 50))
+        for (let i = 1; i <= 10; i++) {
+          document.dispatchEvent(
+            new MouseEvent('mousemove', {
+              clientX: cx + (dx * i) / 10,
+              clientY: cy + (dy * i) / 10,
+              bubbles: true,
+              view: window,
+            }),
+          )
+          await new Promise((r) => setTimeout(r, 16))
+        }
+        document.dispatchEvent(
+          new MouseEvent('mouseup', { clientX: cx + dx, clientY: cy + dy, bubbles: true, view: window }),
+        )
+        await new Promise((r) => setTimeout(r, 100))
+      },
+      {
+        handleSel: '#node-resize .bf-flow__node[data-id="rs1"] .bf-flow__resize-handle[data-position="bottom-right"]',
+        dx: -200, // try to shrink way below minimum
+        dy: -200,
+      },
+    )
+
+    // Check dimensions — should not be smaller than min
+    const finalBox = await page.locator('#node-resize .bf-flow__node[data-id="rs1"]').boundingBox()
+    expect(finalBox).toBeTruthy()
+    // Width should be at least minWidth (80px), accounting for zoom
+    expect(finalBox!.width).toBeGreaterThanOrEqual(75) // slight tolerance for border-box/rounding
+    expect(finalBox!.height).toBeGreaterThanOrEqual(45)
+  })
+})

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -57,9 +57,12 @@
 <h2>Custom Edge Types</h2>
 <div id="custom-edges" class="test-container"></div>
 
+<h2>Node Resize</h2>
+<div id="node-resize" class="test-container"></div>
+
 <script type="module">
 import { createRoot } from '@barefootjs/client'
-import { initFlow, initBackground, initControls, initMiniMap } from '@barefootjs/xyflow'
+import { initFlow, initBackground, initControls, initMiniMap, initNodeResizer, useFlow } from '@barefootjs/xyflow'
 
 // Debug: trace mousedown → D3 drag flow
 document.addEventListener('mousedown', (e) => {
@@ -398,6 +401,81 @@ createRoot(() => {
     edges: [],
     isValidConnection: (connection) => {
       return connection.target === 'v-allowed'
+    },
+  })
+})
+
+// Node Resize — resizable nodes with min/max constraints
+createRoot(() => {
+  window.__resizeLog = []
+
+  function resizableNodeRenderer(props) {
+    const el = this
+    const wrapper = document.createElement('div')
+    wrapper.className = 'resizable-node-content'
+    wrapper.style.padding = '12px 16px'
+    wrapper.style.minWidth = '100%'
+    wrapper.style.minHeight = '100%'
+    wrapper.style.boxSizing = 'border-box'
+
+    const title = document.createElement('div')
+    title.className = 'resizable-node-title'
+    title.textContent = props.data?.label ?? 'Resizable'
+    title.style.fontWeight = 'bold'
+    title.style.fontSize = '13px'
+    wrapper.appendChild(title)
+
+    const dims = document.createElement('div')
+    dims.className = 'resizable-node-dims'
+    dims.style.fontSize = '11px'
+    dims.style.opacity = '0.7'
+    dims.style.marginTop = '4px'
+    dims.textContent = `${props.width ?? '?'} x ${props.height ?? '?'}`
+    wrapper.appendChild(dims)
+
+    el.appendChild(wrapper)
+
+    // Get the node element (.bf-flow__node) from the content container
+    const nodeEl = el.closest('.bf-flow__node')
+
+    // Set initial dimensions on the node element
+    if (nodeEl) {
+      nodeEl.style.width = `${props.data?.initialWidth ?? 150}px`
+      nodeEl.style.height = `${props.data?.initialHeight ?? 80}px`
+    }
+
+    // Use useFlow() to access the store from context (provided by initFlow)
+    const store = useFlow()
+    if (nodeEl && store) {
+      initNodeResizer(nodeEl, props.id, store, {
+        minWidth: props.data?.minWidth ?? 80,
+        minHeight: props.data?.minHeight ?? 50,
+        maxWidth: props.data?.maxWidth ?? 400,
+        maxHeight: props.data?.maxHeight ?? 300,
+        onResize: (event, params) => {
+          window.__resizeLog.push({
+            nodeId: props.id,
+            width: params.width,
+            height: params.height,
+          })
+          dims.textContent = `${Math.round(params.width)} x ${Math.round(params.height)}`
+        },
+      })
+    }
+  }
+
+  initFlow(document.getElementById('node-resize'), {
+    nodes: [
+      { id: 'rs1', type: 'resizable', position: { x: 50, y: 50 }, data: { label: 'Resizable A', initialWidth: 150, initialHeight: 80, minWidth: 80, minHeight: 50, maxWidth: 400, maxHeight: 300 } },
+      { id: 'rs2', type: 'resizable', position: { x: 300, y: 50 }, data: { label: 'Resizable B', initialWidth: 180, initialHeight: 100, minWidth: 100, minHeight: 60, maxWidth: 500, maxHeight: 400 } },
+      { id: 'rs3', position: { x: 150, y: 220 }, data: { label: 'Not Resizable' } },
+    ],
+    edges: [
+      { id: 'ers1-2', source: 'rs1', target: 'rs2' },
+      { id: 'ers1-3', source: 'rs1', target: 'rs3' },
+    ],
+    nodeTypes: {
+      resizable: resizableNodeRenderer,
     },
   })
 })

--- a/packages/xyflow/src/flow.ts
+++ b/packages/xyflow/src/flow.ts
@@ -284,6 +284,81 @@ function injectDefaultStyles() {
       border-radius: 2px;
       pointer-events: none;
     }
+    .bf-flow__node-resizer {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .bf-flow__resize-handle {
+      position: absolute;
+      pointer-events: all;
+      z-index: 10;
+    }
+    .bf-flow__resize-handle--corner {
+      width: 8px;
+      height: 8px;
+      background: #fff;
+      border: 1px solid #1a192b;
+      border-radius: 1px;
+    }
+    .bf-flow__resize-handle--top-left {
+      top: -4px;
+      left: -4px;
+      cursor: nwse-resize;
+    }
+    .bf-flow__resize-handle--top-right {
+      top: -4px;
+      right: -4px;
+      cursor: nesw-resize;
+    }
+    .bf-flow__resize-handle--bottom-left {
+      bottom: -4px;
+      left: -4px;
+      cursor: nesw-resize;
+    }
+    .bf-flow__resize-handle--bottom-right {
+      bottom: -4px;
+      right: -4px;
+      cursor: nwse-resize;
+    }
+    .bf-flow__resize-handle--line {
+      background: transparent;
+    }
+    .bf-flow__resize-handle--line.bf-flow__resize-handle--top {
+      top: -2px;
+      left: 0;
+      right: 0;
+      height: 4px;
+      cursor: ns-resize;
+    }
+    .bf-flow__resize-handle--line.bf-flow__resize-handle--bottom {
+      bottom: -2px;
+      left: 0;
+      right: 0;
+      height: 4px;
+      cursor: ns-resize;
+    }
+    .bf-flow__resize-handle--line.bf-flow__resize-handle--left {
+      left: -2px;
+      top: 0;
+      bottom: 0;
+      width: 4px;
+      cursor: ew-resize;
+    }
+    .bf-flow__resize-handle--line.bf-flow__resize-handle--right {
+      right: -2px;
+      top: 0;
+      bottom: 0;
+      width: 4px;
+      cursor: ew-resize;
+    }
+    .bf-flow__resize-handle--line:hover {
+      background: rgba(26, 25, 43, 0.1);
+    }
+    .bf-flow__resize-handle--corner:hover {
+      background: #1a192b;
+      border-color: #1a192b;
+    }
   `
   document.head.appendChild(style)
 }

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -7,6 +7,17 @@ export { createEdgeRenderer, createEdgeLabelRenderer } from './edge-renderer'
 export { createHandle, initHandle } from './handle'
 export type { HandleType, HandleProps } from './handle'
 export { attachConnectionHandler, attachReconnectionHandler } from './connection'
+export { initNodeResizer, ResizeControlVariant } from './node-resizer'
+export type {
+  NodeResizerOptions,
+  ControlPosition,
+  ControlLinePosition,
+  OnResize,
+  OnResizeStart,
+  OnResizeEnd,
+  ShouldResize,
+  ResizeControlDirection,
+} from './node-resizer'
 export { useFlow, useViewport, useNodes, useEdges, useNodesInitialized } from './hooks'
 export { setupKeyboardHandlers, setupNodeSelection, setupSelectionRectangle } from './selection'
 export type { SelectionRectOptions } from './selection'

--- a/packages/xyflow/src/node-resizer.ts
+++ b/packages/xyflow/src/node-resizer.ts
@@ -1,0 +1,277 @@
+import { onCleanup, untrack } from '@barefootjs/client'
+import {
+  XYResizer,
+  XY_RESIZER_HANDLE_POSITIONS,
+  XY_RESIZER_LINE_POSITIONS,
+  ResizeControlVariant,
+  updateNodeInternals,
+} from '@xyflow/system'
+import type {
+  NodeBase,
+  InternalNodeUpdate,
+  ControlPosition,
+  ControlLinePosition,
+  OnResize,
+  OnResizeStart,
+  OnResizeEnd,
+  ShouldResize,
+  ResizeControlDirection,
+} from '@xyflow/system'
+import type { XYResizerChange, XYResizerChildChange, XYResizerInstance } from '@xyflow/system'
+import type { FlowStore } from './types'
+
+/**
+ * Options for initNodeResizer.
+ */
+export type NodeResizerOptions = {
+  /** Minimum width the node can be resized to (default: 10) */
+  minWidth?: number
+  /** Minimum height the node can be resized to (default: 10) */
+  minHeight?: number
+  /** Maximum width the node can be resized to (default: Infinity) */
+  maxWidth?: number
+  /** Maximum height the node can be resized to (default: Infinity) */
+  maxHeight?: number
+  /** Whether to keep the aspect ratio during resize (default: false) */
+  keepAspectRatio?: boolean
+  /** Which variant of resize controls to use: 'handle' (corners) or 'line' (edges) */
+  variant?: ResizeControlVariant | 'handle' | 'line'
+  /** Callback fired when resize starts */
+  onResizeStart?: OnResizeStart
+  /** Callback fired during resize with new dimensions */
+  onResize?: OnResize
+  /** Callback fired when resize ends */
+  onResizeEnd?: OnResizeEnd
+  /** Callback to determine if resize should proceed */
+  shouldResize?: ShouldResize
+  /** Whether the node is resizable (default: true) */
+  isVisible?: boolean
+  /** CSS color for the resize handle lines/corners */
+  color?: string
+}
+
+/**
+ * Initialize resize handles on a node element.
+ *
+ * Creates resize handle elements (corners and/or lines) and attaches
+ * XYResizer from @xyflow/system for the resize logic.
+ *
+ * Usage:
+ *   // Inside a custom node type function:
+ *   initNodeResizer(this.parentElement, {
+ *     nodeId: props.id,
+ *     store,
+ *     minWidth: 100,
+ *     minHeight: 50,
+ *     onResize: (event, params) => console.log('Resized:', params),
+ *   })
+ */
+export function initNodeResizer<NodeType extends NodeBase>(
+  nodeEl: HTMLElement,
+  nodeId: string,
+  store: FlowStore<NodeType>,
+  options: NodeResizerOptions = {},
+): () => void {
+  const {
+    minWidth = 10,
+    minHeight = 10,
+    maxWidth = Number.MAX_SAFE_INTEGER,
+    maxHeight = Number.MAX_SAFE_INTEGER,
+    keepAspectRatio = false,
+    variant = ResizeControlVariant.Handle,
+    onResizeStart,
+    onResize,
+    onResizeEnd,
+    shouldResize,
+    isVisible = true,
+    color,
+  } = options
+
+  if (!isVisible) return () => {}
+
+  const resolvedVariant =
+    typeof variant === 'string'
+      ? variant === 'line'
+        ? ResizeControlVariant.Line
+        : ResizeControlVariant.Handle
+      : variant
+
+  // Determine which positions to use based on variant
+  const positions: ControlPosition[] =
+    resolvedVariant === ResizeControlVariant.Line
+      ? (XY_RESIZER_LINE_POSITIONS as ControlPosition[])
+      : XY_RESIZER_HANDLE_POSITIONS
+
+  // Mark node as resizable for CSS
+  nodeEl.classList.add('bf-flow__node--resizable')
+
+  // Container for resize handles
+  const container = document.createElement('div')
+  container.className = 'bf-flow__node-resizer'
+  nodeEl.appendChild(container)
+
+  const resizerInstances: XYResizerInstance[] = []
+
+  for (const position of positions) {
+    const handleEl = document.createElement('div')
+    handleEl.className = `bf-flow__resize-handle bf-flow__resize-handle--${position}`
+
+    if (resolvedVariant === ResizeControlVariant.Line) {
+      handleEl.classList.add('bf-flow__resize-handle--line')
+    } else {
+      handleEl.classList.add('bf-flow__resize-handle--corner')
+    }
+
+    handleEl.dataset.position = position
+
+    if (color) {
+      handleEl.style.borderColor = color
+      handleEl.style.backgroundColor = color
+    }
+
+    container.appendChild(handleEl)
+
+    // Create XYResizer instance for this handle
+    const resizerInstance = XYResizer({
+      domNode: handleEl as HTMLDivElement,
+      nodeId,
+      getStoreItems: () => {
+        const nodeLookup = untrack(store.nodeLookup)
+        const transform = store.getTransform()
+        return {
+          nodeLookup,
+          transform,
+          snapGrid: store.snapToGrid ? store.snapGrid : undefined,
+          snapToGrid: store.snapToGrid,
+          nodeOrigin: store.nodeOrigin,
+          paneDomNode: untrack(store.domNode) as HTMLDivElement | null,
+        }
+      },
+      onChange: (changes: XYResizerChange, childChanges: XYResizerChildChange[]) => {
+        // Apply dimension and position changes to the node
+        const lookup = untrack(store.nodeLookup)
+        const node = lookup.get(nodeId)
+        if (!node) return
+
+        // Update measured dimensions
+        if (changes.width != null) {
+          node.measured.width = changes.width
+          nodeEl.style.width = `${changes.width}px`
+        }
+        if (changes.height != null) {
+          node.measured.height = changes.height
+          nodeEl.style.height = `${changes.height}px`
+        }
+
+        // Update position if changed (e.g., resizing from top-left)
+        if (changes.x != null || changes.y != null) {
+          const newX = changes.x ?? node.internals.positionAbsolute.x
+          const newY = changes.y ?? node.internals.positionAbsolute.y
+
+          node.internals.positionAbsolute = { x: newX, y: newY }
+          node.internals.userNode.position = { x: newX, y: newY }
+          nodeEl.style.transform = `translate(${newX}px, ${newY}px)`
+        }
+
+        // Apply child position changes
+        for (const childChange of childChanges) {
+          const childNode = lookup.get(childChange.id)
+          if (childNode) {
+            childNode.internals.positionAbsolute = childChange.position
+            childNode.internals.userNode.position = childChange.position
+          }
+        }
+
+        // Update node internals for edge recalculation
+        const updates = new Map<string, InternalNodeUpdate>()
+        updates.set(nodeId, {
+          id: nodeId,
+          nodeElement: nodeEl as HTMLDivElement,
+          force: true,
+        })
+
+        const parentLookup = untrack(store.parentLookup)
+        updateNodeInternals(
+          updates,
+          lookup,
+          parentLookup,
+          untrack(store.domNode),
+          store.nodeOrigin,
+          store.nodeExtent,
+        )
+
+        // Notify position-dependent subscribers (edges etc.)
+        store.triggerPositionUpdate()
+      },
+      onEnd: (change) => {
+        // Commit final dimensions to the nodes array
+        store.setNodes((prev) =>
+          prev.map((n) =>
+            n.id === nodeId
+              ? {
+                  ...n,
+                  position: { x: change.x, y: change.y },
+                  measured: { width: change.width, height: change.height },
+                  style: {
+                    ...(n as any).style,
+                    width: change.width,
+                    height: change.height,
+                  },
+                }
+              : n,
+          ),
+        )
+      },
+    })
+
+    // Determine resize direction for line handles
+    const isLineHandle = resolvedVariant === ResizeControlVariant.Line
+    let resizeDirection: ResizeControlDirection | undefined
+    if (isLineHandle) {
+      if (position === 'left' || position === 'right') {
+        resizeDirection = 'horizontal'
+      } else if (position === 'top' || position === 'bottom') {
+        resizeDirection = 'vertical'
+      }
+    }
+
+    // Configure the resizer instance
+    resizerInstance.update({
+      controlPosition: position,
+      boundaries: { minWidth, minHeight, maxWidth, maxHeight },
+      keepAspectRatio,
+      resizeDirection,
+      onResizeStart,
+      onResize,
+      onResizeEnd,
+      shouldResize,
+    })
+
+    resizerInstances.push(resizerInstance)
+  }
+
+  // Cleanup function
+  const cleanup = () => {
+    for (const instance of resizerInstances) {
+      instance.destroy()
+    }
+    container.remove()
+    nodeEl.classList.remove('bf-flow__node--resizable')
+  }
+
+  onCleanup(cleanup)
+
+  return cleanup
+}
+
+// Re-export types that consumers might need
+export { ResizeControlVariant }
+export type {
+  ControlPosition,
+  ControlLinePosition,
+  OnResize,
+  OnResizeStart,
+  OnResizeEnd,
+  ShouldResize,
+  ResizeControlDirection,
+}


### PR DESCRIPTION
## Summary

- Add `initNodeResizer()` function that uses `@xyflow/system`'s `XYResizer` for drag-to-resize on flow nodes
- New module `packages/xyflow/src/node-resizer.ts` with full TypeScript types and JSDoc
- CSS styles for corner handles (`.bf-flow__resize-handle--corner`) and line handles (`.bf-flow__resize-handle--line`)
- Support for `minWidth`/`minHeight`/`maxWidth`/`maxHeight` constraints, `keepAspectRatio`, `onResize`/`onResizeStart`/`onResizeEnd` callbacks
- Exported from package index alongside `ResizeControlVariant` enum and related types

## Test plan

- [x] 7 new E2E tests in `flow.spec.ts` (Node Resize section)
  - Resize handles render on resizable nodes (4 corner handles)
  - Handles have correct `data-position` attributes
  - Non-resizable nodes do not get resize handles
  - Resizable nodes get `bf-flow__node--resizable` CSS class
  - Resize container element (`.bf-flow__node-resizer`) exists
  - Dragging bottom-right handle fires `onResize` callback
  - Min constraints prevent shrinking below `minWidth`/`minHeight`
- [x] All 111 E2E tests pass (104 existing + 7 new)
- [x] All 29 unit tests pass
- [x] React reference demo added to `tmp/xyflow-react-ref/app.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)