### PR TITLE
Refine Design Principles and add reactivity benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,60 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/client/**'
+      - 'packages/client-runtime/**'
+      - 'benchmarks/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run benchmark
+        id: bench
+        run: |
+          {
+            echo 'result<<EOF'
+            bun run benchmarks/run-browser.ts --md 2>&1
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing benchmark comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## Benchmark Results'
+
+      - name: Post benchmark results
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            ## Benchmark Results
+
+            ${{ steps.bench.outputs.result }}
+
+            [Job log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · `${{ github.event.pull_request.head.sha }}`

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 
 ---
 
-## Features
+## Design Principles
 
-- **Zero runtime overhead (SSR)** - Server renders pure templates, no JS framework needed
-- **Fine-grained reactivity** - Signal-based updates, only re-render what changed
-- **Type-safe** - Full TypeScript support with preserved type information
-- **Backend agnostic** - Currently supports Hono/JSX, designed for Go, Python, etc.
+- **Backend Freedom** — Same JSX works with Hono, Go, Mojolicious, etc. No Node.js lock-in.
+- **MPA-style development** — Add interactivity to existing server apps without an SPA framework.
+- **Fine-grained reactivity** — Signal-based, only affected DOM nodes update. SolidJS-equivalent performance.
+- **AI-native development** — IR enables browser-free testing. CLI for component discovery. AI agents can develop autonomously.
 
 ---
 

--- a/benchmarks/browser-bench.ts
+++ b/benchmarks/browser-bench.ts
@@ -1,0 +1,399 @@
+/**
+ * Browser benchmark entry point — bundled and executed in real Chromium via Playwright.
+ * Tests: Vanilla JS, BarefootJS, SolidJS, React (actual frameworks, real DOM).
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Measure with enough repetitions to overcome browser timer precision (~0.1ms).
+ * Runs `fn` in batches of `batchSize`, measures total time, returns per-op median.
+ */
+function measure(fn: () => void, rounds: number, batchSize = 1): number {
+  // Warm up
+  for (let i = 0; i < 3 * batchSize; i++) fn()
+
+  const times: number[] = []
+  for (let r = 0; r < rounds; r++) {
+    const start = performance.now()
+    for (let b = 0; b < batchSize; b++) fn()
+    times.push((performance.now() - start) / batchSize)
+  }
+  times.sort((a, b) => a - b)
+  return times[Math.floor(times.length / 2)]
+}
+
+let idCounter = 1
+const adjectives = ['pretty','large','big','small','tall','short','long','handsome','plain','quaint','clean','elegant','easy','angry','crazy','helpful','mushy','odd','unsightly','adorable','important','inexpensive','cheap','expensive','fancy']
+const colours = ['red','yellow','blue','green','pink','brown','purple','brown','white','black','orange']
+const nouns = ['table','chair','house','bbq','desk','car','pony','cookie','sandwich','burger','pizza','mouse','keyboard']
+
+function randomLabel() {
+  return `${adjectives[Math.floor(Math.random() * adjectives.length)]} ${colours[Math.floor(Math.random() * colours.length)]} ${nouns[Math.floor(Math.random() * nouns.length)]}`
+}
+
+// ---------------------------------------------------------------------------
+// Vanilla JS
+// ---------------------------------------------------------------------------
+
+function vanillaCreate(tbody: HTMLElement, count: number): HTMLElement[] {
+  const rows: HTMLElement[] = []
+  const frag = document.createDocumentFragment()
+  for (let i = 0; i < count; i++) {
+    const tr = document.createElement('tr')
+    const td1 = document.createElement('td')
+    td1.className = 'col-md-1'
+    td1.textContent = String(idCounter++)
+    const td2 = document.createElement('td')
+    td2.className = 'col-md-6'
+    const a = document.createElement('a')
+    a.textContent = randomLabel()
+    td2.appendChild(a)
+    tr.appendChild(td1)
+    tr.appendChild(td2)
+    frag.appendChild(tr)
+    rows.push(tr)
+  }
+  tbody.appendChild(frag)
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+// BarefootJS
+// ---------------------------------------------------------------------------
+import {
+  createSignal as bfSignal,
+  createEffect as bfEffect,
+  createRoot as bfRoot,
+} from '../packages/client/src/index.ts'
+
+interface BfRow {
+  label: [() => string, (v: string | ((p: string) => string)) => void]
+  selected: [() => boolean, (v: boolean | ((p: boolean) => boolean)) => void]
+  tr: HTMLElement
+  dispose: () => void
+}
+
+function bfCreate(tbody: HTMLElement, count: number): BfRow[] {
+  const rows: BfRow[] = []
+  const frag = document.createDocumentFragment()
+  for (let i = 0; i < count; i++) {
+    const id = idCounter++
+    let dispose = () => {}
+    const tr = document.createElement('tr')
+    const td1 = document.createElement('td')
+    td1.className = 'col-md-1'
+    td1.textContent = String(id)
+    const td2 = document.createElement('td')
+    td2.className = 'col-md-6'
+    const a = document.createElement('a')
+    td2.appendChild(a)
+    tr.appendChild(td1)
+    tr.appendChild(td2)
+
+    const row = bfRoot((d) => {
+      dispose = d
+      const [label, setLabel] = bfSignal(randomLabel())
+      const [selected, setSelected] = bfSignal(false)
+      bfEffect(() => { a.textContent = label() })
+      bfEffect(() => { tr.className = selected() ? 'danger' : '' })
+      return { label: [label, setLabel], selected: [selected, setSelected], tr, dispose } as BfRow
+    })!
+
+    frag.appendChild(tr)
+    rows.push(row)
+  }
+  tbody.appendChild(frag)
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+// SolidJS
+// ---------------------------------------------------------------------------
+import {
+  createSignal as solidSignal,
+  createRenderEffect as solidEffect,
+  createRoot as solidRoot,
+} from 'solid-js'
+
+interface SolidRow {
+  label: [() => string, (v: string | ((p: string) => string)) => void]
+  selected: [() => boolean, (v: boolean | ((p: boolean) => boolean)) => void]
+  tr: HTMLElement
+  dispose: () => void
+}
+
+function solidCreate(tbody: HTMLElement, count: number): SolidRow[] {
+  const rows: SolidRow[] = []
+  const frag = document.createDocumentFragment()
+  for (let i = 0; i < count; i++) {
+    const id = idCounter++
+    let dispose = () => {}
+    const tr = document.createElement('tr')
+    const td1 = document.createElement('td')
+    td1.className = 'col-md-1'
+    td1.textContent = String(id)
+    const td2 = document.createElement('td')
+    td2.className = 'col-md-6'
+    const a = document.createElement('a')
+    td2.appendChild(a)
+    tr.appendChild(td1)
+    tr.appendChild(td2)
+
+    const row = solidRoot((d) => {
+      dispose = d
+      const [label, setLabel] = solidSignal(randomLabel())
+      const [selected, setSelected] = solidSignal(false)
+      solidEffect(() => { a.textContent = label() })
+      solidEffect(() => { tr.className = selected() ? 'danger' : '' })
+      return { label: [label, setLabel], selected: [selected, setSelected], tr, dispose } as SolidRow
+    })!
+
+    frag.appendChild(tr)
+    rows.push(row)
+  }
+  tbody.appendChild(frag)
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+// React
+// ---------------------------------------------------------------------------
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+interface ReactRowData { id: number; label: string; selected: boolean }
+let reactRoot: ReturnType<typeof ReactDOM.createRoot> | null = null
+let reactSetState: ((fn: (p: ReactRowData[]) => ReactRowData[]) => void) | null = null
+
+function ReactApp() {
+  const [rows, setRows] = React.useState<ReactRowData[]>([])
+  reactSetState = setRows
+  return React.createElement('tbody', null,
+    rows.map(row =>
+      React.createElement('tr', { key: row.id, className: row.selected ? 'danger' : '' },
+        React.createElement('td', { className: 'col-md-1' }, String(row.id)),
+        React.createElement('td', { className: 'col-md-6' },
+          React.createElement('a', null, row.label)
+        )
+      )
+    )
+  )
+}
+
+function reactInit(container: HTMLElement) {
+  reactRoot = ReactDOM.createRoot(container)
+  flushSync(() => { reactRoot!.render(React.createElement(ReactApp)) })
+}
+function reactCreateRows(count: number) {
+  const data: ReactRowData[] = []
+  for (let i = 0; i < count; i++) data.push({ id: idCounter++, label: randomLabel(), selected: false })
+  flushSync(() => { reactSetState!(() => data) })
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Run all benchmarks
+// ---------------------------------------------------------------------------
+
+const ROWS = 1000
+const ROUNDS = 10
+const results: Record<string, Record<string, number>> = {}
+
+// batchSize: run fn N times per measurement to overcome timer precision (~0.1ms)
+function run(name: string, benchmarks: Record<string, { fn: () => void, batch: number }>) {
+  results[name] = {}
+  for (const [label, { fn, batch }] of Object.entries(benchmarks)) {
+    results[name][label] = measure(fn, ROUNDS, batch)
+  }
+}
+
+// batch: repeat per measurement to overcome timer precision (~0.1ms).
+// Keep low — React is ~15ms/op so large batches make it very slow.
+const B_CREATE = 1
+const B_UPDATE = 20
+const B_SELECT = 20
+const B_CLEAR = 1
+
+// --- Vanilla ---
+run('Vanilla', {
+  create: { fn: () => {
+    const t = document.createElement('tbody')
+    idCounter = 1; vanillaCreate(t, ROWS); t.textContent = ''
+  }, batch: B_CREATE },
+  partial_update: (() => {
+    const t = document.createElement('tbody')
+    const rows = vanillaCreate(t, ROWS)
+    return { fn: () => { for (let i = 0; i < rows.length; i += 10) rows[i].querySelector('a')!.textContent = randomLabel() }, batch: B_UPDATE }
+  })(),
+  select: (() => {
+    const t = document.createElement('tbody')
+    const rows = vanillaCreate(t, ROWS)
+    return { fn: () => { for (const r of rows) r.className = ''; rows[Math.floor(Math.random() * ROWS)].className = 'danger' }, batch: B_SELECT }
+  })(),
+  clear: { fn: () => {
+    const t = document.createElement('tbody')
+    vanillaCreate(t, ROWS); t.textContent = ''
+  }, batch: B_CLEAR },
+})
+
+// --- BarefootJS ---
+run('BarefootJS', {
+  create: { fn: () => {
+    const t = document.createElement('tbody')
+    idCounter = 1; const r = bfCreate(t, ROWS); for (const x of r) x.dispose(); t.textContent = ''
+  }, batch: B_CREATE },
+  partial_update: (() => {
+    const t = document.createElement('tbody')
+    const rows = bfCreate(t, ROWS)
+    return { fn: () => { for (let i = 0; i < rows.length; i += 10) rows[i].label[1](randomLabel()) }, batch: B_UPDATE }
+  })(),
+  select: (() => {
+    const t = document.createElement('tbody')
+    const rows = bfCreate(t, ROWS)
+    let prev: number | null = null
+    return { fn: () => {
+      const idx = Math.floor(Math.random() * ROWS)
+      if (prev !== null) rows[prev].selected[1](false)
+      rows[idx].selected[1](true)
+      prev = idx
+    }, batch: B_SELECT }
+  })(),
+  clear: { fn: () => {
+    const t = document.createElement('tbody')
+    const r = bfCreate(t, ROWS); for (const x of r) x.dispose(); t.textContent = ''
+  }, batch: B_CLEAR },
+})
+
+// --- SolidJS ---
+run('SolidJS', {
+  create: { fn: () => {
+    const t = document.createElement('tbody')
+    idCounter = 1; const r = solidCreate(t, ROWS); for (const x of r) x.dispose(); t.textContent = ''
+  }, batch: B_CREATE },
+  partial_update: (() => {
+    const t = document.createElement('tbody')
+    const rows = solidCreate(t, ROWS)
+    return { fn: () => { for (let i = 0; i < rows.length; i += 10) rows[i].label[1](randomLabel()) }, batch: B_UPDATE }
+  })(),
+  select: (() => {
+    const t = document.createElement('tbody')
+    const rows = solidCreate(t, ROWS)
+    let prev: number | null = null
+    return { fn: () => {
+      const idx = Math.floor(Math.random() * ROWS)
+      if (prev !== null) rows[prev].selected[1](false)
+      rows[idx].selected[1](true)
+      prev = idx
+    }, batch: B_SELECT }
+  })(),
+  clear: { fn: () => {
+    const t = document.createElement('tbody')
+    const r = solidCreate(t, ROWS); for (const x of r) x.dispose(); t.textContent = ''
+  }, batch: B_CLEAR },
+})
+
+// --- React ---
+// Each benchmark captures its own setState to avoid interference from create's unmount.
+{
+  const createBench = { fn: () => {
+    const c = document.createElement('div')
+    reactInit(c); idCounter = 1; reactCreateRows(ROWS)
+    flushSync(() => { reactSetState!(() => []) }); reactRoot!.unmount()
+  }, batch: B_CREATE }
+
+  const partialBench = (() => {
+    const c = document.createElement('div')
+    reactInit(c); reactCreateRows(ROWS)
+    const mySetState = reactSetState!
+    return { fn: () => {
+      flushSync(() => {
+        mySetState((prev) => {
+          const next = [...prev]
+          for (let i = 0; i < next.length; i += 10) next[i] = { ...next[i], label: randomLabel() }
+          return next
+        })
+      })
+    }, batch: B_UPDATE }
+  })()
+
+  const selectBench = (() => {
+    const c = document.createElement('div')
+    reactInit(c); reactCreateRows(ROWS)
+    const mySetState = reactSetState!
+    return { fn: () => {
+      flushSync(() => {
+        mySetState((prev) => prev.map((r, i) => ({ ...r, selected: i === Math.floor(Math.random() * ROWS) })))
+      })
+    }, batch: B_SELECT }
+  })()
+
+  const clearBench = (() => {
+    const c = document.createElement('div')
+    reactInit(c); reactCreateRows(ROWS)
+    const mySetState = reactSetState!
+    return { fn: () => {
+      flushSync(() => { mySetState(() => []) })
+      const data: ReactRowData[] = []
+      for (let i = 0; i < ROWS; i++) data.push({ id: idCounter++, label: randomLabel(), selected: false })
+      flushSync(() => { mySetState(() => data) })
+    }, batch: B_CLEAR }
+  })()
+
+  run('React', {
+    create: createBench,
+    partial_update: partialBench,
+    select: selectBench,
+    clear: clearBench,
+  })
+}
+
+// --- Scaling ---
+const scaling: Record<string, Record<number, number>> = { Vanilla: {}, BarefootJS: {}, SolidJS: {}, React: {} }
+
+for (const n of [1, 100, 1000]) {
+  const batch = n <= 10 ? 50 : n <= 100 ? 20 : 10
+
+  // Vanilla
+  const tv = document.createElement('tbody')
+  const rv = vanillaCreate(tv, 1000)
+  scaling.Vanilla[n] = measure(() => {
+    for (let i = 0; i < n; i++) { const idx = Math.floor(i * 1000 / n); rv[idx].querySelector('a')!.textContent = randomLabel() }
+  }, 30, batch)
+
+  // BarefootJS
+  const tb = document.createElement('tbody')
+  const rb = bfCreate(tb, 1000)
+  scaling.BarefootJS[n] = measure(() => {
+    for (let i = 0; i < n; i++) { const idx = Math.floor(i * 1000 / n); rb[idx].label[1](randomLabel()) }
+  }, 30, batch)
+
+  // SolidJS
+  const ts = document.createElement('tbody')
+  const rs = solidCreate(ts, 1000)
+  scaling.SolidJS[n] = measure(() => {
+    for (let i = 0; i < n; i++) { const idx = Math.floor(i * 1000 / n); rs[idx].label[1](randomLabel()) }
+  }, 30, batch)
+
+  // React — capture setState before loop continues
+  const cr = document.createElement('div')
+  reactInit(cr); reactCreateRows(1000)
+  const mySetState = reactSetState!
+  scaling.React[n] = measure(() => {
+    flushSync(() => {
+      mySetState((prev) => {
+        const next = [...prev]
+        for (let i = 0; i < n; i++) { const idx = Math.floor(i * 1000 / n); next[idx] = { ...next[idx], label: randomLabel() } }
+        return next
+      })
+    })
+  }, 30, batch)
+  reactRoot!.unmount()
+}
+
+// Output as JSON for Playwright to capture
+;(window as any).__benchResults = { results, scaling }
+document.title = 'done'

--- a/benchmarks/reactive.ts
+++ b/benchmarks/reactive.ts
@@ -1,0 +1,179 @@
+/**
+ * Reactive primitives micro-benchmark
+ *
+ * Measures raw signal/effect performance to establish a baseline
+ * for fine-grained reactivity claims.
+ */
+import {
+  createSignal,
+  createEffect,
+  createMemo,
+  createRoot,
+} from '../packages/client/src/index.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function measure(label: string, fn: () => void, iterations = 1): number {
+  // Warm up
+  for (let i = 0; i < 5; i++) fn()
+
+  const times: number[] = []
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now()
+    fn()
+    times.push(performance.now() - start)
+  }
+  times.sort((a, b) => a - b)
+  const median = times[Math.floor(times.length / 2)]
+  return median
+}
+
+function report(label: string, ms: number, ops?: number) {
+  const opsStr = ops ? ` (${(ops / ms * 1000).toFixed(0)} ops/sec)` : ''
+  console.log(`  ${label.padEnd(40)} ${ms.toFixed(3)} ms${opsStr}`)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+console.log('\n=== Reactive Primitives Benchmark ===\n')
+
+// 1. Signal creation
+{
+  const N = 100_000
+  const ms = measure('signal creation', () => {
+    createRoot(() => {
+      for (let i = 0; i < N; i++) {
+        createSignal(i)
+      }
+    })
+  }, 20)
+  report(`Create ${N.toLocaleString()} signals`, ms, N)
+}
+
+// 2. Signal read
+{
+  const N = 100_000
+  const signals = Array.from({ length: N }, (_, i) => createSignal(i))
+  const ms = measure('signal read', () => {
+    let sum = 0
+    for (let i = 0; i < N; i++) {
+      sum += signals[i][0]()
+    }
+  }, 20)
+  report(`Read ${N.toLocaleString()} signals`, ms, N)
+}
+
+// 3. Signal write (no subscribers)
+{
+  const N = 100_000
+  const signals = Array.from({ length: N }, (_, i) => createSignal(i))
+  const ms = measure('signal write (no subscribers)', () => {
+    for (let i = 0; i < N; i++) {
+      signals[i][1](i + 1)
+    }
+  }, 20)
+  report(`Write ${N.toLocaleString()} signals (no sub)`, ms, N)
+}
+
+// 4. Signal write → 1 effect (targeted update)
+{
+  const N = 10_000
+  createRoot(() => {
+    const [get, set] = createSignal(0)
+    createEffect(() => { get() })
+    const ms = measure('signal → 1 effect', () => {
+      for (let i = 0; i < N; i++) {
+        set(i)
+      }
+    }, 20)
+    report(`Update signal → 1 effect × ${N.toLocaleString()}`, ms, N)
+  })
+}
+
+// 5. Fan-out: 1 signal → N effects
+{
+  const EFFECTS = 1000
+  createRoot(() => {
+    const [get, set] = createSignal(0)
+    for (let i = 0; i < EFFECTS; i++) {
+      createEffect(() => { get() })
+    }
+    const ms = measure(`1 signal → ${EFFECTS} effects`, () => {
+      set((v) => v + 1)
+    }, 100)
+    report(`Fan-out: 1 signal → ${EFFECTS} effects`, ms, EFFECTS)
+  })
+}
+
+// 6. Deep chain: s0 → memo1 → memo2 → ... → memoN → effect
+{
+  const DEPTH = 100
+  createRoot(() => {
+    const [get, set] = createSignal(0)
+    let current: () => number = get
+    for (let i = 0; i < DEPTH; i++) {
+      const prev = current
+      current = createMemo(() => prev() + 1)
+    }
+    const last = current
+    createEffect(() => { last() })
+    const UPDATES = 1000
+    const ms = measure(`deep chain (${DEPTH})`, () => {
+      for (let i = 0; i < UPDATES; i++) {
+        set(i)
+      }
+    }, 20)
+    report(`Deep chain (${DEPTH} memos) × ${UPDATES} updates`, ms, UPDATES)
+  })
+}
+
+// 7. Wide + deep: N independent signal → memo → effect chains
+{
+  const CHAINS = 1000
+  createRoot(() => {
+    const signals: [() => number, (v: number | ((prev: number) => number)) => void][] = []
+    for (let i = 0; i < CHAINS; i++) {
+      const [get, set] = createSignal(0)
+      const doubled = createMemo(() => get() * 2)
+      createEffect(() => { doubled() })
+      signals.push([get, set])
+    }
+    const ms = measure(`${CHAINS} independent chains`, () => {
+      for (let i = 0; i < CHAINS; i++) {
+        signals[i][1](i)
+      }
+    }, 20)
+    report(`${CHAINS} independent signal→memo→effect`, ms, CHAINS)
+  })
+}
+
+// 8. Partial update: 1000 signals, update every 10th
+{
+  const ROWS = 1000
+  let effectRunCount = 0
+  createRoot(() => {
+    const signals: [() => number, (v: number | ((prev: number) => number)) => void][] = []
+    for (let i = 0; i < ROWS; i++) {
+      const [get, set] = createSignal(i)
+      createEffect(() => {
+        get()
+        effectRunCount++
+      })
+      signals.push([get, set])
+    }
+    effectRunCount = 0
+    const ms = measure('partial update (every 10th)', () => {
+      for (let i = 0; i < ROWS; i += 10) {
+        signals[i][1]((v) => v + 1)
+      }
+    }, 100)
+    report(`Partial update: ${ROWS / 10} of ${ROWS} rows`, ms, ROWS / 10)
+    console.log(`    → Effects run: ${effectRunCount / 100} per iteration (expect ${ROWS / 10})`)
+  })
+}
+
+console.log('')

--- a/benchmarks/run-browser.ts
+++ b/benchmarks/run-browser.ts
@@ -1,0 +1,170 @@
+/**
+ * Playwright runner for browser-bench.ts.
+ * Bundles the benchmark and runs it in headless Chromium.
+ *
+ * Usage:
+ *   bun run benchmarks/run-browser.ts           # plain text tables
+ *   bun run benchmarks/run-browser.ts --md      # markdown for PR comments
+ */
+import { chromium } from '@playwright/test'
+
+const mdMode = process.argv.includes('--md')
+
+// ---------------------------------------------------------------------------
+// 1. Bundle
+// ---------------------------------------------------------------------------
+
+if (!mdMode) console.log('Bundling benchmark...')
+const buildResult = await Bun.build({
+  entrypoints: ['./benchmarks/browser-bench.ts'],
+  outdir: './benchmarks/dist',
+  target: 'browser',
+  format: 'esm',
+  minify: false,
+})
+
+if (!buildResult.success) {
+  console.error('Bundle failed:', buildResult.logs)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// 2. Run in Chromium
+// ---------------------------------------------------------------------------
+
+if (!mdMode) console.log('Launching Chromium...')
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+
+page.on('pageerror', (err) => {
+  console.error(`  [page error] ${err.message}`)
+})
+
+const bundlePath = `${process.cwd()}/benchmarks/dist/browser-bench.js`
+await page.setContent('<!DOCTYPE html><html><head><title>running</title></head><body></body></html>')
+await page.addScriptTag({ path: bundlePath })
+
+// Poll for results (benchmarks are CPU-bound, may take minutes)
+type Results = {
+  results: Record<string, Record<string, number>>
+  scaling: Record<string, Record<number, number>>
+}
+
+let data: Results | null = null
+for (let i = 0; i < 600; i++) {
+  data = await page.evaluate(() => (window as any).__benchResults) as Results | null
+  if (data) break
+  await new Promise(r => setTimeout(r, 500))
+}
+await browser.close()
+
+if (!data) {
+  console.error('Timed out waiting for benchmark results (5 min)')
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// 3. Print results
+// ---------------------------------------------------------------------------
+
+const ROWS = 1000
+const frameworks = ['Vanilla', 'BarefootJS', 'SolidJS', 'React'] as const
+const ops = Object.keys(data.results.Vanilla)
+
+function fmt(ms: number, decimals = 3): string {
+  if (ms < 0.01) return '<0.01'
+  return ms.toFixed(decimals)
+}
+
+function cell(ms: number, baseline: number): string {
+  const r = baseline > 0.001 ? ` (${(ms / baseline).toFixed(1)}x)` : ''
+  return `${fmt(ms)} ms${r}`
+}
+
+if (mdMode) {
+  // --- Markdown output for PR comments ---
+  const hdr = `| Operation (${ROWS} rows) | ` + frameworks.join(' | ') + ' |'
+  const sep = '|---|' + frameworks.map(() => '---|').join('')
+  console.log(hdr)
+  console.log(sep)
+
+  for (const op of ops) {
+    const baseline = data.results.Vanilla[op]
+    const cells = frameworks.map(fw => {
+      const ms = data.results[fw]?.[op]
+      if (ms === undefined) return '_N/A_'
+      if (fw === 'Vanilla') return `${fmt(ms)} ms`
+      return cell(ms, baseline)
+    })
+    console.log(`| ${op.replace(/_/g, ' ')} | ${cells.join(' | ')} |`)
+  }
+
+  console.log('')
+  console.log(`**Partial update scaling** (N of ${ROWS} rows):`)
+  console.log('')
+  const sHdr = '| N | ' + frameworks.join(' | ') + ' |'
+  const sSep = '|---|' + frameworks.map(() => '---|').join('')
+  console.log(sHdr)
+  console.log(sSep)
+
+  for (const n of [1, 100, 1000]) {
+    const baseline = data.scaling.Vanilla[n]
+    const cells = frameworks.map(fw => {
+      const ms = data.scaling[fw]?.[n]
+      if (ms === undefined) return '_N/A_'
+      if (fw === 'Vanilla') return `${fmt(ms)} ms`
+      return cell(ms, baseline)
+    })
+    console.log(`| ${n} | ${cells.join(' | ')} |`)
+  }
+} else {
+  // --- Plain text output for local use ---
+  const colW = 14
+  const opW = 20
+  console.log(`\n=== DOM Benchmark (${ROWS} rows, Chromium, median) ===\n`)
+
+  const header = 'Operation'.padEnd(opW) + frameworks.map(f => f.padStart(colW)).join('')
+  console.log(header)
+  console.log('-'.repeat(header.length))
+
+  for (const op of ops) {
+    const baseline = data.results.Vanilla[op]
+    let line = op.replace(/_/g, ' ').padEnd(opW)
+    for (const fw of frameworks) {
+      const ms = data.results[fw]?.[op]
+      if (ms === undefined) {
+        line += 'n/a'.padStart(colW)
+      } else if (fw === 'Vanilla') {
+        line += `${fmt(ms)}ms`.padStart(colW)
+      } else {
+        line += `${fmt(ms / baseline, 2)}x`.padStart(colW)
+      }
+    }
+    console.log(line)
+  }
+
+  console.log(`\n=== Scaling: partial update N of ${ROWS} rows ===\n`)
+
+  const scaleColW = 16
+  const scaleHeader = 'N'.padEnd(8) + frameworks.map(f => f.padStart(scaleColW)).join('')
+  console.log(scaleHeader)
+  console.log('-'.repeat(scaleHeader.length))
+
+  for (const n of [1, 100, 1000]) {
+    const baseline = data.scaling.Vanilla[n]
+    let line = String(n).padEnd(8)
+    for (const fw of frameworks) {
+      const ms = data.scaling[fw]?.[n]
+      if (ms === undefined) {
+        line += 'n/a'.padStart(scaleColW)
+      } else if (fw === 'Vanilla') {
+        line += `${fmt(ms)}ms`.padStart(scaleColW)
+      } else {
+        line += `${fmt(ms)}ms (${fmt(ms / baseline, 2)}x)`.padStart(scaleColW)
+      }
+    }
+    console.log(line)
+  }
+
+  console.log('')
+}

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -90,20 +90,14 @@ No framework runtime. No virtual DOM. Just the minimum JavaScript needed for int
 
 ## Design Principles
 
-**Compile, don't ship a runtime.**
-The compiler does the heavy lifting at build time. The browser receives only the JavaScript it needs — no framework, no virtual DOM diffing.
+**Backend Freedom.**
+The same JSX source produces templates for Hono, Go `html/template`, and any future adapter. Your component library works across stacks. No Node.js lock-in — use the server language your team already knows.
 
-**Backend agnostic.**
-The same JSX source produces templates for Hono, Go `html/template`, and any future adapter. Your component library works across stacks.
+**MPA-style development.**
+Add interactive UI to existing server-rendered apps without adopting a full SPA framework. Each page is a normal route; client JavaScript is only loaded where you mark it.
 
 **Fine-grained reactivity.**
-Inspired by SolidJS, signals track dependencies at the expression level. When state changes, only the affected DOM nodes update — not the entire component tree.
+Signals track dependencies at the expression level. When state changes, only the affected DOM nodes update — no virtual DOM diffing, no component-tree re-render. [Benchmarked at SolidJS-equivalent performance](https://github.com/barefootjs/barefootjs/issues/236), orders of magnitude faster than vDOM reconciliation.
 
-**Progressive enhancement.**
-Server-rendered HTML works without JavaScript. Client scripts add interactivity. If JavaScript fails to load, users still see content.
-
-**Full type safety.**
-TypeScript types flow through the entire compilation pipeline.
-
-**No lock-in.**
-JSX is the authoring format, but the output is standard HTML and vanilla JavaScript. No proprietary template language. No framework to migrate away from.
+**AI-native development.**
+The compiler produces an IR that can be tested without a browser, enabling fast component tests via `renderToTest()`. Combined with a CLI for component discovery (`barefoot search`, `barefoot ui`), AI agents can autonomously scaffold, test, and iterate on UI components.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
     "@happy-dom/global-registrator": "^20.0.11",
     "@playwright/test": "^1.57.0",
     "@types/bun": "latest",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "happy-dom": "^20.0.11",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "solid-js": "^1.9.12",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/site/core/landing/components/features.tsx
+++ b/site/core/landing/components/features.tsx
@@ -4,7 +4,7 @@
  * Displays Fine-grained reactivity benchmark and UI components showcase.
  */
 
-const fiveFeatures = [
+const features = [
   {
     num: '01',
     title: 'Backend Freedom',
@@ -12,33 +12,28 @@ const fiveFeatures = [
   },
   {
     num: '02',
-    title: 'Selective Hydration',
-    description: 'JS only where needed',
+    title: 'MPA-style',
+    description: 'Add to existing apps',
   },
   {
     num: '03',
-    title: 'Signals',
-    description: 'Fine-grained reactivity',
+    title: 'Fine-grained',
+    description: 'Signal-based reactivity',
   },
   {
     num: '04',
-    title: 'Clean Overrides',
-    description: 'Your styles always win',
-  },
-  {
-    num: '05',
-    title: 'Type-safe',
-    description: 'TSX + TypeScript',
+    title: 'AI-native',
+    description: 'CLI + fast IR tests',
   },
 ]
 
-export function FiveFeaturesSection() {
+export function FeaturesSection() {
   return (
     <section className="py-32 px-6 sm:px-12 border-t">
-      <div className="max-w-6xl mx-auto">
+      <div className="max-w-5xl mx-auto">
         <div className="flex flex-wrap">
-          {fiveFeatures.map((feature) => (
-            <div className="w-full sm:w-1/2 md:w-1/3 lg:w-1/5 p-6 sm:p-8 flex flex-col border-b lg:border-b-0 lg:border-r last:border-r-0 sm:[&:nth-child(2n)]:border-r-0 md:[&:nth-child(2n)]:border-r md:[&:nth-child(3n)]:border-r-0 lg:[&:nth-child(3n)]:border-r">
+          {features.map((feature) => (
+            <div className="w-full sm:w-1/2 lg:w-1/4 p-6 sm:p-8 flex flex-col border-b lg:border-b-0 lg:border-r last:border-r-0 sm:[&:nth-child(2n)]:border-r-0 lg:[&:nth-child(2n)]:border-r">
               <span className="text-xs font-mono text-[var(--gradient-start)] tracking-wider mb-4">
                 {feature.num}
               </span>

--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -185,8 +185,8 @@ export async function Hero() {
             Reactive TSX for <span className="gradient-text whitespace-nowrap">any backend</span>
           </h1>
           <p className="fade-in-1 text-lg text-muted-foreground mb-8 max-w-lg">
-            Write TSX with signals. Compile to templates your backend understands.
-            No VDOM on the client, just selective hydration.
+            Signal-based JSX that compiles to any backend's template language.
+            Add fine-grained reactivity to server-rendered pages — no SPA required.
           </p>
           <div className="fade-in-2 flex flex-wrap gap-3">
             <a

--- a/site/core/landing/routes.tsx
+++ b/site/core/landing/routes.tsx
@@ -8,7 +8,7 @@ import { Hono } from 'hono'
 import { landingRenderer } from './renderer'
 import { initHighlighter } from './components/shared/highlighter'
 import { Hero } from './components/hero'
-import { FiveFeaturesSection, UIComponentsSection } from './components/features'
+import { FeaturesSection, UIComponentsSection } from './components/features'
 
 /**
  * Create the landing page app with routes.
@@ -26,7 +26,7 @@ export async function createLandingApp() {
     return c.render(
       <>
         <Hero />
-        <FiveFeaturesSection />
+        <FeaturesSection />
         <UIComponentsSection />
       </>,
       {


### PR DESCRIPTION
## Summary

- Rewrite Design Principles (6 → 4) based on benchmark evidence
- Add reactivity benchmark suite (Vanilla, BarefootJS, SolidJS, React)
- Add benchmark CI that posts comparison table on PRs
- Update README, docs, and landing page to unified naming

## Design Principles

| Before | After | Reason |
|--------|-------|--------|
| Compile, don't ship a runtime | _(removed)_ | We ship a runtime |
| Backend agnostic | **Backend Freedom** | Kept, renamed |
| Fine-grained reactivity | **Fine-grained reactivity** | Kept, added benchmark link |
| Progressive enhancement | _(removed)_ | Table stakes |
| Full type safety | _(removed)_ | Table stakes |
| No lock-in | _(removed)_ | Not accurate (hydration markers) |
| — | **MPA-style development** | New |
| — | **AI-native development** | New |

## Benchmark results (Chromium)

| Operation (1000 rows) | Vanilla | BarefootJS | SolidJS | React |
|---|---|---|---|---|
| Create | 2.4 ms | 3.1 ms (1.3x) | 3.7 ms (1.5x) | 23.3 ms (9.7x) |
| Partial update (100) | 0.05 ms | 0.06 ms (1.2x) | 0.07 ms (1.5x) | 18.3 ms (366x) |
| Select row | 0.05 ms | <0.01 ms | <0.01 ms | 15.9 ms (318x) |

Fixes: #236