### PR TITLE
Replace native HTML elements with UI components in demos

### DIFF
--- a/packages/adapter-tests/fixtures/style-attribute.ts
+++ b/packages/adapter-tests/fixtures/style-attribute.ts
@@ -12,3 +12,30 @@ export function StyleAttribute() {
     <div style="color: red; font-size: 16px" bf-s="test">Styled</div>
   `,
 })
+
+export const fixtureStaticObject = createFixture({
+  id: 'style-object-static',
+  description: 'Inline style object with static string values converts to CSS string',
+  source: `
+export function StyleObjectStatic() {
+  return <div style={{ background: 'var(--bg-surface)', color: 'var(--text-primary)' }}>Hello</div>
+}
+`,
+  expectedHtml: `
+    <div style="background:var(--bg-surface);color:var(--text-primary)" bf-s="test">Hello</div>
+  `,
+})
+
+export const fixtureDynamicObject = createFixture({
+  id: 'style-object-dynamic',
+  description: 'Inline style object with dynamic prop value renders as CSS string',
+  source: `
+export function StyleObjectDynamic({ color }: { color: string }) {
+  return <div style={{ backgroundColor: color, padding: '8px' }}>Hello</div>
+}
+`,
+  props: { color: 'red' },
+  expectedHtml: `
+    <div style="background-color:red;padding:8px" bf-s="test" bf="s0">Hello</div>
+  `,
+})

--- a/packages/client-runtime/src/component.ts
+++ b/packages/client-runtime/src/component.ts
@@ -335,29 +335,11 @@ export function parseHTML(html: string): DocumentFragment {
  * Check if a value contains DOM elements (HTMLElement instances).
  */
 function hasDomElements(value: unknown): boolean {
-  if (value instanceof HTMLElement) return true
+  if (value instanceof Element) return true
   if (Array.isArray(value)) return value.some(hasDomElements)
   return false
 }
 
-
-/**
- * Insert DOM children into a shell element.
- * - HTMLElement → appendChild directly
- * - Array → iterate, appendChild each element, create text nodes for strings
- * - string/number → create text node
- */
-function insertDomChildren(element: HTMLElement, children: unknown): void {
-  if (children instanceof HTMLElement) {
-    element.appendChild(children)
-  } else if (Array.isArray(children)) {
-    for (const child of children) {
-      insertDomChildren(element, child)
-    }
-  } else if (typeof children === 'string' || typeof children === 'number') {
-    element.appendChild(document.createTextNode(String(children)))
-  }
-}
 
 /**
  * Insert getter children into an element.
@@ -367,11 +349,11 @@ function insertDomChildren(element: HTMLElement, children: unknown): void {
  * Arrays may contain a mix of DOM elements and HTML strings.
  */
 function insertGetterChildren(element: HTMLElement, children: unknown): void {
-  if (children instanceof HTMLElement) {
+  if (children instanceof Element) {
     element.appendChild(children)
   } else if (Array.isArray(children)) {
     for (const child of (children as unknown[]).flat()) {
-      if (child instanceof HTMLElement) {
+      if (child instanceof Element) {
         element.appendChild(child)
       } else if (typeof child === 'string' && child.length > 0) {
         element.appendChild(parseHTML(child.trim()))

--- a/packages/client-runtime/src/component.ts
+++ b/packages/client-runtime/src/component.ts
@@ -144,20 +144,7 @@ export function createComponent(
   if (childrenIsGetter) {
     const children = untrack(() => childrenDescriptor!.get!())
     if (children != null) {
-      if (hasDomElements(children)) {
-        // DOM elements from createComponent calls
-        insertDomChildren(element, children)
-      } else if (Array.isArray(children)) {
-        // Non-DOM array: join and insert as HTML
-        const joined = (children as unknown[]).flat()
-          .map(c => c == null ? '' : String(c)).join('')
-        if (joined.length > 0) element.appendChild(parseHTML(joined))
-      } else if (typeof children === 'string' && children.length > 0) {
-        // HTML string or literal text: parse and insert
-        element.appendChild(parseHTML(children.trim()))
-      } else if (typeof children === 'number') {
-        element.appendChild(document.createTextNode(String(children)))
-      }
+      insertGetterChildren(element, children)
     }
   }
 
@@ -368,6 +355,33 @@ function insertDomChildren(element: HTMLElement, children: unknown): void {
       insertDomChildren(element, child)
     }
   } else if (typeof children === 'string' || typeof children === 'number') {
+    element.appendChild(document.createTextNode(String(children)))
+  }
+}
+
+/**
+ * Insert getter children into an element.
+ * Unlike insertDomChildren, strings are parsed as HTML (not text nodes) because
+ * getter children may return HTML strings from compiler-generated template literals
+ * (e.g. `<span class="...">Required</span>`).
+ * Arrays may contain a mix of DOM elements and HTML strings.
+ */
+function insertGetterChildren(element: HTMLElement, children: unknown): void {
+  if (children instanceof HTMLElement) {
+    element.appendChild(children)
+  } else if (Array.isArray(children)) {
+    for (const child of (children as unknown[]).flat()) {
+      if (child instanceof HTMLElement) {
+        element.appendChild(child)
+      } else if (typeof child === 'string' && child.length > 0) {
+        element.appendChild(parseHTML(child.trim()))
+      } else if (typeof child === 'number') {
+        element.appendChild(document.createTextNode(String(child)))
+      }
+    }
+  } else if (typeof children === 'string' && (children as string).length > 0) {
+    element.appendChild(parseHTML((children as string).trim()))
+  } else if (typeof children === 'number') {
     element.appendChild(document.createTextNode(String(children)))
   }
 }

--- a/packages/client-runtime/src/component.ts
+++ b/packages/client-runtime/src/component.ts
@@ -76,26 +76,42 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 2. Evaluate children and props for template HTML generation.
+  // 2. Generate scope ID early so renderChild() inside the template can use it
+  //    as the parent prefix for child scope IDs (e.g., "Select_abc_s5").
+  const scopeId = `${name}_${generateId()}`
+
+  // 3. Generate HTML shell from props (without DOM children).
   // Use untrack() so signal reads during prop evaluation don't contaminate
   // the caller's effect tracking. This prevents full list re-render when
   // e.g. an Input's value={signal()} changes during typing.
   // Component reactivity is handled by init()'s own createEffect calls.
-  const childrenDescriptor = Object.getOwnPropertyDescriptor(props, 'children')
-  const children = untrack(() =>
-    childrenDescriptor && typeof childrenDescriptor.get === 'function'
-      ? childrenDescriptor.get()
-      : props.children
-  )
-
-  // 3. Generate HTML from props
-  // When children contain DOM elements, pass empty children for shell HTML
+  //
+  // Children are NOT evaluated yet — they may create child components whose
+  // init functions call useContext(). The parent must provideContext() first
+  // (step 6), so children evaluation is deferred to step 7.
   const unwrappedProps = untrack(() => unwrapPropsForTemplate(props))
-  const hasDomChildren = children != null && hasDomElements(children)
-  if (hasDomChildren) {
+
+  // Check if children prop is a getter (DOM children from createComponent calls).
+  // We detect this before evaluating so we can pass empty children to the template.
+  const childrenDescriptor = Object.getOwnPropertyDescriptor(props, 'children')
+  const hasChildrenGetter = childrenDescriptor && typeof childrenDescriptor.get === 'function'
+
+  // For template rendering, always use empty children — DOM children are inserted later.
+  // String children are already in unwrappedProps from unwrapPropsForTemplate.
+  // Also guard against undefined children producing literal "undefined" text in templates.
+  if (hasChildrenGetter || unwrappedProps.children === undefined) {
     unwrappedProps.children = ''
   }
-  const html = templateFn(unwrappedProps)
+
+  // Set parent scope ID so nested renderChild() calls produce consistent
+  // scope IDs (e.g., "Select_abc_s1" instead of "SelectTrigger_random_s1").
+  setParentScopeId(scopeId)
+  let html: string
+  try {
+    html = templateFn(unwrappedProps)
+  } finally {
+    setParentScopeId(null)
+  }
 
   // 4. Create DOM element
   const element = parseHTML(html.trim()).firstChild as HTMLElement
@@ -105,25 +121,33 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 5. Insert DOM children into the shell element
-  if (hasDomChildren) {
-    insertDomChildren(element, children)
-  }
-
-  // 6. Set scope ID and key attributes
-  const scopeId = `${name}_${generateId()}`
+  // 5. Set scope ID and key attributes
   element.setAttribute(BF_SCOPE, scopeId)
   if (key !== undefined) {
     element.setAttribute(BF_KEY, String(key))
   }
 
-  // 7. Initialize the component synchronously
-  // Event handlers need to be bound immediately so user interactions work right away.
-  // Nested effects are now supported in createEffect, so we don't need queueMicrotask.
+  // 6. Initialize the parent component BEFORE creating children.
+  // This ensures provideContext() runs first, so child components
+  // created in step 7 can find the context via useContext().
   const initFn = getComponentInit(name)
   if (initFn) {
-    // Pass original props (with getters) for reactivity
     initFn(element, props)
+  }
+
+  // 7. Now evaluate and insert DOM children.
+  // Children getters may call createComponent() which triggers child init.
+  // Context is now available from step 6.
+  if (hasChildrenGetter) {
+    const children = untrack(() => childrenDescriptor!.get!())
+    if (children != null && hasDomElements(children)) {
+      insertDomChildren(element, children)
+    }
+  } else {
+    const children = props.children
+    if (children != null && hasDomElements(children)) {
+      insertDomChildren(element, children)
+    }
   }
 
   // 8. Mark element as initialized
@@ -210,6 +234,12 @@ export function renderChild(
     return `<div bf-s="~${scopePrefix}${suffix}"${keyAttr}></div>`
   }
 
+  // Guard against undefined children producing literal "undefined" text in templates.
+  // Components rendered via renderChild may not receive a children prop when the
+  // compiler omits it (e.g., nested loop CSR paths).
+  if (props.children === undefined) {
+    props = { ...props, children: '' }
+  }
   const html = templateFn(props).trim()
   // Inject bf-s scope attribute with ~ child prefix into the first element tag.
   // The ~ prefix marks this as a child component so hydrate()'s requestAnimationFrame
@@ -328,7 +358,17 @@ function insertDomChildren(element: HTMLElement, children: unknown): void {
     for (const child of children) {
       insertDomChildren(element, child)
     }
-  } else if (typeof children === 'string' || typeof children === 'number') {
+  } else if (typeof children === 'string') {
+    // Strings containing HTML tags (from compiler-generated template fragments)
+    // must be parsed as HTML, not inserted as text nodes.
+    if (children.includes('<')) {
+      const tpl = document.createElement('template')
+      tpl.innerHTML = children
+      element.appendChild(tpl.content)
+    } else {
+      element.appendChild(document.createTextNode(children))
+    }
+  } else if (typeof children === 'number') {
     element.appendChild(document.createTextNode(String(children)))
   }
 }

--- a/packages/client-runtime/src/component.ts
+++ b/packages/client-runtime/src/component.ts
@@ -9,6 +9,7 @@ import { getTemplate } from './template'
 import { getComponentInit } from './registry'
 import { hydratedScopes } from './hydration-state'
 import { untrack } from '@barefootjs/client'
+import { setCurrentScope } from './context'
 import { BF_SCOPE, BF_KEY } from '@barefootjs/shared'
 import type { ComponentDef } from './types'
 
@@ -76,38 +77,47 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 2. Evaluate children and props for template HTML generation.
-  // Use untrack() so signal reads during prop evaluation don't contaminate
-  // the caller's effect tracking. This prevents full list re-render when
-  // e.g. an Input's value={signal()} changes during typing.
-  // Component reactivity is handled by init()'s own createEffect calls.
+  // 2. Check for getter children.
+  // Children defined via a getter are evaluated AFTER initFn so that context
+  // providers set up by the parent are available when children are created.
   const childrenDescriptor = Object.getOwnPropertyDescriptor(props, 'children')
-  const children = untrack(() =>
-    childrenDescriptor && typeof childrenDescriptor.get === 'function'
-      ? childrenDescriptor.get()
-      : props.children
-  )
+  const childrenIsGetter = childrenDescriptor != null && typeof childrenDescriptor.get === 'function'
 
-  // 3. Generate HTML from props
-  // When children contain DOM elements, pass empty children for shell HTML
-  const unwrappedProps = untrack(() => unwrapPropsForTemplate(props))
-  const hasDomChildren = children != null && hasDomElements(children)
-  if (hasDomChildren) {
-    unwrappedProps.children = ''
-  }
+  // 3. Evaluate props for template HTML generation, skipping the children getter.
+  // Use untrack() so signal reads don't contaminate the caller's effect tracking.
+  const unwrappedProps = untrack(() => {
+    const result: Record<string, unknown> = {}
+    for (const k of Object.keys(props)) {
+      if (k === 'children' && childrenIsGetter) {
+        result.children = '' // Deferred — will be inserted after initFn
+        continue
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(props, k)
+      if (descriptor && typeof descriptor.get === 'function') {
+        result[k] = descriptor.get()
+      } else {
+        result[k] = props[k]
+      }
+    }
+    // Template functions expect children as an HTML string, not an array.
+    if (Array.isArray(result.children) && !hasDomElements(result.children)) {
+      result.children = (result.children as unknown[])
+        .flat()
+        .map(c => c == null ? '' : String(c))
+        .join('')
+    }
+    return result
+  })
+
+  // 4. Generate HTML from props
   const html = templateFn(unwrappedProps)
 
-  // 4. Create DOM element
+  // 5. Create DOM element
   const element = parseHTML(html.trim()).firstChild as HTMLElement
 
   if (!element) {
     console.warn(`[BarefootJS] Template returned empty HTML for component: ${name}`)
     return createPlaceholder(name, key)
-  }
-
-  // 5. Insert DOM children into the shell element
-  if (hasDomChildren) {
-    insertDomChildren(element, children)
   }
 
   // 6. Set scope ID and key attributes
@@ -117,19 +127,47 @@ export function createComponent(
     element.setAttribute(BF_KEY, String(key))
   }
 
-  // 7. Initialize the component synchronously
-  // Event handlers need to be bound immediately so user interactions work right away.
-  // Nested effects are now supported in createEffect, so we don't need queueMicrotask.
+  // 7. Set currentScope so provideContext/useContext are element-scoped.
+  // This allows context providers in initFn to store context on this element.
+  const prevScope = setCurrentScope(element)
+
+  // 8. Initialize the component (context providers set up here).
   const initFn = getComponentInit(name)
   if (initFn) {
     // Pass original props (with getters) for reactivity
     initFn(element, props)
   }
 
-  // 8. Mark element as initialized
+  // 9. Evaluate getter children and insert them.
+  // Children are evaluated NOW (after initFn) so that context provided by
+  // the parent is in the global store when children call useContext().
+  if (childrenIsGetter) {
+    const children = untrack(() => childrenDescriptor!.get!())
+    if (children != null) {
+      if (hasDomElements(children)) {
+        // DOM elements from createComponent calls
+        insertDomChildren(element, children)
+      } else if (Array.isArray(children)) {
+        // Non-DOM array: join and insert as HTML
+        const joined = (children as unknown[]).flat()
+          .map(c => c == null ? '' : String(c)).join('')
+        if (joined.length > 0) element.appendChild(parseHTML(joined))
+      } else if (typeof children === 'string' && children.length > 0) {
+        // HTML string or literal text: parse and insert
+        element.appendChild(parseHTML(children.trim()))
+      } else if (typeof children === 'number') {
+        element.appendChild(document.createTextNode(String(children)))
+      }
+    }
+  }
+
+  // 10. Restore previous scope
+  setCurrentScope(prevScope)
+
+  // 11. Mark element as initialized
   hydratedScopes.add(element)
 
-  // 9. Store props and register update function for element reuse in reconcileList
+  // 12. Store props and register update function for element reuse in reconcileList
   propsMap.set(element, props)
   registerPropsUpdate(element, name, props)
 
@@ -314,6 +352,7 @@ function hasDomElements(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(hasDomElements)
   return false
 }
+
 
 /**
  * Insert DOM children into a shell element.

--- a/packages/client-runtime/src/component.ts
+++ b/packages/client-runtime/src/component.ts
@@ -76,42 +76,26 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 2. Generate scope ID early so renderChild() inside the template can use it
-  //    as the parent prefix for child scope IDs (e.g., "Select_abc_s5").
-  const scopeId = `${name}_${generateId()}`
-
-  // 3. Generate HTML shell from props (without DOM children).
+  // 2. Evaluate children and props for template HTML generation.
   // Use untrack() so signal reads during prop evaluation don't contaminate
   // the caller's effect tracking. This prevents full list re-render when
   // e.g. an Input's value={signal()} changes during typing.
   // Component reactivity is handled by init()'s own createEffect calls.
-  //
-  // Children are NOT evaluated yet — they may create child components whose
-  // init functions call useContext(). The parent must provideContext() first
-  // (step 6), so children evaluation is deferred to step 7.
-  const unwrappedProps = untrack(() => unwrapPropsForTemplate(props))
-
-  // Check if children prop is a getter (DOM children from createComponent calls).
-  // We detect this before evaluating so we can pass empty children to the template.
   const childrenDescriptor = Object.getOwnPropertyDescriptor(props, 'children')
-  const hasChildrenGetter = childrenDescriptor && typeof childrenDescriptor.get === 'function'
+  const children = untrack(() =>
+    childrenDescriptor && typeof childrenDescriptor.get === 'function'
+      ? childrenDescriptor.get()
+      : props.children
+  )
 
-  // For template rendering, always use empty children — DOM children are inserted later.
-  // String children are already in unwrappedProps from unwrapPropsForTemplate.
-  // Also guard against undefined children producing literal "undefined" text in templates.
-  if (hasChildrenGetter || unwrappedProps.children === undefined) {
+  // 3. Generate HTML from props
+  // When children contain DOM elements, pass empty children for shell HTML
+  const unwrappedProps = untrack(() => unwrapPropsForTemplate(props))
+  const hasDomChildren = children != null && hasDomElements(children)
+  if (hasDomChildren) {
     unwrappedProps.children = ''
   }
-
-  // Set parent scope ID so nested renderChild() calls produce consistent
-  // scope IDs (e.g., "Select_abc_s1" instead of "SelectTrigger_random_s1").
-  setParentScopeId(scopeId)
-  let html: string
-  try {
-    html = templateFn(unwrappedProps)
-  } finally {
-    setParentScopeId(null)
-  }
+  const html = templateFn(unwrappedProps)
 
   // 4. Create DOM element
   const element = parseHTML(html.trim()).firstChild as HTMLElement
@@ -121,33 +105,25 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 5. Set scope ID and key attributes
+  // 5. Insert DOM children into the shell element
+  if (hasDomChildren) {
+    insertDomChildren(element, children)
+  }
+
+  // 6. Set scope ID and key attributes
+  const scopeId = `${name}_${generateId()}`
   element.setAttribute(BF_SCOPE, scopeId)
   if (key !== undefined) {
     element.setAttribute(BF_KEY, String(key))
   }
 
-  // 6. Initialize the parent component BEFORE creating children.
-  // This ensures provideContext() runs first, so child components
-  // created in step 7 can find the context via useContext().
+  // 7. Initialize the component synchronously
+  // Event handlers need to be bound immediately so user interactions work right away.
+  // Nested effects are now supported in createEffect, so we don't need queueMicrotask.
   const initFn = getComponentInit(name)
   if (initFn) {
+    // Pass original props (with getters) for reactivity
     initFn(element, props)
-  }
-
-  // 7. Now evaluate and insert DOM children.
-  // Children getters may call createComponent() which triggers child init.
-  // Context is now available from step 6.
-  if (hasChildrenGetter) {
-    const children = untrack(() => childrenDescriptor!.get!())
-    if (children != null && hasDomElements(children)) {
-      insertDomChildren(element, children)
-    }
-  } else {
-    const children = props.children
-    if (children != null && hasDomElements(children)) {
-      insertDomChildren(element, children)
-    }
   }
 
   // 8. Mark element as initialized
@@ -234,12 +210,6 @@ export function renderChild(
     return `<div bf-s="~${scopePrefix}${suffix}"${keyAttr}></div>`
   }
 
-  // Guard against undefined children producing literal "undefined" text in templates.
-  // Components rendered via renderChild may not receive a children prop when the
-  // compiler omits it (e.g., nested loop CSR paths).
-  if (props.children === undefined) {
-    props = { ...props, children: '' }
-  }
   const html = templateFn(props).trim()
   // Inject bf-s scope attribute with ~ child prefix into the first element tag.
   // The ~ prefix marks this as a child component so hydrate()'s requestAnimationFrame
@@ -358,17 +328,7 @@ function insertDomChildren(element: HTMLElement, children: unknown): void {
     for (const child of children) {
       insertDomChildren(element, child)
     }
-  } else if (typeof children === 'string') {
-    // Strings containing HTML tags (from compiler-generated template fragments)
-    // must be parsed as HTML, not inserted as text nodes.
-    if (children.includes('<')) {
-      const tpl = document.createElement('template')
-      tpl.innerHTML = children
-      element.appendChild(tpl.content)
-    } else {
-      element.appendChild(document.createTextNode(children))
-    }
-  } else if (typeof children === 'number') {
+  } else if (typeof children === 'string' || typeof children === 'number') {
     element.appendChild(document.createTextNode(String(children)))
   }
 }

--- a/packages/client-runtime/src/map-array.ts
+++ b/packages/client-runtime/src/map-array.ts
@@ -21,13 +21,10 @@ type ItemScope<T> = {
   setItem: (v: T) => void
 }
 
-/** Find loop boundary comment markers in a container.
- *  Searches direct children first, then walks descendants for nested cases
- *  (e.g., loop markers inside a child component like SelectContent). */
+/** Find loop boundary comment markers in a container. */
 function findLoopMarkers(container: HTMLElement): { start: Comment | null; end: Comment | null } {
   let start: Comment | null = null
   let end: Comment | null = null
-  // Try direct children first (fast path)
   for (const node of Array.from(container.childNodes)) {
     if (node.nodeType === Node.COMMENT_NODE) {
       const value = (node as Comment).nodeValue
@@ -36,17 +33,6 @@ function findLoopMarkers(container: HTMLElement): { start: Comment | null; end: 
     }
   }
   if (start && end) return { start, end }
-  // Fallback: walk descendants (handles loops inside child components)
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_COMMENT)
-  start = null
-  end = null
-  let comment: Comment | null
-  while ((comment = walker.nextNode() as Comment | null)) {
-    const value = comment.nodeValue
-    if (value === BF_LOOP_START) start = comment
-    else if (value === BF_LOOP_END) end = comment
-    if (start && end) return { start, end }
-  }
   return { start: null, end: null }
 }
 

--- a/packages/client-runtime/src/map-array.ts
+++ b/packages/client-runtime/src/map-array.ts
@@ -21,10 +21,13 @@ type ItemScope<T> = {
   setItem: (v: T) => void
 }
 
-/** Find loop boundary comment markers in a container. */
+/** Find loop boundary comment markers in a container.
+ *  Searches direct children first, then walks descendants for nested cases
+ *  (e.g., loop markers inside a child component like SelectContent). */
 function findLoopMarkers(container: HTMLElement): { start: Comment | null; end: Comment | null } {
   let start: Comment | null = null
   let end: Comment | null = null
+  // Try direct children first (fast path)
   for (const node of Array.from(container.childNodes)) {
     if (node.nodeType === Node.COMMENT_NODE) {
       const value = (node as Comment).nodeValue
@@ -33,6 +36,17 @@ function findLoopMarkers(container: HTMLElement): { start: Comment | null; end: 
     }
   }
   if (start && end) return { start, end }
+  // Fallback: walk descendants (handles loops inside child components)
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_COMMENT)
+  start = null
+  end = null
+  let comment: Comment | null
+  while ((comment = walker.nextNode() as Comment | null)) {
+    const value = comment.nodeValue
+    if (value === BF_LOOP_START) start = comment
+    else if (value === BF_LOOP_END) end = comment
+    if (start && end) return { start, end }
+  }
   return { start: null, end: null }
 }
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -83,10 +83,17 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
         break
       }
       case 'fragment':
-      case 'component':
       case 'provider':
         for (const child of n.children) walk(child, parentSlotId)
         break
+      case 'component': {
+        // Use the component's own slotId as the container for inner loops,
+        // so loops inside child components (e.g., SelectContent) use that
+        // component's element as the mapArray container instead of __branchScope.
+        const mySlotId = n.slotId ?? parentSlotId
+        for (const child of n.children) walk(child, mySlotId)
+        break
+      }
       case 'conditional': {
         const prev = insideCond
         insideCond = true

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -324,9 +324,14 @@ function emitBranchInnerLoops(
     const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
     // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
     const wrappedTemplate = inner.itemTemplate
-    const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
+    // Find the container for the inner loop. Try bf= attribute (plain elements) first,
+    // then bf-s$ suffix match (component scope elements like SelectContent).
+    const csl = inner.containerSlotId
+    const containerExpr = csl
+      ? `(${scopeVar}.querySelector('[bf="${csl}"]') ?? ${scopeVar}.querySelector('[bf-s$="_${csl}"]') ?? ${scopeVar})`
+      : scopeVar
 
-    lines.push(`${indent}{ const __bic${uid} = ${containerSelector !== 'null' ? `${scopeVar}.querySelector(${containerSelector})` : scopeVar}`)
+    lines.push(`${indent}{ const __bic${uid} = ${containerExpr}`)
     lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${inner.param}, __bidx${uid}, __existing) => {`)
     lines.push(`${indent}  const __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
     if (inner.key) {

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -333,7 +333,7 @@ function emitBranchInnerLoops(
 
     lines.push(`${indent}{ const __bic${uid} = ${containerExpr}`)
     lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${inner.param}, __bidx${uid}, __existing) => {`)
-    lines.push(`${indent}  const __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
+    lines.push(`${indent}  let __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
     if (inner.key) {
       const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
       lines.push(`${indent}  __bel${uid}.setAttribute('${keyAttrName(1)}', String(${wrappedKey}))`)
@@ -1035,9 +1035,13 @@ function emitComponentAndEventSetup(
       const keyArg = keyProp ? `, ${wrap(keyProp.value)}` : ''
       if (childrenRefsLoop) {
         const wrappedChildren = wrap(rawChildrenExpr!)
-        ls.push(`${indent}{ const __ph = ${elVar}.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) { const __comp = createComponent('${comp.name}', ${propsExpr}${keyArg}); __ph.replaceWith(__comp); createEffect(() => { const __v = ${wrappedChildren}; __comp.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+        // Use qsa so the placeholder element is found even when it IS elVar itself
+        // (e.g., loop body = bare component: <div data-bf-ph="sN"> is both the item and the placeholder).
+        // When __ph === elVar, the element is detached so replaceWith is a no-op; reassign instead.
+        ls.push(`${indent}{ const __ph = qsa(${elVar}, '[${DATA_BF_PH}="${phId}"]'); if (__ph) { const __comp = createComponent('${comp.name}', ${propsExpr}${keyArg}); if (__ph === ${elVar}) ${elVar} = __comp; else __ph.replaceWith(__comp); createEffect(() => { const __v = ${wrappedChildren}; __comp.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
-        ls.push(`${indent}{ const __ph = ${elVar}.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) __ph.replaceWith(createComponent('${comp.name}', ${propsExpr}${keyArg})) }`)
+        // Same qsa + reassignment fix for the non-children-reactive case.
+        ls.push(`${indent}{ const __ph = qsa(${elVar}, '[${DATA_BF_PH}="${phId}"]'); if (__ph) { const __comp = createComponent('${comp.name}', ${propsExpr}${keyArg}); if (__ph === ${elVar}) ${elVar} = __comp; else __ph.replaceWith(__comp) } }`)
       }
     } else {
       const selector = buildCompSelector(comp)
@@ -1160,7 +1164,7 @@ function emitInnerLoopSetup(
       ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `qsa(${parentElVar}, ${containerSelector})` : parentElVar}`)
       ls.push(`${indent}if (__ic${uid}) mapArray(() => ${arrayExpr} || [], __ic${uid}, ${keyFn}, (${inner.param}, __innerIdx${uid}, __existing) => {`)
       // SSR/CSR branch
-      ls.push(`${indent}  const __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
+      ls.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
       if (inner.key) {
         // Inside renderItem, inner.param is an accessor
         const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -291,7 +291,7 @@ function emitBranchChildComponentInits(
     // SSR: element has bf-s attribute → initChild.
     // CSR: element is a placeholder (data-bf-ph) → createComponent to replace it.
     const phId = comp.slotId || comp.name
-    lines.push(`${indent}{ let __c = __branchScope.querySelector('${selector}'); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) { __c = createComponent('${comp.name}', ${propsExpr}); __ph.replaceWith(__c) } } if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
+    lines.push(`${indent}{ let __c = qsa(__branchScope, '${selector}'); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${phId}"]'); if (__ph) { __c = createComponent('${comp.name}', ${propsExpr}); __ph.replaceWith(__c) } } if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
   }
 }
 
@@ -335,9 +335,19 @@ function emitBranchInnerLoops(
     }
     // Components and events inside inner loop items
     const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
+    // Recursively wrap IR nodes for inner loop param accessor conversion
+    const wrapIRNodeBranch = (node: any): any => {
+      if (node.type === 'component') {
+        return { ...node, props: node.props.map((p: any) => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })), children: node.children?.map(wrapIRNodeBranch) }
+      }
+      if (node.type === 'expression' && node.expr) return { ...node, expr: wrapInner(node.expr) }
+      if (node.children) return { ...node, children: node.children.map(wrapIRNodeBranch) }
+      return node
+    }
     const comps = (inner.childComponents ?? []).map(comp => ({
       ...comp,
       props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+      children: comp.children?.map(wrapIRNodeBranch),
     }))
     const events = (inner.childEvents ?? []).map(ev => ({
       ...ev,
@@ -677,7 +687,9 @@ function buildComponentPropsExpr(
   })
   if ('children' in comp && Array.isArray(comp.children) && comp.children.length > 0) {
     const childrenExpr = irChildrenToJsExpr(comp.children)
-    entries.push(`get children() { return ${wrap(childrenExpr)} }`)
+    if (childrenExpr && childrenExpr !== "''") {
+      entries.push(`get children() { return ${wrap(childrenExpr)} }`)
+    }
   }
   return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
 }
@@ -712,9 +724,9 @@ function emitComponentLoopReconciliation(lines: string[], elem: LoopElement, key
       const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
       if (childrenRefsLoop) {
         const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param)
-        lines.push(`      { const __c = __existing.querySelector('${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+        lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
-        lines.push(`      { const __c = __existing.querySelector('${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
+        lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
       }
     }
     // Emit reactive effects for conditionals/texts inside component children
@@ -734,9 +746,9 @@ function emitComponentLoopReconciliation(lines: string[], elem: LoopElement, key
       const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
       if (childrenRefsLoop) {
         const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param)
-        lines.push(`    { const __c = __csrEl.querySelector('${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+        lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
-        lines.push(`    { const __c = __csrEl.querySelector('${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
+        lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
       }
     }
     if (elem.childConditionals && elem.childConditionals.length > 0) {
@@ -1026,9 +1038,9 @@ function emitComponentAndEventSetup(
       const selector = buildCompSelector(comp)
       if (childrenRefsLoop) {
         const wrappedChildren = wrap(rawChildrenExpr!)
-        ls.push(`${indent}{ const __c = ${elVar}.querySelector('${selector}'); if (__c) { initChild('${comp.name}', __c, ${propsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+        ls.push(`${indent}{ const __c = qsa(${elVar}, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${propsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
-        ls.push(`${indent}{ const __c = ${elVar}.querySelector('${selector}'); if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
+        ls.push(`${indent}{ const __c = qsa(${elVar}, '${selector}'); if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
       }
     }
   }
@@ -1057,6 +1069,13 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
     ? ctx.outerComps.filter(c => !c.slotId || !condCompSlotIds.has(c.slotId))
     : ctx.outerComps
 
+  // Hoist mapPreamble before the SSR/CSR split so variables it declares
+  // (e.g. `const f = arr.find(...)`) are accessible in both branches and in
+  // any reactive attribute getters emitted after the if/else block.
+  if (ctx.elem.mapPreamble) {
+    ls.push(`${indent}${wrap(ctx.elem.mapPreamble)}`)
+  }
+
   // Branch: SSR (existing element) vs CSR (create from template)
   ls.push(`${indent}let __el`)
   ls.push(`${indent}if (__existing) {`)
@@ -1067,9 +1086,6 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
   emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'ssr', param)
   ls.push(`${indent}} else {`)
   // CSR: create element from template, replace placeholders with createComponent
-  if (ctx.elem.mapPreamble) {
-    ls.push(`${indent}  ${wrap(ctx.elem.mapPreamble)}`)
-  }
   ls.push(`${indent}  const __tpl = document.createElement('template')`)
   // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
   ls.push(`${indent}  __tpl.innerHTML = \`${ctx.elem.template}\``)
@@ -1147,14 +1163,36 @@ function emitInnerLoopSetup(
       }
       // Set up components and events — wrap inner loop param as accessor
       if (level.comps.length > 0 || level.events.length > 0) {
-        // Pre-wrap both component props and event handlers with inner loop param
+        // Pre-wrap both component props and event handlers with inner loop param.
+        // Children IR nodes must be wrapped recursively so nested component props
+        // (e.g., SelectItem value inside SelectContent inside Select) also get
+        // the inner loop param converted to signal accessor form.
         const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
-        const wrappedComps = level.comps.map(comp => ({
-          ...comp,
-          props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
-          children: comp.children?.map(c => c.type === 'expression' && c.expr
-            ? { ...c, expr: wrapInner(c.expr) } : c),
-        }))
+        const wrapIRNode = (node: any): any => {
+          if (node.type === 'component') {
+            return {
+              ...node,
+              props: node.props.map((p: any) => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+              children: node.children?.map(wrapIRNode),
+            }
+          }
+          if (node.type === 'expression' && node.expr) {
+            return { ...node, expr: wrapInner(node.expr) }
+          }
+          if (node.children) {
+            return { ...node, children: node.children.map(wrapIRNode) }
+          }
+          return node
+        }
+        const wrappedComps = level.comps.map(comp => {
+          const wrapped = {
+            ...comp,
+            props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+            children: comp.children?.map(wrapIRNode),
+          }
+          if (comp.name === 'Select') console.error('[DEBUG-WRAP] before:', comp.children?.length, 'after:', wrapped.children?.length)
+          return wrapped
+        })
         const wrappedEvents = level.events.map(ev => ({
           ...ev,
           handler: wrapInner(ev.handler),

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -505,6 +505,9 @@ function collectBranchInnerLoops(
         childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
       })
     } else if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
+      // For component nodes (e.g., SelectContent), track their slotId so inner loops
+      // use the component element as their container rather than the branch scope.
+      if (n.type === 'component' && n.slotId) lastSlotId = n.slotId
       for (const child of n.children) walk(child)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -442,12 +442,16 @@ function collectBranchInnerLoops(
 ): LoopChildConditional['whenTrueInnerLoops'] {
   const { irToPlaceholderTemplate } = require('./html-template')
   const loops: import('./types').NestedLoopInfo[] = []
-  let lastSlotId: string | null = null
 
-  function walk(n: IRNode): void {
+  // Pass the current container's slotId down through the tree.
+  // A loop uses parentContainerSlotId as its container.
+  // When entering a component, its slotId becomes the container for its children,
+  // but NOT for its siblings — this prevents a sibling component's slotId from
+  // being used as the loop container.
+  function walk(n: IRNode, parentContainerSlotId: string | null = null): void {
     if (n.type === 'element') {
-      if (n.slotId) lastSlotId = n.slotId
-      for (const child of n.children) walk(child)
+      const mySlotId = n.slotId ?? parentContainerSlotId
+      for (const child of n.children) walk(child, mySlotId)
     } else if (n.type === 'loop') {
       const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
       const itemTemplate = n.children.map((c: IRNode) => irToPlaceholderTemplate(c, undefined, 1, loopParamsForTemplate)).join('')
@@ -496,7 +500,7 @@ function collectBranchInnerLoops(
         array: n.array,
         param: n.param,
         key: n.key ?? '',
-        containerSlotId: lastSlotId,
+        containerSlotId: parentContainerSlotId,
         itemTemplate,
         refsOuterParam: refsOuter,
         reactiveTexts: reactiveTexts.length > 0 ? reactiveTexts : undefined,
@@ -505,14 +509,14 @@ function collectBranchInnerLoops(
         childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
       })
     } else if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
-      // For component nodes (e.g., SelectContent), track their slotId so inner loops
+      // For component nodes (e.g., SelectContent), pass slotId to children so inner loops
       // use the component element as their container rather than the branch scope.
-      if (n.type === 'component' && n.slotId) lastSlotId = n.slotId
-      for (const child of n.children) walk(child)
+      const mySlotId = (n.type === 'component' && n.slotId) ? n.slotId : parentContainerSlotId
+      for (const child of n.children) walk(child, mySlotId)
     }
   }
 
-  walk(node)
+  walk(node, null)
   return loops.length > 0 ? loops : undefined
 }
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -462,7 +462,7 @@ function collectBranchInnerLoops(
       }
       // Collect child components and events inside inner loop items
       // Walk loop body children (not the loop node itself, which traverseForComponents skips)
-      const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[] }> = []
+      const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }> = []
       for (const child of n.children) {
         rawComps.push(...collectConditionalBranchChildComponents(child))
       }
@@ -476,7 +476,7 @@ function collectBranchInnerLoops(
           isLiteral: p.isLiteral ?? false,
           isEventHandler: p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase(),
         })),
-        children: [] as import('../types').IRNode[],
+        children: c.children,
         loopDepth: 1,
       }))
       const childEvents: import('./types').LoopChildEvent[] = []

--- a/site/ui/components/form-builder-demo.tsx
+++ b/site/ui/components/form-builder-demo.tsx
@@ -20,6 +20,13 @@ import { Button } from '@ui/components/ui/button'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Input } from '@ui/components/ui/input'
 import { Label } from '@ui/components/ui/label'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@ui/components/ui/select'
 import { Textarea } from '@ui/components/ui/textarea'
 import {
   ToastProvider,
@@ -254,17 +261,21 @@ export function FormBuilderDemo() {
 
                 {/* Row 1: type selector + label + controls */}
                 <div className="flex items-center gap-1.5">
-                  <select
+                  <Select
                     value={field.type}
-                    onChange={(e) => updateField(field.id, { type: e.target.value as FieldType })}
-                    className="w-28 flex-shrink-0 field-type-select h-8 rounded-md border border-input bg-transparent px-3 text-sm appearance-none cursor-pointer"
+                    onValueChange={(v: string) => updateField(field.id, { type: v as FieldType })}
                   >
-                    <option value="text">Text</option>
-                    <option value="textarea">Textarea</option>
-                    <option value="select">Select</option>
-                    <option value="checkbox">Checkbox</option>
-                    <option value="group">Group</option>
-                  </select>
+                    <SelectTrigger className="w-28 flex-shrink-0 field-type-select h-8 text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="text">Text</SelectItem>
+                      <SelectItem value="textarea">Textarea</SelectItem>
+                      <SelectItem value="select">Select</SelectItem>
+                      <SelectItem value="checkbox">Checkbox</SelectItem>
+                      <SelectItem value="group">Group</SelectItem>
+                    </SelectContent>
+                  </Select>
 
                   <Input
                     value={field.label}
@@ -315,26 +326,26 @@ export function FormBuilderDemo() {
                     {/* Nested loop: group children */}
                     {field.children.map(child => (
                       <div key={child.id} className="child-field flex items-center gap-1.5 pl-3 border-l-2 border-muted">
-                        <select
+                        <Select
                           value={child.type}
-                          onChange={(e) => updateChildField(field.id, child.id, { type: e.target.value as 'text' | 'checkbox' | 'select' })}
-                          className="w-24 shrink-0 child-type-select h-8 rounded-md border border-input bg-transparent px-3 text-sm appearance-none cursor-pointer"
+                          onValueChange={(v: string) => updateChildField(field.id, child.id, { type: v as 'text' | 'checkbox' | 'select' })}
                         >
-                          <option value="text">Text</option>
-                          <option value="checkbox">Checkbox</option>
-                          <option value="select">Select</option>
-                        </select>
+                          <SelectTrigger className="w-24 shrink-0 child-type-select h-8 text-sm">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="text">Text</SelectItem>
+                            <SelectItem value="checkbox">Checkbox</SelectItem>
+                            <SelectItem value="select">Select</SelectItem>
+                          </SelectContent>
+                        </Select>
                         <Input
                           value={child.label}
                           onInput={(e) => updateChildField(field.id, child.id, { label: e.target.value })}
                           className="flex-1 h-8 text-sm child-label-input"
                           placeholder="Child label"
                         />
-                        <button
-                          type="button"
-                          className="remove-child shrink-0 text-muted-foreground hover:text-destructive h-7 w-7 rounded-md inline-flex items-center justify-center text-base hover:bg-accent"
-                          onClick={() => removeChildField(field.id, child.id)}
-                        >×</button>
+                        <Button variant="ghost" size="icon-sm" className="remove-child shrink-0 text-muted-foreground hover:text-destructive" onClick={() => removeChildField(field.id, child.id)}>×</Button>
                       </div>
                     ))}
                     <Button variant="outline" size="sm" className="add-child-btn" onClick={() => addChildField(field.id)}>
@@ -345,14 +356,14 @@ export function FormBuilderDemo() {
 
                 {/* Row 2: required + visibility condition */}
                 <div className="flex items-center gap-4 pt-1">
-                  <label className="flex items-center gap-1.5 cursor-pointer shrink-0">
+                  <Label className="gap-1.5 cursor-pointer shrink-0">
                     <Checkbox
                       checked={field.required}
                       onCheckedChange={(v) => updateField(field.id, { required: v })}
                       className="required-checkbox"
                     />
                     <span className="text-xs text-muted-foreground">Required</span>
-                  </label>
+                  </Label>
 
                   <div className="flex items-center gap-1.5 flex-1 min-w-0">
                     <span className="text-xs text-muted-foreground whitespace-nowrap">Show when:</span>
@@ -423,60 +434,67 @@ export function FormBuilderDemo() {
                       {field.label}
                       {field.required ? <span className="text-destructive ml-1">*</span> : null}
                     </Label>
-                    <select
+                    <Select
                       value={previewValues()[field.label] || ''}
-                      onChange={(e) => updatePreviewValue(field.label, e.target.value)}
-                      className="preview-select w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm appearance-none cursor-pointer"
+                      onValueChange={(v: string) => updatePreviewValue(field.label, v)}
                     >
-                      <option value="">Select…</option>
-                      {field.options.split(',').map(opt => (
-                        <option key={opt.trim()} value={opt.trim()}>{opt.trim()}</option>
-                      ))}
-                    </select>
+                      <SelectTrigger className="preview-select">
+                        <SelectValue placeholder="Select…" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {field.options.split(',').map(opt => (
+                          <SelectItem key={opt.trim()} value={opt.trim()}>{opt.trim()}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
                 ) : null}
 
                 {field.type === 'checkbox' ? (
-                  <label className="flex items-center gap-2 cursor-pointer">
+                  <Label className="cursor-pointer">
                     <Checkbox className="preview-checkbox" />
                     <span className="text-sm">
                       {field.label}
                       {field.required ? <span className="text-destructive ml-1">*</span> : null}
                     </span>
-                  </label>
+                  </Label>
                 ) : null}
 
                 {field.type === 'group' ? (
                   <div className="group-preview space-y-3">
-                    <Label className="text-sm font-medium">{field.label}</Label>
+                    <Label>{field.label}</Label>
                     <div className="pl-4 border-l-2 border-muted space-y-3">
                       {/* Nested loop: group children in preview */}
                       {field.children.map(child => (
                         <div key={child.id} className="child-preview">
                           {child.type === 'text' ? (
                             <div className="space-y-1">
-                              <label className="text-xs font-medium leading-none">
+                              <Label className="text-xs">
                                 {child.label}
                                 {child.required ? <span className="text-destructive ml-1">*</span> : null}
-                              </label>
+                              </Label>
                               <Input placeholder={child.label} className="preview-child-input" />
                             </div>
                           ) : null}
                           {child.type === 'checkbox' ? (
-                            <label className="flex items-center gap-2 cursor-pointer">
+                            <Label className="cursor-pointer">
                               <Checkbox />
                               <span className="text-sm">{child.label}</span>
-                            </label>
+                            </Label>
                           ) : null}
                           {child.type === 'select' ? (
                             <div className="space-y-1">
-                              <label className="text-xs font-medium leading-none">{child.label}</label>
-                              <select className="preview-child-select w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm appearance-none cursor-pointer">
-                                <option value="">Select…</option>
-                                {child.options.split(',').map(opt => (
-                                  <option key={opt.trim()} value={opt.trim()}>{opt.trim()}</option>
-                                ))}
-                              </select>
+                              <Label className="text-xs">{child.label}</Label>
+                              <Select>
+                                <SelectTrigger className="preview-child-select">
+                                  <SelectValue placeholder="Select…" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {child.options.split(',').map(opt => (
+                                    <SelectItem key={opt.trim()} value={opt.trim()}>{opt.trim()}</SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
                             </div>
                           ) : null}
                         </div>

--- a/site/ui/components/pivot-table-demo.tsx
+++ b/site/ui/components/pivot-table-demo.tsx
@@ -14,6 +14,7 @@
 
 import { createSignal, createMemo } from '@barefootjs/client'
 import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
 import {
   Select,
   SelectTrigger,
@@ -431,13 +432,9 @@ export function PivotTableDemo() {
                 >
                   <GripVerticalIcon className="w-3 h-3 opacity-60" />
                   {f.label}
-                  <button
-                    className="field-remove-btn ml-0.5 opacity-60 hover:opacity-100"
-                    onClick={() => removeField(fid)}
-                    aria-label={`Remove ${f.label}`}
-                  >
+                  <Button variant="ghost" size="icon-sm" className="field-remove-btn ml-0.5 opacity-60 hover:opacity-100" onClick={() => removeField(fid)} aria-label={`Remove ${f.label}`}>
                     <XIcon className="w-3 h-3" />
-                  </button>
+                  </Button>
                 </div>
               )
             })}
@@ -460,13 +457,9 @@ export function PivotTableDemo() {
               >
                 <GripVerticalIcon className="w-3 h-3 opacity-60" />
                 {columnLabel()}
-                <button
-                  className="field-remove-btn ml-0.5 opacity-60 hover:opacity-100"
-                  onClick={() => removeField(columnField() as FieldId)}
-                  aria-label={`Remove ${columnLabel()}`}
-                >
+                <Button variant="ghost" size="icon-sm" className="field-remove-btn ml-0.5 opacity-60 hover:opacity-100" onClick={() => removeField(columnField() as FieldId)} aria-label={`Remove ${columnLabel()}`}>
                   <XIcon className="w-3 h-3" />
-                </button>
+                </Button>
               </div>
             ) : null}
           </div>

--- a/site/ui/components/pivot-table-demo.tsx
+++ b/site/ui/components/pivot-table-demo.tsx
@@ -353,8 +353,16 @@ export function PivotTableDemo() {
   const groupCount = createMemo(() => visibleRows().length)
 
   // Helper memos for field labels (avoids IIFE in JSX which breaks CSR codegen)
+  // insert() only re-renders branch templates on condition changes, not on signal
+  // changes within a branch — so reactive expressions that stay in the same branch
+  // must be extracted into memos to get proper reactive text updates.
   const columnLabel = createMemo(() => ALL_FIELDS.find(x => x.id === columnField())?.label ?? '')
   const valueLabel = createMemo(() => ALL_FIELDS.find(x => x.id === valueField())?.label ?? '')
+  const rowFieldsHeader = createMemo(() =>
+    rowFields().length > 0
+      ? rowFields().map((f: DimensionId) => ALL_FIELDS.find(x => x.id === f)?.label ?? '').join(' / ')
+      : 'Groups'
+  )
 
   // Helper functions for row rendering (defined at component level to avoid
   // local variable scoping issues inside .map() callbacks — the compiler
@@ -511,9 +519,7 @@ export function PivotTableDemo() {
           <thead>
             <tr className="bg-muted/50">
               <th className="text-left p-2 pl-3 font-medium border-r min-w-[180px]">
-                {rowFields().length > 0
-                  ? rowFields().map((f: DimensionId) => ALL_FIELDS.find(x => x.id === f)?.label).join(' / ')
-                  : 'Groups'}
+                {rowFieldsHeader()}
               </th>
               {columnValues().map((cv: string) => (
                 <th key={cv} className="pivot-header p-2 text-right font-medium border-r min-w-[90px]">

--- a/site/ui/e2e/form-builder.spec.ts
+++ b/site/ui/e2e/form-builder.spec.ts
@@ -8,6 +8,13 @@ test.describe('Form Builder Block', () => {
   const section = (page: any) =>
     page.locator('[bf-s^="FormBuilderDemo_"]:not([data-slot])').first()
 
+  // Helper: select an option from a custom <Select> component by value
+  const selectTypeOption = async (page: any, trigger: any, value: string) => {
+    await trigger.click()
+    const openContent = page.locator('[data-slot="select-content"][data-state="open"]')
+    await openContent.locator(`[data-slot="select-item"][data-value="${value}"]`).click()
+  }
+
   // --- Initial Render ---
 
   test.describe('Initial Render', () => {
@@ -29,21 +36,21 @@ test.describe('Form Builder Block', () => {
     test('first field has type text and label Full Name', async ({ page }) => {
       const s = section(page)
       const first = s.locator('.field-editor').first()
-      await expect(first.locator('.field-type-select')).toHaveValue('text')
+      await expect(first.locator('.field-type-select')).toContainText('Text')
       await expect(first.locator('.field-label-input')).toHaveValue('Full Name')
     })
 
     test('select field has options input', async ({ page }) => {
       const s = section(page)
       const countryField = s.locator('.field-editor').nth(2)
-      await expect(countryField.locator('.field-type-select')).toHaveValue('select')
+      await expect(countryField.locator('.field-type-select')).toContainText('Select')
       await expect(countryField.locator('.options-input')).toBeVisible()
     })
 
     test('group field shows child fields', async ({ page }) => {
       const s = section(page)
       const groupField = s.locator('.field-editor').nth(3)
-      await expect(groupField.locator('.field-type-select')).toHaveValue('group')
+      await expect(groupField.locator('.field-type-select')).toContainText('Group')
       await expect(groupField.locator('.child-field')).toHaveCount(3)
     })
   })
@@ -62,7 +69,7 @@ test.describe('Form Builder Block', () => {
       const s = section(page)
       await s.locator('.add-select-btn').click()
       const newField = s.locator('.field-editor').last()
-      await expect(newField.locator('.field-type-select')).toHaveValue('select')
+      await expect(newField.locator('.field-type-select')).toContainText('Select')
       await expect(newField.locator('.options-input')).toBeVisible()
     })
 
@@ -70,7 +77,7 @@ test.describe('Form Builder Block', () => {
       const s = section(page)
       await s.locator('.add-group-btn').click()
       const newField = s.locator('.field-editor').last()
-      await expect(newField.locator('.field-type-select')).toHaveValue('group')
+      await expect(newField.locator('.field-type-select')).toContainText('Group')
       await expect(newField.locator('.add-child-btn')).toBeVisible()
     })
 
@@ -84,7 +91,7 @@ test.describe('Form Builder Block', () => {
       const s = section(page)
       await s.locator('.add-textarea-btn').click()
       const newField = s.locator('.field-editor').last()
-      await expect(newField.locator('.field-type-select')).toHaveValue('textarea')
+      await expect(newField.locator('.field-type-select')).toContainText('Textarea')
       await expect(newField.locator('.placeholder-input')).toBeVisible()
     })
   })
@@ -107,14 +114,14 @@ test.describe('Form Builder Block', () => {
       const s = section(page)
       const first = s.locator('.field-editor').first()
       await expect(first.locator('.options-input')).not.toBeVisible()
-      await first.locator('.field-type-select').selectOption('select')
+      await selectTypeOption(page, first.locator('.field-type-select'), 'select')
       await expect(first.locator('.options-input')).toBeVisible()
     })
 
     test('switching to group shows children area', async ({ page }) => {
       const s = section(page)
       const second = s.locator('.field-editor').nth(1)
-      await second.locator('.field-type-select').selectOption('group')
+      await selectTypeOption(page, second.locator('.field-type-select'), 'group')
       await expect(second.locator('.group-children')).toBeVisible()
       await expect(second.locator('.add-child-btn')).toBeVisible()
     })
@@ -124,7 +131,7 @@ test.describe('Form Builder Block', () => {
       // Country field (index 2) is a select
       const countryField = s.locator('.field-editor').nth(2)
       await expect(countryField.locator('.options-input')).toBeVisible()
-      await countryField.locator('.field-type-select').selectOption('text')
+      await selectTypeOption(page, countryField.locator('.field-type-select'), 'text')
       await expect(countryField.locator('.options-input')).not.toBeVisible()
     })
   })
@@ -203,8 +210,8 @@ test.describe('Form Builder Block', () => {
       const s = section(page)
       const groupField = s.locator('.field-editor').nth(3)
       const firstChild = groupField.locator('.child-field').first()
-      await firstChild.locator('.child-type-select').selectOption('checkbox')
-      await expect(firstChild.locator('.child-type-select')).toHaveValue('checkbox')
+      await selectTypeOption(page, firstChild.locator('.child-type-select'), 'checkbox')
+      await expect(firstChild.locator('.child-type-select')).toContainText('Checkbox')
     })
 
     test('child label input is editable', async ({ page }) => {
@@ -309,11 +316,13 @@ test.describe('Form Builder Block', () => {
 
     test('select field preview shows option list', async ({ page }) => {
       const s = section(page)
-      // Country is a select field → preview should have options
-      const previewSelect = s.locator('.preview-field-select select, .preview-field-select .preview-select select').first()
-      const optionCount = await previewSelect.locator('option').count()
-      // 'Select…' placeholder + 4 country options
+      // Country is a select field → open the preview select and verify options
+      const previewSelectTrigger = s.locator('.preview-field-select .preview-select').first()
+      await previewSelectTrigger.click()
+      const optionCount = await page.locator('[data-slot="select-item"]').count()
+      // At least 2 country options
       expect(optionCount).toBeGreaterThanOrEqual(2)
+      await page.keyboard.press('Escape')
     })
 
     test('add child button shows no undefined text', async ({ page }) => {

--- a/site/ui/e2e/pivot-table.spec.ts
+++ b/site/ui/e2e/pivot-table.spec.ts
@@ -225,6 +225,41 @@ test.describe('Pivot Table Block', () => {
       await s.locator('.axis-zone-columns .pivot-field-quarter .field-remove-btn').click()
       await expect(s.locator('.axis-zone-available .pivot-field-quarter')).toBeVisible()
     })
+
+    test('dragging available field into rows shows X button on new field', async ({ page }) => {
+      const s = section(page)
+
+      // Rows starts with [region, product] (max 2). Remove one to make room.
+      await s.locator('.axis-zone-rows .pivot-field-region .field-remove-btn').click()
+
+      // Salesperson is now available — drag it into Rows
+      const source = s.locator('.axis-zone-available .pivot-field-salesperson')
+      const target = s.locator('.axis-zone-rows')
+      await source.dragTo(target)
+
+      // Salesperson should now appear in Rows zone with a remove button
+      const newField = s.locator('.axis-zone-rows .pivot-field-salesperson')
+      await expect(newField).toBeVisible()
+      await expect(newField.locator('.field-remove-btn')).toBeVisible()
+    })
+
+    test('re-adding a removed field to rows shows X button', async ({ page }) => {
+      const s = section(page)
+
+      // Remove Product from rows → it moves to Available
+      await s.locator('.axis-zone-rows .pivot-field-product .field-remove-btn').click()
+      await expect(s.locator('.axis-zone-available .pivot-field-product')).toBeVisible()
+
+      // Drag Product back into rows
+      const source = s.locator('.axis-zone-available .pivot-field-product')
+      const target = s.locator('.axis-zone-rows')
+      await source.dragTo(target)
+
+      // X button must be visible on the re-added field
+      const newField = s.locator('.axis-zone-rows .pivot-field-product')
+      await expect(newField).toBeVisible()
+      await expect(newField.locator('.field-remove-btn')).toBeVisible()
+    })
   })
 
   test.describe('Grand Totals', () => {

--- a/ui/components/ui/select/index.tsx
+++ b/ui/components/ui/select/index.tsx
@@ -250,10 +250,12 @@ function SelectContent(props: SelectContentProps) {
     const triggerEl = findSiblingSlot(el, '[data-slot="select-trigger"]')
     if (triggerEl) contentTriggerMap.set(el, triggerEl)
 
-    // Portal to body to escape overflow clipping
+    // Portal to body to escape overflow clipping.
+    // Deferred via microtask so that sibling initChild calls (e.g., SelectItem)
+    // can find their elements via querySelector before they leave the DOM subtree.
     if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
       const ownerScope = el.closest('[bf-s]') ?? undefined
-      createPortal(el, document.body, { ownerScope })
+      queueMicrotask(() => createPortal(el, document.body, { ownerScope }))
     }
 
     const ctx = useContext(SelectContext)


### PR DESCRIPTION
## Summary

Now that compiler bugs (#837–#840) are fixed, child components work correctly inside loops and conditional branches. Replace native elements that were used as workarounds with the project's UI components.

### FormBuilderDemo
- Native \`<select>\` → \`<Select>\` component (field type selector, child type selector)
- Native \`<button>\` → \`<Button>\` for remove-child action
- Native \`<label>\` → \`<Label>\` for checkbox wrappers and field labels

### PivotTableDemo
- Native \`<button>\` → \`<Button>\` for field remove buttons

## Compiler/Runtime fixes included

These bugs were discovered through stress-testing the demos:

**Compiler (`emit-control-flow.ts`, `reactivity.ts`, `collect-elements.ts`):**
- Inner loop \`childComponents\` now carries \`children\` (was always \`[]\`)
- \`qsa\` (self-inclusive scope query) used instead of \`querySelector\` for child component lookups
- Inner loop param expressions recursively wrapped as signal accessors
- Branch inner loop container resolution falls back to \`[bf-s$="_slotId"]\` when exact bf match fails
- CSR loop items where the loop body is a single bare component: \`__bel\` now declared with \`let\` so it can be reassigned after \`replaceWith\`; placeholder lookup switched to \`qsa\` (checks self) to handle the case where the placeholder IS the loop element itself
- \`collectBranchInnerLoops\` / \`collectInnerLoops\` now track \`slotId\` through component nodes so inner loop \`mapArray\` uses the correct container element

**Runtime (`component.ts`):**
- \`createComponent()\` defers getter children evaluation until after \`initFn\` runs, so context providers set up by the parent are available when children call \`useContext()\`
- \`setCurrentScope(element)\` set before \`initFn\` so \`provideContext\` is element-scoped
- \`insertGetterChildren\` / \`hasDomElements\` check \`instanceof Element\` instead of \`instanceof HTMLElement\` — icon components render as \`<svg>\` (\`SVGElement\`), which is not a subclass of \`HTMLElement\`, so icons inside Button were silently dropped in CSR-created list items

**UI component (`select/index.tsx`):**
- \`createPortal\` deferred via \`queueMicrotask\` so sibling \`initChild\` calls can find elements before they leave the DOM subtree

## Test plan

- [x] All compiler + adapter tests pass
- [x] form-builder E2E: 36/36 (CSR Select type display, options, HTML children, re-ordering)
- [x] pivot-table E2E: 26/26 (drag-in field shows × button, re-added field shows × button)
- [x] cart, tasks-table, file-upload, checkout, analytics-dashboard: all pass
- [x] Select dropdowns open/close and select values correctly
- [x] Remove buttons work in both demos

🤖 Generated with [Claude Code](https://claude.com/claude-code)