### PR TITLE
Refine docs/core/ for conciseness and clarity

### DIFF
--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -64,15 +64,15 @@
 
 ## Documentation Conventions
 
-Throughout this documentation, code examples use **switchable tabs** for the following:
+Code examples use **switchable tabs** for adapter output and package manager commands. Preferences persist across pages.
 
-**Adapter** — Examples show output for your selected adapter:
+**Adapter** — Hono (default) or Go Template:
 
 <!-- tabs:adapter -->
 - Hono (default)
 - Go Template
 
-**Package Manager** — Install commands match your toolchain:
+**Package Manager** — npm (default), bun, pnpm, or yarn:
 
 <!-- tabs:pm -->
 - npm (default)
@@ -80,7 +80,4 @@ Throughout this documentation, code examples use **switchable tabs** for the fol
 - pnpm
 - yarn
 
-These preferences persist across pages.
-
-> **Note for non-JavaScript developers:**
-> Sections marked with 💡 provide brief explanations of JSX and TypeScript concepts for developers coming from Go, Python, or other backend languages.
+> Sections marked with 💡 explain JSX and TypeScript concepts for developers from Go, Python, or other backend languages.

--- a/docs/core/adapters.md
+++ b/docs/core/adapters.md
@@ -5,7 +5,7 @@ description: Bridge between the compiler's IR and your backend's template langua
 
 # Adapters
 
-Adapters are the bridge between the compiler's IR and your backend's template language. The compiler produces a backend-agnostic Intermediate Representation (IR); an adapter converts it into a template your server can render.
+An adapter converts the compiler's IR into a template your server can render. The same JSX source produces correct output for any adapter.
 
 ```
 JSX Source
@@ -15,8 +15,6 @@ JSX Source
 [Phase 2a] IR → Adapter → Marked Template  (server)
 [Phase 2b] IR → Client JS                  (browser)
 ```
-
-The same JSX source produces correct output for any adapter. Your component library works across stacks.
 
 ## Available Adapters
 

--- a/docs/core/adapters/adapter-architecture.md
+++ b/docs/core/adapters/adapter-architecture.md
@@ -5,16 +5,14 @@ description: How adapters convert the compiler's IR into server-renderable templ
 
 # Adapter Architecture
 
-An adapter converts the compiler's Intermediate Representation (IR) into a template format your server can render. This page explains how adapters work, the interface they implement, and the IR contract they consume.
+An adapter converts the compiler's IR into a template format your server can render.
 
 
-## The Role of an Adapter
+## Role
 
-The BarefootJS compiler runs in two phases:
-
-1. **Phase 1** parses JSX and produces a `ComponentIR` — a JSON tree that captures the component structure, reactive expressions, event handlers, and type information. This IR is backend-agnostic.
-2. **Phase 2a** passes the IR to an adapter, which generates a marked template in the target language.
-3. **Phase 2b** generates client JS directly from the IR (adapters are not involved in this step).
+1. **Phase 1** parses JSX → backend-agnostic `ComponentIR` (JSON tree)
+2. **Phase 2a** adapter converts IR → marked template in target language
+3. **Phase 2b** generates client JS from IR (no adapter involved)
 
 ```
 ComponentIR (JSON)
@@ -33,12 +31,10 @@ ComponentIR (JSON)
 Marked Template + optional types
 ```
 
