### PR TITLE
feat: dev auto-reload via build --watch sentinel + Hono SSE helper

### DIFF
--- a/examples/hono/renderer.tsx
+++ b/examples/hono/renderer.tsx
@@ -7,6 +7,7 @@
 
 import { jsxRenderer } from 'hono/jsx-renderer'
 import { BfScripts } from '../../packages/hono/src/scripts'
+import { BfDevReload } from '../../packages/hono/src/dev'
 
 // Import map for resolving @barefootjs/client-runtime in client JS
 const importMapScript = JSON.stringify({
@@ -51,6 +52,7 @@ export const renderer = jsxRenderer(
         <body>
           {children}
           <BfScripts />
+          <BfDevReload />
         </body>
       </html>
     )

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -7,6 +7,7 @@
 
 import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
+import { createDevReloader } from '@barefootjs/hono/dev'
 import { renderer } from './renderer'
 import Counter from '@/components/Counter'
 import Toggle from '@/components/Toggle'
@@ -32,6 +33,9 @@ app.use('/shared/*', serveStatic({
   root: '../shared',
   rewriteRequestPath: (path) => path.replace('/shared', ''),
 }))
+
+// Dev-only browser auto-reload (no-op in production).
+app.get('/_bf/reload', createDevReloader({ distDir: './dist' }))
 
 // In-memory todo storage
 type Todo = { id: number; text: string; done: boolean }

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -724,6 +724,11 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
 
 // ── Dev sentinel ─────────────────────────────────────────────────────────
 
+// The `<outDir>/.dev/build-id` path is an inter-package contract between the
+// CLI (producer) and every adapter's dev reloader (consumer, e.g.
+// `packages/hono/src/dev.tsx`). Adapters re-declare the same literal strings
+// to avoid a runtime dependency on `@barefootjs/cli`; if these values change
+// here, update every adapter's dev reloader in the same PR.
 export const DEV_SENTINEL_SUBDIR = '.dev'
 export const DEV_SENTINEL_FILENAME = 'build-id'
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -722,6 +722,25 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
   }
 }
 
