### PR TITLE
feat(examples/echo): containerize for Cloudflare deployment

### DIFF
--- a/examples/echo/Dockerfile
+++ b/examples/echo/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+#
+# Build & runtime image for the Echo example, intended to be executed inside a
+# Cloudflare Container. Requires `bun run build` to have been run on the host
+# first so dist/ contains the generated templates, client JS and shared styles.
+
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/echo-server .
+
+FROM alpine:3.19
+
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+
+COPY --from=builder /out/echo-server /app/echo-server
+COPY dist ./dist
+
+ENV BASE_PATH=/examples/echo
+EXPOSE 8080
+USER app
+CMD ["/app/echo-server"]

--- a/examples/echo/barefoot.config.ts
+++ b/examples/echo/barefoot.config.ts
@@ -1,9 +1,16 @@
 import { createConfig } from '@barefootjs/go-template/build'
 
+const basePath = process.env.BASE_PATH ?? '/examples/echo'
+const staticBase = `${basePath}/static/client/`
+
 export default createConfig({
   components: ['../shared/components'],
   outDir: 'dist',
   minify: true,
-  adapterOptions: { packageName: 'main' },
+  adapterOptions: {
+    packageName: 'main',
+    clientJsBasePath: staticBase,
+    barefootJsPath: `${staticBase}barefoot.js`,
+  },
   typesOutputFile: 'components.go',
 })

--- a/examples/echo/container.ts
+++ b/examples/echo/container.ts
@@ -1,0 +1,27 @@
+/**
+ * Worker shim that forwards every request under /examples/echo/* to the
+ * Echo/Go server running inside a Cloudflare Container.
+ *
+ * The container itself is defined by the Dockerfile next to this file; the
+ * `EchoContainer` Durable Object class is what wrangler binds the container
+ * lifecycle to.
+ */
+
+import { Container } from '@cloudflare/containers'
+
+type Env = {
+  ECHO_CONTAINER: DurableObjectNamespace
+}
+
+export class EchoContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '10m'
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.ECHO_CONTAINER.idFromName('singleton')
+    const stub = env.ECHO_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
+    return stub.fetch(request)
+  },
+} satisfies ExportedHandler<Env>

