### PR TITLE
Update docs/core examples to match current compiler output

### DIFF
--- a/docs/core/adapters/adapter-architecture.md
+++ b/docs/core/adapters/adapter-architecture.md
@@ -136,7 +136,7 @@ An HTML element with attributes, events, and children.
   attrs: IRAttribute[]     // Static and dynamic attributes
   events: IREvent[]        // Event handlers (onClick, onChange, etc.)
   children: IRNode[]       // Child nodes
-  slotId: string | null    // Hydration slot ID (e.g., 'slot_0')
+  slotId: string | null    // Hydration slot ID (e.g., 's0')
   needsScope: boolean      // True if this is the component root
 }
 ```
@@ -220,8 +220,8 @@ A nested component invocation.
 | Marker | Example | Purpose |
 |--------|---------|---------|
 | `bf-s` | `<div bf-s="Counter_a1b2">` | Component boundary — scopes all queries inside |
-| `bf` | `<p bf="slot_0">` | Interactive element — target for effects and event handlers |
-| `bf-c` | `<div bf-c="slot_2">` | Conditional block — target for DOM switching |
+| `bf` | `<p bf="s0">` | Interactive element — target for effects and event handlers |
+| `bf-c` | `<div bf-c="s2">` | Conditional block — target for DOM switching |
 
 
 

--- a/docs/core/adapters/custom-adapter.md
+++ b/docs/core/adapters/custom-adapter.md
@@ -314,15 +314,14 @@ const adapter = new TestAdapter()
 const output = adapter.generate(ir)
 
 console.log(output.template)
-// export function Counter({ initial = 0, __instanceId, __bfScope }: CounterPropsWithHydration) {
+// export function Counter({ __instanceId, ... }) {
 //   const __scopeId = ...
-//   const count = () => initial
-//   const setCount = () => {}
+//   const count = () => 0
 //
 //   return (
 //     <div bf-s={__scopeId}>
-//       <span bf="slot_0">{count()}</span>
-//       <button bf="slot_1" onClick={() => {}}>+1</button>
+//       <span bf="s1">Count: {bfText("s0")}{count()}{bfTextEnd()}</span>
+//       <button bf="s2" onClick={() => {}}>+1</button>
 //     </div>
 //   )
 // }

--- a/docs/core/adapters/go-template-adapter.md
+++ b/docs/core/adapters/go-template-adapter.md
@@ -47,8 +47,8 @@ const adapter = new GoTemplateAdapter({
 **Source:**
 
 ```tsx