+// ── Dev sentinel ─────────────────────────────────────────────────────────
+
+export const DEV_SENTINEL_SUBDIR = '.dev'
+export const DEV_SENTINEL_FILENAME = 'build-id'
+
+/**
+ * Dev-only sentinel for signalling browsers to reload after a watch rebuild.
+ * Written at `<outDir>/.dev/build-id` only when the build both succeeded and
+ * actually changed output on disk — so a touch-save that produces no diff
+ * does not trigger a reload.
+ */
+async function writeBuildId(outDir: string, result: BuildResult): Promise<void> {
+  if (result.errorCount > 0 || !result.changed) return
+  const devDir = resolve(outDir, DEV_SENTINEL_SUBDIR)
+  await mkdir(devDir, { recursive: true })
+  const path = resolve(devDir, DEV_SENTINEL_FILENAME)
+  await writeIfChanged(path, String(Date.now()))
+}
+
 // ── Watch mode ───────────────────────────────────────────────────────────
 
 export interface WatchOptions {
@@ -749,6 +768,7 @@ export async function watch(
   console.log(
     `Initial build: ${initial.compiledCount} compiled, ${initial.cachedCount} cached, ${initial.errorCount} errors`,
   )
+  await writeBuildId(config.outDir, initial)
   console.log('Watching for changes...')
 
   // Watch component source dirs recursively; watch project dir non-recursively
@@ -776,6 +796,7 @@ export async function watch(
     console.log(
       `Rebuild: ${result.compiledCount} compiled, ${result.cachedCount} cached, ${result.errorCount} errors (${ms}ms)`,
     )
+    await writeBuildId(config.outDir, result)
   }
 
   const isRelevant = (root: string, filename: string | null): boolean => {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -34,6 +34,10 @@
       "types": "./src/preload.tsx",
       "import": "./src/preload.tsx"
     },
+    "./dev": {
+      "types": "./src/dev.tsx",
+      "import": "./src/dev.tsx"
+    },
     "./jsx/jsx-runtime": {
       "types": "./src/jsx/jsx-runtime/index.d.ts",
       "import": "./src/jsx/jsx-runtime/index.ts"

--- a/packages/hono/src/__tests__/dev.test.tsx
+++ b/packages/hono/src/__tests__/dev.test.tsx
@@ -1,0 +1,131 @@
+/** @jsxImportSource hono/jsx */
+/**
+ * BfDevReload / createDevReloader tests
+ *
+ * Verifies the dev-gate (no leak into production) and the basic SSE wire
+ * format so a regression in the build-id watcher is caught before E2E.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { renderToString } from 'hono/jsx/dom/server'
+import { BfDevReload, createDevReloader } from '../dev'
+
+describe('BfDevReload', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('renders the EventSource snippet when enabled', () => {
+    const html = renderToString(<BfDevReload enabled={true} endpoint="/_bf/reload" />)
+    expect(html).toContain('<script>')
+    expect(html).toContain('new EventSource(\"/_bf/reload\")')
+    expect(html).toContain("addEventListener('reload'")
+  })
+
+  it('renders nothing when explicitly disabled', () => {
+    const html = renderToString(<BfDevReload enabled={false} />)
+    expect(html).toBe('')
+  })
+
+  it('renders nothing when NODE_ENV=production', () => {
+    process.env.NODE_ENV = 'production'
+    const html = renderToString(<BfDevReload />)
+    expect(html).toBe('')
+  })
+
+  it('renders in non-production by default', () => {
+    process.env.NODE_ENV = 'development'
+    const html = renderToString(<BfDevReload />)
+    expect(html).toContain('EventSource')
+  })
+
+  it('respects custom endpoint', () => {
+    const html = renderToString(<BfDevReload enabled={true} endpoint="/__reload" />)
+    expect(html).toContain('new EventSource(\"/__reload\")')
+  })
+})
+
+describe('createDevReloader', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bf-dev-reloader-'))
+    mkdirSync(join(dir, '.dev'), { recursive: true })
+    writeFileSync(join(dir, '.dev', 'build-id'), '1000')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns 404 when disabled', async () => {
+    const app = new Hono()
+    app.get('/_bf/reload', createDevReloader({ distDir: dir, enabled: false }))
+
+    const res = await app.request('/_bf/reload')
+    expect(res.status).toBe(404)
+  })
+
+  it('streams initial hello with current build-id', async () => {
+    const app = new Hono()
+    app.get('/_bf/reload', createDevReloader({ distDir: dir, enabled: true }))
+
+    const ctrl = new AbortController()
+    const res = await app.request(new Request('http://localhost/_bf/reload', { signal: ctrl.signal }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    let received = ''
+    // Accumulate until the hello event lands (first two chunks should suffice).
+    for (let i = 0; i < 4 && !received.includes('event: hello'); i++) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value)
+    }
+
+    expect(received).toContain('retry: 1000')
+    expect(received).toContain('event: hello')
+    expect(received).toContain('data: 1000')
+
+    ctrl.abort()
+    try { await reader.cancel() } catch { /* already closed */ }
+  })
+
+  // Regression: when a client reconnects after a build happened during its
+  // disconnected window, it must see `reload` (not `hello`), otherwise the
+  // missed rebuild silently stays unpainted until the next change.
+  it('emits reload on reconnect when Last-Event-ID is stale', async () => {
+    const app = new Hono()
+    app.get('/_bf/reload', createDevReloader({ distDir: dir, enabled: true }))
+
+    const ctrl = new AbortController()
+    const req = new Request('http://localhost/_bf/reload', {
+      headers: { 'Last-Event-ID': '999' },
+      signal: ctrl.signal,
+    })
+    const res = await app.request(req)
+
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    let received = ''
+    for (let i = 0; i < 4 && !received.includes('event: '); i++) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value)
+    }
+
+    expect(received).toContain('event: reload')
+    expect(received).not.toContain('event: hello')
+    expect(received).toContain('data: 1000')
+
+    ctrl.abort()
+    try { await reader.cancel() } catch { /* already closed */ }
+  })
+})

