### PR TITLE
Add adapter implementation guide and testing patterns to specs

### DIFF
--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -232,10 +232,41 @@ The Intermediate Representation (IR) is a pure JSON tree structure. Full type de
 - `IRElement` - HTML/SVG elements with attrs, events, children
 - `IRText` - Static text content
 - `IRExpression` - Dynamic expressions (reactive or static)
-- `IRConditional` - Ternary/logical conditionals
+- `IRConditional` - Ternary/logical conditionals (`cond ? a : b`, `cond && a`)
+- `IRIfStatement` - Component-level conditional returns (`if (cond) return <A/>; return <B/>`)
 - `IRLoop` - Array mapping (.map()), with optional `filterPredicate` and `sortComparator`
 - `IRComponent` - Child component references
 - `IRSlot` - Slot placeholders
+
+### IRIfStatement
+
+Represents component-level `if`/`else` returns (early returns). Unlike `IRConditional` (inline ternary/logical), `IRIfStatement` is produced when the component function has multiple return statements guarded by `if` blocks.
+
+```typescript
+interface IRIfStatement {
+  type: 'if-statement'
+  condition: string           // JS condition expression
+  consequent: IRNode          // JSX for the then branch
+  alternate: IRNode | null    // Else branch (another IRIfStatement for else-if, or IRNode)
+}
+```
+
+SSR renders only the matching branch. Client JS handles all branches and switches at runtime. This means the SSR HTML contains markers from only one branch, while client JS references markers from all branches.
+
+### IRLoop.filterPredicate
+
+When `.filter().map()` chains are detected, the compiler extracts the filter into `IRLoop.filterPredicate`:
+
+```typescript
+interface FilterPredicate {
+  param: string              // Filter callback parameter (e.g., 't')
+  predicate?: ParsedExpr     // Simple expression body
+  blockBody?: ParsedStatement[] // Complex block body with if/return
+  raw: string                // Original JS source
+}
+```
+
+Adapters should render the filter as a conditional wrapper inside the loop (e.g., `if (condition) { children }`), not by pre-filtering the array. The filter param may differ from the loop param (e.g., filter uses `t`, loop uses `todo`) — adapters must map between them.
 
 ### Metadata
 
@@ -297,6 +328,66 @@ The **hydration contract** between template and client JS is maintained through 
 
 - **HonoAdapter** (`@barefootjs/hono`) - Generates hono/jsx compatible TSX
 - **GoTemplateAdapter** (`@barefootjs/go-template`) - Generates Go html/template files
+- **MojoAdapter** (`@barefootjs/mojolicious`) - Generates Mojolicious EP template files (.html.ep)
+
+### Implementing a New Adapter
+
+When implementing a new adapter, handle these concerns in addition to the basic `TemplateAdapter` interface:
+
+#### Child Component Rendering
+
+Child components produce `IRComponent` nodes. The adapter emits a call to the runtime's child-render mechanism (e.g., `render_child('name', prop => val)`). Key rules:
+
+- **Skip `onXxx` callback props** — Event handler props (names matching `/^on[A-Z]/`) are client-only and should be omitted from SSR output.
+- **Pass `_bf_slot` for static children** — Non-loop children have unique `slotId`s. Pass this to the child renderer so it can set the correct scope ID (`{parentScope}_{slotId}`). Loop children use `{ChildName}_{random}` pattern instead.
+- **`scriptBaseName` for in-file children** — Non-default-export components in the same file should register the default export's `.client.js` file, not their own.
+
+#### `bf-p` Props Serialization
+
+Components with client-side interactivity need initial props serialized in `bf-p` attribute for hydration. The JSON must contain data the client JS needs to initialize signals (e.g., `initialTodos`, `variant`).
+
+**Encoding caution:** For non-JS backends, ensure the JSON is a character string (not byte string) when embedded in templates. In Perl, use `to_json` (character string) instead of `encode_json` (byte string) to prevent double UTF-8 encoding.
+
+#### IRIfStatement (Conditional Returns)
+
+When `ir.root.type === 'if-statement'`, the adapter must render the if/else branches. The root node is not a standard element — it requires special handling before `renderNode()`.
+
+#### Filter Predicate in Loops
+
+When `IRLoop.filterPredicate` is present, wrap loop children in a conditional:
+
+```
+for each item in array:
+  if (filterCondition(item)):
+    render children
+```
+
+For complex block body filters (with `if/return` statements), collect all return paths and combine with OR logic. See `GoTemplateAdapter.renderBlockBodyCondition()` as reference.
+
+The filter predicate uses a `ParsedExpr` AST (not raw string). Adapters must implement recursive `ParsedExpr` → target language conversion for:
+
+| ParsedExpr kind | Purpose |
+|---|---|
+| `identifier` | Variables, filter params |
+| `literal` | String, number, boolean values |
+| `member` | Property access (`t.done`) |
+| `call` | Signal getter calls (`filter()`) |
+| `binary` | Comparisons (`===`, `>`) — handle string vs numeric comparison |
+| `unary` | Negation (`!`) — mind operator precedence in target language |
+| `logical` | `&&`, `\|\|` |
+| `higher-order` | `filter()`, `every()`, `some()` on arrays |
+
+#### Standalone Higher-Order Expressions
+
+Expressions like `todos().filter(t => !t.done).length` appear as `IRExpression` nodes (not inside loops). Use `parseExpression()` from `@barefootjs/jsx` to get the `ParsedExpr` AST, detect `higher-order` kind, and convert to the target language's equivalent (e.g., Perl `grep`, Go `bf_filter` helper).
+
+#### Character Encoding
+
+For non-JS backends, ensure proper UTF-8 handling:
+
+- Template output should be character strings, with encoding handled by the framework's output layer
+- JSON embedded in HTML attributes (`bf-p`) must not be double-encoded
+- Add `<meta charset="UTF-8">` to HTML layouts
 
 ---
 

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -249,12 +249,15 @@ Verify that each adapter (Hono, GoTemplate) produces correct HTML from the same 
 packages/adapter-tests/fixtures/
   Priority 1 (Core reactivity):   counter, signal-with-fallback, memo, effect, ...
   Priority 2 (Props):             props-static, props-reactive, nested-elements
