### PR TITLE
refactor(client-runtime): simplify CSR render API

### DIFF
--- a/docs/core/adapters.md
+++ b/docs/core/adapters.md
@@ -22,6 +22,9 @@ JSX Source
 |---------|--------|---------|---------|
 | [`HonoAdapter`](./adapters/hono-adapter.md) | `.tsx` | Hono / JSX-based servers | `@barefootjs/hono` |
 | [`GoTemplateAdapter`](./adapters/go-template-adapter.md) | `.tmpl` + `_types.go` | Go `html/template` | `@barefootjs/go-template` |
+| [CSR](./adapters/csr.md) | — (client-rendered) | None (browser-only) | `@barefootjs/client-runtime` |
+
+> CSR is not an IR→template adapter. It renders components directly in the browser using client-side template functions — use it when the server can't (or shouldn't) emit the initial HTML.
 
 ## Pages
 
@@ -30,4 +33,5 @@ JSX Source
 | [Adapter Architecture](./adapters/adapter-architecture.md) | How adapters work, the `TemplateAdapter` interface, and the IR contract |
 | [Hono Adapter](./adapters/hono-adapter.md) | Configuration and output format for Hono / JSX-based servers |
 | [Go Template Adapter](./adapters/go-template-adapter.md) | Configuration and output format for Go `html/template` |
+| [CSR](./adapters/csr.md) | Client-side rendering without a server-rendered template |
 | [Writing a Custom Adapter](./adapters/custom-adapter.md) | Step-by-step guide to implementing your own adapter |

--- a/docs/core/adapters/csr.md
+++ b/docs/core/adapters/csr.md
@@ -1,0 +1,79 @@
+---
+title: CSR (Client-Side Rendering)
+description: Render BarefootJS components directly in the browser without a server-rendered template.
+---
+
+# CSR (Client-Side Rendering)
+
+CSR renders BarefootJS components directly in the browser, without any server-rendered initial HTML. Use it when the server can't (or shouldn't) emit the initial markup.
+
+Unlike the other entries in this section, CSR is not an IR→template adapter. It reuses the client-side template function that the compiler generates for each component, and mounts the resulting DOM into a container you pick.
+
+## When to use CSR
+
+Typical case: **static file hosting**. You have an HTML file you drop onto S3, GitHub Pages, or any static CDN — no backend renders the page. CSR lets you add interactive BarefootJS components to that page without setting up a server template.
+
+When you do control the server (Hono, Go, etc.), prefer SSR + hydration instead. It renders faster to first paint and works without JavaScript enabled for static parts.
+
+## Configuration
+
+Set `clientOnly: true` in `barefoot.config.ts`. This skips marked template output and emits only client JS plus the runtime bundle:
+
+```typescript
+// barefoot.config.ts
+import { createConfig } from '@barefootjs/hono/build'
+
+export default createConfig({
+  components: ['./components'],
+  outDir: 'dist',
+  clientOnly: true,
+})
+```
+
+Build output:
+
+```
+dist/
+└── components/
+    ├── barefoot.js        # client runtime bundle
+    └── Counter.client.js  # compiled component
+```
+
+## API
+
+```typescript
+import { render } from '@barefootjs/client-runtime'
+
+render(container, componentName, props?)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `container` | `HTMLElement` | Target element. Its content is replaced. |
+| `componentName` | `string` | Registered component name (same as the exported JSX function). |
+| `props` | `Record<string, unknown>` | Optional props passed to the component. |
+
+The component must be registered first by importing its `.client.js` file — that import triggers the compiler-generated `registerComponent` / `registerTemplate` calls.
+
+## Example
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="importmap">
+    { "imports": { "@barefootjs/client-runtime": "/static/components/barefoot.js" } }
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+    import { render } from '@barefootjs/client-runtime'
+    await import('/static/components/Counter.client.js')
+    render(document.getElementById('app'), 'Counter', { initialCount: 0 })
+  </script>
+</body>
+</html>
+```
+
+See [`examples/csr/`](https://github.com/barefootjs/barefootjs/tree/main/examples/csr) for a runnable end-to-end example.

--- a/examples/csr/pages/conditional-return-link.html
+++ b/examples/csr/pages/conditional-return-link.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/ConditionalReturn.client.js')
-    const init = getComponentInit('ConditionalReturn')
-    const template = getTemplate('ConditionalReturn')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template }, { variant: 'link' })
-    }
+    render(document.getElementById('app'), 'ConditionalReturn', { variant: 'link' })
   </script>
 </body>
 </html>

