### PR TITLE
fix(test): add exhaustive check to IR-to-TestNode convert()

### DIFF
--- a/packages/test/__tests__/render-to-test.test.ts
+++ b/packages/test/__tests__/render-to-test.test.ts
@@ -125,6 +125,30 @@ export { Static }
   })
 })
 
+describe('<Async> streaming boundary', () => {
+  test('exposes resolved children as a fragment', () => {
+    const source = `
+function ProductPage() {
+  return (
+    <div>
+      <Async fallback={<p>Loading...</p>}>
+        <span>Resolved</span>
+      </Async>
+    </div>
+  )
+}
+
+export { ProductPage }
+`
+    const result = renderToTest(source, 'product-page.tsx')
+    const span = result.find({ tag: 'span' })
+    expect(span).not.toBeNull()
+    expect(span!.text).toBeNull()
+    const textChild = span!.children.find(c => c.type === 'text')
+    expect(textChild?.text).toBe('Resolved')
+  })
+})
+
 describe('Error detection', () => {
   test('missing "use client" reports BF001', () => {
     const source = `

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -16,6 +16,7 @@ import type {
   IRSlot,
   IRIfStatement,
   IRProvider,
+  IRAsync,
 } from '@barefootjs/jsx'
 
 type IRAttribute = IRElement['attrs'][number]
@@ -49,6 +50,12 @@ function convert(node: IRNode, cmap: Map<string, string>): TestNode {
       return convertIfStatement(node, cmap)
     case 'provider':
       return convertProvider(node, cmap)
+    case 'async':
+      return convertAsync(node, cmap)
+    default: {
+      const _exhaustive: never = node
+      throw new Error(`Unhandled IR node type: ${(_exhaustive as IRNode).type}`)
+    }
   }
 }
 
@@ -317,6 +324,30 @@ function convertProvider(node: IRProvider, cmap: Map<string, string>): TestNode 
   const children = node.children.map(c => convert(c, cmap))
 
   if (children.length === 1) return children[0]
+
+  return new TestNode({
+    tag: null,
+    type: 'fragment',
+    children,
+    text: null,
+    props: {},
+    classes: [],
+    role: null,
+    aria: {},
+    dataState: null,
+    events: [],
+    reactive: false,
+    componentName: null,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Async
+// ---------------------------------------------------------------------------
+
+function convertAsync(node: IRAsync, cmap: Map<string, string>): TestNode {
+  // Represent the resolved content as a fragment; tests assert on final state.
+  const children = node.children.map(c => convert(c, cmap))
 
   return new TestNode({
     tag: null,


### PR DESCRIPTION
## Summary

- Resolves TS2366 build failure in \`packages/test/src/ir-to-test-node.ts\` by adding a \`never\`-based default branch to the \`switch\` in \`convert()\`.
- Adds the missing \`case 'async'\` branch (surfaced by the exhaustive check) so \`IRAsync\` nodes are converted to a fragment of their resolved children.

## Why

The switch covered most \`IRNode\` variants but TS could not prove exhaustiveness, so \`convert()\` could implicitly return \`undefined\` — breaking \`bun run --filter @barefootjs/test build\`. The exhaustive-default pattern also catches any future \`IRNode\` variant at compile time.

Closes #892

## Test plan

- [x] \`bun run --filter @barefootjs/test build\` passes
- [x] \`bun run --filter @barefootjs/test test\` — 11 pass, 0 fail
- [x] \`bun run build\` across workspace passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)