### PR TITLE
feat(echo): browser auto-reload via bfdev SSE handler

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	bf "github.com/barefootjs/runtime/bf"
+	"github.com/barefootjs/runtime/bf/bfdev"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -114,15 +116,25 @@ func main() {
 
 	// Renderer. In dev mode (APP_ENV=development), templates reload on each
 	// request so edits picked up by `bun run build:watch` appear without
-	// restarting the server.
+	// restarting the server. A dev-only EventSource snippet is injected
+	// before </body> so the browser reloads automatically on every rebuild.
 	devMode := isDevEnv()
+	devSnippet := bfdev.Snippet(bfdev.Config{Disabled: !devMode})
+	layout := defaultLayout
+	if devSnippet != "" {
+		layout = func(ctx *bf.RenderContext) string {
+			html := defaultLayout(ctx)
+			return strings.Replace(html, "</body>", string(devSnippet)+"\n</body>", 1)
+		}
+	}
 	e.Renderer = &EchoRenderer{
-		bf:      bf.NewRenderer(loadTemplates(), defaultLayout),
-		layout:  defaultLayout,
+		bf:      bf.NewRenderer(loadTemplates(), layout),
+		layout:  layout,
 		devMode: devMode,
 	}
 	if devMode {
 		e.Logger.Info("Dev mode: templates will reload on each request")
+		e.GET("/_bf/reload", echo.WrapHandler(bfdev.NewReloadHandler(bfdev.Config{DistDir: "./dist"})))
 	}
 
 	// Routes

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -500,13 +500,17 @@ export async function build(
     }
   }
 
-  // 7b. Post-build hook (after minification, before manifest write)
+  // 7b. Post-build hook (after minification, before manifest write).
+  // Post-build writes (e.g. adapter-generated Go types) happen outside the
+  // writeIfChanged tracking above, so the hook uses `markChanged()` to bubble
+  // up real file changes — keeps the dev-reload sentinel honest.
   if (config.postBuild) {
     await config.postBuild({
       types: collectedTypes,
       outDir: config.outDir,
       projectDir: config.projectDir,
       manifest,
+      markChanged: () => { anyOutputChanged = true },
     })
   }
 

