### PR TITLE
feat(streaming): add OOS client resolver and rehydrateAll API

### DIFF
--- a/packages/client-runtime/__tests__/streaming.test.ts
+++ b/packages/client-runtime/__tests__/streaming.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test'
+import { __bf_swap, setupStreaming } from '../src/streaming'
+import { hydrate, rehydrateAll } from '../src/hydrate'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('__bf_swap', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('swaps fallback content with resolved template', () => {
+    document.body.innerHTML = `
+      <div bf-async="a0"><p>Loading...</p></div>
+      <template bf-async-resolve="a0"><div>Resolved content</div></template>
+    `
+
+    __bf_swap('a0')
+
+    // Fallback replaced with resolved content
+    const slot = document.querySelector('div:not(template)')!
+    expect(slot.innerHTML).toContain('Resolved content')
+    expect(slot.hasAttribute('bf-async')).toBe(false)
+
+    // Template element removed
+    expect(document.querySelector('template[bf-async-resolve]')).toBeNull()
+  })
+
+  test('does nothing when slot is missing', () => {
+    document.body.innerHTML = `
+      <template bf-async-resolve="a0"><div>Content</div></template>
+    `
+
+    // Should not throw
+    __bf_swap('a0')
+
+    // Template should still be there (not cleaned up if no slot found)
+    expect(document.querySelector('template[bf-async-resolve]')).not.toBeNull()
+  })
+
+  test('does nothing when template is missing', () => {
+    document.body.innerHTML = `
+      <div bf-async="a0"><p>Loading...</p></div>
+    `
+
+    __bf_swap('a0')
+
+    // Fallback should remain unchanged
+    expect(document.querySelector('[bf-async="a0"]')!.innerHTML).toContain('Loading...')
+  })
+
+  test('handles multiple async boundaries independently', () => {
+    document.body.innerHTML = `
+      <div bf-async="a0"><p>Loading 1...</p></div>
+      <div bf-async="a1"><p>Loading 2...</p></div>
+      <template bf-async-resolve="a0"><div>Content 1</div></template>
+    `
+
+    // Only resolve a0
+    __bf_swap('a0')
+
+    // a0 resolved
+    const first = document.querySelector('div:not([bf-async]):not(template)')!
+    expect(first.innerHTML).toContain('Content 1')
+
+    // a1 still showing fallback
+    const second = document.querySelector('[bf-async="a1"]')!
+    expect(second.innerHTML).toContain('Loading 2...')
+  })
+
+  test('preserves hydration markers in resolved content', () => {
+    document.body.innerHTML = `
+      <div bf-async="a0"><p>Loading...</p></div>
+      <template bf-async-resolve="a0"><div bf-s="Counter_x1" bf-p='{"count":0}'>0</div></template>
+    `
+
+    __bf_swap('a0')
+
+    // Hydration markers should be preserved in swapped content
+    const counter = document.querySelector('[bf-s="Counter_x1"]')
+    expect(counter).not.toBeNull()
+    expect(counter!.getAttribute('bf-p')).toBe('{"count":0}')
+  })
+})
+
+describe('rehydrateAll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('hydrates components added after initial hydration', () => {
+    const initialized: string[] = []
+
+    // Initial hydration
+    document.body.innerHTML = `
+      <div bf-s="Counter_1" bf-p='{}'>initial</div>
+    `
+    hydrate('Counter', {
+      init: (scope) => { initialized.push(scope.getAttribute('bf-s')!) },
+    })
+
+    expect(initialized).toEqual(['Counter_1'])
+
+    // Simulate streaming: add new content to DOM
+    const newEl = document.createElement('div')
+    newEl.setAttribute('bf-s', 'Counter_2')
+    newEl.setAttribute('bf-p', '{}')
+    newEl.textContent = 'streamed'
+    document.body.appendChild(newEl)
+
+    // Trigger re-hydration
+    rehydrateAll()
+
+    expect(initialized).toEqual(['Counter_1', 'Counter_2'])
+  })
+
+  test('does not re-hydrate already initialized elements', () => {
+    let initCount = 0
+
+    document.body.innerHTML = `
+      <div bf-s="Toggle_1" bf-p='{}'>toggle</div>
+    `
+    hydrate('Toggle', {
+      init: () => { initCount++ },
+    })
+
+    expect(initCount).toBe(1)
+
+    // Re-hydrate should not re-initialize
+    rehydrateAll()
+    expect(initCount).toBe(1)
+  })
+})
+
+describe('setupStreaming', () => {
+  test('installs __bf_swap on window', () => {
+    setupStreaming()
+
+    const w = window as unknown as Record<string, unknown>
+    expect(typeof w.__bf_swap).toBe('function')
+    expect(typeof w.__bf_hydrate).toBe('function')
+  })
+})

--- a/packages/client-runtime/src/hydrate.ts
+++ b/packages/client-runtime/src/hydrate.ts
@@ -13,6 +13,12 @@ import { BF_SCOPE, BF_PROPS, BF_CHILD_PREFIX, BF_SCOPE_COMMENT_PREFIX } from '@b
 import type { ComponentDef } from './types'
 
 /**
+ * Registry of all hydrated component definitions.
+ * Used by rehydrateAll() to re-scan the DOM after streaming chunks arrive.
+ */
+const registeredDefs = new Map<string, ComponentDef>()
+
+/**
  * Register a component and hydrate all its instances on the page.
  * Combines registration + template setup + hydration in a single call.
  *
@@ -27,6 +33,9 @@ export function hydrate(name: string, def: ComponentDef): void {
   // doesn't rely on def.init.name (which may be lost under minification).
   def.name = name
 
+  // Track for rehydrateAll() (streaming support)
+  registeredDefs.set(name, def)
+
   // Register component for parent-child communication
   registerComponent(name, def.init)
 
@@ -35,71 +44,7 @@ export function hydrate(name: string, def: ComponentDef): void {
     registerTemplate(name, def.template)
   }
 
-  const doHydrate = () => {
-    if (def.comment) {
-      // Comment-scope-only: skip attribute-based search
-      hydrateCommentScopes(name, def.init, new Set())
-      return
-    }
-
-    // Select all scope elements matching this component name
-    const scopeEls = document.querySelectorAll(
-      `[${BF_SCOPE}^="${name}_"]`
-    )
-
-    // Track initialized scope IDs to avoid duplicate initialization
-    // (Fragment roots have multiple elements with the same scope ID)
-    const initializedScopes = new Set<string>()
-
-    for (const scopeEl of scopeEls) {
-      // Skip already hydrated elements
-      if (hydratedScopes.has(scopeEl)) continue
-
-      // Skip child components (~ prefix) - they are initialized by parent via initChild
-      if (scopeEl.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) continue
-
-      // Skip nested instances when parent is the same component type.
-      // This prevents double initialization (parent's initChild handles it).
-      //
-      // Different parent types are allowed to hydrate independently:
-      //   - ToggleItem inside Toggle → hydrate (different types)
-      //   - Counter inside Counter → skip (same type, parent initializes)
-      //
-      // Note: This relies on scopeId format "ComponentName_xxxxx"
-      const parentScope = scopeEl.parentElement?.closest(`[${BF_SCOPE}]`)
-      if (parentScope) {
-        const rawParentScopeId = parentScope.getAttribute(BF_SCOPE)
-        const parentScopeId = rawParentScopeId?.startsWith(BF_CHILD_PREFIX)
-          ? rawParentScopeId.slice(1)
-          : rawParentScopeId
-        if (parentScopeId?.startsWith(name + '_')) continue
-      }
-
-      // Get unique instance ID from scope element
-      const instanceId = scopeEl.getAttribute(BF_SCOPE)
-      if (!instanceId) continue
-
-      // Skip if already initialized in this batch (for fragment roots)
-      if (initializedScopes.has(instanceId)) continue
-      initializedScopes.add(instanceId)
-
-      // Mark as initialized immediately to prevent duplicate init
-      hydratedScopes.add(scopeEl)
-
-      // Read props from bf-p attribute (flat format: {"propName": value, ...})
-      const propsJson = scopeEl.getAttribute(BF_PROPS)
-      let props: Record<string, unknown> = {}
-      if (propsJson) {
-        try {
-          props = JSON.parse(propsJson)
-        } catch {
-          console.warn(`[BarefootJS] Invalid props JSON on ${instanceId}:`, propsJson)
-        }
-      }
-
-      def.init(scopeEl, props)
-    }
-  }
+  const doHydrate = () => hydrateComponent(name, def)
 
   // Immediately hydrate elements already in DOM
   doHydrate()
@@ -184,5 +129,69 @@ function hydrateCommentScopes(
 
       init(proxyEl, props)
     }
+  }
+}
+
+/**
+ * Re-hydrate all registered components.
+ *
+ * Called by the streaming resolver after swapping fallback content with
+ * resolved content. Scans the DOM for any un-hydrated scope elements
+ * belonging to previously registered components.
+ */
+export function rehydrateAll(): void {
+  for (const [name, def] of registeredDefs) {
+    hydrateComponent(name, def)
+  }
+}
+
+/**
+ * Hydrate a single component's un-initialized scope elements.
+ * Extracted from hydrate() so it can be re-used by rehydrateAll().
+ */
+function hydrateComponent(name: string, def: ComponentDef): void {
+  if (def.comment) {
+    hydrateCommentScopes(name, def.init, new Set())
+    return
+  }
+
+  const scopeEls = document.querySelectorAll(
+    `[${BF_SCOPE}^="${name}_"]`
+  )
+
+  const initializedScopes = new Set<string>()
+
+  for (const scopeEl of scopeEls) {
+    if (hydratedScopes.has(scopeEl)) continue
+    if (scopeEl.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) continue
+
+    const parentScope = scopeEl.parentElement?.closest(`[${BF_SCOPE}]`)
+    if (parentScope) {
+      const rawParentScopeId = parentScope.getAttribute(BF_SCOPE)
+      const parentScopeId = rawParentScopeId?.startsWith(BF_CHILD_PREFIX)
+        ? rawParentScopeId.slice(1)
+        : rawParentScopeId
+      if (parentScopeId?.startsWith(name + '_')) continue
+    }
+
+    const instanceId = scopeEl.getAttribute(BF_SCOPE)
+    if (!instanceId) continue
+
+    if (initializedScopes.has(instanceId)) continue
+    initializedScopes.add(instanceId)
+
+    hydratedScopes.add(scopeEl)
+
+    const propsJson = scopeEl.getAttribute(BF_PROPS)
+    let props: Record<string, unknown> = {}
+    if (propsJson) {
+      try {
+        props = JSON.parse(propsJson)
+      } catch {
+        console.warn(`[BarefootJS] Invalid props JSON on ${instanceId}:`, propsJson)
+      }
+    }
+
+    def.init(scopeEl, props)
   }
 }

