### PR TITLE
Fix curried event handler return value discarded in mapArray (#837)

### DIFF
--- a/packages/jsx/src/__tests__/curried-event-handlers.test.ts
+++ b/packages/jsx/src/__tests__/curried-event-handlers.test.ts
@@ -1,0 +1,143 @@
+/**
+ * BarefootJS Compiler - Curried event handlers in mapArray (#837)
+ *
+ * When an event handler attribute is a call expression that returns a function
+ * (curried handler pattern), the compiler must:
+ * - In the event delegation path: call the result with (e) → (handler(id))(e)
+ * - In the direct addEventListener path (nested loops): pass the call expression
+ *   directly as the handler value → addEventListener(event, handler(id))
+ *
+ * Previously, both paths wrapped the expression in (e) => { expr } which
+ * discarded the returned function and never passed the event.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('curried event handlers in mapArray (#837)', () => {
+  test('delegation path: curried handler result is called with event', () => {
+    // onDragStart={handleDragStart(item.id)} where handleDragStart returns a function.
+    // The delegation callback must call (handleDragStart(item.id))(e), not just
+    // evaluate handleDragStart(item.id) as a statement (which discards the result).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      function handleDragStart(id: string) {
+        return (e: DragEvent) => { e.dataTransfer?.setData("text/plain", id) }
+      }
+
+      type Item = { id: string; label: string }
+
+      export function DragList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((item) => (
+              <li key={item.id} onDragStart={handleDragStart(item.id)}>
+                {item.label}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'DragList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Delegation callback must call the returned handler with (e)
+    expect(content).toContain('(handleDragStart(item.id))(e)')
+
+    // The broken pattern (discards return value, never passes e) must not appear
+    expect(content).not.toMatch(/if \(item\) handleDragStart\(item\.id\)(?!\()/)
+  })
+
+  test('delegation path: regular arrow function handler still works', () => {
+    // onClick={() => removeItem(item.id)} — non-curried arrow function handler.
+    // Must still generate correct delegation: (() => removeItem(item.id))(e).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      type Item = { id: string }
+
+      export function App() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const removeItem = (id: string) => setItems(prev => prev.filter(i => i.id !== id))
+        return (
+          <ul>
+            {items().map((item) => (
+              <li key={item.id} onClick={() => removeItem(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'App.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Arrow function handler: called via (handler)(e)
+    expect(content).toContain('(() => removeItem(item.id))(e)')
+  })
+
+  test('direct addEventListener path: curried handler passed as value (nested loop)', () => {
+    // In nested loops (outer + inner), events on inner items use direct addEventListener
+    // (not delegation). The curried handler must be passed as the handler value:
+    //   addEventListener('dragstart', handleDragStart(child().id))
+    // NOT wrapped in (e) => { handleDragStart(child().id) } which discards the result.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      function handleDragStart(id: string) {
+        return (e: DragEvent) => { e.dataTransfer?.setData("text/plain", id) }
+      }
+
+      type Child = { id: string; label: string }
+      type Group = { id: string; children: Child[] }
+
+      export function NestedDragList() {
+        const [groups, setGroups] = createSignal<Group[]>([])
+        return (
+          <div>
+            {groups().map(group => (
+              <div key={group.id}>
+                {group.children.map(child => (
+                  <div key={child.id} onDragStart={handleDragStart(child.id)}>
+                    {child.label}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'NestedDragList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Curried handler passed directly as addEventListener value (evaluated at item setup time)
+    expect(content).toContain("addEventListener('dragstart', handleDragStart(child().id))")
+
+    // The broken pattern (wraps in (e) => { } and discards return) must not appear
+    expect(content).not.toContain('(e) => { handleDragStart(')
+  })
+})

--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -132,4 +132,49 @@ describe('nested loops/conditionals inside mapArray (#830)', () => {
     const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
     expect(mapArrayCount).toBeGreaterThanOrEqual(3)
   })
+
+  test('reactive text inside conditional inside inner loop uses re-query pattern (#840)', () => {
+    // When a reactive text is inside a conditional branch inside a nested (inner) loop,
+    // insert() may replace the SSR element after the text node is captured.
+    // The generated code must use the re-query pattern:
+    //   createEffect(() => { const [__rt] = $t(...) ... })
+    // NOT the capture-then-effect pattern:
+    //   { const [__rt] = $t(...); if (__rt) createEffect(() => ...) }
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      type Child = { id: string; type: 'text' | 'other'; label: string }
+      type Group = { id: string; children: Child[] }
+
+      export function App() {
+        const [groups, setGroups] = createSignal<Group[]>([])
+        return (
+          <div>
+            {groups().map(group => (
+              <div key={group.id}>
+                {group.children.map(child => (
+                  <div key={child.id}>
+                    {child.type === 'text' ? (
+                      <label>{child.label}</label>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'App.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Re-query pattern: $t() inside createEffect so it always finds the live node
+    expect(content).toContain('createEffect(() => { const [__rt] = $t(')
+  })
 })

--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -131,6 +131,47 @@ describe('reactive attributes inside .map() callbacks', () => {
     expect(constDecls.length).toBe(uniqueDecls.size)
   })
 
+  test('map param name matching CSS class substring: static part not transformed (#838)', () => {
+    // When loop param is "row" and a template literal class contains "pivot-row",
+    // the static string "pivot-row" must not become "pivot-row()" in the output.
+    // Only actual signal references inside interpolations should be transformed.
+    const source = `
+      'use client'
+
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      type Row = { id: string; isActive: boolean }
+
+      export function PivotTable() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        return (
+          <table>
+            {rows().map((row) => (
+              <tr class={\`pivot-row \${row.isActive ? "active" : ""}\`}>
+                <td>{row.id}</td>
+              </tr>
+            ))}
+          </table>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'PivotTable.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Static string "pivot-row" must NOT be transformed to "pivot-row()"
+    expect(content).not.toContain('pivot-row()')
+
+    // The interpolated expression "row.isActive" must be transformed to "row().isActive"
+    expect(content).toContain('row().isActive')
+
+    // The static text "pivot-row" must still appear in the output
+    expect(content).toContain('pivot-row')
+  })
+
   test('static array: non-reactive className does NOT generate createEffect', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -921,11 +921,9 @@ interface CompositeLoopContext {
 
 /** Emit a single addEventListener call for a child event on a given element. */
 function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChildEvent, loopParam?: string): void {
-  let handler = ev.handler.trim().startsWith('(') || ev.handler.trim().startsWith('function')
-    ? `(${ev.handler})(e)`
-    : ev.handler
-  if (loopParam) handler = wrapLoopParamAsAccessor(handler, loopParam)
-  ls.push(`${indent}{ const __e = qsa(${elVar}, '[bf="${ev.childSlotId}"]'); if (__e) __e.addEventListener('${toDomEventName(ev.eventName)}', (e) => { ${handler} }) }`)
+  let handler = loopParam ? wrapLoopParamAsAccessor(ev.handler, loopParam) : ev.handler
+  handler = wrapHandlerInBlock(handler)
+  ls.push(`${indent}{ const __e = qsa(${elVar}, '[bf="${ev.childSlotId}"]'); if (__e) __e.addEventListener('${toDomEventName(ev.eventName)}', ${handler}) }`)
 }
 
 /** Build the component-finder CSS selector for SSR hydration initChild. */
