### PR TITLE
Add regression tests for #838 and #840

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -132,4 +132,49 @@ describe('nested loops/conditionals inside mapArray (#830)', () => {
     const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
     expect(mapArrayCount).toBeGreaterThanOrEqual(3)
   })
+
+  test('reactive text inside conditional inside inner loop uses re-query pattern (#840)', () => {
+    // When a reactive text is inside a conditional branch inside a nested (inner) loop,
+    // insert() may replace the SSR element after the text node is captured.
+    // The generated code must use the re-query pattern:
+    //   createEffect(() => { const [__rt] = $t(...) ... })
+    // NOT the capture-then-effect pattern:
+    //   { const [__rt] = $t(...); if (__rt) createEffect(() => ...) }
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      type Child = { id: string; type: 'text' | 'other'; label: string }
+      type Group = { id: string; children: Child[] }
+
+      export function App() {
+        const [groups, setGroups] = createSignal<Group[]>([])
+        return (
+          <div>
+            {groups().map(group => (
+              <div key={group.id}>
+                {group.children.map(child => (
+                  <div key={child.id}>
+                    {child.type === 'text' ? (
+                      <label>{child.label}</label>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'App.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Re-query pattern: $t() inside createEffect so it always finds the live node
+    expect(content).toContain('createEffect(() => { const [__rt] = $t(')
+  })
 })

--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -131,6 +131,47 @@ describe('reactive attributes inside .map() callbacks', () => {
     expect(constDecls.length).toBe(uniqueDecls.size)
   })
 
+  test('map param name matching CSS class substring: static part not transformed (#838)', () => {
+    // When loop param is "row" and a template literal class contains "pivot-row",
+    // the static string "pivot-row" must not become "pivot-row()" in the output.
+    // Only actual signal references inside interpolations should be transformed.
+    const source = `
+      'use client'
+
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      type Row = { id: string; isActive: boolean }
+
+      export function PivotTable() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        return (
+          <table>
+            {rows().map((row) => (
+              <tr class={\`pivot-row \${row.isActive ? "active" : ""}\`}>
+                <td>{row.id}</td>
+              </tr>
+            ))}
+          </table>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'PivotTable.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Static string "pivot-row" must NOT be transformed to "pivot-row()"
+    expect(content).not.toContain('pivot-row()')
+
+    // The interpolated expression "row.isActive" must be transformed to "row().isActive"
+    expect(content).toContain('row().isActive')
+
+    // The static text "pivot-row" must still appear in the output
+    expect(content).toContain('pivot-row')
+  })
+
   test('static array: non-reactive className does NOT generate createEffect', () => {
     const source = `
       'use client'


### PR DESCRIPTION
## Summary

- Adds a regression test for **#838**: verifies that when the `.map()` parameter is named `row`, static CSS class substrings like `pivot-row` in template literals are **not** transformed to `pivot-row()` — only actual signal references inside interpolations are wrapped
- Adds a regression test for **#840**: verifies that reactive text inside a conditional branch inside a nested (inner) loop generates the re-query pattern `createEffect(() => { const [__rt] = $t(...) })`, preventing stale DOM references after `insert()` replaces the SSR element

Both bugs are already fixed in `main` (via PR #831 / #836). These tests lock in the correct behavior as permanent regression guards.

## Test plan

- [x] `reactive-attrs-in-map.test.ts` — #838 test passes
- [x] `nested-loop-conditional.test.ts` — #840 test passes
- [x] All 724 compiler/adapter/dom tests pass

Closes #838
Closes #840