--- a/examples/csr/pages/conditional-return.html
+++ b/examples/csr/pages/conditional-return.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/ConditionalReturn.client.js')
-    const init = getComponentInit('ConditionalReturn')
-    const template = getTemplate('ConditionalReturn')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'ConditionalReturn')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/counter.html
+++ b/examples/csr/pages/counter.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/Counter.client.js')
-    const init = getComponentInit('Counter')
-    const template = getTemplate('Counter')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'Counter')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/form.html
+++ b/examples/csr/pages/form.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/Form.client.js')
-    const init = getComponentInit('Form')
-    const template = getTemplate('Form')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'Form')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/portal.html
+++ b/examples/csr/pages/portal.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/PortalExample.client.js')
-    const init = getComponentInit('PortalExample')
-    const template = getTemplate('PortalExample')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'PortalExample')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/props-reactivity.html
+++ b/examples/csr/pages/props-reactivity.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/ReactiveProps.client.js')
-    const init = getComponentInit('PropsReactivityComparison')
-    const template = getTemplate('PropsReactivityComparison')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'PropsReactivityComparison')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/reactive-props.html
+++ b/examples/csr/pages/reactive-props.html
@@ -15,13 +15,9 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/ReactiveProps.client.js')
-    const init = getComponentInit('ReactiveProps')
-    const template = getTemplate('ReactiveProps')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template })
-    }
+    render(document.getElementById('app'), 'ReactiveProps')
   </script>
 </body>
 </html>

--- a/examples/csr/pages/todos.html
+++ b/examples/csr/pages/todos.html
@@ -12,18 +12,14 @@
 <body>
   <div id="app"></div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/TodoApp.client.js')
 
     // Fetch initial todos from API
     const response = await fetch('/api/todos')
     const initialTodos = await response.json()
 
-    const init = getComponentInit('TodoApp')
-    const template = getTemplate('TodoApp')
-    if (init && template) {
-      render(document.getElementById('app'), { init, template }, { initialTodos })
-    }
+    render(document.getElementById('app'), 'TodoApp', { initialTodos })
   </script>
 </body>
 </html>

--- a/examples/csr/pages/toggle.html
+++ b/examples/csr/pages/toggle.html
@@ -15,18 +15,14 @@
     <p><a href="/">← Back</a></p>
   </div>
   <script type="module">
-    import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
+    import { render } from '@barefootjs/client-runtime'
     await import('/static/components/Toggle.client.js')
-    const init = getComponentInit('Toggle')
-    const template = getTemplate('Toggle')
-    if (init && template) {
-      const toggleItems = [
-        { label: 'Setting 1', defaultOn: true },
-        { label: 'Setting 2', defaultOn: false },
-        { label: 'Setting 3', defaultOn: false },
-      ]
-      render(document.getElementById('app'), { init, template }, { toggleItems })
-    }
+    const toggleItems = [
+      { label: 'Setting 1', defaultOn: true },
+      { label: 'Setting 2', defaultOn: false },
+      { label: 'Setting 3', defaultOn: false },
+    ]
+    render(document.getElementById('app'), 'Toggle', { toggleItems })
   </script>
 </body>
 </html>

--- a/packages/client-runtime/__tests__/render.test.ts
+++ b/packages/client-runtime/__tests__/render.test.ts
@@ -1,8 +1,12 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { render } from '../src/render'
 import { createComponent } from '../src/component'
+import { registerComponent } from '../src/registry'
+import { registerTemplate } from '../src/template'
 import { hydratedScopes } from '../src/hydration-state'
 import type { ComponentDef } from '../src/types'