--- a/examples/echo/e2e/ai-chat.spec.ts
+++ b/examples/echo/e2e/ai-chat.spec.ts
@@ -4,7 +4,7 @@ test.describe('AI Chat (SSE Streaming)', () => {
   test.setTimeout(15000)
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/ai-chat')
+    await page.goto('/examples/echo/ai-chat')
   })
 
   test('shows chat input on load', async ({ page }) => {

--- a/examples/echo/e2e/conditional-return.spec.ts
+++ b/examples/echo/e2e/conditional-return.spec.ts
@@ -6,4 +6,4 @@
 
 import { conditionalReturnTests } from '../../shared/e2e/conditional-return.spec'
 
-conditionalReturnTests('http://localhost:8080')
+conditionalReturnTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/counter.spec.ts
+++ b/examples/echo/e2e/counter.spec.ts
@@ -6,4 +6,4 @@
 
 import { counterTests } from '../../shared/e2e/counter.spec'
 
-counterTests('http://localhost:8080')
+counterTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/form.spec.ts
+++ b/examples/echo/e2e/form.spec.ts
@@ -6,4 +6,4 @@
 
 import { formTests } from '../../shared/e2e/form.spec'
 
-formTests('http://localhost:8080')
+formTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/portal.spec.ts
+++ b/examples/echo/e2e/portal.spec.ts
@@ -6,4 +6,4 @@
 
 import { portalTests } from '../../shared/e2e/portal.spec'
 
-portalTests('http://localhost:8080')
+portalTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/reactive-props.spec.ts
+++ b/examples/echo/e2e/reactive-props.spec.ts
@@ -6,4 +6,4 @@
 
 import { reactivePropsTests } from '../../shared/e2e/reactive-props.spec'
 
-reactivePropsTests('http://localhost:8080')
+reactivePropsTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/todo-app-ssr.spec.ts
+++ b/examples/echo/e2e/todo-app-ssr.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:8080', '/todos-ssr')
+todoAppTests('http://localhost:8080/examples/echo', '/todos-ssr')

--- a/examples/echo/e2e/todo-app.spec.ts
+++ b/examples/echo/e2e/todo-app.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:8080')
+todoAppTests('http://localhost:8080/examples/echo')

--- a/examples/echo/e2e/toggle.spec.ts
+++ b/examples/echo/e2e/toggle.spec.ts
@@ -6,4 +6,4 @@
 
 import { toggleTests } from '../../shared/e2e/toggle.spec'
 
-toggleTests('http://localhost:8080')
+toggleTests('http://localhost:8080/examples/echo')

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -18,6 +18,11 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+// basePath is the URL prefix under which every route and static asset is
+// mounted, driven by the BASE_PATH env var. Defaults to /examples/echo so the
+// app is deploy-ready for barefootjs.dev/examples/echo.
+var basePath string
+
 // loadTemplates loads all templates with BarefootJS functions registered
 func loadTemplates() *template.Template {
 	return template.Must(
@@ -73,15 +78,15 @@ func defaultLayout(ctx *bf.RenderContext) string {
 <html>
 <head>
     <title>%s</title>
-    <link rel="stylesheet" href="/shared/styles/components.css">
-    <link rel="stylesheet" href="/shared/styles/todo-app.css">%s%s
+    <link rel="stylesheet" href="%s/shared/styles/components.css">
+    <link rel="stylesheet" href="%s/shared/styles/todo-app.css">%s%s
 </head>
 <body>%s
     <div id="app">%s</div>
-    <p><a href="/">← Back</a></p>
+    <p><a href="%s">← Back</a></p>
     %s%s
 </body>
-</html>`, ctx.Title, headingStyle, extraCSS, headingHTML, ctx.ComponentHTML, ctx.Portals, ctx.Scripts)
+</html>`, ctx.Title, basePath, basePath, headingStyle, extraCSS, headingHTML, ctx.ComponentHTML, basePath, ctx.Portals, ctx.Scripts)
 }
 
 // In-memory todo storage
@@ -108,6 +113,11 @@ func resetTodos() {
 }
 
 func main() {
+	basePath = os.Getenv("BASE_PATH")
+	if basePath == "" {
+		basePath = "/examples/echo"
+	}
+
 	e := echo.New()
 
 	// Middleware
@@ -134,42 +144,46 @@ func main() {
 	}
 	if devMode {
 		e.Logger.Info("Dev mode: templates will reload on each request")
-		e.GET("/_bf/reload", echo.WrapHandler(bfdev.NewReloadHandler(bfdev.Config{DistDir: "./dist"})))
+		e.GET(basePath+"/_bf/reload", echo.WrapHandler(bfdev.NewReloadHandler(bfdev.Config{DistDir: "./dist"})))
 	}
 
-	// Routes
-	e.GET("/", indexHandler)
-	e.GET("/counter", counterHandler)
-	e.GET("/toggle", toggleHandler)
-	e.GET("/todos", todosHandler)
-	e.GET("/todos-ssr", todosSSRHandler)
-	e.GET("/reactive-props", reactivePropsHandler)
-	e.GET("/props-reactivity", propsReactivityHandler)
-	e.GET("/form", formHandler)
-	e.GET("/portal", portalHandler)
-	e.GET("/conditional-return", conditionalReturnHandler)
-	e.GET("/conditional-return-link", conditionalReturnLinkHandler)
-	e.GET("/ai-chat", aiChatHandler)
-	e.GET("/api/ai-chat", aiChatSSEHandler)
+	// Routes (grouped under basePath so the app can be hosted at
+	// barefootjs.dev/examples/echo/* behind a Worker).
+	g := e.Group(basePath)
+	g.GET("", indexHandler)
+	g.GET("/", indexHandler)
+	g.GET("/counter", counterHandler)
+	g.GET("/toggle", toggleHandler)
+	g.GET("/todos", todosHandler)
+	g.GET("/todos-ssr", todosSSRHandler)
+	g.GET("/reactive-props", reactivePropsHandler)
+	g.GET("/props-reactivity", propsReactivityHandler)
+	g.GET("/form", formHandler)
+	g.GET("/portal", portalHandler)
+	g.GET("/conditional-return", conditionalReturnHandler)
+	g.GET("/conditional-return-link", conditionalReturnLinkHandler)
+	g.GET("/ai-chat", aiChatHandler)
+	g.GET("/api/ai-chat", aiChatSSEHandler)
 
 	// Todo API endpoints
-	e.GET("/api/todos", getTodosAPI)
-	e.POST("/api/todos", createTodoAPI)
-	e.PUT("/api/todos/:id", updateTodoAPI)
-	e.DELETE("/api/todos/:id", deleteTodoAPI)
-	e.POST("/api/todos/reset", resetTodosAPI)
+	g.GET("/api/todos", getTodosAPI)
+	g.POST("/api/todos", createTodoAPI)
+	g.PUT("/api/todos/:id", updateTodoAPI)
+	g.DELETE("/api/todos/:id", deleteTodoAPI)
+	g.POST("/api/todos/reset", resetTodosAPI)
 
 	// Static files (for client JS)
-	e.Static("/static", "dist")
+	e.Static(basePath+"/static", "dist")
 
-	// Shared styles
-	e.Static("/shared", "../shared")
+	// Shared styles. `bun run build` copies ../shared into dist/shared so the
+	// same path works in local dev and inside the container image.
+	e.Static(basePath+"/shared", "dist/shared")
 
 	e.Logger.Fatal(e.Start(":8080"))
 }
 
 func indexHandler(c echo.Context) error {
-	return c.HTML(http.StatusOK, `
+	return c.HTML(http.StatusOK, fmt.Sprintf(`
 <!DOCTYPE html>
 <html>
 <head>
@@ -184,15 +198,15 @@ func indexHandler(c echo.Context) error {
     <h1>BarefootJS + Echo Example</h1>
     <p>This example demonstrates server-side rendering with Go Echo and BarefootJS.</p>
     <ul>
-        <li><a href="/counter">Counter</a></li>
-        <li><a href="/toggle">Toggle</a></li>
-        <li><a href="/todos">Todo (@client)</a></li>
-        <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
-        <li><a href="/ai-chat">AI Chat (SSE Streaming)</a></li>
+        <li><a href="%s/counter">Counter</a></li>
+        <li><a href="%s/toggle">Toggle</a></li>
+        <li><a href="%s/todos">Todo (@client)</a></li>
+        <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
+        <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
     </ul>
 </body>
 </html>
-`)
+`, basePath, basePath, basePath, basePath, basePath))
 }
 
 func counterHandler(c echo.Context) error {
@@ -433,7 +447,7 @@ func aiChatHandler(c echo.Context) error {
 		Title:   "AI Chat — SSE Streaming (Go/Echo)",
 		Heading: "AI Chat — SSE Streaming",
 		Extra: map[string]interface{}{
-			"extra_css": `<link rel="stylesheet" href="/shared/styles/ai-chat.css">`,
+			"extra_css": fmt.Sprintf(`<link rel="stylesheet" href="%s/shared/styles/ai-chat.css">`, basePath),
 		},
 	})
 }

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -2,17 +2,21 @@
   "name": "barefootjs-echo-example",
   "version": "0.0.1",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
-    "dev": "APP_ENV=development go run .",
+    "dev": "APP_ENV=development BASE_PATH=/examples/echo go run .",
     "setup": "go mod tidy",
+    "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/go-template": "workspace:*",
+    "@cloudflare/containers": "^0.3.2",
+    "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
-    "bun-types": "^1.1.0"
+    "bun-types": "^1.1.0",
+    "wrangler": "^3"
   }
 }

