### PR TITLE
fix(inspect): track dynamic attribute bindings in dependency graph

### DIFF
--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -48,6 +48,27 @@ const dashboardSource = `
   }
 `
 
+// Component with dynamic attribute bindings (style, aria-*, class)
+const sliderLikeSource = `
+  'use client'
+  import { createSignal, createMemo } from '@barefootjs/client-runtime'
+
+  export function RangeInput() {
+    const [value, setValue] = createSignal(50)
+    const pct = createMemo(() => value() / 100)
+    return (
+      <div>
+        <div style={\`width: \${pct()}%\`} />
+        <span
+          aria-valuenow={value()}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+    )
+  }
+`
+
 const todoSource = `
   'use client'
   import { createSignal, createMemo } from '@barefootjs/client-runtime'
@@ -115,6 +136,26 @@ describe('buildComponentGraph', () => {
     // count is consumed by memo:doubled and effect:e0
     expect(countSignal.consumers).toContain('memo:doubled')
     expect(countSignal.consumers).toContain('effect:e0')
+  })
+
+  test('extracts dynamic attribute bindings (style, aria-*)', () => {
+    const graph = buildComponentGraph(sliderLikeSource, 'RangeInput.tsx')
+    const attrBindings = graph.domBindings.filter(d => d.type === 'attribute')
+    expect(attrBindings.length).toBeGreaterThanOrEqual(1)
+    // style depends on the memo `pct`
+    const styleBinding = attrBindings.find(d => d.label.includes('style'))
+    expect(styleBinding).toBeDefined()
+    expect(styleBinding!.deps).toContain('pct')
+    // aria-valuenow depends on `value`
+    const ariaBinding = attrBindings.find(d => d.label.includes('aria-valuenow'))
+    expect(ariaBinding).toBeDefined()
+    expect(ariaBinding!.deps).toContain('value')
+  })
+
+  test('includes attr bindings in memo consumer list', () => {
+    const graph = buildComponentGraph(sliderLikeSource, 'RangeInput.tsx')
+    const pct = graph.memos.find(m => m.name === 'pct')!
+    expect(pct.consumers.some(c => c.includes('style'))).toBe(true)
   })
 
   test('returns empty graph for stateless component', () => {

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -12,6 +12,7 @@ import type {
   IRConditional,
   IRElement,
   IRLoop,
+  IRTemplateLiteral,
   SignalInfo,
   MemoInfo,
   EffectInfo,
@@ -325,7 +326,9 @@ export function formatComponentGraph(graph: ComponentGraph): string {
     for (const d of graph.domBindings) {
       const arrow = d.type === 'event' ? ' ->' : ' <-'
       const depStr = d.deps.join(', ')
-      lines.push(`    ${d.type} "${d.slotId}"${arrow} ${depStr}`)
+      // For attribute bindings use the attr name; for others use slotId
+      const id = d.type === 'attribute' ? `"${d.label}"` : `"${d.slotId}"`
+      lines.push(`    ${d.type} ${id}${arrow} ${depStr}`)
     }
   }
 
@@ -496,6 +499,22 @@ function collectDomBindings(
 ): void {
   switch (node.type) {
     case 'element': {
+      // Dynamic attribute bindings (style, class, aria-*, data-*, etc.)
+      for (const attr of node.attrs) {
+        if (!attr.dynamic) continue
+        const expr = attrValueToString(attr.value)
+        if (!expr) continue
+        const deps = extractReactiveDeps(expr, signalGetters, memoNames)
+        if (deps.length > 0) {
+          bindings.push({
+            kind: 'dom',
+            label: attr.name,
+            slotId: node.slotId ?? '?',
+            deps,
+            type: 'attribute',
+          })
+        }
+      }
       // Event handlers
       for (const event of node.events) {
         const deps = extractReactiveDeps(event.handler, signalGetters, memoNames)
@@ -576,6 +595,16 @@ function collectDomBindings(
       break
     }
   }
+}
+
+/** Convert an IRAttribute value to a flat string for reactive dep extraction. */
+function attrValueToString(value: string | IRTemplateLiteral | null): string | null {
+  if (value === null) return null
+  if (typeof value === 'string') return value
+  // IRTemplateLiteral: join all ternary expressions
+  return value.parts
+    .map(p => p.type === 'ternary' ? `${p.condition} ${p.whenTrue} ${p.whenFalse}` : '')
+    .join(' ')
 }
 
 /** Extract reactive getter names (signal/memo calls) from an expression. */


### PR DESCRIPTION
## Summary

- `barefoot inspect` was silently dropping `style`, `aria-*`, `class`, and other dynamic attribute bindings from the dependency graph
- Memos like `percentage` in Slider appeared to have no DOM consumers, even though they drove `style` updates — making `why-update` output misleading
- Root cause: `collectDomBindings` only scanned `element.events`, not `element.attrs`

## Changes

- Scan `dynamic` attrs on `IRElement` for reactive deps in `collectDomBindings`
- Add `attrValueToString` helper to handle both `string` and `IRTemplateLiteral` attr values
- Display attribute bindings using attr name (`"style"`) instead of slotId in `barefoot inspect` output
- Add tests covering style and aria-* attribute binding detection

## Before / After

**Before** (`barefoot inspect slider`):
```
percentage <- min, max, currentValue
dependency graph:
  currentValue -> memo:percentage    ← percentage has no downstream
```

**After**:
```
percentage <- min, max, currentValue
dom bindings:
  attribute "style" <- percentage
dependency graph:
  currentValue -> memo:percentage
  percentage -> dom:style            ← correctly traced to DOM
```

## Test plan

- [x] All 611 tests pass (`bun test packages/jsx/src/__tests__/`)
- [x] `barefoot inspect slider` shows `attribute "style" <- percentage`
- [x] `barefoot why-update slider percentage` shows `-> style`
- [x] New tests added: `extracts dynamic attribute bindings (style, aria-*)` and `includes attr bindings in memo consumer list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)