### PR TITLE
Fix broken menu and pagination links after Core Concepts reorganization

### DIFF
--- a/site/core/lib/navigation.ts
+++ b/site/core/lib/navigation.ts
@@ -49,11 +49,11 @@ export const navigation: NavItem[] = [
     title: 'Core Concepts',
     slug: 'core-concepts',
     children: [
-      { title: 'Two-Phase Compilation', slug: 'core-concepts/compilation' },
-      { title: 'Signal-Based Reactivity', slug: 'core-concepts/reactivity' },
-      { title: 'Hydration Model', slug: 'core-concepts/hydration' },
-      { title: '"use client" Directive', slug: 'core-concepts/use-client' },
-      { title: 'Clean Overrides', slug: 'core-concepts/clean-overrides' },
+      { title: 'Backend Freedom', slug: 'core-concepts/backend-freedom' },
+      { title: 'MPA-style Development', slug: 'core-concepts/mpa-style' },
+      { title: 'Fine-grained Reactivity', slug: 'core-concepts/reactivity' },
+      { title: 'AI-native Development', slug: 'core-concepts/ai-native' },
+      { title: 'How It Works', slug: 'core-concepts/how-it-works' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- PR #864 reorganized `docs/core/core-concepts/` (renamed/deleted/added files) but didn't update the navigation config in `site/core/lib/navigation.ts`
- Sidebar menu items and prev/next pagination links were pointing to deleted pages (`compilation`, `hydration`, `use-client`, `clean-overrides`)
- Updated slugs and titles to match the new structure (`backend-freedom`, `mpa-style`, `reactivity`, `ai-native`, `how-it-works`)

## Test plan

- [ ] Verify sidebar menu shows the correct Core Concepts pages (Backend Freedom, MPA-style Development, Fine-grained Reactivity, AI-native Development, How It Works)
- [ ] Verify clicking each menu item navigates to the correct page
- [ ] Verify prev/next pagination links at the bottom of each Core Concepts page work correctly
- [ ] Verify pagination from Introduction → Core Concepts → Backend Freedom flows correctly

Fixes broken links introduced in #864.

https://claude.ai/code/session_0164AE8tv8XGi3xw8RrY8n17