### PR TITLE
fix(xyflow): annotate EdgeComponentProps with EdgeType generic (closes #895)

### DIFF
--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -159,7 +159,7 @@ export function createEdgeRenderer<
         // Clear and re-render custom content
         group.innerHTML = ''
 
-        const edgeProps: EdgeComponentProps = {
+        const edgeProps: EdgeComponentProps<EdgeType> = {
           id: edge.id,
           source: edge.source,
           target: edge.target,
@@ -169,10 +169,10 @@ export function createEdgeRenderer<
           targetY: edgePos.targetY,
           sourcePosition: edgePos.sourcePosition,
           targetPosition: edgePos.targetPosition,
-          data: (edge as any).data,
+          data: edge.data,
           selected: !!edge.selected,
           animated: !!edge.animated,
-          label: (edge as any).label,
+          label: (edge as EdgeType & { label?: string }).label,
           svgGroup: group,
         }
 
@@ -365,7 +365,7 @@ export function createEdgeLabelRenderer<
       if (!pos) continue
 
       // Only render label if the edge has one
-      const labelText = (edge as any).label
+      const labelText = (edge as EdgeType & { label?: string }).label
       if (!labelText) {
         // No label — remove if previously existed
         const existing = labelElements.get(edge.id)


### PR DESCRIPTION
## Summary
- Annotate `edgeProps` in `edge-renderer.ts:162` with the `EdgeType` generic so it matches the `customEdgeType` parameter type.
- Drop `(edge as any).data` — `EdgeBase` already declares `data`, so the cast was unnecessary.
- Narrow the two `(edge as any).label` casts (lines 175, 368) to `EdgeType & { label?: string }`. `label` isn't on `EdgeBase` but may exist on user-supplied edge subtypes.

Fixes the TS2345 reported in #895:
```
src/edge-renderer.ts(179,24): error TS2345: Argument of type 'EdgeComponentProps' is not assignable to parameter of type 'EdgeComponentProps<EdgeType>'.
```

## Test plan
- [x] `bun run build` — full workspace build is now clean (no TS2345)
- [x] `bun test src` in `packages/xyflow` — 29 pass
- [x] `bun test` in `packages/client` — 209 pass
- [ ] CI green