### PR TITLE
Implement CSS cascade layers for UnoCSS integration

### DIFF
--- a/site/core/styles/globals.css
+++ b/site/core/styles/globals.css
@@ -4,51 +4,60 @@
  * Color tokens are provided by tokens.css (concatenated by build.ts).
  */
 
+/* CSS Cascade Layer ordering for UnoCSS + component class overrides.
+ * Priority (lowest → highest): preflights < base < shortcuts < components < default
+ * Base resets go into @layer base (above preflights, below component classes).
+ * User override classes stay in @layer default, so they always win. */
+@layer preflights, base, shortcuts, components, default;
+
 /* ── Reset & Base ──────────────────────────────────────────── */
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  border-width: 0;
-  border-style: solid;
-  border-color: var(--border);
-}
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border-width: 0;
+    border-style: solid;
+    /* border-color: var(--border) is set via UnoCSS custom preflight
+     * (uno.config.ts) to ensure it runs after preset-wind4's reset. */
+  }
 
-:root {
-  --sidebar-width: 14rem;    /* 224px — matches UI site (w-56) */
-  --content-max-width: 1000px; /* matches UI site (max-w-[1000px]) */
-}
+  :root {
+    --sidebar-width: 14rem;    /* 224px — matches UI site (w-56) */
+    --content-max-width: 1000px; /* matches UI site (max-w-[1000px]) */
+  }
 
-html {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.6;
-  color: var(--foreground);
-  background: var(--background);
-  -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
-}
+  html {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--foreground);
+    background: var(--background);
+    -webkit-font-smoothing: antialiased;
+    scroll-behavior: smooth;
+  }
 
-body {
-  min-height: 100vh;
-  font-family: var(--font-sans);
-  background-color: var(--background);
-  color: var(--foreground);
-}
+  body {
+    min-height: 100vh;
+    font-family: var(--font-sans);
+    background-color: var(--background);
+    color: var(--foreground);
+  }
 
-button {
-  border-width: 0;
-  border-style: solid;
-  background-color: transparent;
-  color: inherit;
-  font: inherit;
-}
+  button {
+    border-width: 0;
+    border-style: solid;
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+  }
 
-code, kbd, samp, pre {
-  font-family: var(--font-mono);
+  code, kbd, samp, pre {
+    font-family: var(--font-mono);
+  }
 }
 
 /* ── Theme transition ──────────────────────────────────────── */

--- a/site/core/uno.config.ts
+++ b/site/core/uno.config.ts
@@ -2,6 +2,22 @@ import { defineConfig, presetWind4 } from 'unocss'
 
 export default defineConfig({
   presets: [presetWind4()],
+  // Custom preflight: re-apply border-color after preset-wind4's reset preflight.
+  // preset-wind4 uses `border: 0 solid` which implicitly sets border-color to
+  // currentColor. This preflight runs after the reset (same @layer base, later
+  // source order) so var(--border) wins.
+  preflights: [{
+    getCSS: () => '*, ::before, ::after { border-color: var(--border); }',
+    layer: 'base',
+  }],
+  // Wrap UnoCSS output in CSS @layer blocks for cascade ordering.
+  // Order: preflights < base < shortcuts < components < default
+  outputToCssLayers: true,
+  layers: {
+    preflights: -2,
+    components: -1,
+    default: 0,
+  },
   safelist: [
     'hidden', 'sm:block', 'sm:hidden', 'lg:block',
     'border-input',


### PR DESCRIPTION
## Summary
This PR establishes proper CSS cascade layer ordering to resolve style conflicts between UnoCSS-generated utilities and component base styles. The changes ensure predictable style precedence and fix issues where UnoCSS presets were overriding custom base resets.

## Key Changes

- **Added CSS `@layer` declarations** in `globals.css` to define cascade layer order: `preflights < base < shortcuts < components < default`. This ensures base resets have appropriate priority relative to utility classes.

- **Wrapped base styles in `@layer base`** to separate them from utility layers and prevent unintended overrides by UnoCSS utilities.

- **Configured UnoCSS cascade layers** in `uno.config.ts`:
  - Enabled `outputToCssLayers: true` to wrap UnoCSS output in layer blocks
  - Defined explicit layer priorities with `preflights: -2` and `components: -1`
  - Added custom preflight rule to re-apply `border-color: var(--border)` after preset-wind4's reset, ensuring the design token wins over the preset's implicit `currentColor` value

- **Removed inline `border-color` from universal selector** in globals.css and moved it to the UnoCSS custom preflight for proper layer ordering and consistency.

## Implementation Details

The custom preflight in `uno.config.ts` addresses a specific conflict: preset-wind4's reset uses `border: 0 solid`, which implicitly sets `border-color` to `currentColor`. By placing the custom preflight in the `base` layer with later source order, `var(--border)` correctly overrides the preset's implicit value. This approach maintains the reset's intent while respecting the design system's color tokens.

https://claude.ai/code/session_01BFMNPiSR2GcfoKLsARGoae