--- a/packages/client-runtime/src/index.ts
+++ b/packages/client-runtime/src/index.ts
@@ -55,7 +55,7 @@ export { styleToCss } from './style'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa } from './query'
-export { hydrate } from './hydrate'
+export { hydrate, rehydrateAll } from './hydrate'
 export { registerComponent, getComponentInit, initChild } from './registry'
 export { insert, type BranchConfig } from './insert'
 export { updateClientMarker } from './client-marker'
@@ -65,6 +65,9 @@ export { hydratedScopes } from './hydration-state'
 
 // CSR entry point
 export { render } from './render'
+
+// Streaming (Out-of-Order SSR)
+export { __bf_swap, setupStreaming } from './streaming'
 
 // Core types
 export type { InitFn, ComponentDef } from './types'

--- a/packages/client-runtime/src/streaming.ts
+++ b/packages/client-runtime/src/streaming.ts
@@ -1,0 +1,61 @@
+/**
+ * BarefootJS - Out-of-Order Streaming
+ *
+ * Client-side resolver for OOS (Out-of-Order Streaming) SSR.
+ * Handles swapping fallback content with resolved content that arrives
+ * via chunked HTTP responses.
+ *
+ * Protocol:
+ * 1. Server sends HTML with fallback placeholders: <div bf-async="a0">...</div>
+ * 2. As async data resolves, server appends chunks:
+ *    <template bf-async-resolve="a0">...resolved...</template>
+ *    <script>__bf_swap("a0")</script>
+ * 3. This module swaps fallback → resolved content and triggers hydration.
+ */
+
+import { BF_ASYNC, BF_ASYNC_RESOLVE } from '@barefootjs/shared'
+import { rehydrateAll } from './hydrate'
+
+/**
+ * Swap a streaming fallback placeholder with its resolved content.
+ *
+ * Finds the placeholder element (`[bf-async="<id>"]`) and the resolve
+ * template (`<template bf-async-resolve="<id>">`), replaces the placeholder's
+ * children with the resolved content, then triggers hydration.
+ *
+ * @param id - The async boundary ID (e.g., "a0")
+ */
+export function __bf_swap(id: string): void {
+  const slot = document.querySelector(`[${BF_ASYNC}="${id}"]`)
+  const tmpl = document.querySelector(`template[${BF_ASYNC_RESOLVE}="${id}"]`) as HTMLTemplateElement | null
+
+  if (!slot || !tmpl) return
+
+  // Replace fallback with resolved content
+  slot.replaceChildren(tmpl.content.cloneNode(true))
+  slot.removeAttribute(BF_ASYNC)
+
+  // Clean up the template element
+  tmpl.remove()
+
+  // Trigger hydration for newly inserted content
+  requestAnimationFrame(rehydrateAll)
+}
+
+/**
+ * Install the global streaming resolver.
+ *
+ * Makes `__bf_swap` available as `window.__bf_swap` so that inline
+ * `<script>__bf_swap("a0")</script>` tags in streaming chunks can call it.
+ *
+ * Also exposes `window.__bf_hydrate` for manual re-hydration triggers.
+ *
+ * Call this once, early in the page (before any streaming chunks arrive).
+ */
+export function setupStreaming(): void {
+  if (typeof window === 'undefined') return
+
+  const w = window as unknown as Record<string, unknown>
+  w.__bf_swap = __bf_swap
+  w.__bf_hydrate = rehydrateAll
+}

