### PR TITLE
feat: add Dashboard Builder block + fix memo block-body inlining

### DIFF
--- a/packages/jsx/src/__tests__/hydrate-template.test.ts
+++ b/packages/jsx/src/__tests__/hydrate-template.test.ts
@@ -207,4 +207,46 @@ describe('hydrate() template generation for signal-bearing components', () => {
     // The word 'size' inside 'size-4' should not be replaced with the constant value
     expect(content).not.toMatch(/'\(props\.size/)
   })
+
+  test('block-body memo with local decls: wraps body in IIFE instead of dropping decls', () => {
+    // Regression for a bug surfaced by the Dashboard Builder block:
+    // createMemo(() => { const i = sig(); return i < 0 ? 'a' : items()[i] ? items()[i].label : 'a' })
+    // used to emit only the trailing return expression into the SSR template,
+    // leaving `i` unbound at runtime. The fix keeps the whole body in scope
+    // by wrapping block bodies with local decls in an IIFE.
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client-runtime'
+      interface Props { initialBars: { label: string; value: number }[] }
+      export function ChartWidget(props: Props) {
+        const [bars] = createSignal(props.initialBars)
+        const [selectedIndex] = createSignal(-1)
+        const selectedLabel = createMemo(() => {
+          const i = selectedIndex()
+          if (i < 0) return 'Total'
+          const b = bars()[i]
+          return b ? b.label : 'Total'
+        })
+        return <div className="chart-selected-label">{selectedLabel()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'ChartWidget.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // The hydrate template for ChartWidget must contain the full IIFE-wrapped
+    // memo body, not just the trailing `return` expression. Looking for the
+    // `const b =` decl inside the template literal is the strongest signal
+    // that local bindings survived inlining.
+    const templateMatch = content.match(/hydrate\('ChartWidget',\s*\{[^`]*template:[^`]*`([\s\S]*?)`\s*\}/)
+    expect(templateMatch).toBeTruthy()
+    const template = templateMatch![1]
+    expect(template).toContain('const i =')
+    expect(template).toContain('const b =')
+    // Must be wrapped in an IIFE form so bindings stay in scope at template eval time
+    expect(template).toMatch(/\(\(\)\s*=>\s*\{[\s\S]*const b =/)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -261,11 +261,17 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
     if (arrowMatch) {
       const body = arrowMatch[1].trim()
       if (body.startsWith('{')) {
-        // Block body: extract return expression.
-        // Use greedy .+ to capture the full return value including nested braces
-        // (e.g., return { a, b, c } must capture the entire object literal).
-        const returnMatch = body.match(/return\s+(.+)\s*[;}]?\s*}$/)
-        expr = returnMatch ? returnMatch[1] : expr
+        // Block body: detect the trivial `{ return <expr>; }` shape. A bare
+        // return expression can be inlined directly. Any other body (local
+        // `const`/`let` declarations, guard clauses, multiple statements)
+        // must be wrapped in an IIFE so that intermediate bindings remain in
+        // scope when the expression is inlined into the SSR template.
+        const simpleReturn = body.match(/^\{\s*return\s+([\s\S]+?)\s*;?\s*\}$/)
+        if (simpleReturn) {
+          expr = simpleReturn[1]
+        } else {
+          expr = `(() => ${body})()`
+        }
       } else {
         expr = body
       }

--- a/site/ui/components/dashboard-builder-demo.tsx
+++ b/site/ui/components/dashboard-builder-demo.tsx
@@ -1,0 +1,578 @@
+"use client"
+/**
+ * DashboardBuilderDemo
+ *
+ * Dynamic widget composition with per-widget signal isolation.
+ *
+ * Compiler stress targets:
+ * - Per-widget signal isolation: each child widget owns its internal signals.
+ *   Multiple instances of the same widget type each get an isolated reactive scope.
+ * - Dynamic component switching inside .map(): the loop body renders different
+ *   child components based on config.type — a ternary chain returning distinct
+ *   JSX element types (StatWidget / ProgressWidget / TodoWidget / ChartWidget).
+ * - Layout memo dependent on widget count: gridCols memo recomputes grid class
+ *   from widgets().length, driving dynamic CSS class updates on the container.
+ * - Independent signal trees: interacting with one widget (e.g., incrementing
+ *   StatWidget A) must not invalidate memos or trigger updates in sibling widgets.
+ * - Loop rebuild on config change: adding/removing/moving widgets reshapes the
+ *   loop, and new child components initialize with their own fresh signal state.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+
+import {
+  ArrowUpDownIcon,
+  CheckIcon,
+} from '@ui/components/ui/icon'
+
+// --- Types ---
+
+type WidgetType = 'stat' | 'progress' | 'todo' | 'chart'
+type WidgetSize = 'sm' | 'md' | 'lg'
+
+type WidgetConfig = {
+  id: number
+  type: WidgetType
+  title: string
+  size: WidgetSize
+}
+
+// --- Data ---
+
+let _nextId = 100
+function nextWidgetId(): number {
+  return _nextId++
+}
+
+const initialWidgets: WidgetConfig[] = [
+  { id: 1, type: 'stat', title: 'Revenue', size: 'md' },
+  { id: 2, type: 'progress', title: 'Quarterly Goal', size: 'md' },
+  { id: 3, type: 'todo', title: 'Action Items', size: 'md' },
+  { id: 4, type: 'chart', title: 'Weekly Visits', size: 'md' },
+]
+
+const WIDGET_LABELS: Record<WidgetType, string> = {
+  stat: 'Stat',
+  progress: 'Progress',
+  todo: 'Todo',
+  chart: 'Chart',
+}
+
+// --- Child Widgets (each with its own signal scope) ---
+
+type StatWidgetProps = {
+  initialValue: number
+  step: number
+}
+
+export function StatWidget(props: StatWidgetProps) {
+  const [value, setValue] = createSignal(props.initialValue)
+  const [startValue] = createSignal(props.initialValue)
+
+  const delta = createMemo(() => value() - startValue())
+  const trendLabel = createMemo(() => {
+    const d = delta()
+    if (d > 0) return `+${d}`
+    if (d < 0) return String(d)
+    return '±0'
+  })
+  const trendClass = createMemo(() => {
+    const d = delta()
+    if (d > 0) return 'text-emerald-600 dark:text-emerald-400'
+    if (d < 0) return 'text-rose-600 dark:text-rose-400'
+    return 'text-muted-foreground'
+  })
+
+  return (
+    <div className="stat-widget flex flex-col gap-2 h-full">
+      <div className="text-3xl font-semibold tabular-nums stat-value">
+        {value()}
+      </div>
+      <div className={`text-xs font-medium tabular-nums stat-trend ${trendClass()}`}>
+        {trendLabel()}
+      </div>
+      <div className="flex items-center gap-1 mt-auto">
+        <button
+          type="button"
+          className="stat-decrement inline-flex items-center justify-center w-7 h-7 rounded-md border border-input bg-background text-sm hover:bg-accent"
+          onClick={() => setValue(value() - props.step)}
+          aria-label="Decrement"
+        >−</button>
+        <button
+          type="button"
+          className="stat-increment inline-flex items-center justify-center w-7 h-7 rounded-md border border-input bg-background text-sm hover:bg-accent"
+          onClick={() => setValue(value() + props.step)}
+          aria-label="Increment"
+        >+</button>
+      </div>
+    </div>
+  )
+}
+
+type ProgressWidgetProps = {
+  initialProgress: number
+}
+
+export function ProgressWidget(props: ProgressWidgetProps) {
+  const [progress, setProgress] = createSignal(props.initialProgress)
+
+  const clamped = createMemo(() => Math.max(0, Math.min(100, progress())))
+  const barStyle = createMemo(() => `width: ${clamped()}%`)
+  const label = createMemo(() => `${clamped()}%`)
+  const status = createMemo(() => {
+    const p = clamped()
+    if (p >= 100) return 'Complete'
+    if (p >= 75) return 'On track'
+    if (p >= 40) return 'In progress'
+    return 'Behind'
+  })
+
+  return (
+    <div className="progress-widget flex flex-col gap-3 h-full">
+      <div className="flex items-baseline justify-between">
+        <div className="text-2xl font-semibold tabular-nums progress-label">
+          {label()}
+        </div>
+        <div className="text-xs text-muted-foreground progress-status">
+          {status()}
+        </div>
+      </div>
+      <div className="h-2 rounded-full bg-muted overflow-hidden">
+        <div
+          className="progress-bar h-full bg-primary transition-all"
+          style={barStyle()}
+        />
+      </div>
+      <div className="flex items-center gap-1 mt-auto">
+        <button
+          type="button"
+          className="progress-decrement inline-flex items-center justify-center h-7 px-2 text-xs rounded-md border border-input bg-background hover:bg-accent"
+          onClick={() => setProgress(clamped() - 10)}
+        >-10%</button>
+        <button
+          type="button"
+          className="progress-increment inline-flex items-center justify-center h-7 px-2 text-xs rounded-md border border-input bg-background hover:bg-accent"
+          onClick={() => setProgress(clamped() + 10)}
+        >+10%</button>
+        <button
+          type="button"
+          className="progress-reset inline-flex items-center justify-center h-7 px-2 text-xs rounded-md hover:bg-accent ml-auto text-muted-foreground"
+          onClick={() => setProgress(0)}
+        >Reset</button>
+      </div>
+    </div>
+  )
+}
+
+type TodoItem = {
+  id: number
+  text: string
+  done: boolean
+}
+
+export function TodoWidget() {
+  const [todos, setTodos] = createSignal<TodoItem[]>([
+    { id: 1, text: 'Review PRs', done: false },
+    { id: 2, text: 'Ship release', done: false },
+    { id: 3, text: 'Write docs', done: true },
+  ])
+  const [draft, setDraft] = createSignal('')
+
+  const remaining = createMemo(() => todos().filter((t: TodoItem) => !t.done).length)
+  const total = createMemo(() => todos().length)
+  const summary = createMemo(() => `${remaining()} of ${total()} remaining`)
+
+  let _todoId = 100
+  const addTodo = () => {
+    const text = draft().trim()
+    if (text.length === 0) return
+    setTodos((prev: TodoItem[]) => [...prev, { id: ++_todoId, text, done: false }])
+    setDraft('')
+  }
+
+  const toggleTodo = (id: number) => {
+    setTodos((prev: TodoItem[]) => prev.map((t: TodoItem) => t.id === id ? { ...t, done: !t.done } : t))
+  }
+
+  const removeTodo = (id: number) => {
+    setTodos((prev: TodoItem[]) => prev.filter((t: TodoItem) => t.id !== id))
+  }
+
+  return (
+    <div className="todo-widget flex flex-col gap-2 h-full">
+      <div className="text-xs text-muted-foreground todo-summary">
+        {summary()}
+      </div>
+      <div className="space-y-1 todo-list max-h-40 overflow-y-auto">
+        {todos().map((t: TodoItem) => (
+          <div
+            key={t.id}
+            className={`todo-item flex items-center gap-2 rounded-md px-2 py-1 text-sm hover:bg-accent/40${t.done ? ' todo-item-done' : ''}`}
+            onClick={() => {}}
+          >
+            <button
+              type="button"
+              className={`todo-toggle w-4 h-4 rounded border flex items-center justify-center shrink-0${t.done ? ' bg-primary border-primary text-primary-foreground' : ' border-input'}`}
+              onClick={() => toggleTodo(t.id)}
+              aria-pressed={t.done}
+              aria-label={t.done ? 'Mark incomplete' : 'Mark complete'}
+            >
+              {t.done ? <CheckIcon className="w-3 h-3" /> : null}
+            </button>
+            <span className={`flex-1 truncate${t.done ? ' line-through text-muted-foreground' : ''}`}>
+              {t.text}
+            </span>
+            <button
+              type="button"
+              className="todo-remove inline-flex items-center justify-center w-5 h-5 rounded-md text-muted-foreground opacity-40 hover:opacity-100 hover:bg-accent shrink-0 text-xs"
+              onClick={() => removeTodo(t.id)}
+              aria-label="Remove todo"
+            >×</button>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-1 mt-auto">
+        <input
+          type="text"
+          value={draft()}
+          onInput={(e: any) => setDraft(e.target.value)}
+          placeholder="Add an item…"
+          className="todo-input flex-1 h-7 rounded-md border border-input bg-background px-2 text-xs"
+        />
+        <button
+          type="button"
+          className="todo-add inline-flex items-center justify-center h-7 px-2 text-xs rounded-md border border-input bg-background hover:bg-accent"
+          onClick={addTodo}
+        >Add</button>
+      </div>
+    </div>
+  )
+}
+
+type ChartBar = {
+  label: string
+  value: number
+}
+
+type ChartWidgetProps = {
+  initialBars: ChartBar[]
+}
+
+export function ChartWidget(props: ChartWidgetProps) {
+  const [bars, setBars] = createSignal<ChartBar[]>(props.initialBars)
+  const [selectedKey, setSelectedKey] = createSignal<string>('')
+
+  const maxValue = createMemo(() => {
+    const vs = bars().map((b: ChartBar) => b.value)
+    return vs.length > 0 ? Math.max(...vs) : 1
+  })
+  const total = createMemo(() => bars().reduce((s: number, b: ChartBar) => s + b.value, 0))
+  const selectedLabel = createMemo(() => selectedKey() || 'Total')
+  const selectedValue = createMemo(() => {
+    const k = selectedKey()
+    if (!k) return total()
+    const match = bars().find((b: ChartBar) => b.label === k)
+    return match ? match.value : 0
+  })
+
+  const bumpSelected = (delta: number) => {
+    const k = selectedKey()
+    if (!k) return
+    setBars((prev: ChartBar[]) => prev.map((b: ChartBar) => b.label === k ? { ...b, value: Math.max(0, b.value + delta) } : b))
+  }
+
+  const toggleBar = (label: string) => {
+    setSelectedKey(selectedKey() === label ? '' : label)
+  }
+
+  return (
+    <div className="chart-widget flex flex-col gap-2 h-full">
+      <div className="flex items-baseline justify-between">
+        <div>
+          <div className="text-xs text-muted-foreground chart-selected-label">
+            {selectedLabel()}
+          </div>
+          <div className="text-2xl font-semibold tabular-nums chart-selected-value">
+            {selectedValue()}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="chart-decrement inline-flex items-center justify-center w-7 h-7 rounded-md border border-input bg-background text-sm hover:bg-accent"
+            onClick={() => bumpSelected(-5)}
+            aria-label="Decrement selected bar"
+          >−</button>
+          <button
+            type="button"
+            className="chart-increment inline-flex items-center justify-center w-7 h-7 rounded-md border border-input bg-background text-sm hover:bg-accent"
+            onClick={() => bumpSelected(5)}
+            aria-label="Increment selected bar"
+          >+</button>
+        </div>
+      </div>
+      <div className="flex items-end gap-1.5 h-24 chart-bars">
+        {bars().map((b: ChartBar) => (
+          <button
+            key={b.label}
+            type="button"
+            className={`chart-bar flex-1 h-full flex flex-col justify-end rounded-sm overflow-hidden bg-transparent p-0 border-0${selectedKey() === b.label ? ' chart-bar-selected' : ''}`}
+            onClick={() => toggleBar(b.label)}
+            aria-label={`${b.label}: ${b.value}`}
+            aria-pressed={selectedKey() === b.label}
+          >
+            <span
+              className={`chart-bar-fill block w-full rounded-sm transition-colors${selectedKey() === b.label ? ' bg-primary' : ' bg-primary/30 hover:bg-primary/50'}`}
+              style={`height: ${Math.round((b.value / maxValue()) * 100)}%`}
+            />
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+        {bars().map((b: ChartBar) => (
+          <span key={b.label} className="chart-bar-label flex-1 text-center">
+            {b.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// --- Parent component ---
+
+const STAT_PRESETS = [
+  { value: 24500, step: 100 },
+  { value: 128, step: 1 },
+  { value: 42, step: 5 },
+]
+
+const CHART_PRESETS: ChartBar[][] = [
+  [
+    { label: 'Mon', value: 12 },
+    { label: 'Tue', value: 18 },
+    { label: 'Wed', value: 9 },
+    { label: 'Thu', value: 22 },
+    { label: 'Fri', value: 15 },
+  ],
+  [
+    { label: 'Q1', value: 45 },
+    { label: 'Q2', value: 68 },
+    { label: 'Q3', value: 52 },
+    { label: 'Q4', value: 71 },
+  ],
+  [
+    { label: 'A', value: 5 },
+    { label: 'B', value: 15 },
+    { label: 'C', value: 25 },
+  ],
+]
+
+// Module-level preset lookup so the DashboardBuilderDemo template can
+// reference them when .map() renders child components. Functions declared
+// inside a component are not visible from the module-level template that
+// runs when a new item is mounted.
+function statPresetFor(id: number) {
+  return STAT_PRESETS[id % STAT_PRESETS.length]
+}
+
+function chartPresetFor(id: number): ChartBar[] {
+  return CHART_PRESETS[id % CHART_PRESETS.length]
+}
+
+function widgetSizeClass(size: WidgetSize): string {
+  return size === 'lg' ? 'md:col-span-2' : ''
+}
+
+function widgetSizeLabel(size: WidgetSize): string {
+  return size.toUpperCase()
+}
+
+export function DashboardBuilderDemo() {
+  const [widgets, setWidgets] = createSignal<WidgetConfig[]>(initialWidgets)
+
+  // Layout memo: grid column classes computed from widget count
+  const gridCols = createMemo(() => {
+    const count = widgets().length
+    if (count <= 1) return 'grid-cols-1'
+    if (count === 2) return 'grid-cols-1 md:grid-cols-2'
+    if (count === 3) return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+    return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+  })
+
+  // Memos derived from widgets() — demonstrate layout/config reactivity
+  const widgetCount = createMemo(() => widgets().length)
+  const statCount = createMemo(() => widgets().filter((w: WidgetConfig) => w.type === 'stat').length)
+  const progressCount = createMemo(() => widgets().filter((w: WidgetConfig) => w.type === 'progress').length)
+  const todoCount = createMemo(() => widgets().filter((w: WidgetConfig) => w.type === 'todo').length)
+  const chartCount = createMemo(() => widgets().filter((w: WidgetConfig) => w.type === 'chart').length)
+
+  // Actions
+  const addWidget = (type: WidgetType) => {
+    const titles: Record<WidgetType, string> = {
+      stat: 'New Stat',
+      progress: 'New Progress',
+      todo: 'New Todo',
+      chart: 'New Chart',
+    }
+    setWidgets((prev: WidgetConfig[]) => [...prev, {
+      id: nextWidgetId(),
+      type,
+      title: titles[type],
+      size: 'md' as WidgetSize,
+    }])
+  }
+
+  const removeWidget = (id: number) => {
+    setWidgets((prev: WidgetConfig[]) => prev.filter((w: WidgetConfig) => w.id !== id))
+  }
+
+  const moveWidget = (id: number, dir: 'up' | 'down') => {
+    setWidgets((prev: WidgetConfig[]) => {
+      const idx = prev.findIndex((w: WidgetConfig) => w.id === id)
+      if (idx === -1) return prev
+      const newIdx = dir === 'up' ? idx - 1 : idx + 1
+      if (newIdx < 0 || newIdx >= prev.length) return prev
+      const result = [...prev]
+      const [moved] = result.splice(idx, 1)
+      result.splice(newIdx, 0, moved)
+      return result
+    })
+  }
+
+  const cycleSize = (id: number) => {
+    const order: WidgetSize[] = ['sm', 'md', 'lg']
+    setWidgets((prev: WidgetConfig[]) => prev.map((w: WidgetConfig) => {
+      if (w.id !== id) return w
+      const i = order.indexOf(w.size)
+      return { ...w, size: order[(i + 1) % order.length] }
+    }))
+  }
+
+  const updateTitle = (id: number, title: string) => {
+    setWidgets((prev: WidgetConfig[]) => prev.map((w: WidgetConfig) => w.id === id ? { ...w, title } : w))
+  }
+
+  return (
+    <div className="dashboard-builder-demo w-full space-y-4">
+
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold">Dashboard Builder</h2>
+          <Badge variant="secondary" className="widget-count">
+            {widgetCount()} widgets
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="stat-count-badge">Stat: <span className="font-medium text-foreground">{statCount()}</span></span>
+          <span>·</span>
+          <span className="progress-count-badge">Progress: <span className="font-medium text-foreground">{progressCount()}</span></span>
+          <span>·</span>
+          <span className="todo-count-badge">Todo: <span className="font-medium text-foreground">{todoCount()}</span></span>
+          <span>·</span>
+          <span className="chart-count-badge">Chart: <span className="font-medium text-foreground">{chartCount()}</span></span>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center flex-wrap gap-2 rounded-lg border bg-card p-2">
+        <span className="text-xs text-muted-foreground mr-1">Add:</span>
+        <Button variant="outline" size="sm" className="add-stat-btn h-7 px-2 text-xs" onClick={() => addWidget('stat')}>
+          + Stat
+        </Button>
+        <Button variant="outline" size="sm" className="add-progress-btn h-7 px-2 text-xs" onClick={() => addWidget('progress')}>
+          + Progress
+        </Button>
+        <Button variant="outline" size="sm" className="add-todo-btn h-7 px-2 text-xs" onClick={() => addWidget('todo')}>
+          + Todo
+        </Button>
+        <Button variant="outline" size="sm" className="add-chart-btn h-7 px-2 text-xs" onClick={() => addWidget('chart')}>
+          + Chart
+        </Button>
+      </div>
+
+      {/* Widget grid */}
+      <div className={`dashboard-grid grid gap-3 ${gridCols()}`}>
+        {widgets().map((w: WidgetConfig) => (
+          <div
+            key={w.id}
+            data-widget-type={w.type}
+            data-widget-size={w.size}
+            className={`widget-cell rounded-lg border bg-card p-3 flex flex-col gap-2 ${widgetSizeClass(w.size)}`}
+          >
+            {/* Widget header */}
+            <div className="widget-header flex items-center flex-wrap gap-1.5">
+              <span className="widget-type-badge inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+                {WIDGET_LABELS[w.type]}
+              </span>
+              <input
+                type="text"
+                value={w.title}
+                onInput={(e: any) => updateTitle(w.id, e.target.value)}
+                className="widget-title-input flex-1 min-w-0 h-7 rounded-md border border-input bg-background px-2 text-sm font-medium"
+                placeholder="Widget title"
+              />
+              <button
+                type="button"
+                className="widget-size-toggle inline-flex items-center justify-center w-7 h-7 rounded-md text-[10px] font-semibold hover:bg-accent shrink-0"
+                onClick={() => cycleSize(w.id)}
+                aria-label={`Size: ${w.size}`}
+                title={`Size: ${w.size}`}
+              >{widgetSizeLabel(w.size)}</button>
+              <button
+                type="button"
+                className="widget-move-up inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-accent shrink-0"
+                onClick={() => moveWidget(w.id, 'up')}
+                aria-label="Move up"
+              >↑</button>
+              <button
+                type="button"
+                className="widget-move-down inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-accent shrink-0"
+                onClick={() => moveWidget(w.id, 'down')}
+                aria-label="Move down"
+              >↓</button>
+              <button
+                type="button"
+                className="widget-remove inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive shrink-0"
+                onClick={() => removeWidget(w.id)}
+                aria-label="Remove widget"
+              >×</button>
+            </div>
+
+            {/* Widget body — dynamic component switching based on type */}
+            <div className="widget-body flex-1">
+              {w.type === 'stat' ? (
+                <StatWidget
+                  initialValue={statPresetFor(w.id).value}
+                  step={statPresetFor(w.id).step}
+                />
+              ) : null}
+              {w.type === 'progress' ? (
+                <ProgressWidget initialProgress={35} />
+              ) : null}
+              {w.type === 'todo' ? (
+                <TodoWidget />
+              ) : null}
+              {w.type === 'chart' ? (
+                <ChartWidget initialBars={chartPresetFor(w.id)} />
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Empty state */}
+      {widgetCount() === 0 ? (
+        <div className="dashboard-empty rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          <div className="flex flex-col items-center gap-2">
+            <ArrowUpDownIcon className="w-5 h-5 opacity-50" />
+            <p>No widgets yet. Add one from the toolbar above.</p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -129,6 +129,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'spreadsheet', title: 'Spreadsheet', description: 'Spreadsheet grid with cell editing, formula evaluation, selection, and 2D nested loops' },
   { slug: 'form-builder', title: 'Form Builder', description: 'Signal-driven form builder with heterogeneous loop, dynamic field type switching, nested groups, and conditional visibility' },
   { slug: 'pivot-table', title: 'Pivot Table', description: 'Dynamic row/column grouping with multi-level aggregation, drag axis config, and expand/collapse groups' },
+  { slug: 'dashboard-builder', title: 'Dashboard Builder', description: 'Dynamic widget composition with per-widget signal isolation, dynamic component switching per item, and layout memo driven by widget count' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/dashboard-builder.spec.ts
+++ b/site/ui/e2e/dashboard-builder.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Dashboard Builder Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/dashboard-builder')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="DashboardBuilderDemo_"]:not([data-slot])').first()
+
+  // --- Initial Render ---
+
+  test.describe('Initial Render', () => {
+    test('shows widget count badge', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.widget-count')).toContainText('4 widgets')
+    })
+
+    test('renders four initial widget cells', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.widget-cell')).toHaveCount(4)
+    })
+
+    test('renders one of each widget type initially', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.stat-widget')).toHaveCount(1)
+      await expect(s.locator('.progress-widget')).toHaveCount(1)
+      await expect(s.locator('.todo-widget')).toHaveCount(1)
+      await expect(s.locator('.chart-widget')).toHaveCount(1)
+    })
+
+    test('shows count badge per widget type', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.stat-count-badge')).toContainText('1')
+      await expect(s.locator('.progress-count-badge')).toContainText('1')
+      await expect(s.locator('.todo-count-badge')).toContainText('1')
+      await expect(s.locator('.chart-count-badge')).toContainText('1')
+    })
+
+    test('renders toolbar with add buttons', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.add-stat-btn')).toBeVisible()
+      await expect(s.locator('.add-progress-btn')).toBeVisible()
+      await expect(s.locator('.add-todo-btn')).toBeVisible()
+      await expect(s.locator('.add-chart-btn')).toBeVisible()
+    })
+  })
+
+  // --- Per-Widget Signal Isolation ---
+
+  test.describe('Per-Widget Signal Isolation', () => {
+    test('incrementing one StatWidget does not affect a second StatWidget', async ({ page }) => {
+      const s = section(page)
+
+      // Add a second stat widget
+      await s.locator('.add-stat-btn').click()
+      await expect(s.locator('.stat-widget')).toHaveCount(2)
+
+      const firstStat = s.locator('.stat-widget').nth(0)
+      const secondStat = s.locator('.stat-widget').nth(1)
+
+      const firstBefore = await firstStat.locator('.stat-value').textContent()
+      const secondBefore = await secondStat.locator('.stat-value').textContent()
+
+      // Increment only the first
+      await firstStat.locator('.stat-increment').click()
+      await firstStat.locator('.stat-increment').click()
+
+      const firstAfter = await firstStat.locator('.stat-value').textContent()
+      const secondAfter = await secondStat.locator('.stat-value').textContent()
+
+      expect(firstAfter).not.toBe(firstBefore)
+      expect(secondAfter).toBe(secondBefore)
+    })
+
+    test('StatWidget trend reflects only its own deltas', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-stat-btn').click()
+
+      const firstStat = s.locator('.stat-widget').nth(0)
+      const secondStat = s.locator('.stat-widget').nth(1)
+
+      await firstStat.locator('.stat-increment').click()
+
+      const firstTrend = await firstStat.locator('.stat-trend').textContent()
+      const secondTrend = await secondStat.locator('.stat-trend').textContent()
+
+      expect(firstTrend?.trim()).not.toBe('±0')
+      expect(secondTrend?.trim()).toBe('±0')
+    })
+
+    test('TodoWidget maintains independent todo list per instance', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-todo-btn').click()
+      await expect(s.locator('.todo-widget')).toHaveCount(2)
+
+      const firstTodo = s.locator('.todo-widget').nth(0)
+      const secondTodo = s.locator('.todo-widget').nth(1)
+
+      // Toggle the first item in the first TodoWidget
+      await firstTodo.locator('.todo-toggle').first().click()
+
+      // First should have a done item
+      await expect(firstTodo.locator('.todo-item-done')).toHaveCount(2)
+      // Second should still have its default done count (1 from initial)
+      await expect(secondTodo.locator('.todo-item-done')).toHaveCount(1)
+    })
+
+    test('ProgressWidget increments are scoped to the widget', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-progress-btn').click()
+
+      const firstProg = s.locator('.progress-widget').nth(0)
+      const secondProg = s.locator('.progress-widget').nth(1)
+
+      const firstBefore = await firstProg.locator('.progress-label').textContent()
+      const secondBefore = await secondProg.locator('.progress-label').textContent()
+
+      await firstProg.locator('.progress-increment').click()
+      await firstProg.locator('.progress-increment').click()
+
+      const firstAfter = await firstProg.locator('.progress-label').textContent()
+      const secondAfter = await secondProg.locator('.progress-label').textContent()
+
+      expect(firstAfter).not.toBe(firstBefore)
+      expect(secondAfter).toBe(secondBefore)
+    })
+  })
+
+  // --- Dynamic Component Switching ---
+
+  test.describe('Dynamic Component Switching', () => {
+    test('adding a stat widget mounts a StatWidget instance', async ({ page }) => {
+      const s = section(page)
+      const before = await s.locator('.stat-widget').count()
+      await s.locator('.add-stat-btn').click()
+      await expect(s.locator('.stat-widget')).toHaveCount(before + 1)
+    })
+
+    test('adding a progress widget mounts a ProgressWidget instance', async ({ page }) => {
+      const s = section(page)
+      const before = await s.locator('.progress-widget').count()
+      await s.locator('.add-progress-btn').click()
+      await expect(s.locator('.progress-widget')).toHaveCount(before + 1)
+    })
+
+    test('adding a chart widget mounts a ChartWidget instance', async ({ page }) => {
+      const s = section(page)
+      const before = await s.locator('.chart-widget').count()
+      await s.locator('.add-chart-btn').click()
+      await expect(s.locator('.chart-widget')).toHaveCount(before + 1)
+    })
+
+    test('newly mounted widget is interactive with its own state', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-stat-btn').click()
+
+      const newStat = s.locator('.stat-widget').last()
+      const before = await newStat.locator('.stat-value').textContent()
+
+      await newStat.locator('.stat-increment').click()
+
+      const after = await newStat.locator('.stat-value').textContent()
+      expect(after).not.toBe(before)
+    })
+
+    test('new chart widget responds to its own bar selection', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.add-chart-btn').click()
+
+      const newChart = s.locator('.chart-widget').last()
+      const before = await newChart.locator('.chart-selected-label').textContent()
+
+      // Clicking a bar selects it and updates the label
+      await newChart.locator('.chart-bar').first().click()
+
+      const after = await newChart.locator('.chart-selected-label').textContent()
+      expect(after).not.toBe(before)
+    })
+  })
+
+  // --- Widget Count Badges ---
+
+  test.describe('Widget Count Reactivity', () => {
+    test('widget count updates when adding', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.widget-count')).toContainText('4')
+
+      await s.locator('.add-stat-btn').click()
+      await expect(s.locator('.widget-count')).toContainText('5')
+    })
+
+    test('widget count updates when removing', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.widget-count')).toContainText('4')
+
+      await s.locator('.widget-cell').first().locator('.widget-remove').click()
+      await expect(s.locator('.widget-count')).toContainText('3')
+    })
+
+    test('per-type count badge updates when adding that type', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.stat-count-badge')).toContainText('1')
+
+      await s.locator('.add-stat-btn').click()
+      await expect(s.locator('.stat-count-badge')).toContainText('2')
+
+      await s.locator('.add-stat-btn').click()
+      await expect(s.locator('.stat-count-badge')).toContainText('3')
+    })
+
+    test('other-type badges stay unchanged when one type is added', async ({ page }) => {
+      const s = section(page)
+
+      await s.locator('.add-stat-btn').click()
+
+      await expect(s.locator('.progress-count-badge')).toContainText('1')
+      await expect(s.locator('.todo-count-badge')).toContainText('1')
+      await expect(s.locator('.chart-count-badge')).toContainText('1')
+    })
+  })
+
+  // --- Layout / Widget Management ---
+
+  test.describe('Widget Management', () => {
+    test('remove widget deletes the cell', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.widget-cell').first().locator('.widget-remove').click()
+      await expect(s.locator('.widget-cell')).toHaveCount(3)
+    })
+
+    test('removing all widgets shows empty state', async ({ page }) => {
+      const s = section(page)
+      // Remove all 4
+      for (let i = 0; i < 4; i++) {
+        await s.locator('.widget-cell').first().locator('.widget-remove').click()
+      }
+      await expect(s.locator('.dashboard-empty')).toBeVisible()
+      await expect(s.locator('.widget-count')).toContainText('0')
+    })
+
+    test('move widget down swaps its position', async ({ page }) => {
+      const s = section(page)
+      const firstTypeBefore = await s.locator('.widget-cell').first().getAttribute('data-widget-type')
+      const secondTypeBefore = await s.locator('.widget-cell').nth(1).getAttribute('data-widget-type')
+
+      await s.locator('.widget-cell').first().locator('.widget-move-down').click()
+
+      const firstTypeAfter = await s.locator('.widget-cell').first().getAttribute('data-widget-type')
+      const secondTypeAfter = await s.locator('.widget-cell').nth(1).getAttribute('data-widget-type')
+
+      expect(firstTypeAfter).toBe(secondTypeBefore)
+      expect(secondTypeAfter).toBe(firstTypeBefore)
+    })
+
+    test('cycle size changes data-widget-size attribute', async ({ page }) => {
+      const s = section(page)
+      const cell = s.locator('.widget-cell').first()
+      const before = await cell.getAttribute('data-widget-size')
+      expect(before).toBe('md')
+
+      await cell.locator('.widget-size-toggle').click()
+      const after = await cell.getAttribute('data-widget-size')
+      expect(after).not.toBe(before)
+    })
+
+    test('editing a widget title keeps the same cell count', async ({ page }) => {
+      const s = section(page)
+
+      const countBefore = await s.locator('.widget-cell').count()
+      const statCell = s.locator('[data-widget-type="stat"]').first()
+      await statCell.locator('.widget-title-input').fill('Revenue (updated)')
+
+      // Editing the title must not spawn or drop any widget cell
+      await expect(s.locator('.widget-cell')).toHaveCount(countBefore)
+      await expect(statCell.locator('.widget-title-input')).toHaveValue('Revenue (updated)')
+    })
+  })
+})

