### PR TITLE
feat(cli): make @barefootjs/cli npm-publishable via esbuild bundle

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,11 +3,27 @@
   "version": "0.0.1",
   "description": "CLI for agent-driven UI component discovery and scaffolding",
   "type": "module",
-  "private": true,
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "bin": {
+    "barefoot": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "node ./scripts/build.mjs",
+    "clean": "rm -rf dist",
+    "test": "bun test"
+  },
   "dependencies": {
-    "@barefootjs/client-runtime": "workspace:*",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.0.0"
+  },
+  "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
-    "@barefootjs/preview": "workspace:*"
+    "@types/node": "^22.0.0"
   }
 }

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Bundle the CLI into a single file for npm distribution.
+//
+// - Entry: src/index.ts
+// - Output: dist/index.js (ESM, single file)
+// - Externals: typescript (needed at runtime by bundled jsx compiler),
+//   esbuild (used by runtime.ts for transpile).
+// - Everything else — including workspace packages like @barefootjs/jsx —
+//   is bundled inline so the published CLI is self-contained.
+
+import { build } from 'esbuild'
+import { chmodSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgDir = resolve(here, '..')
+const entry = resolve(pkgDir, 'src/index.ts')
+const outfile = resolve(pkgDir, 'dist/index.js')
+
+await build({
+  entryPoints: [entry],
+  outfile,
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  // Keep runtime deps external so they are resolved from node_modules, not inlined.
+  external: ['typescript', 'esbuild'],
+  // Source index.ts carries the shebang; esbuild preserves it. No banner needed.
+  legalComments: 'none',
+  logLevel: 'info',
+})
+
+// Make the bundle executable so `bin` symlinks work.
+chmodSync(outfile, 0o755)
+
+console.log(`Built: ${outfile}`)

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -160,12 +160,8 @@ describe('resolveBuildConfigFromTs', () => {
 // ── minification ────────────────────────────────────────────────────────
 
 describe('minification does not re-introduce jsxDEV', () => {
-  test('Bun.Transpiler with loader: js preserves HTML in template literals', () => {
-    const transpiler = new Bun.Transpiler({
-      loader: 'js',
-      minifyWhitespace: true,
-      minifySyntax: true,
-    })
+  test('transpile(minify: true) preserves HTML in template literals', async () => {
+    const { transpile } = await import('../lib/runtime')
 
     const clientJs = `
 import { createSignal, createEffect } from '@barefootjs/client-runtime'
@@ -176,11 +172,13 @@ export function __bf_init_Counter(el, props) {
   el.appendChild(__tpl.content.cloneNode(true))
 }
 `
-    const result = transpiler.transformSync(clientJs)
+    const result = transpile(clientJs, { loader: 'js', minify: true })
 
     expect(result).not.toContain('jsxDEV')
     expect(result).not.toContain('jsx(')
     expect(result).toContain('innerHTML')
     expect(result).toContain('counter')
+    // Hydration hook identifier must survive minification
+    expect(result).toContain('__bf_init_Counter')
   })
 })

--- a/packages/cli/src/commands/meta-extract.ts
+++ b/packages/cli/src/commands/meta-extract.ts
@@ -2,9 +2,9 @@
 // Uses the compiler's analyzeComponent() for precise extraction,
 // with regex-based JSDoc parsing for descriptions/examples.
 
-import { Glob } from 'bun'
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import path from 'path'
+import { globFiles } from '../lib/runtime'
 import { analyzeComponent, listExportedComponents } from '@barefootjs/jsx'
 import type { AnalyzerContext } from '@barefootjs/jsx'
 import type { CliContext } from '../context'
@@ -231,12 +231,8 @@ export async function run(_args: string[], ctx: CliContext): Promise<void> {
   const registry = loadRegistry(ctx.root)
 
   // Glob all component index.tsx files (colocated structure)
-  const glob = new Glob('*/index.tsx')
-  const files: string[] = []
-  for await (const file of glob.scan({ cwd: componentsDir })) {
-    files.push(path.join(componentsDir, file))
-  }
-  files.sort()
+  const matched = await globFiles('*/index.tsx', { cwd: componentsDir })
+  const files = matched.map(f => path.join(componentsDir, f)).sort()
 
   const indexEntries: MetaIndexEntry[] = []
   let count = 0

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,4 +1,13 @@
 // barefoot preview — start preview dev server for visual check.
+//
+// `preview` is not shipped in the npm distribution of `@barefootjs/cli`.
+// The current preview package is a monorepo-internal dev tool (hardcoded
+// paths, Hono + Bun-specific `hono/bun`, `bunx unocss` shell-out). A
+// publish-ready rewrite is tracked in
+// https://github.com/barefootjs/barefootjs/issues/885.
+//
+// When the CLI is run from inside the barefootjs monorepo (source tree
+// available), we still delegate to the existing preview package.
 
 import type { CliContext } from '../context'
 
@@ -10,7 +19,23 @@ export async function run(args: string[], _ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  // Delegate to packages/preview (long-running server)
-  const { runPreview } = await import('../../../preview/src/index')
+  let runPreview: ((name: string) => Promise<void>) | null = null
+  try {
+    // Build the specifier at runtime so the bundler does not statically
+    // resolve (and inline) the monorepo-internal preview package.
+    const specifier = ['..', '..', '..', 'preview', 'src', 'index'].join('/')
+    const mod = (await import(specifier)) as { runPreview: (name: string) => Promise<void> }
+    runPreview = mod.runPreview
+  } catch {
+    // Preview package not available in this distribution.
+  }
+
+  if (!runPreview) {
+    console.error('barefoot preview is not available in the npm distribution yet.')
+    console.error('Tracking issue: https://github.com/barefootjs/barefootjs/issues/885')
+    console.error('Workaround: run the barefootjs monorepo locally with bun.')
+    process.exit(1)
+  }
+
   await runPreview(component)
 }

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -3,6 +3,7 @@
 import { resolve } from 'node:path'
 import type { CliContext } from '../context'
 import type { TokenSet, Token, ColorToken } from '../../../../site/shared/tokens/schema'
+import { fileExists } from '../lib/runtime'
 
 type CategoryName = 'typography' | 'spacing' | 'borderRadius' | 'transitions' | 'layout' | 'colors' | 'shadows'
 
@@ -16,8 +17,7 @@ async function loadTokenSet(ctx: CliContext): Promise<TokenSet> {
   )
   const base = await loadTokens(resolve(ctx.root, 'site/shared/tokens/tokens.json'))
   const uiJsonPath = resolve(ctx.root, 'site/ui/tokens.json')
-  const uiFile = Bun.file(uiJsonPath)
-  if (await uiFile.exists()) {
+  if (await fileExists(uiJsonPath)) {
     const ext = await loadTokens(uiJsonPath)
     return mergeTokenSets(base, ext)
   }

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -2,6 +2,9 @@
 
 import { existsSync, readFileSync } from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'node:url'
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url))
 
 export interface BarefootConfig {
   $schema?: string
@@ -60,12 +63,12 @@ export function createContext(jsonFlag: boolean): CliContext {
     const config = loadBarefootConfig(configPath)
     const metaDir = path.resolve(projectDir, config.paths.meta)
     // root = monorepo root (for source lookups); projectDir = user project
-    const root = path.resolve(import.meta.dir, '../../..')
+    const root = path.resolve(thisDir, '../../..')
     return { root, metaDir, jsonFlag, config, projectDir }
   }
 
   // Fallback: monorepo mode
-  const root = path.resolve(import.meta.dir, '../../..')
+  const root = path.resolve(thisDir, '../../..')
   const metaDir = path.join(root, 'ui/meta')
   return { root, metaDir, jsonFlag, config: null, projectDir: null }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 // CLI entry point: arg parse → switch dispatch.
 
 import { createContext } from './context'

--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -2,6 +2,7 @@
 // produced output paths so unchanged components can skip recompilation.
 
 import { resolve } from 'node:path'
+import { fileExists, hashString, readText, writeText } from './runtime'
 
 export const CACHE_VERSION = 1
 export const CACHE_FILENAME = '.buildcache.json'
@@ -26,9 +27,9 @@ export interface BuildCache {
   entries: Record<string, CacheEntry>
 }
 
-/** Hash a string via Bun.hash; short hex is plenty for collision-resistant equality checks. */
+/** Hash a string for cache-equality checks. Short hex is plenty. */
 export function hashContent(content: string): string {
-  return Bun.hash(content).toString(16)
+  return hashString(content)
 }
 
 export function emptyCache(globalHash: string): BuildCache {
@@ -37,10 +38,9 @@ export function emptyCache(globalHash: string): BuildCache {
 
 export async function loadCache(outDir: string): Promise<BuildCache | null> {
   const path = resolve(outDir, CACHE_FILENAME)
-  const file = Bun.file(path)
-  if (!(await file.exists())) return null
+  if (!(await fileExists(path))) return null
   try {
-    const parsed = JSON.parse(await file.text()) as BuildCache
+    const parsed = JSON.parse(await readText(path)) as BuildCache
     if (parsed.version !== CACHE_VERSION) return null
     return parsed
   } catch {
@@ -50,7 +50,7 @@ export async function loadCache(outDir: string): Promise<BuildCache | null> {
 
 export async function saveCache(outDir: string, cache: BuildCache): Promise<void> {
   const path = resolve(outDir, CACHE_FILENAME)
-  await Bun.write(path, JSON.stringify(cache, null, 2))
+  await writeText(path, JSON.stringify(cache, null, 2))
 }
 
 /** True when the entry's source and every recorded dep still has a matching hash. */

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -15,6 +15,7 @@ import {
   type CacheEntry,
 } from './build-cache'
 import { writeIfChanged } from './fs-utils'
+import { fileExists, readBytes, readText, transpile } from './runtime'
 
 export { resolveRelativeImports } from './resolve-imports'
 
@@ -126,8 +127,7 @@ export async function discoverComponentFiles(
  * Generate a short content hash string (8 hex chars).
  */
 export function generateHash(content: string): string {
-  const hash = Bun.hash(content)
-  return hash.toString(16).slice(0, 8)
+  return hashContent(content).slice(0, 8)
 }
 
 // ── Resolve BuildConfig from BarefootBuildConfig ─────────────────────────
@@ -179,9 +179,8 @@ export async function computeGlobalHash(config: BuildConfig): Promise<string> {
     resolve(config.projectDir, 'barefoot.config.mjs'),
   ]
   for (const cand of configCandidates) {
-    const file = Bun.file(cand)
-    if (await file.exists()) {
-      parts.push(await file.text())
+    if (await fileExists(cand)) {
+      parts.push(await readText(cand))
       break
     }
   }
@@ -241,15 +240,13 @@ export async function build(
 
   if (domDistFile) {
     const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
-    let runtimeContent: string | ArrayBuffer
+    let runtimeContent: string | Uint8Array
     if (config.minify) {
       // Minify at copy time so the minify pass below doesn't need to touch
       // barefoot.js (keeping it out of the per-build write loop).
-      // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
-      const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
-      runtimeContent = transpiler.transformSync(await Bun.file(domDistFile).text())
+      runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
     } else {
-      runtimeContent = await Bun.file(domDistFile).arrayBuffer()
+      runtimeContent = await readBytes(domDistFile)
     }
     const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
     if (wrote) {
@@ -285,7 +282,7 @@ export async function build(
   const sourceHashes = new Map<string, string>()
   const sourceContents = new Map<string, string>()
   for (const file of allFiles) {
-    const content = await Bun.file(file).text()
+    const content = await readText(file)
     sourceContents.set(file, content)
     sourceHashes.set(file, hashContent(content))
   }
@@ -301,9 +298,8 @@ export async function build(
   }
   const extraDepHashes = new Map<string, string>()
   await Promise.all([...extraDepPaths].map(async (p) => {
-    const file = Bun.file(p)
-    if (await file.exists()) {
-      extraDepHashes.set(p, hashContent(await file.text()))
+    if (await fileExists(p)) {
+      extraDepHashes.set(p, hashContent(await readText(p)))
     }
   }))
   const lookupDepHash = (absPath: string): string | null => {
@@ -402,7 +398,7 @@ export async function build(
     if (!entry.clientJs) continue
     const filePath = resolve(config.outDir, entry.clientJs)
     try {
-      clientJsFiles.set(name, await Bun.file(filePath).text())
+      clientJsFiles.set(name, await readText(filePath))
     } catch {
       // File may not exist (e.g. __barefoot__)
     }
@@ -433,7 +429,7 @@ export async function build(
       if (!entry.clientJs || name === '__barefoot__') continue
       const filePath = resolve(config.outDir, entry.clientJs)
       try {
-        let content = await Bun.file(filePath).text()
+        let content = await readText(filePath)
         if (content.includes('@barefootjs/client-runtime')) {
           content = content.replace(
             /from ['"]@barefootjs\/client-runtime['"]/g,
@@ -452,15 +448,13 @@ export async function build(
   // 7. Minify client JS (after combine so all files are final).
   // Runtime (__barefoot__) is already minified at copy time above.
   if (config.minify) {
-    // @ts-expect-error minifySyntax is supported at runtime but missing from older bun-types
-    const transpiler = new Bun.Transpiler({ loader: 'js', minifyWhitespace: true, minifySyntax: true })
     for (const [name, entry] of Object.entries(manifest)) {
       if (!entry.clientJs || name === '__barefoot__') continue
       const filePath = resolve(config.outDir, entry.clientJs)
       try {
-        const content = await Bun.file(filePath).text()
+        const content = await readText(filePath)
         if (content) {
-          const minified = transpiler.transformSync(content)
+          const minified = transpile(content, { loader: 'js', minify: true })
           if (await writeIfChanged(filePath, minified)) {
             anyOutputChanged = true
           }
@@ -536,7 +530,7 @@ async function collectRelativeImportDeps(
     const candidates = [base, ...EXT_CANDIDATES.map((ext) => base + ext)]
     for (const cand of candidates) {
       if (seen.has(cand)) continue
-      if (await Bun.file(cand).exists()) {
+      if (await fileExists(cand)) {
         seen.add(cand)
         results.push(cand)
         break
@@ -591,12 +585,12 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
   // imports are picked up by lexically scanning the source for relative imports.
   const deps: Record<string, string> = {}
   for (const depPath of await collectRelativeImportDeps(entryPath, sourceContent)) {
-    deps[depPath] = hashContent(await Bun.file(depPath).text())
+    deps[depPath] = hashContent(await readText(depPath))
   }
 
   const result = await compileJSX(
     entryPath,
-    async (path) => Bun.file(path).text(),
+    async (path) => readText(path),
     { adapter: config.adapter },
   )
 

--- a/packages/cli/src/lib/fs-utils.ts
+++ b/packages/cli/src/lib/fs-utils.ts
@@ -1,5 +1,7 @@
 // Filesystem helpers shared across build pipeline steps.
 
+import { fileExists, readBytes, readText, writeBytes, writeText } from './runtime'
+
 /**
  * Write content to path only when it differs from what is already on disk.
  * Returns true when a write occurred. Avoids re-firing file watchers when
@@ -7,27 +9,30 @@
  */
 export async function writeIfChanged(
   path: string,
-  content: string | ArrayBufferView | ArrayBuffer | Blob,
+  content: string | ArrayBufferView | ArrayBuffer,
 ): Promise<boolean> {
-  const existing = Bun.file(path)
-  if (await existing.exists()) {
+  if (await fileExists(path)) {
     if (typeof content === 'string') {
-      const prev = await existing.text()
+      const prev = await readText(path)
       if (prev === content) return false
-    } else {
-      const prev = new Uint8Array(await existing.arrayBuffer())
-      const next = await toUint8Array(content)
-      if (equalBytes(prev, next)) return false
+      await writeText(path, content)
+      return true
     }
+    const prev = await readBytes(path)
+    const next = toUint8Array(content)
+    if (equalBytes(prev, next)) return false
+    await writeBytes(path, next)
+    return true
   }
-  await Bun.write(path, content as Parameters<typeof Bun.write>[1])
+  if (typeof content === 'string') {
+    await writeText(path, content)
+  } else {
+    await writeBytes(path, toUint8Array(content))
+  }
   return true
 }
 
-async function toUint8Array(
-  content: ArrayBufferView | ArrayBuffer | Blob,
-): Promise<Uint8Array> {
-  if (content instanceof Blob) return new Uint8Array(await content.arrayBuffer())
+function toUint8Array(content: ArrayBufferView | ArrayBuffer): Uint8Array {
   if (content instanceof ArrayBuffer) return new Uint8Array(content)
   return new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
 }

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -2,6 +2,7 @@
 
 import { dirname, resolve } from 'node:path'
 import { RELATIVE_IMPORT_RE } from './patterns'
+import { fileExists, readText, transpile, writeText } from './runtime'
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -20,7 +21,7 @@ export interface ResolveRelativeImportsOptions {
  * Resolve relative imports in compiled client JS files.
  *
  * For each client JS file in the manifest:
- * - `.ts` imports: transpile with Bun.Transpiler and inline the code
+ * - `.ts` imports: transpile and inline the code
  * - `.tsx` imports: strip (server component, already rendered at SSR time)
  * - Not found / already inlined: strip
  */
@@ -32,7 +33,7 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
     const filePath = resolve(distDir, entry.clientJs)
     let content: string
     try {
-      content = await Bun.file(filePath).text()
+      content = await readText(filePath)
     } catch {
       continue
     }
@@ -54,7 +55,7 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       for (const dir of searchDirs) {
         const basePath = resolve(dir, importPath)
         for (const ext of ['.ts', '.tsx', '.js']) {
-          if (await Bun.file(basePath + ext).exists()) {
+          if (await fileExists(basePath + ext)) {
             sourceFile = basePath + ext
             break
           }
@@ -78,9 +79,8 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       }
 
       // Transpile and inline pure TS utility modules
-      const sourceContent = await Bun.file(sourceFile).text()
-      const transpiler = new Bun.Transpiler({ loader: 'ts' })
-      let jsCode = transpiler.transformSync(sourceContent)
+      const sourceContent = await readText(sourceFile)
+      let jsCode = transpile(sourceContent, { loader: 'ts' })
 
       // Convert exports to plain declarations for inlining
       jsCode = jsCode
@@ -93,6 +93,6 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       console.log(`Inlined: ${importPath} into ${entry.clientJs}`)
     }
 
-    await Bun.write(filePath, content)
+    await writeText(filePath, content)
   }
 }

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -1,0 +1,103 @@
+/**
+ * Node-compatible runtime primitives used by the CLI build pipeline.
+ *
+ * Centralizes the handful of operations that historically targeted Bun
+ * (file I/O, hashing, TS transpilation, glob matching) so the published
+ * CLI runs unchanged under `node` / `npx` / `pnpm dlx` / `bunx`.
+ *
+ * Requires Node >= 22 (for `fs/promises.glob`).
+ */
+
+import { createHash } from 'node:crypto'
+import { access, readFile, writeFile, glob as fsGlob } from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
+import { transformSync } from 'esbuild'
+
+export async function readText(path: string): Promise<string> {
+  return readFile(path, 'utf8')
+}
+
+export async function readBytes(path: string): Promise<Uint8Array> {
+  const buf = await readFile(path)
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+export async function writeText(path: string, content: string): Promise<void> {
+  await writeFile(path, content, 'utf8')
+}
+
+export async function writeBytes(
+  path: string,
+  content: Uint8Array | ArrayBuffer,
+): Promise<void> {
+  const bytes = content instanceof ArrayBuffer ? new Uint8Array(content) : content
+  await writeFile(path, bytes)
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Short non-cryptographic hash used for cache keys and content addressing.
+ * sha256 truncated to 16 hex chars — plenty for equality checks, short
+ * enough to embed in filenames.
+ *
+ * Note: switching from Bun.hash to sha256 changes the hash value space, so
+ * existing `.buildcache.json` files will invalidate on first run after
+ * upgrading. This is correct — a one-shot full rebuild, then cache
+ * works normally again.
+ */
+export function hashString(content: string): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 16)
+}
+
+export interface TranspileOptions {
+  /** Source loader. Defaults to 'js'. */
+  loader?: 'ts' | 'tsx' | 'js' | 'jsx'
+  /** Produce minified output. Preserves identifiers and template literals. */
+  minify?: boolean
+}
+
+/**
+ * Transpile JS/TS source. Replaces `Bun.Transpiler` at the same call sites.
+ *
+ * Minification semantics match the compiler's original expectations: whitespace
+ * and syntax are minified, identifiers are preserved (so hydration hooks like
+ * `__bf_init_*` survive), and template literal contents (including inlined
+ * HTML) are untouched.
+ */
+export function transpile(source: string, options: TranspileOptions = {}): string {
+  const { loader = 'js', minify = false } = options
+  const result = transformSync(source, {
+    loader,
+    minifyWhitespace: minify,
+    minifySyntax: minify,
+    minifyIdentifiers: false,
+    target: 'es2022',
+    format: 'esm',
+    legalComments: 'none',
+  })
+  return result.code
+}
+
+export interface GlobOptions {
+  cwd: string
+}
+
+/**
+ * Match files by glob pattern. Returns paths relative to `cwd`.
+ * Uses Node 22's built-in `fs.promises.glob` (no runtime dep).
+ */
+export async function globFiles(pattern: string, options: GlobOptions): Promise<string[]> {
+  const results: string[] = []
+  for await (const entry of fsGlob(pattern, { cwd: options.cwd })) {
+    results.push(entry as string)
+  }
+  return results
+}


### PR DESCRIPTION
## Summary

First step toward publishing `@barefootjs/cli` to npm. Swaps Bun-specific APIs for Node-compatible equivalents behind a thin abstraction, then bundles the CLI into a single file with esbuild so it can be launched directly via `npx` / `pnpm dlx` / `bunx`.

Optimized for agent-driven usage — zero install config, works in plain Node environments.

## Motivation

The CLI was written against Bun APIs (`Bun.file`, `Bun.Transpiler`, `Bun.hash`, `Bun.Glob`, `import.meta.dir`), which blocked agents and CI runners on plain Node. This PR makes the CLI publishable with the minimum surface change, and keeps the `bun run barefoot` path working for monorepo developers.

## Changes

### New: `packages/cli/src/lib/runtime.ts`

Thin boundary module abstracting fs / hash / glob / transpile. Call sites import from this module instead of touching `Bun.*` directly, so the backend can be swapped later (e.g. to reintroduce a Bun-native implementation alongside the Node one).

### Bun.* replacements

| Bun API | Replacement |
|---|---|
| `Bun.file` / `Bun.write` | `node:fs/promises` |
| `Bun.Transpiler` | `esbuild.transformSync` (identifier-preserving minify, template-literal HTML left untouched) |
| `Bun.hash` | `node:crypto` sha256 truncated to 16 hex chars |
| `Bun.Glob` | Node 22 built-in `fs/promises.glob` (no runtime dep) |
| `import.meta.dir` | `fileURLToPath(import.meta.url)` |

### Bundle

- `scripts/build.mjs` uses esbuild to produce `dist/index.js` (~481KB)
- `@barefootjs/jsx` and transitive workspace deps inlined
- `typescript` and `esbuild` stay external (inlining them would balloon the bundle to ~15MB+)
- Shebang (`#!/usr/bin/env node`) preserved, output is `chmod +x`

### Package manifest

- `bin: { barefoot: dist/index.js }`
- `files: ["dist"]`
- `engines: { node: ">=22" }` — uses built-in `fs.glob`; Node 20 hits EOL this month
- Drop `private: true`
- Drop unused workspace deps (`@barefootjs/preview` was a phantom dep, `@barefootjs/client-runtime` appeared only in string literals)

### Preview command stub

`barefoot preview` now prints a hint pointing at #885 when running from the bundled distribution (the dynamic import for the monorepo preview source fails gracefully). The `bun run barefoot preview <component>` monorepo path still resolves the source module, so dev usage is unchanged.

## Cache invalidation note

Switching the hash algorithm changes the value space, so existing `.buildcache.json` files invalidate once on upgrade. This is correct by construction — one full rebuild, then incremental resumes normally.

## Test plan

- [x] `packages/cli`: 278/278 tests pass
- [x] `bun test packages/`: 1545/1546 (the one failure is a pre-existing Playwright e2e file being picked up by `bun:test` — unrelated)
- [x] `node packages/cli/dist/index.js search button` / `core advanced/ir-schema` / `preview checkbox` — all work
- [x] `npm pack` → clean Node 22 dir → `npm install ./pkg.tgz` → `npx barefoot` ✓
- [x] `pnpm dlx ./pkg.tgz` ✓
- [x] `bunx barefoot` (after local install) ✓
- [x] `bun run barefoot` (monorepo dev) ✓

## Out of scope

- `@barefootjs/preview` rewrite for external (non-monorepo) users — tracked in #885
- `tokens` / `meta:extract` commands still assume the monorepo layout — functional inside the monorepo, external-project support is a separate concern
- Publishing to the npm registry itself — this PR only makes the package publishable; actual release is a follow-up

## Related

- Depends on #884 (merged) — `ReactivityAnalyzer` boundary
- Follow-up: #885 — preview rewrite

https://claude.ai/code/session_01X4ZMpUYeLgXWhWRpW7rwox