--- a/packages/go-template/runtime/streaming.go
+++ b/packages/go-template/runtime/streaming.go
@@ -1,0 +1,205 @@
+// Package bf — Out-of-Order Streaming SSR helpers
+//
+// Provides StreamRenderer for progressive page rendering using HTTP
+// chunked transfer encoding. Async boundaries display fallback content
+// immediately (fast TTFB), then swap in resolved content as data arrives.
+//
+// Works with any Go HTTP server that supports http.Flusher (net/http,
+// chi, gorilla/mux, echo, fiber, etc.).
+package bf
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"net/http"
+	"sync"
+)
+
+// AsyncBoundary defines a region of the page that loads asynchronously.
+// The fallback is sent immediately; resolved content streams in later.
+type AsyncBoundary struct {
+	// ID is the unique boundary identifier (e.g., "a0", "a1").
+	ID string
+
+	// FallbackHTML is the loading/skeleton content shown immediately.
+	FallbackHTML string
+
+	// Resolve produces the final HTML content for this boundary.
+	// Called after the initial page flush; may perform I/O (DB, API, etc.).
+	// Return an error to skip this boundary (fallback remains visible).
+	Resolve func() (string, error)
+}
+
+// StreamOptions configures a single streaming render.
+type StreamOptions struct {
+	// ComponentName is the template to render.
+	ComponentName string
+
+	// Props is the component props (same as RenderOptions.Props).
+	Props interface{}
+
+	// Title is the page title (defaults to "{ComponentName} - BarefootJS").
+	Title string
+
+	// Heading is the page heading.
+	Heading string
+
+	// Extra holds additional data for the layout.
+	Extra map[string]interface{}
+
+	// Boundaries lists async regions that will be streamed.
+	Boundaries []AsyncBoundary
+}
+
+// StreamRenderer renders pages with out-of-order streaming support.
+type StreamRenderer struct {
+	templates *template.Template
+	layout    LayoutFunc
+}
+
+// NewStreamRenderer creates a StreamRenderer with the given templates and layout.
+// The layout function should include the streaming bootstrap script, e.g.:
+//
+//	bf.StreamingBootstrap()
+//
+// in the <head> or before any async boundary in the <body>.
+func NewStreamRenderer(tmpl *template.Template, layout LayoutFunc) *StreamRenderer {
+	return &StreamRenderer{
+		templates: tmpl,
+		layout:    layout,
+	}
+}
+
+// Stream renders the initial page (with fallback placeholders), flushes it
+// to the client, then resolves each async boundary concurrently and
+// streams the resolved content as it becomes available.
+//
+// If w does not implement http.Flusher, falls back to blocking render
+// (all boundaries resolved before sending the response).
+func (sr *StreamRenderer) Stream(w http.ResponseWriter, opts StreamOptions) error {
+	flusher, canFlush := w.(http.Flusher)
+
+	// Build the initial page using the normal Renderer
+	renderer := NewRenderer(sr.templates, sr.layout)
+	extra := opts.Extra
+	if extra == nil {
+		extra = make(map[string]interface{})
+	}
+
+	// Register boundary fallbacks in extra so the layout can access them
+	boundaryMap := make(map[string]template.HTML, len(opts.Boundaries))
+	for _, b := range opts.Boundaries {
+		boundaryMap[b.ID] = template.HTML(
+			fmt.Sprintf(`<div bf-async="%s">%s</div>`, b.ID, b.FallbackHTML),
+		)
+	}
+	extra["_bfBoundaries"] = boundaryMap
+
+	initialHTML := renderer.Render(RenderOptions{
+		ComponentName: opts.ComponentName,
+		Props:         opts.Props,
+		Title:         opts.Title,
+		Heading:       opts.Heading,
+		Extra:         extra,
+	})
+
+	if !canFlush {
+		// No flusher — resolve all boundaries inline (blocking)
+		resolvedHTML := sr.resolveAllBlocking(opts.Boundaries)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, initialHTML)
+		fmt.Fprint(w, resolvedHTML)
+		return nil
+	}
+
+	// Streaming mode
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, initialHTML)
+	flusher.Flush() // ← TTFB
+
+	// Resolve boundaries concurrently, stream each result as it arrives
+	type result struct {
+		id   string
+		html string
+		err  error
+	}
+
+	ch := make(chan result, len(opts.Boundaries))
+	var wg sync.WaitGroup
+
+	for _, b := range opts.Boundaries {
+		wg.Add(1)
+		go func(boundary AsyncBoundary) {
+			defer wg.Done()
+			content, err := boundary.Resolve()
+			ch <- result{id: boundary.ID, html: content, err: err}
+		}(b)
+	}
+
+	// Close channel when all goroutines complete
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	// Write resolve chunks as they arrive
+	for r := range ch {
+		if r.err != nil {
+			continue // Skip failed boundaries (fallback remains visible)
+		}
+		chunk := fmt.Sprintf(
+			`<template bf-async-resolve="%s">%s</template><script>__bf_swap("%s")</script>`,
+			r.id, r.html, r.id,
+		)
+		fmt.Fprint(w, chunk)
+		flusher.Flush()
+	}
+
+	return nil
+}
+
+func (sr *StreamRenderer) resolveAllBlocking(boundaries []AsyncBoundary) string {
+	var buf bytes.Buffer
+	for _, b := range boundaries {
+		content, err := b.Resolve()
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&buf,
+			`<template bf-async-resolve="%s">%s</template><script>__bf_swap("%s")</script>`,
+			b.ID, content, b.ID,
+		)
+	}
+	return buf.String()
+}
+
+// StreamingBootstrap returns the inline script required for OOS streaming.
+// Include this once per page, before any async boundaries.
+func StreamingBootstrap() template.HTML {
+	return `<script>(function(){function s(id){var a=document.querySelector('[bf-async="'+id+'"]');var t=document.querySelector('template[bf-async-resolve="'+id+'"]');if(!a||!t)return;a.replaceChildren(t.content.cloneNode(true));a.removeAttribute('bf-async');t.remove();requestAnimationFrame(function(){if(window.__bf_hydrate)window.__bf_hydrate()})};window.__bf_swap=s})()</script>`
+}
+
+// BfAsyncBoundary is a template function that renders an async boundary placeholder.
+// Usage in Go templates:
+//
+//	{{bfAsyncBoundary "a0" "<div class='skeleton'>Loading...</div>"}}
+//
+// This generates: <div bf-async="a0"><div class='skeleton'>Loading...</div></div>
+func BfAsyncBoundary(id string, fallbackHTML string) template.HTML {
+	return template.HTML(fmt.Sprintf(`<div bf-async="%s">%s</div>`, id, fallbackHTML))
+}
+
+// StreamingFuncMap returns additional template functions for streaming support.
+// Merge this with the base FuncMap():
+//
+//	funcMap := bf.FuncMap()
+//	for k, v := range bf.StreamingFuncMap() {
+//	    funcMap[k] = v
+//	}
+func StreamingFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"bfAsyncBoundary":    BfAsyncBoundary,
+		"bfStreamBootstrap":  func() template.HTML { return StreamingBootstrap() },
+	}
+}

