### PR TITLE
fix(compiler): inject mapPreamble in event delegation handlers

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1802,6 +1802,39 @@ describe('Client JS generation', () => {
       expect(loop.children[0].type).toBe('element')
     })
 
+    test('block body map with onClick: preamble available in event delegation handler (#851)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client-runtime'
+
+        export function List() {
+          const [items, setItems] = createSignal([{ name: 'a' }])
+          const handleClick = (label: string) => console.log(label)
+          return (
+            <ul>
+              {items().map(item => {
+                const label = item.name.toUpperCase()
+                return <li><button onClick={() => handleClick(label)}>{label}</button></li>
+              })}
+            </ul>
+          )
+        }
+      `
+
+      const result = compileJSXSync(source, 'List.tsx', { adapter })
+
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const js = clientJs!.content
+
+      // Preamble must appear in event delegation handler as well as renderItem
+      expect(js).toContain(".addEventListener('click', (e) => {")
+      const count = js.split('const label = item.name.toUpperCase()').length - 1
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+
     test('Hono adapter generates block body SSR output', () => {
       const honoAdapter = new HonoAdapter()
       const source = `

--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -298,3 +298,77 @@ describe('direct map call as conditional branch (#783)', () => {
     expect(js).toContain('.map(')
   })
 })
+
+describe('mapPreamble in event delegation handlers (#851)', () => {
+  test('keyed loop with block body: preamble appears in event delegation handler', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function List() {
+        const [items, setItems] = createSignal([{ id: '1', name: 'a' }])
+        const handleClick = (label: string) => console.log(label)
+        return (
+          <ul>
+            {items().map(item => {
+              const label = item.name.toUpperCase()
+              return <li key={item.id}><button onClick={() => handleClick(label)}>{label}</button></li>
+            })}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Preamble must appear in event delegation handler (not only in renderItem)
+    expect(js).toContain(".addEventListener('click', (e) => {")
+    const count = js.split('const label = item.name.toUpperCase()').length - 1
+    expect(count).toBeGreaterThanOrEqual(2)
+  })
+
+  test('branch loop with block body: preamble appears in branch event delegation handler (#851)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function List() {
+        const [items, setItems] = createSignal([{ id: '1', name: 'a' }])
+        const [currentId, setCurrentId] = createSignal('')
+        const handleClick = (id: string) => console.log('click', id)
+        const handleClose = () => console.log('close')
+        return (
+          <ul>
+            {items().length > 0 && (
+              <div>
+                {items().map(item => {
+                  const isCurrent = item.id === currentId()
+                  return (
+                    <li key={item.id} onClick={() => (isCurrent ? handleClose() : handleClick(item.id))}>
+                      {item.name}
+                    </li>
+                  )
+                })}
+              </div>
+            )}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // Preamble must appear inside the delegation handler
+    expect(js).toContain(".addEventListener('click', (e) => {")
+    const count = js.split('const isCurrent = item.id === currentId()').length - 1
+    expect(count).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -621,6 +621,7 @@ function emitStaticArrayUpdates(lines: string[], elem: LoopElement): void {
       const idxOffset = elem.siblingOffset ? ` - ${elem.siblingOffset}` : ''
       ls.push(`        const __idx = Array.from(${cVar}.children).indexOf(__el)${idxOffset}`)
       ls.push(`        const ${elem.param} = ${elem.array}[__idx]`)
+      if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
       ls.push(`        if (${elem.param}) ${handlerCall}`)
       ls.push(`      }`)
     })
@@ -823,6 +824,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
         ls.push(`      if (li) {`)
         ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
         ls.push(`        const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
+        if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
         ls.push(`        if (${elem.param}) ${handlerCall}`)
         ls.push(`      }`)
       } else {
@@ -846,6 +848,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
         }
         // Guard all resolved variables
         const allParams = [elem.param, ...ev.nestedLoops.map(n => n.param)]
+        if (elem.mapPreamble) ls.push(`      ${elem.mapPreamble}`)
         ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
       }
     })
@@ -856,6 +859,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
       ls.push(`      if (li && li.parentElement) {`)
       ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
       ls.push(`        const ${elem.param} = ${elem.array}[idx]`)
+      if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
       ls.push(`        if (${elem.param}) ${handlerCall}`)
       ls.push(`      }`)
     })
@@ -879,6 +883,7 @@ function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchL
         ls.push(`      if (li) {`)
         ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
         ls.push(`        const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
+        if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
         ls.push(`        if (${loop.param}) ${handlerCall}`)
         ls.push(`      }`)
       } else {
@@ -897,6 +902,7 @@ function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchL
           ls.push(`      const ${nested.param} = ${loop.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
         }
         const allParams = [loop.param, ...ev.nestedLoops.map(n => n.param)]
+        if (loop.mapPreamble) ls.push(`      ${loop.mapPreamble}`)
         ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
       }
     })
@@ -907,6 +913,7 @@ function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchL
       ls.push(`      if (li && li.parentElement) {`)
       ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
       ls.push(`        const ${loop.param} = ${loop.array}[idx]`)
+      if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
       ls.push(`        if (${loop.param}) ${handlerCall}`)
       ls.push(`      }`)
     })


### PR DESCRIPTION
## Summary

- Block-body `.map()` callbacks extract preamble statements (e.g., `const isCurrent = item.id === currentId()`) into `mapPreamble`
- These were correctly injected in `mapArray` renderItem callbacks, but the three event delegation emitters recovered the loop item without re-executing the preamble — making the variables `undefined` at runtime
- Fix: inject `mapPreamble` after item lookup, before handler call, in 7 places across `emitDynamicLoopEventDelegation`, `emitBranchLoopEventDelegation`, and static-array event delegation
- The preamble is NOT wrapped with `wrapLoopParamAsAccessor` because in delegation context the loop param is a plain value (not a signal accessor)

## Test plan

- [ ] New unit test: keyed dynamic loop with block body `.map()` + onClick referencing preamble variable — verifies preamble appears in delegation handler
- [ ] New unit test: branch loop (`.map()` inside conditional) with block body + onClick — reproduces the exact issue #851 scenario
- [ ] New unit test: non-keyed dynamic loop with block body `.map()` + onClick
- [ ] All 568 compiler unit tests pass
- [ ] All 1419 package tests pass (1 pre-existing Playwright E2E failure in xyflow unrelated to this change)

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)