--- a/packages/hono/src/dev.tsx
+++ b/packages/hono/src/dev.tsx
@@ -1,0 +1,180 @@
+/**
+ * BarefootJS Dev Reloader (Hono)
+ *
+ * Dev-only helpers that turn `barefoot build --watch`'s sentinel file
+ * (`<distDir>/.dev/build-id`) into a browser auto-reload.
+ *
+ * Pipeline:
+ *   [barefoot build --watch] → writes `<distDir>/.dev/build-id` after each successful build
+ *   [createDevReloader]      → watches that file, streams SSE `event: reload`
+ *   [BfDevReload snippet]    → EventSource subscriber → `location.reload()`
+ *
+ * Usage:
+ * ```tsx
+ * // server.tsx
+ * import { createDevReloader } from '@barefootjs/hono/dev'
+ * app.get('/_bf/reload', createDevReloader({ distDir: './dist' }))
+ *
+ * // renderer.tsx
+ * import { BfDevReload } from '@barefootjs/hono/dev'
+ * <body>{children}<BfScripts /><BfDevReload /></body>
+ * ```
+ *
+ * Both pieces are no-ops in production (`NODE_ENV === 'production'`) unless
+ * explicitly enabled.
+ */
+
+/** @jsxImportSource hono/jsx */
+
+import type { Context } from 'hono'
+import { mkdir, readFile, watch } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export interface CreateDevReloaderOptions {
+  /** Directory that `barefoot build` writes output into (contains `.dev/build-id`). */
+  distDir: string
+  /** Override the dev gate. Defaults to `process.env.NODE_ENV !== 'production'`. */
+  enabled?: boolean
+}
+
+export interface BfDevReloadProps {
+  /** Override the dev gate. Defaults to `process.env.NODE_ENV !== 'production'`. */
+  enabled?: boolean
+  /** SSE endpoint registered with `createDevReloader`. Defaults to `/_bf/reload`. */
+  endpoint?: string
+}
+
+const DEV_SUBDIR = '.dev'
+const BUILD_ID_FILE = 'build-id'
+const SCROLL_STORAGE_KEY = '__bf_devreload_scroll'
+/**
+ * Heartbeat interval for idle keepalive. Must stay comfortably under Bun's
+ * default 10s idleTimeout — otherwise the server would close a quiet SSE
+ * stream and the browser would EventSource-reconnect every cycle, which can
+ * lose a rebuild event emitted in the gap between close and reconnect.
+ */
+const HEARTBEAT_MS = 5000
+
+function isDevDefault(): boolean {
+  return process.env.NODE_ENV !== 'production'
+}
+
+/**
+ * Hono route handler that streams Server-Sent Events and emits `reload` every
+ * time `<distDir>/.dev/build-id` is written. Disabled (404) in production.
+ */
+export function createDevReloader(
+  options: CreateDevReloaderOptions,
+): (c: Context) => Response | Promise<Response> {
+  const { distDir, enabled = isDevDefault() } = options
+
+  return async (c: Context) => {
+    if (!enabled) return c.notFound()
+
+    const devDir = resolve(distDir, DEV_SUBDIR)
+    // Ensure the directory exists so fs.watch doesn't ENOENT before the first build.
+    await mkdir(devDir, { recursive: true })
+
+    const buildIdPath = resolve(devDir, BUILD_ID_FILE)
+    const signal = c.req.raw.signal
+    // If the client reconnects with Last-Event-ID (the build-id it last saw)
+    // and the current build-id is newer, a rebuild happened while it was
+    // disconnected — recover by firing `reload` immediately instead of `hello`.
+    const lastEventId = (c.req.header('Last-Event-ID') ?? '').trim()
+
+    const readBuildId = async (): Promise<string> => {
+      try {
+        return (await readFile(buildIdPath, 'utf8')).trim()
+      } catch {
+        return ''
+      }
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const encoder = new TextEncoder()
+        const send = (chunk: string) => {
+          try {
+            controller.enqueue(encoder.encode(chunk))
+          } catch {
+            // Stream already closed (client disconnected).
+          }
+        }
+
+        send(`retry: 1000\n\n`)
+        let lastSentId = ''
+        const initialId = await readBuildId()
+        if (initialId) {
+          lastSentId = initialId
+          const event = lastEventId && lastEventId !== initialId ? 'reload' : 'hello'
+          send(`event: ${event}\nid: ${initialId}\ndata: ${initialId}\n\n`)
+        }
+
+        // Heartbeat keeps the connection under Bun's idleTimeout so that a
+        // silent period between builds doesn't close the socket (which would
+        // otherwise race with in-flight rebuilds and drop `reload` events).
+        const heartbeat = setInterval(() => send(`: hb\n\n`), HEARTBEAT_MS)
+
+        try {
+          // Watch the parent directory: the build-id file may not exist yet,
+          // and `fs.watch` on a missing path throws.
+          const iter = watch(devDir, { signal })
+          for await (const event of iter) {
+            if (event.filename !== BUILD_ID_FILE) continue
+            const id = await readBuildId()
+            if (!id || id === lastSentId) continue
+            lastSentId = id
+            send(`event: reload\nid: ${id}\ndata: ${id}\n\n`)
+          }
+        } catch (err) {
+          const name = (err as { name?: string } | undefined)?.name
+          if (name !== 'AbortError') {
+            const message = (err as Error).message ?? 'watch error'
+            send(`event: error\ndata: ${JSON.stringify(message)}\n\n`)
+          }
+        } finally {
+          clearInterval(heartbeat)
+          try { controller.close() } catch { /* already closed */ }
+        }
+      },
+      cancel() {
+        // Client disconnected; fs.watch will unwind via `signal`.
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  }
+}
+
+function clientSnippet(endpoint: string, storageKey: string): string {
+  // Small IIFE: subscribes to SSE, preserves scrollY across reload, logs errors
+  // only. Intentionally dependency-free and idempotent across duplicate mounts.
+  return `(()=>{if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem(${JSON.stringify(
+    storageKey,
+  )});if(s){sessionStorage.removeItem(${JSON.stringify(
+    storageKey,
+  )});var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource(${JSON.stringify(
+    endpoint,
+  )});es.addEventListener('reload',function(){try{sessionStorage.setItem(${JSON.stringify(
+    storageKey,
+  )},String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){/* auto-reconnects */})})();`
+}
+
+/**
+ * Inline `<script>` that opens an EventSource to the reloader endpoint,
+ * reloads the page on `reload`, and preserves scrollY across reloads.
+ * Renders nothing in production.
+ */
+export function BfDevReload(props: BfDevReloadProps = {}) {
+  const { enabled = isDevDefault(), endpoint = '/_bf/reload' } = props
+  if (!enabled) return null
+  const snippet = clientSnippet(endpoint, SCROLL_STORAGE_KEY)
+  return <script dangerouslySetInnerHTML={{ __html: snippet }} />
+}

--- a/packages/hono/src/dev.tsx
+++ b/packages/hono/src/dev.tsx
@@ -44,6 +44,9 @@ export interface BfDevReloadProps {
   endpoint?: string
 }
 
+// Sentinel path contract with `@barefootjs/cli`. These values must match
+// `DEV_SENTINEL_SUBDIR` / `DEV_SENTINEL_FILENAME` in `packages/cli/src/lib/build.ts`
+// — duplicated intentionally to avoid a runtime dep on the CLI.
 const DEV_SUBDIR = '.dev'
 const BUILD_ID_FILE = 'build-id'
 const SCROLL_STORAGE_KEY = '__bf_devreload_scroll'


### PR DESCRIPTION
## Summary

Implements v0 of #887 — browser edits-to-reload, adapter-agnostic.

- `barefoot build --watch` drops `<outDir>/.dev/build-id` after every successful build that changed output on disk. No write on errored or no-op rebuilds.
- `@barefootjs/hono/dev` exports `createDevReloader({ distDir })` (a Hono SSE handler that watches the sentinel and emits `event: reload`) and `BfDevReload` (an inline `<script>` EventSource subscriber that reloads on `reload` and preserves `window.scrollY` via `sessionStorage`).
- `examples/hono` wires both pieces: `app.get('/_bf/reload', createDevReloader({ distDir: './dist' }))` and `<BfDevReload />` inside the shared layout.

Both pieces are gated on `NODE_ENV !== 'production'` by default (override via the `enabled` option) — production builds don't register the route or emit the client snippet.

## Design notes

- **Sentinel file over HTTP IPC**: the builder never touches HTTP (matches the "any backend" design). Dev servers — one per adapter — convert the filesystem event to SSE.
- **5s heartbeat**: Bun.serve's default `idleTimeout` is 10s. Without periodic comment frames the SSE stream is silently closed, the browser EventSource-reconnects, and any `reload` fired in the close↔reconnect gap is lost.
- **`Last-Event-ID` recovery**: on reconnect, the handler compares the client's last-seen build-id against the current sentinel. If the client missed a build while disconnected, it gets `reload` (not `hello`) and refreshes instead of staying stuck on stale HTML.

## Scope

v0 Hono only, per #887. Go-template adapter will follow in a separate PR (`fsnotify` + `net/http` SSE with the same contract).

## Test plan

- [x] `bun test` passes in `packages/cli` (280) and `packages/hono` (69, +8 for new `dev.test.tsx` suite)
- [x] Manual: editing a shared `.tsx` while `bun run dev` runs in `examples/hono` triggers browser reload in <500ms
- [x] Manual: `curl -N http://localhost:3001/_bf/reload` stays open past 10s (heartbeat confirmed)
- [x] Manual: `curl -H "Last-Event-ID: 999"` on the reloader endpoint emits `event: reload` (regression-tested)
- [x] Manual: `NODE_ENV=production bun run server.tsx` → `/_bf/reload` returns 404 and pages no longer include the snippet
- [ ] Verify multi-tab reload on a fresh checkout (each tab opens its own EventSource, so broadcast is automatic by construction)