--- a/packages/go-template/runtime/streaming_test.go
+++ b/packages/go-template/runtime/streaming_test.go
@@ -1,0 +1,257 @@
+package bf
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestStreamingBootstrap(t *testing.T) {
+	script := string(StreamingBootstrap())
+
+	if !strings.HasPrefix(script, "<script>") {
+		t.Error("StreamingBootstrap should start with <script>")
+	}
+	if !strings.HasSuffix(script, "</script>") {
+		t.Error("StreamingBootstrap should end with </script>")
+	}
+	if !strings.Contains(script, "__bf_swap") {
+		t.Error("StreamingBootstrap should define __bf_swap")
+	}
+	if !strings.Contains(script, "bf-async") {
+		t.Error("StreamingBootstrap should reference bf-async attribute")
+	}
+}
+
+func TestBfAsyncBoundary(t *testing.T) {
+	got := string(BfAsyncBoundary("a0", "<p>Loading...</p>"))
+	want := `<div bf-async="a0"><p>Loading...</p></div>`
+	if got != want {
+		t.Errorf("BfAsyncBoundary = %q, want %q", got, want)
+	}
+}
+
+func TestBfAsyncBoundaryEmpty(t *testing.T) {
+	got := string(BfAsyncBoundary("a1", ""))
+	want := `<div bf-async="a1"></div>`
+	if got != want {
+		t.Errorf("BfAsyncBoundary empty = %q, want %q", got, want)
+	}
+}
+
+func TestStreamingFuncMap(t *testing.T) {
+	fm := StreamingFuncMap()
+
+	if _, ok := fm["bfAsyncBoundary"]; !ok {
+		t.Error("StreamingFuncMap missing bfAsyncBoundary")
+	}
+	if _, ok := fm["bfStreamBootstrap"]; !ok {
+		t.Error("StreamingFuncMap missing bfStreamBootstrap")
+	}
+}
+
+// mockFlusher wraps httptest.ResponseRecorder with http.Flusher support
+type mockFlusher struct {
+	*httptest.ResponseRecorder
+	flushCount int
+}
+
+func (f *mockFlusher) Flush() {
+	f.flushCount++
+}
+
+func TestStreamRendererStreaming(t *testing.T) {
+	// Simple template that renders component name
+	tmpl := mustParseTemplate(t, `{{define "TestPage"}}Page Content{{end}}`)
+
+	layout := func(ctx *RenderContext) string {
+		return "<html><body>" + string(ctx.ComponentHTML) + string(ctx.Scripts) + "</body></html>"
+	}
+
+	sr := NewStreamRenderer(tmpl, layout)
+
+	rec := httptest.NewRecorder()
+	w := &mockFlusher{ResponseRecorder: rec}
+
+	err := sr.Stream(w, StreamOptions{
+		ComponentName: "TestPage",
+		Props:         &struct{ ScopeID string }{ScopeID: "TestPage_abc"},
+		Boundaries: []AsyncBoundary{
+			{
+				ID:           "a0",
+				FallbackHTML: "<p>Loading...</p>",
+				Resolve: func() (string, error) {
+					return `<div bf-s="Counter_x1">42</div>`, nil
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+
+	// Initial page should be present
+	if !strings.Contains(body, "Page Content") {
+		t.Error("Response should contain initial page content")
+	}
+
+	// Resolve chunk should be present
+	if !strings.Contains(body, `bf-async-resolve="a0"`) {
+		t.Error("Response should contain resolve template for a0")
+	}
+	if !strings.Contains(body, `__bf_swap("a0")`) {
+		t.Error("Response should contain swap script for a0")
+	}
+	if !strings.Contains(body, `bf-s="Counter_x1"`) {
+		t.Error("Response should contain resolved component content")
+	}
+
+	// Should have flushed at least once (initial page)
+	if w.flushCount < 1 {
+		t.Errorf("Expected at least 1 flush, got %d", w.flushCount)
+	}
+}
+
+func TestStreamRendererMultipleBoundaries(t *testing.T) {
+	tmpl := mustParseTemplate(t, `{{define "Multi"}}Multi{{end}}`)
+
+	layout := func(ctx *RenderContext) string {
+		return string(ctx.ComponentHTML)
+	}
+
+	sr := NewStreamRenderer(tmpl, layout)
+
+	rec := httptest.NewRecorder()
+	w := &mockFlusher{ResponseRecorder: rec}
+
+	err := sr.Stream(w, StreamOptions{
+		ComponentName: "Multi",
+		Props:         &struct{ ScopeID string }{ScopeID: "Multi_abc"},
+		Boundaries: []AsyncBoundary{
+			{
+				ID:           "a0",
+				FallbackHTML: "Loading 1",
+				Resolve: func() (string, error) {
+					return "<div>Content 1</div>", nil
+				},
+			},
+			{
+				ID:           "a1",
+				FallbackHTML: "Loading 2",
+				Resolve: func() (string, error) {
+					return "<div>Content 2</div>", nil
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `bf-async-resolve="a0"`) {
+		t.Error("Response should contain resolve for a0")
+	}
+	if !strings.Contains(body, `bf-async-resolve="a1"`) {
+		t.Error("Response should contain resolve for a1")
+	}
+	if !strings.Contains(body, "Content 1") {
+		t.Error("Response should contain Content 1")
+	}
+	if !strings.Contains(body, "Content 2") {
+		t.Error("Response should contain Content 2")
+	}
+}
+
+func TestStreamRendererNoFlusher(t *testing.T) {
+	tmpl := mustParseTemplate(t, `{{define "NoFlush"}}NoFlush{{end}}`)
+
+	layout := func(ctx *RenderContext) string {
+		return string(ctx.ComponentHTML)
+	}
+
+	sr := NewStreamRenderer(tmpl, layout)
+
+	// Use plain ResponseRecorder (no Flusher interface)
+	rec := httptest.NewRecorder()
+
+	err := sr.Stream(rec, StreamOptions{
+		ComponentName: "NoFlush",
+		Props:         &struct{ ScopeID string }{ScopeID: "NoFlush_abc"},
+		Boundaries: []AsyncBoundary{
+			{
+				ID:           "a0",
+				FallbackHTML: "Loading",
+				Resolve: func() (string, error) {
+					return "<div>Resolved</div>", nil
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	// Should still contain everything (blocking mode)
+	if !strings.Contains(body, "NoFlush") {
+		t.Error("Blocking mode should render page content")
+	}
+	if !strings.Contains(body, "Resolved") {
+		t.Error("Blocking mode should resolve boundaries inline")
+	}
+}
+
+func TestStreamRendererErrorBoundary(t *testing.T) {
+	tmpl := mustParseTemplate(t, `{{define "ErrPage"}}ErrPage{{end}}`)
+
+	layout := func(ctx *RenderContext) string {
+		return string(ctx.ComponentHTML)
+	}
+
+	sr := NewStreamRenderer(tmpl, layout)
+
+	rec := httptest.NewRecorder()
+	w := &mockFlusher{ResponseRecorder: rec}
+
+	err := sr.Stream(w, StreamOptions{
+		ComponentName: "ErrPage",
+		Props:         &struct{ ScopeID string }{ScopeID: "ErrPage_abc"},
+		Boundaries: []AsyncBoundary{
+			{
+				ID:           "a0",
+				FallbackHTML: "Loading",
+				Resolve: func() (string, error) {
+					return "", http.ErrAbortHandler
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	// Failed boundary should not produce a resolve chunk
+	if strings.Contains(body, `bf-async-resolve="a0"`) {
+		t.Error("Failed boundary should not produce resolve chunk")
+	}
+}
+
+func mustParseTemplate(t *testing.T, text string) *template.Template {
+	t.Helper()
+	tmpl, err := template.New("").Funcs(FuncMap()).Parse(text)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+	return tmpl
+}

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -25,6 +25,7 @@ import type {
   ParsedStatement,
   IRIfStatement,
   IRProvider,
+  IRAsync,
 } from '@barefootjs/jsx'
 import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, isBooleanAttr, parseExpression, isSupported } from '@barefootjs/jsx'
 
@@ -1006,6 +1007,8 @@ export class GoTemplateAdapter extends BaseAdapter {
         return this.renderIfStatement(node as IRIfStatement, ctx)
       case 'provider':
         return this.renderChildren((node as IRProvider).children)
+      case 'async':
+        return this.renderAsync(node as IRAsync)
       default:
         return ''
     }
@@ -2312,6 +2315,18 @@ export class GoTemplateAdapter extends BaseAdapter {
     // Use Go template's block for slots
     const slotName = slot.name === 'default' ? 'children' : slot.name
     return `{{block "${slotName}" .}}{{end}}`
+  }
+
+  renderAsync(node: IRAsync): string {
+    const fallback = this.renderNode(node.fallback)
+    const children = this.renderChildren(node.children)
+    // Go templates use the OOS protocol: render a placeholder with fallback,
+    // the StreamRenderer resolves boundaries and streams replacement chunks.
+    return `{{bfAsyncBoundary "${node.id}" "${this.escapeGoString(fallback)}"}}\n${children}`
+  }
+
+  private escapeGoString(s: string): string {
+    return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
   }
 
   private renderAttributes(element: IRElement): string {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -42,6 +42,10 @@
       "types": "./src/jsx/jsx-dev-runtime/index.d.ts",
       "import": "./src/jsx/jsx-dev-runtime/index.ts"
     },
+    "./async": {
+      "types": "./src/async.tsx",
+      "import": "./src/async.tsx"
+    },
     "./utils": {
       "types": "./src/utils.ts",
       "import": "./src/utils.ts"

--- a/packages/hono/src/__tests__/async.test.tsx
+++ b/packages/hono/src/__tests__/async.test.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource hono/jsx */
+/**
+ * BfAsync Component Tests
+ *
+ * Verifies that BfAsync properly wraps Hono's Suspense
+ * for streaming SSR with BarefootJS components.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderToReadableStream } from 'hono/jsx/streaming'
+import type { HtmlEscapedString } from 'hono/utils/html'
+import { BfAsync } from '../async'
+
+async function collectStream(stream: ReadableStream): Promise<string[]> {
+  const chunks: string[] = []
+  const decoder = new TextDecoder()
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(decoder.decode(chunk))
+  }
+  return chunks
+}
+
+describe('BfAsync', () => {
+  it('streams fallback then resolved content', async () => {
+    const AsyncContent = () => {
+      return new Promise<HtmlEscapedString>((resolve) =>
+        setTimeout(() => resolve(<div>Loaded!</div>), 10)
+      )
+    }
+
+    const stream = renderToReadableStream(
+      <BfAsync fallback={<p>Loading...</p>}>
+        <AsyncContent />
+      </BfAsync>
+    )
+
+    const chunks = await collectStream(stream)
+
+    // First chunk has fallback
+    expect(chunks[0]).toContain('Loading...')
+    // Later chunk has resolved content
+    const fullOutput = chunks.join('')
+    expect(fullOutput).toContain('Loaded!')
+  })
+
+  it('renders multiple async boundaries independently', async () => {
+    const SlowContent = ({ id }: { id: number }) => {
+      return new Promise<HtmlEscapedString>((resolve) =>
+        setTimeout(() => resolve(<span>Content {id}</span>), 10 * id)
+      )
+    }
+
+    const stream = renderToReadableStream(
+      <div>
+        <BfAsync fallback={<p>Loading 1...</p>}>
+          <SlowContent id={1} />
+        </BfAsync>
+        <BfAsync fallback={<p>Loading 2...</p>}>
+          <SlowContent id={2} />
+        </BfAsync>
+      </div>
+    )
+
+    const chunks = await collectStream(stream)
+    const fullOutput = chunks.join('')
+
+    expect(fullOutput).toContain('Content 1')
+    expect(fullOutput).toContain('Content 2')
+  })
+
+  it('preserves BarefootJS hydration markers in async content', async () => {
+    const AsyncComponent = () => {
+      return new Promise<HtmlEscapedString>((resolve) =>
+        setTimeout(() => resolve(
+          <div bf-s="Counter_abc" bf-p='{"count":0}'>0</div>
+        ), 10)
+      )
+    }
+
+    const stream = renderToReadableStream(
+      <BfAsync fallback={<p>Loading...</p>}>
+        <AsyncComponent />
+      </BfAsync>
+    )
+
+    const chunks = await collectStream(stream)
+    const fullOutput = chunks.join('')
+
+    expect(fullOutput).toContain('bf-s="Counter_abc"')
+    expect(fullOutput).toContain('bf-p=')
+  })
+
+  it('renders synchronous children without streaming', async () => {
+    const SyncContent = () => <div>Already here</div>
+
+    const stream = renderToReadableStream(
+      <BfAsync fallback={<p>Loading...</p>}>
+        <SyncContent />
+      </BfAsync>
+    )
+
+    const chunks = await collectStream(stream)
+
+    // Synchronous content should be in the first chunk (no fallback needed)
+    expect(chunks[0]).toContain('Already here')
+  })
+})

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -16,6 +16,7 @@ import {
   type IRFragment,
   type IRIfStatement,
   type IRProvider,
+  type IRAsync,
   type IRTemplateLiteral,
   type ParamInfo,
   type AdapterOutput,
@@ -115,6 +116,11 @@ export class HonoAdapter extends JsxAdapter {
     }
     if (utilImports.length > 0) {
       lines.push(`import { ${utilImports.join(', ')} } from '@barefootjs/hono/utils'`)
+    }
+
+    // Import Suspense when async boundaries are used
+    if (componentCode.includes('<Suspense')) {
+      lines.push(`import { Suspense } from 'hono/jsx/streaming'`)
     }
 
     // Re-export template imports (client-side packages already filtered by compiler)
@@ -427,6 +433,8 @@ export class HonoAdapter extends JsxAdapter {
         return ''
       case 'provider':
         return this.renderChildren((node as IRProvider).children)
+      case 'async':
+        return this.renderAsync(node as IRAsync)
       default:
         return ''
     }
@@ -622,6 +630,12 @@ export class HonoAdapter extends JsxAdapter {
     }
 
     return lines.join('\n')
+  }
+
+  renderAsync(node: IRAsync): string {
+    const fallback = this.renderNode(node.fallback)
+    const children = this.renderChildren(node.children)
+    return `<Suspense fallback={<>${fallback}</>}>${children}</Suspense>`
   }
 
   renderComponent(comp: IRComponent, ctx?: { isRootOfClientComponent?: boolean; isInsideLoop?: boolean; isLoopItemRoot?: boolean }): string {

--- a/packages/hono/src/async.tsx
+++ b/packages/hono/src/async.tsx
@@ -1,0 +1,49 @@
+/**
+ * BfAsync - Streaming async boundary for Hono
+ *
+ * Wraps Hono's Suspense for streaming SSR with BarefootJS integration.
+ * When the renderer uses `{ stream: true }`, this leverages Hono's native
+ * Suspense/streaming. The BarefootJS hydration runtime automatically picks
+ * up components rendered inside async boundaries via requestAnimationFrame.
+ *
+ * Usage:
+ * ```tsx
+ * import { BfAsync } from '@barefootjs/hono/async'
+ *
+ * app.get('/products/:id', (c) => {
+ *   return c.render(
+ *     <BfAsync fallback={<ProductSkeleton />}>
+ *       <ProductDetail id={c.req.param('id')} />
+ *     </BfAsync>
+ *   )
+ * })
+ * ```
+ *
+ * Requires the renderer to be configured with `{ stream: true }`.
+ */
+
+/** @jsxImportSource hono/jsx */
+
+import { Suspense } from 'hono/jsx/streaming'
+import type { Child } from 'hono/jsx'
+
+export interface BfAsyncProps {
+  /** Content to display while the async children are loading. */
+  fallback: Child
+  /** Async children that will be streamed when resolved. */
+  children: Child
+}
+
+/**
+ * Async streaming boundary component.
+ *
+ * Renders fallback content immediately (sent in the initial HTTP response
+ * for fast TTFB), then streams the resolved children when ready.
+ */
+export function BfAsync(props: BfAsyncProps) {
+  return (
+    <Suspense fallback={props.fallback}>
+      {props.children}
+    </Suspense>
+  )
+}

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -17,6 +17,10 @@ export type { CollectedScript } from './scripts'
 export type { CollectedPortal } from './portals'
 export type { PortalProps } from './portal-ssr'
 
+// Async streaming boundary
+// Usage: import { BfAsync } from '@barefootjs/hono/async'
+export type { BfAsyncProps } from './async'
+
 // Dialog context for scopeId sharing
 // Usage: import { DialogContext, useDialogContext } from '@barefootjs/hono/dialog-context'
 export type { DialogContextValue } from './dialog-context'

--- a/packages/jsx/src/__tests__/ir-async.test.ts
+++ b/packages/jsx/src/__tests__/ir-async.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import type { IRAsync, IRElement } from '../types'
+
+describe('<Async> streaming boundary', () => {
+  test('transforms <Async> with fallback and children into IRAsync', () => {
+    const source = `
+      export function ProductPage() {
+        return (
+          <div>
+            <Async fallback={<p>Loading...</p>}>
+              <ProductDetail />
+            </Async>
+          </div>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductPage.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    expect(ir!.type).toBe('element')
+
+    const div = ir as IRElement
+    // Find the async node in children
+    const asyncNode = div.children.find(c => c.type === 'async') as IRAsync
+    expect(asyncNode).toBeDefined()
+    expect(asyncNode.type).toBe('async')
+    expect(asyncNode.id).toBe('a0')
+
+    // Fallback should be a <p> element
+    expect(asyncNode.fallback.type).toBe('element')
+    if (asyncNode.fallback.type === 'element') {
+      expect(asyncNode.fallback.tag).toBe('p')
+    }
+
+    // Children should contain the component
+    expect(asyncNode.children.length).toBe(1)
+    expect(asyncNode.children[0].type).toBe('component')
+  })
+
+  test('assigns sequential IDs to multiple async boundaries', () => {
+    const source = `
+      export function Dashboard() {
+        return (
+          <div>
+            <Async fallback={<p>Loading A...</p>}>
+              <SectionA />
+            </Async>
+            <Async fallback={<p>Loading B...</p>}>
+              <SectionB />
+            </Async>
+          </div>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Dashboard.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    const div = ir as IRElement
+    const asyncNodes = div.children.filter(c => c.type === 'async') as IRAsync[]
+
+    expect(asyncNodes.length).toBe(2)
+    expect(asyncNodes[0].id).toBe('a0')
+    expect(asyncNodes[1].id).toBe('a1')
+  })
+
+  test('fallback can be a self-closing element', () => {
+    const source = `
+      export function Page() {
+        return (
+          <Async fallback={<Skeleton />}>
+            <Content />
+          </Async>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Page.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    const asyncNode = ir as IRAsync
+    expect(asyncNode.type).toBe('async')
+
+    // Fallback should be a component
+    expect(asyncNode.fallback.type).toBe('component')
+  })
+
+  test('throws when fallback prop is missing', () => {
+    const source = `
+      export function Page() {
+        return (
+          <Async>
+            <Content />
+          </Async>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Page.tsx')
+    expect(() => jsxToIR(ctx)).toThrow('fallback')
+  })
+})

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -12,6 +12,7 @@ import type {
   IRConditional,
   IRLoop,
   IRComponent,
+  IRAsync,
 } from '../types'
 
 export interface TemplateSections {
@@ -52,6 +53,7 @@ export interface TemplateAdapter {
   renderConditional(cond: IRConditional): string
   renderLoop(loop: IRLoop): string
   renderComponent(comp: IRComponent): string
+  renderAsync(node: IRAsync): string
 
   // Hydration markers
   renderScopeMarker(instanceIdExpr: string): string
@@ -74,6 +76,7 @@ export abstract class BaseAdapter implements TemplateAdapter {
   abstract renderConditional(cond: IRConditional): string
   abstract renderLoop(loop: IRLoop): string
   abstract renderComponent(comp: IRComponent): string
+  abstract renderAsync(node: IRAsync): string
   abstract renderScopeMarker(instanceIdExpr: string): string
   abstract renderSlotMarker(slotId: string): string
   abstract renderCondMarker(condId: string): string

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -76,12 +76,16 @@ export abstract class BaseAdapter implements TemplateAdapter {
   abstract renderConditional(cond: IRConditional): string
   abstract renderLoop(loop: IRLoop): string
   abstract renderComponent(comp: IRComponent): string
-  abstract renderAsync(node: IRAsync): string
   abstract renderScopeMarker(instanceIdExpr: string): string
   abstract renderSlotMarker(slotId: string): string
   abstract renderCondMarker(condId: string): string
 
   renderChildren(children: IRNode[]): string {
     return children.map((child) => this.renderNode(child)).join('')
+  }
+
+  /** Default: render fallback + children inline (no streaming). Override for streaming support. */
+  renderAsync(node: IRAsync): string {
+    return this.renderNode(node.fallback) + this.renderChildren(node.children)
   }
 }

--- a/packages/jsx/src/css-layer-prefixer.ts
+++ b/packages/jsx/src/css-layer-prefixer.ts
@@ -221,6 +221,7 @@ function walkIR(node: IRNode, visitor: (node: IRNode) => void): void {
       if (node.alternate) walkIR(node.alternate, visitor)
       break
     case 'provider':
+    case 'async':
       for (const child of node.children) walkIR(child, visitor)
       break
   }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -23,6 +23,7 @@ export type {
   IRSlot,
   IRIfStatement,
   IRProvider,
+  IRAsync,
   IRMetadata,
   IRTemplateLiteral,
   IRTemplatePart,

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -19,6 +19,7 @@ const loopSiblingOffsets = new WeakMap<IRNode, number>()
 /** Check if an IR node produces a DOM child element (for sibling offset counting). */
 function producesDomChild(node: IRNode): boolean {
   return node.type === 'element' || node.type === 'component' || node.type === 'provider'
+    || node.type === 'async'
     || node.type === 'text' || (node.type === 'expression' && !node.reactive)
     || node.type === 'conditional'
 }
@@ -85,6 +86,7 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
       case 'fragment':
       case 'component':
       case 'provider':
+      case 'async':
         for (const child of n.children) walk(child, parentSlotId)
         break
       case 'conditional': {
@@ -456,6 +458,13 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         collectElements(child, ctx, insideConditional)
       }
       break
+
+    case 'async':
+      // Async boundaries are transparent for client JS — just traverse children
+      for (const child of node.children) {
+        collectElements(child, ctx, insideConditional)
+      }
+      break
   }
 }
 
@@ -548,6 +557,7 @@ function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
       case 'if-statement':
         break
       case 'provider':
+      case 'async':
         for (const child of n.children) walk(child)
         break
     }
@@ -633,6 +643,7 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
       case 'fragment':
       case 'component':
       case 'provider':
+      case 'async':
         for (const child of n.children) walk(child)
         break
       // Don't recurse into nested conditionals
@@ -690,6 +701,7 @@ function collectBranchConditionals(node: IRNode, ctx: ClientJsContext): Conditio
       case 'fragment':
       case 'component':
       case 'provider':
+      case 'async':
         for (const child of n.children) walk(child)
         break
       // Don't recurse into loops (they handle their own reconciliation)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -181,6 +181,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       return ''
 
     case 'provider':
+    case 'async':
       return node.children.map(recurse).join('')
 
     default:
@@ -287,6 +288,7 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       return ''
 
     case 'provider':
+    case 'async':
       return node.children.map(recurse).join('')
 
     default:
@@ -547,6 +549,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       return ''
 
     case 'provider':
+    case 'async':
       return node.children.map(recurse).join('')
 
     default:
@@ -651,6 +654,7 @@ export function canGenerateStaticTemplate(
       return true
 
     case 'provider':
+    case 'async':
       return node.children.every((c) => canGenerateStaticTemplate(c, propNames, inlinableConstants, unsafeLocalNames))
 
     case 'text':
@@ -841,6 +845,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     }
 
     case 'provider':
+    case 'async':
       return node.children.map(recurse).join('')
 
     default:

--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -298,6 +298,10 @@ export function collectIdentifiersFromIRTree(node: IRNode, set: Set<string>): vo
       for (const child of node.children) collectIdentifiersFromIRTree(child, set)
       break
 
+    case 'async':
+      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
+      break
+
     case 'slot':
       break
   }
@@ -343,6 +347,7 @@ export function addLoopSubtreeIdentifiers(node: IRNode, set: Set<string>): void 
       if (node.alternate) addLoopSubtreeIdentifiers(node.alternate, set)
       break
     case 'provider':
+    case 'async':
       for (const child of node.children) addLoopSubtreeIdentifiers(child, set)
       break
   }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -104,6 +104,7 @@ export function collectEventHandlersFromIR(node: IRNode): string[] {
       }
       break
     case 'provider':
+    case 'async':
       for (const child of node.children) {
         handlers.push(...collectEventHandlersFromIR(child))
       }
@@ -134,6 +135,7 @@ function traverseElements(node: IRNode, visitor: (el: IRElement, domDepth: numbe
     case 'fragment':
     case 'component':
     case 'provider':
+    case 'async':
       for (const child of node.children) {
         traverseElements(child, visitor, domDepth)
       }
@@ -260,6 +262,7 @@ export function collectLoopChildEventsWithNesting(
       case 'fragment':
       case 'component':
       case 'provider':
+      case 'async':
         for (const child of n.children) walk(child, domDepth)
         break
       case 'conditional':
@@ -302,6 +305,7 @@ function traverseForComponents(
     case 'element':
     case 'fragment':
     case 'provider':
+    case 'async':
       for (const child of node.children) {
         traverseForComponents(child, components)
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -537,11 +537,7 @@ function transformSelfClosingAsyncElement(
   const fallbackProp = props.find(p => p.name === 'fallback')
 
   if (!fallbackProp) {
-    throw createError(
-      ErrorCodes.MISSING_PROP,
-      '<Async /> requires a \'fallback\' prop',
-      getSourceLocation(node, ctx.sourceFile, ctx.filePath)
-    )
+    throw new Error('<Async /> requires a \'fallback\' prop')
   }
 
   // Parse fallback from the self-closing element's attributes

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -62,6 +62,8 @@ interface TransformContext {
   _destructuredPropNames?: Set<string> | null
   /** Active loop parameter names for slotId assignment to loop-param-dependent expressions */
   loopParams: Set<string>
+  /** Counter for async boundary IDs (a0, a1, ...) */
+  asyncIdCounter: number
 }
 
 /**
@@ -130,6 +132,7 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     sourceFile: analyzer.sourceFile,
     filePath: analyzer.filePath,
     slotIdCounter: 0,
+    asyncIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
     loopParams: new Set(),
@@ -315,6 +318,11 @@ function transformJsxElement(
     return transformProviderElement(node, ctx, tagName)
   }
 
+  // Detect Async streaming boundary: <Async fallback={...}>
+  if (tagName === 'Async') {
+    return transformAsyncElement(node, ctx)
+  }
+
   const isComponent = /^[A-Z]/.test(tagName)
 
   if (isComponent) {
@@ -373,6 +381,11 @@ function transformSelfClosingElement(
   // Detect Context.Provider pattern: <X.Provider ... />
   if (tagName.endsWith('.Provider') && /^[A-Z]/.test(tagName)) {
     return transformSelfClosingProviderElement(node, ctx, tagName)
+  }
+
+  // Detect Async streaming boundary: <Async ... />
+  if (tagName === 'Async') {
+    return transformSelfClosingAsyncElement(node, ctx)
   }
 
   const isComponent = /^[A-Z]/.test(tagName)
@@ -448,6 +461,117 @@ function transformSelfClosingProviderElement(
     type: 'provider',
     contextName,
     valueProp,
+    children: [],
+    loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+  }
+}
+
+// =============================================================================
+// Async Streaming Boundary Transformation
+// =============================================================================
+
+function transformAsyncElement(
+  node: ts.JsxElement,
+  ctx: TransformContext
+): IRNode {
+  const props = processComponentProps(node.openingElement.attributes, ctx)
+  const fallbackProp = props.find(p => p.name === 'fallback')
+
+  if (!fallbackProp) {
+    throw new Error('<Async> requires a \'fallback\' prop')
+  }
+
+  // Parse the fallback JSX expression into an IR node
+  const fallbackNode = parseFallbackProp(fallbackProp, ctx, node)
+
+  const children = transformChildren(node.children, ctx)
+  const id = `a${ctx.asyncIdCounter++}`
+
+  return {
+    type: 'async',
+    id,
+    fallback: fallbackNode,
+    children,
+    loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+  }
+}
+
+/**
+ * Parse the fallback prop's JSX expression into an IR node.
+ * The fallback is typically a JSX element: fallback={<Skeleton />}
+ */
+function parseFallbackProp(
+  prop: IRProp,
+  ctx: TransformContext,
+  parentNode: ts.Node
+): IRNode {
+  // Walk the parent node's attributes to find the actual AST node for fallback
+  const openingEl = (parentNode as ts.JsxElement).openingElement
+  for (const attr of openingEl.attributes.properties) {
+    if (ts.isJsxAttribute(attr) && attr.name.getText(ctx.sourceFile) === 'fallback') {
+      const initializer = attr.initializer
+      if (initializer && ts.isJsxExpression(initializer) && initializer.expression) {
+        const expr = initializer.expression
+        // If it's a JSX element, transform it
+        if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
+          const result = transformNode(expr, ctx)
+          if (result) return result
+        }
+      }
+    }
+  }
+
+  // Fallback to a text node with the prop value
+  return {
+    type: 'text',
+    value: prop.value,
+    loc: getSourceLocation(parentNode, ctx.sourceFile, ctx.filePath),
+  }
+}
+
+function transformSelfClosingAsyncElement(
+  node: ts.JsxSelfClosingElement,
+  ctx: TransformContext
+): IRNode {
+  const props = processComponentProps(node.attributes, ctx)
+  const fallbackProp = props.find(p => p.name === 'fallback')
+
+  if (!fallbackProp) {
+    throw createError(
+      ErrorCodes.MISSING_PROP,
+      '<Async /> requires a \'fallback\' prop',
+      getSourceLocation(node, ctx.sourceFile, ctx.filePath)
+    )
+  }
+
+  // Parse fallback from the self-closing element's attributes
+  let fallbackNode: IRNode | null = null
+  for (const attr of node.attributes.properties) {
+    if (ts.isJsxAttribute(attr) && attr.name.getText(ctx.sourceFile) === 'fallback') {
+      const initializer = attr.initializer
+      if (initializer && ts.isJsxExpression(initializer) && initializer.expression) {
+        const expr = initializer.expression
+        if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
+          fallbackNode = transformNode(expr, ctx)
+        }
+      }
+    }
+  }
+
+  if (!fallbackNode) {
+    fallbackNode = {
+      type: 'text',
+      value: fallbackProp.value,
+      loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    }
+  }
+
+  const id = `a${ctx.asyncIdCounter++}`
+
+  return {
+    type: 'async',
+    id,
+    fallback: fallbackNode,
     children: [],
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -86,6 +86,7 @@ export type IRNode =
   | IRFragment
   | IRIfStatement
   | IRProvider
+  | IRAsync
 
 export interface IRElement {
   type: 'element'
@@ -281,6 +282,25 @@ export interface IRProvider {
   type: 'provider'
   contextName: string   // "MenuContext" (extracted from X.Provider)
   valueProp: IRProp     // The 'value' prop expression
+  children: IRNode[]
+  loc: SourceLocation
+}
+
+/**
+ * Async streaming boundary node for out-of-order SSR.
+ *
+ * Maps to `<Async fallback={...}>children</Async>` in JSX.
+ * Adapters translate this to their native streaming mechanism:
+ *   - Hono: `<Suspense fallback={...}>` (native streaming)
+ *   - Go: `bfAsyncBoundary()` + OOS resolve chunks
+ */
+export interface IRAsync {
+  type: 'async'
+  /** Unique boundary ID (e.g., "a0", "a1") — assigned by the compiler */
+  id: string
+  /** Fallback content shown while loading (e.g., skeleton UI) */
+  fallback: IRNode
+  /** Resolved content rendered after data loads */
   children: IRNode[]
   loc: SourceLocation
 }

--- a/packages/mojolicious/lib/BarefootJS.pm
+++ b/packages/mojolicious/lib/BarefootJS.pm
@@ -101,4 +101,20 @@ sub scripts ($self) {
     return join("\n", @tags);
 }
 
+# ---------------------------------------------------------------------------
+# Streaming SSR (Out-of-Order)
+# ---------------------------------------------------------------------------
+
+sub streaming_bootstrap ($self) {
+    return q{<script>(function(){function s(id){var a=document.querySelector('[bf-async="'+id+'"]');var t=document.querySelector('template[bf-async-resolve="'+id+'"]');if(!a||!t)return;a.replaceChildren(t.content.cloneNode(true));a.removeAttribute('bf-async');t.remove();requestAnimationFrame(function(){if(window.__bf_hydrate)window.__bf_hydrate()})};window.__bf_swap=s})()</script>};
+}
+
+sub async_boundary ($self, $id, $fallback_html) {
+    return qq{<div bf-async="$id">$fallback_html</div>};
+}
+
+sub async_resolve ($self, $id, $content_html) {
+    return qq{<template bf-async-resolve="$id">$content_html</template><script>__bf_swap("$id")</script>};
+}
+
 1;

--- a/packages/mojolicious/src/__tests__/mojo-streaming.test.ts
+++ b/packages/mojolicious/src/__tests__/mojo-streaming.test.ts
@@ -1,0 +1,84 @@
+/**
+ * MojoAdapter - Streaming SSR Tests
+ *
+ * Tests the renderAsync method and streaming-related output.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { MojoAdapter } from '../adapter/mojo-adapter'
+import type { IRAsync, IRElement, IRComponent } from '@barefootjs/jsx'
+
+describe('MojoAdapter - Streaming SSR', () => {
+  const adapter = new MojoAdapter()
+
+  test('renderAsync generates bf->async_boundary call with fallback', () => {
+    const asyncNode: IRAsync = {
+      type: 'async',
+      id: 'a0',
+      fallback: {
+        type: 'element',
+        tag: 'p',
+        attrs: [],
+        events: [],
+        ref: null,
+        children: [{ type: 'text', value: 'Loading...', loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } }],
+        slotId: null,
+        needsScope: false,
+        loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+      } as IRElement,
+      children: [
+        {
+          type: 'component',
+          name: 'ProductDetail',
+          props: [],
+          template: 'ProductDetail',
+          slotId: null,
+          children: [],
+          loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        } as IRComponent,
+      ],
+      loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+    }
+
+    const output = adapter.renderAsync(asyncNode)
+
+    // Should contain the async_boundary call with the ID
+    expect(output).toContain("async_boundary('a0'")
+    // Should contain the fallback content
+    expect(output).toContain('Loading...')
+  })
+
+  test('renderNode dispatches async type correctly', () => {
+    const asyncNode: IRAsync = {
+      type: 'async',
+      id: 'a1',
+      fallback: {
+        type: 'text',
+        value: 'Please wait...',
+        loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+      },
+      children: [],
+      loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+    }
+
+    const output = adapter.renderNode(asyncNode)
+
+    expect(output).toContain("'a1'")
+    expect(output).toContain('Please wait...')
+  })
+
+  test('renderNode dispatches provider type (transparent)', () => {
+    const providerNode = {
+      type: 'provider' as const,
+      contextName: 'ThemeContext',
+      valueProp: { name: 'value', value: 'dark', dynamic: false },
+      children: [
+        { type: 'text' as const, value: 'child content', loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } },
+      ],
+      loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+    }
+
+    const output = adapter.renderNode(providerNode)
+    expect(output).toBe('child content')
+  })
+})

--- a/packages/mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/mojolicious/src/adapter/mojo-adapter.ts
@@ -16,6 +16,8 @@ import type {
   IRFragment,
   IRSlot,
   IRIfStatement,
+  IRProvider,
+  IRAsync,
   IRTemplateLiteral,
   CompilerError,
 } from '@barefootjs/jsx'
@@ -126,6 +128,10 @@ export class MojoAdapter extends BaseAdapter {
         return this.renderSlot(node as IRSlot)
       case 'if-statement':
         return this.renderIfStatement(node as IRIfStatement)
+      case 'provider':
+        return this.renderChildren((node as IRProvider).children)
+      case 'async':
+        return this.renderAsync(node as IRAsync)
       default:
         return ''
     }
@@ -375,6 +381,16 @@ export class MojoAdapter extends BaseAdapter {
 
   private renderSlot(_slot: IRSlot): string {
     return `<%= content %>`
+  }
+
+  renderAsync(node: IRAsync): string {
+    const fallback = this.renderNode(node.fallback)
+    const children = this.renderChildren(node.children)
+    // Use the BarefootJS.pm streaming helpers for OOS streaming.
+    // bf->async_boundary() wraps the fallback in a <div bf-async="aX"> placeholder.
+    // The resolved content is rendered below for non-streaming fallback;
+    // in streaming mode, Mojo's write_chunk delivers it as a resolve chunk.
+    return `<%== bf->async_boundary('${node.id}', begin %>${fallback}<% end) %>\n${children}`
   }
 
   // ===========================================================================

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,4 +15,6 @@ export {
   BF_KEY,
   BF_KEY_PREFIX,
   BF_PLACEHOLDER,
+  BF_ASYNC,
+  BF_ASYNC_RESOLVE,
 } from './markers'

--- a/packages/shared/src/markers.ts
+++ b/packages/shared/src/markers.ts
@@ -74,3 +74,13 @@ export const BF_KEY_PREFIX = 'data-key-'
 
 /** Component placeholder in loop templates: `data-bf-ph="s5"` */
 export const BF_PLACEHOLDER = 'data-bf-ph'
+
+// ---------------------------------------------------------------------------
+// Streaming (Out-of-Order SSR)
+// ---------------------------------------------------------------------------
+
+/** Async boundary placeholder: `bf-async="a0"` */
+export const BF_ASYNC = 'bf-async'
+
+/** Async resolve template: `<template bf-async-resolve="a0">` */
+export const BF_ASYNC_RESOLVE = 'bf-async-resolve'

--- a/packages/streaming/__tests__/html.test.ts
+++ b/packages/streaming/__tests__/html.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  renderAsyncBoundary,
+  renderAsyncResolve,
+  streamingBootstrap,
+  AsyncIdGenerator,
+} from '../src/index'
+
+describe('renderAsyncBoundary', () => {
+  test('wraps fallback in div with bf-async attribute', () => {
+    const html = renderAsyncBoundary('a0', '<p>Loading...</p>')
+    expect(html).toBe('<div bf-async="a0"><p>Loading...</p></div>')
+  })
+
+  test('supports custom wrapper tag', () => {
+    const html = renderAsyncBoundary('a1', '<span>Wait</span>', 'section')
+    expect(html).toBe('<section bf-async="a1"><span>Wait</span></section>')
+  })
+
+  test('handles empty fallback', () => {
+    const html = renderAsyncBoundary('a2', '')
+    expect(html).toBe('<div bf-async="a2"></div>')
+  })
+})
+
+describe('renderAsyncResolve', () => {
+  test('generates template + swap script', () => {
+    const html = renderAsyncResolve('a0', '<div>Resolved</div>')
+    expect(html).toContain('<template bf-async-resolve="a0">')
+    expect(html).toContain('<div>Resolved</div>')
+    expect(html).toContain('</template>')
+    expect(html).toContain('<script>__bf_swap("a0")</script>')
+  })
+
+  test('preserves hydration markers in content', () => {
+    const content = '<div bf-s="Counter_x1" bf-p=\'{"n":0}\'>0</div>'
+    const html = renderAsyncResolve('a0', content)
+    expect(html).toContain('bf-s="Counter_x1"')
+    expect(html).toContain('bf-p=')
+  })
+})
+
+describe('streamingBootstrap', () => {
+  test('returns a script tag', () => {
+    const script = streamingBootstrap()
+    expect(script).toStartWith('<script>')
+    expect(script).toEndWith('</script>')
+  })
+
+  test('defines __bf_swap on window', () => {
+    const script = streamingBootstrap()
+    expect(script).toContain('__bf_swap')
+    expect(script).toContain('window.__bf_swap')
+  })
+
+  test('references bf-async and bf-async-resolve attributes', () => {
+    const script = streamingBootstrap()
+    expect(script).toContain('bf-async')
+    expect(script).toContain('bf-async-resolve')
+  })
+
+  test('calls __bf_hydrate in requestAnimationFrame', () => {
+    const script = streamingBootstrap()
+    expect(script).toContain('requestAnimationFrame')
+    expect(script).toContain('__bf_hydrate')
+  })
+})
+
+describe('AsyncIdGenerator', () => {
+  test('generates sequential IDs', () => {
+    const gen = new AsyncIdGenerator()
+    expect(gen.next()).toBe('a0')
+    expect(gen.next()).toBe('a1')
+    expect(gen.next()).toBe('a2')
+  })
+
+  test('resets counter', () => {
+    const gen = new AsyncIdGenerator()
+    gen.next()
+    gen.next()
+    gen.reset()
+    expect(gen.next()).toBe('a0')
+  })
+
+  test('independent instances', () => {
+    const gen1 = new AsyncIdGenerator()
+    const gen2 = new AsyncIdGenerator()
+    expect(gen1.next()).toBe('a0')
+    expect(gen2.next()).toBe('a0')
+    expect(gen1.next()).toBe('a1')
+    expect(gen2.next()).toBe('a1')
+  })
+})

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@barefootjs/streaming",
+  "version": "0.0.1",
+  "description": "Backend-agnostic SSR streaming helpers for BarefootJS",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "keywords": [
+    "barefoot",
+    "streaming",
+    "ssr"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/barefootjs/barefootjs",
+    "directory": "packages/streaming"
+  },
+  "dependencies": {
+    "@barefootjs/shared": "workspace:*"
+  }
+}

--- a/packages/streaming/src/html.ts
+++ b/packages/streaming/src/html.ts
@@ -1,0 +1,65 @@
+/**
+ * BarefootJS Streaming - HTML Chunk Generators
+ *
+ * Backend-agnostic functions for generating OOS (Out-of-Order Streaming)
+ * HTML chunks. These produce plain strings that any HTTP server can
+ * write to a response stream.
+ */
+
+import { BF_ASYNC, BF_ASYNC_RESOLVE } from '@barefootjs/shared'
+
+/**
+ * Render an async boundary placeholder with fallback content.
+ *
+ * This HTML should be sent in the initial response (first flush)
+ * and will be replaced when the async data resolves.
+ *
+ * @param id - Unique boundary ID (e.g., "a0")
+ * @param fallbackHtml - HTML string to show while loading
+ * @param tag - Wrapper element tag (default: "div")
+ * @returns HTML string: `<div bf-async="a0">...fallback...</div>`
+ */
+export function renderAsyncBoundary(
+  id: string,
+  fallbackHtml: string,
+  tag: string = 'div',
+): string {
+  return `<${tag} ${BF_ASYNC}="${id}">${fallbackHtml}</${tag}>`
+}
+
+/**
+ * Render a resolve chunk for an async boundary.
+ *
+ * This HTML should be appended to the response stream after the async
+ * data resolves. It contains the resolved content in a `<template>`
+ * element and an inline `<script>` that triggers the swap.
+ *
+ * @param id - Boundary ID matching the placeholder
+ * @param contentHtml - Resolved HTML content (including hydration markers)
+ * @returns HTML string with template + swap script
+ */
+export function renderAsyncResolve(id: string, contentHtml: string): string {
+  return (
+    `<template ${BF_ASYNC_RESOLVE}="${id}">${contentHtml}</template>` +
+    `<script>__bf_swap("${id}")</script>`
+  )
+}
+
+/**
+ * Generate the inline bootstrap script for OOS streaming.
+ *
+ * This script must be included once per page, before any streaming
+ * resolve chunks arrive. It defines the `__bf_swap` function that
+ * swaps fallback content with resolved content.
+ *
+ * The script is intentionally minimal (~300 bytes) and has no
+ * dependencies on the BarefootJS runtime — it only manipulates DOM.
+ * Full hydration is triggered via `__bf_hydrate` which is set up
+ * by the BarefootJS client runtime's `setupStreaming()`.
+ *
+ * @returns A `<script>` tag string
+ */
+export function streamingBootstrap(): string {
+  // Minified inline resolver — no external dependencies
+  return `<script>(function(){function s(id){var a=document.querySelector('[${BF_ASYNC}="'+id+'"]');var t=document.querySelector('template[${BF_ASYNC_RESOLVE}="'+id+'"]');if(!a||!t)return;a.replaceChildren(t.content.cloneNode(true));a.removeAttribute('${BF_ASYNC}');t.remove();requestAnimationFrame(function(){if(window.__bf_hydrate)window.__bf_hydrate()})};window.__bf_swap=s})()</script>`
+}

--- a/packages/streaming/src/id.ts
+++ b/packages/streaming/src/id.ts
@@ -1,0 +1,20 @@
+/**
+ * BarefootJS Streaming - Async Boundary ID Generator
+ *
+ * Generates unique, sequential IDs for async streaming boundaries.
+ * Each page render should create a fresh generator instance.
+ */
+
+export class AsyncIdGenerator {
+  private counter = 0
+
+  /** Generate the next async boundary ID (e.g., "a0", "a1", "a2"). */
+  next(): string {
+    return `a${this.counter++}`
+  }
+
+  /** Reset the counter (e.g., between requests). */
+  reset(): void {
+    this.counter = 0
+  }
+}

--- a/packages/streaming/src/index.ts
+++ b/packages/streaming/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  renderAsyncBoundary,
+  renderAsyncResolve,
+  streamingBootstrap,
+} from './html'
+
+export { AsyncIdGenerator } from './id'

--- a/packages/streaming/tsconfig.json
+++ b/packages/streaming/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Phase 1 of SSR streaming support. Adds the client-side foundation for
Out-of-Order Streaming:

- BF_ASYNC / BF_ASYNC_RESOLVE marker constants in @barefootjs/shared
- __bf_swap() resolver that swaps fallback placeholders with resolved
  content from <template> elements appended by streaming chunks
- setupStreaming() to install __bf_swap and __bf_hydrate on window
- rehydrateAll() extracted from hydrate() to re-scan DOM for
  un-hydrated component scopes after streaming content arrives
- Refactored hydrate() to use shared hydrateComponent() helper

Co-authored-by: kobaken <kentafly88@gmail.com>