--- a/packages/go-template/runtime/bfdev/bfdev.go
+++ b/packages/go-template/runtime/bfdev/bfdev.go
@@ -1,0 +1,201 @@
+// Package bfdev provides a dev-only browser auto-reload handler.
+//
+// It watches `<distDir>/.dev/build-id` (produced by `barefoot build --watch`
+// in the @barefootjs/cli package) and streams SSE `event: reload` whenever
+// the sentinel changes. Combined with the inline client snippet returned by
+// Snippet, editing a .tsx component triggers a browser reload automatically.
+//
+// The handler is framework-agnostic (net/http.Handler). Echo users can mount
+// it via echo.WrapHandler; other routers use it as-is.
+//
+// Example (Echo):
+//
+//	if bfdev.IsDevDefault() {
+//	    e.GET("/_bf/reload", echo.WrapHandler(bfdev.NewReloadHandler(bfdev.Config{
+//	        DistDir: "./dist",
+//	    })))
+//	}
+//
+// Example (net/http):
+//
+//	http.Handle("/_bf/reload", bfdev.NewReloadHandler(bfdev.Config{DistDir: "./dist"}))
+package bfdev
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Sentinel path contract with `@barefootjs/cli`
+// (`packages/cli/src/lib/build.ts`, DEV_SENTINEL_SUBDIR / DEV_SENTINEL_FILENAME).
+// Duplicated here so the Go runtime avoids a dependency on the CLI. If the
+// CLI changes these values, update this package in the same PR.
+const (
+	devSubdir        = ".dev"
+	buildIDFile      = "build-id"
+	scrollStorageKey = "__bf_devreload_scroll"
+
+	// heartbeatInterval keeps the SSE stream under the framework's idle
+	// timeout (Bun.serve defaults to 10s; Go/Echo defaults are more forgiving
+	// but middleware-level timeouts exist in the wild). 5s leaves comfortable
+	// headroom.
+	heartbeatInterval = 5 * time.Second
+
+	// pollInterval is how often the handler checks `.dev/build-id`. Uses
+	// polling instead of fsnotify to keep the runtime dependency-free — dev
+	// latency of ~500ms is imperceptible next to the browser's reload time.
+	pollInterval = 500 * time.Millisecond
+)
+
+// Config configures a dev reload handler or snippet.
+type Config struct {
+	// DistDir is the directory that `barefoot build` writes output into
+	// (contains `.dev/build-id`). Required for the handler; ignored by
+	// Snippet.
+	DistDir string
+
+	// Endpoint is the public SSE URL the client will connect to. Used only by
+	// Snippet to populate the EventSource URL. Defaults to "/_bf/reload" when
+	// empty.
+	Endpoint string
+
+	// Disabled, when true, makes NewReloadHandler return a 404 handler and
+	// Snippet return an empty fragment. Intended for production builds.
+	Disabled bool
+}
+
+// IsDevDefault reports whether the process is running in a development
+// environment using the common Go convention of APP_ENV=development.
+// Callers can use this to populate Config.Disabled:
+//
+//	cfg := bfdev.Config{DistDir: "./dist", Disabled: !bfdev.IsDevDefault()}
+func IsDevDefault() bool {
+	return os.Getenv("APP_ENV") == "development"
+}
+
+// NewReloadHandler returns an http.Handler that streams Server-Sent Events
+// and emits `event: reload` whenever `<DistDir>/.dev/build-id` changes. When
+// cfg.Disabled is true, the handler responds 404 and never opens a stream.
+func NewReloadHandler(cfg Config) http.Handler {
+	if cfg.Disabled {
+		return http.HandlerFunc(http.NotFound)
+	}
+	devDir := filepath.Join(cfg.DistDir, devSubdir)
+	buildIDPath := filepath.Join(devDir, buildIDFile)
+	// Ensure the directory exists so the first read does not race with the
+	// initial build. Ignore the error: subsequent reads simply return "".
+	_ = os.MkdirAll(devDir, 0o755)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+		h := w.Header()
+		h.Set("Content-Type", "text/event-stream")
+		h.Set("Cache-Control", "no-cache, no-transform")
+		h.Set("Connection", "keep-alive")
+		h.Set("X-Accel-Buffering", "no")
+
+		send := func(chunk string) bool {
+			if _, err := fmt.Fprint(w, chunk); err != nil {
+				return false
+			}
+			flusher.Flush()
+			return true
+		}
+
+		if !send("retry: 1000\n\n") {
+			return
+		}
+
+		lastEventID := strings.TrimSpace(r.Header.Get("Last-Event-ID"))
+		initialID := readBuildID(buildIDPath)
+		lastSent := ""
+		if initialID != "" {
+			lastSent = initialID
+			// When the client reconnects with a stale Last-Event-ID, a build
+			// happened during its disconnected window — fire `reload`
+			// immediately so the missed rebuild does not silently stay
+			// unpainted until the next change.
+			event := "hello"
+			if lastEventID != "" && lastEventID != initialID {
+				event = "reload"
+			}
+			if !send(fmt.Sprintf("event: %s\nid: %s\ndata: %s\n\n", event, initialID, initialID)) {
+				return
+			}
+		}
+
+		ctx := r.Context()
+		hbTicker := time.NewTicker(heartbeatInterval)
+		defer hbTicker.Stop()
+		pollTicker := time.NewTicker(pollInterval)
+		defer pollTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-hbTicker.C:
+				if !send(": hb\n\n") {
+					return
+				}
+			case <-pollTicker.C:
+				id := readBuildID(buildIDPath)
+				if id == "" || id == lastSent {
+					continue
+				}
+				lastSent = id
+				if !send(fmt.Sprintf("event: reload\nid: %s\ndata: %s\n\n", id, id)) {
+					return
+				}
+			}
+		}
+	})
+}
+
+func readBuildID(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// Snippet returns an inline <script> that subscribes to the SSE endpoint,
+// reloads on `reload`, and preserves window.scrollY across reloads via
+// sessionStorage. Returns an empty fragment when cfg.Disabled is true.
+//
+// Place it before </body>, typically just after the rendered scripts.
+func Snippet(cfg Config) template.HTML {
+	if cfg.Disabled {
+		return ""
+	}
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = "/_bf/reload"
+	}
+	// Small IIFE: EventSource subscriber + scrollY preservation. Idempotent
+	// across duplicate mounts (guarded by window.__bfDevReload).
+	js := fmt.Sprintf(
+		`(function(){if(window.__bfDevReload)return;window.__bfDevReload=1;`+
+			`try{var s=sessionStorage.getItem(%q);if(s){sessionStorage.removeItem(%q);`+
+			`var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};`+
+			`if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}`+
+			`var es=new EventSource(%q);`+
+			`es.addEventListener('reload',function(){try{sessionStorage.setItem(%q,String(window.scrollY))}catch(e){}location.reload()});`+
+			`es.addEventListener('error',function(){})})();`,
+		scrollStorageKey, scrollStorageKey, endpoint, scrollStorageKey,
+	)
+	// Safe: `js` is assembled from package-internal literals plus `endpoint`
+	// escaped by %q (Go-syntax quoting == valid JS string literal for the
+	// ASCII endpoint paths this accepts).
+	return template.HTML("<script>" + js + "</script>") //nolint:gosec
+}