-  Priority 3 (Conditionals):      ternary, logical-and, conditional-class
+  Priority 3 (Conditionals):      ternary, logical-and, conditional-class, if-statement
   Priority 4 (Loops):             map-basic, map-with-index, filter-simple, sort-simple
   Priority 5 (Elements):          void-elements, dynamic-attributes, style-attribute
   Priority 6 (Advanced):          fragment, client-only, event-handlers
   Priority 7 (Multi-file):        child-component, multiple-instances
+  Priority 8 (CSR conformance):   boolean-dynamic-attr, child-component-init, reactive-prop-binding
 ```
+
+**Note on `if-statement`:** SSR renders only one branch, but client JS references markers from all branches. The SSR-Hydration contract test skips this fixture for the JS→HTML direction marker check.
 
 ### Adding a fixture
 
@@ -427,6 +430,36 @@ test.describe('Checkbox', () => {
 })
 ```
 
+### Shared E2E test suites for examples
+
+Example apps (`examples/echo/`, `examples/hono/`, `examples/mojolicious/`) share E2E test suites from `examples/shared/e2e/`. Each shared test function is parameterized with a `baseUrl` and optional path:
+
+```typescript
+// examples/shared/e2e/toggle.spec.ts (shared suite)
+export function toggleTests(baseUrl: string) {
+  test.describe('Toggle Component', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${baseUrl}/toggle`)
+    })
+    // ... tests ...
+  })
+}
+
+// examples/mojolicious/e2e/toggle.spec.ts (example wrapper)
+import { toggleTests } from '../../shared/e2e/toggle.spec'
+toggleTests('http://localhost:3004')
+```
+
+Available shared suites: `counterTests`, `toggleTests`, `formTests`, `conditionalReturnTests`, `reactivePropsTests`, `todoAppTests`, `portalTests`.
+
+`todoAppTests` accepts an optional second parameter for the path (default `/todos`), enabling reuse for SSR variants:
+
+```typescript
+todoAppTests('http://localhost:3004', '/todos-ssr')
+```
+
+Each example's `playwright.config.ts` configures the webServer command, port, and single-worker mode for CI (to avoid shared state conflicts with `/api/todos`).
+
 ---
 
 ## Decision Guide: Where to Write a Test
@@ -437,6 +470,7 @@ test.describe('Checkbox', () => {
 | New compiler transformation rule | Compiler Unit | `packages/jsx/src/__tests__/my-rule.test.ts` |
 | New compiler error code | Compiler Unit | Add to existing or new error-specific test file |
 | New adapter or adapter bug fix | Adapter Conformance | Add/fix fixture in `packages/adapter-tests/fixtures/` |
+| New example app E2E | E2E (shared suite) | Wrapper in `examples/*/e2e/` calling shared test function |
 | New runtime primitive | Runtime Unit | `packages/dom/__tests__/my-primitive.test.ts` |
 | Click/keyboard behavior | E2E | `site/ui/e2e/my-component.spec.ts` |
 | Hydration bug (user reports) | Fix in compiler, verify with E2E | Root cause in `packages/jsx/`, E2E confirms fix |


### PR DESCRIPTION
## Summary

Documents lessons learned from implementing the Mojolicious adapter (#821, #825).

### spec/compiler.md
- Add `IRIfStatement` and `IRLoop.filterPredicate` to IR Schema with structure definitions
- Add MojoAdapter to Available Adapters list
- New section: **Implementing a New Adapter** — covers child component rendering, `bf-p` encoding, callback prop handling, filter predicate `ParsedExpr` conversion, `IRIfStatement` support, and character encoding for non-JS backends

### spec/testing.md
- Add `if-statement` and Priority 8 (CSR conformance) to fixture structure
- Note on SSR-Hydration contract behavior for `if-statement` fixtures
- New section: **Shared E2E test suites for examples** — documents the `examples/shared/e2e/` parameterized test pattern
- Add "New example app E2E" to decision guide

## Test plan

- [x] Spec changes are documentation only — no code changes
- [x] All existing tests still pass (jsx 557/557, mojolicious 43/43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)