### PR TITLE
feat(examples/hono): migrate to Cloudflare Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ out
 dist
 *.tgz
 
+# Cloudflare Workers artifacts
+examples/*/public
+examples/*/.wrangler
+
 # code coverage
 coverage
 *.lcov

--- a/examples/hono/barefoot.config.ts
+++ b/examples/hono/barefoot.config.ts
@@ -1,7 +1,15 @@
 import { createConfig } from '@barefootjs/hono/build'
 
+const basePath = process.env.BASE_PATH ?? '/examples/hono'
+const staticBase = `${basePath}/static/components/`
+
 export default createConfig({
   components: ['components', '../shared/components'],
   outDir: 'dist',
   minify: true,
+  scriptBasePath: staticBase,
+  adapterOptions: {
+    clientJsBasePath: staticBase,
+    barefootJsPath: `${staticBase}barefoot.js`,
+  },
 })

--- a/examples/hono/e2e/ai-chat.spec.ts
+++ b/examples/hono/e2e/ai-chat.spec.ts
@@ -4,7 +4,7 @@ test.describe('AI Chat (SSE Streaming)', () => {
   test.setTimeout(15000)
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/ai-chat')
+    await page.goto('/examples/hono/ai-chat')
   })
 
   test('shows chat input on load', async ({ page }) => {

--- a/examples/hono/e2e/conditional-return.spec.ts
+++ b/examples/hono/e2e/conditional-return.spec.ts
@@ -6,4 +6,4 @@
 
 import { conditionalReturnTests } from '../../shared/e2e/conditional-return.spec'
 
-conditionalReturnTests('http://localhost:3001')
+conditionalReturnTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/counter.spec.ts
+++ b/examples/hono/e2e/counter.spec.ts
@@ -6,4 +6,4 @@
 
 import { counterTests } from '../../shared/e2e/counter.spec'
 
-counterTests('http://localhost:3001')
+counterTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/form.spec.ts
+++ b/examples/hono/e2e/form.spec.ts
@@ -6,4 +6,4 @@
 
 import { formTests } from '../../shared/e2e/form.spec'
 
-formTests('http://localhost:3001')
+formTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/portal.spec.ts
+++ b/examples/hono/e2e/portal.spec.ts
@@ -6,4 +6,4 @@
 
 import { portalTests } from '../../shared/e2e/portal.spec'
 
-portalTests('http://localhost:3001')
+portalTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/reactive-props.spec.ts
+++ b/examples/hono/e2e/reactive-props.spec.ts
@@ -6,4 +6,4 @@
 
 import { reactivePropsTests } from '../../shared/e2e/reactive-props.spec'
 
-reactivePropsTests('http://localhost:3001')
+reactivePropsTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/todo-app-ssr.spec.ts
+++ b/examples/hono/e2e/todo-app-ssr.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3001', '/todos-ssr')
+todoAppTests('http://localhost:3001/examples/hono', '/todos-ssr')

--- a/examples/hono/e2e/todo-app.spec.ts
+++ b/examples/hono/e2e/todo-app.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3001')
+todoAppTests('http://localhost:3001/examples/hono')

--- a/examples/hono/e2e/toggle.spec.ts
+++ b/examples/hono/e2e/toggle.spec.ts
@@ -6,4 +6,4 @@
 
 import { toggleTests } from '../../shared/e2e/toggle.spec'
 
-toggleTests('http://localhost:3001')
+toggleTests('http://localhost:3001/examples/hono')

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -2,9 +2,10 @@
   "name": "barefootjs-hono-jsx-example",
   "version": "0.0.1",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-public.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
-    "dev": "bun run build && concurrently -n build,server -c cyan,green 'bun run build:watch' 'bun run --watch server.tsx'",
+    "dev": "bun run build && wrangler dev",
+    "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },
@@ -14,6 +15,7 @@
     "hono": "^4"
   },
   "devDependencies": {
-    "bun-types": "^1.1.0"
+    "bun-types": "^1.1.0",
+    "wrangler": "^3"
   }
 }

--- a/examples/hono/playwright.config.ts
+++ b/examples/hono/playwright.config.ts
@@ -20,9 +20,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'bun run server.tsx',
-    url: 'http://localhost:3001',
+    command: 'bun run build && bunx wrangler dev',
+    url: 'http://localhost:3001/examples/hono',
     reuseExistingServer: !process.env.CI,