@@ -1247,9 +1245,7 @@ function emitLoopEventDelegation(
       const childVar = varSlotId(ev.childSlotId)
       lines.push(`    const ${childVar}El = target.closest('[bf="${ev.childSlotId}"]')`)
       lines.push(`    if (${childVar}El) {`)
-      const handlerCall = ev.handler.trim().startsWith('(') || ev.handler.trim().startsWith('function')
-        ? `(${ev.handler})(e)`
-        : ev.handler
+      const handlerCall = `(${ev.handler.trim()})(e)`
       emitItemLookup(lines, ev, handlerCall, containerVar)
       lines.push(`      return`)
       lines.push(`    }`)


### PR DESCRIPTION
## Summary

Fixes compiler bug where event handler call expressions like `onDragStart={handleDragStart(id)}` inside `.map()` callbacks were compiled incorrectly — the returned handler function was discarded and the event was never forwarded.

**Root cause:** Two code paths both failed to handle curried handlers:

1. **Event delegation path** (`emitLoopEventDelegation`): handler was emitted as a bare statement `handleDragStart(item.id)`, calling the function but discarding the return value
2. **Direct addEventListener path** (`emitEventSetup`, used in nested loops): handler was wrapped as `(e) => { handleDragStart(id) }`, same problem

**Fix:**

- Delegation path: always wrap as `(handler)(e)` so the result is called with the event
  ```js
  // Before (broken)
  if (item) handleDragStart(item.id)
  // After (fixed)
  if (item) (handleDragStart(item.id))(e)
  ```
- Direct path: pass the handler expression directly to `addEventListener` (matches non-loop behavior)
  ```js
  // Before (broken)
  __e.addEventListener('dragstart', (e) => { handleDragStart(child().id) })
  // After (fixed)
  __e.addEventListener('dragstart', handleDragStart(child().id))
  ```

The fix also correctly handles:
- Arrow function handlers `() => removeItem(id)` — unchanged behavior
- Identifier handlers `handleClick` — now correctly called with `(e)`

## Test plan

- [x] New test file `curried-event-handlers.test.ts` with 3 tests covering delegation and direct paths
- [x] All 727 compiler/adapter/dom tests pass

Closes #837