### PR TITLE
Add source maps for client JS and CLI debugging tools (#863)

### DIFF
--- a/packages/cli/src/commands/debug-test.ts
+++ b/packages/cli/src/commands/debug-test.ts
@@ -1,0 +1,40 @@
+// barefoot test --debug <component> — Signal change tracing.
+//
+// Extends renderToTest() with a signal trace log that shows
+// every signal initialization and its effect bindings.
+// Works entirely from IR — no browser required.
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: barefoot test --debug <component>')
+    process.exit(1)
+  }
+
+  const { buildComponentGraph, generateStaticTrace, formatSignalTrace } = await import('@barefootjs/jsx')
+
+  const resolved = resolveComponentSource(componentName, ctx)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+
+  const trace = generateStaticTrace(graph)
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(trace, null, 2))
+  } else {
+    console.log(`# ${graph.componentName} — Signal Trace`)
+    console.log()
+    console.log(formatSignalTrace(trace))
+  }
+}

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,0 +1,36 @@
+// barefoot inspect <component> — Show signal dependency graph from IR.
+//
+// Analyzes a component's reactive structure without running any code.
+// AI agents can use this to understand a component before making changes.
+
+import { readFileSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: barefoot inspect <component>')
+    process.exit(1)
+  }
+
+  const { buildComponentGraph, formatComponentGraph, graphToJSON } = await import('@barefootjs/jsx')
+
+  const resolved = resolveComponentSource(componentName, ctx)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in: ui/components/ui/, and by file path.')
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(graphToJSON(graph), null, 2))
+  } else {
+    console.log(formatComponentGraph(graph))
+  }
+}