-    timeout: 10000,
+    timeout: 30000,
   },
 })

--- a/examples/hono/renderer.tsx
+++ b/examples/hono/renderer.tsx
@@ -7,6 +7,7 @@
 
 import { jsxRenderer } from 'hono/jsx-renderer'
 import { BfScripts } from '../../packages/hono/src/scripts'
+import { BfDevReload } from '../../packages/hono/src/dev-reload'
 
 const BASE_PATH = process.env.BASE_PATH ?? '/examples/hono'
 
@@ -53,6 +54,7 @@ export const renderer = jsxRenderer(
         <body>
           {children}
           <BfScripts />
+          <BfDevReload endpoint={`${BASE_PATH}/_bf/reload`} />
         </body>
       </html>
     )

--- a/examples/hono/renderer.tsx
+++ b/examples/hono/renderer.tsx
@@ -7,13 +7,14 @@
 
 import { jsxRenderer } from 'hono/jsx-renderer'
 import { BfScripts } from '../../packages/hono/src/scripts'
-import { BfDevReload } from '../../packages/hono/src/dev'
+
+const BASE_PATH = process.env.BASE_PATH ?? '/examples/hono'
 
 // Import map for resolving @barefootjs/client in client JS
 const importMapScript = JSON.stringify({
   imports: {
-    '@barefootjs/client': '/static/components/barefoot.js',
-    '@barefootjs/client/runtime': '/static/components/barefoot.js',
+    '@barefootjs/client': `${BASE_PATH}/static/components/barefoot.js`,
+    '@barefootjs/client/runtime': `${BASE_PATH}/static/components/barefoot.js`,
   },
 })
 
@@ -26,9 +27,9 @@ export const renderer = jsxRenderer(
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>BarefootJS + Hono/JSX</title>
           <script type="importmap" dangerouslySetInnerHTML={{ __html: importMapScript }} />
-          <link rel="stylesheet" href="/shared/styles/components.css" />
-          <link rel="stylesheet" href="/shared/styles/todo-app.css" />
-          <link rel="stylesheet" href="/shared/styles/ai-chat.css" />
+          <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/components.css`} />
+          <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/todo-app.css`} />
+          <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/ai-chat.css`} />
           <style>{`
             body:not(:has(.todoapp)) {
               font-family: system-ui, sans-serif;
@@ -52,7 +53,6 @@ export const renderer = jsxRenderer(
         <body>
           {children}
           <BfScripts />
-          <BfDevReload />
         </body>
       </html>
     )

--- a/examples/hono/scripts/assemble-public.ts
+++ b/examples/hono/scripts/assemble-public.ts
@@ -1,0 +1,42 @@
+/**
+ * Assemble ./public/ for Cloudflare Workers Assets.
+ *
+ * Mirrors the URL layout expected by the Worker:
+ *   /examples/hono/static/components/*  ← dist/components/*.{js,map}
+ *   /examples/hono/shared/styles/*      ← ../shared/styles/*
+ */
+
+import { readdir, mkdir, copyFile, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+const BASE = '/examples/hono'
+const PUBLIC_DIR = join(ROOT, 'public')
+
+async function copyDir(src: string, destRel: string, filter?: (name: string) => boolean) {
+  const dest = join(PUBLIC_DIR, destRel)
+  await mkdir(dest, { recursive: true })
+  const entries = await readdir(src, { withFileTypes: true })
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (filter && !filter(e.name)) continue
+    await copyFile(join(src, e.name), join(dest, e.name))
+  }
+}
+
+await rm(PUBLIC_DIR, { recursive: true, force: true })
+
+await copyDir(
+  join(ROOT, 'dist/components'),
+  `${BASE}/static/components`,
+  (name) => name.endsWith('.js') || name.endsWith('.map') || name === 'manifest.json',
+)
+
+await copyDir(
+  join(ROOT, '../shared/styles'),
+  `${BASE}/shared/styles`,
+)
+
+console.log(`Assembled ./public${BASE}/`)

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Hono } from 'hono'
+import { createDevReloader } from '@barefootjs/hono/dev-worker'
 import { renderer } from './renderer'
 import Counter from '@/components/Counter'
 import Toggle from '@/components/Toggle'