+import type { InitFn } from '../src/types'
+import type { TemplateFn } from '../src/template'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
 beforeAll(() => {
@@ -10,6 +14,11 @@ beforeAll(() => {
     GlobalRegistrator.register()
   }
 })
+
+function registerTestComponent(name: string, init: InitFn, template: TemplateFn): void {
+  registerComponent(name, init)
+  registerTemplate(name, template)
+}
 
 describe('render', () => {
   beforeEach(() => {
@@ -21,12 +30,13 @@ describe('render', () => {
     document.body.appendChild(container)
 
     const initialized: Element[] = []
-    const def: ComponentDef = {
-      init: (scope) => { initialized.push(scope) },
-      template: (props) => `<div class="counter">${props.count ?? 0}</div>`
-    }
+    registerTestComponent(
+      'RenderTest_Basic',
+      (scope) => { initialized.push(scope) },
+      (props) => `<div class="counter">${props.count ?? 0}</div>`
+    )
 
-    render(container, def, { count: 42 })
+    render(container, 'RenderTest_Basic', { count: 42 })
 
     expect(container.children.length).toBe(1)
     expect(container.firstElementChild?.textContent).toBe('42')
@@ -39,12 +49,13 @@ describe('render', () => {
     container.innerHTML = '<p>old content</p>'
     document.body.appendChild(container)
 
-    const def: ComponentDef = {
-      init: () => {},
-      template: () => `<div>new content</div>`
-    }
+    registerTestComponent(
+      'RenderTest_Clear',
+      () => {},
+      () => `<div>new content</div>`
+    )
 
-    render(container, def)
+    render(container, 'RenderTest_Clear')
 
     expect(container.children.length).toBe(1)
     expect(container.firstElementChild?.textContent).toBe('new content')
@@ -54,23 +65,21 @@ describe('render', () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
 
-    const def: ComponentDef = {
-      init: () => {},
-      template: () => `<div>content</div>`
-    }
+    registerTestComponent(
+      'RenderTest_Scope',
+      () => {},
+      () => `<div>content</div>`
+    )
 
-    render(container, def)
+    render(container, 'RenderTest_Scope')
 
     expect(container.firstElementChild?.hasAttribute('bf-s')).toBe(true)
   })
 
-  test('throws without template', () => {
+  test('throws when component is not registered', () => {
     const container = document.createElement('div')
-    const def: ComponentDef = {
-      init: () => {}
-    }
 
-    expect(() => render(container, def)).toThrow('template')
+    expect(() => render(container, 'RenderTest_NotRegistered')).toThrow('not registered')
   })
 
   test('passes props to init', () => {
@@ -78,12 +87,13 @@ describe('render', () => {
     document.body.appendChild(container)
 
     const receivedProps: Record<string, unknown>[] = []
-    const def: ComponentDef = {
-      init: (_scope, props) => { receivedProps.push(props) },
-      template: () => `<div>content</div>`
-    }
+    registerTestComponent(
+      'RenderTest_Props',
+      (_scope, props) => { receivedProps.push(props) },
+      () => `<div>content</div>`
+    )
 
-    render(container, def, { foo: 'bar' })
+    render(container, 'RenderTest_Props', { foo: 'bar' })
 
     expect(receivedProps.length).toBe(1)
     expect(receivedProps[0]).toEqual({ foo: 'bar' })
@@ -93,12 +103,13 @@ describe('render', () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
 
-    const def: ComponentDef = {
-      init: () => {},
-      template: () => `<div>content</div>`
-    }
+    registerTestComponent(
+      'RenderTest_Hydrated',
+      () => {},
+      () => `<div>content</div>`
+    )
 
-    render(container, def)
+    render(container, 'RenderTest_Hydrated')
 
     const element = container.firstElementChild!
     expect(hydratedScopes.has(element)).toBe(true)

--- a/packages/client-runtime/src/render.ts
+++ b/packages/client-runtime/src/render.ts
@@ -8,40 +8,49 @@
 
 import { BF_SCOPE } from '@barefootjs/shared'
 import { hydratedScopes } from './hydration-state'
-import type { ComponentDef } from './types'
+import { getComponentInit } from './registry'
+import { getTemplate } from './template'
 
 /**
- * Render a component into a container element (CSR mode).
+ * Render a registered component into a container element (CSR mode).
  *
- * Creates the component's DOM from its template, mounts it into
+ * Looks up the component's init and template functions by name from
+ * the registry, generates its DOM from the template, mounts it into
  * the container, and initializes it with the given props.
+ *
+ * The component must be registered first by importing its `.client.js`
+ * file (which calls `registerComponent` + `registerTemplate` internally).
  *
  * Unlike hydrate(), this function does not require pre-rendered HTML.
  * The container's content is replaced entirely.
  *
  * @param container - Target DOM element to render into
- * @param def - Component definition with init and template functions
+ * @param componentName - Registered component name (e.g., 'Counter')
  * @param props - Props to pass to the component
  *
  * @example
  * import { render } from '@barefootjs/client-runtime'
- * import { Counter } from './Counter'
+ * await import('/static/components/Counter.client.js')
  *
- * render(document.getElementById('app')!, Counter, { initialCount: 0 })
+ * render(document.getElementById('app')!, 'Counter', { initialCount: 0 })
  */
 export function render(
   container: HTMLElement,
-  def: ComponentDef,
+  componentName: string,
   props: Record<string, unknown> = {}
 ): void {
-  if (!def.template) {
-    throw new Error('[BarefootJS] render() requires a ComponentDef with a template function')
+  const init = getComponentInit(componentName)
+  const template = getTemplate(componentName)
+
+  if (!init || !template) {
+    throw new Error(
+      `[BarefootJS] Component "${componentName}" is not registered. ` +
+      `Did you import its .client.js file before calling render()?`
+    )
   }
 
-  // Generate HTML from template
-  const html = def.template(props).trim()
+  const html = template(props).trim()
 
-  // Create DOM element
   const tpl = document.createElement('template')
   tpl.innerHTML = html
   const element = tpl.content.firstChild as HTMLElement
@@ -50,20 +59,15 @@ export function render(
     throw new Error('[BarefootJS] render(): template returned empty HTML')
   }
 
-  // Set scope ID if not present
   if (!element.getAttribute(BF_SCOPE)) {
     const id = Math.random().toString(36).slice(2, 8)
-    const name = def.name || def.init.name?.replace(/^init/, '') || 'Component'
-    element.setAttribute(BF_SCOPE, `${name}_${id}`)
+    element.setAttribute(BF_SCOPE, `${componentName}_${id}`)
   }
 
-  // Mount into container
   container.innerHTML = ''
   container.appendChild(element)
 
-  // Initialize the component
-  def.init(element, props)
+  init(element, props)
 
-  // Mark as hydrated so reconcileList doesn't re-initialize
   hydratedScopes.add(element)
 }


### PR DESCRIPTION
## Summary

- Replace the verbose `render(container, { init, template }, props)` pattern with a single-signature `render(container, componentName, props?)` that looks up init/template from the registry internally.
- Update 9 CSR example HTML pages to the new API.
- Add a new **CSR** page under the Adapters section (`docs/core/adapters/csr.md`) covering when to use CSR and the minimal usage pattern.

### Before / After

```js
// Before
import { render, getComponentInit, getTemplate } from '@barefootjs/client-runtime'
await import('/static/components/Counter.client.js')
const init = getComponentInit('Counter')
const template = getTemplate('Counter')
if (init && template) {
  render(document.getElementById('app'), { init, template })
}

// After
import { render } from '@barefootjs/client-runtime'
await import('/static/components/Counter.client.js')
render(document.getElementById('app'), 'Counter')
```

### Motivation

The old API forced every caller to reach into the registry manually. The new signature is easier to read, easier for AI agents to generate, and removes the need for `getComponentInit` / `getTemplate` at call sites.

### Breaking change

`render()` no longer accepts a `ComponentDef` object. External users (only `examples/csr/pages/*.html` in this repo) must switch to the string-based form. The `registerComponent` / `registerTemplate` / `getComponentInit` / `getTemplate` exports remain available for advanced use cases.

## Test plan

- [x] `bun test` in `packages/client-runtime` — 150 pass
- [x] `bun test` in `packages/jsx` — 611 pass
- [x] `bun test` in `packages/adapter-tests` — 177 pass
- [x] `bun run build` in `packages/client-runtime` — succeeds
- [x] `bun run build` in `examples/csr` — 10 components compiled
- [ ] Manually run `examples/csr` dev server and verify each page mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)