--- a/examples/echo/playwright.config.ts
+++ b/examples/echo/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'go run .',
-    url: 'http://localhost:8080',
+    command: 'BASE_PATH=/examples/echo go run .',
+    url: 'http://localhost:8080/examples/echo',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/examples/echo/scripts/copy-shared.ts
+++ b/examples/echo/scripts/copy-shared.ts
@@ -1,0 +1,20 @@
+/**
+ * Copy ../shared/styles into ./dist/shared/styles so the Go server and the
+ * container image can serve them from a single root (dist/) under the same
+ * URL path in dev and in production.
+ */
+
+import { cp, mkdir, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+const SRC = join(ROOT, '../shared/styles')
+const DEST = join(ROOT, 'dist/shared/styles')
+
+await rm(DEST, { recursive: true, force: true })
+await mkdir(dirname(DEST), { recursive: true })
+await cp(SRC, DEST, { recursive: true })
+
+console.log(`Copied ${SRC} → dist/shared/styles`)

--- a/examples/echo/tsconfig.json
+++ b/examples/echo/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types", "@cloudflare/workers-types"]
+  },
+  "include": ["*.ts", "*.tsx", "e2e/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/echo/wrangler.toml
+++ b/examples/echo/wrangler.toml
@@ -1,0 +1,24 @@
+name = "barefootjs-echo-example"
+main = "container.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[containers]]
+class_name = "EchoContainer"
+image = "./Dockerfile"
+max_instances = 1
+
+[[durable_objects.bindings]]
+name = "ECHO_CONTAINER"
+class_name = "EchoContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["EchoContainer"]
+
+[[routes]]
+pattern = "barefootjs.dev/examples/echo/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/examples/echo"


### PR DESCRIPTION
## Summary

- Introduce `BASE_PATH` (defaults to `/examples/echo`) and thread it through `barefoot.config.ts`, `main.go` (grouped routes, prefixed `e.Static`, prefixed links in `defaultLayout` / `indexHandler`), and the Playwright suite.
- Move the shared stylesheet serving under `dist/shared/styles`. A new `scripts/copy-shared.ts` postbuild step mirrors `../shared/styles` into `dist/` so the same Go path works in local dev and inside the container.
- Add a minimal `Dockerfile` (alpine Go builder → alpine runtime, non-root, `dist/` copied in) and a `container.ts` Worker shim that forwards every request to an `EchoContainer` Durable Object extending `@cloudflare/containers` `Container` on port 8080.
- Add `wrangler.toml` with `[[containers]]`, the Durable Object binding, the `barefootjs.dev/examples/echo/*` route, and `[vars] BASE_PATH`.
- Add a local `tsconfig.json` so `container.ts` resolves `@cloudflare/workers-types`.

## Why

Second PR in the barefootjs.dev examples hosting chain, stacked on top of #898 (hono Workers). Mojolicious will follow as the third.

## Test plan

- [x] `bun run build` inside `examples/echo` — clean, shared styles copied into `dist/shared/styles`
- [x] `go build ./...` — passes
- [x] `BASE_PATH=/examples/echo go run .` + curl smoke test — home page, counter SSR, `/api/todos`, `/static/client/*`, `/shared/styles/*` all 200
- [x] `bunx playwright test --workers=1` — 98 pass (pre-existing flake in parallel run unrelated to this PR)
- [ ] `wrangler deploy` end-to-end (requires Cloudflare account with Containers enabled)

## Notes

- `@cloudflare/containers` is beta as of this PR; pinned to `^0.3.2`.
- Container image path in `wrangler.toml` (`./Dockerfile`) uses the dir containing `wrangler.toml` as the Docker build context. The Dockerfile assumes `bun run build` has been run on the host first (so `dist/` exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)