@@ -23,6 +24,12 @@ const link = (path: string) => `${BASE_PATH}${path === '/' ? '' : path}`
 const app = new Hono().basePath(BASE_PATH)
 
 app.use(renderer)
+
+// Dev-only browser auto-reload. Detects Worker cold starts via a boot id
+// sent in SSE Last-Event-ID — a code change restarts the isolate, the
+// stream drops, the client reconnects, the boot id differs, reload fires.
+// No-op in production (NODE_ENV=production).
+app.get('/_bf/reload', createDevReloader())
 
 // In-memory todo storage. Workers isolates are ephemeral, so this resets
 // on cold start — acceptable for a demo.

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -1,13 +1,11 @@
 /**
- * BarefootJS + Hono/JSX SSR Server
+ * BarefootJS + Hono/JSX on Cloudflare Workers
  *
- * Uses hono/jsx with BarefootJS components.
- * Components are imported as JSX and rendered server-side.
+ * Static assets are served by Workers Assets (binding = ASSETS, directory = ./public).
+ * The Worker only handles SSR and API routes.
  */
 
 import { Hono } from 'hono'
-import { serveStatic } from 'hono/bun'
-import { createDevReloader } from '@barefootjs/hono/dev'
 import { renderer } from './renderer'
 import Counter from '@/components/Counter'
 import Toggle from '@/components/Toggle'
@@ -19,25 +17,15 @@ import PortalExample from '@/components/PortalExample'
 import ConditionalReturn from '@/components/ConditionalReturn'
 import { AIChatPage } from './components/AIChatPage'
 
-const app = new Hono()
+const BASE_PATH = process.env.BASE_PATH ?? '/examples/hono'
+const link = (path: string) => `${BASE_PATH}${path === '/' ? '' : path}`
+
+const app = new Hono().basePath(BASE_PATH)
 
 app.use(renderer)
 
