### PR TITLE
fix(site): preserve sidebar navigation entry order

### DIFF
--- a/site/shared/components/sidebar-page-nav.tsx
+++ b/site/shared/components/sidebar-page-nav.tsx
@@ -78,30 +78,28 @@ interface SidebarNavProps {
 
 /**
  * Renders the sidebar navigation.
- * Groups and links are rendered as separate lists to work around
- * a compiler limitation with conditional JSX inside map().
+ * Entries are rendered in the order they appear in the array,
+ * preserving the intended navigation ordering.
  */
 export function SidebarNav({ entries, currentPath }: SidebarNavProps) {
-  const groups = entries.filter(isGroup) as SidebarGroup[]
-  const links = entries.filter(e => !isGroup(e)) as SidebarLink[]
-
   return (
     <div className="space-y-1">
-      {groups.map(group => (
-        <SidebarGroupSection
-          key={group.title}
-          group={group}
-          currentPath={currentPath}
-        />
-      ))}
-      {links.map(link => (
-        <SidebarItemLink
-          key={link.href}
-          title={link.title}
-          href={link.href}
-          isActive={currentPath === link.href}
-        />
-      ))}
+      {entries.map(entry =>
+        isGroup(entry) ? (
+          <SidebarGroupSection
+            key={entry.title}
+            group={entry}
+            currentPath={currentPath}
+          />
+        ) : (
+          <SidebarItemLink
+            key={entry.href}
+            title={entry.title}
+            href={entry.href}
+            isActive={currentPath === entry.href}
+          />
+        )
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `SidebarNav` was splitting entries into groups and links, rendering all groups before links — this ignored the original array order from `navigation.ts`
- Introduction (a standalone link) always appeared at the bottom despite being defined first in the navigation config
- Now renders entries in their original order, so Introduction appears at the top as intended

## Test plan
- [ ] Verify Introduction appears at the top of the Core docs sidebar
- [ ] Verify all other navigation groups (Core Concepts, Reactivity, etc.) still render correctly with accordions

🤖 Generated with [Claude Code](https://claude.com/claude-code)