### PR TITLE
Fix outer loop param wrapping in nested insert() bindEvents (#833)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -266,8 +266,9 @@ function emitBranchChildComponentInits(
   indent: string,
   components: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children?: import('../types').IRNode[] }>,
   loopParam?: string,
+  wrapFn?: (expr: string) => string,
 ): void {
-  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr
+  const wrap = wrapFn ?? (loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr)
   for (const comp of components) {
     // Use slotId suffix match only when available to avoid matching
     // siblings of the same component type (e.g. two Buttons with different slotIds).
@@ -306,9 +307,10 @@ function emitBranchInnerLoops(
   scopeVar: string,
   innerLoops: import('./types').NestedLoopInfo[] | undefined,
   outerLoopParam?: string,
+  outerWrapFn?: (expr: string) => string,
 ): void {
   if (!innerLoops || !outerLoopParam) return
-  const wrapOuter = (expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam)
+  const wrapOuter = outerWrapFn ?? ((expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam))
 
   for (let i = 0; i < innerLoops.length; i++) {
     const inner = innerLoops[i]
@@ -390,15 +392,15 @@ function emitNestedLoopChildConditionals(
     lines.push(`${indent}insert(${scopeVar}, '${cond.slotId}', () => ${wrap(cond.condition)}, {`)
     lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents, loopParam)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrueInnerLoops, loopParam)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents, loopParam, wrap)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrueInnerLoops, loopParam, wrap)
     emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrueConditionals, wrap, loopParam)
     lines.push(`${indent}  }`)
     lines.push(`${indent}}, {`)
     lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents, loopParam)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalseInnerLoops, loopParam)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents, loopParam, wrap)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalseInnerLoops, loopParam, wrap)
     emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalseConditionals, wrap, loopParam)
     lines.push(`${indent}  }`)
     lines.push(`${indent}})`)

--- a/site/ui/e2e/social-feed.spec.ts
+++ b/site/ui/e2e/social-feed.spec.ts
@@ -55,9 +55,7 @@ test.describe('Social Feed Block (#830)', () => {
     await expect(s.locator('text=I\'ll add a section on that in the follow-up')).toBeVisible()
   })
 
-  // Skipped: compiler wrapping bug — addReply(post.id, ...) emitted instead of
-  // addReply(post().id, ...) in insert() bindEvents at depth 3. Tracked separately.
-  test.skip('add reply via input appends to reply list', async ({ page }) => {
+  test('add reply via input appends to reply list', async ({ page }) => {
     const s = section(page)
 
     const replyInput = s.locator('input[placeholder="Reply..."]').first()


### PR DESCRIPTION
## Summary

Fixes #833 — `emitBranchChildComponentInits` and `emitBranchInnerLoops` created their own single-param wrappers from `loopParam`, losing ancestor loop params at depth 3+.

## Change

Add optional `wrapFn` / `outerWrapFn` parameters to both functions. When called from `emitNestedLoopChildConditionals` (depth 2+), the full wrapping chain is passed through. Existing depth-1 callers are unaffected.

```diff
- addReply(post.id, comment().id, input.value)   // post not wrapped
+ addReply(post().id, comment().id, input.value)  // all params wrapped
```

**+9 / -9 lines** in `emit-control-flow.ts` (signature changes + call site updates).

## Test plan

- [x] 559 unit tests pass (`bun test packages/jsx/`)
- [x] Build succeeds
- [x] Compiled `social-feed-demo-*.js` shows `post().id` at all 4 call sites
- [x] `social-feed.spec.ts` — 10 tests pass (add-reply unskipped)
- [x] `file-browser.spec.ts` — 8 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)