### PR TITLE
refactor(jsx): extract ReactivityAnalyzer boundary with reasoned output

### DIFF
--- a/packages/jsx/src/__tests__/reactive-type-detection.test.ts
+++ b/packages/jsx/src/__tests__/reactive-type-detection.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test'
 import ts from 'typescript'
 import path from 'path'
-import { isReactiveType, containsReactiveExpression } from '../reactivity-checker'
+import { isReactiveType, containsReactiveExpression, analyzeReactivity } from '../reactivity-checker'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
 import type { IRExpression, IRConditional } from '../types'
@@ -344,6 +344,121 @@ describe('containsReactiveExpression', () => {
 
     expect(refDecl).toBeDefined()
     expect(containsReactiveExpression(refDecl!.initializer!, checker)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Unit Tests: analyzeReactivity (rich reasoning)
+// =============================================================================
+
+describe('analyzeReactivity', () => {
+  function initializerOf(sourceFile: ts.SourceFile, name: string): ts.Expression {
+    const decl = findNode(sourceFile, node =>
+      ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name
+    ) as ts.VariableDeclaration | undefined
+    if (!decl?.initializer) throw new Error(`no initializer for ${name}`)
+    return decl.initializer
+  }
+
+  test('signal call — reason: brand via callee', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const result = count();
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'result'), checker)
+
+    expect(analysis.isReactive).toBe(true)
+    expect(analysis.reason.kind).toBe('brand')
+    if (analysis.reason.kind === 'brand') {
+      expect(analysis.reason.via).toBe('callee')
+      expect(analysis.reason.nodeText).toBe('count()')
+    }
+  })
+
+  test('bare signal reference — reason: brand via identifier', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const ref = count;
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'ref'), checker)
+
+    expect(analysis.isReactive).toBe(true)
+    expect(analysis.reason.kind).toBe('brand')
+    if (analysis.reason.kind === 'brand') {
+      expect(analysis.reason.via).toBe('identifier')
+      expect(analysis.reason.nodeText).toBe('count')
+    }
+  })
+
+  test('method call on branded object — reason: brand via callee', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const username = useField('username');
+      const result = username.error();
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'result'), checker)
+
+    expect(analysis.isReactive).toBe(true)
+    expect(analysis.reason.kind).toBe('brand')
+    if (analysis.reason.kind === 'brand') {
+      expect(analysis.reason.via).toBe('callee')
+      expect(analysis.reason.nodeText).toBe('username.error()')
+    }
+  })
+
+  test('reactive inside non-reactive call — reason: child via sub-expression', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      function formatDate(d: number): string { return String(d); }
+      const [count, setCount] = createSignal(0);
+      const result = formatDate(count());
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'result'), checker)
+
+    expect(analysis.isReactive).toBe(true)
+    expect(analysis.reason.kind).toBe('child')
+    if (analysis.reason.kind === 'child') {
+      expect(analysis.reason.via).toBe('sub-expression')
+      expect(analysis.reason.childText).toBe('count()')
+      expect(analysis.reason.childReason.kind).toBe('brand')
+    }
+  })
+
+  test('binary expression with reactive operand — reason: child via sub-expression', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const result = count() > 0;
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'result'), checker)
+
+    expect(analysis.isReactive).toBe(true)
+    expect(analysis.reason.kind).toBe('child')
+    if (analysis.reason.kind === 'child') {
+      expect(analysis.reason.childText).toBe('count()')
+      expect(analysis.reason.childReason.kind).toBe('brand')
+      if (analysis.reason.childReason.kind === 'brand') {
+        expect(analysis.reason.childReason.via).toBe('callee')
+      }
+    }
+  })
+
+  test('string literal — reason: not-reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const result = "hello";
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'result'), checker)
+
+    expect(analysis.isReactive).toBe(false)
+    expect(analysis.reason.kind).toBe('not-reactive')
+  })
+
+  test('setter function — reason: not-reactive', () => {
+    const { sourceFile, checker } = createTestProgram(`
+      const [count, setCount] = createSignal(0);
+      const ref = setCount;
+    `)
+    const analysis = analyzeReactivity(initializerOf(sourceFile, 'ref'), checker)
+
+    expect(analysis.isReactive).toBe(false)
+    expect(analysis.reason.kind).toBe('not-reactive')
   })
 })
 

--- a/packages/jsx/src/reactivity-checker.ts
+++ b/packages/jsx/src/reactivity-checker.ts
@@ -4,6 +4,10 @@
  * Detects reactive expressions by checking for the Reactive<T> brand type
  * from @barefootjs/client. Any expression involving a value typed as Reactive<T>
  * is recognized as reactive.
+ *
+ * This module is the pluggable boundary between the compiler and its type
+ * resolution backend. Call sites consume `ReactivityAnalyzer`; swapping the
+ * implementation (e.g., migrating from tsc to tsgo) does not ripple outward.
  */
 
 import ts from 'typescript'
@@ -19,44 +23,160 @@ export function isReactiveType(type: ts.Type): boolean {
 }
 
 /**
- * Check if an AST node or any sub-expression contains a reactive type.
- * Walks the AST recursively, checking each identifier and property access
- * against the TypeChecker to find Reactive<T>-branded types.
+ * Why a node was determined to carry reactivity (or not).
+ *
+ * Preserved as a structured chain so agent-facing tooling (`barefoot why-update`,
+ * compiler diagnostics) can explain which sub-expression holds the Reactive<T>
+ * brand without re-running the analysis.
  */