-export function Greeting({ name }: { name: string }) {
-  return <h1>Hello, {name}</h1>
+export function Greeting(props: { name: string }) {
+  return <p>Hello, {props.name}!</p>
 }
 ```
 
@@ -56,29 +56,15 @@ export function Greeting({ name }: { name: string }) {
 
 ```go-template
 {{define "Greeting"}}
-<h1>Hello, {{.Name}}</h1>
+<p bf-s="{{bfScopeAttr .}}" {{bfPropsAttr .}} bf="s1">
+  Hello, {{bfTextStart "s0"}}{{.Name}}{{bfTextEnd}}!
+</p>
 {{end}}
 ```
 
-**Output (_types.go):**
-
-```go
-package components
-
-type GreetingInput struct {
-    Name string `json:"name"`
-}
-
-type GreetingProps struct {
-    Name string `json:"name"`
-}
-
-func NewGreetingProps(input GreetingInput) GreetingProps {
-    return GreetingProps{
-        Name: input.Name,
-    }
-}
-```
+- `bfScopeAttr` — generates the `bf-s` scope ID
+- `bfPropsAttr` — serializes props for client hydration
+- `bfTextStart` / `bfTextEnd` — text node markers (rendered as `<!--bf:s0-->...<!--/-->`)
 
 ### Client Component
 
@@ -88,12 +74,12 @@ func NewGreetingProps(input GreetingInput) GreetingProps {
 "use client"
 import { createSignal } from '@barefootjs/client'
 
-export function Counter({ initial = 0 }: { initial?: number }) {
-  const [count, setCount] = createSignal(initial)
+export function Counter(props: { initial?: number }) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
 
   return (
     <div>
-      <p>{count()}</p>
+      <span>Count: {count()}</span>
       <button onClick={() => setCount(n => n + 1)}>+1</button>
     </div>
   )
@@ -104,10 +90,10 @@ export function Counter({ initial = 0 }: { initial?: number }) {
 
 ```go-template
 {{define "Counter"}}
-{{template "bf_register_script" "Counter"}}
+{{if .Scripts}}{{.Scripts.Register "/static/client/barefoot.js"}}{{.Scripts.Register "/static/client/Counter.client.js"}}{{end}}
 <div bf-s="{{bfScopeAttr .}}" {{bfPropsAttr .}}>
-  <p bf="slot_0">{{.Initial}}</p>
-  <button bf="slot_1">+1</button>
+  <span bf="s1">Count: {{bfTextStart "s0"}}{{.Count}}{{bfTextEnd}}</span>
+  <button bf="s2">+1</button>
 </div>
 {{end}}
 ```
@@ -158,25 +144,25 @@ Field names are automatically capitalized to follow Go conventions.
 ### `.map()`
 
 ```tsx
-{items.map(item => <li>{item.name}</li>)}
+{items().map(item => <li>{item}</li>)}
 ```
 
 ```go-template
-{{range .Items}}
-<li>{{.Name}}</li>
+{{range $_, $item := .Items}}
+<li>{{bfTextStart "s0"}}{{.Item}}{{bfTextEnd}}</li>
 {{end}}
 ```
 
 ### `.filter().map()`
 
 ```tsx
-{items.filter(t => t.completed).map(t => <li>{t.name}</li>)}
+{items().filter(item => item.active).map(item => <li>{item.name}</li>)}
 ```
 
 ```go-template
-{{range bf_filter .Items "Completed" true}}
-<li>{{.Name}}</li>
-{{end}}
+{{range $_, $item := .Items}}{{if .Active}}
+<li>{{bfTextStart "s0"}}{{.Item.Name}}{{bfTextEnd}}</li>
+{{end}}{{end}}
 ```
 
 For complex filter predicates, the adapter generates template block functions.
@@ -189,7 +175,7 @@ For complex filter predicates, the adapter generates template block functions.
 
 ```go-template
 {{range bf_sort .Items "Priority" "asc"}}
-<li>{{.Name}}</li>
+<li>{{bfTextStart "s0"}}{{.Name}}{{bfTextEnd}}</li>
 {{end}}
 ```
 
@@ -242,22 +228,24 @@ Ternaries become `{{if}}...{{else}}...{{end}}`:
 **Source:**
 
 ```tsx
-{isActive ? <span>Active</span> : <span>Inactive</span>}
+{loggedIn() ? <span>Welcome back!</span> : <span>Please log in</span>}
 ```
 
 **Output:**
 
 ```go-template
-{{if .IsActive}}<span>Active</span>{{else}}<span>Inactive</span>{{end}}
+{{if .LoggedIn}}<span bf-c="s0">Welcome back!</span>{{else}}<span bf-c="s0">Please log in</span>{{end}}
 ```
+
+Element branches use `bf-c` for conditional markers. Text-only ternaries use `bfComment` markers instead.
 
 
 ## Script Registration
 
-Each client component registers its script:
+Client components register their scripts via the `.Scripts` interface:
 
 ```go-template
-{{template "bf_register_script" "Counter"}}
+{{if .Scripts}}{{.Scripts.Register "/static/client/barefoot.js"}}{{.Scripts.Register "/static/client/Counter.client.js"}}{{end}}
 ```
 
 The `ScriptCollector` tracks needed scripts and renders `<script>` tags at page end. Each script loads at most once.

--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -47,21 +47,30 @@ const adapter = new HonoAdapter({
 
 ### Server Component
 
-Without `"use client"`, no hydration markers or client JS:
+Without `"use client"`, the template is generated with props access and hydration markers (for potential parent hydration), but no client JS:
 
 **Source:**
 
 ```tsx
-export function Greeting({ name }: { name: string }) {
-  return <h1>Hello, {name}</h1>
+export function Greeting(props: { name: string }) {
+  return <h1>Hello, {props.name}!</h1>
 }
 ```
 
 **Output (.hono.tsx):**
 
 ```tsx
-export function Greeting({ name }: { name: string }) {
-  return <h1>Hello, {name}</h1>
+import { bfText, bfTextEnd } from '@barefootjs/hono/utils'
+
+export function Greeting(__allProps: { name: string } & { __instanceId?: string; ... }) {
+  const { __instanceId, ..., ...props } = __allProps
+  const __scopeId = __instanceId || `Greeting_${...}`
+
+  return (
+    <h1 bf-s={...} bf="s1">
+      Hello, {bfText("s0")}{props.name}{bfTextEnd()}!
+    </h1>
+  )
 }
 ```
 
@@ -73,12 +82,12 @@ export function Greeting({ name }: { name: string }) {
 "use client"
 import { createSignal } from '@barefootjs/client'
 
-export function Counter({ initial = 0 }: { initial?: number }) {
-  const [count, setCount] = createSignal(initial)
+export function Counter(props: { initial?: number }) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
 
   return (
     <div>
-      <p>{count()}</p>
+      <span>Count: {count()}</span>
       <button onClick={() => setCount(n => n + 1)}>+1</button>
     </div>
   )
@@ -88,25 +97,28 @@ export function Counter({ initial = 0 }: { initial?: number }) {
 **Output (.hono.tsx):**
 
 ```tsx
-export function Counter({ initial = 0, __instanceId, __bfScope }: CounterPropsWithHydration) {
+import { bfText, bfTextEnd } from '@barefootjs/hono/utils'
+
+export function Counter(__allProps: { initial?: number } & { __instanceId?: string; ... }) {
+  const { __instanceId, ..., ...props } = __allProps
   const __scopeId = __instanceId || `Counter_${Math.random().toString(36).slice(2, 8)}`
-  const count = () => initial ?? 0
-  const setCount = () => {}
+  const count = () => props.initial ?? 0    // signal → server-side stub
 
   return (
-    <div bf-s={__scopeId} {...(__bfPropsJson ? { "bf-p": __bfPropsJson } : {})}>
-      <p bf="slot_0">{count()}</p>
-      <button bf="slot_1">+1</button>
+    <div bf-s={...} {...(... ? { "bf-p": __bfPropsJson } : {})}>
+      <span bf="s1">Count: {bfText("s0")}{count()}{bfTextEnd()}</span>
+      <button onClick={() => {}} bf="s2">+1</button>
     </div>
   )
 }
 ```
 
-- `bf-s` — component boundary
-- `bf="slot_N"` — client JS targets
-- Signal stubs (`count = () => initial ?? 0`) — render initial values server-side
-- `bf-p` — serialized props for client hydration
-- Event handlers are removed (client JS only)
+- `bf-s` — component scope boundary (unique per instance)
+- `bf="sN"` — client JS targets (elements, text nodes)
+- `bfText("s0")` / `bfTextEnd()` — text node markers (rendered as `<!--bf:s0-->...<!--/-->`)
+- Signal stubs (`count = () => props.initial ?? 0`) — render initial values server-side
+- `bf-p` — serialized props JSON for client hydration
+- Event handlers are replaced with no-ops (client JS handles the real ones)
 
 
 ## Script Collection
@@ -147,18 +159,27 @@ These are used internally — no manual passing needed.
 
 ## Conditional Rendering
 
-Ternaries compile with `bf-c` markers:
+Ternaries with element branches use `bf-c` markers. Text-only ternaries use comment markers:
 
-**Source:**
+**Element branches:**
 
 ```tsx
-{isActive() ? <span>Active</span> : <span>Inactive</span>}
+{loggedIn() ? <span>Welcome back!</span> : <span>Please log in</span>}
 ```
 
-**Output:**
+```tsx
+{loggedIn() ? <span bf-c="s0">Welcome back!</span> : <span bf-c="s0">Please log in</span>}
+```
+
+**Text-only branches:**
 
 ```tsx
-{isActive() ? <span bf-c="slot_2">Active</span> : <span bf-c="slot_2">Inactive</span>}
+{on() ? 'ON' : 'OFF'}
+```
+
+```tsx
+{on() ? <>{bfComment("cond-start:s0")}{'ON'}{bfComment("cond-end:s0")}</>
+      : <>{bfComment("cond-start:s0")}{'OFF'}{bfComment("cond-end:s0")}</>}
 ```
 
 ## Loop Rendering
@@ -166,13 +187,13 @@ Ternaries compile with `bf-c` markers:
 **Source:**
 
 ```tsx
-{items().map(item => <li>{item.name}</li>)}
+{items().map(item => <li>{item}</li>)}
 ```
 
 **Output:**
 
 ```tsx
-{items().map(item => <li>{item.name}</li>)}
+{bfComment('loop')}{items().map((item) => <li>{bfText("s0")}{item}{bfTextEnd()}</li>)}{bfComment('/loop')}
 ```
 
-For child components in loops, the adapter generates unique instance IDs per iteration using the loop index or `key`.
+Loop markers (`<!--bf-loop-->...<!--bf-/loop-->`) are used for reconciliation. For child components in loops, the adapter generates unique instance IDs per iteration using the loop index or `key`.

--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -187,7 +187,7 @@ A sync effect is generated:
 
 ```javascript
 createEffect(() => {
-  const __val = props.checked
+  const __val = _p.checked
   if (__val !== undefined) setChecked(__val)
 })
 ```
@@ -195,64 +195,59 @@ createEffect(() => {
 ### 4. Code Generation Order
 
 ```javascript
-import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
+import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client-runtime'
 
-export function initCounter(__scope, props = {}) {
+export function initCounter(__scope, _p = {}) {
   if (!__scope) return
 
-  // 1. Props extraction (with defaults)
-  const label = props.label ?? 'Click'
-
-  // 2. Early constants (no reactive deps)
+  // 1. Early constants (no reactive deps)
   const baseClass = 'counter'
 
-  // 3. Local functions / handlers (before signals so signal initializers
-  //    can reference them, e.g., createSignal(toArray(props.x)))
+  // 2. Local functions / handlers (before signals so signal initializers
+  //    can reference them, e.g., createSignal(toArray(_p.x)))
   const handleClick = () => { setCount(n => n + 1) }
 
-  // 4. Signals, memos, controlled signal sync, and late constants
-  const [count, setCount] = createSignal(props.initial ?? 0)
+  // 3. Signals, memos, controlled signal sync, and late constants
+  const [count, setCount] = createSignal(_p.initial ?? 0)
   createEffect(() => {                          // controlled signal sync
-    const __val = props.initial
+    const __val = _p.initial
     if (__val !== undefined) setCount(__val)
   })
   const doubled = createMemo(() => count() * 2)
-  const displayValue = `Count: ${count()}`      // late constant (reactive deps)
 
-  // 5. Element references (always destructured, always returns array)
-  //    $()  — regular elements:  find(scope, '[bf="id"]')
+  // 4. Element references (always destructured, always returns array)
+  //    $()  — regular elements:  querySelector('[bf="id"]') within scope
   //    $t() — text nodes:        find comment marker <!--bf:id-->
-  //    $c() — child components:  find(scope, '[bf-s$="_id"]')
   const [_s3] = $(__scope, 's3')
   const [_s0, _s2] = $t(__scope, 's0', 's2')
 
-  // 6. Dynamic text updates
+  // 5. Dynamic text updates
   createEffect(() => {
     const __val = count()
-    if (_s0) _s0.nodeValue = String(__val)
+    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
   })
 
-  // 7. Reactive attribute updates
+  // 6. Reactive attribute updates
   createEffect(() => {
     if (_s3) { _s3.disabled = !!(count() > 10) }
   })
 
-  // 8. Conditional updates
-  // insert(_s4, () => isOpen() ? panelHtml : null)
+  // 7. Conditional updates (insert with comment markers)
+  // insert(__scope, 's4', () => isOpen(), trueBranch, falseBranch)
 
-  // 9. Loop updates
-  // reconcileElements(_s5, items(), getKey, renderItem)
+  // 8. Loop updates (mapArray with reconciliation)
+  // mapArray(() => items(), _s5, null, (item, idx, existing) => { ... })
 
-  // 10. Event handlers
-  if (_s3) _s3.onclick = handleClick
+  // 9. Event handlers
+  if (_s3) _s3.addEventListener('click', handleClick)
 
-  // 11. Reactive prop bindings / child component props
-  // 12. Ref callbacks
-  // 13. User-defined effects and onMounts
+  // 10. Reactive prop bindings / child component props
+  // 11. Ref callbacks
+  // 12. User-defined effects and onMounts
   createEffect(() => { console.log('Count changed:', count()) })
   onMount(() => { console.log('Mounted') })
 
-  // 14. Provider setup and child component initialization
+  // 13. Provider setup and child component initialization
 }
 
 // Registration: hydrate() registers the component and initializes all
@@ -260,7 +255,10 @@ export function initCounter(__scope, props = {}) {
 // 1. Static template (no signal deps) → always included
 // 2. CSR fallback template → only when used as a child component
 // Top-level-only components with signals skip template to save bytes.
-hydrate('Counter', { init: initCounter })
+hydrate('Counter', {
+  init: initCounter,
+  template: (_p) => `<div><p bf="s1">Count: <!--bf:s0-->${(0)}<!--/--></p>...</div>`
+})
 ```
 
 ### 5. Import Detection
@@ -268,7 +266,7 @@ hydrate('Counter', { init: initCounter })
 Only used imports are included:
 
 ```javascript
-import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client'
+import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from '@barefootjs/client-runtime'
 ```
 
 ### 6. Template Registration
@@ -278,7 +276,7 @@ import { $, $t, createEffect, createMemo, createSignal, hydrate, onMount } from 
 ```javascript
 hydrate('Button', {
   init: initButton,
-  template: (props) => `<button class="${props.className ?? ''}" bf="s0">${props.children}</button>`
+  template: (_p) => `<button ${(_p.className ?? '') != null ? 'class="' + (_p.className ?? '') + '"' : ''} bf="s0">${_p.children}</button>`
 })
 ```
 
@@ -288,7 +286,7 @@ hydrate('Button', {
 // StatusBadge is used by Dashboard in the same file → gets CSR fallback
 hydrate('StatusBadge', {
   init: initStatusBadge,
-  template: (props) => `<span bf="s0">${props.active ? 'on' : 'off'}</span>`
+  template: (_p) => `<span bf="s0">${_p.active ? 'on' : 'off'}</span>`
 })
 
 // Dashboard is top-level only → no template (saves bytes)

--- a/docs/core/components/component-authoring.md
+++ b/docs/core/components/component-authoring.md
@@ -29,14 +29,13 @@ Client components use reactive primitives and ship JavaScript to the browser. Th
 "use client"
 import { createSignal } from '@barefootjs/client'
 
-export function Counter({ initial = 0 }) {
-  const [count, setCount] = createSignal(initial)
+export function Counter() {
+  const [count, setCount] = createSignal(0)
 
   return (
-    <div>
-      <p>{count()}</p>
-      <button onClick={() => setCount(n => n + 1)}>+1</button>
-    </div>
+    <button onClick={() => setCount(n => n + 1)}>
+      Count: {count()}
+    </button>
   )
 }
 ```
@@ -84,22 +83,26 @@ export function Toggle() {
   const [on, setOn] = createSignal(false)
 
   return (
-    <button onClick={() => setOn(v => !v)}>
+    <button onClick={() => setOn(prev => !prev)}>
       {on() ? 'ON' : 'OFF'}
     </button>
   )
 }
 ```
 
-**Marked template (Hono):**
+**Marked template:**
 
 <!-- tabs:adapter -->
 <!-- tab:Hono -->
 ```tsx
-export function Toggle() {
+export function Toggle({ __instanceId, ... }) {
+  const __scopeId = __instanceId || `Toggle_${...}`
+  const on = () => false
+
   return (
-    <button bf-s="Toggle" bf="slot_0">
-      OFF
+    <button bf-s={__scopeId} bf="s1">
+      {on() ? <>{bfComment("cond-start:s0")}{'ON'}{bfComment("cond-end:s0")}</>
+            : <>{bfComment("cond-start:s0")}{'OFF'}{bfComment("cond-end:s0")}</>}
     </button>
   )
 }
@@ -107,8 +110,9 @@ export function Toggle() {
 <!-- tab:Go Template -->
 ```go-template
 {{define "Toggle"}}
-<button bf-s="{{.ScopeID}}" bf="slot_0">
-  OFF
+<button bf-s="{{bfScopeAttr .}}" bf="s1">
+  {{if .On}}{{bfComment "cond-start:s0"}}{{"ON"}}{{bfComment "cond-end:s0"}}
+  {{else}}{{bfComment "cond-start:s0"}}{{"OFF"}}{{bfComment "cond-end:s0"}}{{end}}
 </button>
 {{end}}
 ```
@@ -117,24 +121,30 @@ export function Toggle() {
 **Client JS:**
 
 ```js
-import { createSignal, createEffect, $, hydrate } from '@barefootjs/client'
+import { $, createSignal, hydrate, insert } from '@barefootjs/client-runtime'
 
-export function initToggle(__scope, props = {}) {
+export function initToggle(__scope, _p = {}) {
+  if (!__scope) return
+
   const [on, setOn] = createSignal(false)
 
-  const _s0 = $(__scope, 's0')
+  const [_s1, _s0] = $(__scope, 's1', 's0')
 
-  createEffect(() => {
-    if (_s0) _s0.textContent = on() ? 'ON' : 'OFF'
+  insert(__scope, 's0', () => on(), {
+    template: () => `<!--bf-cond-start:s0-->ON<!--bf-cond-end:s0-->`,
+    bindEvents: (__branchScope) => {}
+  }, {
+    template: () => `<!--bf-cond-start:s0-->OFF<!--bf-cond-end:s0-->`,
+    bindEvents: (__branchScope) => {}
   })
 
-  if (_s0) _s0.onclick = () => setOn(v => !v)
+  if (_s1) _s1.addEventListener('click', () => { setOn(prev => !prev) })
 }
 
-hydrate('Toggle', { init: initToggle })
+hydrate('Toggle', { init: initToggle, template: ... })
 ```
 
-Only the text node bound to `on()` updates when the signal changes.
+Only the conditional branch bound to `on()` updates when the signal changes. The `insert()` function handles DOM swapping using comment markers as boundaries.
 
 
 ## Composition Rules

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -8,7 +8,7 @@ description: Share state with deeply nested children without prop drilling using
 Context shares state with deeply nested children without prop drilling. It is the foundation of compound components (Dialog, Accordion, Tabs).
 
 ```tsx
-import { createContext, useContext } from '@barefootjs/client'
+import { createContext, useContext } from '@barefootjs/client-runtime'
 ```
 
 
@@ -63,7 +63,7 @@ const value = useContext(MyContext)
 
 ```tsx
 "use client"
-import { createContext, useContext } from '@barefootjs/client'
+import { createContext, useContext } from '@barefootjs/client-runtime'
 
 // 1. Create the context
 const ThemeContext = createContext<'light' | 'dark'>('light')
@@ -104,7 +104,7 @@ A group of related components sharing internal state. The root provides state; s
 
 ```tsx
 "use client"
-import { createSignal, createContext, useContext, createEffect } from '@barefootjs/client'
+import { createSignal, createContext, useContext, createEffect } from '@barefootjs/client-runtime'
 
 // Context type
 interface AccordionContextValue {

--- a/docs/core/components/portals.md
+++ b/docs/core/components/portals.md
@@ -8,7 +8,7 @@ description: Render elements outside their parent DOM hierarchy for overlays, mo
 Portals render elements outside their parent DOM hierarchy — useful for overlays, modals, and tooltips that need to escape `overflow: hidden` or `z-index` stacking contexts.
 
 ```tsx
-import { createPortal } from '@barefootjs/client'
+import { createPortal } from '@barefootjs/client-runtime'
 ```
 
 
@@ -50,7 +50,7 @@ Create portals inside `ref` callbacks:
 
 ```tsx
 "use client"
-import { createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/client'
+import { createSignal, createEffect, createPortal, isSSRPortal } from '@barefootjs/client-runtime'
 
 export function Tooltip(props: { text: string; children?: Child }) {
   const [visible, setVisible] = createSignal(false)
@@ -89,7 +89,7 @@ export function Tooltip(props: { text: string; children?: Child }) {
 `isSSRPortal` checks whether an element was already portaled during SSR to prevent double-portaling:
 
 ```tsx
-import { isSSRPortal } from '@barefootjs/client'
+import { isSSRPortal } from '@barefootjs/client-runtime'
 
 const handleMount = (el: HTMLElement) => {
   // Skip if already portaled during SSR
@@ -102,7 +102,7 @@ const handleMount = (el: HTMLElement) => {
 After hydration, remove SSR placeholders:
 
 ```tsx
-import { cleanupPortalPlaceholder } from '@barefootjs/client'
+import { cleanupPortalPlaceholder } from '@barefootjs/client-runtime'
 
 cleanupPortalPlaceholder(portalId)
 ```
@@ -128,7 +128,7 @@ Dialog overlays are a common portal use case:
 
 ```tsx
 "use client"
-import { createPortal, isSSRPortal, useContext, createEffect } from '@barefootjs/client'
+import { createPortal, isSSRPortal, useContext, createEffect } from '@barefootjs/client-runtime'
 
 function DialogOverlay() {
   const handleMount = (el: HTMLElement) => {
@@ -165,7 +165,7 @@ The overlay accesses `DialogContext` from the component tree but is moved to `do
 Combine `portal.unmount()` with `onCleanup`:
 
 ```tsx
-import { createPortal, onCleanup } from '@barefootjs/client'
+import { createPortal, onCleanup } from '@barefootjs/client-runtime'
 
 const handleMount = (el: HTMLElement) => {
   const portal = createPortal(el, document.body)

--- a/docs/core/core-concepts/compilation.md
+++ b/docs/core/core-concepts/compilation.md
@@ -31,44 +31,44 @@ Given this source:
 "use client"
 import { createSignal } from '@barefootjs/client'
 
-export function Counter({ initial = 0 }) {
-  const [count, setCount] = createSignal(initial)
+export function Counter() {
+  const [count, setCount] = createSignal(0)
 
   return (
-    <div>
-      <p>{count()}</p>
-      <button onClick={() => setCount(n => n + 1)}>+1</button>
-    </div>
+    <button onClick={() => setCount(n => n + 1)}>
+      Count: {count()}
+    </button>
   )
 }
 ```
 
 Phase 1 produces an IR that records:
-- A signal `count` with setter `setCount` and initial value `initial`
-- A reactive expression `count()` at `slot_0`
-- A click handler on the button at `slot_1`
+- A signal `count` with setter `setCount` and initial value `0`
+- A reactive text expression `count()` → slot `s0`
+- A click handler on the button → slot `s1`
 
 Phase 2a produces a marked template:
 
 <!-- tabs:adapter -->
 <!-- tab:Hono -->
 ```tsx
-export function Counter(props) {
+export function Counter({ __instanceId, ... }) {
+  const __scopeId = __instanceId || `Counter_${Math.random().toString(36).slice(2, 8)}`
+  const count = () => 0   // server-side stub
+
   return (
-    <div bf-s="Counter">
-      <p bf="slot_0">{props.initial ?? 0}</p>
-      <button bf="slot_1">+1</button>
-    </div>
+    <button bf-s={__scopeId} bf="s1">
+      Count: {bfText("s0")}{count()}{bfTextEnd()}
+    </button>
   )
 }
 ```
 <!-- tab:Go Template -->
 ```go-template
 {{define "Counter"}}
-<div bf-s="{{.ScopeID}}">
-  <p bf="slot_0">{{.Initial}}</p>
-  <button bf="slot_1">+1</button>
-</div>
+<button bf-s="{{bfScopeAttr .}}" bf="s1">
+  Count: {{bfTextStart "s0"}}{{.Count}}{{bfTextEnd}}
+</button>
 {{end}}
 ```
 <!-- /tabs -->
@@ -76,22 +76,28 @@ export function Counter(props) {
 Phase 2b produces client JS:
 
 ```js
-import { createSignal, createEffect, find, hydrate } from '@barefootjs/client'
+import { $, $t, createEffect, createSignal, hydrate } from '@barefootjs/client-runtime'
 
-export function initCounter(__scope, props = {}) {
-  const [count, setCount] = createSignal(props.initial ?? 0)
+export function initCounter(__scope, _p = {}) {
+  if (!__scope) return
 
-  const _slot_0 = find(__scope, '[bf="slot_0"]')
-  const _slot_1 = find(__scope, '[bf="slot_1"]')
+  const [count, setCount] = createSignal(0)
+
+  const [_s1] = $(__scope, 's1')       // element lookup
+  const [_s0] = $t(__scope, 's0')      // text node lookup
 
   createEffect(() => {
-    if (_slot_0) _slot_0.textContent = String(count())
+    const __val = count()
+    if (_s0) _s0.nodeValue = String(__val ?? '')
   })
 
-  if (_slot_1) _slot_1.onclick = () => setCount(n => n + 1)
+  if (_s1) _s1.addEventListener('click', () => { setCount(n => n + 1) })
 }
 
-hydrate('Counter', { init: initCounter })
+hydrate('Counter', {
+  init: initCounter,
+  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${(0)}<!--/--></button>`
+})
 ```
 
 The server renders the HTML. The browser runs only the client JS to make it interactive.

--- a/docs/core/core-concepts/hydration.md
+++ b/docs/core/core-concepts/hydration.md
@@ -36,13 +36,13 @@ Server HTML (static)
     ↓
 Client JS loads
     ↓
-hydrate('Counter', { init: initCounter })
+hydrate('Counter', { init: initCounter, template: ... })
     ↓
-Find uninitialized <div bf-s="Counter_a1b2">
+Find uninitialized <... bf-s="Counter_a1b2">
     ↓
 Read props from bf-p attribute
     ↓
-Run init(): createSignal, createEffect, attach event handlers
+Run init(): createSignal, createEffect, addEventListener
     ↓
 Track scope as initialized (internal hydratedScopes Set)
     ↓
@@ -51,15 +51,15 @@ Page is interactive
 
 ## Scoped Queries
 
-`find()` searches within a scope boundary, excluding nested component scopes.
+`$()` and `$t()` search within a scope boundary, excluding nested component scopes.
 
 ```html
 <div bf-s="TodoApp_x1">        <!-- TodoApp scope -->
-  <h1 bf="slot_0">Todo</h1>        <!-- belongs to TodoApp -->
+  <h1 bf="s0">Todo</h1>            <!-- belongs to TodoApp -->
   <div bf-s="~TodoItem_y1">     <!-- TodoItem scope (~ = child, excluded from TodoApp queries) -->
-    <span bf="slot_0">Buy milk</span>
+    <span bf="s0">Buy milk</span>
   </div>
 </div>
 ```
 
-When TodoApp's init calls `find(scope, '[bf="slot_0"]')`, it finds the `<h1>`, not the `<span>` inside TodoItem.
+When TodoApp's init calls `$(__scope, 's0')`, it finds the `<h1>`, not the `<span>` inside TodoItem. The `~` prefix on `bf-s` marks a child component scope, which is excluded from parent queries.

--- a/docs/core/core-concepts/reactivity.md
+++ b/docs/core/core-concepts/reactivity.md
@@ -56,7 +56,7 @@ setCount(1)
     ↓
 Signal notifies subscribers
     ↓
-Effect re-runs: _slot_0.textContent = String(count())
+Effect re-runs: _s0.nodeValue = String(count())
     ↓
 Only <p> updates. The rest of the DOM is untouched.
 ```

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -15,14 +15,13 @@ Write familiar JSX with fine-grained reactivity — the compiler splits it into 
 "use client"
 import { createSignal } from '@barefootjs/client'
 
-export function Counter({ initial = 0 }) {
-  const [count, setCount] = createSignal(initial)
+export function Counter() {
+  const [count, setCount] = createSignal(0)
 
   return (
-    <div>
-      <p>{count()}</p>
-      <button onClick={() => setCount(n => n + 1)}>+1</button>
-    </div>
+    <button onClick={() => setCount(n => n + 1)}>
+      Count: {count()}
+    </button>
   )
 }
 ```
@@ -34,12 +33,14 @@ This single file compiles into two outputs:
 **Marked template** — Renders static HTML with hydration markers:
 
 ```tsx
-export function Counter(props) {
+export function Counter({ __instanceId, ... }) {
+  const __scopeId = __instanceId || `Counter_${Math.random().toString(36).slice(2, 8)}`
+  const count = () => 0
+
   return (
-    <div bf-s="Counter">
-      <p bf="slot_0">{props.initial ?? 0}</p>
-      <button bf="slot_1">+1</button>
-    </div>
+    <button bf-s={__scopeId} bf="s1">
+      Count: {bfText("s0")}{count()}{bfTextEnd()}
+    </button>
   )
 }
 ```
@@ -49,10 +50,9 @@ export function Counter(props) {
 
 ```go-template
 {{define "Counter"}}
-<div bf-s="{{.ScopeID}}">
-  <p bf="slot_0">{{.Initial}}</p>
-  <button bf="slot_1">+1</button>
-</div>
+<button bf-s="{{bfScopeAttr .}}" bf="s1">
+  Count: {{bfTextStart "s0"}}{{.Count}}{{bfTextEnd}}
+</button>
 {{end}}
 ```
 
@@ -61,22 +61,28 @@ export function Counter(props) {
 **Client script** — Wires up only the interactive parts:
 
 ```js
-import { createSignal, createEffect, find, hydrate } from '@barefootjs/client'
+import { $, $t, createEffect, createSignal, hydrate } from '@barefootjs/client-runtime'
 
-export function initCounter(__scope, props = {}) {
-  const [count, setCount] = createSignal(props.initial ?? 0)
+export function initCounter(__scope, _p = {}) {
+  if (!__scope) return
 
-  const _slot_0 = find(__scope, '[bf="slot_0"]')
-  const _slot_1 = find(__scope, '[bf="slot_1"]')
+  const [count, setCount] = createSignal(0)
+
+  const [_s1] = $(__scope, 's1')       // find element with bf="s1"
+  const [_s0] = $t(__scope, 's0')      // find text node at <!--bf:s0-->
 
   createEffect(() => {
-    if (_slot_0) _slot_0.textContent = String(count())
+    const __val = count()
+    if (_s0) _s0.nodeValue = String(__val ?? '')
   })
 
-  if (_slot_1) _slot_1.onclick = () => setCount(n => n + 1)
+  if (_s1) _s1.addEventListener('click', () => { setCount(n => n + 1) })
 }
 
-hydrate('Counter', { init: initCounter })
+hydrate('Counter', {
+  init: initCounter,
+  template: (_p) => `<button bf="s1"> Count: <!--bf:s0-->${(0)}<!--/--></button>`
+})
 ```
 
 No framework runtime. No virtual DOM. Just the minimum JavaScript needed for interactivity.

--- a/docs/core/reactivity/create-effect.md
+++ b/docs/core/reactivity/create-effect.md
@@ -111,10 +111,11 @@ The compiler generates effects for reactive attributes:
 
 ```tsx
 // Source
-<button disabled={!accepted()}>Submit</button>
+<button disabled={loading()}>Submit</button>
 
 // Generated client JS
+const [_s0] = $(__scope, 's0')
 createEffect(() => {
-  button.disabled = !accepted()
+  if (_s0) { _s0.disabled = !!(loading()) }
 })
 ```

--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -37,14 +37,16 @@ The compiler skips template generation for the expression. The server outputs a 
 **Server output:**
 
 ```html
-<!--bf-client:slot_5-->
+<!--bf-client:s2--><!--/-->
 ```
 
 **Client JS:**
 
 ```js
-// The expression is evaluated on the client and inserted into the DOM
-insert(scope, 'slot_5', () => todos().filter(t => !t.done).length)
+// @client: s2
+createEffect(() => {
+  updateClientMarker(__scope, 's2', todos().filter(t => !t.done).length)
+})
 ```
 
 

--- a/docs/core/rendering/fragment.md
+++ b/docs/core/rendering/fragment.md
@@ -32,10 +32,10 @@ No extra hydration markers are generated for transparent fragments.
 Fragments don't produce a DOM node. For conditional fragments, the compiler uses HTML comment markers as boundaries:
 
 ```html
-<!--bf-cond-start:slot_0-->
+<!--bf-cond-start:s0-->
 <h1>Title</h1>
 <p>Description</p>
-<!--bf-cond-end:slot_0-->
+<!--bf-cond-end:s0-->
 ```
 
 The client runtime uses these comment markers to locate and swap the fragment content when the condition changes.


### PR DESCRIPTION
Verified code examples against the actual compiler and fixed:
- Import path: @barefootjs/client → @barefootjs/client-runtime
- Slot IDs: slot_0/slot_1 → s0/s1/s2
- Element lookup API: find() → $() / $t()
- hydrate() signature: now includes template parameter
- Hono output: bfText/bfTextEnd markers, scope ID generation, __allProps pattern
- Go template: bfScopeAttr, bfTextStart/bfTextEnd, .Scripts.Register
- Comment markers: <!--bf:s0-->, <!--bf-cond-start:s0-->, <!--bf-loop-->
- Client JS: addEventListener, insert() for conditionals, mapArray() for loops

Co-authored-by: kobaken <kentafly88@gmail.com>

https://claude.ai/code/session_01QSocTg8EtQhBoFYJJxsHWq