--- a/packages/cli/src/commands/why-update.ts
+++ b/packages/cli/src/commands/why-update.ts
@@ -1,0 +1,49 @@
+// barefoot why-update <component> <signal> — Show update propagation path.
+//
+// Reverse-lookup: "why does this DOM node update?"
+// Shows every signal, memo, effect, and DOM binding in the propagation chain.
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+  const targetName = args[1]
+
+  if (!componentName || !targetName) {
+    console.error('Error: Component name and signal/memo name required.')
+    console.error('Usage: barefoot why-update <component> <signal|memo>')
+    process.exit(1)
+  }
+
+  const { buildComponentGraph, traceUpdatePath, formatUpdatePath } = await import('@barefootjs/jsx')
+
+  const resolved = resolveComponentSource(componentName, ctx)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+  const path = traceUpdatePath(graph, targetName)
+
+  if (!path) {
+    console.error(`Error: Signal or memo "${targetName}" not found in ${graph.componentName}.`)
+    const available = [
+      ...graph.signals.map(s => s.name),
+      ...graph.memos.map(m => m.name),
+    ]
+    if (available.length > 0) {
+      console.error(`Available: ${available.join(', ')}`)
+    }
+    process.exit(1)
+  }
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(path, null, 2))
+  } else {
+    console.log(formatUpdatePath(path))
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,9 +28,12 @@ Commands:
   preview:generate <comp> [--force]  Generate preview file from component metadata
   tokens [--category <cat>]   List design tokens (categories: typography, spacing, etc.)
   meta:extract                Extract metadata from ui/components/ui/*.tsx
+  inspect <component>         Show signal dependency graph from IR
+  why-update <comp> <signal>  Show update propagation path for a signal/memo
 
 Options:
   --json                      Output in JSON format
+  --debug                     (test) Output signal change trace log
 
 Workflow:
   1. barefoot init                         — Initialize project
@@ -39,7 +42,9 @@ Workflow:
   4. barefoot ui <component>               — Learn props and usage
   5. barefoot core <topic>                 — Read framework docs
   6. bun test <path>                       — Verify
-  7. barefoot preview <component>          — Visual preview in browser`)
+  7. barefoot preview <component>          — Visual preview in browser
+  8. barefoot inspect <component>          — Debug: signal dependency graph
+  9. barefoot why-update <comp> <signal>   — Debug: update propagation path`)
 }
 
 switch (command) {
@@ -80,8 +85,15 @@ switch (command) {
   }
 
   case 'test': {
-    const { run } = await import('./commands/test')
-    run(commandArgs, ctx)
+    // barefoot test --debug <component> routes to debug-test command
+    if (commandArgs.includes('--debug')) {
+      const debugArgs = commandArgs.filter(a => a !== '--debug')
+      const { run } = await import('./commands/debug-test')
+      await run(debugArgs, ctx)
+    } else {
+      const { run } = await import('./commands/test')
+      run(commandArgs, ctx)
+    }
     break
   }
 
@@ -117,6 +129,18 @@ switch (command) {
 
   case 'meta:extract': {
     const { run } = await import('./commands/meta-extract')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'inspect': {
+    const { run } = await import('./commands/inspect')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'why-update': {
+    const { run } = await import('./commands/why-update')
     await run(commandArgs, ctx)
     break
   }

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -1,0 +1,52 @@
+// Resolve a component name or file path to a source file + optional component name.
+//
+// Resolution order:
+// 1. Direct file path (absolute or relative)
+// 2. ui/components/ui/<name>/index.tsx (monorepo layout)
+// 3. barefoot.json configured component directory
+
+import { existsSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+
+export interface ResolvedSource {
+  filePath: string
+  componentName?: string
+}
+
+export function resolveComponentSource(nameOrPath: string, ctx: CliContext): ResolvedSource | null {
+  // 1. Direct file path
+  if (nameOrPath.endsWith('.tsx') || nameOrPath.endsWith('.ts')) {
+    const abs = path.isAbsolute(nameOrPath) ? nameOrPath : path.resolve(nameOrPath)
+    if (existsSync(abs)) {
+      return { filePath: abs }
+    }
+  }
+
+  // 2. ui/components/ui/<name>/index.tsx (monorepo)
+  const monoPath = path.join(ctx.root, 'ui/components/ui', nameOrPath, 'index.tsx')
+  if (existsSync(monoPath)) {
+    return { filePath: monoPath }
+  }
+
+  // 3. barefoot.json configured directory
+  if (ctx.config && ctx.projectDir) {
+    const configPath = path.join(ctx.projectDir, ctx.config.paths.components, nameOrPath, 'index.tsx')
+    if (existsSync(configPath)) {
+      return { filePath: configPath }
+    }
+    // Also try direct file
+    const directPath = path.join(ctx.projectDir, ctx.config.paths.components, `${nameOrPath}.tsx`)
+    if (existsSync(directPath)) {
+      return { filePath: directPath }
+    }
+  }
+
+  // 4. Try as a PascalCase component name in current directory
+  const cwdPath = path.resolve(`${nameOrPath}.tsx`)
+  if (existsSync(cwdPath)) {
+    return { filePath: cwdPath }
+  }
+
+  return null
+}

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Debug analysis utilities tests.
+ *
+ * Verifies that `buildComponentGraph`, `traceUpdatePath`, and `generateStaticTrace`
+ * correctly extract reactive dependency information from component IR.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  buildComponentGraph,
+  traceUpdatePath,
+  formatComponentGraph,
+  formatUpdatePath,
+  formatSignalTrace,
+  generateStaticTrace,
+  graphToJSON,
+} from '../debug'
+
+const counterSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client-runtime'
+
+  export function Counter() {
+    const [count, setCount] = createSignal(0)
+    return (
+      <button onClick={() => setCount(n => n + 1)}>
+        Count: {count()}
+      </button>
+    )
+  }
+`
+
+const dashboardSource = `
+  'use client'
+  import { createSignal, createEffect, createMemo } from '@barefootjs/client-runtime'
+
+  export function Dashboard() {
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    createEffect(() => console.log(count()))
+    return (
+      <div>
+        <span>{count()}</span>
+        <span>{doubled()}</span>
+        <button onClick={() => setCount(n => n + 1)}>+</button>
+      </div>
+    )
+  }
+`
+
+const todoSource = `
+  'use client'
+  import { createSignal, createMemo } from '@barefootjs/client-runtime'
+
+  export function TodoList() {
+    const [todos, setTodos] = createSignal([])
+    const [filter, setFilter] = createSignal('all')
+    const filteredTodos = createMemo(() => {
+      const f = filter()
+      return todos().filter(t => f === 'all' || t.status === f)
+    })
+    return (
+      <div>
+        <ul>{filteredTodos().map(t => <li>{t.text}</li>)}</ul>
+      </div>
+    )
+  }
+`
+
+describe('buildComponentGraph', () => {
+  test('extracts signals from a simple counter', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    expect(graph.componentName).toBe('Counter')
+    expect(graph.signals).toHaveLength(1)
+    expect(graph.signals[0].name).toBe('count')
+    expect(graph.signals[0].setter).toBe('setCount')
+    expect(graph.signals[0].initialValue).toBe('0')
+  })
+
+  test('extracts memos and effects', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    expect(graph.signals).toHaveLength(1)
+    expect(graph.memos).toHaveLength(1)
+    expect(graph.memos[0].name).toBe('doubled')
+    expect(graph.memos[0].deps).toContain('count')
+    expect(graph.effects).toHaveLength(1)
+    expect(graph.effects[0].deps).toContain('count')
+  })
+
+  test('extracts DOM bindings for reactive text', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const textBindings = graph.domBindings.filter(d => d.type === 'text')
+    expect(textBindings.length).toBeGreaterThanOrEqual(1)
+    expect(textBindings[0].deps).toContain('count')
+  })
+
+  test('extracts event handler bindings', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const eventBindings = graph.domBindings.filter(d => d.type === 'event')
+    expect(eventBindings.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('handles components with multiple signals and memos', () => {
+    const graph = buildComponentGraph(todoSource, 'TodoList.tsx')
+    expect(graph.signals).toHaveLength(2)
+    expect(graph.memos).toHaveLength(1)
+    expect(graph.memos[0].name).toBe('filteredTodos')
+    expect(graph.memos[0].deps).toContain('todos')
+    expect(graph.memos[0].deps).toContain('filter')
+  })
+
+  test('builds consumer lists for signals', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const countSignal = graph.signals.find(s => s.name === 'count')!
+    // count is consumed by memo:doubled and effect:e0
+    expect(countSignal.consumers).toContain('memo:doubled')
+    expect(countSignal.consumers).toContain('effect:e0')
+  })
+
+  test('returns empty graph for stateless component', () => {
+    const source = `
+      export function Card(props: { title: string }) {
+        return <div className="card">{props.title}</div>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Card.tsx')
+    expect(graph.componentName).toBe('Card')
+    expect(graph.signals).toHaveLength(0)
+    expect(graph.memos).toHaveLength(0)
+    expect(graph.effects).toHaveLength(0)
+  })
+})
+
+describe('traceUpdatePath', () => {
+  test('traces signal to DOM updates', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const path = traceUpdatePath(graph, 'count')
+    expect(path).not.toBeNull()
+    expect(path!.target).toBe('count')
+    expect(path!.kind).toBe('signal')
+    expect(path!.dependents.length).toBeGreaterThan(0)
+  })
+
+  test('traces signal through memo to DOM', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const path = traceUpdatePath(graph, 'count')
+    expect(path).not.toBeNull()
+    // count → memo:doubled → dom binding, and count → effect
+    const memoEntry = path!.dependents.find(d => d.kind === 'memo')
+    expect(memoEntry).toBeDefined()
+    expect(memoEntry!.name).toBe('doubled')
+  })
+
+  test('traces memo directly', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const path = traceUpdatePath(graph, 'doubled')
+    expect(path).not.toBeNull()
+    expect(path!.target).toBe('doubled')
+    expect(path!.kind).toBe('memo')
+  })
+
+  test('returns null for unknown name', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const path = traceUpdatePath(graph, 'nonExistent')
+    expect(path).toBeNull()
+  })
+
+  test('traces multiple dependencies for todo list', () => {
+    const graph = buildComponentGraph(todoSource, 'TodoList.tsx')
+
+    const todosPath = traceUpdatePath(graph, 'todos')
+    expect(todosPath).not.toBeNull()
+    // todos → filteredTodos (memo)
+    const memoEntry = todosPath!.dependents.find(d => d.kind === 'memo')
+    expect(memoEntry).toBeDefined()
+    expect(memoEntry!.name).toBe('filteredTodos')
+
+    const filterPath = traceUpdatePath(graph, 'filter')
+    expect(filterPath).not.toBeNull()
+    const filterMemoEntry = filterPath!.dependents.find(d => d.kind === 'memo')
+    expect(filterMemoEntry).toBeDefined()
+    expect(filterMemoEntry!.name).toBe('filteredTodos')
+  })
+})
+
+describe('formatComponentGraph', () => {
+  test('produces readable output', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const output = formatComponentGraph(graph)
+    expect(output).toContain('Counter')
+    expect(output).toContain('signals:')
+    expect(output).toContain('count')
+    expect(output).toContain('initial: 0')
+  })
+
+  test('includes dependency graph section', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const output = formatComponentGraph(graph)
+    expect(output).toContain('dependency graph:')
+    expect(output).toContain('count -> memo:doubled')
+  })
+})
+
+describe('formatUpdatePath', () => {
+  test('produces readable output', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const path = traceUpdatePath(graph, 'count')!
+    const output = formatUpdatePath(path)
+    expect(output).toContain('count (signal)')
+    expect(output).toContain('doubled (memo)')
+  })
+})
+
+describe('generateStaticTrace', () => {
+  test('produces init entries for signals', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const trace = generateStaticTrace(graph)
+    const initEntries = trace.filter(t => t.type === 'init')
+    expect(initEntries.length).toBeGreaterThanOrEqual(1)
+    expect(initEntries[0].signal).toBe('count')
+    expect(initEntries[0].value).toBe('0')
+  })
+
+  test('produces render entry', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const trace = generateStaticTrace(graph)
+    const renderEntries = trace.filter(t => t.type === 'render')
+    expect(renderEntries).toHaveLength(1)
+    expect(renderEntries[0].detail).toBe('initial')
+  })
+
+  test('produces effect entries', () => {
+    const graph = buildComponentGraph(dashboardSource, 'Dashboard.tsx')
+    const trace = generateStaticTrace(graph)
+    const effectEntries = trace.filter(t => t.type === 'effect')
+    expect(effectEntries.length).toBeGreaterThan(0)
+  })
+
+  test('format produces readable output', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const trace = generateStaticTrace(graph)
+    const output = formatSignalTrace(trace)
+    expect(output).toContain('[init] count = 0')
+    expect(output).toContain('[render] initial')
+  })
+})
+
+describe('graphToJSON', () => {
+  test('produces valid JSON structure', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const json = graphToJSON(graph)
+    expect(json).toHaveProperty('componentName', 'Counter')
+    expect(json).toHaveProperty('signals')
+    expect(json).toHaveProperty('memos')
+    expect(json).toHaveProperty('effects')
+    expect(json).toHaveProperty('domBindings')
+  })
+})

--- a/packages/jsx/src/__tests__/source-maps.test.ts
+++ b/packages/jsx/src/__tests__/source-maps.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Source map generation tests.
+ *
+ * Verifies that compiled client JS produces valid V3 source maps
+ * that map back to the original .tsx source locations.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { SourceMapGenerator, buildSourceMapFromIR } from '../ir-to-client-js/source-map'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { buildMetadata } from '../compiler'
+import { generateClientJs, analyzeClientNeeds } from '../ir-to-client-js'
+import type { ComponentIR, SourceMapV3 } from '../types'
+
+const adapter = new TestAdapter()
+
+describe('VLQ encoding', () => {
+  test('SourceMapGenerator produces valid V3 format', () => {
+    const gen = new SourceMapGenerator('test.client.js')
+    gen.addSource('test.tsx')
+    gen.addMappingFromLoc(0, 0, { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 10 } })
+
+    const map = gen.toJSON()
+    expect(map.version).toBe(3)
+    expect(map.file).toBe('test.client.js')
+    expect(map.sources).toEqual(['test.tsx'])
+    expect(map.mappings).toBeTruthy()
+    expect(typeof map.mappings).toBe('string')
+  })
+
+  test('multiple mappings across lines', () => {
+    const gen = new SourceMapGenerator('out.js')
+    gen.addSource('src.tsx')
+
+    // Line 0, col 0 → src.tsx line 5, col 2
+    gen.addMappingFromLoc(0, 0, { file: 'src.tsx', start: { line: 5, column: 2 }, end: { line: 5, column: 10 } })
+    // Line 2, col 4 → src.tsx line 10, col 0
+    gen.addMappingFromLoc(2, 4, { file: 'src.tsx', start: { line: 10, column: 0 }, end: { line: 10, column: 20 } })
+
+    const map = gen.toJSON()
+    // Should have semicolons separating lines
+    expect(map.mappings).toContain(';')
+    expect(map.sources).toEqual(['src.tsx'])
+  })
+})
+
+describe('Source map generation via compiler', () => {
+  test('compileJSXSync with sourceMaps: true produces source map file', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <button onClick={() => setCount(n => n + 1)}>
+            Count: {count()}
+          </button>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter, sourceMaps: true })
+
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs?.content).toContain('//# sourceMappingURL=')
+
+    const sourceMap = result.files.find(f => f.type === 'sourceMap')
+    expect(sourceMap).toBeDefined()
+    expect(sourceMap?.path).toEndWith('.client.js.map')
+
+    const map = JSON.parse(sourceMap!.content) as SourceMapV3
+    expect(map.version).toBe(3)
+    expect(map.sources).toContain('Counter.tsx')
+    expect(map.mappings.length).toBeGreaterThan(0)
+  })
+
+  test('compileJSXSync without sourceMaps does not produce source map', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+
+    const sourceMap = result.files.find(f => f.type === 'sourceMap')
+    expect(sourceMap).toBeUndefined()
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    if (clientJs) {
+      expect(clientJs.content).not.toContain('//# sourceMappingURL=')
+    }
+  })
+
+  test('source map maps signals to original source locations', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <div>{count()}</div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter, sourceMaps: true })
+
+    const sourceMapFile = result.files.find(f => f.type === 'sourceMap')
+    expect(sourceMapFile).toBeDefined()
+
+    const map = JSON.parse(sourceMapFile!.content) as SourceMapV3
+    // Source map should reference the original file
+    expect(map.sources).toContain('Counter.tsx')
+    // Should have non-empty mappings (signal + effect + init function)
+    expect(map.mappings.replace(/;/g, '')).not.toBe('')
+  })
+
+  test('source map for component with effects and memos', () => {
+    const source = `
+      'use client'
+      import { createSignal, createEffect, createMemo } from '@barefootjs/client-runtime'
+
+      export function Dashboard() {
+        const [count, setCount] = createSignal(0)
+        const doubled = createMemo(() => count() * 2)
+        createEffect(() => console.log(count()))
+        return <div>{doubled()}</div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Dashboard.tsx', { adapter, sourceMaps: true })
+
+    const sourceMapFile = result.files.find(f => f.type === 'sourceMap')
+    expect(sourceMapFile).toBeDefined()
+
+    const map = JSON.parse(sourceMapFile!.content) as SourceMapV3
+    expect(map.sources).toContain('Dashboard.tsx')
+    // Multiple lines should have mappings (signal, memo, effect, init)
+    const nonEmptyLines = map.mappings.split(';').filter(s => s.length > 0)
+    expect(nonEmptyLines.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('buildSourceMapFromIR', () => {
+  test('generates mappings for a compiled component', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client-runtime'
+
+      export function Toggle() {
+        const [on, setOn] = createSignal(false)
+        return <button onClick={() => setOn(v => !v)}>{on() ? 'ON' : 'OFF'}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Toggle.tsx')
+    const ir = jsxToIR(ctx)!
+    const metadata = buildMetadata(ctx)
+    const componentIR: ComponentIR = {
+      version: '0.1',
+      metadata,
+      root: ir,
+      errors: [],
+    }
+    componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
+    const clientJs = generateClientJs(componentIR)
+
+    const map = buildSourceMapFromIR(clientJs, componentIR, 'Toggle.client.js')
+
+    expect(map.version).toBe(3)
+    expect(map.file).toBe('Toggle.client.js')
+    expect(map.sources).toContain('Toggle.tsx')
+    expect(map.mappings.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -15,7 +15,7 @@ import type {
 import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listComponentFunctions, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
-import { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
+import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'
 import { generateModuleExports } from './module-exports'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
 
@@ -132,14 +132,25 @@ export async function compileJSX(
     type: 'markedTemplate',
   })
 
-  const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
-  errors.push(...componentIR.errors)
-  if (clientJs) {
-    files.push({
-      path: entryPath.replace(/\.tsx?$/, '.client.js'),
-      content: clientJs,
-      type: 'clientJs',
+  const clientJsPath = entryPath.replace(/\.tsx?$/, '.client.js')
+  if (options.sourceMaps) {
+    const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
+      sourceMaps: true,
+      generatedFileName: clientJsPath.split('/').pop(),
     })
+    errors.push(...componentIR.errors)
+    if (result.code) {
+      files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
+      if (result.sourceMap) {
+        files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+      }
+    }
+  } else {
+    const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
+    errors.push(...componentIR.errors)
+    if (clientJs) {
+      files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
+    }
   }
 
   return { files, errors }
@@ -490,14 +501,25 @@ export function compileJSXSync(
     type: 'markedTemplate',
   })
 
-  const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
-  errors.push(...componentIR.errors)
-  if (clientJs) {
-    files.push({
-      path: filePath.replace(/\.tsx?$/, '.client.js'),
-      content: clientJs,
-      type: 'clientJs',
+  const clientJsPath = filePath.replace(/\.tsx?$/, '.client.js')
+  if (options.sourceMaps) {
+    const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
+      sourceMaps: true,
+      generatedFileName: clientJsPath.split('/').pop(),
     })
+    errors.push(...componentIR.errors)
+    if (result.code) {
+      files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
+      if (result.sourceMap) {
+        files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+      }
+    }
+  } else {
+    const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
+    errors.push(...componentIR.errors)
+    if (clientJs) {
+      files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
+    }
   }
 
   return { files, errors }

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1,0 +1,628 @@
+/**
+ * Debug analysis utilities for IR-based component inspection.
+ *
+ * Provides static analysis of signal dependency graphs, update propagation
+ * paths, and component reactive structure — all without running any code.
+ */
+
+import type {
+  ComponentIR,
+  IRNode,
+  IRExpression,
+  IRConditional,
+  IRElement,
+  IRLoop,
+  SignalInfo,
+  MemoInfo,
+  EffectInfo,
+} from './types'
+import { analyzeComponent, listComponentFunctions } from './analyzer'
+import { jsxToIR } from './jsx-to-ir'
+import { buildMetadata } from './compiler'
+import { analyzeClientNeeds } from './ir-to-client-js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SignalNode {
+  kind: 'signal'
+  name: string
+  setter: string | null
+  initialValue: string
+  consumers: string[] // names of memos/effects/DOM nodes that read this signal
+  loc: { file: string; line: number }
+}
+
+export interface MemoNode {
+  kind: 'memo'
+  name: string
+  deps: string[] // signal/memo names this memo depends on
+  consumers: string[] // names of effects/DOM nodes that read this memo
+  computation: string
+  loc: { file: string; line: number }
+}
+
+export interface EffectNode {
+  kind: 'effect'
+  label: string
+  deps: string[]
+  body: string
+  loc: { file: string; line: number }
+}
+
+export interface DomBinding {
+  kind: 'dom'
+  label: string // e.g., 'text node "s0"', 'click handler "s1"'
+  slotId: string
+  deps: string[]
+  type: 'text' | 'event' | 'conditional' | 'loop' | 'attribute'
+}
+
+export interface ComponentGraph {
+  componentName: string
+  sourceFile: string
+  signals: SignalNode[]
+  memos: MemoNode[]
+  effects: EffectNode[]
+  domBindings: DomBinding[]
+}
+
+export interface UpdatePath {
+  target: string
+  kind: 'signal' | 'memo'
+  dependents: UpdatePathEntry[]
+}
+
+export interface UpdatePathEntry {
+  name: string
+  kind: 'memo' | 'effect' | 'dom'
+  label: string
+  /** Transitive dependents — memos/effects that depend on this entry */
+  children: UpdatePathEntry[]
+}
+
+// =============================================================================
+// Analysis: Build Component Graph
+// =============================================================================
+
+/**
+ * Analyze a component source and build a full reactive dependency graph.
+ * This is the core analysis used by `barefoot inspect` and `barefoot why-update`.
+ */
+export function buildComponentGraph(source: string, filePath: string, componentName?: string): ComponentGraph {
+  const ctx = analyzeComponent(source, filePath, componentName)
+
+  if (!ctx.jsxReturn) {
+    return {
+      componentName: ctx.componentName || componentName || 'Unknown',
+      sourceFile: filePath,
+      signals: [],
+      memos: [],
+      effects: [],
+      domBindings: [],
+    }
+  }
+
+  const ir = jsxToIR(ctx)
+  if (!ir) {
+    return {
+      componentName: ctx.componentName || 'Unknown',
+      sourceFile: filePath,
+      signals: [],
+      memos: [],
+      effects: [],
+      domBindings: [],
+    }
+  }
+
+  const metadata = buildMetadata(ctx)
+  const componentIR: ComponentIR = {
+    version: '0.1',
+    metadata,
+    root: ir,
+    errors: [],
+  }
+
+  return buildGraphFromIR(componentIR)
+}
+
+/**
+ * Build the dependency graph from a pre-compiled ComponentIR.
+ */
+export function buildGraphFromIR(ir: ComponentIR): ComponentGraph {
+  const meta = ir.metadata
+  const signalGetters = new Set(meta.signals.map(s => s.getter))
+  const memoNames = new Set(meta.memos.map(m => m.name))
+  const signalSetters = new Map(meta.signals.filter(s => s.setter).map(s => [s.setter!, s.getter]))
+
+  // Collect DOM bindings from IR tree
+  const domBindings: DomBinding[] = []
+  collectDomBindings(ir.root, domBindings, signalGetters, memoNames)
+
+  // Build consumer lists for signals
+  const signalConsumers = new Map<string, string[]>()
+  for (const s of meta.signals) signalConsumers.set(s.getter, [])
+
+  // Memos consume signals
+  for (const memo of meta.memos) {
+    for (const dep of memo.deps) {
+      signalConsumers.get(dep)?.push(`memo:${memo.name}`)
+    }
+  }
+
+  // Effects consume signals
+  for (let i = 0; i < meta.effects.length; i++) {
+    const effect = meta.effects[i]
+    for (const dep of effect.deps) {
+      signalConsumers.get(dep)?.push(`effect:e${i}`)
+    }
+  }
+
+  // DOM bindings consume signals
+  for (const dom of domBindings) {
+    for (const dep of dom.deps) {
+      signalConsumers.get(dep)?.push(`dom:${dom.label}`)
+    }
+  }
+
+  // Build consumer lists for memos
+  const memoConsumers = new Map<string, string[]>()
+  for (const m of meta.memos) memoConsumers.set(m.name, [])
+
+  for (let i = 0; i < meta.effects.length; i++) {
+    const effect = meta.effects[i]
+    for (const dep of effect.deps) {
+      memoConsumers.get(dep)?.push(`effect:e${i}`)
+    }
+  }
+
+  for (const dom of domBindings) {
+    for (const dep of dom.deps) {
+      memoConsumers.get(dep)?.push(`dom:${dom.label}`)
+    }
+  }
+
+  // Also track memo→memo dependencies
+  for (const memo of meta.memos) {
+    for (const dep of memo.deps) {
+      memoConsumers.get(dep)?.push(`memo:${memo.name}`)
+    }
+  }
+
+  const signals: SignalNode[] = meta.signals.map(s => ({
+    kind: 'signal',
+    name: s.getter,
+    setter: s.setter,
+    initialValue: s.initialValue,
+    consumers: signalConsumers.get(s.getter) ?? [],
+    loc: { file: s.loc.file, line: s.loc.start.line },
+  }))
+
+  const memos: MemoNode[] = meta.memos.map(m => ({
+    kind: 'memo',
+    name: m.name,
+    deps: m.deps,
+    consumers: memoConsumers.get(m.name) ?? [],
+    computation: m.computation,
+    loc: { file: m.loc.file, line: m.loc.start.line },
+  }))
+
+  const effects: EffectNode[] = meta.effects.map((e, i) => ({
+    kind: 'effect',
+    label: `e${i}`,
+    deps: e.deps,
+    body: e.body,
+    loc: { file: e.loc.file, line: e.loc.start.line },
+  }))
+
+  return {
+    componentName: meta.componentName,
+    sourceFile: findSourceFile(meta) ?? '',
+    signals,
+    memos,
+    effects,
+    domBindings,
+  }
+}
+
+// =============================================================================
+// Analysis: Update Propagation Path (why-update)
+// =============================================================================
+
+/**
+ * Trace the update propagation path from a signal or memo.
+ * Shows all downstream effects, memos, and DOM bindings.
+ */
+export function traceUpdatePath(graph: ComponentGraph, targetName: string): UpdatePath | null {
+  // Find the target in signals or memos
+  const signal = graph.signals.find(s => s.name === targetName)
+  const memo = graph.memos.find(m => m.name === targetName)
+
+  if (!signal && !memo) return null
+
+  const kind = signal ? 'signal' : 'memo'
+  const consumers = signal ? signal.consumers : memo!.consumers
+
+  const dependents = consumers.map(consumer => buildUpdateEntry(consumer, graph, new Set()))
+
+  return { target: targetName, kind: kind as 'signal' | 'memo', dependents }
+}
+
+function buildUpdateEntry(consumer: string, graph: ComponentGraph, visited: Set<string>): UpdatePathEntry {
+  if (visited.has(consumer)) {
+    return { name: consumer, kind: 'memo', label: `${consumer} (circular)`, children: [] }
+  }
+  visited.add(consumer)
+
+  const [type, name] = consumer.split(':')
+
+  if (type === 'memo') {
+    const memo = graph.memos.find(m => m.name === name)
+    if (memo) {
+      const children = memo.consumers
+        .map(c => buildUpdateEntry(c, graph, new Set(visited)))
+      return { name: memo.name, kind: 'memo', label: `${memo.name} (memo)`, children }
+    }
+  }
+
+  if (type === 'effect') {
+    const effect = graph.effects.find(e => e.label === name)
+    return {
+      name: name,
+      kind: 'effect',
+      label: effect ? `effect ${name}` : name,
+      children: [],
+    }
+  }
+
+  if (type === 'dom') {
+    return { name: name, kind: 'dom', label: name, children: [] }
+  }
+
+  return { name: consumer, kind: 'effect', label: consumer, children: [] }
+}
+
+// =============================================================================
+// Formatting: Human-readable output
+// =============================================================================
+
+/** Format the component graph as a human-readable string for `barefoot inspect`. */
+export function formatComponentGraph(graph: ComponentGraph): string {
+  const lines: string[] = []
+
+  lines.push(`${graph.componentName} (${graph.sourceFile})`)
+
+  // Signals
+  if (graph.signals.length > 0) {
+    lines.push(`  signals:`)
+    for (const s of graph.signals) {
+      lines.push(`    ${s.name} (initial: ${s.initialValue})`)
+    }
+  }
+
+  // Memos
+  if (graph.memos.length > 0) {
+    lines.push(`  memos:`)
+    for (const m of graph.memos) {
+      const depStr = m.deps.length > 0 ? ` <- ${m.deps.join(', ')}` : ''
+      lines.push(`    ${m.name}${depStr}`)
+    }
+  }
+
+  // Effects
+  if (graph.effects.length > 0) {
+    lines.push(`  effects:`)
+    for (const e of graph.effects) {
+      const depStr = e.deps.length > 0 ? ` <- ${e.deps.join(', ')}` : ''
+      lines.push(`    ${e.label}${depStr}`)
+    }
+  }
+
+  // DOM bindings
+  if (graph.domBindings.length > 0) {
+    lines.push(`  dom bindings:`)
+    for (const d of graph.domBindings) {
+      const arrow = d.type === 'event' ? ' ->' : ' <-'
+      const depStr = d.deps.join(', ')
+      lines.push(`    ${d.type} "${d.slotId}"${arrow} ${depStr}`)
+    }
+  }
+
+  // Dependency graph
+  if (graph.signals.length > 0 || graph.memos.length > 0) {
+    lines.push(`  dependency graph:`)
+    for (const s of graph.signals) {
+      for (const consumer of s.consumers) {
+        lines.push(`    ${s.name} -> ${consumer}`)
+      }
+    }
+    for (const m of graph.memos) {
+      for (const consumer of m.consumers) {
+        lines.push(`    ${m.name} -> ${consumer}`)
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/** Format an update path as a human-readable string for `barefoot why-update`. */
+export function formatUpdatePath(path: UpdatePath): string {
+  const lines: string[] = []
+
+  lines.push(`${path.target} (${path.kind})`)
+
+  for (const entry of path.dependents) {
+    formatEntry(entry, lines, '  ')
+  }
+
+  return lines.join('\n')
+}
+
+function formatEntry(entry: UpdatePathEntry, lines: string[], indent: string): void {
+  const arrow = entry.kind === 'dom' ? '->' : '<-'
+  lines.push(`${indent}${arrow} ${entry.label}`)
+  for (const child of entry.children) {
+    formatEntry(child, lines, indent + '  ')
+  }
+}
+
+/** Format the component graph as JSON for `--json` output. */
+export function graphToJSON(graph: ComponentGraph): object {
+  return {
+    componentName: graph.componentName,
+    sourceFile: graph.sourceFile,
+    signals: graph.signals.map(s => ({
+      name: s.name,
+      setter: s.setter,
+      initialValue: s.initialValue,
+      consumers: s.consumers,
+      loc: s.loc,
+    })),
+    memos: graph.memos.map(m => ({
+      name: m.name,
+      deps: m.deps,
+      consumers: m.consumers,
+      computation: m.computation,
+      loc: m.loc,
+    })),
+    effects: graph.effects.map(e => ({
+      label: e.label,
+      deps: e.deps,
+      body: e.body,
+      loc: e.loc,
+    })),
+    domBindings: graph.domBindings.map(d => ({
+      label: d.label,
+      slotId: d.slotId,
+      deps: d.deps,
+      type: d.type,
+    })),
+  }
+}
+
+// =============================================================================
+// Signal Trace for test --debug
+// =============================================================================
+
+export interface SignalTrace {
+  type: 'init' | 'render' | 'set' | 'effect'
+  signal?: string
+  value?: string
+  oldValue?: string
+  slotId?: string
+  detail?: string
+}
+
+/**
+ * Generate a static signal trace for a component.
+ * This shows the initialization sequence without executing any code.
+ */
+export function generateStaticTrace(graph: ComponentGraph): SignalTrace[] {
+  const trace: SignalTrace[] = []
+
+  // [init] signal = initialValue
+  for (const signal of graph.signals) {
+    trace.push({
+      type: 'init',
+      signal: signal.name,
+      value: signal.initialValue,
+    })
+  }
+
+  // [init] memo = computation
+  for (const memo of graph.memos) {
+    trace.push({
+      type: 'init',
+      signal: memo.name,
+      detail: `memo(${memo.computation})`,
+    })
+  }
+
+  // [render] initial render
+  trace.push({ type: 'render', detail: 'initial' })
+
+  // [effect] effect dependencies
+  for (const effect of graph.effects) {
+    trace.push({
+      type: 'effect',
+      detail: `${effect.label} depends on: ${effect.deps.join(', ') || 'none'}`,
+    })
+  }
+
+  // For each DOM binding, trace the initial binding
+  for (const dom of graph.domBindings) {
+    if (dom.type === 'text') {
+      trace.push({
+        type: 'effect',
+        slotId: dom.slotId,
+        detail: `text "${dom.slotId}" bound to: ${dom.deps.join(', ')}`,
+      })
+    }
+  }
+
+  return trace
+}
+
+/** Format a signal trace as a human-readable string. */
+export function formatSignalTrace(traces: SignalTrace[]): string {
+  return traces.map(t => {
+    switch (t.type) {
+      case 'init':
+        return `[init] ${t.signal} = ${t.value ?? t.detail}`
+      case 'render':
+        return `[render] ${t.detail}`
+      case 'set':
+        return `[set] ${t.signal}: ${t.oldValue} -> ${t.value}`
+      case 'effect':
+        return `[effect] ${t.detail}`
+      default:
+        return `[${t.type}] ${t.detail}`
+    }
+  }).join('\n')
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Collect DOM bindings (text updates, event handlers, etc.) from the IR tree. */
+function collectDomBindings(
+  node: IRNode,
+  bindings: DomBinding[],
+  signalGetters: Set<string>,
+  memoNames: Set<string>,
+): void {
+  switch (node.type) {
+    case 'element': {
+      // Event handlers
+      for (const event of node.events) {
+        const deps = extractReactiveDeps(event.handler, signalGetters, memoNames)
+        if (deps.length > 0 || true) {
+          bindings.push({
+            kind: 'dom',
+            label: `${event.name} handler "${node.slotId ?? '?'}"`,
+            slotId: node.slotId ?? '?',
+            deps: extractSetterRefs(event.handler, signalGetters),
+            type: 'event',
+          })
+        }
+      }
+      // Recurse
+      for (const child of node.children) {
+        collectDomBindings(child, bindings, signalGetters, memoNames)
+      }
+      break
+    }
+    case 'expression': {
+      if (node.reactive && node.slotId) {
+        const deps = extractReactiveDeps(node.expr, signalGetters, memoNames)
+        bindings.push({
+          kind: 'dom',
+          label: `text "${node.slotId}"`,
+          slotId: node.slotId,
+          deps,
+          type: 'text',
+        })
+      }
+      break
+    }
+    case 'conditional': {
+      if (node.reactive && node.slotId) {
+        const deps = extractReactiveDeps(node.condition, signalGetters, memoNames)
+        bindings.push({
+          kind: 'dom',
+          label: `conditional "${node.slotId}"`,
+          slotId: node.slotId,
+          deps,
+          type: 'conditional',
+        })
+      }
+      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames)
+      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames)
+      break
+    }
+    case 'loop': {
+      if (node.slotId) {
+        const deps = extractReactiveDeps(node.array, signalGetters, memoNames)
+        if (deps.length > 0) {
+          bindings.push({
+            kind: 'dom',
+            label: `loop "${node.slotId}"`,
+            slotId: node.slotId,
+            deps,
+            type: 'loop',
+          })
+        }
+      }
+      for (const child of node.children) {
+        collectDomBindings(child, bindings, signalGetters, memoNames)
+      }
+      break
+    }
+    case 'fragment':
+    case 'provider': {
+      for (const child of node.children) {
+        collectDomBindings(child, bindings, signalGetters, memoNames)
+      }
+      break
+    }
+    case 'if-statement': {
+      collectDomBindings(node.consequent, bindings, signalGetters, memoNames)
+      if (node.alternate) {
+        collectDomBindings(node.alternate, bindings, signalGetters, memoNames)
+      }
+      break
+    }
+  }
+}
+
+/** Extract reactive getter names (signal/memo calls) from an expression. */
+function extractReactiveDeps(expr: string, signalGetters: Set<string>, memoNames: Set<string>): string[] {
+  const deps: string[] = []
+  for (const getter of signalGetters) {
+    if (new RegExp(`\\b${getter}\\s*\\(`).test(expr)) {
+      deps.push(getter)
+    }
+  }
+  for (const memo of memoNames) {
+    if (new RegExp(`\\b${memo}\\s*\\(`).test(expr)) {
+      deps.push(memo)
+    }
+  }
+  return deps
+}
+
+/** Extract setter references from an event handler expression. */
+function extractSetterRefs(expr: string, signalGetters: Set<string>): string[] {
+  const refs: string[] = []
+  // Look for setter calls: setXxx(...)
+  const matches = expr.matchAll(/\b(set[A-Z]\w*)\s*\(/g)
+  for (const match of matches) {
+    refs.push(match[1])
+  }
+  // Also detect signal getter reads in handler
+  for (const getter of signalGetters) {
+    if (new RegExp(`\\b${getter}\\s*\\(`).test(expr)) {
+      refs.push(getter)
+    }
+  }
+  return refs
+}
+
+function findSourceFile(meta: ComponentIR['metadata']): string | null {
+  for (const s of meta.signals) {
+    if (s.loc?.file) return s.loc.file
+  }
+  for (const m of meta.memos) {
+    if (m.loc?.file) return m.loc.file
+  }
+  for (const e of meta.effects) {
+    if (e.loc?.file) return e.loc.file
+  }
+  return null
+}
+
+// Re-export for CLI convenience
+export { listComponentFunctions }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -49,7 +49,12 @@ export { JsxAdapter } from './adapters/jsx-adapter'
 export type { JsxAdapterConfig } from './adapters/jsx-adapter'
 
 // Client JS Generator
-export { generateClientJs, analyzeClientNeeds } from './ir-to-client-js'
+export { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'
+export type { ClientJsResult } from './ir-to-client-js'
+
+// Source Map
+export { SourceMapGenerator, buildSourceMapFromIR } from './ir-to-client-js/source-map'
+export type { SourceMapV3 } from './ir-to-client-js/source-map'
 
 // Client JS Combiner (for build scripts)
 export { combineParentChildClientJs } from './combine-client-js'
@@ -77,6 +82,19 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 // Expression Parser
 export { parseExpression, isSupported, exprToString, parseBlockBody } from './expression-parser'
 export type { ParsedExpr, ParsedStatement, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+
+// Debug analysis
+export {
+  buildComponentGraph,
+  buildGraphFromIR,
+  traceUpdatePath,
+  formatComponentGraph,
+  formatUpdatePath,
+  formatSignalTrace,
+  generateStaticTrace,
+  graphToJSON,
+} from './debug'
+export type { ComponentGraph, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace } from './debug'
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -14,19 +14,47 @@ import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate }
 import { PROPS_PARAM } from './utils'
 import { buildInlinableConstants, buildSignalAndMemoMaps, buildCsrInlinableConstants } from './emit-registration'
 import { IMPORT_PLACEHOLDER, detectUsedImports } from './imports'
+import { buildSourceMapFromIR, type SourceMapV3 } from './source-map'
+
+export interface ClientJsResult {
+  code: string
+  sourceMap?: SourceMapV3
+}
 
 /** Public entry point: IR → client JS string. Returns '' if no client JS is needed. */
 export function generateClientJs(ir: ComponentIR, siblingComponents?: string[], localImportPrefixes?: string[]): string {
+  return generateClientJsWithSourceMap(ir, siblingComponents, localImportPrefixes).code
+}
+
+/**
+ * Generate client JS with optional source map.
+ * When sourceMaps is true, returns both the JS code and a V3 source map.
+ */
+export function generateClientJsWithSourceMap(
+  ir: ComponentIR,
+  siblingComponents?: string[],
+  localImportPrefixes?: string[],
+  options?: { sourceMaps?: boolean; generatedFileName?: string },
+): ClientJsResult {
   const ctx = createContext(ir)
   collectElements(ir.root, ctx)
   ir.errors.push(...ctx.warnings)
 
   if (!needsClientJs(ctx)) {
-    // Stateless components still need template registration so renderChild() can find them (#435)
-    return generateTemplateOnlyMount(ir, ctx)
+    const code = generateTemplateOnlyMount(ir, ctx)
+    return { code }
   }
 
-  return generateInitFunction(ir, ctx, siblingComponents, localImportPrefixes)
+  const code = generateInitFunction(ir, ctx, siblingComponents, localImportPrefixes)
+
+  if (options?.sourceMaps && code) {
+    const fileName = options.generatedFileName ?? `${ir.metadata.componentName}.client.js`
+    const sourceMap = buildSourceMapFromIR(code, ir, fileName)
+    const codeWithUrl = code + `\n//# sourceMappingURL=${fileName}.map`
+    return { code: codeWithUrl, sourceMap }
+  }
+
+  return { code }
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/source-map.ts
+++ b/packages/jsx/src/ir-to-client-js/source-map.ts
@@ -1,0 +1,336 @@
+/**
+ * Source Map V3 generator for client JS output.
+ *
+ * Produces standard source maps (https://sourcemaps.info/spec.html) that map
+ * generated client JS back to original .tsx source files.
+ * No external dependencies — VLQ encoding is implemented inline.
+ */
+
+import type { SourceLocation } from '../types'
+
+// =============================================================================
+// VLQ Base64 Encoding
+// =============================================================================
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function encodeVLQ(value: number): string {
+  let vlq = value < 0 ? ((-value) << 1) + 1 : value << 1
+  let encoded = ''
+  do {
+    let digit = vlq & 0x1f
+    vlq >>>= 5
+    if (vlq > 0) digit |= 0x20
+    encoded += BASE64_CHARS[digit]
+  } while (vlq > 0)
+  return encoded
+}
+
+// =============================================================================
+// Source Map Builder
+// =============================================================================
+
+export interface SourceMapping {
+  /** Generated line (0-indexed) */
+  generatedLine: number
+  /** Generated column (0-indexed) */
+  generatedColumn: number
+  /** Source file index */
+  sourceIndex: number
+  /** Original line (0-indexed) */
+  originalLine: number
+  /** Original column (0-indexed) */
+  originalColumn: number
+}
+
+export interface SourceMapV3 {
+  version: 3
+  file: string
+  sourceRoot: string
+  sources: string[]
+  sourcesContent: (string | null)[]
+  names: string[]
+  mappings: string
+}
+
+export class SourceMapGenerator {
+  private sources: string[] = []
+  private sourcesContent: (string | null)[] = []
+  private sourceIndexMap = new Map<string, number>()
+  private mappings: SourceMapping[] = []
+  private file: string
+
+  constructor(generatedFile: string) {
+    this.file = generatedFile
+  }
+
+  /**
+   * Register a source file and return its index.
+   * If content is provided, it's stored for inline source content.
+   */
+  addSource(sourcePath: string, content?: string): number {
+    const existing = this.sourceIndexMap.get(sourcePath)
+    if (existing !== undefined) return existing
+    const index = this.sources.length
+    this.sources.push(sourcePath)
+    this.sourcesContent.push(content ?? null)
+    this.sourceIndexMap.set(sourcePath, index)
+    return index
+  }
+
+  /**
+   * Add a mapping from a generated position to a source position.
+   * Uses SourceLocation from the IR for convenience.
+   */
+  addMappingFromLoc(generatedLine: number, generatedColumn: number, loc: SourceLocation): void {
+    const sourceIndex = this.addSource(loc.file)
+    this.mappings.push({
+      generatedLine,
+      generatedColumn,
+      sourceIndex,
+      originalLine: loc.start.line - 1, // Convert to 0-indexed
+      originalColumn: loc.start.column,
+    })
+  }
+
+  /** Produce the V3 source map JSON object. */
+  toJSON(): SourceMapV3 {
+    return {
+      version: 3,
+      file: this.file,
+      sourceRoot: '',
+      sources: this.sources,
+      sourcesContent: this.sourcesContent,
+      names: [],
+      mappings: this.encodeMappings(),
+    }
+  }
+
+  /** Produce the source map as a JSON string. */
+  toString(): string {
+    return JSON.stringify(this.toJSON())
+  }
+
+  /** Encode all mappings into the V3 "mappings" string. */
+  private encodeMappings(): string {
+    // Sort mappings by generated position
+    const sorted = [...this.mappings].sort((a, b) =>
+      a.generatedLine - b.generatedLine || a.generatedColumn - b.generatedColumn
+    )
+
+    const lines: string[][] = []
+
+    let prevGeneratedColumn = 0
+    let prevSourceIndex = 0
+    let prevOriginalLine = 0
+    let prevOriginalColumn = 0
+    let prevGeneratedLine = 0
+
+    for (const mapping of sorted) {
+      // Fill empty lines
+      while (lines.length <= mapping.generatedLine) {
+        lines.push([])
+        if (lines.length > 1) {
+          prevGeneratedColumn = 0
+        }
+      }
+
+      if (mapping.generatedLine !== prevGeneratedLine) {
+        prevGeneratedColumn = 0
+        prevGeneratedLine = mapping.generatedLine
+      }
+
+      const segment =
+        encodeVLQ(mapping.generatedColumn - prevGeneratedColumn) +
+        encodeVLQ(mapping.sourceIndex - prevSourceIndex) +
+        encodeVLQ(mapping.originalLine - prevOriginalLine) +
+        encodeVLQ(mapping.originalColumn - prevOriginalColumn)
+
+      lines[mapping.generatedLine].push(segment)
+
+      prevGeneratedColumn = mapping.generatedColumn
+      prevSourceIndex = mapping.sourceIndex
+      prevOriginalLine = mapping.originalLine
+      prevOriginalColumn = mapping.originalColumn
+    }
+
+    return lines.map(segments => segments.join(',')).join(';')
+  }
+}
+
+// =============================================================================
+// Code Builder with Source Map Tracking
+// =============================================================================
+
+/**
+ * A code builder that tracks line counts and can record source mappings.
+ * Wraps a string[] lines array, recording optional source locations for each line.
+ */
+export class MappedCodeBuilder {
+  private lines: string[] = []
+  private generator: SourceMapGenerator | null
+
+  constructor(generator: SourceMapGenerator | null) {
+    this.generator = generator
+  }
+
+  /** Current line count (0-indexed next line). */
+  get lineCount(): number {
+    return this.lines.length
+  }
+
+  /** Push a line of code, optionally mapping it to a source location. */
+  push(line: string, loc?: SourceLocation): void {
+    if (loc && this.generator) {
+      // Map to the first non-whitespace column
+      const indent = line.length - line.trimStart().length
+      this.generator.addMappingFromLoc(this.lines.length, indent, loc)
+    }
+    this.lines.push(line)
+  }
+
+  /** Push multiple lines at once. */
+  pushLines(code: string, loc?: SourceLocation): void {
+    const codeLines = code.split('\n')
+    for (let i = 0; i < codeLines.length; i++) {
+      this.push(codeLines[i], i === 0 ? loc : undefined)
+    }
+  }
+
+  /** Join all lines into a single string. */
+  join(separator: string = '\n'): string {
+    return this.lines.join(separator)
+  }
+
+  /** Get the underlying lines array (for compatibility). */
+  getLines(): string[] {
+    return this.lines
+  }
+}
+
+/**
+ * Build source map for already-generated client JS by post-processing.
+ * Maps key code patterns back to their source locations using IR metadata.
+ *
+ * This is used when the code has already been generated without a MappedCodeBuilder,
+ * providing an "after the fact" source map based on the IR metadata.
+ */
+export function buildSourceMapFromIR(
+  generatedCode: string,
+  ir: import('../types').ComponentIR,
+  generatedFileName: string,
+): SourceMapV3 {
+  const gen = new SourceMapGenerator(generatedFileName)
+  const lines = generatedCode.split('\n')
+  const meta = ir.metadata
+
+  // Register the source file from the first available location
+  const sourceFile = findSourceFile(ir)
+  if (!sourceFile) {
+    return gen.toJSON()
+  }
+
+  gen.addSource(sourceFile)
+
+  // Map signal declarations
+  for (const signal of meta.signals) {
+    const pattern = signal.setter
+      ? `createSignal(`
+      : signal.getter
+    const lineIdx = findLineIndex(lines, pattern)
+    if (lineIdx >= 0) {
+      gen.addMappingFromLoc(lineIdx, indentOf(lines[lineIdx]), signal.loc)
+    }
+  }
+
+  // Map memo declarations
+  for (const memo of meta.memos) {
+    const lineIdx = findLineIndex(lines, `createMemo(`)
+    if (lineIdx >= 0) {
+      gen.addMappingFromLoc(lineIdx, indentOf(lines[lineIdx]), memo.loc)
+    }
+  }
+
+  // Map effect bodies
+  for (const effect of meta.effects) {
+    const lineIdx = findLineIndex(lines, `createEffect(`)
+    if (lineIdx >= 0) {
+      gen.addMappingFromLoc(lineIdx, indentOf(lines[lineIdx]), effect.loc)
+    }
+  }
+
+  // Map onMount callbacks
+  for (const onMount of meta.onMounts) {
+    const lineIdx = findLineIndex(lines, `onMount(`)
+    if (lineIdx >= 0) {
+      gen.addMappingFromLoc(lineIdx, indentOf(lines[lineIdx]), onMount.loc)
+    }
+  }
+
+  // Map event handlers by looking for on() calls with event names
+  mapEventHandlers(lines, ir.root, gen)
+
+  // Map the init function declaration to the component function
+  const initLine = findLineIndex(lines, `export function init${meta.componentName}(`)
+  if (initLine >= 0 && ir.root.loc) {
+    gen.addMappingFromLoc(initLine, 0, ir.root.loc)
+  }
+
+  return gen.toJSON()
+}
+
+/** Find the source file path from the IR (first available SourceLocation). */
+function findSourceFile(ir: import('../types').ComponentIR): string | null {
+  if (ir.root.loc?.file) return ir.root.loc.file
+  for (const s of ir.metadata.signals) {
+    if (s.loc?.file) return s.loc.file
+  }
+  for (const m of ir.metadata.memos) {
+    if (m.loc?.file) return m.loc.file
+  }
+  return null
+}
+
+/** Find the first line index containing a pattern. */
+function findLineIndex(lines: string[], pattern: string, startFrom = 0): number {
+  for (let i = startFrom; i < lines.length; i++) {
+    if (lines[i].includes(pattern)) return i
+  }
+  return -1
+}
+
+/** Get indent level (number of leading whitespace chars). */
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length
+}
+
+/** Map event handlers from IR tree to generated code lines. */
+function mapEventHandlers(
+  lines: string[],
+  node: import('../types').IRNode,
+  gen: SourceMapGenerator,
+): void {
+  if (node.type === 'element') {
+    for (const event of node.events) {
+      const pattern = `'${event.name}'`
+      const lineIdx = findLineIndex(lines, pattern)
+      if (lineIdx >= 0) {
+        gen.addMappingFromLoc(lineIdx, indentOf(lines[lineIdx]), event.loc)
+      }
+    }
+    for (const child of node.children) {
+      mapEventHandlers(lines, child, gen)
+    }
+  } else if (node.type === 'fragment' || node.type === 'provider') {
+    for (const child of node.children) {
+      mapEventHandlers(lines, child, gen)
+    }
+  } else if (node.type === 'conditional') {
+    mapEventHandlers(lines, node.whenTrue, gen)
+    mapEventHandlers(lines, node.whenFalse, gen)
+  } else if (node.type === 'loop') {
+    for (const child of node.children) {
+      mapEventHandlers(lines, child, gen)
+    }
+  }
+}

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -550,7 +550,7 @@ export interface CompileOptions {
 export interface FileOutput {
   path: string
   content: string
-  type: 'markedTemplate' | 'clientJs' | 'ir'
+  type: 'markedTemplate' | 'clientJs' | 'ir' | 'sourceMap'
 }
 
 export interface CompileResult {


### PR DESCRIPTION
Phase 1 — Source maps:
- Add SourceMapGenerator with V3 format and VLQ encoding (no deps)
- Thread sourceMaps option through CompileOptions → compiler pipeline
- Generate .js.map files alongside client JS when sourceMaps: true
- Add //# sourceMappingURL= comment to client JS output
- Map signal declarations, memos, effects, event handlers to source

Phase 2 — CLI debugging tools:
- `barefoot inspect <component>` — static signal dependency graph from IR
- `barefoot test --debug <component>` — signal change trace log
- `barefoot why-update <component> <signal>` — update propagation path
- All commands work without a browser, using IR analysis only
- Support --json flag for machine-readable output

Co-authored-by: kobaken <kentafly88@gmail.com>