--- a/packages/go-template/runtime/bfdev/bfdev_test.go
+++ b/packages/go-template/runtime/bfdev/bfdev_test.go
@@ -1,0 +1,183 @@
+package bfdev
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeBuildID(t *testing.T, dir, id string) {
+	t.Helper()
+	devDir := filepath.Join(dir, ".dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "build-id"), []byte(id), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnippet_DisabledReturnsEmpty(t *testing.T) {
+	if got := Snippet(Config{Disabled: true}); got != "" {
+		t.Errorf("Snippet(disabled) = %q, want empty", got)
+	}
+}
+
+func TestSnippet_ContainsEventSource(t *testing.T) {
+	got := string(Snippet(Config{}))
+	if !strings.Contains(got, "<script>") {
+		t.Errorf("snippet missing <script>: %q", got)
+	}
+	if !strings.Contains(got, `new EventSource("/_bf/reload")`) {
+		t.Errorf("snippet missing default EventSource URL: %q", got)
+	}
+	if !strings.Contains(got, "addEventListener('reload'") {
+		t.Errorf("snippet missing reload listener: %q", got)
+	}
+}
+
+func TestSnippet_CustomEndpoint(t *testing.T) {
+	got := string(Snippet(Config{Endpoint: "/__reload"}))
+	if !strings.Contains(got, `new EventSource("/__reload")`) {
+		t.Errorf("snippet did not use custom endpoint: %q", got)
+	}
+}
+
+func TestNewReloadHandler_DisabledReturns404(t *testing.T) {
+	srv := httptest.NewServer(NewReloadHandler(Config{DistDir: t.TempDir(), Disabled: true}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// readSSEUntil reads lines from r until `contains` is seen or `timeout` elapses.
+// Returns the accumulated text.
+func readSSEUntil(t *testing.T, r *http.Response, contains string, timeout time.Duration) string {
+	t.Helper()
+	done := make(chan string, 1)
+	go func() {
+		sc := bufio.NewScanner(r.Body)
+		var acc strings.Builder
+		for sc.Scan() {
+			acc.WriteString(sc.Text())
+			acc.WriteByte('\n')
+			if strings.Contains(acc.String(), contains) {
+				done <- acc.String()
+				return
+			}
+		}
+		done <- acc.String()
+	}()
+	select {
+	case got := <-done:
+		return got
+	case <-time.After(timeout):
+		t.Fatalf("timeout waiting for %q", contains)
+		return ""
+	}
+}
+
+func TestNewReloadHandler_InitialHello(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildID(t, dir, "1000")
+
+	srv := httptest.NewServer(NewReloadHandler(Config{DistDir: dir}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	body := readSSEUntil(t, resp, "data: 1000", 2*time.Second)
+	if !strings.Contains(body, "retry: 1000") {
+		t.Errorf("missing retry: %q", body)
+	}
+	if !strings.Contains(body, "event: hello") {
+		t.Errorf("missing hello: %q", body)
+	}
+	if !strings.Contains(body, "data: 1000") {
+		t.Errorf("missing build-id data: %q", body)
+	}
+}
+
+// Regression: a client reconnecting with a stale Last-Event-ID must see
+// `reload` immediately, otherwise the build that happened during its
+// disconnected window silently stays unpainted until the next change.
+func TestNewReloadHandler_StaleLastEventIDEmitsReload(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildID(t, dir, "2000")
+
+	srv := httptest.NewServer(NewReloadHandler(Config{DistDir: dir}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Last-Event-ID", "1999")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body := readSSEUntil(t, resp, "data: 2000", 2*time.Second)
+	if !strings.Contains(body, "event: reload") {
+		t.Errorf("expected reload on stale Last-Event-ID, got: %q", body)
+	}
+	if strings.Contains(body, "event: hello") {
+		t.Errorf("should not emit hello when stale, got: %q", body)
+	}
+	if !strings.Contains(body, "data: 2000") {
+		t.Errorf("missing current build-id: %q", body)
+	}
+}
+
+// When the build-id changes after connection is established, the handler
+// should detect it via polling and emit a `reload` event.
+func TestNewReloadHandler_DetectsBuildIDChange(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildID(t, dir, "3000")
+
+	srv := httptest.NewServer(NewReloadHandler(Config{DistDir: dir}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Drain the initial hello before simulating a rebuild so we don't confuse
+	// it with the expected reload below.
+	_ = readSSEUntil(t, resp, "data: 3000", 2*time.Second)
+
+	time.Sleep(pollInterval)
+	writeBuildID(t, dir, "3001")
+
+	body := readSSEUntil(t, resp, "data: 3001", 2*time.Second)
+	if !strings.Contains(body, "event: reload") {
+		t.Errorf("expected reload after build-id change, got: %q", body)
+	}
+	if !strings.Contains(body, "data: 3001") {
+		t.Errorf("expected new build-id in data, got: %q", body)
+	}
+}

--- a/packages/go-template/src/build.ts
+++ b/packages/go-template/src/build.ts
@@ -214,8 +214,14 @@ export function createConfig(options: GoTemplateBuildOptions = {}) {
     if (content) {
       const { resolve } = await import('node:path')
       const outPath = resolve(ctx.projectDir, typesOutputFile)
-      await Bun.write(outPath, content)
-      console.log(`Generated: ${typesOutputFile}`)
+      // Write only when content changed so cache-hit builds don't trip the
+      // dev-reload sentinel (ctx.markChanged) and trigger a spurious reload.
+      const prev = await Bun.file(outPath).text().catch(() => null)
+      if (prev !== content) {
+        await Bun.write(outPath, content)
+        ctx.markChanged?.()
+        console.log(`Generated: ${typesOutputFile}`)
+      }
     }
   }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -79,6 +79,19 @@ export interface PostBuildContext {
   projectDir: string
   /** Build manifest */
   manifest: Record<string, { clientJs?: string; markedTemplate: string }>
+  /**
+   * Signal that the post-build step wrote (or otherwise altered) outputs the
+   * CLI does not track directly — e.g. adapter-generated files produced
+   * outside `outDir`. Used by the CLI's dev-reload sentinel so the browser
+   * reloads only when a build actually changed the world.
+   *
+   * Adapters should call this after a real write (use your own
+   * write-if-changed logic to decide). Safe to call multiple times per build.
+   *
+   * Optional on the type so older callers that construct a ctx manually (e.g.
+   * in tests) don't have to supply one; the CLI always provides one at runtime.
+   */
+  markChanged?: () => void
 }
 
 export interface BuildOptions {


### PR DESCRIPTION
## Summary

Extends #887's dev auto-reload from Hono to Go/Echo. Generic `net/http.Handler` in a new `bfdev` subpackage under `@barefootjs/go-template/runtime`, so Echo / gin / chi / plain net/http can all mount it the same way.

- **`packages/go-template/runtime/bfdev`** (new): `NewReloadHandler(Config)` streams SSE `event: reload` when `<distDir>/.dev/build-id` changes; `Snippet(Config)` returns the inline `<script>` EventSource subscriber (5s heartbeat, `Last-Event-ID` recovery, `sessionStorage` scroll preservation — same semantics as `@barefootjs/hono/dev`).
- **`packages/jsx` / `packages/cli`**: added `PostBuildContext.markChanged()` so adapters that write files outside `outDir` (via postBuild) can opt into the dev-reload sentinel. Optional field — existing callers untouched.
- **`packages/go-template`**: `components.go` now uses read-then-compare before rewriting, and signals real writes via `markChanged()`. Before this, post-build re-wrote the file every rebuild and the sentinel either ignored the change or fired on every cache-hit.
- **`examples/echo/main.go`**: registers `/_bf/reload` and injects the snippet before `</body>`, both gated on `APP_ENV=development` to match the existing template hot-reload convention.

## Design notes

- **Why not fsnotify**: the runtime module stays dependency-free (just `go.mod` + stdlib). A 500ms polling loop is enough for a dev-latency UX, and far simpler to port to other adapters.
- **Why a new subpackage instead of a new `packages/echo`**: the handler is pure net/http. Echo needs a single `echo.WrapHandler(...)` call, which doesn't justify a new Go module. If Echo-specific helpers accumulate later, we can promote.
- **Sentinel path contract**: `.dev/build-id` matches the `DEV_SENTINEL_*` constants in `packages/cli/src/lib/build.ts`. Comments on both sides point at each other (same pattern as the Hono PR).

## Test plan

- [x] `go test ./bfdev/...` passes (6 tests covering Snippet on/off, 404 when disabled, initial `hello`, stale `Last-Event-ID` → `reload`, build-id change → `reload`)
- [x] `bun test` passes in cli (280), hono (69), go-template (56) — no regressions
- [x] Manual: `APP_ENV=development go run .` + `bun run build:watch`, editing `examples/shared/components/Counter.tsx` triggers `event: reload` over `/_bf/reload` and the HTML reflects the change within ~500ms
- [x] Manual: without `APP_ENV=development`, `/_bf/reload` returns 404 and `/counter` does not include the snippet
- [x] Manual: `curl -N http://localhost:8080/_bf/reload` stays open past 10s (heartbeat confirmed)
- [ ] Verify multi-tab reload (each tab opens its own EventSource, so broadcast is automatic)