-The adapter's job is to translate each IR node into the correct syntax for the target template language, inserting hydration markers (`bf-*` attributes) so the client JS can find and wire up interactive elements.
+Each IR node is translated into the target template language with hydration markers (`bf-*` attributes).
 
 
-## The `TemplateAdapter` Interface
-
-Every adapter implements the `TemplateAdapter` interface:
+## `TemplateAdapter` Interface
 
 ```typescript
 interface TemplateAdapter {
@@ -68,8 +64,6 @@ interface TemplateAdapter {
 
 ### `generate()`
 
-The main entry point. Receives the full `ComponentIR` and returns an `AdapterOutput`:
-
 ```typescript
 interface AdapterOutput {
   template: string     // The generated template code
@@ -89,8 +83,6 @@ interface AdapterGenerateOptions {
 
 ### Node rendering methods
 
-Each method translates one IR node type into the target template language:
-
 | Method | IR Node | Responsibility |
 |--------|---------|----------------|
 | `renderElement()` | `IRElement` | HTML elements with attributes, events, and hydration markers |
@@ -102,8 +94,6 @@ Each method translates one IR node type into the target template language:
 
 ### Hydration marker methods
 
-These generate the `bf-*` attributes in the target language's syntax:
-
 | Method | Marker | Purpose |
 |--------|--------|---------|
 | `renderScopeMarker()` | `bf-s` | Component boundary for scoped hydration |
@@ -111,9 +101,9 @@ These generate the `bf-*` attributes in the target language's syntax:
 | `renderCondMarker()` | `bf-c` | Conditional block for DOM switching |
 
 
-## The `BaseAdapter` Class
+## `BaseAdapter` Class
 
-For convenience, the compiler provides a `BaseAdapter` abstract class that implements the `TemplateAdapter` interface and adds a `renderChildren()` utility:
+`BaseAdapter` implements the `TemplateAdapter` interface with a `renderChildren()` utility:
 
 ```typescript
 abstract class BaseAdapter implements TemplateAdapter {
@@ -128,12 +118,12 @@ abstract class BaseAdapter implements TemplateAdapter {
 }
 ```
 
-Extending `BaseAdapter` is optional — you can implement `TemplateAdapter` directly if preferred.
+Extending `BaseAdapter` is optional.
 
 
 ## IR Node Types
 
-The IR tree is composed of these node types. Each adapter must handle all of them:
+Each adapter must handle all IR node types:
 
 ### `IRElement`
 
@@ -225,7 +215,7 @@ A nested component invocation.
 
 ## Hydration Markers
 
-Adapters insert `bf-*` attributes into the template so the client JS knows where to attach behavior:
+`bf-*` attributes tell the client JS where to attach behavior:
 
 | Marker | Example | Purpose |
 |--------|---------|---------|
@@ -233,22 +223,19 @@ Adapters insert `bf-*` attributes into the template so the client JS knows where
 | `bf` | `<p bf="slot_0">` | Interactive element — target for effects and event handlers |
 | `bf-c` | `<div bf-c="slot_2">` | Conditional block — target for DOM switching |
 
-The client JS uses these markers to find elements within a scope boundary, without interfering with nested component scopes.
 
 
 ## Script Registration
 
-Client components need their client JS loaded in the browser. Adapters handle this by registering scripts during server rendering:
+Adapters register client JS during server rendering to ensure each script loads exactly once:
 
-- **Hono**: Uses `useRequestContext()` to collect script paths. The `BfScripts` component renders the collected `<script>` tags.
-- **Go Template**: Uses a `ScriptCollector` that tracks which component scripts are needed. The server renders the script tags at the end of the page.
-
-This ensures each component's client JS is loaded exactly once, regardless of how many instances appear on the page.
+- **Hono**: `useRequestContext()` collects script paths; `BfScripts` renders the `<script>` tags.
+- **Go Template**: `ScriptCollector` tracks needed scripts; renders `<script>` tags at page end.
 
 
 ## Type Generation
 
-For typed backend languages, adapters can implement `generateTypes()` to produce type definitions alongside the template. The Go Template adapter generates:
+For typed backends, `generateTypes()` produces type definitions alongside the template. The Go Template adapter generates:
 
 - **Go structs** for component input and props types
 - **JSON tags** for prop serialization
@@ -272,4 +259,4 @@ func NewCounterProps(input CounterInput) CounterProps {
 }
 ```
 
-Adapters for dynamically-typed languages (like Hono/TypeScript) can skip this by not implementing `generateTypes()`.
+Dynamically-typed adapters (like Hono) skip this.

--- a/docs/core/adapters/custom-adapter.md
+++ b/docs/core/adapters/custom-adapter.md
@@ -5,12 +5,12 @@ description: Step-by-step guide to building a custom adapter using the TestAdapt
 
 # Writing a Custom Adapter
 
-This guide walks through building a custom adapter, using the `TestAdapter` (`packages/jsx/src/adapters/test-adapter.ts`) as a concrete example. The TestAdapter is a minimal, working adapter included in the compiler package — it generates simple JSX output and demonstrates every method you need to implement.
+Build a custom adapter using the `TestAdapter` (`packages/jsx/src/adapters/test-adapter.ts`) as reference — a minimal working adapter that generates JSX output.
 
 
 ## Step 1: Implement `TemplateAdapter`
 
-Create a class that extends `BaseAdapter` (or implements `TemplateAdapter` directly):
+Extend `BaseAdapter` or implement `TemplateAdapter` directly:
 
 ```typescript
 import type {
@@ -53,12 +53,9 @@ export class TestAdapter extends BaseAdapter {
 }
 ```
 
-The `generate()` method is the entry point. It receives the full `ComponentIR` and returns an `AdapterOutput` containing the generated template, optional types, and the file extension.
-
-
 ## Step 2: Implement `renderNode()`
 
-The dispatcher routes each IR node to the correct rendering method:
+Route each IR node to the correct rendering method:
 
 ```typescript
 renderNode(node: IRNode): string {
@@ -76,16 +73,9 @@ renderNode(node: IRNode): string {
 }
 ```
 
-Each `case` maps to one of the required `TemplateAdapter` methods. The `text` and `fragment` cases are simple enough to handle inline.
-
-
 ## Step 3: Implement Element Rendering
 
-Elements are the most common node type. You need to:
-
-1. Render the HTML tag and attributes
-2. Insert hydration markers (`bf-s`, `bf`)
-3. Render children recursively
+Render the tag, attributes, hydration markers, and children:
 
 ```typescript
 renderElement(element: IRElement): string {
@@ -110,8 +100,6 @@ renderElement(element: IRElement): string {
 ```
 
 ### Attributes
-
-The `renderAttributes()` helper handles static attributes, dynamic expressions, spread attributes, and event handlers:
 
 ```typescript
 private renderAttributes(element: IRElement): string {
@@ -141,12 +129,12 @@ private renderAttributes(element: IRElement): string {
 }
 ```
 
-**Note:** The TestAdapter renders event handlers as no-op stubs (`() => {}`) since JSX expects them to be present. In non-JSX adapters (like Go Template), event handlers are simply omitted — they only exist in the client JS.
+The TestAdapter renders event handlers as no-op stubs for JSX. Non-JSX adapters omit them — handlers exist only in client JS.
 
 
 ## Step 4: Implement Expression Rendering
 
-Expressions render dynamic values. Reactive expressions with a `slotId` get wrapped in a `<span>` with a hydration marker so the client JS can update them:
+Reactive expressions with a `slotId` get a hydration marker for client JS updates:
 
 ```typescript
 renderExpression(expr: IRExpression): string {
@@ -160,12 +148,12 @@ renderExpression(expr: IRExpression): string {
 }
 ```
 
-Since the TestAdapter outputs JSX, expressions pass through as-is (`{count()}`). A non-JSX adapter would need to convert the JavaScript expression into the target template language (e.g., `count()` → `{{.Count}}` for Go).
+Non-JSX adapters convert expressions to the target language (e.g., `count()` → `{{.Count}}`).
 
 
 ## Step 5: Implement Conditional Rendering
 
-Ternary expressions in JSX stay as JSX ternaries in the TestAdapter output:
+Ternaries pass through in JSX adapters:
 
 ```typescript
 renderConditional(cond: IRConditional): string {
@@ -186,12 +174,12 @@ renderConditional(cond: IRConditional): string {
 {isActive ? <span>Active</span> : <span>Inactive</span>}
 ```
 
-A non-JSX adapter would translate this into the target language's conditional syntax (e.g., `{{if .IsActive}}...{{else}}...{{end}}` for Go).
+Non-JSX adapters translate to the target conditional syntax (e.g., `{{if .IsActive}}...{{else}}...{{end}}`).
 
 
 ## Step 6: Implement Loop Rendering
 
-Array `.map()` calls stay as JSX map expressions:
+`.map()` calls stay as JSX:
 
 ```typescript
 renderLoop(loop: IRLoop): string {
@@ -212,12 +200,12 @@ renderLoop(loop: IRLoop): string {
 {items.map((item) => <li>{item.name}</li>)}
 ```
 
-A non-JSX adapter would translate this into the target language's iteration syntax (e.g., `{{range .Items}}...{{end}}` for Go).
+Non-JSX adapters translate to the target iteration syntax (e.g., `{{range .Items}}...{{end}}`).
 
 
 ## Step 7: Implement Component Rendering
 
-Nested components are rendered as JSX elements with the parent's scope ID passed through:
+Pass the parent's scope ID to nested components:
 
 ```typescript
 renderComponent(comp: IRComponent): string {
@@ -234,12 +222,7 @@ renderComponent(comp: IRComponent): string {
 }
 ```
 
-The `__bfScope` prop passes the parent's scope ID so nested components can participate in the hydration hierarchy.
-
-
 ## Step 8: Implement Hydration Markers
-
-These methods generate the `bf-*` attributes in the target language's syntax:
 
 ```typescript
 renderScopeMarker(instanceIdExpr: string): string {
@@ -255,12 +238,9 @@ renderCondMarker(condId: string): string {
 }
 ```
 
-The TestAdapter uses JSX expression syntax (`{...}`) for the scope marker since the value is dynamic. The slot and cond markers use plain string attributes since slot IDs are compile-time constants.
-
-
 ## Step 9: Generate Signal Initializers
 
-Client components need signal getters to return initial values during SSR. The TestAdapter creates stub functions:
+Signal getters return initial values during SSR via stub functions:
 
 ```typescript
 private generateSignalInitializers(ir: ComponentIR): string {
@@ -279,18 +259,15 @@ private generateSignalInitializers(ir: ComponentIR): string {
 }
 ```
 
-For example, `const [count, setCount] = createSignal(initial)` becomes:
+`const [count, setCount] = createSignal(initial)` becomes:
 ```typescript
 const count = () => initial   // getter returns initial value
 const setCount = () => {}     // setter is a no-op on the server
 ```
 
-This allows the template to evaluate `count()` during SSR and render the initial value.
-
-
 ## Optional: Type Generation
 
-If your backend language is typed, implement `generateTypes()`. The TestAdapter generates a hydration-extended props type:
+For typed backends, implement `generateTypes()`:
 
 ```typescript
 generateTypes(ir: ComponentIR): string | null {
@@ -311,9 +288,7 @@ generateTypes(ir: ComponentIR): string | null {
 For dynamically-typed backends, return `null`.
 
 
-## Testing Your Adapter
-
-Use the compiler to verify your adapter output:
+## Testing
 
 ```typescript
 import { compileJsxToIR } from '@barefootjs/jsx'
@@ -356,7 +331,7 @@ console.log(output.template)
 
 ## Checklist
 
-When building a custom adapter, ensure you handle:
+Ensure you handle:
 
 - [ ] All IR node types (`element`, `text`, `expression`, `conditional`, `loop`, `component`, `fragment`, `slot`)
 - [ ] Hydration markers (`bf-s`, `bf`, `bf-c`) on interactive elements
@@ -369,7 +344,7 @@ When building a custom adapter, ensure you handle:
 - [ ] Script registration for client JS loading
 - [ ] `/* @client */` directive (skip client-only expressions server-side)
 
-Production adapters handle additional concerns beyond what the TestAdapter covers:
+Production adapters also handle:
 
 - [ ] Void HTML elements (`<input>`, `<br>`, etc.) — no closing tag
 - [ ] Expression translation to the target template language

--- a/docs/core/adapters/go-template-adapter.md
+++ b/docs/core/adapters/go-template-adapter.md
@@ -5,7 +5,7 @@ description: Generate Go html/template files and type definitions from the compi
 
 # Go Template Adapter
 
-The Go Template adapter generates Go `html/template` files (`.tmpl`) and Go type definitions (`_types.go`) from the compiler's IR. It is designed for Go backends using the standard `html/template` package.
+Generates Go `html/template` files (`.tmpl`) and type definitions (`_types.go`) from the compiler's IR.
 
 ```
 npm install @barefootjs/go-template
@@ -115,8 +115,6 @@ export function Counter({ initial = 0 }: { initial?: number }) {
 
 ## Expression Translation
 
-The adapter translates JavaScript expressions into Go template syntax. This is the most complex part of the adapter, as the two languages have fundamentally different expression models.
-
 ### Property Access
 
 ```
@@ -156,8 +154,6 @@ Field names are automatically capitalized to follow Go conventions.
 
 
 ## Array Methods
-
-The adapter translates JavaScript array methods into Go template functions and blocks.
 
 ### `.map()`
 
@@ -210,11 +206,11 @@ For complex filter predicates, the adapter generates template block functions.
 
 ## Type Generation
 
-The Go adapter generates type-safe Go code alongside the template. For each component, it produces:
+For each component, the adapter generates:
 
-1. **Input struct** — The external API (what the caller passes)
-2. **Props struct** — The internal representation (includes hydration fields)
-3. **Constructor function** — `New{Component}Props()` with default values
+1. **Input struct** — external API
+2. **Props struct** — internal representation (includes hydration fields)
+3. **Constructor** — `New{Component}Props()` with defaults
 
 ### Type Mapping
 
@@ -229,8 +225,6 @@ The Go adapter generates type-safe Go code alongside the template. For each comp
 
 ### Nested Components
 
-When a component renders child components, the adapter generates Props structs for the children and includes them as fields in the parent's Props struct:
-
 ```tsx
 export function TodoList({ items }: { items: TodoItem[] }) {
   return (
@@ -241,12 +235,9 @@ export function TodoList({ items }: { items: TodoItem[] }) {
 }
 ```
 
-The generated Go types include a `TodoItems` field of type `[]TodoItemProps`, pre-populated by the constructor function.
-
-
 ## Conditional Rendering
 
-Ternary expressions translate to `{{if}}...{{else}}...{{end}}` blocks:
+Ternaries become `{{if}}...{{else}}...{{end}}`:
 
 **Source:**
 
@@ -263,18 +254,18 @@ Ternary expressions translate to `{{if}}...{{else}}...{{end}}` blocks:
 
 ## Script Registration
 
-The adapter uses a `ScriptCollector` pattern. Each client component registers its script with:
+Each client component registers its script:
 
 ```go-template
 {{template "bf_register_script" "Counter"}}
 ```
 
-The Go server's `ScriptCollector` tracks which scripts are needed and renders the appropriate `<script>` tags at the end of the page. Each component's script is included at most once.
+The `ScriptCollector` tracks needed scripts and renders `<script>` tags at page end. Each script loads at most once.
 
 
 ## Go Helper Functions
 
-The adapter assumes these helper functions are available in the Go template `FuncMap`:
+These helper functions must be in the Go template `FuncMap`:
 
 | Function | Purpose |
 |----------|---------|
@@ -287,4 +278,4 @@ The adapter assumes these helper functions are available in the Go template `Fun
 | `bf_json` | JSON-encode a value for props serialization |
 | `bf_concat` | String concatenation |
 
-These are provided by the BarefootJS Go runtime package.
+Provided by the BarefootJS Go runtime package.

--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -5,7 +5,7 @@ description: Generate Hono JSX templates from the compiler's IR for Hono-based s
 
 # Hono Adapter
 
-The Hono adapter generates Hono JSX (`.hono.tsx`) files from the compiler's IR. It is designed for Hono-based servers and any JSX-compatible TypeScript backend.
+Generates Hono JSX (`.hono.tsx`) files from the compiler's IR. Works with Hono and any JSX-compatible TypeScript backend.
 
 ```
 npm install @barefootjs/hono
@@ -47,7 +47,7 @@ const adapter = new HonoAdapter({
 
 ### Server Component
 
-A server-only component (no `"use client"`) produces a plain Hono JSX function:
+Without `"use client"`, no hydration markers or client JS:
 
 **Source:**
 
@@ -65,11 +65,7 @@ export function Greeting({ name }: { name: string }) {
 }
 ```
 
-No hydration markers, no client JS.
-
 ### Client Component
-
-A client component produces a Hono JSX function with hydration markers and props serialization:
 
 **Source:**
 
@@ -106,20 +102,16 @@ export function Counter({ initial = 0, __instanceId, __bfScope }: CounterPropsWi
 }
 ```
 
-Key aspects of the output:
-
-- **`bf-s`** on the root element identifies the component boundary
-- **`bf="slot_N"`** marks elements that the client JS will target
-- **Signal stubs** (`count = () => initial ?? 0`) allow the template to render the initial value server-side
-- **`bf-p`** attribute serializes props as JSON for client-side hydration
-- **Event handlers are removed** — they exist only in the client JS
+- `bf-s` — component boundary
+- `bf="slot_N"` — client JS targets
+- Signal stubs (`count = () => initial ?? 0`) — render initial values server-side
+- `bf-p` — serialized props for client hydration
+- Event handlers are removed (client JS only)
 
 
 ## Script Collection
 
-Script collection is handled as a build-time post-processing step. After compiling with HonoAdapter, the build script injects `useRequestContext()` calls into the generated marked templates to register client scripts during SSR.
-
-At the end of the page, the `BfScripts` component renders the collected `<script>` tags:
+A build-time post-processing step injects `useRequestContext()` calls into generated templates. `BfScripts` renders the collected `<script>` tags:
 
 ```tsx
 import { BfScripts } from '@barefootjs/hono'
@@ -136,12 +128,12 @@ export function Layout({ children }) {
 }
 ```
 
-This ensures each component's client JS is loaded exactly once, even if the component appears multiple times on the page. See `site/ui/build.ts` for the `addScriptCollection()` implementation pattern.
+Each component's client JS loads once regardless of instance count. See `site/ui/build.ts` for the `addScriptCollection()` pattern.
 
 
 ## Hydration Props
 
-The adapter extends every client component's props with hydration-related fields:
+Every client component's props are extended with hydration fields:
 
 | Prop | Purpose |
 |------|---------|
@@ -150,12 +142,12 @@ The adapter extends every client component's props with hydration-related fields
 | `__bfChild` | Marks this component as a child instance (adds `~` prefix to `bf-s` value) |
 | `data-key` | Stable key for list-rendered instances |
 
-These props are used internally by the hydration system and do not need to be passed manually when using components.
+These are used internally — no manual passing needed.
 
 
 ## Conditional Rendering
 
-Ternary expressions in JSX compile to conditional output with hydration markers:
+Ternaries compile with `bf-c` markers:
 
 **Source:**
 
@@ -169,12 +161,7 @@ Ternary expressions in JSX compile to conditional output with hydration markers:
 {isActive() ? <span bf-c="slot_2">Active</span> : <span bf-c="slot_2">Inactive</span>}
 ```
 
-The client JS uses the `bf-c` marker to swap DOM nodes when the condition changes.
-
-
 ## Loop Rendering
-
-Array `.map()` calls compile to JSX map expressions:
 
 **Source:**
 
@@ -188,4 +175,4 @@ Array `.map()` calls compile to JSX map expressions:
 {items().map(item => <li>{item.name}</li>)}
 ```
 
-For loops with child components, the adapter generates unique instance IDs per iteration using the loop index or a `key` prop.
+For child components in loops, the adapter generates unique instance IDs per iteration using the loop index or `key`.

--- a/docs/core/advanced.md
+++ b/docs/core/advanced.md
@@ -5,8 +5,6 @@ description: Compiler internals, IR schema, error codes, and performance optimiz
 
 # Advanced
 
-This section covers BarefootJS internals for contributors, adapter authors, and developers who want deeper understanding of the compilation pipeline.
-
 - [IR Schema Reference](./advanced/ir-schema.md) — The intermediate representation node types and metadata
 - [Compiler Internals](./advanced/compiler-internals.md) — Pipeline phases, reactivity analysis, and code generation
 - [Error Codes Reference](./advanced/error-codes.md) — All compiler errors and warnings with solutions

--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -5,8 +5,6 @@ description: How the BarefootJS compiler transforms JSX into marked templates an
 
 # Compiler Internals
 
-This page explains how the BarefootJS compiler transforms JSX source into marked templates and client JavaScript. Understanding these internals is useful for debugging compilation issues, writing custom adapters, or contributing to the compiler.
-
 ## Pipeline Overview
 
 ```
@@ -45,15 +43,15 @@ compileJSX(entryPath: string, readFile: ReadFileFn, options: CompileOptions): Pr
 compileJSXSync(source: string, filePath: string, options: CompileOptions): CompileResult
 ```
 
-Both support multi-component files — the compiler detects all exported components and compiles each independently, then merges the output.
+Both support multi-component files.
 
 ---
 
 ## Phase 1: Analysis
 
-The analyzer (`analyzer.ts`) performs a **single-pass** AST walk using TypeScript's compiler API. It collects everything the later phases need:
+The analyzer (`analyzer.ts`) performs a **single-pass** AST walk using TypeScript's compiler API.
 
-### What the Analyzer Extracts
+### Extracted Data
 
 | Category | Data | Example |
 |----------|------|---------|
@@ -71,15 +69,13 @@ The analyzer (`analyzer.ts`) performs a **single-pass** AST walk using TypeScrip
 
 ### `"use client"` Validation
 
-The analyzer checks for the `"use client"` directive at the top of the file. If the file contains reactive APIs (`createSignal`, `createEffect`, event handlers) but lacks the directive, it emits **BF001**:
+Files with reactive APIs but no `"use client"` emit **BF001**:
 
 ```
 error[BF001]: 'use client' directive required for components with createSignal
 ```
 
 ### Props Destructuring Detection
-
-When props are destructured in the function parameter, the analyzer emits **BF043** (warning):
 
 ```tsx
 // ⚠️ BF043: Destructuring captures values once — may lose reactivity
@@ -89,36 +85,32 @@ function Child({ count }: Props) { ... }
 function Child(props: Props) { ... }
 ```
 
-The warning can be suppressed with `// @bf-ignore props-destructuring`.
+Suppress with `// @bf-ignore props-destructuring`.
 
 ---
 
 ## Phase 2: JSX → IR
 
-The `jsxToIR` function (`jsx-to-ir.ts`) transforms the analyzed JSX AST into the IR node tree.
+`jsxToIR` (`jsx-to-ir.ts`) transforms the analyzed JSX AST into the IR node tree.
 
 ### Reactivity Detection
 
-The core decision at this phase is: **is this expression reactive?**
-
-The compiler uses a two-tier detection strategy:
+Two-tier strategy to determine if an expression is reactive:
 
 1. **TypeChecker path** — Walks the AST and checks each node's type for the `Reactive<T>` brand via `checker.getTypeAtLocation()`. This detects all reactive getters: signals, memos, and library-provided reactive accessors (e.g., `FieldReturn.error`, `FormReturn.isSubmitting`).
 
 2. **Regex fallback** — Pattern-matches known signal/memo names and props references. Used when the TypeChecker cannot resolve imported types.
 
-An expression is reactive if it matches any of:
+Reactive if any match:
 - A `Reactive<T>`-branded type (via TypeChecker)
 - A signal getter: `count()` — regex pattern `\bcount\s*\(`
 - A memo: `doubled()` — same pattern
 - A props reference: `props.value` — per-prop name matching (excludes `children`)
 - A local constant derived from any of the above (taint analysis)
 
-Reactive expressions get a `slotId` assigned, which becomes a `bf` hydration marker in the output.
-
 ### Slot ID Assignment
 
-Elements receive a `slotId` (making them findable during hydration) when they have:
+Elements receive a `slotId` when they have:
 
 1. Event handlers (`onClick`, `onInput`, etc.)
 2. Dynamic children (reactive expressions, loops, conditionals)
@@ -128,7 +120,7 @@ Elements receive a `slotId` (making them findable during hydration) when they ha
 
 ### Filter/Sort Chain Parsing
 
-The compiler parses `.filter()` and `.sort()` chains before `.map()` for template-level evaluation:
+`.filter()` and `.sort()` chains before `.map()` are parsed for template-level evaluation:
 
 ```tsx
 {todos().filter(t => !t.done).sort((a, b) => a.date - b.date).map(t => (
@@ -136,19 +128,17 @@ The compiler parses `.filter()` and `.sort()` chains before `.map()` for templat
 ))}
 ```
 
-Simple patterns (e.g., `t => !t.done`, `(a, b) => a.price - b.price`) can be compiled for template-level evaluation. Complex patterns trigger **BF021** with a suggestion to use `/* @client */`. See [Error Codes Reference](./error-codes.md#bf021--unsupported-jsx-pattern) for details.
+Simple patterns compile for template-level evaluation. Complex patterns trigger **BF021**. See [Error Codes](./error-codes.md#bf021--unsupported-jsx-pattern).
 
 ### Auto Scope Wrapping
 
-If a component's IR root is a Provider (Context.Provider) with no wrapper element, the compiler wraps it in `<div style="display:contents">` to provide a DOM anchor for scope identification during hydration. The scope element is passed directly as the first argument to the init function.
+If the IR root is a Provider with no wrapper element, the compiler wraps it in `<div style="display:contents">` for scope identification during hydration.
 
 ---
 
 ## Phase 3a: Template Generation (Adapter)
 
-Adapters implement the `TemplateAdapter` interface to convert IR nodes into backend-specific templates. See [Adapter Architecture](../adapters/adapter-architecture.md) for the full interface.
-
-Each adapter handles:
+See [Adapter Architecture](../adapters/adapter-architecture.md). Each adapter handles:
 - `renderElement()` — HTML elements with hydration markers
 - `renderExpression()` — Dynamic values in the target template language
 - `renderConditional()` — Template-level conditionals
@@ -159,11 +149,7 @@ Each adapter handles:
 
 ## Phase 3b: Client JS Generation
 
-The `ir-to-client-js` module generates minimal JavaScript for hydration. It operates in several sub-phases:
-
 ### 1. Element Collection
-
-Walk the IR tree and categorize elements:
 
 | Category | Description | Example |
 |----------|-------------|---------|
@@ -177,8 +163,6 @@ Walk the IR tree and categorize elements:
 
 ### 2. Dependency Resolution
 
-Constants and functions are sorted by dependency:
-
 ```typescript
 // "Early" constants — no reactive deps, emitted first
 const baseClass = 'btn'
@@ -190,7 +174,7 @@ const displayValue = `Count: ${count()}`
 
 ### 3. Controlled Signal Detection
 
-The compiler detects when a signal name matches a prop name:
+When a signal name matches a prop name:
 
 ```tsx
 function Switch(props: Props) {
@@ -199,7 +183,7 @@ function Switch(props: Props) {
 }
 ```
 
-This generates a sync effect immediately after the signal creation:
+A sync effect is generated:
 
 ```javascript
 createEffect(() => {
@@ -209,8 +193,6 @@ createEffect(() => {
 ```
 
 ### 4. Code Generation Order
-
-The generated `init` function follows this structure:
 
 ```javascript
 import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
@@ -283,7 +265,7 @@ hydrate('Counter', { init: initCounter })
 
 ### 5. Import Detection
 
-The generator scans the output code and includes only the `@barefootjs/client-runtime` imports actually used:
+Only used imports are included:
 
 ```javascript
 import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
@@ -291,9 +273,7 @@ import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from 
 
 ### 6. Template Registration
 
-The compiler decides whether to include a `template` function in the `hydrate()` call based on two factors:
-
-**Static template** — When `canGenerateStaticTemplate()` returns true (no signal-dependent expressions), a lightweight template is always included:
+**Static template** — No signal-dependent expressions:
 
 ```javascript
 hydrate('Button', {
@@ -302,7 +282,7 @@ hydrate('Button', {
 })
 ```
 
-**CSR fallback template** — When a component has signals (can't generate a static template) but is used as a child by another component in the same file, a CSR fallback template is generated. This template replaces signal calls with initial values so `createComponent()` can render the component in loops and conditionals:
+**CSR fallback template** — Component has signals but is used as a child in the same file:
 
 ```javascript
 // StatusBadge is used by Dashboard in the same file → gets CSR fallback
@@ -315,19 +295,18 @@ hydrate('StatusBadge', {
 hydrate('Dashboard', { init: initDashboard })
 ```
 
-**No template** — Top-level-only components with signals skip template generation entirely. They are hydrated from server-rendered HTML and never need to be created dynamically by `createComponent()`.
+**No template** — Top-level-only components with signals. Hydrated from server HTML only.
 
 ---
 
 ## Multi-Component Files
 
-When a file exports multiple components, the compiler uses a **two-pass** approach:
+Two-pass approach for multi-component files:
 
-1. **Pass 1** — Detects all exports via `listExportedComponents()`, then runs analysis and JSX → IR for each component
-2. **Between passes** — Scans all IRs with `collectComponentNamesFromIR()` to build a `usedAsChild` set (components referenced by other components in the same file)
-3. **Pass 2** — Runs adapter generation and client JS generation for each component, passing `usedAsChild` so that only child components get CSR fallback templates
-4. Merges templates — deduplicates shared imports and type definitions
-5. Merges client JS — combines imports by source module
+1. **Pass 1** — Detect exports, analyze, and generate IR for each
+2. **Between passes** — Build `usedAsChild` set via `collectComponentNamesFromIR()`
+3. **Pass 2** — Generate templates and client JS; only child components get CSR fallback templates
+4. Merge templates (deduplicate imports/types) and client JS (combine imports)
 
 ```tsx
 // Both compiled from the same file

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -5,9 +5,9 @@ description: Complete list of BF-prefixed compiler error codes with explanations
 
 # Error Codes Reference
 
-BarefootJS compiler errors follow the format `BF` + 3-digit code. Errors include source location and actionable suggestions.
+Errors follow the format `BF` + 3-digit code with source location and fix suggestions.
 
-## Error Format
+## Format
 
 ```
 error[BF001]: 'use client' directive required for components with createSignal
@@ -26,7 +26,7 @@ error[BF001]: 'use client' directive required for components with createSignal
 
 ### BF001 — Missing `"use client"` Directive
 
-**Trigger:** A component uses reactive APIs (`createSignal`, `createEffect`, event handlers) but the file doesn't start with `"use client"`.
+**Trigger:** Reactive APIs used without `"use client"`.
 
 ```tsx
 // ❌ BF001
@@ -37,7 +37,7 @@ export function Counter() {
 }
 ```
 
-**Fix:** Add the directive at the top of the file:
+**Fix:**
 
 ```tsx
 // ✅ Fixed
@@ -48,7 +48,7 @@ export function Counter() { ... }
 
 ### BF002 — Invalid Directive Position
 
-**Trigger:** `"use client"` is not the first statement in the file.
+**Trigger:** `"use client"` not first statement.
 
 ```tsx
 // ❌ BF002
@@ -56,13 +56,13 @@ import { createSignal } from '@barefootjs/client'
 "use client"
 ```
 
-**Fix:** Move the directive to the very first line (before any imports).
+**Fix:** Move to the first line (before imports).
 
 ### BF003 — Client Component Importing Server Component
 
-**Trigger:** A `"use client"` component imports from a file that doesn't have `"use client"`.
+**Trigger:** Client component imports from a file without `"use client"`.
 
-**Fix:** Either add `"use client"` to the imported file, or restructure the import to only reference types/constants (which are safe to import).
+**Fix:** Add `"use client"` to the imported file, or import only types/constants.
 
 ---
 
@@ -70,7 +70,7 @@ import { createSignal } from '@barefootjs/client'
 
 ### BF010 — Unknown Signal Reference
 
-**Trigger:** Code references a signal getter that wasn't declared in the component.
+**Trigger:** Undeclared signal getter referenced.
 
 ```tsx
 "use client"
@@ -79,7 +79,7 @@ export function Counter() {
 }
 ```
 
-**Fix:** Declare the signal:
+**Fix:**
 
 ```tsx
 const [count, setCount] = createSignal(0)
@@ -87,7 +87,7 @@ const [count, setCount] = createSignal(0)
 
 ### BF011 — Signal Used Outside Component
 
-**Trigger:** `createSignal` is called at module level instead of inside a component function.
+**Trigger:** `createSignal` at module level.
 
 ```tsx
 // ❌ BF011 — module-level signal
@@ -98,7 +98,7 @@ export function Counter() {
 }
 ```
 
-**Fix:** Move the signal inside the component:
+**Fix:**
 
 ```tsx
 export function Counter() {
@@ -109,7 +109,7 @@ export function Counter() {
 
 ### BF012 — Invalid Signal Usage
 
-**Trigger:** Signal API used in an unsupported pattern.
+**Trigger:** Unsupported signal API pattern.
 
 ---
 
@@ -117,26 +117,22 @@ export function Counter() {
 
 ### BF020 — Invalid JSX Expression
 
-**Trigger:** An expression in JSX braces can't be compiled.
+**Trigger:** Uncompilable JSX expression.
 
 ### BF021 — Unsupported JSX Pattern
 
-**Trigger:** An array method chain before `.map()` cannot be compiled to an SSR template. Unsupported patterns fall back to client-side evaluation.
+**Trigger:** Array method chain before `.map()` cannot compile to SSR template.
 
 #### SSR-Compatible Chains
-
-Only the following chain patterns are SSR-compiled as preprocessing before `.map()`:
 
 - `.filter().map()`
 - `.sort().map()` / `.toSorted().map()`
 - `.filter().sort().map()`
 - `.sort().filter().map()`
 
-Other method chains such as `.reduce()`, `.slice()`, `.flatMap()` are not detected and fall back to client-side evaluation.
+Other chains (`.reduce()`, `.slice()`, `.flatMap()`) fall back to client-side evaluation.
 
 #### filter: Supported Predicates
-
-Arrow function expression bodies composed of the following elements:
 
 - Property access: `t.done`, `t.price`
 - Literals: `'active'`, `5`, `true`
@@ -158,7 +154,7 @@ Arrow function expression bodies composed of the following elements:
 
 #### sort: Supported Comparators
 
-Only simple subtraction patterns of the form `(a, b) => a.field - b.field`:
+Simple subtraction: `(a, b) => a.field - b.field`:
 
 ```tsx
 // ✅ SSR-compilable
@@ -172,8 +168,6 @@ Only simple subtraction patterns of the form `(a, b) => a.field - b.field`:
 
 #### Workaround
 
-Add `/* @client */` to evaluate on the client side:
-
 ```tsx
 {/* @client */ todos().filter(t => t.items.some(i => i.done)).map(t => (
   <li>{t.name}</li>
@@ -182,11 +176,11 @@ Add `/* @client */` to evaluate on the client side:
 
 ### BF022 — Invalid JSX Attribute
 
-**Trigger:** An attribute value can't be compiled.
+**Trigger:** Uncompilable attribute value.
 
 ### BF023 — Missing Key in List
 
-**Trigger:** A `.map()` loop doesn't provide a `key` prop for reconciliation.
+**Trigger:** `.map()` loop without `key` prop.
 
 ```tsx
 // ❌ BF023
@@ -206,11 +200,11 @@ Add `/* @client */` to evaluate on the client side:
 
 ### BF030 — Type Inference Failed
 
-**Trigger:** The compiler can't infer the type of a signal or expression for the target template language.
+**Trigger:** Type inference failed for signal or expression.
 
 ### BF031 — Props Type Mismatch
 
-**Trigger:** A prop value doesn't match the declared type in the component's interface.
+**Trigger:** Prop value doesn't match declared type.
 
 ---
 
@@ -218,19 +212,19 @@ Add `/* @client */` to evaluate on the client side:
 
 ### BF040 — Component Not Found
 
-**Trigger:** A referenced child component can't be resolved.
+**Trigger:** Unresolvable child component reference.
 
 ### BF041 — Circular Dependency
 
-**Trigger:** Two components import each other.
+**Trigger:** Mutual component imports.
 
 ### BF042 — Invalid Component Name
 
-**Trigger:** Component name doesn't follow PascalCase convention.
+**Trigger:** Non-PascalCase component name.
 
 ### BF043 — Props Destructuring (Warning)
 
-**Trigger:** Props are destructured in the function parameter, which captures values once and may lose reactivity.
+**Trigger:** Props destructured in function parameter.
 
 ```tsx
 // ⚠️ BF043
@@ -266,14 +260,14 @@ function Child({ initialCount }: Props) {
 
 ### BF044 — Signal/Memo Getter Not Called
 
-**Trigger:** A signal or memo getter is passed as a value without calling it, so the receiving side gets the getter function instead of the current value.
+**Trigger:** Signal/memo getter passed without calling it.
 
 ```tsx
 // ⚠️ BF044
 <Child count={count} />  // Passing getter function, not the value
 ```
 
-**Fix:** Call the getter:
+**Fix:**
 
 ```tsx
 // ✅ Fixed
@@ -284,7 +278,7 @@ function Child({ initialCount }: Props) {
 
 ## Suppressing Warnings
 
-Use `@bf-ignore` to suppress specific warnings:
+Suppress with `@bf-ignore`:
 
 ```tsx
 // @bf-ignore props-destructuring

--- a/docs/core/advanced/ir-schema.md
+++ b/docs/core/advanced/ir-schema.md
@@ -5,7 +5,7 @@ description: JSON tree structure of the Intermediate Representation consumed by 
 
 # IR Schema Reference
 
-The Intermediate Representation (IR) is a pure JSON tree structure that sits between JSX parsing and template/client-JS generation. It is **JSX-independent** — adapters consume IR without any knowledge of the original JSX syntax.
+The IR is a JSON tree between JSX parsing and output generation. Adapters consume IR without knowledge of the original JSX syntax.
 
 ## Pipeline Position
 
@@ -14,11 +14,9 @@ JSX Source → [Phase 1: analyzer + jsx-to-ir] → IR → [Phase 2a: adapter] �
                                                    → [Phase 2b: ir-to-client-js] → Client JS
 ```
 
-## Source
+## Node Types
 
-The IR type definitions live in [`packages/jsx/src/types.ts`](../../../packages/jsx/src/types.ts). All node types, attributes, and metadata are defined in this file.
-
-Key node types:
+Defined in [`packages/jsx/src/types.ts`](../../../packages/jsx/src/types.ts):
 
 | Type | Description |
 |------|-------------|
@@ -36,7 +34,7 @@ Key node types:
 
 ## Hydration Markers
 
-The `slotId` and `needsScope` fields in the IR map to HTML attributes in the rendered template:
+`slotId` and `needsScope` map to HTML attributes:
 
 | IR Field | HTML Output | Purpose |
 |----------|------------|---------|
@@ -44,13 +42,12 @@ The `slotId` and `needsScope` fields in the IR map to HTML attributes in the ren
 | `slotId: "0"` | `bf="0"` | Reference for interactive elements |
 | Conditional `slotId` | `bf-c="1"` | Anchor for conditional branches |
 
-The client runtime uses these markers to locate elements that need hydration without a full DOM traversal.
 
 ---
 
 ## Debugging
 
-Pass `outputIR: true` to output the IR as JSON:
+Pass `outputIR: true` to inspect the IR:
 
 ```typescript
 import { compileJSXSync } from '@barefootjs/jsx'

--- a/docs/core/advanced/performance.md
+++ b/docs/core/advanced/performance.md
@@ -5,13 +5,9 @@ description: Strategies to minimize bundle size, reduce hydration cost, and opti
 
 # Performance Optimization
 
-BarefootJS is designed for performance by default — server-side rendering with minimal client JavaScript. This guide covers strategies to minimize bundle size, reduce hydration cost, and optimize runtime reactivity.
+## Zero-JS by Default
 
-## How BarefootJS Achieves Performance
-
-### Zero-JS by Default
-
-Components without reactive state generate **no client JavaScript at all**. Only components with `"use client"` produce client-side code:
+Components without `"use client"` generate **no client JavaScript**:
 
 ```tsx
 // Server-only — 0 bytes of client JS
@@ -25,22 +21,15 @@ export function Header() {
 }
 ```
 
-### Minimal Hydration
+## Minimal Hydration
 
-Unlike frameworks that ship the full component tree to the client, BarefootJS sends only:
-- Signal initialization
-- Event handler bindings
-- Effect setup for reactive updates
-
-The HTML structure is never re-created on the client — it was already rendered by the server.
+Only signals, event handlers, and effects are sent to the client. The HTML structure is never re-created — the server already rendered it.
 
 ---
 
 ## Reducing Client JS Size
 
-### Minimize Signal Count
-
-Each signal adds tracking overhead. Use `createMemo` for derived values instead of separate signals:
+### Use Memos for Derived Values
 
 ```tsx
 // ❌ Redundant signal
@@ -53,9 +42,9 @@ const [count, setCount] = createSignal(0)
 const doubled = createMemo(() => count() * 2)  // Computed, no extra signal
 ```
 
-### Use Static Arrays When Possible
+### Prefer Static Arrays
 
-If a list doesn't change after initial render, the compiler detects it as a **static array** and skips list reconciliation:
+The compiler detects static arrays and skips reconciliation:
 
 ```tsx
 // Static — no reconciliation generated
@@ -71,9 +60,7 @@ const [items, setItems] = createSignal([...])
 
 ## Optimizing Hydration
 
-### Use Keys for List Reconciliation
-
-Always provide stable keys for dynamic lists. Without keys, the reconciler can't reuse DOM nodes:
+### Stable Keys for Lists
 
 ```tsx
 // ✅ Stable key — DOM nodes reused when list changes
@@ -83,17 +70,15 @@ Always provide stable keys for dynamic lists. Without keys, the reconciler can't
 {items().map((item, i) => <li key={i}>{item.name}</li>)}
 ```
 
-### Preserve Focus in Lists
+### Focus Preservation
 
-The reconciler automatically preserves focused elements during list updates. If a focused input is in a list item, it won't lose focus when the list re-renders. This is built-in — no action needed on your part.
+The reconciler preserves focused elements during list updates automatically.
 
 ---
 
 ## Optimizing Reactivity
 
-### Use `untrack` for One-Time Reads
-
-When you need a signal's current value without subscribing to changes:
+### `untrack` for One-Time Reads
 
 ```tsx
 createEffect(() => {
@@ -103,9 +88,7 @@ createEffect(() => {
 })
 ```
 
-### Avoid Effects for Derived Data
-
-`createMemo` is cheaper than `createEffect` + `createSignal`:
+### Memo Over Effect + Signal
 
 ```tsx
 // ❌ Effect → Signal chain (two subscriptions)
@@ -116,9 +99,7 @@ createEffect(() => setTotal(price() * quantity()))
 const total = createMemo(() => price() * quantity())
 ```
 
-### Guard Effect Side Effects
-
-Effects with the same result can skip expensive operations:
+### Guard DOM Updates
 
 ```tsx
 createEffect(() => {
@@ -129,6 +110,6 @@ createEffect(() => {
 })
 ```
 
-> **Note:** The compiler already generates guarded updates for text content and common attributes. This tip applies to custom effects.
+The compiler already generates guarded updates for text content and common attributes. This applies to custom effects only.
 
 

--- a/docs/core/components.md
+++ b/docs/core/components.md
@@ -5,7 +5,7 @@ description: How to author, compose, and type components in BarefootJS, includin
 
 # Components
 
-This section covers how to author, compose, and type components in BarefootJS. For the `"use client"` directive and the server/client boundary, see [Core Concepts](./core-concepts.md#the-use-client-directive).
+For the `"use client"` directive and the server/client boundary, see [Core Concepts — `"use client"`](./core-concepts/use-client.md).
 
 ## Pages
 

--- a/docs/core/components/children-slots.md
+++ b/docs/core/components/children-slots.md
@@ -5,12 +5,10 @@ description: Accept nested JSX content via the children prop and enable polymorp
 
 # Children & Slots
 
-Components accept nested JSX content through the `children` prop. The `Slot` component enables polymorphic rendering with the `asChild` pattern.
+Nested JSX content is passed via the `children` prop. The `Slot` component enables polymorphic rendering with `asChild`.
 
 
 ## Children
-
-Any JSX nested inside a component tag is passed as the `children` prop:
 
 ```tsx
 <Card>
@@ -30,8 +28,6 @@ function Card(props: { children?: Child }) {
 
 ## Passing Children Through
 
-A component can pass `children` to a child element or another component:
-
 ```tsx
 function Panel(props: { title: string; children?: Child }) {
   return (
@@ -43,12 +39,12 @@ function Panel(props: { title: string; children?: Child }) {
 }
 ```
 
-Wrapping `children` in a fragment (`<>{props.children}</>`) is treated as **transparent** — the compiler skips the fragment and processes children directly without extra hydration markers. See [Fragment](../rendering/fragment.md) for details.
+Wrapping `children` in a fragment (`<>{props.children}</>`) is **transparent** — the compiler skips the fragment without extra hydration markers. See [Fragment](../rendering/fragment.md).
 
 
 ## The `Slot` Component
 
-`Slot` renders the child element with merged props and classes. It enables the **`asChild` pattern**, where a component's styling and behavior are applied to its child element instead of a wrapper:
+`Slot` merges props and classes onto its child element, enabling the **`asChild` pattern**:
 
 ```tsx
 import { Slot } from './slot'
@@ -65,12 +61,7 @@ function Button({ className, asChild, children, ...props }: ButtonProps) {
 
 ### How `Slot` Works
 
-When `Slot` receives a valid element as `children`, it:
-
-1. Extracts the child element's tag and props
-2. Merges `className` from both `Slot` and the child (concatenated, space-separated)
-3. Spreads remaining props from `Slot` onto the child
-4. Renders the child's tag with the merged result
+`Slot` extracts the child's tag, merges `className` (space-separated), spreads remaining props, and renders the child's tag with the merged result.
 
 ```tsx
 // Input
@@ -87,7 +78,7 @@ If `children` is not a valid element (e.g., a string), `Slot` falls back to rend
 
 ## The `asChild` Pattern
 
-`asChild` lets a component delegate rendering to its child element. This is useful when you want a component's styling without its default HTML tag.
+`asChild` delegates rendering to the child element — the component's styling without its default HTML tag.
 
 ### Default rendering (no `asChild`)
 
@@ -105,13 +96,13 @@ If `children` is not a valid element (e.g., a string), `Slot` falls back to rend
 // Renders: <a href="/dashboard" className="btn btn-primary">Go to Dashboard</a>
 ```
 
-The `<a>` tag receives Button's classes and props. The component controls styling; the caller controls the underlying element.
+The `<a>` tag receives Button's classes and props. The component controls styling; the caller controls the element.
 
 ### When to Use `asChild`
 
-- **Navigation buttons** — Render a `<a>` with button styling
-- **Custom triggers** — Render a custom element as a dialog or dropdown trigger
-- **Accessibility** — Use the semantically correct element while reusing component styles
+- Navigation buttons (render `<a>` with button styling)
+- Custom triggers (dialog or dropdown)
+- Semantic elements with reused component styles
 
 ```tsx
 // Dialog trigger as a custom element
@@ -121,9 +112,7 @@ The `<a>` tag receives Button's classes and props. The component controls stylin
 ```
 
 
-## Compound Component Children
-
-Compound components use children to compose sub-components declaratively:
+## Compound Components
 
 ```tsx
 <Dialog open={open()} onOpenChange={setOpen}>
@@ -142,12 +131,10 @@ Compound components use children to compose sub-components declaratively:
 </Dialog>
 ```
 
-Each sub-component reads shared state from a context provider defined in the root component. See [Context API](./context-api.md) for how this works.
+Sub-components read shared state from a context provider. See [Context API](./context-api.md).
 
 
-## Children in List Rendering
-
-When rendering lists, pass data and callbacks to child components via props:
+## List Rendering
 
 ```tsx
 {todos().map(todo => (
@@ -160,4 +147,4 @@ When rendering lists, pass data and callbacks to child components via props:
 ))}
 ```
 
-The `key` attribute is required for efficient list updates. The compiler emits warning `BF023` if `key` is missing.
+`key` is required for efficient list updates (warning `BF023` if missing).

--- a/docs/core/components/component-authoring.md
+++ b/docs/core/components/component-authoring.md
@@ -5,12 +5,12 @@ description: Learn how to write server and client components in BarefootJS using
 
 # Component Authoring
 
-A BarefootJS component is a function that returns JSX. Components come in two kinds: **server components** and **client components**.
+Components are functions that return JSX, in two kinds: **server components** and **client components**.
 
 
 ## Server Components
 
-A server component renders HTML on the server. It has no client-side JavaScript.
+Server components render HTML on the server with no client-side JavaScript.
 
 ```tsx
 export function Greeting({ name }: { name: string }) {
@@ -18,12 +18,12 @@ export function Greeting({ name }: { name: string }) {
 }
 ```
 
-Server components can access databases, read files, use secrets — anything that should stay on the server. They produce a template that is rendered once per request.
+Server components can access databases, read files, and use secrets. They produce a template rendered once per request.
 
 
 ## Client Components
 
-A client component uses reactive primitives and ships JavaScript to the browser. It requires the `"use client"` directive at the top of the file:
+Client components use reactive primitives and ship JavaScript to the browser. They require the `"use client"` directive:
 
 ```tsx
 "use client"
@@ -41,23 +41,18 @@ export function Counter({ initial = 0 }) {
 }
 ```
 
-The compiler produces two outputs from this source:
-
-1. **Marked Template** — Server-rendered HTML with `bf-*` attributes
-2. **Client JS** — A minimal script that creates signals, binds effects, and attaches event handlers
-
-See [Core Concepts — Two-Phase Compilation](../core-concepts.md#two-phase-compilation) for details.
+The compiler produces a **marked template** (server HTML with `bf-*` attributes) and **client JS** (signals, effects, event handlers). See [Two-Phase Compilation](../core-concepts/compilation.md) for details.
 
 ### When `"use client"` Is Required
 
-Add `"use client"` when a component uses any of these:
+Add `"use client"` when a component uses:
 
 - `createSignal`, `createEffect`, `createMemo`
 - `onMount`, `onCleanup`, `untrack`
 - `createContext`, `useContext`
 - Event handlers (`onClick`, `onChange`, etc.)
 
-Without the directive, the compiler emits an error:
+Without the directive:
 
 ```
 error[BF001]: 'use client' directive required for components with createSignal
@@ -66,7 +61,7 @@ error[BF001]: 'use client' directive required for components with createSignal
 
 ## Component Naming
 
-Component names must start with an uppercase letter. This is how the compiler distinguishes components from HTML elements:
+Component names must start with an uppercase letter:
 
 ```tsx
 // ✅ Component
@@ -78,8 +73,6 @@ function todoItem() { ... }
 
 
 ## Compilation Output
-
-A client component compiles into a marked template and a client init function. Here is a minimal example to illustrate the full pipeline:
 
 **Source:**
 
@@ -141,12 +134,10 @@ export function initToggle(__scope, props = {}) {
 hydrate('Toggle', { init: initToggle })
 ```
 
-The server renders static HTML. The browser runs the init function to make it interactive. Only the specific text node bound to `on()` updates when the signal changes.
+Only the text node bound to `on()` updates when the signal changes.
 
 
 ## Composition Rules
-
-Server and client components follow a one-way composition rule:
 
 | From | To | Allowed |
 |------|----|---------|
@@ -155,7 +146,7 @@ Server and client components follow a one-way composition rule:
 | Client component | Client component | ✅ |
 | Client component | Server component | ❌ |
 
-A client component cannot import a server component because server-only code does not exist in the browser. The compiler emits error `BF003` if this is attempted.
+Server-only code does not exist in the browser. The compiler emits `BF003` if a client component imports a server component.
 
 ```tsx
 // Page.tsx — server component
@@ -178,12 +169,9 @@ import { Counter } from './Counter'    // ✅ Client → Client
 import { UserList } from './UserList'  // ❌ BF003: Client → Server
 ```
 
-Think of `"use client"` as a one-way gate: once you cross into client territory, everything below must also be a client component.
-
-
 ## Ref Callbacks
 
-Client components use `ref` callbacks for imperative DOM access. The callback receives the DOM element after it is mounted:
+`ref` callbacks provide imperative DOM access. The callback receives the element after mount:
 
 ```tsx
 "use client"
@@ -198,7 +186,7 @@ export function AutoFocus() {
 }
 ```
 
-Ref callbacks are the primary mechanism for attaching side effects to specific elements. They are often combined with `createEffect` for reactive DOM updates:
+Combine with `createEffect` for reactive DOM updates:
 
 ```tsx
 const handleMount = (el: HTMLElement) => {

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -5,7 +5,7 @@ description: Share state with deeply nested children without prop drilling using
 
 # Context API
 
-Context lets a parent component share state with deeply nested children without passing props through every level. It is the foundation of compound component patterns like Dialog, Accordion, and Tabs.
+Context shares state with deeply nested children without prop drilling. It is the foundation of compound components (Dialog, Accordion, Tabs).
 
 ```tsx
 import { createContext, useContext } from '@barefootjs/client'
@@ -33,7 +33,7 @@ type Context<T> = {
 
 ## `Context.Provider`
 
-Provides a value to all descendant components. Any component inside the provider tree can read the value with `useContext`.
+Provides a value to all descendants. Components inside the provider tree read it with `useContext`.
 
 ```tsx
 <MyContext.Provider value={someValue}>
@@ -41,7 +41,7 @@ Provides a value to all descendant components. Any component inside the provider
 </MyContext.Provider>
 ```
 
-The compiler transforms `<Context.Provider>` into an internal `provideContext()` call. At runtime, the value is set synchronously before children initialize, so `useContext` always sees the provided value.
+The compiler transforms this into a `provideContext()` call. The value is set synchronously before children initialize.
 
 
 ## `useContext`
@@ -98,7 +98,7 @@ export function ThemedButton(props: { children?: Child }) {
 
 ## Compound Components
 
-Context is most commonly used for compound components — a group of related components that share internal state. The root component provides the state; sub-components consume it.
+A group of related components sharing internal state. The root provides state; sub-components consume it.
 
 ### Example: Accordion
 
@@ -182,7 +182,7 @@ function AccordionContent(props: { itemId: string; children?: Child }) {
 
 ## Reactive Context Values
 
-Context values can contain signal getters. When a child component reads a signal getter from context inside a `createEffect`, the effect re-runs when the signal changes:
+Context values can contain signal getters. Effects that read them re-run when the signal changes:
 
 ```tsx
 // Provider passes signal getter
@@ -198,12 +198,12 @@ createEffect(() => {
 })
 ```
 
-The signal getter `ctx.activeItem()` is called inside the effect, so the effect subscribes to `activeItem`. When `activeItem` changes (via `toggle`), only the affected effects re-run.
+`ctx.activeItem()` inside the effect subscribes to `activeItem`. When it changes, only affected effects re-run.
 
 
 ## Context Without a Default
 
-When `createContext` is called without a default value, `useContext` throws if no `Provider` ancestor is found. This is the recommended pattern for compound components where a provider is always expected:
+Without a default value, `useContext` throws if no `Provider` ancestor exists. Recommended for compound components:
 
 ```tsx
 const DialogContext = createContext<DialogContextValue>()
@@ -218,12 +218,12 @@ function DialogTrigger(props: { children?: Child }) {
 }
 ```
 
-This catches composition errors early. If a sub-component is accidentally used outside its parent, the error message identifies the missing provider.
+This catches composition errors early — the error identifies the missing provider.
 
 
 ## Context With a Default
 
-When a default is provided, `useContext` always succeeds:
+With a default, `useContext` always succeeds:
 
 ```tsx
 const ThemeContext = createContext<'light' | 'dark'>('light')
@@ -232,4 +232,4 @@ const ThemeContext = createContext<'light' | 'dark'>('light')
 const theme = useContext(ThemeContext)
 ```
 
-Use this pattern for optional contexts where a sensible fallback exists.
+Use for optional contexts with a sensible fallback.

--- a/docs/core/components/portals.md
+++ b/docs/core/components/portals.md
@@ -5,7 +5,7 @@ description: Render elements outside their parent DOM hierarchy for overlays, mo
 
 # Portals
 
-A portal renders an element outside its parent DOM hierarchy. This is useful for overlays, modals, and tooltips that need to escape `overflow: hidden`, `z-index` stacking contexts, or other CSS containment.
+Portals render elements outside their parent DOM hierarchy — useful for overlays, modals, and tooltips that need to escape `overflow: hidden` or `z-index` stacking contexts.
 
 ```tsx
 import { createPortal } from '@barefootjs/client'
@@ -14,7 +14,7 @@ import { createPortal } from '@barefootjs/client'
 
 ## `createPortal`
 
-Moves an element to a different container in the DOM.
+Moves an element to a different DOM container.
 
 ```tsx
 createPortal(children, container?, options?)
@@ -46,7 +46,7 @@ function createPortal(
 
 ## Basic Usage
 
-Portals are typically created inside a `ref` callback. The element is moved to `document.body` (or another container) after it is mounted:
+Create portals inside `ref` callbacks:
 
 ```tsx
 "use client"
@@ -86,7 +86,7 @@ export function Tooltip(props: { text: string; children?: Child }) {
 
 ## SSR Portal Detection
 
-When a portal is server-rendered, it is already in the correct position in the DOM. `isSSRPortal` checks whether an element was already portaled during SSR to prevent double-portaling:
+`isSSRPortal` checks whether an element was already portaled during SSR to prevent double-portaling:
 
 ```tsx
 import { isSSRPortal } from '@barefootjs/client'
@@ -99,7 +99,7 @@ const handleMount = (el: HTMLElement) => {
 }
 ```
 
-SSR portals are marked with `bf-pi` attributes. After hydration, call `cleanupPortalPlaceholder` to remove the SSR placeholder:
+After hydration, remove SSR placeholders:
 
 ```tsx
 import { cleanupPortalPlaceholder } from '@barefootjs/client'
@@ -110,9 +110,7 @@ cleanupPortalPlaceholder(portalId)
 
 ## Owner Scope
 
-By default, an element moved to `document.body` via a portal is outside its original component's scope. This means the runtime's `find()` function cannot locate it when searching within the component boundary.
-
-The `ownerScope` option solves this by linking the portaled element back to its parent component:
+A portaled element is outside its original component's scope, so `find()` cannot locate it. The `ownerScope` option links it back:
 
 ```tsx
 const handleMount = (el: HTMLElement) => {
@@ -121,12 +119,12 @@ const handleMount = (el: HTMLElement) => {
 }
 ```
 
-The portal sets `bf-po` on the moved element, so scoped queries from the owner component still find it.
+`bf-po` on the moved element lets scoped queries from the owner still find it.
 
 
 ## Dialog Example
 
-A common use of portals is moving dialog overlays and content to `document.body`:
+Dialog overlays are a common portal use case:
 
 ```tsx
 "use client"
@@ -159,12 +157,12 @@ function DialogOverlay() {
 }
 ```
 
-The overlay is rendered inside the `<Dialog>` component tree (so it can access `DialogContext`), but is moved to `document.body` by the portal (so it escapes any CSS containment).
+The overlay accesses `DialogContext` from the component tree but is moved to `document.body` to escape CSS containment.
 
 
 ## Cleanup
 
-Use `portal.unmount()` to remove a portaled element. Combine with `onCleanup` to clean up when a component is destroyed:
+Combine `portal.unmount()` with `onCleanup`:
 
 ```tsx
 import { createPortal, onCleanup } from '@barefootjs/client'
@@ -181,11 +179,9 @@ const handleMount = (el: HTMLElement) => {
 
 ## Custom Container
 
-By default, `createPortal` appends to `document.body`. You can specify a different container:
+Specify a different container instead of the default `document.body`:
 
 ```tsx
 const container = document.getElementById('modal-root')!
 createPortal(el, container)
 ```
-
-This is useful when you have a dedicated mount point in your HTML layout for modals or notifications.

--- a/docs/core/components/props-type-safety.md
+++ b/docs/core/components/props-type-safety.md
@@ -5,14 +5,12 @@ description: Type component props with TypeScript interfaces and preserve type i
 
 # Props & Type Safety
 
-Component props in BarefootJS are typed with TypeScript interfaces. The compiler preserves type information through compilation, and the adapter uses it to generate type-safe marked templates.
+The compiler preserves TypeScript type information through compilation. Adapters use it to generate type-safe templates.
 
-Props in client components are reactive — **how you access them matters**. See [Props Reactivity](../reactivity/props-reactivity.md) for the full explanation. This page focuses on typing patterns.
+Props in client components are reactive — see [Props Reactivity](../reactivity/props-reactivity.md). This page covers typing patterns.
 
 
 ## Defining Props
-
-Define props as an interface or type alias and annotate the function parameter:
 
 ```tsx
 interface GreetingProps {
@@ -37,7 +35,7 @@ function Button(props: { variant?: 'default' | 'primary'; children?: Child }) {
 }
 ```
 
-For props that are only used as an initial value for a signal, default parameter syntax is also fine. Note that the compiler emits warning `BF043` for destructuring, so add `@bf-ignore` to signal intent:
+For initial-value-only props, default parameter syntax works. Add `@bf-ignore` to suppress the `BF043` destructuring warning:
 
 ```tsx
 // @bf-ignore props-destructuring
@@ -50,7 +48,7 @@ function Counter({ initial = 0 }: { initial?: number }) {
 
 ## Extending HTML Attributes
 
-For components that wrap native elements, extend the corresponding HTML attribute type:
+Extend HTML attribute types for components wrapping native elements:
 
 ```tsx
 import type { ButtonHTMLAttributes } from '@barefootjs/jsx'
@@ -69,12 +67,12 @@ function Button(props: ButtonProps) {
 }
 ```
 
-This lets callers pass any standard button attribute (`type`, `disabled`, `aria-label`, etc.) alongside custom props.
+Callers can pass standard button attributes (`type`, `disabled`, `aria-label`, etc.) alongside custom props.
 
 
 ## Rest Spreading
 
-Use rest syntax to forward unknown props to the underlying element. Since rest spreading captures values once, use it for server components or for attributes that don't need reactive updates:
+Rest spreading captures values once, so use it for server components or non-reactive attributes:
 
 ```tsx
 function Card(props: { title: string; children?: Child } & HTMLAttributes) {
@@ -96,4 +94,4 @@ function Card(props: { title: string; children?: Child } & HTMLAttributes) {
 
 ## Type Preservation
 
-The compiler captures TypeScript type information for props and carries it through the IR. Each adapter uses this information to generate type-safe server output. For details on how types are mapped to specific backends, see [Adapters](../adapters.md).
+The compiler carries TypeScript type information through the IR. Each adapter uses it for type-safe server output. See [Adapters](../adapters.md) for backend-specific type mapping.

--- a/docs/core/core-concepts.md
+++ b/docs/core/core-concepts.md
@@ -5,8 +5,6 @@ description: Two-phase compilation, signal-based reactivity, hydration, and clea
 
 # Core Concepts
 
-BarefootJS has a small number of key ideas. Understanding them makes everything else click.
-
 ## Pages
 
 | Topic | Description |

--- a/docs/core/core-concepts/clean-overrides.md
+++ b/docs/core/core-concepts/clean-overrides.md
@@ -5,36 +5,20 @@ description: CSS Cascade Layers ensure user styles always beat component default
 
 # Clean Overrides (CSS Layers)
 
-BarefootJS uses CSS Cascade Layers to guarantee that user-supplied classes always override component base classes — without runtime JS, without merge functions, and without worrying about generation order.
+BarefootJS uses CSS Cascade Layers to guarantee that user-supplied classes always override component base classes — no runtime JS, no merge functions, no generation-order concerns.
 
-## The Problem
+## Why Layers?
 
-When a component defines base classes and a user passes override classes, both have equal CSS specificity. The winner depends on which CSS rule appears later in the stylesheet — which in turn depends on the order the CSS toolchain happens to generate them.
+When a component's base classes and a user's override classes have equal specificity, the winner depends on stylesheet generation order. This is fragile.
 
-```tsx
-// Component defines base classes
-<button className="bg-primary text-white">
-
-// User wants to override the background
-<Button className="bg-red-500">
-```
-
-If `bg-primary` is generated after `bg-red-500` in the CSS output, the user's override silently fails. This is fragile and order-dependent.
-
-## The Solution
-
-CSS Cascade Layers provide a spec-level mechanism for controlling style priority. Styles in a named `@layer` always lose to un-layered styles, regardless of specificity or source order.
-
-BarefootJS puts component base classes into `@layer components`. User-supplied classes remain un-layered. The cascade guarantees the user wins:
+CSS Cascade Layers solve this: styles in a named `@layer` always lose to un-layered styles, regardless of specificity or source order. BarefootJS puts component base classes into `@layer components`. User-supplied classes remain un-layered:
 
 ```css
 /* Layer ordering: lowest → highest priority */
 @layer preflights, base, shortcuts, components, default;
 ```
 
-Un-layered styles (user overrides) always beat any layer — this is defined by the CSS spec, not by any toolchain convention.
-
-## How It Works
+## Compile-Time Prefixing
 
 The compiler's `cssLayerPrefix` option prefixes component base classes at compile time.
 
@@ -93,13 +77,13 @@ Applied classes:
 Result: bg-red-500 wins. Always.
 ```
 
-## Key Properties
+## Properties
 
-- **Zero runtime cost** — Prefixing happens at compile time. No JS runs in the browser to merge classes.
-- **Works with any CSS tool** — The `layer-components:` prefix convention is supported by UnoCSS. Any tool that supports CSS Cascade Layers can use this approach.
-- **No merge function needed** — The CSS cascade handles class conflict resolution natively.
-- **Language-independent** — The prefixing is applied to the IR, so Go, Rust, and Node adapters all benefit equally.
-- **Preserves both classes** — Both classes remain in the DOM. DevTools shows exactly what was applied and what was overridden.
+- **Zero runtime cost** — Prefixing happens at compile time.
+- **Works with any CSS tool** — UnoCSS supports the `layer-components:` prefix. Any tool with Cascade Layer support works.
+- **No merge function needed** — The CSS cascade handles conflict resolution natively.
+- **Language-independent** — Prefixing is applied to the IR, so all adapters benefit equally.
+- **Preserves both classes** — Both classes remain in the DOM. DevTools shows what was applied and overridden.
 
 ## Configuration
 

--- a/docs/core/core-concepts/compilation.md
+++ b/docs/core/core-concepts/compilation.md
@@ -98,11 +98,9 @@ The server renders the HTML. The browser runs only the client JS to make it inte
 
 ## Adapters
 
-The IR is backend-agnostic. An **adapter** converts it to the template format your server needs:
+An **adapter** converts the backend-agnostic IR to the template format your server needs. See [Adapters](../adapters.md) for details.
 
 | Adapter | Output | Backend |
 |---------|--------|---------|
 | `HonoAdapter` | `.hono.tsx` | Hono / JSX-based servers |
 | `GoTemplateAdapter` | `.tmpl` + `_types.go` | Go `html/template` |
-
-The same JSX source produces correct output for each adapter. See [Adapters](../adapters.md) for details.

--- a/docs/core/core-concepts/hydration.md
+++ b/docs/core/core-concepts/hydration.md
@@ -5,7 +5,7 @@ description: Marker-driven hydration that makes server-rendered HTML interactive
 
 # Hydration Model
 
-Hydration is the process of making server-rendered HTML interactive. BarefootJS uses a **marker-driven** approach.
+BarefootJS uses **marker-driven** hydration to make server-rendered HTML interactive.
 
 ## Hydration Markers
 
@@ -51,7 +51,7 @@ Page is interactive
 
 ## Scoped Queries
 
-Each component only hydrates its own elements. The runtime's `find()` function searches within a scope boundary, excluding nested component scopes. This prevents components from interfering with each other.
+`find()` searches within a scope boundary, excluding nested component scopes.
 
 ```html
 <div bf-s="TodoApp_x1">        <!-- TodoApp scope -->

--- a/docs/core/core-concepts/reactivity.md
+++ b/docs/core/core-concepts/reactivity.md
@@ -7,7 +7,7 @@ description: Fine-grained reactivity with signals, effects, and memos
 
 BarefootJS uses fine-grained reactivity inspired by SolidJS. The core primitives are **signals**, **effects**, and **memos**.
 
-All reactive getters carry the `Reactive<T>` phantom brand — a compile-time type marker that the compiler uses to identify reactive expressions. The brand has no runtime cost; it enables the compiler to detect reactivity via TypeScript's type system rather than name-based pattern matching alone.
+All reactive getters carry the `Reactive<T>` phantom brand — a compile-time marker that enables the compiler to detect reactivity via TypeScript's type system. The brand has no runtime cost.
 
 ## Signals
 
@@ -21,7 +21,7 @@ setCount(5)          // Write: set to 5
 setCount(n => n + 1) // Write: updater function
 ```
 
-The getter is a **function call** — `count()`, not `count`. This is how the reactivity system tracks which effects depend on which signals. The getter is typed as `Reactive<() => T>`, which the compiler recognizes as a reactive expression.
+The getter is a **function call** — `count()`, not `count`. This is how the reactivity system tracks dependencies. The getter is typed as `Reactive<() => T>`.
 
 ## Effects
 
@@ -33,7 +33,7 @@ createEffect(() => {
 })
 ```
 
-The first time it runs, the system records that `count` was read. When `count` changes, the effect re-runs automatically. No dependency array is needed.
+The system records that `count` was read. When `count` changes, the effect re-runs. No dependency array is needed.
 
 ## Memos
 
@@ -47,9 +47,9 @@ doubled() // Returns the cached result
 
 Like effects, memos track dependencies automatically. Unlike effects, they return a value and only recompute when dependencies change.
 
-## How It Works
+## Update Flow
 
-When a signal getter is called inside an effect, the effect subscribes to that signal. When the setter is called, all subscribed effects re-run. This happens at the **expression level** — only the specific DOM nodes that depend on a signal are updated.
+Updates happen at the **expression level** — only the DOM nodes that depend on a signal are updated.
 
 ```
 setCount(1)

--- a/docs/core/core-concepts/use-client.md
+++ b/docs/core/core-concepts/use-client.md
@@ -5,7 +5,7 @@ description: Marking components for client-side interactivity
 
 # The `"use client"` Directive
 
-Components that use reactive primitives (`createSignal`, `createEffect`, etc.) must include the `"use client"` directive at the top of the file:
+Components with reactive primitives (`createSignal`, `createEffect`, etc.) require `"use client"` at the top of the file:
 
 ```tsx
 "use client"
@@ -17,13 +17,7 @@ export function Counter() {
 }
 ```
 
-This tells the compiler:
-
-- **Generate client JS** for this component
-- **Add hydration markers** to the marked template
-- **Validate** that reactive APIs are only used in client components
-
-Without the directive, the compiler produces a server-only template with no client JS. A component without `"use client"` that tries to use `createSignal` will get an error:
+The directive tells the compiler to generate client JS and add hydration markers to the template. Without it, the compiler produces a server-only template. Using reactive APIs without the directive triggers an error:
 
 ```
 error[BF001]: 'use client' directive required for components with createSignal
@@ -38,7 +32,7 @@ error[BF001]: 'use client' directive required for components with createSignal
 
 ## Security Boundary
 
-`"use client"` marks a **security boundary**. Code in a client component is compiled into JavaScript that runs in the browser — meaning it is **visible to the user**. Never include secrets, database access, or other sensitive logic in a `"use client"` file.
+`"use client"` marks a **security boundary**. Code in a client component runs in the browser and is visible to the user. Never include secrets, database access, or other sensitive logic in a `"use client"` file.
 
 ```tsx
 // server-only.tsx — NO "use client"
@@ -67,11 +61,11 @@ export function Counter() {
 
 ## Server and Client Component Composition
 
-Server components and client components have a clear composition rule:
+Composition follows a one-way rule:
 
-- **Server component → Client component**: A server component can render a client component as a child. The server renders the HTML with hydration markers, and the client JS takes over in the browser.
-- **Client component → Client component**: A client component can render other client components.
-- **Client component → Server component**: Not allowed. A client component cannot import and render a server-only component, because server-only code does not exist on the client.
+- **Server → Client**: Allowed. The server renders HTML with hydration markers; the client JS takes over.
+- **Client → Client**: Allowed.
+- **Client → Server**: Not allowed. Server-only code does not exist on the client.
 
 ```tsx
 // Page.tsx — server component
@@ -95,4 +89,4 @@ import { Counter } from './Counter'    // ✅ Client → Client
 import { UserList } from './UserList'  // ❌ Client → Server (error)
 ```
 
-Think of `"use client"` as a one-way gate: once you cross into client territory, everything below must also be a client component.
+Once you cross into client territory, everything below must also be a client component.

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -82,44 +82,22 @@ hydrate('Counter', { init: initCounter })
 No framework runtime. No virtual DOM. Just the minimum JavaScript needed for interactivity.
 
 
-## Why BarefootJS?
+## Design Principles
 
-### The Problem
-
-Modern frontend frameworks ship large JavaScript runtimes to the browser, even when most of the page is static content. Server-side rendering helps with initial load, but hydration still requires downloading and executing the full framework.
-
-If your backend is Go, Python, or Perl, the gap is wider: you either maintain separate template and JavaScript codebases, or adopt a JavaScript-only stack.
-
-### The BarefootJS Approach
-
-BarefootJS compiles JSX into **native templates for your backend** and **minimal client JS** — bridging server rendering and client interactivity without a runtime.
-
-- **Backend agnostic** — The same JSX source produces templates for any backend (Go, TypeScript, etc.)
-- **Fine-grained reactivity** — Signals track dependencies at the expression level, updating only the affected DOM nodes
-- **Minimal client JS** — Each component ships only the JavaScript it needs, not a framework runtime
-- **Full type safety** — TypeScript types flow through the entire compilation pipeline
-
-
-## Design Philosophy
-
-**1. Compile, don't ship a runtime.**
+**Compile, don't ship a runtime.**
 The compiler does the heavy lifting at build time. The browser receives only the JavaScript it needs — no framework, no virtual DOM diffing.
 
-**2. Backend agnostic.**
+**Backend agnostic.**
 The same JSX source produces templates for Hono, Go `html/template`, and any future adapter. Your component library works across stacks.
 
-**3. Fine-grained reactivity.**
+**Fine-grained reactivity.**
 Inspired by SolidJS, signals track dependencies at the expression level. When state changes, only the affected DOM nodes update — not the entire component tree.
 
-**4. Progressive enhancement.**
-Server-rendered HTML works without JavaScript. Client scripts enhance the page with interactivity. If JavaScript fails to load, users still see content.
+**Progressive enhancement.**
+Server-rendered HTML works without JavaScript. Client scripts add interactivity. If JavaScript fails to load, users still see content.
 
-**5. Familiar syntax, no lock-in.**
-JSX is the authoring format, but the output is standard HTML and vanilla JavaScript. There is no proprietary template language to learn and no framework to migrate away from.
+**Full type safety.**
+TypeScript types flow through the entire compilation pipeline.
 
-
-## Who is it for?
-
-- **Full-stack TypeScript developers** who want reactive UI without shipping a framework runtime to the browser
-- **Backend teams** (Go, Python, etc.) who need interactive components without adopting a JavaScript-only stack
-- **Performance-focused teams** who need minimal client JS with fine-grained DOM updates
+**No lock-in.**
+JSX is the authoring format, but the output is standard HTML and vanilla JavaScript. No proprietary template language. No framework to migrate away from.

--- a/docs/core/reactivity.md
+++ b/docs/core/reactivity.md
@@ -5,9 +5,7 @@ description: Fine-grained reactive primitives inspired by SolidJS, including sig
 
 # Reactivity
 
-BarefootJS uses fine-grained reactivity inspired by SolidJS. For a conceptual overview, see [Core Concepts](./core-concepts.md#signal-based-reactivity).
-
-All reactive primitives are imported from `@barefootjs/client-runtime`:
+All reactive primitives are imported from `@barefootjs/client`:
 
 ```tsx
 import { createSignal, createEffect, createMemo, onMount, onCleanup, untrack } from '@barefootjs/client'

--- a/docs/core/reactivity/create-effect.md
+++ b/docs/core/reactivity/create-effect.md
@@ -26,12 +26,12 @@ createEffect(() => {
 setCount(1) // Effect re-runs, title becomes "Count: 1"
 ```
 
-Dependencies are tracked automatically — every signal getter called during execution is recorded. No dependency array is needed.
+Dependencies are tracked automatically. No dependency array is needed.
 
 
-## Automatic Dependency Tracking
+## Conditional Dependencies
 
-The effect tracks whichever signals are actually read in each run. If a conditional branch skips a signal read, that signal is not a dependency for that run:
+Dependencies change per run. If a branch skips a signal read, that signal is not tracked for that run:
 
 ```tsx
 const [showName, setShowName] = createSignal(true)
@@ -50,7 +50,7 @@ createEffect(() => {
 
 ## Cleanup
 
-Effects often set up resources that need to be torn down before the next run. There are two ways to register cleanup.
+Two ways to register cleanup for resources that need teardown before re-run.
 
 ### Return a function
 
@@ -75,7 +75,7 @@ createEffect(() => {
 
 ## Common Patterns
 
-### Syncing with localStorage
+### localStorage sync
 
 ```tsx
 const [theme, setTheme] = createSignal('light')
@@ -85,7 +85,7 @@ createEffect(() => {
 })
 ```
 
-### Fetching data
+### Data fetching
 
 ```tsx
 const [query, setQuery] = createSignal('')
@@ -105,9 +105,9 @@ createEffect(() => {
 
 When `query` changes, the previous fetch is aborted before the new one starts.
 
-### Updating DOM attributes
+### Reactive attributes
 
-The compiler generates effects like this for reactive attributes:
+The compiler generates effects for reactive attributes:
 
 ```tsx
 // Source

--- a/docs/core/reactivity/create-memo.md
+++ b/docs/core/reactivity/create-memo.md
@@ -13,7 +13,7 @@ import { createMemo } from '@barefootjs/client'
 const getter = createMemo<T>(fn: () => T): Memo<T>
 ```
 
-Returns a read-only getter function typed as `Memo<T>` (alias for `Reactive<() => T>`). The `Reactive<T>` brand is a compile-time marker that the compiler uses to identify reactive expressions.
+Returns a read-only getter typed as `Memo<T>` (alias for `Reactive<() => T>`).
 
 
 ## Basic Usage
@@ -53,7 +53,7 @@ const filteredTodos = createMemo(() => {
 createEffect(() => console.log(filteredTodos().length))
 ```
 
-For simple expressions used only once, a memo is not necessary — the signal getter in JSX is sufficient:
+For simple expressions used once, a memo is unnecessary:
 
 ```tsx
 // No memo needed
@@ -88,4 +88,4 @@ Each memo in the chain only recomputes when its direct dependencies change.
 | Triggers other effects | Yes (acts as a signal) | No |
 | Used for | Derived data | Side effects (DOM, fetch, logging) |
 
-Internally, `createMemo` is sugar over `createSignal` + `createEffect` — it creates a signal and an effect that updates it when dependencies change. This means a memo behaves exactly like a read-only signal to the rest of the reactive system.
+Internally, `createMemo` is sugar over `createSignal` + `createEffect`. A memo behaves like a read-only signal to the rest of the reactive system.

--- a/docs/core/reactivity/create-signal.md
+++ b/docs/core/reactivity/create-signal.md
@@ -24,7 +24,7 @@ type Signal<T> = [
 ]
 ```
 
-The getter carries the `Reactive<T>` phantom brand — a compile-time marker that the compiler uses to identify reactive expressions. The brand has no runtime cost.
+The getter carries the `Reactive<T>` phantom brand — a compile-time marker for reactive expression detection. No runtime cost.
 
 
 ## Basic Usage
@@ -49,7 +49,7 @@ The getter is a **function call** — `count()`, not `count`. This is how the re
 
 ## Equality Check
 
-The setter uses `Object.is` to compare the new value with the current value. If they are identical, no effects are triggered:
+The setter uses `Object.is` to compare values. Identical values do not trigger effects:
 
 ```tsx
 const [name, setName] = createSignal('Alice')
@@ -73,7 +73,7 @@ setTodos([...todos(), { text: 'Walk dog' }])
 
 ## With Effects
 
-When a signal is read inside an effect, the effect automatically subscribes to changes:
+Reading a signal inside an effect subscribes the effect to changes:
 
 ```tsx
 const [count, setCount] = createSignal(0)
@@ -89,7 +89,7 @@ setCount(2) // Logs: "Count is: 2"
 
 ## With JSX
 
-In BarefootJS components, signal getters in JSX expressions create fine-grained DOM updates:
+Signal getters in JSX expressions create fine-grained DOM updates:
 
 ```tsx
 "use client"
@@ -112,7 +112,7 @@ The compiler generates an effect that updates only the `<p>` text content when `
 
 ## Type Inference
 
-The type parameter is inferred from the initial value:
+Type is inferred from the initial value:
 
 ```tsx
 const [count, setCount] = createSignal(0)        // Signal<number>

--- a/docs/core/reactivity/on-cleanup.md
+++ b/docs/core/reactivity/on-cleanup.md
@@ -5,7 +5,7 @@ description: Registers a cleanup function that runs when the owning effect re-ru
 
 # onCleanup
 
-Registers a cleanup function in the current reactive context. Called when the owning effect re-runs or the component is destroyed.
+Registers a cleanup function. Called when the owning effect re-runs or the component is destroyed.
 
 ```tsx
 import { onCleanup } from '@barefootjs/client'
@@ -23,12 +23,12 @@ createEffect(() => {
 })
 ```
 
-When the effect re-runs (because a dependency changed), the cleanup function runs first, clearing the previous interval before a new one is created.
+On re-run, the cleanup function runs first, clearing the previous interval before creating a new one.
 
 
 ## Multiple Cleanups
 
-You can call `onCleanup` multiple times within the same context. Cleanups execute in reverse order (last registered, first called):
+`onCleanup` can be called multiple times. Cleanups execute in reverse order (last registered, first called):
 
 ```tsx
 createEffect(() => {

--- a/docs/core/reactivity/on-mount.md
+++ b/docs/core/reactivity/on-mount.md
@@ -27,7 +27,7 @@ Unlike `createEffect`, this function never re-runs. It executes once at initiali
 
 ## Common Patterns
 
-### Reading browser state
+### Browser state
 
 ```tsx
 onMount(() => {
@@ -36,7 +36,7 @@ onMount(() => {
 })
 ```
 
-### Setting up event listeners
+### Event listeners
 
 ```tsx
 onMount(() => {
@@ -46,7 +46,7 @@ onMount(() => {
 })
 ```
 
-### Focusing an element
+### Focus
 
 ```tsx
 onMount(() => {
@@ -57,13 +57,7 @@ onMount(() => {
 
 ## How It Works
 
-`onMount` is equivalent to:
-
-```tsx
-createEffect(() => untrack(fn))
-```
-
-The function runs inside an effect context (so `onCleanup` works), but `untrack` prevents any signal reads from being tracked as dependencies.
+`onMount` is equivalent to `createEffect(() => untrack(fn))`. The function runs inside an effect context (so `onCleanup` works), but `untrack` prevents dependency tracking.
 
 
 ## `onMount` vs `createEffect`

--- a/docs/core/reactivity/props-reactivity.md
+++ b/docs/core/reactivity/props-reactivity.md
@@ -5,12 +5,12 @@ description: How prop access patterns determine whether reactive updates propaga
 
 # Props Reactivity
 
-Props in BarefootJS can be reactive. The compiler wraps dynamic prop expressions in getters, so **how you access props determines whether updates propagate**.
+**How you access props determines whether updates propagate.** The compiler wraps dynamic prop expressions in getters.
 
 
 ## Direct Access — Reactive
 
-Accessing props via `props.xxx` maintains reactivity. Each access calls the underlying getter:
+`props.xxx` maintains reactivity. Each access calls the underlying getter:
 
 ```tsx
 function Display(props: { value: number }) {
@@ -24,7 +24,7 @@ function Display(props: { value: number }) {
 
 ## Destructuring — Captures Once
 
-Destructuring calls the getter immediately and stores the result. The value is captured at that moment and does not update:
+Destructuring calls the getter once and stores the result. The value does not update:
 
 ```tsx
 function Display({ value }: { value: number }) {
@@ -35,7 +35,7 @@ function Display({ value }: { value: number }) {
 }
 ```
 
-The compiler emits a warning (`BF043`) when it detects props destructuring in a client component, since this is a common source of bugs:
+The compiler emits `BF043` when it detects props destructuring in a client component:
 
 ```
 warning[BF043]: Props destructuring breaks reactivity
@@ -48,7 +48,7 @@ warning[BF043]: Props destructuring breaks reactivity
    = help: Access props via `props.value` to maintain reactivity
 ```
 
-If you intentionally want to capture a value once (e.g., for an initial value), suppress the warning with the `@bf-ignore` directive:
+Suppress with `@bf-ignore` when capturing intentionally (e.g., initial values):
 
 ```tsx
 // @bf-ignore props-destructuring
@@ -59,18 +59,9 @@ function Counter({ initial }: { initial: number }) {
 ```
 
 
-## When Destructuring Is Fine
+## When Destructuring Is Safe
 
-Destructuring is safe when you use the value as an **initial value** for local state:
-
-```tsx
-function Counter({ initial }: { initial: number }) {
-  const [count, setCount] = createSignal(initial) // OK — initial value only
-  return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
-}
-```
-
-It is also safe for values that never change, such as an `id` or a static label.
+Destructuring is safe for **initial values** of local state and for values that never change (`id`, static labels).
 
 
 ## Summary
@@ -84,7 +75,7 @@ It is also safe for values that never change, such as an `id` or a static label.
 
 ## How It Works
 
-When a parent passes a dynamic expression, the compiler transforms it into a getter on the props object:
+The compiler transforms dynamic prop expressions into getters:
 
 ```tsx
 // Parent
@@ -94,7 +85,7 @@ When a parent passes a dynamic expression, the compiler transforms it into a get
 { get value() { return count() } }
 ```
 
-- `props.value` → calls the getter → calls `count()` → dependency is tracked
-- `const { value } = props` → calls the getter once → stores the number → no further tracking
+- `props.value` → calls getter → calls `count()` → dependency tracked
+- `const { value } = props` → calls getter once → stores the number → no further tracking
 
-This is the same model as SolidJS. If you are coming from React, where destructuring props is idiomatic and safe, this is the most important behavioral difference to be aware of.
+This is the same model as SolidJS. If you are coming from React, this is the key behavioral difference.

--- a/docs/core/reactivity/untrack.md
+++ b/docs/core/reactivity/untrack.md
@@ -5,7 +5,7 @@ description: Executes a function without tracking signal dependencies in the cur
 
 # untrack
 
-Executes a function without tracking signal dependencies. Signal reads inside the function do not register the current effect as a subscriber.
+Executes a function without tracking signal dependencies.
 
 ```tsx
 import { untrack } from '@barefootjs/client'
@@ -37,7 +37,7 @@ setName('Bob') // Effect does NOT re-run
 
 ## When to Use
 
-### Reading a value without subscribing
+### Read without subscribing
 
 ```tsx
 createEffect(() => {
@@ -47,7 +47,7 @@ createEffect(() => {
 })
 ```
 
-### Logging without creating dependencies
+### Log without dependencies
 
 ```tsx
 createEffect(() => {
@@ -56,9 +56,9 @@ createEffect(() => {
 })
 ```
 
-### Breaking circular patterns
+### Break circular dependencies
 
-If two signals depend on each other through effects, `untrack` can break the cycle by reading one without subscribing:
+`untrack` breaks cycles where two signals depend on each other through effects:
 
 ```tsx
 createEffect(() => {

--- a/docs/core/rendering.md
+++ b/docs/core/rendering.md
@@ -5,8 +5,6 @@ description: BarefootJS-specific JSX behavior covering compatibility, fragments,
 
 # Templates & Rendering
 
-This section covers BarefootJS-specific JSX behavior. Standard JSX knowledge is assumed.
-
 ## Pages
 
 | Topic | Description |

--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -5,7 +5,7 @@ description: Mark JSX expressions for client-only evaluation when the compiler c
 
 # /* @client */ Directive
 
-The `/* @client */` comment directive marks a JSX expression for **client-only evaluation**. The server renders a placeholder; the browser evaluates the expression at runtime.
+Marks a JSX expression for **client-only evaluation**. The server renders a placeholder; the browser evaluates the expression at runtime.
 
 ```tsx
 {/* @client */ expression}
@@ -14,7 +14,7 @@ The `/* @client */` comment directive marks a JSX expression for **client-only e
 
 ## When to Use
 
-When the compiler encounters an expression it cannot translate to a marked template, it emits a **compile error** (`BF021`). Adding `/* @client */` resolves the error by explicitly opting into client-only evaluation.
+The compiler emits `BF021` for expressions it cannot translate to a marked template. `/* @client */` resolves the error by opting into client-only evaluation.
 
 ```
 error[BF021]: Expression cannot be compiled to marked template
@@ -32,7 +32,7 @@ See [JSX Compatibility — Limitations](./jsx-compatibility.md#limitations) for 
 
 ## How It Works
 
-With `/* @client */`, the compiler skips marked template generation for the expression. The server outputs a comment marker and the client JS evaluates the expression entirely:
+The compiler skips template generation for the expression. The server outputs a comment marker; the client JS evaluates it:
 
 **Server output:**
 
@@ -51,8 +51,6 @@ insert(scope, 'slot_5', () => todos().filter(t => !t.done).length)
 ## Examples
 
 ### Unsupported patterns
-
-Patterns that the compiler cannot translate to marked templates require `/* @client */`:
 
 ```tsx
 // Nested higher-order methods
@@ -79,4 +77,4 @@ Compare with the [TodoAppSSR version](https://github.com/barefootjs/barefootjs/b
 
 ## Trade-off
 
-`/* @client */` means the expression has **no server-rendered content** — the user sees the placeholder until client JS loads and evaluates. Use it only when the compiler cannot generate a marked template equivalent. For expressions that the compiler can handle, omit the directive to get server-rendered initial values.
+`/* @client */` means **no server-rendered content** for the expression — users see a placeholder until client JS loads. Omit the directive when the compiler can generate a template equivalent to get server-rendered initial values.

--- a/docs/core/rendering/fragment.md
+++ b/docs/core/rendering/fragment.md
@@ -29,9 +29,7 @@ No extra hydration markers are generated for transparent fragments.
 
 ## Fragments and Hydration
 
-Fragments don't produce a DOM node, so the compiler handles hydration differently from regular elements.
-
-For conditional fragments, the compiler uses HTML comment markers as boundaries:
+Fragments don't produce a DOM node. For conditional fragments, the compiler uses HTML comment markers as boundaries:
 
 ```html
 <!--bf-cond-start:slot_0-->

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -5,12 +5,10 @@ description: Standard JSX syntax support in BarefootJS, including control flow a
 
 # JSX Compatibility
 
-BarefootJS uses standard JSX syntax. If you have written React or SolidJS components, most patterns work as you expect.
+Standard JSX syntax works. This page covers BarefootJS-specific behavior and limitations.
 
 
 ## Control Flow
-
-Standard JavaScript control flow in JSX works:
 
 ```tsx
 // Ternary
@@ -29,15 +27,13 @@ return <div>...</div>
 
 ## List Rendering
 
-`.map()` renders lists:
-
 ```tsx
 {todos().map(todo => (
   <TodoItem key={todo.id} todo={todo} />
 ))}
 ```
 
-`.filter().map()` chains work when the predicate uses supported expressions — simple single expressions and block bodies with variable declarations, `if`/`return` statements:
+`.filter().map()` chains work when the predicate uses simple expressions or block bodies with `if`/`return`:
 
 ```tsx
 // ✅ Simple predicate
@@ -75,8 +71,6 @@ Some comparators (e.g., `localeCompare`, block bodies) are not supported and wil
 
 ## Event Handling
 
-`on*` attributes bind event handlers. The handler receives the native DOM event:
-
 ```tsx
 <button onClick={() => setCount(n => n + 1)}>+1</button>
 <input onInput={(e) => setText((e.target as HTMLInputElement).value)} />
@@ -85,8 +79,6 @@ Some comparators (e.g., `localeCompare`, block bodies) are not supported and wil
 
 
 ## Dynamic Attributes
-
-Expressions in attributes are reactive:
 
 ```tsx
 <button disabled={!accepted()}>Submit</button>
@@ -97,13 +89,11 @@ Expressions in attributes are reactive:
 
 ## Limitations
 
-BarefootJS compiles JSX into marked templates (Go `html/template`, Hono JSX, etc.) **and** client JS. Some JavaScript expressions cannot be translated into marked template syntax.
-
-When the compiler encounters an unsupported expression, it emits a **compile error** (`BF021`). Add [`/* @client */`](./client-directive.md) to explicitly opt into client-only evaluation for these expressions.
+Some JavaScript expressions cannot be translated into marked template syntax. The compiler emits `BF021` for these. Add [`/* @client */`](./client-directive.md) to opt into client-only evaluation.
 
 ### Unsupported patterns
 
-**Nested higher-order methods** — a higher-order method inside a predicate of another:
+**Nested higher-order methods:**
 
 ```tsx
 // ❌ Compile error (BF021)
@@ -113,7 +103,7 @@ When the compiler encounters an unsupported expression, it emits a **compile err
 {/* @client */ items().filter(x => x.tags().filter(t => t.active).length > 0)}
 ```
 
-**Unsupported array methods** — `.reduce()`, `.forEach()`, `.flatMap()` and others cannot be translated to marked template syntax:
+**Unsupported array methods** (`.reduce()`, `.forEach()`, `.flatMap()`):
 
 ```tsx
 // ❌ Compile error (BF021)
@@ -123,7 +113,7 @@ When the compiler encounters an unsupported expression, it emits a **compile err
 {/* @client */ items().reduce((sum, x) => sum + x.price, 0)}
 ```
 
-**Destructuring in predicate parameters** — the compiler requires a single named parameter:
+**Destructuring in predicate parameters:**
 
 ```tsx
 // ❌ Compile error (BF021)
@@ -133,7 +123,7 @@ When the compiler encounters an unsupported expression, it emits a **compile err
 {items().filter(t => t.done).map(...)}
 ```
 
-**Function expressions** — `function` keyword syntax is not supported:
+**Function expressions** (`function` keyword):
 
 ```tsx
 // ❌ Compile error (BF021)
@@ -143,7 +133,7 @@ When the compiler encounters an unsupported expression, it emits a **compile err
 {items().filter(x => x.done)}
 ```
 
-**Unsupported sort comparators** — `localeCompare` and block body comparators cannot be compiled:
+**Unsupported sort comparators** (`localeCompare`, block bodies):
 
 ```tsx
 // ❌ Compile error (BF021)


### PR DESCRIPTION
Remove redundant expressions, filler sentences, and duplicate explanations
across all 34 documentation files. Key changes:

- Merge overlapping "Why BarefootJS?" / "Design Philosophy" / "Who is it for?"
  sections in introduction.md into a single "Design Principles" section
- Remove "This section covers..." filler intros from index pages
- Trim verbose phrasing while preserving all technical information
- Use action-oriented headings ("Why Layers?" instead of "The Problem" / "The Solution")
- Remove duplicate composition rules (kept in both use-client.md and component-authoring.md)
- Fix incorrect package name in reactivity.md (client-runtime → client)

Net result: -231 lines removed with no information loss.

Co-authored-by: kobaken <kentafly88@gmail.com>