### PR TITLE
fix(client): accept ComponentDef in render() (closes #893)

### DIFF
--- a/packages/client/__tests__/runtime/render.test.ts
+++ b/packages/client/__tests__/runtime/render.test.ts
@@ -116,6 +116,69 @@ describe('render', () => {
   })
 })
 
+describe('render with ComponentDef', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('renders from ComponentDef without registry lookup', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const initialized: Array<{ scope: Element; props: Record<string, unknown> }> = []
+    const def: ComponentDef = {
+      name: 'DefBased',
+      init: (scope, props) => { initialized.push({ scope, props }) },
+      template: (props) => `<section>${props.label}</section>`,
+    }
+
+    render(container, def, { label: 'custom-node' })
+
+    expect(container.children.length).toBe(1)
+    expect(container.firstElementChild?.tagName.toLowerCase()).toBe('section')
+    expect(container.firstElementChild?.textContent).toBe('custom-node')
+    expect(initialized.length).toBe(1)
+    expect(initialized[0].props).toEqual({ label: 'custom-node' })
+  })
+
+  test('uses def.name as scope prefix', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const def: ComponentDef = {
+      name: 'MyScopedDef',
+      init: () => {},
+      template: () => `<div>x</div>`,
+    }
+
+    render(container, def)
+
+    const scope = container.firstElementChild?.getAttribute('bf-s') ?? ''
+    expect(scope.startsWith('MyScopedDef_')).toBe(true)
+  })
+
+  test('throws when ComponentDef has no template', () => {
+    const container = document.createElement('div')
+    const def: ComponentDef = { init: () => {} }
+
+    expect(() => render(container, def)).toThrow('requires a template function')
+  })
+
+  test('marks element in hydratedScopes after init', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const def: ComponentDef = {
+      init: () => {},
+      template: () => `<div>x</div>`,
+    }
+
+    render(container, def)
+
+    expect(hydratedScopes.has(container.firstElementChild!)).toBe(true)
+  })
+})
+
 describe('createComponent with ComponentDef', () => {
   beforeEach(() => {
     document.body.innerHTML = ''

--- a/packages/client/src/runtime/render.ts
+++ b/packages/client/src/runtime/render.ts
@@ -9,44 +9,64 @@
 import { BF_SCOPE } from '@barefootjs/shared'
 import { hydratedScopes } from './hydration-state'
 import { getComponentInit } from './registry'
-import { getTemplate } from './template'
+import { getTemplate, type TemplateFn } from './template'
+import type { ComponentDef, InitFn } from './types'
 
 /**
- * Render a registered component into a container element (CSR mode).
+ * Render a component into a container element (CSR mode).
  *
- * Looks up the component's init and template functions by name from
- * the registry, generates its DOM from the template, mounts it into
- * the container, and initializes it with the given props.
+ * Accepts either:
+ * - A registered component name (string) — looks up `init` and `template` from the registry
+ *   (the component must be registered first by importing its `.client.js` file).
+ * - A `ComponentDef` — uses the def's `init` and `template` directly, bypassing the registry.
  *
- * The component must be registered first by importing its `.client.js`
- * file (which calls `registerComponent` + `registerTemplate` internally).
- *
- * Unlike hydrate(), this function does not require pre-rendered HTML.
- * The container's content is replaced entirely.
+ * Generates DOM from the template, mounts it into the container, and initializes it
+ * with the given props. Unlike hydrate(), no pre-rendered HTML is required; the
+ * container's content is replaced entirely.
  *
  * @param container - Target DOM element to render into
- * @param componentName - Registered component name (e.g., 'Counter')
+ * @param nameOrDef - Registered component name or a ComponentDef
  * @param props - Props to pass to the component
  *
  * @example
- * import { render } from '@barefootjs/client'
+ * // By name (registry-based)
  * await import('/static/components/Counter.client.js')
- *
  * render(document.getElementById('app')!, 'Counter', { initialCount: 0 })
+ *
+ * @example
+ * // By ComponentDef (registry-free)
+ * render(container, { name: 'MyNode', init, template }, { id: 'n1' })
  */
 export function render(
   container: HTMLElement,
-  componentName: string,
+  nameOrDef: string | ComponentDef,
   props: Record<string, unknown> = {}
 ): void {
-  const init = getComponentInit(componentName)
-  const template = getTemplate(componentName)
+  let name: string
+  let init: InitFn | undefined
+  let template: TemplateFn | undefined
 
-  if (!init || !template) {
-    throw new Error(
-      `[BarefootJS] Component "${componentName}" is not registered. ` +
-      `Did you import its .client.js file before calling render()?`
-    )
+  if (typeof nameOrDef === 'string') {
+    name = nameOrDef
+    init = getComponentInit(name)
+    template = getTemplate(name)
+
+    if (!init || !template) {
+      throw new Error(
+        `[BarefootJS] Component "${name}" is not registered. ` +
+        `Did you import its .client.js file before calling render()?`
+      )
+    }
+  } else {
+    init = nameOrDef.init
+    template = nameOrDef.template
+    name = nameOrDef.name || init.name?.replace(/^init/, '') || 'Component'
+
+    if (!template) {
+      throw new Error(
+        '[BarefootJS] render(): ComponentDef requires a template function'
+      )
+    }
   }
 
   const html = template(props).trim()
@@ -61,7 +81,7 @@ export function render(
 
   if (!element.getAttribute(BF_SCOPE)) {
     const id = Math.random().toString(36).slice(2, 8)
-    element.setAttribute(BF_SCOPE, `${componentName}_${id}`)
+    element.setAttribute(BF_SCOPE, `${name}_${id}`)
   }
 
   container.innerHTML = ''

--- a/packages/xyflow/src/node-wrapper.ts
+++ b/packages/xyflow/src/node-wrapper.ts
@@ -11,7 +11,6 @@ import type {
   InternalNodeUpdate,
 } from '@xyflow/system'
 import { render } from '@barefootjs/client/runtime'
-import type { ComponentDef } from '@barefootjs/client/runtime'
 import { setupNodeSelection } from './selection'
 import { attachConnectionHandler } from './connection'
 import type { FlowStore, NodeComponentProps } from './types'
@@ -412,7 +411,7 @@ function renderNodeContent<NodeType extends NodeBase>(
       customType.call(contentEl, nodeProps)
     } else {
       // ComponentDef — render via CSR
-      render(contentEl, customType as ComponentDef, nodeProps as unknown as Record<string, unknown>)
+      render(contentEl, customType, nodeProps as unknown as Record<string, unknown>)
     }
 
     // Only add default handles if the custom component didn't create its own.


### PR DESCRIPTION
## Summary
- Extend `render()` in `@barefootjs/client/runtime` to accept `string | ComponentDef`, mirroring `createComponent()`. When given a `ComponentDef`, it uses the def's `init`/`template` directly and bypasses the registry.
- Drop the obsolete `as ComponentDef` cast and unused `ComponentDef` import in `packages/xyflow/src/node-wrapper.ts:414`.
- Add 4 tests covering the ComponentDef path (basic render, scope prefix from `def.name`, missing-template error, `hydratedScopes` registration).

Fixes the TS2345 reported in #893:
```
src/node-wrapper.ts(415,25): error TS2345: Argument of type 'ComponentDef' is not assignable to parameter of type 'string'.
```

Implements option 2 from the issue ("New API for direct ComponentDef") since xyflow's `nodeTypes` are passed directly as `ComponentDef` objects without name-based registration.

## Test plan
- [x] `bun test` in `packages/client` (209 pass)
- [x] `bun test src` in `packages/xyflow` (29 pass)
- [x] `bun run build` succeeds for `@barefootjs/client` and `@barefootjs/xyflow` without the TS2345 from #893
- [ ] CI green

Note: A separate pre-existing TS error in `edge-renderer.ts` was observed and filed as #895; it is unrelated to this change.