### PR TITLE
fix(compiler): add mouseenter/mouseleave/pointerenter/pointerleave to NON_BUBBLING_EVENTS

### DIFF
--- a/packages/jsx/src/__tests__/non-bubbling-event-delegation.test.ts
+++ b/packages/jsx/src/__tests__/non-bubbling-event-delegation.test.ts
@@ -1,0 +1,211 @@
+/**
+ * BarefootJS Compiler - Non-bubbling event delegation (#852)
+ *
+ * Events like mouseenter/mouseleave do not bubble, so event delegation on a
+ * container element must use capture-phase listeners (addEventListener(..., true)).
+ * Without capture, the container never receives these events and handlers silently fail.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('non-bubbling event delegation (#852)', () => {
+  test('onMouseEnter in dynamic loop uses capture-phase delegation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Item { id: string }
+
+      export function HoverList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const handleEnter = (id: string) => console.log('enter', id)
+
+        return (
+          <ul>
+            {items().map(item => (
+              <li onMouseEnter={() => handleEnter(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'HoverList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('mouseenter', (e) => {")
+    expect(content).toContain('}, true)')
+    expect(content).toContain('target.closest')
+    expect(content).toContain('handleEnter(item.id)')
+  })
+
+  test('onMouseLeave in static array loop uses capture-phase delegation', () => {
+    const source = `
+      'use client'
+
+      export function HoverList() {
+        const items = [{ id: '1' }, { id: '2' }]
+        const handleLeave = (id: string) => console.log('leave', id)
+
+        return (
+          <ul>
+            {items.map(item => (
+              <li onMouseLeave={() => handleLeave(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'HoverList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('mouseleave', (e) => {")
+    expect(content).toContain('}, true)')
+    expect(content).toContain('target.closest')
+    expect(content).toContain('handleLeave(item.id)')
+  })
+
+  test('onPointerEnter in loop uses capture-phase delegation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Item { id: string }
+
+      export function PointerList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const handleEnter = (id: string) => console.log('enter', id)
+
+        return (
+          <ul>
+            {items().map(item => (
+              <li onPointerEnter={() => handleEnter(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'PointerList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('pointerenter', (e) => {")
+    expect(content).toContain('}, true)')
+    expect(content).toContain('target.closest')
+    expect(content).toContain('handleEnter(item.id)')
+  })
+
+  test('onPointerLeave in loop uses capture-phase delegation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Item { id: string }
+
+      export function PointerList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const handleLeave = (id: string) => console.log('leave', id)
+
+        return (
+          <ul>
+            {items().map(item => (
+              <li onPointerLeave={() => handleLeave(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'PointerList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('pointerleave', (e) => {")
+    expect(content).toContain('}, true)')
+    expect(content).toContain('target.closest')
+    expect(content).toContain('handleLeave(item.id)')
+  })
+
+  test('onClick in loop does NOT use capture phase (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Item { id: string }
+
+      export function ClickList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const handleClick = (id: string) => console.log('click', id)
+
+        return (
+          <ul>
+            {items().map(item => (
+              <li onClick={() => handleClick(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'ClickList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('click', (e) => {")
+    // Bubble-phase listener closes without capture flag
+    expect(content).toContain('})')
+    // Must NOT have capture flag for click
+    expect(content).not.toContain(".addEventListener('click', (e) => {" + '\n' + '  }, true)')
+  })
+
+  test('onFocus in loop uses capture-phase delegation (existing behavior regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      interface Item { id: string }
+
+      export function FocusList() {
+        const [items, setItems] = createSignal<Item[]>([])
+        const handleFocus = (id: string) => console.log('focus', id)
+
+        return (
+          <ul>
+            {items().map(item => (
+              <li onFocus={() => handleFocus(item.id)}>{item.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'FocusList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    expect(content).toContain(".addEventListener('focus', (e) => {")
+    expect(content).toContain('}, true)')
+    expect(content).toContain('target.closest')
+    expect(content).toContain('handleFocus(item.id)')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -1244,7 +1244,11 @@ type ItemLookupEmitter = (
 ) => void
 
 /** Non-bubbling events that require addEventListener with capture for delegation. */
-const NON_BUBBLING_EVENTS = new Set(['blur', 'focus', 'load', 'unload'])
+const NON_BUBBLING_EVENTS = new Set([
+  'blur', 'focus', 'load', 'unload',
+  'mouseenter', 'mouseleave',
+  'pointerenter', 'pointerleave',
+])
 
 /**
  * Emit event delegation for child events inside a loop (static or dynamic).


### PR DESCRIPTION
## Summary

- Adds `mouseenter`, `mouseleave`, `pointerenter`, and `pointerleave` to `NON_BUBBLING_EVENTS` in `emit-control-flow.ts`
- These events do not bubble, so event delegation in `.map()` loops must use capture-phase listeners — without this, `onMouseEnter`/`onMouseLeave` handlers silently fail
- Adds 6 new tests covering the previously untested capture-phase delegation path

**Note:** `focusin`/`focusout` from the issue suggestion were intentionally omitted — they DO bubble per the DOM spec and work correctly with normal bubble-phase delegation.

Closes #852

## Test plan

- [x] `onMouseEnter` in dynamic loop uses capture-phase delegation (`addEventListener('mouseenter', ..., true)`)
- [x] `onMouseLeave` in static array loop uses capture-phase delegation
- [x] `onPointerEnter` in loop uses capture-phase delegation
- [x] `onPointerLeave` in loop uses capture-phase delegation
- [x] `onClick` in loop does NOT use capture phase (regression guard)
- [x] `onFocus` in loop uses capture phase (existing behavior regression guard)
- [x] All 571 compiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)