-export function containsReactiveExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
-  // Property access chains (e.g., username.error): check the whole expression,
-  // then recurse only into the object part (not the name) to avoid redundant checks
+export type ReactivityReason =
+  | {
+      kind: 'brand'
+      /** Which AST shape matched the brand. */
+      via: 'property-access' | 'identifier' | 'callee'
+      /** Source text of the node that carries the brand. */
+      nodeText: string
+    }
+  | {
+      kind: 'child'
+      /** Which sub-position of the parent contributed the reactive child. */
+      via: 'property-access-object' | 'sub-expression'
+      /** Source text of the reactive child. */
+      childText: string
+      /** Reason the child itself was reactive. */
+      childReason: ReactivityReason
+    }
+  | { kind: 'not-reactive' }
+
+export interface ReactivityAnalysis {
+  isReactive: boolean
+  reason: ReactivityReason
+}
+
+/**
+ * Pluggable backend for reactivity detection.
+ *
+ * The default implementation (`brandTypeReactivityAnalyzer`) resolves types via
+ * TypeScript's TypeChecker. Alternative backends (tsgo programmatic API, custom
+ * symbol tracking, etc.) can satisfy this interface without compiler changes.
+ */
+export interface ReactivityAnalyzer {
+  analyze(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis
+}
+
+const NOT_REACTIVE: ReactivityAnalysis = { isReactive: false, reason: { kind: 'not-reactive' } }
+
+function safeGetText(node: ts.Node): string {
+  try {
+    return node.getText()
+  } catch {
+    return ''
+  }
+}
+
+function analyze(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis {
+  // Property access chains (e.g., username.error): check the whole expression first,
+  // then recurse only into the object part (not the name) to avoid redundant checks.
   if (ts.isPropertyAccessExpression(node)) {
     try {
       const type = checker.getTypeAtLocation(node)
-      if (isReactiveType(type)) return true
+      if (isReactiveType(type)) {
+        return {
+          isReactive: true,
+          reason: { kind: 'brand', via: 'property-access', nodeText: safeGetText(node) },
+        }
+      }
     } catch {
-      // Type resolution can fail for some nodes; continue walking
+      // Type resolution can fail for some nodes; continue walking the object part.
     }
-    return containsReactiveExpression(node.expression, checker)
+    const sub = analyze(node.expression, checker)
+    if (sub.isReactive) {
+      return {
+        isReactive: true,
+        reason: {
+          kind: 'child',
+          via: 'property-access-object',
+          childText: safeGetText(node.expression),
+          childReason: sub.reason,
+        },
+      }
+    }
+    return NOT_REACTIVE
   }
 
-  // Check identifiers directly
+  // Identifiers: brand is attached directly to the identifier's type.
   if (ts.isIdentifier(node)) {
     try {
       const type = checker.getTypeAtLocation(node)
-      if (isReactiveType(type)) return true
+      if (isReactiveType(type)) {
+        return {
+          isReactive: true,
+          reason: { kind: 'brand', via: 'identifier', nodeText: safeGetText(node) },
+        }
+      }
     } catch {
       // continue
     }
-    return false
+    return NOT_REACTIVE
   }
 
-  // Check call expressions — the callee might be Reactive<() => T>
+  // Call expressions: the callee might be Reactive<() => T>.
   if (ts.isCallExpression(node)) {
     try {
       const calleeType = checker.getTypeAtLocation(node.expression)
-      if (isReactiveType(calleeType)) return true
+      if (isReactiveType(calleeType)) {
+        return {
+          isReactive: true,
+          reason: { kind: 'brand', via: 'callee', nodeText: safeGetText(node) },
+        }
+      }
     } catch {
-      // continue
+      // fall through to child recursion so reactive arguments are still found
     }
   }
 
-  // Recurse into children
-  return ts.forEachChild(node, child => containsReactiveExpression(child, checker)) ?? false
+  // Recurse into children: if any sub-expression is reactive, this node is
+  // reactive by composition. Stop at the first reactive child.
+  let foundChild: ReactivityAnalysis | undefined
+  let foundChildText = ''
+  ts.forEachChild(node, child => {
+    if (foundChild?.isReactive) return
+    const result = analyze(child, checker)
+    if (result.isReactive) {
+      foundChild = result
+      foundChildText = safeGetText(child)
+    }
+  })
+  if (foundChild?.isReactive) {
+    return {
+      isReactive: true,
+      reason: {
+        kind: 'child',
+        via: 'sub-expression',
+        childText: foundChildText,
+        childReason: foundChild.reason,
+      },
+    }
+  }
+  return NOT_REACTIVE
+}
+
+export const brandTypeReactivityAnalyzer: ReactivityAnalyzer = { analyze }
+
+/**
+ * Rich analysis: returns both the boolean and the reasoning chain.
+ *
+ * Used by debug/agent-facing tooling (`barefoot why-update`, error diagnostics)
+ * that needs to explain *why* a node was classified as reactive.
+ */
+export function analyzeReactivity(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis {
+  return brandTypeReactivityAnalyzer.analyze(node, checker)
+}
+
+/**
+ * Boolean-only reactivity check. Retained for existing call sites that do not
+ * need the reasoning chain.
+ */
+export function containsReactiveExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
+  return brandTypeReactivityAnalyzer.analyze(node, checker).isReactive
 }


### PR DESCRIPTION
Introduce `ReactivityAnalyzer` interface and `analyzeReactivity()` returning
a structured reason chain (brand / child / not-reactive). This makes the
type-resolution backend swappable (tsc today, tsgo-or-other later) and
gives agent-facing tooling (`barefoot why-update`, diagnostics) enough
signal to explain *why* a node was classified as reactive.

`containsReactiveExpression` is preserved as a thin wrapper for existing
call sites.

https://claude.ai/code/session_01X4ZMpUYeLgXWhWRpW7rwox

Co-authored-by: kobaken <kentafly88@gmail.com>