--- a/site/ui/pages/components/dashboard-builder.tsx
+++ b/site/ui/pages/components/dashboard-builder.tsx
@@ -1,0 +1,152 @@
+/**
+ * Dashboard Builder Reference Page (/components/dashboard-builder)
+ *
+ * Block-level composition pattern: dynamic widget composition with
+ * per-widget signal isolation, dynamic component switching inside a
+ * loop, and layout memo dependent on widget count.
+ */
+
+import { DashboardBuilderDemo } from '@/components/dashboard-builder-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+// Each widget type is its own client component with its own signal scope.
+// Two StatWidget instances each maintain independent value/trend signals —
+// incrementing one does not touch the other.
+
+function StatWidget(props: { initialValue: number; step: number }) {
+  const [value, setValue] = createSignal(props.initialValue)
+  const delta = createMemo(() => value() - props.initialValue)
+  return (
+    <div>
+      <div>{value()}</div>
+      <button onClick={() => setValue(value() + props.step)}>+</button>
+    </div>
+  )
+}
+
+function ProgressWidget(props: { initialProgress: number }) {
+  const [progress, setProgress] = createSignal(props.initialProgress)
+  // ...own bar + status memos
+}
+
+function TodoWidget() { /* own todos signal */ }
+function ChartWidget(props: { initialBars: ChartBar[] }) { /* own bars + selectedIndex */ }
+
+type WidgetConfig = { id: number; type: 'stat' | 'progress' | 'todo' | 'chart'; title: string; size: 'sm' | 'md' | 'lg' }
+
+function DashboardBuilder() {
+  const [widgets, setWidgets] = createSignal<WidgetConfig[]>(initialWidgets)
+
+  // Layout memo: grid column class recomputed whenever widgets are added/removed
+  const gridCols = createMemo(() => {
+    const n = widgets().length
+    if (n <= 1) return 'grid-cols-1'
+    if (n === 2) return 'grid-cols-1 md:grid-cols-2'
+    return 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+  })
+
+  return (
+    <div className={\`grid gap-3 \${gridCols()}\`}>
+      {widgets().map(w => (
+        <div key={w.id} className="widget-cell">
+          {/* Dynamic component switching inside the loop body */}
+          {w.type === 'stat' ? <StatWidget initialValue={...} step={...} /> : null}
+          {w.type === 'progress' ? <ProgressWidget initialProgress={35} /> : null}
+          {w.type === 'todo' ? <TodoWidget /> : null}
+          {w.type === 'chart' ? <ChartWidget initialBars={...} /> : null}
+        </div>
+      ))}
+    </div>
+  )
+}`
+
+export function DashboardBuilderRefPage() {
+  return (
+    <DocPage slug="dashboard-builder" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Dashboard Builder"
+          description="Dynamic widget composition where each widget owns its own signal scope. Add, remove, reorder, and resize heterogeneous widgets; the layout grid reconfigures from a memo driven by widget count."
+          {...getNavLinks('dashboard-builder')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <DashboardBuilderDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Per-Widget Signal Isolation</h3>
+              <p className="text-sm text-muted-foreground">
+                Each widget type (Stat, Progress, Todo, Chart) is a separate client
+                component with its own signal scope. Adding a second StatWidget creates
+                an entirely new reactive instance — its value signal, trend memo, and
+                DOM bindings are independent of every other StatWidget on the page.
+                Incrementing one StatWidget does not invalidate memos in sibling widgets.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Dynamic Component Switching Inside .map()</h3>
+              <p className="text-sm text-muted-foreground">
+                The widget loop body renders a different child component based on
+                <code className="mx-1 text-xs">w.type</code>. A ternary chain returns
+                <code className="mx-1 text-xs">StatWidget</code>, <code className="mx-1 text-xs">ProgressWidget</code>,
+                <code className="mx-1 text-xs">TodoWidget</code>, or <code className="mx-1 text-xs">ChartWidget</code>.
+                Each branch produces a structurally different subtree — the compiler must
+                hydrate the right component per item and wire up its independent signal tree.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Layout Memo Dependent on Widget Count</h3>
+              <p className="text-sm text-muted-foreground">
+                <code className="mr-1 text-xs">gridCols</code> memo reads
+                <code className="mx-1 text-xs">widgets().length</code> and emits a
+                responsive Tailwind grid class. Adding or removing widgets updates
+                the memo, which updates the container's className via a reactive
+                CSS class binding — without re-creating the widget instances.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Loop Rebuild With Fresh Child State</h3>
+              <p className="text-sm text-muted-foreground">
+                Removing a widget filters the config array; adding one appends. Each
+                new child widget mounts with a clean signal scope, initialized from
+                constructor props. This exercises the compiler's keyed-reconciliation
+                path inside <code className="mx-1 text-xs">.map()</code> bodies that
+                emit distinct component types.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Derived Count Badges</h3>
+              <p className="text-sm text-muted-foreground">
+                Four independent memos (stat / progress / todo / chart count) each
+                filter <code className="mx-1 text-xs">widgets()</code> by type and
+                drive a badge. All four recompute on any widget list change, testing
+                fan-out from a single upstream signal.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -84,6 +84,7 @@ import { SpreadsheetRefPage } from './pages/components/spreadsheet'
 import { PermissionMatrixRefPage } from './pages/components/permission-matrix'
 import { FormBuilderRefPage } from './pages/components/form-builder'
 import { PivotTableRefPage } from './pages/components/pivot-table'
+import { DashboardBuilderRefPage } from './pages/components/dashboard-builder'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -570,6 +571,11 @@ export function createApp() {
   // Pivot Table block page
   app.get('/components/pivot-table', (c) => {
     return c.render(<PivotTableRefPage />)
+  })
+
+  // Dashboard Builder block page
+  app.get('/components/dashboard-builder', (c) => {
+    return c.render(<DashboardBuilderRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

Adds **Dashboard Builder** — the third block from Phase 9 Medium Priority (#135) — and fixes one compiler bug that surfaced while building it.

### Dashboard Builder block (`site/ui`)

A widget-composition block that stresses three compiler areas not covered by existing blocks:

- **Per-widget signal isolation** — `StatWidget`, `ProgressWidget`, `TodoWidget`, and `ChartWidget` are each separate stateful client components in the same file. Two instances of the same type maintain fully independent signal scopes.
- **Dynamic component switching inside `.map()`** — the widget loop renders a structurally different child component per item based on `w.type`.
- **Layout memo driven by widget count** — `gridCols` memo reads `widgets().length` and reactively drives the container's grid-cols class.

23-test Playwright spec covers signal isolation, dynamic mounting, per-type count reactivity, and cell management. All pass (1311 total site/ui E2E, 0 skip).

### Compiler fix (`packages/jsx`)

- **Block-body memos dropped local declarations.** `createMemo(() => { const i = sig(); return items()[i]?.label ?? 'x' })` previously inlined only the trailing return expression into the SSR/CSR fallback template, leaving `i` unbound at runtime. Now trivial `{ return expr; }` bodies inline directly; any body with intermediate statements is wrapped in an IIFE so bindings stay in scope.

Covered by a new regression test in `packages/jsx/src/__tests__/hydrate-template.test.ts`.

### Follow-up compiler bugs (not fixed here)

Three further issues surfaced but were worked around in the demo to keep this PR focused. Noted in the Dashboard Builder commit message for the tracking issue:

- `<Button><Icon/></Button>` children are dropped from a child user-defined component's module-level template.
- `.map((item, index) => ...)` event handlers reference `index` in delegated click dispatch, yielding "i is not defined" at runtime.
- Reactive classes on the root element of a `.map()` body get no `bf` id or className effect.

Refs #135.

## Test plan

- [x] `bun run build` clean
- [x] `bun test packages/jsx` — 612 pass, 0 fail (includes new regression test)
- [x] `bun test packages/adapter-tests` — 177 pass, 0 fail
- [x] `bunx playwright test` in `site/ui` — 1311 pass, 0 fail (including 23 new dashboard-builder tests)
- [ ] Manual smoke on `/components/dashboard-builder` — add/remove/reorder widgets, edit titles, verify per-widget state isolation, toggle sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)