### PR TITLE
feat(cli): incremental build with watch mode

### DIFF
--- a/examples/csr/package.json
+++ b/examples/csr/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run ../../packages/cli/src/index.ts build",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "bun run server.ts",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run ../../packages/cli/src/index.ts build",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "go run .",
     "setup": "go mod tidy",
     "test:e2e": "bunx playwright test",

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run ../../packages/cli/src/index.ts build",
-    "dev": "bun run --watch server.tsx",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "dev": "bun run build && concurrently -n build,server -c cyan,green 'bun run build:watch' 'bun run --watch server.tsx'",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },

--- a/examples/mojolicious/package.json
+++ b/examples/mojolicious/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run ../../packages/cli/src/index.ts build",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "perl app.pl daemon -l 'http://*:3004'",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "concurrently": "^9.1.0",
     "happy-dom": "^20.0.11",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/packages/cli/src/__tests__/build-cache.test.ts
+++ b/packages/cli/src/__tests__/build-cache.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  emptyCache,
+  findReverseDependents,
+  hashContent,
+  isEntryFresh,
+  loadCache,
+  saveCache,
+  type CacheEntry,
+} from '../lib/build-cache'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+function makeEntry(hash: string, deps: Record<string, string>): CacheEntry {
+  return { hash, deps, outputs: [], manifestKey: null }
+}
+
+describe('hashContent', () => {
+  test('is stable for identical content', () => {
+    expect(hashContent('hello')).toBe(hashContent('hello'))
+  })
+
+  test('differs for different content', () => {
+    expect(hashContent('hello')).not.toBe(hashContent('world'))
+  })
+})
+
+describe('isEntryFresh', () => {
+  const entry = makeEntry('src-hash-1', {
+    '/abs/dep-a.tsx': 'dep-a-hash-1',
+    '/abs/dep-b.tsx': 'dep-b-hash-1',
+  })
+  const lookup = (hashes: Record<string, string>) => (p: string): string | null =>
+    hashes[p] ?? null
+
+  test('fresh when source and all deps match', () => {
+    expect(
+      isEntryFresh(entry, 'src-hash-1', lookup({
+        '/abs/dep-a.tsx': 'dep-a-hash-1',
+        '/abs/dep-b.tsx': 'dep-b-hash-1',
+      })),
+    ).toBe(true)
+  })
+
+  test('stale when source hash differs', () => {
+    expect(
+      isEntryFresh(entry, 'src-hash-2', lookup({
+        '/abs/dep-a.tsx': 'dep-a-hash-1',
+        '/abs/dep-b.tsx': 'dep-b-hash-1',
+      })),
+    ).toBe(false)
+  })
+
+  test('stale when a dep hash differs', () => {
+    expect(
+      isEntryFresh(entry, 'src-hash-1', lookup({
+        '/abs/dep-a.tsx': 'dep-a-hash-CHANGED',
+        '/abs/dep-b.tsx': 'dep-b-hash-1',
+      })),
+    ).toBe(false)
+  })
+
+  test('stale when a dep was deleted (lookup returns null)', () => {
+    expect(
+      isEntryFresh(entry, 'src-hash-1', lookup({
+        '/abs/dep-a.tsx': 'dep-a-hash-1',
+      })),
+    ).toBe(false)
+  })
+})
+
+describe('findReverseDependents', () => {
+  const cache = emptyCache('global-hash')
+  cache.entries['/abs/parent.tsx'] = makeEntry('p', {
+    '/abs/child.tsx': 'c',
+  })
+  cache.entries['/abs/sibling.tsx'] = makeEntry('s', {
+    '/abs/other.tsx': 'o',
+  })
+
+  test('includes entries whose deps contain a changed path', () => {
+    const affected = findReverseDependents(cache, ['/abs/child.tsx'])
+    expect([...affected]).toEqual(['/abs/parent.tsx'])
+  })
+
+  test('returns empty when no entry depends on the change', () => {
+    const affected = findReverseDependents(cache, ['/abs/unknown.tsx'])
+    expect(affected.size).toBe(0)
+  })
+})
+
+describe('loadCache / saveCache', () => {
+  test('round-trips through disk', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-cache-'))
+    try {
+      const cache = emptyCache('gh')
+      cache.entries['/abs/a.tsx'] = makeEntry('h', { '/abs/b.tsx': 'bh' })
+      await saveCache(dir, cache)
+      const loaded = await loadCache(dir)
+      expect(loaded).not.toBeNull()
+      expect(loaded!.globalHash).toBe('gh')
+      expect(loaded!.entries['/abs/a.tsx'].deps['/abs/b.tsx']).toBe('bh')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when cache file is absent', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-cache-'))
+    try {
+      expect(await loadCache(dir)).toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when cache version mismatches', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-cache-'))
+    try {
+      await Bun.write(join(dir, '.buildcache.json'), JSON.stringify({ version: 999, globalHash: '', entries: {} }))
+      expect(await loadCache(dir)).toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/fs-utils.test.ts
+++ b/packages/cli/src/__tests__/fs-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test'
+import { writeIfChanged } from '../lib/fs-utils'
+import { mkdtempSync, rmSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe('writeIfChanged', () => {
+  test('writes when file does not exist', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-wic-'))
+    try {
+      const p = join(dir, 'new.txt')
+      expect(await writeIfChanged(p, 'hello')).toBe(true)
+      expect(await Bun.file(p).text()).toBe('hello')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('skips write when content matches', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-wic-'))
+    try {
+      const p = join(dir, 'same.txt')
+      await Bun.write(p, 'stable')
+      const mtimeBefore = statSync(p).mtimeMs
+      // Ensure mtime can differ if a write actually happens
+      await new Promise((r) => setTimeout(r, 10))
+      expect(await writeIfChanged(p, 'stable')).toBe(false)
+      expect(statSync(p).mtimeMs).toBe(mtimeBefore)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('writes when content differs', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-wic-'))
+    try {
+      const p = join(dir, 'diff.txt')
+      await Bun.write(p, 'before')
+      expect(await writeIfChanged(p, 'after')).toBe(true)
+      expect(await Bun.file(p).text()).toBe('after')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('handles ArrayBuffer content', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-wic-'))
+    try {
+      const p = join(dir, 'bytes.bin')
+      const bytes = new TextEncoder().encode('binary')
+      expect(await writeIfChanged(p, bytes.buffer as ArrayBuffer)).toBe(true)
+      expect(await writeIfChanged(p, bytes.buffer as ArrayBuffer)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 // `barefoot build` — Compile JSX components using barefoot.config.ts.
 
 import type { CliContext } from '../context'
-import { resolveBuildConfigFromTs, build } from '../lib/build'
+import { resolveBuildConfigFromTs, build, watch } from '../lib/build'
 import { findBuildConfig, loadBuildConfig } from '../lib/config-loader'
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -21,15 +21,36 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   if (args.includes('--minify')) overrides.minify = true
   const config = resolveBuildConfigFromTs(projectDir, tsConfig, overrides)
 
+  const force = args.includes('--force')
+  const watchMode = args.includes('--watch')
+
   console.log(`Adapter: ${config.adapter.name}`)
   console.log(`Source dirs: ${config.componentDirs.join(', ')}`)
   console.log(`Output dir: ${config.outDir}`)
+  if (watchMode) console.log('Mode: watch')
+  if (force) console.log('Force: cache ignored')
   console.log('')
 
-  const result = await build(config)
+  if (watchMode) {
+    const controller = new AbortController()
+    const stop = () => controller.abort()
+    process.on('SIGINT', stop)
+    process.on('SIGTERM', stop)
+    try {
+      await watch(config, { signal: controller.signal })
+    } finally {
+      process.off('SIGINT', stop)
+      process.off('SIGTERM', stop)
+    }
+    return
+  }
+
+  const result = await build(config, { force })
 
   console.log('')
-  console.log(`Build complete: ${result.compiledCount} compiled, ${result.skippedCount} skipped, ${result.errorCount} errors`)
+  console.log(
+    `Build complete: ${result.compiledCount} compiled, ${result.cachedCount} cached, ${result.skippedCount} skipped, ${result.errorCount} errors`,
+  )
 
   if (result.errorCount > 0) {
     process.exit(1)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ function printUsage() {
   console.log(`Usage: barefoot <command> [options]
 
 Commands:
-  build [--minify]            Compile components using barefoot.config.ts
+  build [--minify] [--force] [--watch]  Compile components using barefoot.config.ts
   init [--name <name>] [--from <url>]  Initialize a new BarefootJS project
   add <component...> [--force] [--registry <url>] Add components to your project
   search <query> [--dir <path>] [--registry <url>] Search components and documentation

--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -1,0 +1,86 @@
+// Incremental build cache: tracks per-source hashes, dependency hashes, and
+// produced output paths so unchanged components can skip recompilation.
+
+import { resolve } from 'node:path'
+
+export const CACHE_VERSION = 1
+export const CACHE_FILENAME = '.buildcache.json'
+
+export interface CacheEntry {
+  /** Content hash of the source file itself */
+  hash: string
+  /** Hashes of every file read during compilation (imports, transitive) keyed by abs path */
+  deps: Record<string, string>
+  /** Relative-to-outDir paths produced for this entry */
+  outputs: string[]
+  /** Manifest key this entry contributes to (null when the entry produced no manifest row) */
+  manifestKey: string | null
+  /** Stored manifest row, so cache-hit entries can restore it without recompiling */
+  manifestEntry?: { markedTemplate: string; clientJs?: string }
+}
+
+export interface BuildCache {
+  version: number
+  /** Invalidates every entry when it changes (config file, compiler version, etc.) */
+  globalHash: string
+  entries: Record<string, CacheEntry>
+}
+
+/** Hash a string via Bun.hash; short hex is plenty for collision-resistant equality checks. */
+export function hashContent(content: string): string {
+  return Bun.hash(content).toString(16)
+}
+
+export function emptyCache(globalHash: string): BuildCache {
+  return { version: CACHE_VERSION, globalHash, entries: {} }
+}
+
+export async function loadCache(outDir: string): Promise<BuildCache | null> {
+  const path = resolve(outDir, CACHE_FILENAME)
+  const file = Bun.file(path)
+  if (!(await file.exists())) return null
+  try {
+    const parsed = JSON.parse(await file.text()) as BuildCache
+    if (parsed.version !== CACHE_VERSION) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export async function saveCache(outDir: string, cache: BuildCache): Promise<void> {
+  const path = resolve(outDir, CACHE_FILENAME)
+  await Bun.write(path, JSON.stringify(cache, null, 2))
+}
+
+/** True when the entry's source and every recorded dep still has a matching hash. */
+export function isEntryFresh(
+  entry: CacheEntry,
+  currentSourceHash: string,
+  depHash: (absPath: string) => string | null,
+): boolean {
+  if (entry.hash !== currentSourceHash) return false
+  for (const [depPath, recordedHash] of Object.entries(entry.deps)) {
+    const now = depHash(depPath)
+    if (now === null || now !== recordedHash) return false
+  }
+  return true
+}
+
+/** Return the set of entries whose `deps` include any of `changedPaths` (reverse-dep lookup). */
+export function findReverseDependents(
+  cache: BuildCache,
+  changedPaths: Iterable<string>,
+): Set<string> {
+  const changed = new Set(changedPaths)
+  const affected = new Set<string>()
+  for (const [src, entry] of Object.entries(cache.entries)) {
+    for (const dep of Object.keys(entry.deps)) {
+      if (changed.has(dep)) {
+        affected.add(src)
+        break
+      }
+    }
+  }
+  return affected
+}

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -2,9 +2,19 @@
 
 import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
 import type { TemplateAdapter, OutputLayout, PostBuildContext } from '@barefootjs/jsx'
-import { mkdir, readdir, stat } from 'node:fs/promises'
-import { resolve, basename, relative } from 'node:path'
+import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
+import { resolve, basename, relative, dirname } from 'node:path'
 import { resolveRelativeImports } from './resolve-imports'
+import {
+  emptyCache,
+  hashContent,
+  isEntryFresh,
+  loadCache,
+  saveCache,
+  type BuildCache,
+  type CacheEntry,
+} from './build-cache'
+import { writeIfChanged } from './fs-utils'
 
 export { resolveRelativeImports } from './resolve-imports'
 
@@ -34,14 +44,23 @@ export interface BuildConfig {
 }
 
 export interface BuildResult {
-  /** Number of components compiled */
+  /** Number of components compiled this run */
   compiledCount: number
   /** Number of components skipped (no "use client") */
   skippedCount: number
+  /** Number of components reused from cache without recompilation */
+  cachedCount: number
   /** Number of compilation errors */
   errorCount: number
   /** Manifest entries */
   manifest: Record<string, { clientJs?: string; markedTemplate: string }>
+  /** True when any output file on disk was changed (write or delete) */
+  changed: boolean
+}
+
+export interface BuildRunOptions {
+  /** Ignore the build cache and recompile every entry. */
+  force?: boolean
 }
 
 // ── Utility functions ────────────────────────────────────────────────────
@@ -141,9 +160,42 @@ export function resolveBuildConfigFromTs(
   }
 }
 
+/**
+ * Compute the invalidation hash shared by every cache entry. Captures the
+ * configuration surface that would change build output globally (so a shift
+ * here invalidates the whole cache, not a single entry).
+ */
+export async function computeGlobalHash(config: BuildConfig): Promise<string> {
+  const parts: string[] = [
+    config.adapter.name,
+    String(config.minify),
+    String(config.contentHash),
+    String(config.clientOnly),
+    JSON.stringify(config.outputLayout ?? null),
+  ]
+  const configCandidates = [
+    resolve(config.projectDir, 'barefoot.config.ts'),
+    resolve(config.projectDir, 'barefoot.config.js'),
+    resolve(config.projectDir, 'barefoot.config.mjs'),
+  ]
+  for (const cand of configCandidates) {
+    const file = Bun.file(cand)
+    if (await file.exists()) {
+      parts.push(await file.text())
+      break
+    }
+  }
+  return hashContent(parts.join('\x00'))
+}
+
 // ── Main build pipeline ──────────────────────────────────────────────────
 
-export async function build(config: BuildConfig): Promise<BuildResult> {
+export async function build(
+  config: BuildConfig,
+  options: BuildRunOptions = {},
+): Promise<BuildResult> {
+  const { force = false } = options
+
   // Resolve output directories based on layout
   const layout = config.outputLayout
   const templatesSubdir = layout?.templates ?? 'components'
@@ -161,9 +213,17 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
     ...(runtimeSubdir !== clientJsSubdir ? [mkdir(runtimeOutDir, { recursive: true })] : []),
   ])
 
-  // 1. Build and copy barefoot.js runtime
+  // Load cache (discard if global invalidation flag is set)
+  const globalHash = await computeGlobalHash(config)
+  const loadedCache = force ? null : await loadCache(config.outDir)
+  const cache: BuildCache =
+    loadedCache && loadedCache.globalHash === globalHash
+      ? loadedCache
+      : emptyCache(globalHash)
+  let anyOutputChanged = false
+
+  // 1. Runtime file — copy barefoot.js via writeIfChanged so unchanged runtime is quiet
   const domPkgDir = resolve(config.projectDir, 'node_modules/@barefootjs/client-runtime')
-  // Try workspace path first (monorepo), then node_modules
   const domDistCandidates = [
     resolve(config.projectDir, '../../packages/client-runtime/dist/index.js'),
     resolve(domPkgDir, 'dist/index.js'),
@@ -180,129 +240,160 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
   }
 
   if (domDistFile) {
-    await Bun.write(
-      resolve(runtimeOutDir, 'barefoot.js'),
-      Bun.file(domDistFile)
-    )
-    console.log(`Generated: ${runtimeSubdir}/barefoot.js`)
+    const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
+    let runtimeContent: string | ArrayBuffer
+    if (config.minify) {
+      // Minify at copy time so the minify pass below doesn't need to touch
+      // barefoot.js (keeping it out of the per-build write loop).
+      // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
+      const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
+      runtimeContent = transpiler.transformSync(await Bun.file(domDistFile).text())
+    } else {
+      runtimeContent = await Bun.file(domDistFile).arrayBuffer()
+    }
+    const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
+    if (wrote) {
+      anyOutputChanged = true
+      console.log(`Generated: ${runtimeSubdir}/barefoot.js`)
+    }
   } else {
     console.warn('Warning: @barefootjs/client-runtime dist not found. Skipping barefoot.js copy.')
   }
 
-  // 2. Adapter (already instantiated in config)
-  const adapter = config.adapter
-
-  // 3. Discover component files
+  // 2. Discover component files
   const allFiles: string[] = []
   for (const dir of config.componentDirs) {
     allFiles.push(...await discoverComponentFiles(dir))
   }
+  const allFilesSet = new Set(allFiles)
 
-  // 4. Manifest
+  // 3. Manifest baseline (runtime sentinel always present)
   const manifest: Record<string, { clientJs?: string; markedTemplate: string }> = {
     '__barefoot__': { markedTemplate: '', clientJs: `${runtimeSubdir}/barefoot.js` },
   }
 
   let compiledCount = 0
   let skippedCount = 0
+  let cachedCount = 0
   let errorCount = 0
 
   // Collected types from all components (for postBuild hook)
   const collectedTypes = new Map<string, string>()
 
-  // 5. Compile each component
+  // Pre-hash every source file once so cache-fresh checks (and dep lookups)
+  // are just map lookups during the compile loop.
+  const sourceHashes = new Map<string, string>()
+  const sourceContents = new Map<string, string>()
+  for (const file of allFiles) {
+    const content = await Bun.file(file).text()
+    sourceContents.set(file, content)
+    sourceHashes.set(file, hashContent(content))
+  }
+
+  // Resolve dep hashes referenced in the cache that aren't current sources, so
+  // isEntryFresh can consult a synchronous map. Missing files resolve to null,
+  // which invalidates the cached entry and forces a recompile.
+  const extraDepPaths = new Set<string>()
+  for (const entry of Object.values(cache.entries)) {
+    for (const dep of Object.keys(entry.deps)) {
+      if (!sourceHashes.has(dep)) extraDepPaths.add(dep)
+    }
+  }
+  const extraDepHashes = new Map<string, string>()
+  await Promise.all([...extraDepPaths].map(async (p) => {
+    const file = Bun.file(p)
+    if (await file.exists()) {
+      extraDepHashes.set(p, hashContent(await file.text()))
+    }
+  }))
+  const lookupDepHash = (absPath: string): string | null => {
+    return sourceHashes.get(absPath) ?? extraDepHashes.get(absPath) ?? null
+  }
+
+  // 4. Compile each component (or reuse from cache)
+  const nextEntries: Record<string, CacheEntry> = {}
   for (const entryPath of allFiles) {
-    const sourceContent = await Bun.file(entryPath).text()
+    const sourceContent = sourceContents.get(entryPath)!
     if (!hasUseClientDirective(sourceContent)) {
       skippedCount++
       continue
     }
 
-    const baseFileName = basename(entryPath)
-    const baseNameNoExt = baseFileName.replace('.tsx', '')
-    let clientJsFilename = `${baseNameNoExt}.client.js`
+    const currentHash = sourceHashes.get(entryPath)!
+    const cached = cache.entries[entryPath]
+    const canReuse =
+      !force &&
+      cached !== undefined &&
+      isEntryFresh(cached, currentHash, lookupDepHash)
 
-    const result = await compileJSX(entryPath, async (path) => {
-      return await Bun.file(path).text()
-    }, { adapter })
-
-    // Separate errors and warnings
-    const errors = result.errors.filter(e => e.severity === 'error')
-    const warnings = result.errors.filter(e => e.severity === 'warning')
-
-    if (warnings.length > 0) {
-      console.warn(`Warnings compiling ${relative(config.projectDir, entryPath)}:`)
-      for (const warning of warnings) {
-        console.warn(`  ${warning.message}`)
+    if (canReuse) {
+      nextEntries[entryPath] = cached
+      if (cached.manifestKey && cached.manifestEntry) {
+        manifest[cached.manifestKey] = cached.manifestEntry
       }
-    }
-
-    if (errors.length > 0) {
-      console.error(`Errors compiling ${relative(config.projectDir, entryPath)}:`)
-      for (const error of errors) {
-        console.error(`  ${error.message}`)
-      }
-      errorCount++
+      cachedCount++
       continue
     }
 
-    const markedTemplates = result.files.filter(f => f.type === 'markedTemplate')
-    let clientJsContent = ''
+    const result = await compileEntry({
+      entryPath,
+      sourceContent,
+      config,
+      templatesSubdir,
+      clientJsSubdir,
+      templatesOutDir,
+      clientJsOutDir,
+    })
 
-    for (const file of result.files) {
-      if (file.type === 'clientJs') {
-        clientJsContent = file.content
-      } else if (file.type === 'types') {
-        collectedTypes.set(baseNameNoExt, file.content)
+    if (result.kind === 'error') {
+      errorCount++
+      // Preserve old cache entry so we do not lose prior outputs on a failed
+      // compile (they stay on disk and we reuse the prior manifest row).
+      if (cached) {
+        nextEntries[entryPath] = cached
+        if (cached.manifestKey && cached.manifestEntry) {
+          manifest[cached.manifestKey] = cached.manifestEntry
+        }
       }
+      continue
     }
 
-    if (markedTemplates.length === 0 && !clientJsContent) {
+    if (result.kind === 'skipped') {
       skippedCount++
       continue
     }
 
-    // 5a. Content hash
-    if (config.contentHash && clientJsContent) {
-      const hash = generateHash(clientJsContent)
-      clientJsFilename = `${baseNameNoExt}-${hash}.client.js`
-    }
-
-    const hasClientJs = clientJsContent.length > 0
-
-    // 5c. Write client JS
-    if (hasClientJs) {
-      await Bun.write(resolve(clientJsOutDir, clientJsFilename), clientJsContent)
-      console.log(`Generated: ${clientJsSubdir}/${clientJsFilename}`)
-    }
-
-    // 5d. Write marked templates (skip in clientOnly mode)
-    // Each FileOutput.path already uses adapter.extension, so basename honors it.
-    if (!config.clientOnly && markedTemplates.length > 0) {
-      for (const tpl of markedTemplates) {
-        const outName = basename(tpl.path)
-        let outputContent = tpl.content
-        if (hasClientJs && config.transformMarkedTemplate) {
-          const componentId = outName.replace(/\.[^.]+$/, '')
-          outputContent = config.transformMarkedTemplate(outputContent, componentId, clientJsFilename)
-        }
-        await Bun.write(resolve(templatesOutDir, outName), outputContent)
-        console.log(`Generated: ${templatesSubdir}/${outName}`)
-      }
-    }
-
-    // 5e. Manifest entry (one per source file, pointing at primary template)
-    if (!config.clientOnly && markedTemplates.length > 0) {
-      const primaryTpl =
-        markedTemplates.find(t => basename(t.path).startsWith(baseNameNoExt + '.'))
-        ?? markedTemplates[0]
-      manifest[baseNameNoExt] = {
-        markedTemplate: `${templatesSubdir}/${basename(primaryTpl.path)}`,
-        clientJs: hasClientJs ? `${clientJsSubdir}/${clientJsFilename}` : undefined,
-      }
-    }
-
     compiledCount++
+    if (result.wroteAny) anyOutputChanged = true
+    if (result.types) collectedTypes.set(result.typesKey!, result.types)
+
+    if (result.manifestKey && result.manifestEntry) {
+      manifest[result.manifestKey] = result.manifestEntry
+    }
+
+    nextEntries[entryPath] = {
+      hash: currentHash,
+      deps: result.deps,
+      outputs: result.outputs,
+      manifestKey: result.manifestKey,
+      manifestEntry: result.manifestEntry,
+    }
+  }
+
+  // 5. Prune outputs for cache entries whose source was deleted since last build.
+  const toDelete = Object.keys(cache.entries).filter((p) => !allFilesSet.has(p))
+  for (const deletedPath of toDelete) {
+    const entry = cache.entries[deletedPath]
+    for (const output of entry.outputs) {
+      const abs = resolve(config.outDir, output)
+      try {
+        await unlink(abs)
+        anyOutputChanged = true
+        console.log(`Deleted: ${output}`)
+      } catch {
+        // already gone
+      }
+    }
   }
 
   // 6. Combine parent-child client JS
@@ -322,12 +413,15 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
     for (const [name, content] of combined) {
       const entry = manifest[name]
       if (!entry?.clientJs) continue
-      await Bun.write(resolve(config.outDir, entry.clientJs), content)
-      console.log(`Combined: ${entry.clientJs}`)
+      const filePath = resolve(config.outDir, entry.clientJs)
+      if (await writeIfChanged(filePath, content)) {
+        anyOutputChanged = true
+        console.log(`Combined: ${entry.clientJs}`)
+      }
     }
   }
 
-  // 6b. Resolve relative imports
+  // 6b. Resolve relative imports (idempotent — writeIfChanged keeps it quiet)
   await resolveRelativeImports({ distDir: config.outDir, manifest })
 
   // 6c. Rewrite bare @barefootjs/client-runtime imports to relative barefoot.js path
@@ -345,7 +439,9 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
             /from ['"]@barefootjs\/client-runtime['"]/g,
             `from '${runtimeRelFromClient}'`
           )
-          await Bun.write(filePath, content)
+          if (await writeIfChanged(filePath, content)) {
+            anyOutputChanged = true
+          }
         }
       } catch {
         // File may not exist
@@ -353,17 +449,21 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
     }
   }
 
-  // 7. Minify client JS (after combine so all files are final)
+  // 7. Minify client JS (after combine so all files are final).
+  // Runtime (__barefoot__) is already minified at copy time above.
   if (config.minify) {
     // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
     const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
-    for (const [, entry] of Object.entries(manifest)) {
-      if (!entry.clientJs) continue
+    for (const [name, entry] of Object.entries(manifest)) {
+      if (!entry.clientJs || name === '__barefoot__') continue
       const filePath = resolve(config.outDir, entry.clientJs)
       try {
         const content = await Bun.file(filePath).text()
         if (content) {
-          await Bun.write(filePath, transpiler.transformSync(content))
+          const minified = transpiler.transformSync(content)
+          if (await writeIfChanged(filePath, minified)) {
+            anyOutputChanged = true
+          }
         }
       } catch {
         // File may not exist
@@ -383,14 +483,300 @@ export async function build(config: BuildConfig): Promise<BuildResult> {
 
   // 8. Write manifest (skip in clientOnly mode)
   if (!config.clientOnly) {
-    // Write manifest to the templates directory (or components if no custom layout)
     const manifestDir = resolve(config.outDir, templatesSubdir)
-    await Bun.write(
-      resolve(manifestDir, 'manifest.json'),
-      JSON.stringify(manifest, null, 2)
-    )
-    console.log(`Generated: ${templatesSubdir}/manifest.json`)
+    const manifestPath = resolve(manifestDir, 'manifest.json')
+    const manifestContent = JSON.stringify(manifest, null, 2)
+    if (await writeIfChanged(manifestPath, manifestContent)) {
+      anyOutputChanged = true
+      console.log(`Generated: ${templatesSubdir}/manifest.json`)
+    }
   }
 
-  return { compiledCount, skippedCount, errorCount, manifest }
+  // 9. Persist cache
+  const nextCache: BuildCache = {
+    version: cache.version,
+    globalHash,
+    entries: nextEntries,
+  }
+  await saveCache(config.outDir, nextCache)
+
+  return {
+    compiledCount,
+    skippedCount,
+    cachedCount,
+    errorCount,
+    manifest,
+    changed: anyOutputChanged,
+  }
 }
+
+// ── Dependency scanner ───────────────────────────────────────────────────
+
+const RELATIVE_IMPORT_SCAN_RE = /(?:^|\n)\s*(?:import|export)\s+(?:[^'"\n]+from\s+)?['"](\.[^'"]+)['"]/g
+
+/**
+ * Scan a source file for relative imports and return the set of absolute paths
+ * that resolve to existing files. Used for dependency tracking in the build
+ * cache: when an imported file changes, the importer's cache entry becomes
+ * stale and must be recompiled (so its combined client JS picks up the change).
+ */
+async function collectRelativeImportDeps(
+  entryPath: string,
+  sourceContent: string,
+): Promise<string[]> {
+  const baseDir = dirname(entryPath)
+  const seen = new Set<string>()
+  const results: string[] = []
+  const EXT_CANDIDATES = ['.tsx', '.ts', '/index.tsx', '/index.ts']
+
+  for (const match of sourceContent.matchAll(RELATIVE_IMPORT_SCAN_RE)) {
+    const rel = match[1]
+    if (!rel.startsWith('.')) continue
+    const base = resolve(baseDir, rel)
+    const candidates = [base, ...EXT_CANDIDATES.map((ext) => base + ext)]
+    for (const cand of candidates) {
+      if (seen.has(cand)) continue
+      if (await Bun.file(cand).exists()) {
+        seen.add(cand)
+        results.push(cand)
+        break
+      }
+    }
+  }
+  return results
+}
+
+// ── Per-entry compile helper ─────────────────────────────────────────────
+
+interface CompileEntryArgs {
+  entryPath: string
+  sourceContent: string
+  config: BuildConfig
+  templatesSubdir: string
+  clientJsSubdir: string
+  templatesOutDir: string
+  clientJsOutDir: string
+}
+
+type CompileEntryOutcome =
+  | { kind: 'error' }
+  | { kind: 'skipped' }
+  | {
+      kind: 'compiled'
+      deps: Record<string, string>
+      outputs: string[]
+      manifestKey: string | null
+      manifestEntry?: { markedTemplate: string; clientJs?: string }
+      wroteAny: boolean
+      types?: string
+      typesKey?: string
+    }
+
+async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome> {
+  const {
+    entryPath,
+    sourceContent,
+    config,
+    templatesSubdir,
+    clientJsSubdir,
+    templatesOutDir,
+    clientJsOutDir,
+  } = args
+
+  const baseFileName = basename(entryPath)
+  const baseNameNoExt = baseFileName.replace('.tsx', '')
+  let clientJsFilename = `${baseNameNoExt}.client.js`
+
+  // Track deps: compileJSX only reads the entry file, so transitive deps via
+  // imports are picked up by lexically scanning the source for relative imports.
+  const deps: Record<string, string> = {}
+  for (const depPath of await collectRelativeImportDeps(entryPath, sourceContent)) {
+    deps[depPath] = hashContent(await Bun.file(depPath).text())
+  }
+
+  const result = await compileJSX(
+    entryPath,
+    async (path) => Bun.file(path).text(),
+    { adapter: config.adapter },
+  )
+
+  const errors = result.errors.filter(e => e.severity === 'error')
+  const warnings = result.errors.filter(e => e.severity === 'warning')
+
+  if (warnings.length > 0) {
+    console.warn(`Warnings compiling ${relative(config.projectDir, entryPath)}:`)
+    for (const warning of warnings) {
+      console.warn(`  ${warning.message}`)
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`Errors compiling ${relative(config.projectDir, entryPath)}:`)
+    for (const error of errors) {
+      console.error(`  ${error.message}`)
+    }
+    return { kind: 'error' }
+  }
+
+  const markedTemplates = result.files.filter(f => f.type === 'markedTemplate')
+  let clientJsContent = ''
+  let typesContent: string | undefined
+
+  for (const file of result.files) {
+    if (file.type === 'clientJs') {
+      clientJsContent = file.content
+    } else if (file.type === 'types') {
+      typesContent = file.content
+    }
+  }
+
+  if (markedTemplates.length === 0 && !clientJsContent) {
+    return { kind: 'skipped' }
+  }
+
+  if (config.contentHash && clientJsContent) {
+    const hash = generateHash(clientJsContent)
+    clientJsFilename = `${baseNameNoExt}-${hash}.client.js`
+  }
+
+  const hasClientJs = clientJsContent.length > 0
+  const outputs: string[] = []
+  let wroteAny = false
+
+  if (hasClientJs) {
+    const rel = `${clientJsSubdir}/${clientJsFilename}`
+    outputs.push(rel)
+    if (await writeIfChanged(resolve(clientJsOutDir, clientJsFilename), clientJsContent)) {
+      wroteAny = true
+      console.log(`Generated: ${rel}`)
+    }
+  }
+
+  if (!config.clientOnly && markedTemplates.length > 0) {
+    for (const tpl of markedTemplates) {
+      const outName = basename(tpl.path)
+      let outputContent = tpl.content
+      if (hasClientJs && config.transformMarkedTemplate) {
+        const componentId = outName.replace(/\.[^.]+$/, '')
+        outputContent = config.transformMarkedTemplate(outputContent, componentId, clientJsFilename)
+      }
+      const rel = `${templatesSubdir}/${outName}`
+      outputs.push(rel)
+      if (await writeIfChanged(resolve(templatesOutDir, outName), outputContent)) {
+        wroteAny = true
+        console.log(`Generated: ${rel}`)
+      }
+    }
+  }
+
+  let manifestKey: string | null = null
+  let manifestEntry: { markedTemplate: string; clientJs?: string } | undefined
+  if (!config.clientOnly && markedTemplates.length > 0) {
+    const primaryTpl =
+      markedTemplates.find(t => basename(t.path).startsWith(baseNameNoExt + '.'))
+      ?? markedTemplates[0]
+    manifestKey = baseNameNoExt
+    manifestEntry = {
+      markedTemplate: `${templatesSubdir}/${basename(primaryTpl.path)}`,
+      clientJs: hasClientJs ? `${clientJsSubdir}/${clientJsFilename}` : undefined,
+    }
+  }
+
+  return {
+    kind: 'compiled',
+    deps,
+    outputs,
+    manifestKey,
+    manifestEntry,
+    wroteAny,
+    types: typesContent,
+    typesKey: baseNameNoExt,
+  }
+}
+
+// ── Watch mode ───────────────────────────────────────────────────────────
+
+export interface WatchOptions {
+  /** Debounce delay in ms before applying a batch of file events (default 100) */
+  debounceMs?: number
+  /** Signal to stop watching (optional) */
+  signal?: AbortSignal
+}
+
+/**
+ * Run an initial incremental build and then keep watching source directories
+ * and barefoot.config.ts, re-running incremental builds on change.
+ * Resolves only when `signal` aborts.
+ */
+export async function watch(
+  config: BuildConfig,
+  options: WatchOptions = {},
+): Promise<void> {
+  const { debounceMs = 100, signal } = options
+  const { watch: fsWatch } = await import('node:fs/promises')
+
+  // Initial build
+  const initial = await build(config)
+  console.log('')
+  console.log(
+    `Initial build: ${initial.compiledCount} compiled, ${initial.cachedCount} cached, ${initial.errorCount} errors`,
+  )
+  console.log('Watching for changes...')
+
+  // Watch component source dirs recursively; watch project dir non-recursively
+  // for barefoot.config.ts changes only.
+  const componentRoots = config.componentDirs
+  const configRoot = config.projectDir
+
+  let pending = false
+  let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+  const schedule = () => {
+    pending = true
+    if (flushTimer) clearTimeout(flushTimer)
+    flushTimer = setTimeout(flush, debounceMs)
+  }
+
+  const flush = async () => {
+    flushTimer = null
+    if (!pending) return
+    pending = false
+
+    const t0 = performance.now()
+    const result = await build(config)
+    const ms = (performance.now() - t0).toFixed(0)
+    console.log(
+      `Rebuild: ${result.compiledCount} compiled, ${result.cachedCount} cached, ${result.errorCount} errors (${ms}ms)`,
+    )
+  }
+
+  const isRelevant = (root: string, filename: string | null): boolean => {
+    if (!filename) return false
+    if (root === configRoot) {
+      return /^barefoot\.config\.(ts|js|mjs)$/.test(filename)
+    }
+    return filename.endsWith('.tsx') || filename.endsWith('.ts')
+  }
+
+  const watchRoot = async (root: string, recursive: boolean) => {
+    try {
+      const iter = fsWatch(root, { recursive, signal }) as AsyncIterable<{
+        eventType: string
+        filename: string | null
+      }>
+      for await (const event of iter) {
+        if (!isRelevant(root, event.filename)) continue
+        schedule()
+      }
+    } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') return
+      console.warn(`Watcher for ${root} stopped: ${(err as Error).message}`)
+    }
+  }
+
+  await Promise.all([
+    ...componentRoots.map((r) => watchRoot(r, true)),
+    watchRoot(configRoot, false),
+  ])
+}
+

--- a/packages/cli/src/lib/fs-utils.ts
+++ b/packages/cli/src/lib/fs-utils.ts
@@ -1,0 +1,41 @@
+// Filesystem helpers shared across build pipeline steps.
+
+/**
+ * Write content to path only when it differs from what is already on disk.
+ * Returns true when a write occurred. Avoids re-firing file watchers when
+ * the output is byte-identical to the previous build.
+ */
+export async function writeIfChanged(
+  path: string,
+  content: string | ArrayBufferView | ArrayBuffer | Blob,
+): Promise<boolean> {
+  const existing = Bun.file(path)
+  if (await existing.exists()) {
+    if (typeof content === 'string') {
+      const prev = await existing.text()
+      if (prev === content) return false
+    } else {
+      const prev = new Uint8Array(await existing.arrayBuffer())
+      const next = await toUint8Array(content)
+      if (equalBytes(prev, next)) return false
+    }
+  }
+  await Bun.write(path, content as Parameters<typeof Bun.write>[1])
+  return true
+}
+
+async function toUint8Array(
+  content: ArrayBufferView | ArrayBuffer | Blob,
+): Promise<Uint8Array> {
+  if (content instanceof Blob) return new Uint8Array(await content.arrayBuffer())
+  if (content instanceof ArrayBuffer) return new Uint8Array(content)
+  return new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}


### PR DESCRIPTION
## Summary

Closes #136 and fixes the dev-server-crash problem where `bun run --watch` would read mid-rebuild `dist/` state.

- **Incremental build** via `dist/.buildcache.json`. Each entry records source hash + dep hashes + produced outputs. Fresh entries skip recompilation.
- **Dep-aware invalidation**: source-level relative-import scanning means editing a child component (e.g. `TodoItem`) correctly invalidates its parents (`TodoApp`, `TodoAppSSR`) so combined client JS stays in sync.
- **Quiet writes**: every disk write goes through `writeIfChanged`, so cache-hit builds touch zero files in `dist/` and stop re-triggering `bun --watch`.
- **New flags**: `barefoot build --watch` (recursive `fs.watch` + 100 ms debounce) and `--force` (bypass cache).
- **Cross-platform dev script**: `examples/hono` `dev` now runs `build --watch` and the server under `concurrently` (added to root devDeps for Windows support).

## Measured behaviour on `examples/hono` (10 components)

| Scenario | Result |
| --- | --- |
| Clean build | 10 compiled / 0 cached |
| Re-run, no changes | 0 compiled / 10 cached, zero writes |
| Edit one component | 1 compiled / 9 cached |
| Edit child used by two parents | 3 compiled / 7 cached |
| `--force` | 10 compiled / 0 cached |
| `--watch` incremental | ~33 ms rebuild |

## Test plan

- [x] `bun run build` (root) — clean build succeeds
- [x] `bun test packages/` — 1538 pass (15 new), 1 pre-existing xyflow/Playwright failure unrelated to this change
- [x] `examples/hono` Playwright e2e — 97/98 pass (one flaky timeout under parallel load, passes in isolation)
- [x] `examples/{csr,echo,mojolicious}` — `bun run build` + cached re-run verified
- [x] `bun run dev` in `examples/hono` — `build --watch` + server start in parallel; HTTP 200 on the dev server; SIGINT cleanly kills both

## Scope notes

- `site/ui/build.ts` and `site/core/build.ts` still use their own build scripts and are left for a follow-up PR that consolidates them onto the shared `build()`.
- Cache lives at `dist/.buildcache.json`; `dist/` is already gitignored.