### PR TITLE
feat(mojolicious): browser auto-reload via BarefootJS::DevReload plugin

### DIFF
--- a/examples/mojolicious/app.pl
+++ b/examples/mojolicious/app.pl
@@ -6,6 +6,10 @@ use Mojo::JSON qw(true false encode_json);
 # Load BarefootJS plugin
 plugin 'BarefootJS';
 
+# Dev-only browser auto-reload (no-op in production). The companion snippet
+# is emitted in the layout below via `bf_dev_snippet`.
+plugin 'BarefootJS::DevReload';
+
 # Serve static files (client JS, barefoot.js)
 app->static->paths->[0] = app->home->child('dist');
 
@@ -383,5 +387,6 @@ __DATA__
     <div id="app"><%= content %></div>
     <p><a href="/">← Back</a></p>
     <%== bf->scripts %>
+    <%== bf_dev_snippet %>
 </body>
 </html>

--- a/packages/mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
+++ b/packages/mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
@@ -1,0 +1,150 @@
+package Mojolicious::Plugin::BarefootJS::DevReload;
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+=head1 NAME
+
+Mojolicious::Plugin::BarefootJS::DevReload - Dev-only browser auto-reload for BarefootJS apps
+
+=head1 SYNOPSIS
+
+    # In your Mojolicious::Lite app (development mode)
+    plugin 'BarefootJS::DevReload';
+
+    # Then in your layout template, before </body>:
+    %== bf_dev_snippet
+
+=head1 DESCRIPTION
+
+Companion to C<barefoot build --watch> in C<@barefootjs/cli>. The CLI drops
+C<< <dist>/.dev/build-id >> after every successful rebuild that changed
+output; this plugin watches that file and streams SSE C<< event: reload >>
+to subscribed browsers so an editor save triggers an automatic reload.
+
+Disabled automatically when C<< $app->mode eq 'production' >> (set via
+C<MOJO_MODE=production>). Pass C<< enabled => 0 >> to disable explicitly or
+C<< enabled => 1 >> to force-enable.
+
+=cut
+
+use Mojo::ByteStream qw(b);
+use Mojo::IOLoop;
+use File::Spec;
+
+# Sentinel path contract with @barefootjs/cli (DEV_SENTINEL_SUBDIR /
+# DEV_SENTINEL_FILENAME in packages/cli/src/lib/build.ts). Duplicated so this
+# package avoids a runtime dep on the CLI — keep in sync with the CLI.
+my $DEV_SUBDIR         = '.dev';
+my $BUILD_ID_FILE      = 'build-id';
+my $SCROLL_STORAGE_KEY = '__bf_devreload_scroll';
+
+# Heartbeat < any reasonable proxy/IOLoop idle timeout so a quiet connection
+# doesn't get reaped between rebuilds.
+my $HEARTBEAT_S = 5;
+
+# Polling instead of Linux::Inotify2 / Mac::FSEvents keeps the runtime
+# dependency-free. Sub-second latency is imperceptible next to browser reload.
+my $POLL_S = 0.5;
+
+sub register ($self, $app, $config = {}) {
+    my $dist_dir = $config->{dist_dir} // 'dist';
+    my $endpoint = $config->{endpoint} // '/_bf/reload';
+    my $enabled  = exists $config->{enabled}
+        ? $config->{enabled}
+        : ($app->mode ne 'production');
+
+    # Snippet helper is always registered so templates don't have to branch
+    # on mode — it simply returns an empty ByteStream when disabled.
+    $app->helper(bf_dev_snippet => sub ($c) {
+        return b('') unless $enabled;
+        return b(_snippet($endpoint));
+    });
+
+    return unless $enabled;
+
+    # Resolve dist_dir relative to the Mojolicious home when not already
+    # absolute, so both `dist_dir => 'dist'` (the common case) and
+    # `dist_dir => '/abs/path'` (tests) work.
+    my $dist_abs = File::Spec->file_name_is_absolute($dist_dir)
+        ? $dist_dir
+        : $app->home->child($dist_dir)->to_string;
+    my $dev_dir       = File::Spec->catdir($dist_abs, $DEV_SUBDIR);
+    my $build_id_path = File::Spec->catfile($dev_dir, $BUILD_ID_FILE);
+    mkdir $dev_dir unless -d $dev_dir;
+
+    $app->routes->get($endpoint => sub ($c) {
+        my $last_event_id = $c->req->headers->header('Last-Event-ID') // '';
+        $last_event_id =~ s/^\s+|\s+$//g;
+
+        $c->res->headers->content_type('text/event-stream');
+        $c->res->headers->cache_control('no-cache, no-transform');
+        $c->res->headers->connection('keep-alive');
+        $c->res->headers->header('X-Accel-Buffering' => 'no');
+
+        $c->write("retry: 1000\n\n");
+
+        my $initial_id = _read_build_id($build_id_path);
+        my $last_sent  = '';
+        if (length $initial_id) {
+            $last_sent = $initial_id;
+            # When the client reconnects with a stale Last-Event-ID, a build
+            # happened during its disconnected window — fire `reload`
+            # immediately so the missed rebuild does not silently stay
+            # unpainted until the next change.
+            my $event = (length $last_event_id && $last_event_id ne $initial_id)
+                ? 'reload' : 'hello';
+            $c->write("event: $event\nid: $initial_id\ndata: $initial_id\n\n");
+        }
+
+        my ($hb_id, $poll_id);
+        $c->on(finish => sub {
+            Mojo::IOLoop->remove($hb_id)   if $hb_id;
+            Mojo::IOLoop->remove($poll_id) if $poll_id;
+        });
+
+        $hb_id = Mojo::IOLoop->recurring($HEARTBEAT_S => sub {
+            $c->write(": hb\n\n");
+        });
+        $poll_id = Mojo::IOLoop->recurring($POLL_S => sub {
+            my $id = _read_build_id($build_id_path);
+            return unless length $id;
+            return if $id eq $last_sent;
+            $last_sent = $id;
+            $c->write("event: reload\nid: $id\ndata: $id\n\n");
+        });
+    });
+
+    return;
+}
+
+sub _read_build_id ($path) {
+    return '' unless -f $path;
+    open my $fh, '<', $path or return '';
+    local $/;
+    my $content = <$fh>;
+    close $fh;
+    $content //= '';
+    $content =~ s/^\s+|\s+$//g;
+    return $content;
+}
+
+sub _snippet ($endpoint) {
+    my $ep = _js_str($endpoint);
+    my $sk = _js_str($SCROLL_STORAGE_KEY);
+    # Small IIFE: EventSource subscriber + scrollY preservation. Idempotent
+    # across duplicate mounts (window.__bfDevReload guard).
+    return qq{<script>(function(){if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem($sk);if(s){sessionStorage.removeItem($sk);var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource($ep);es.addEventListener('reload',function(){try{sessionStorage.setItem($sk,String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){})})();</script>};
+}
+
+sub _js_str ($s) {
+    # Minimal JS string escape for the handful of characters that can appear
+    # in a URL path or storage key. Good enough for package-internal + trusted
+    # operator-supplied strings; never interpolate untrusted input here.
+    my $t = $s;
+    $t =~ s/\\/\\\\/g;
+    $t =~ s/"/\\"/g;
+    $t =~ s/\n/\\n/g;
+    $t =~ s/\r/\\r/g;
+    return qq{"$t"};
+}
+
+1;

--- a/packages/mojolicious/t/dev_reload.t
+++ b/packages/mojolicious/t/dev_reload.t
@@ -1,0 +1,170 @@
+use strict;
+use warnings;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+use Test::More;
+use Test::Mojo;
+use Mojolicious::Lite;
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use File::Spec;
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+use Mojo::Server::Daemon;
+use IO::Socket::INET;
+
+# Spin up a real daemon on an ephemeral port and collect bytes via a raw
+# socket read with a short timeout. Going through Mojo::UserAgent against an
+# infinite SSE stream tends to hang because the UA's blocking start() waits
+# for tx completion.
+sub read_sse ($app, $path, %opts) {
+    my $headers = $opts{headers} // {};
+
+    my $daemon = Mojo::Server::Daemon->new(
+        app    => $app,
+        listen => ['http://127.0.0.1'],
+        silent => 1,
+    );
+    $daemon->start;
+    my $port = $daemon->ioloop->acceptor($daemon->acceptors->[0])->port;
+
+    my $sock = IO::Socket::INET->new(
+        PeerAddr => '127.0.0.1',
+        PeerPort => $port,
+        Proto    => 'tcp',
+        Timeout  => 2,
+    ) or die "socket: $!";
+    $sock->autoflush(1);
+
+    my $req = "GET $path HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n";
+    for my $k (keys %$headers) {
+        $req .= "$k: $headers->{$k}\r\n";
+    }
+    $req .= "\r\n";
+    print $sock $req;
+
+    # Pump the IOLoop until bytes arrive or the read deadline passes.
+    my $raw = '';
+    my $deadline = time + 2;
+    $sock->blocking(0);
+    while (time < $deadline && length($raw) < 400) {
+        Mojo::IOLoop->one_tick;
+        my $chunk = '';
+        my $bytes = sysread($sock, $chunk, 4096);
+        if (defined $bytes && $bytes > 0) {
+            $raw .= $chunk;
+        }
+    }
+    close $sock;
+    $daemon->stop;
+
+    # Split off headers; keep only the body (the bytes after the first
+    # CRLFCRLF). Chunked transfer-encoding inserts size lines + CRLFs around
+    # each chunk; we just match substrings so that's fine for our asserts.
+    my ($head, $body) = split /\r\n\r\n/, $raw, 2;
+    $body //= '';
+    my $status = ($head // '') =~ m{^HTTP/\d+\.\d+ (\d+)} ? $1 : 0;
+    my %resp_headers;
+    for my $line (split /\r\n/, $head // '') {
+        next unless $line =~ m{^([^:]+):\s*(.*)$};
+        $resp_headers{lc $1} = $2;
+    }
+
+    diag "SSE status=$status body=\n$body\n" if $ENV{DEBUG_SSE};
+    return { status => $status, headers => \%resp_headers, body => $body };
+}
+
+# Build a minimal Mojolicious::Lite app with the DevReload plugin and a
+# configurable dist dir so tests can pre-seed the sentinel file.
+sub build_app ($dist_dir, %plugin_opts) {
+    my $app = Mojolicious::Lite->new;
+    $app->plugin('BarefootJS::DevReload',
+        { dist_dir => $dist_dir, %plugin_opts });
+    my $t = Test::Mojo->new($app);
+    # SSE endpoint streams forever; cap response + inactivity so streaming
+    # tests don't hang. Applies to all tests using this app; harmless for
+    # the non-streaming ones.
+    $t->ua->max_response_size(4096);
+    $t->ua->inactivity_timeout(2);
+    return $t;
+}
+
+sub write_sentinel ($dist, $id) {
+    my $dir = File::Spec->catdir($dist, '.dev');
+    make_path($dir);
+    open my $fh, '>', File::Spec->catfile($dir, 'build-id') or die $!;
+    print $fh $id;
+    close $fh;
+}
+
+subtest 'snippet helper returns script tag when enabled' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    my $t    = build_app($dist, enabled => 1);
+    my $out  = $t->app->build_controller->bf_dev_snippet;
+    like "$out", qr{<script>},                  'has <script>';
+    like "$out", qr{new EventSource\("/_bf/reload"\)}, 'default endpoint';
+    like "$out", qr{addEventListener\('reload'},       'reload listener';
+};
+
+subtest 'snippet helper empty when disabled' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    my $t    = build_app($dist, enabled => 0);
+    my $out  = $t->app->build_controller->bf_dev_snippet;
+    is "$out", '', 'empty string';
+};
+
+subtest '/_bf/reload returns 404 when disabled' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    my $t    = build_app($dist, enabled => 0);
+    $t->get_ok('/_bf/reload')->status_is(404);
+};
+
+subtest '/_bf/reload streams SSE headers and initial hello' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    write_sentinel($dist, '1234567890');
+    my $t = build_app($dist, enabled => 1);
+
+    my $r = read_sse($t->app, '/_bf/reload');
+    is $r->{status}, 200, 'status 200';
+    is $r->{headers}{'content-type'}, 'text/event-stream', 'content type';
+    is $r->{headers}{'cache-control'}, 'no-cache, no-transform', 'cache-control';
+    like $r->{body}, qr/retry: 1000/,      'retry frame present';
+    like $r->{body}, qr/event: hello/,     'hello event emitted';
+    like $r->{body}, qr/data: 1234567890/, 'current build-id in data';
+};
+
+# Regression: a client reconnecting with a stale Last-Event-ID must see
+# `reload` (not `hello`), otherwise the build fired during its disconnected
+# window stays unpainted until the next change.
+subtest 'stale Last-Event-ID yields reload on reconnect' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    write_sentinel($dist, 'B');
+    my $t = build_app($dist, enabled => 1);
+
+    my $r = read_sse(
+        $t->app, '/_bf/reload',
+        headers => { 'Last-Event-ID' => 'A' },
+    );
+    is $r->{status}, 200, 'status 200';
+    like   $r->{body}, qr/event: reload/, 'reload on stale id';
+    unlike $r->{body}, qr/event: hello/,  'no hello on stale id';
+    like   $r->{body}, qr/data: B/,       'current build-id in data';
+};
+
+subtest 'custom endpoint is honored in snippet + route' => sub {
+    my $dist = tempdir(CLEANUP => 1);
+    write_sentinel($dist, 'X');
+    my $t = build_app($dist, enabled => 1, endpoint => '/__reload');
+
+    my $out = $t->app->build_controller->bf_dev_snippet;
+    like "$out", qr{new EventSource\("/__reload"\)}, 'snippet uses custom endpoint';
+
+    my $r = read_sse($t->app, '/__reload');
+    is $r->{status}, 200, 'custom endpoint live';
+    is $r->{headers}{'content-type'}, 'text/event-stream', 'content type';
+
+    $t->get_ok('/_bf/reload')->status_is(404, 'default endpoint disabled');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Extends #887's dev auto-reload from Hono (#888) and Echo (#889) to Mojolicious. Same contract: `barefoot build --watch` drops `<dist>/.dev/build-id` after every meaningful rebuild; the Perl plugin watches it and streams SSE `event: reload` so every open browser tab refreshes automatically.

- **`packages/mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm`** (new): Mojolicious plugin exposing an SSE route at `/_bf/reload` (polling-based, no external deps) plus a `bf_dev_snippet` template helper that returns the inline EventSource subscriber. 5s heartbeat, `Last-Event-ID` reconnect recovery, `sessionStorage` scroll preservation — identical semantics to the Hono and Go variants.
- **`packages/mojolicious/t/dev_reload.t`** (new): 6 subtests. SSE streaming tests read bytes directly via `IO::Socket::INET` against a real `Mojo::Server::Daemon` on an ephemeral port — Test::Mojo's blocking wait-for-body hangs on an infinite stream.
- **`examples/mojolicious/app.pl`**: registers the plugin and emits `<%== bf_dev_snippet %>` in the shared layout.

## Design notes

- **Why a plugin (not Mojolicious::Controller::Role etc.)**: plugins are the idiomatic way to register routes + helpers atomically in Mojolicious::Lite, and match the existing `Mojolicious::Plugin::BarefootJS` pattern in this package.
- **Why polling over `Linux::Inotify2` / `Mac::FSEvents`**: keeps the runtime deps-free. 500ms latency is imperceptible next to browser reload.
- **Mode gating**: `app->mode eq 'production'` disables both the route and the snippet — matches Mojolicious's own `MOJO_MODE=production` convention, so no new env var.
- **Sentinel path contract**: `.dev/build-id`, kept in sync with `DEV_SENTINEL_*` in `packages/cli/src/lib/build.ts` (comment on both sides).

## Test plan

- [x] `prove -l t/dev_reload.t` passes all 6 subtests (snippet enabled/disabled, `/_bf/reload` 404 when disabled, SSE initial hello, stale `Last-Event-ID` → `reload`, custom endpoint)
- [x] Manual: `bun run dev` + `bun run build:watch` in `examples/mojolicious/`; editing `examples/shared/components/Counter.tsx` triggers `event: reload` on `/_bf/reload` and the HTML reflects the change within ~500ms
- [x] Manual: `curl -N http://localhost:3004/_bf/reload` stays open past 10s (heartbeat confirmed)
- [x] Manual: `MOJO_MODE=production perl app.pl daemon -l 'http://*:3004'` → `/_bf/reload` returns 404 and `/counter` does not include the snippet
- [ ] Verify multi-tab reload in a real browser (each tab opens its own EventSource, so broadcast is automatic)