-app.use('/static/*', serveStatic({
-  root: './dist',
-  rewriteRequestPath: (path) => path.replace('/static', ''),
-}))
-
-// Serve shared styles
-app.use('/shared/*', serveStatic({
-  root: '../shared',
-  rewriteRequestPath: (path) => path.replace('/shared', ''),
-}))
-
-// Dev-only browser auto-reload (no-op in production).
-app.get('/_bf/reload', createDevReloader({ distDir: './dist' }))
-
-// In-memory todo storage
+// In-memory todo storage. Workers isolates are ephemeral, so this resets
+// on cold start — acceptable for a demo.
 type Todo = { id: number; text: string; done: boolean }
 let todos: Todo[] = [
   { id: 1, text: 'Setup project', done: false },
@@ -46,18 +34,17 @@ let todos: Todo[] = [
 ]
 let nextId = 4
 
-// Pages - using JSX components directly
 app.get('/', (c) => {
   return c.render(
     <div>
       <h1>BarefootJS + Hono/JSX Examples</h1>
       <nav>
         <ul>
-          <li><a href="/counter">Counter</a></li>
-          <li><a href="/toggle">Toggle</a></li>
-          <li><a href="/todos">Todo (@client)</a></li>
-          <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
-          <li><a href="/ai-chat">AI Chat (SSE Streaming)</a></li>
+          <li><a href={link('/counter')}>Counter</a></li>
+          <li><a href={link('/toggle')}>Toggle</a></li>
+          <li><a href={link('/todos')}>Todo (@client)</a></li>
+          <li><a href={link('/todos-ssr')}>Todo (no @client markers)</a></li>
+          <li><a href={link('/ai-chat')}>AI Chat (SSE Streaming)</a></li>
         </ul>
       </nav>
     </div>
@@ -69,7 +56,7 @@ app.get('/counter', (c) => {
     <div>
       <h1>Counter Example</h1>
       <Counter />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
@@ -84,7 +71,7 @@ app.get('/toggle', (c) => {
     <div>
       <h1>Toggle Example</h1>
       <Toggle toggleItems={toggleItems} />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
@@ -93,7 +80,7 @@ app.get('/todos', (c) => {
   return c.render(
     <div id="app">
       <TodoApp initialTodos={todos} />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
@@ -102,63 +89,57 @@ app.get('/todos-ssr', (c) => {
   return c.render(
     <div id="app">
       <TodoAppSSR initialTodos={todos} />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// Reactive Props test page (verifies reactivity model from spec/compiler.md)
 app.get('/reactive-props', (c) => {
   return c.render(
     <div>
       <h1>Reactive Props Test</h1>
       <ReactiveProps />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// Props Reactivity Comparison test page
-// Demonstrates difference between props.xxx (reactive) and destructured (not reactive)
 app.get('/props-reactivity', (c) => {
   return c.render(
     <div>
       <h1>Props Reactivity Comparison</h1>
       <PropsReactivityComparison />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// Form example (checkbox + button interaction)
 app.get('/form', (c) => {
   return c.render(
     <div>
       <h1>Form Example</h1>
       <Form />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// Portal example
 app.get('/portal', (c) => {
   return c.render(
     <div>
       <h1>Portal Example</h1>
       <PortalExample />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// Conditional return (if/else JSX branches)
 app.get('/conditional-return', (c) => {
   return c.render(
     <div>
       <h1>Conditional Return Example</h1>
       <ConditionalReturn />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
@@ -168,18 +149,15 @@ app.get('/conditional-return-link', (c) => {
     <div>
       <h1>Conditional Return Example (Link)</h1>
       <ConditionalReturn variant="link" />
-      <p><a href="/">← Back</a></p>
+      <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
-// AI Chat with SSE streaming
 app.get('/ai-chat', (c) => {
   return c.render(<AIChatPage />)
 })
 
-// SSE endpoint: streams a dummy response token by token.
-// Replace this endpoint with a real LLM streaming API (e.g. OpenAI, Anthropic) for production use.
 const FAKE_RESPONSES = [
   '[Dummy response] This text is streaming one character at a time via Server-Sent Events. Replace /api/ai-chat in server.tsx with a real LLM API to make this chat functional.',
   '[Dummy response] BarefootJS streams tokens using the SSE protocol. Each character arrives as a separate "data:" event. Wire up OpenAI or Anthropic here for real AI responses.',
@@ -190,7 +168,7 @@ const FAKE_RESPONSES = [
 
 app.get('/api/ai-chat', () => {
   const text = FAKE_RESPONSES[Math.floor(Math.random() * FAKE_RESPONSES.length)]
-  const chars = [...text] // Unicode-safe split
+  const chars = [...text]
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -214,7 +192,6 @@ app.get('/api/ai-chat', () => {
   })
 })
 
-// REST API
 app.get('/api/todos', (c) => c.json(todos))
 
 app.post('/api/todos', async (c) => {
@@ -248,7 +225,6 @@ app.delete('/api/todos/:id', (c) => {
   return c.json({ success: true })
 })
 
-// Reset todos to initial state (for testing)
 app.post('/api/todos/reset', (c) => {
   todos = [
     { id: 1, text: 'Setup project', done: false },
@@ -259,4 +235,4 @@ app.post('/api/todos/reset', (c) => {
   return c.json({ success: true })
 })
 
-export default { port: 3001, fetch: app.fetch }
+export default app

--- a/examples/hono/wrangler.toml
+++ b/examples/hono/wrangler.toml
@@ -1,0 +1,18 @@
+name = "barefootjs-hono-example"
+main = "server.tsx"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+
+[[routes]]
+pattern = "barefootjs.dev/examples/hono/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/examples/hono"
+
+[dev]
+port = 3001

--- a/examples/shared/components/AIChatInteractive.tsx
+++ b/examples/shared/components/AIChatInteractive.tsx
@@ -34,7 +34,7 @@ export function AIChatInteractive() {
     setIsStreaming(true)
     setStreamingText('')
 
-    const es = new EventSource(`/api/ai-chat?q=${encodeURIComponent(trimmed)}`)
+    const es = new EventSource(`api/ai-chat?q=${encodeURIComponent(trimmed)}`)
 
     es.onmessage = (e) => {
       if (e.data === '[DONE]') {

--- a/examples/shared/components/TodoApp.tsx
+++ b/examples/shared/components/TodoApp.tsx
@@ -51,7 +51,7 @@ function TodoApp(props: Props) {
     if (!text) return
 
     try {
-      const res = await fetch('/api/todos', {
+      const res = await fetch('api/todos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
@@ -75,7 +75,7 @@ function TodoApp(props: Props) {
     if (!todo) return
 
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`api/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ done: !todo.done }),
@@ -89,7 +89,7 @@ function TodoApp(props: Props) {
 
   const handleDelete = async (id: number) => {
     try {
-      await fetch(`/api/todos/${id}`, { method: 'DELETE' })
+      await fetch(`api/todos/${id}`, { method: 'DELETE' })
       setTodos(todos().filter(t => t.id !== id))
     } catch (err) {
       console.error('Failed to delete todo:', err)
@@ -108,7 +108,7 @@ function TodoApp(props: Props) {
     }
 
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`api/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: trimmedText }),
@@ -124,7 +124,7 @@ function TodoApp(props: Props) {
     const completedTodos = todos().filter(t => t.done)
     for (const todo of completedTodos) {
       try {
-        await fetch(`/api/todos/${todo.id}`, { method: 'DELETE' })
+        await fetch(`api/todos/${todo.id}`, { method: 'DELETE' })
       } catch (err) {
         console.error('Failed to delete todo:', err)
       }
@@ -139,7 +139,7 @@ function TodoApp(props: Props) {
     for (const todo of todos()) {
       if (todo.done !== newDoneState) {
         try {
-          await fetch(`/api/todos/${todo.id}`, {
+          await fetch(`api/todos/${todo.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ done: newDoneState }),

--- a/examples/shared/components/TodoAppSSR.tsx
+++ b/examples/shared/components/TodoAppSSR.tsx
@@ -51,7 +51,7 @@ function TodoAppSSR(props: Props) {
     if (!text) return
 
     try {
-      const res = await fetch('/api/todos', {
+      const res = await fetch('api/todos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
@@ -75,7 +75,7 @@ function TodoAppSSR(props: Props) {
     if (!todo) return
 
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`api/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ done: !todo.done }),
@@ -89,7 +89,7 @@ function TodoAppSSR(props: Props) {
 
   const handleDelete = async (id: number) => {
     try {
-      await fetch(`/api/todos/${id}`, { method: 'DELETE' })
+      await fetch(`api/todos/${id}`, { method: 'DELETE' })
       setTodos(todos().filter(t => t.id !== id))
     } catch (err) {
       console.error('Failed to delete todo:', err)
@@ -108,7 +108,7 @@ function TodoAppSSR(props: Props) {
     }
 
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`api/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: trimmedText }),
@@ -124,7 +124,7 @@ function TodoAppSSR(props: Props) {
     const completedTodos = todos().filter(t => t.done)
     for (const todo of completedTodos) {
       try {
-        await fetch(`/api/todos/${todo.id}`, { method: 'DELETE' })
+        await fetch(`api/todos/${todo.id}`, { method: 'DELETE' })
       } catch (err) {
         console.error('Failed to delete todo:', err)
       }
@@ -139,7 +139,7 @@ function TodoAppSSR(props: Props) {
     for (const todo of todos()) {
       if (todo.done !== newDoneState) {
         try {
-          await fetch(`/api/todos/${todo.id}`, {
+          await fetch(`api/todos/${todo.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ done: newDoneState }),

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -435,4 +435,33 @@ export function ConditionalComponent(props: { variant: string }) {
       expect(scopeCommentCount).toBeGreaterThanOrEqual(2)
     })
   })
+
+  describe('script registration - asset paths', () => {
+    const source = `
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <div>{count()}</div>
+}
+`
+
+    test('defaults to /static/client/', () => {
+      const result = compileAndGenerate(source)
+      expect(result.template).toContain('{{.Scripts.Register "/static/client/barefoot.js"}}')
+      expect(result.template).toContain('{{.Scripts.Register "/static/client/Counter.client.js"}}')
+    })
+
+    test('honors clientJsBasePath and barefootJsPath options', () => {
+      const adapter = new GoTemplateAdapter({
+        clientJsBasePath: '/examples/echo/client/',
+        barefootJsPath: '/examples/echo/client/barefoot.js',
+      })
+      const result = compileAndGenerate(source, adapter)
+      expect(result.template).toContain('{{.Scripts.Register "/examples/echo/client/barefoot.js"}}')
+      expect(result.template).toContain('{{.Scripts.Register "/examples/echo/client/Counter.client.js"}}')
+      expect(result.template).not.toContain('/static/client/')
+    })
+  })
 })

--- a/packages/go-template/src/adapter/go-template-adapter.ts
+++ b/packages/go-template/src/adapter/go-template-adapter.ts
@@ -40,6 +40,17 @@ interface NestedComponentInfo extends IRLoopChildComponent {
 export interface GoTemplateAdapterOptions {
   /** Go package name for generated types (default: 'components') */
   packageName?: string
+
+  /**
+   * Base path for client JS files (e.g., '/static/client/').
+   * Used to generate script registration paths.
+   */
+  clientJsBasePath?: string
+
+  /**
+   * Path to barefoot.js runtime (e.g., '/static/client/barefoot.js').
+   */
+  barefootJsPath?: string
 }
 
 /**
@@ -76,6 +87,8 @@ export class GoTemplateAdapter extends BaseAdapter {
     super()
     this.options = {
       packageName: options.packageName ?? 'components',
+      clientJsBasePath: options.clientJsBasePath ?? '/static/client/',
+      barefootJsPath: options.barefootJsPath ?? '/static/client/barefoot.js',
     }
   }
 
@@ -236,12 +249,12 @@ export class GoTemplateAdapter extends BaseAdapter {
     const registrations: string[] = []
 
     // Register barefoot.js runtime first
-    registrations.push(`{{.Scripts.Register "/static/client/barefoot.js"}}`)
+    registrations.push(`{{.Scripts.Register "${this.options.barefootJsPath}"}}`)
 
     // Register this component's script
     // Use scriptBaseName if provided (for non-default exports sharing parent's .client.js)
     const scriptName = scriptBaseName || ir.metadata.componentName
-    registrations.push(`{{.Scripts.Register "/static/client/${scriptName}.client.js"}}`)
+    registrations.push(`{{.Scripts.Register "${this.options.clientJsBasePath}${scriptName}.client.js"}}`)
 
     // Wrap in nil check to safely handle cases where Scripts is not set
     return `{{if .Scripts}}${registrations.join('')}{{end}}\n`

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -38,6 +38,14 @@
       "types": "./src/dev.tsx",
       "import": "./src/dev.tsx"
     },
+    "./dev-reload": {
+      "types": "./src/dev-reload.tsx",
+      "import": "./src/dev-reload.tsx"
+    },
+    "./dev-worker": {
+      "types": "./src/dev-worker.ts",
+      "import": "./src/dev-worker.ts"
+    },
     "./jsx/jsx-runtime": {
       "types": "./src/jsx/jsx-runtime/index.d.ts",
       "import": "./src/jsx/jsx-runtime/index.ts"

--- a/packages/hono/src/dev-reload.tsx
+++ b/packages/hono/src/dev-reload.tsx
@@ -1,0 +1,53 @@
+/**
+ * BarefootJS Dev Reload client snippet (Workers-safe).
+ *
+ * Standalone module for the `<BfDevReload />` component so environments that
+ * can't load `node:fs` (Cloudflare Workers, Deno Deploy, edge runtimes) can
+ * still emit the browser-side reload script without pulling the Bun-backed
+ * server watcher from `./dev`.
+ *
+ * Pair with one of:
+ *   - `createDevReloader` from `@barefootjs/hono/dev`        (Bun + local fs)
+ *   - `createDevReloader` from `@barefootjs/hono/dev-worker` (Cloudflare Workers)
+ */
+
+/** @jsxImportSource hono/jsx */
+
+const SCROLL_STORAGE_KEY = '__bf_devreload_scroll'
+
+export interface BfDevReloadProps {
+  /** Override the dev gate. Defaults to `process.env.NODE_ENV !== 'production'`. */
+  enabled?: boolean
+  /** SSE endpoint registered with `createDevReloader`. Defaults to `/_bf/reload`. */
+  endpoint?: string
+}
+
+function isDevDefault(): boolean {
+  return process.env.NODE_ENV !== 'production'
+}
+
+function clientSnippet(endpoint: string, storageKey: string): string {
+  // Small IIFE: subscribes to SSE, preserves scrollY across reload, logs errors
+  // only. Intentionally dependency-free and idempotent across duplicate mounts.
+  return `(()=>{if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem(${JSON.stringify(
+    storageKey,
+  )});if(s){sessionStorage.removeItem(${JSON.stringify(
+    storageKey,
+  )});var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource(${JSON.stringify(
+    endpoint,
+  )});es.addEventListener('reload',function(){try{sessionStorage.setItem(${JSON.stringify(
+    storageKey,
+  )},String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){/* auto-reconnects */})})();`
+}
+
+/**
+ * Inline `<script>` that opens an EventSource to the reloader endpoint,
+ * reloads the page on `reload`, and preserves scrollY across reloads.
+ * Renders nothing in production.
+ */
+export function BfDevReload(props: BfDevReloadProps = {}) {
+  const { enabled = isDevDefault(), endpoint = '/_bf/reload' } = props
+  if (!enabled) return null
+  const snippet = clientSnippet(endpoint, SCROLL_STORAGE_KEY)
+  return <script dangerouslySetInnerHTML={{ __html: snippet }} />
+}

--- a/packages/hono/src/dev-worker.ts
+++ b/packages/hono/src/dev-worker.ts
@@ -1,0 +1,93 @@
+/**
+ * BarefootJS Dev Reloader for Cloudflare Workers / other edge runtimes.
+ *
+ * Unlike `./dev`'s `createDevReloader`, this variant does not watch the local
+ * filesystem — it generates a fresh boot ID on every cold start and relies on
+ * the standard SSE `Last-Event-ID` reconnection protocol to detect restarts:
+ *
+ *   1. First connect       → send `event: hello`, `id: <BOOT_ID>`.
+ *   2. Worker restart      → SSE stream drops, client reconnects with
+ *      `Last-Event-ID: <old BOOT_ID>`.
+ *   3. Server sees mismatch → send `event: reload`, client refreshes.
+ *
+ * Pair with `BfDevReload` from `@barefootjs/hono/dev-reload`.
+ */
+
+import type { Context } from 'hono'
+
+export interface CreateDevReloaderOptions {
+  /** Override the dev gate. Defaults to `process.env.NODE_ENV !== 'production'`. */
+  enabled?: boolean
+}
+
+const HEARTBEAT_MS = 5000
+
+// Generated once per Worker isolate. A cold start or code change rotates this,
+// which is exactly the signal we want to surface to the browser.
+const BOOT_ID = generateBootId()
+
+function generateBootId(): string {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return Date.now().toString(36) + Math.random().toString(36).slice(2, 10)
+  }
+}
+
+function isDevDefault(): boolean {
+  return process.env.NODE_ENV !== 'production'
+}
+
+/**
+ * Hono route handler that streams Server-Sent Events. Returns 404 in
+ * production (`NODE_ENV=production`) unless `enabled` is set explicitly.
+ */
+export function createDevReloader(
+  options: CreateDevReloaderOptions = {},
+): (c: Context) => Response | Promise<Response> {
+  const { enabled = isDevDefault() } = options
+
+  return (c: Context) => {
+    if (!enabled) return c.notFound()
+
+    const lastEventId = (c.req.header('Last-Event-ID') ?? '').trim()
+    const signal = c.req.raw.signal
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder()
+        const send = (chunk: string) => {
+          try {
+            controller.enqueue(encoder.encode(chunk))
+          } catch {
+            // Stream already closed (client disconnected).
+          }
+        }
+
+        send(`retry: 1000\n\n`)
+        // On reconnect with a different boot id, the Worker restarted (or was
+        // evicted from the isolate cache) while the client was disconnected —
+        // signal a reload so the browser picks up any new code + assets.
+        const event = lastEventId && lastEventId !== BOOT_ID ? 'reload' : 'hello'
+        send(`event: ${event}\nid: ${BOOT_ID}\ndata: ${BOOT_ID}\n\n`)
+
+        const heartbeat = setInterval(() => send(`: hb\n\n`), HEARTBEAT_MS)
+        const onAbort = () => {
+          clearInterval(heartbeat)
+          try { controller.close() } catch { /* already closed */ }
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener('abort', onAbort, { once: true })
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  }
+}

--- a/packages/hono/src/dev.tsx
+++ b/packages/hono/src/dev.tsx
@@ -24,11 +24,15 @@
  * explicitly enabled.
  */
 
-/** @jsxImportSource hono/jsx */
-
 import type { Context } from 'hono'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { resolve } from 'node:path'
+
+// Re-export BfDevReload from its dependency-free home so `import { BfDevReload }
+// from '@barefootjs/hono/dev'` keeps working for existing callers. Runtimes that
+// can't load node:fs (Workers, edge) should import it directly from
+// '@barefootjs/hono/dev-reload' to avoid pulling this file's fs imports.
+export { BfDevReload, type BfDevReloadProps } from './dev-reload'
 
 export interface CreateDevReloaderOptions {
   /** Directory that `barefoot build` writes output into (contains `.dev/build-id`). */
@@ -37,19 +41,11 @@ export interface CreateDevReloaderOptions {
   enabled?: boolean
 }
 
-export interface BfDevReloadProps {
-  /** Override the dev gate. Defaults to `process.env.NODE_ENV !== 'production'`. */
-  enabled?: boolean
-  /** SSE endpoint registered with `createDevReloader`. Defaults to `/_bf/reload`. */
-  endpoint?: string
-}
-
 // Sentinel path contract with `@barefootjs/cli`. These values must match
 // `DEV_SENTINEL_SUBDIR` / `DEV_SENTINEL_FILENAME` in `packages/cli/src/lib/build.ts`
 // — duplicated intentionally to avoid a runtime dep on the CLI.
 const DEV_SUBDIR = '.dev'
 const BUILD_ID_FILE = 'build-id'
-const SCROLL_STORAGE_KEY = '__bf_devreload_scroll'
 /**
  * Heartbeat interval for idle keepalive. Must stay comfortably under Bun's
  * default 10s idleTimeout — otherwise the server would close a quiet SSE
@@ -156,28 +152,3 @@ export function createDevReloader(
   }
 }
 
-function clientSnippet(endpoint: string, storageKey: string): string {
-  // Small IIFE: subscribes to SSE, preserves scrollY across reload, logs errors
-  // only. Intentionally dependency-free and idempotent across duplicate mounts.
-  return `(()=>{if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem(${JSON.stringify(
-    storageKey,
-  )});if(s){sessionStorage.removeItem(${JSON.stringify(
-    storageKey,
-  )});var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource(${JSON.stringify(
-    endpoint,
-  )});es.addEventListener('reload',function(){try{sessionStorage.setItem(${JSON.stringify(
-    storageKey,
-  )},String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){/* auto-reconnects */})})();`
-}
-
-/**
- * Inline `<script>` that opens an EventSource to the reloader endpoint,
- * reloads the page on `reload`, and preserves scrollY across reloads.
- * Renders nothing in production.
- */
-export function BfDevReload(props: BfDevReloadProps = {}) {
-  const { enabled = isDevDefault(), endpoint = '/_bf/reload' } = props
-  if (!enabled) return null
-  const snippet = clientSnippet(endpoint, SCROLL_STORAGE_KEY)
-  return <script dangerouslySetInnerHTML={{ __html: snippet }} />
-}


### PR DESCRIPTION
## Summary

- Switch the Hono example from Bun runtime to Cloudflare Workers so it can be deployed under `barefootjs.dev/examples/hono/*`. Static assets are served via the Workers Assets binding (`[assets]` in `wrangler.toml`), assembled into `./public` by a small build step.
- Introduce a `BASE_PATH` knob (defaults to `/examples/hono`) that threads through `barefoot.config.ts`, `renderer.tsx` (import map + CSS), and `server.tsx` (`app.basePath` + `link()` helper). Local E2E hit the same prefix via `wrangler dev`.
- Drop the leading slash on `fetch()` / `EventSource` URLs in shared Todo / AIChat components so the same client code resolves correctly under any mount path — root for the Echo / Mojolicious examples today, `/examples/hono` for the Worker.
- Mirror `clientJsBasePath` / `barefootJsPath` options onto the `go-template` adapter (defaults unchanged) so the upcoming Echo containerization PR can remap its asset paths the same way.

## Why

Preparing `barefootjs.dev/examples/{hono,echo,mojolicious}` hosting. This PR is the first in a 3-PR chain; Echo and Mojolicious will follow as Cloudflare Containers on top of this foundation.

## Test plan

- [x] `bun test packages/` — 1569 pass (1 pre-existing unrelated failure in `packages/xyflow/e2e/flow.spec.ts`, a Playwright spec picked up by `bun test`)
- [x] `bun run build` at repo root — clean
- [x] `bun run test:e2e` in `examples/hono` — 98 pass (Playwright launches `wrangler dev` on port 3001)
- [ ] Verify actual Cloudflare deploy once DNS/route is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)