### PR TITLE
feat(examples/mojolicious): containerize for Cloudflare deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 examples/*/public
 examples/*/.wrangler
 
+# Mojolicious example: staged BarefootJS Perl plugin copy
+examples/mojolicious/lib
+
 # code coverage
 coverage
 *.lcov

--- a/examples/mojolicious/Dockerfile
+++ b/examples/mojolicious/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+#
+# Build & runtime image for the Mojolicious example, intended to be executed
+# inside a Cloudflare Container. Requires `bun run build` to have been run on
+# the host first so dist/ (templates, client JS, styles) and lib/ (BarefootJS
+# Perl plugin) exist alongside app.pl.
+
+FROM perl:5.38-slim AS deps
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends make gcc libc-dev \
+ && rm -rf /var/lib/apt/lists/*
+RUN cpanm --notest Mojolicious
+
+FROM perl:5.38-slim
+RUN useradd -m -r -s /bin/false app
+WORKDIR /app
+
+COPY --from=deps /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=deps /usr/local/share/perl /usr/local/share/perl
+COPY --from=deps /usr/local/bin /usr/local/bin
+
+COPY app.pl ./
+COPY lib ./lib
+COPY dist ./dist
+
+ENV BASE_PATH=/examples/mojolicious
+ENV MOJO_MODE=production
+EXPOSE 8080
+USER app
+CMD ["perl", "app.pl", "daemon", "-l", "http://*:8080"]

--- a/examples/mojolicious/app.pl
+++ b/examples/mojolicious/app.pl
@@ -1,6 +1,9 @@
 #!/usr/bin/env perl
 use Mojolicious::Lite -signatures;
-use lib '../../packages/mojolicious/lib';
+# `lib` is populated by scripts/copy-plugin.pl at build time (used in the
+# container); `../../packages/mojolicious/lib` is the workspace source (used
+# in local dev). Both are listed so either location resolves.
+use lib 'lib', '../../packages/mojolicious/lib';
 use Mojo::JSON qw(true false encode_json);
 
 # Load BarefootJS plugin
@@ -10,10 +13,14 @@ plugin 'BarefootJS';
 # is emitted in the layout below via `bf_dev_snippet`.
 plugin 'BarefootJS::DevReload';
 
-# Serve static files (client JS, barefoot.js)
-app->static->paths->[0] = app->home->child('dist');
+# URL prefix the app is mounted under. Defaults to /examples/mojolicious so
+# the app is deploy-ready for barefootjs.dev/examples/mojolicious.
+my $BASE_PATH = $ENV{BASE_PATH} // '/examples/mojolicious';
+app->defaults(base_path => $BASE_PATH);
 
-# Serve shared styles
+# Static file roots: dist/ for generated client JS and templates; ../shared
+# for design-system stylesheets shared across all example backends.
+app->static->paths->[0] = app->home->child('dist');
 push @{app->static->paths}, app->home->child('../shared');
 
 # Template directory
@@ -108,11 +115,24 @@ helper render_component => sub ($c, $component, %opts) {
 };
 
 # ---------------------------------------------------------------------------
-# Routes
+# Routes (grouped under $BASE_PATH)
 # ---------------------------------------------------------------------------
 
-get '/' => sub ($c) {
-    $c->render(inline => <<~'HTML');
+my $r = app->routes->under($BASE_PATH);
+
+# Proxy static asset URLs that include the base-path prefix into the standard
+# static paths. Mojolicious's built-in static serving does not support URL
+# prefixes natively, so we forward /$BASE_PATH/client/* and
+# /$BASE_PATH/styles/* to reply->static.
+$r->get('/client/*asset' => sub ($c) {
+    $c->reply->static('client/' . ($c->stash('asset') // '')) or $c->reply->not_found;
+});
+$r->get('/styles/*asset' => sub ($c) {
+    $c->reply->static('styles/' . ($c->stash('asset') // '')) or $c->reply->not_found;
+});
+
+$r->get('/' => sub ($c) {
+    $c->render(inline => <<~HTML);
     <!DOCTYPE html>
     <html>
     <head>
@@ -127,18 +147,18 @@ get '/' => sub ($c) {
         <h1>BarefootJS + Mojolicious Example</h1>
         <p>This example demonstrates server-side rendering with Mojolicious and BarefootJS.</p>
         <ul>
-            <li><a href="/counter">Counter</a></li>
-            <li><a href="/toggle">Toggle</a></li>
-            <li><a href="/todos">Todo (@client)</a></li>
-            <li><a href="/todos-ssr">Todo (no @client markers)</a></li>
-            <li><a href="/ai-chat">AI Chat (SSE Streaming)</a></li>
+            <li><a href="$BASE_PATH/counter">Counter</a></li>
+            <li><a href="$BASE_PATH/toggle">Toggle</a></li>
+            <li><a href="$BASE_PATH/todos">Todo (\@client)</a></li>
+            <li><a href="$BASE_PATH/todos-ssr">Todo (no \@client markers)</a></li>
+            <li><a href="$BASE_PATH/ai-chat">AI Chat (SSE Streaming)</a></li>
         </ul>
     </body>
     </html>
     HTML
-};
+});
 
-get '/counter' => sub ($c) {
+$r->get('/counter' => sub ($c) {
     $c->render_component('Counter',
         props => { initial => 0 },
         stash => {
@@ -148,9 +168,9 @@ get '/counter' => sub ($c) {
         },
         heading => 'Counter Component',
     );
-};
+});
 
-get '/toggle' => sub ($c) {
+$r->get('/toggle' => sub ($c) {
     my $items = [
         { label => 'Setting 1', defaultOn => \1 },
         { label => 'Setting 2', defaultOn => \0 },
@@ -168,42 +188,42 @@ get '/toggle' => sub ($c) {
         stash => { toggleItems => $items },
         heading => 'Toggle Component',
     );
-};
+});
 
-get '/form' => sub ($c) {
+$r->get('/form' => sub ($c) {
     $c->render_component('Form',
         props   => {},
         stash   => { accepted => 0 },
         heading => 'Form Example',
     );
-};
+});
 
-get '/reactive-props' => sub ($c) {
+$r->get('/reactive-props' => sub ($c) {
     $c->render_component('ReactiveProps',
         children => { reactive_child => 'ReactiveChild' },
         props    => {},
         stash    => { count => 0, doubled => 0 },
         heading  => 'Reactive Props Test',
     );
-};
+});
 
-get '/conditional-return' => sub ($c) {
+$r->get('/conditional-return' => sub ($c) {
     $c->render_component('ConditionalReturn',
         props => { variant => '' },
         stash => { variant => '', count => 0 },
         heading => 'Conditional Return Example',
     );
-};
+});
 
-get '/conditional-return-link' => sub ($c) {
+$r->get('/conditional-return-link' => sub ($c) {
     $c->render_component('ConditionalReturn',
         props => { variant => 'link' },
         stash => { variant => 'link', count => 0 },
         heading => 'Conditional Return Example (Link)',
     );
-};
+});
 
-get '/todos' => sub ($c) {
+$r->get('/todos' => sub ($c) {
     my @current_todos = map { {%$_} } @todos;  # shallow copy
     my $done_count = scalar grep { $_->{done} } @current_todos;
 
@@ -217,9 +237,9 @@ get '/todos' => sub ($c) {
             doneCount => $done_count,
         },
     );
-};
+});
 
-get '/todos-ssr' => sub ($c) {
+$r->get('/todos-ssr' => sub ($c) {
     my @current_todos = map { {%$_} } @todos;
     my $done_count = scalar grep { $_->{done} } @current_todos;
 
@@ -233,9 +253,9 @@ get '/todos-ssr' => sub ($c) {
             doneCount => $done_count,
         },
     );
-};
+});
 
-get '/props-reactivity' => sub ($c) {
+$r->get('/props-reactivity' => sub ($c) {
     $c->render_component('PropsReactivityComparison',
         children => {
             props_style_child        => 'PropsStyleChild',
@@ -255,15 +275,15 @@ get '/props-reactivity' => sub ($c) {
         stash   => { count => 1 },
         heading => 'Props Reactivity Comparison',
     );
-};
+});
 
-get '/portal' => sub ($c) {
+$r->get('/portal' => sub ($c) {
     $c->render_component('PortalExample',
         props   => {},
         stash   => { open => 0 },
         heading => 'Portal Example',
     );
-};
+});
 
 # ---------------------------------------------------------------------------
 # AI Chat — SSE Streaming Example
@@ -277,7 +297,7 @@ my @ai_responses = (
     "[Dummy response] Out-of-Order Streaming SSR and interactive SSE streaming are two different features of BarefootJS.",
 );
 
-get '/ai-chat' => sub ($c) {
+$r->get('/ai-chat' => sub ($c) {
     $c->render_component('AIChatInteractive',
         title   => 'AI Chat — SSE Streaming (Mojolicious)',
         heading => 'AI Chat — SSE Streaming',
@@ -286,12 +306,12 @@ get '/ai-chat' => sub ($c) {
             input         => '',
             streamingText => '',
             isStreaming   => 0,
-            extra_css     => '<link rel="stylesheet" href="/styles/ai-chat.css">',
+            extra_css     => qq{<link rel="stylesheet" href="$BASE_PATH/styles/ai-chat.css">},
         },
     );
-};
+});
 
-get '/api/ai-chat' => sub ($c) {
+$r->get('/api/ai-chat' => sub ($c) {
     my $text = $ai_responses[int(rand(scalar @ai_responses))];
     my @chars = split //, $text;
 
@@ -312,17 +332,17 @@ get '/api/ai-chat' => sub ($c) {
             $c->write("data: [DONE]\n\n" => sub { $c->finish });
         }
     });
-};
+});
 
 # ---------------------------------------------------------------------------
 # Todo API
 # ---------------------------------------------------------------------------
 
-get '/api/todos' => sub ($c) {
+$r->get('/api/todos' => sub ($c) {
     $c->render(json => \@todos);
-};
+});
 
-post '/api/todos' => sub ($c) {
+$r->post('/api/todos' => sub ($c) {
     my $input = $c->req->json;
     my $todo = {
         id      => $next_id++,
@@ -332,9 +352,9 @@ post '/api/todos' => sub ($c) {
     };
     push @todos, $todo;
     $c->render(json => $todo, status => 201);
-};
+});
 
-put '/api/todos/:id' => sub ($c) {
+$r->put('/api/todos/:id' => sub ($c) {
     my $id = $c->param('id');
     my $input = $c->req->json;
     for my $todo (@todos) {
@@ -345,31 +365,32 @@ put '/api/todos/:id' => sub ($c) {
         }
     }
     $c->render(json => { error => 'not found' }, status => 404);
-};
+});
 
-del '/api/todos/:id' => sub ($c) {
+$r->delete('/api/todos/:id' => sub ($c) {
     my $id = $c->param('id');
     @todos = grep { $_->{id} != $id } @todos;
     $c->rendered(204);
-};
+});
 
-post '/api/todos/reset' => sub ($c) {
+$r->post('/api/todos/reset' => sub ($c) {
     reset_todos();
     $c->rendered(200);
-};
+});
 
 app->start;
 
 __DATA__
 
 @@ layouts/default.html.ep
+% my $bp = stash('base_path') // '';
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
     <title><%= $title %></title>
-    <link rel="stylesheet" href="/styles/components.css">
-    <link rel="stylesheet" href="/styles/todo-app.css">
+    <link rel="stylesheet" href="<%= $bp %>/styles/components.css">
+    <link rel="stylesheet" href="<%= $bp %>/styles/todo-app.css">
     % my $extra_css = stash('extra_css') // '';
     % if ($extra_css) {
     <%== $extra_css %>
@@ -385,7 +406,7 @@ __DATA__
     <h1><%= $heading %></h1>
     % }
     <div id="app"><%= content %></div>
-    <p><a href="/">← Back</a></p>
+    <p><a href="<%= $bp %>/">← Back</a></p>
     <%== bf->scripts %>
     <%== bf_dev_snippet %>
 </body>

--- a/examples/mojolicious/barefoot.config.ts
+++ b/examples/mojolicious/barefoot.config.ts
@@ -1,10 +1,13 @@
 import { createConfig } from '@barefootjs/mojolicious/build'
 
+const basePath = process.env.BASE_PATH ?? '/examples/mojolicious'
+const clientBase = `${basePath}/client/`
+
 export default createConfig({
   components: ['../shared/components'],
   outDir: 'dist',
   adapterOptions: {
-    clientJsBasePath: '/client/',
-    barefootJsPath: '/client/barefoot.js',
+    clientJsBasePath: clientBase,
+    barefootJsPath: `${clientBase}barefoot.js`,
   },
 })

--- a/examples/mojolicious/container.ts
+++ b/examples/mojolicious/container.ts
@@ -1,0 +1,23 @@
+/**
+ * Worker shim that forwards every request under /examples/mojolicious/* to
+ * the Mojolicious app running inside a Cloudflare Container.
+ */
+
+import { Container } from '@cloudflare/containers'
+
+type Env = {
+  MOJO_CONTAINER: DurableObjectNamespace
+}
+
+export class MojoContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '10m'
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.MOJO_CONTAINER.idFromName('singleton')
+    const stub = env.MOJO_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
+    return stub.fetch(request)
+  },
+} satisfies ExportedHandler<Env>

--- a/examples/mojolicious/e2e/ai-chat.spec.ts
+++ b/examples/mojolicious/e2e/ai-chat.spec.ts
@@ -4,7 +4,7 @@ test.describe('AI Chat (SSE Streaming)', () => {
   test.setTimeout(15000)
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/ai-chat')
+    await page.goto('/examples/mojolicious/ai-chat')
   })
 
   test('shows chat input on load', async ({ page }) => {

--- a/examples/mojolicious/e2e/conditional-return.spec.ts
+++ b/examples/mojolicious/e2e/conditional-return.spec.ts
@@ -6,4 +6,4 @@
 
 import { conditionalReturnTests } from '../../shared/e2e/conditional-return.spec'
 
-conditionalReturnTests('http://localhost:3004')
+conditionalReturnTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/counter.spec.ts
+++ b/examples/mojolicious/e2e/counter.spec.ts
@@ -6,4 +6,4 @@
 
 import { counterTests } from '../../shared/e2e/counter.spec'
 
-counterTests('http://localhost:3004')
+counterTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/form.spec.ts
+++ b/examples/mojolicious/e2e/form.spec.ts
@@ -6,4 +6,4 @@
 
 import { formTests } from '../../shared/e2e/form.spec'
 
-formTests('http://localhost:3004')
+formTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/portal.spec.ts
+++ b/examples/mojolicious/e2e/portal.spec.ts
@@ -6,4 +6,4 @@
 
 import { portalTests } from '../../shared/e2e/portal.spec'
 
-portalTests('http://localhost:3004')
+portalTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/reactive-props.spec.ts
+++ b/examples/mojolicious/e2e/reactive-props.spec.ts
@@ -6,4 +6,4 @@
 
 import { reactivePropsTests } from '../../shared/e2e/reactive-props.spec'
 
-reactivePropsTests('http://localhost:3004')
+reactivePropsTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/todo-app-ssr.spec.ts
+++ b/examples/mojolicious/e2e/todo-app-ssr.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3004', '/todos-ssr')
+todoAppTests('http://localhost:3004/examples/mojolicious', '/todos-ssr')

--- a/examples/mojolicious/e2e/todo-app.spec.ts
+++ b/examples/mojolicious/e2e/todo-app.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3004')
+todoAppTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/e2e/toggle.spec.ts
+++ b/examples/mojolicious/e2e/toggle.spec.ts
@@ -6,4 +6,4 @@
 
 import { toggleTests } from '../../shared/e2e/toggle.spec'
 
-toggleTests('http://localhost:3004')
+toggleTests('http://localhost:3004/examples/mojolicious')

--- a/examples/mojolicious/package.json
+++ b/examples/mojolicious/package.json
@@ -2,16 +2,20 @@
   "name": "barefootjs-mojolicious-example",
   "version": "0.0.1",
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-deps.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
-    "dev": "perl app.pl daemon -l 'http://*:3004'",
+    "dev": "BASE_PATH=/examples/mojolicious perl app.pl daemon -l 'http://*:3004'",
+    "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/mojolicious": "workspace:*",
+    "@cloudflare/containers": "^0.3.2",
+    "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
-    "bun-types": "^1.1.0"
+    "bun-types": "^1.1.0",
+    "wrangler": "^3"
   }
 }

--- a/examples/mojolicious/playwright.config.ts
+++ b/examples/mojolicious/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "perl app.pl daemon -l 'http://*:3004'",
-    url: 'http://localhost:3004',
+    command: "BASE_PATH=/examples/mojolicious perl app.pl daemon -l 'http://*:3004'",
+    url: 'http://localhost:3004/examples/mojolicious/',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/examples/mojolicious/scripts/assemble-deps.ts
+++ b/examples/mojolicious/scripts/assemble-deps.ts
@@ -1,0 +1,25 @@
+/**
+ * Post-build step that stages Perl sources and shared styles under the
+ * mojolicious example directory so the same layout works in local dev and
+ * inside the container image.
+ *
+ *   ./lib          ← packages/mojolicious/lib (BarefootJS Mojo plugin)
+ *   ./dist/styles  ← examples/shared/styles  (design-system stylesheets)
+ */
+
+import { cp, mkdir, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+
+async function mirror(src: string, dest: string) {
+  await rm(dest, { recursive: true, force: true })
+  await mkdir(dirname(dest), { recursive: true })
+  await cp(src, dest, { recursive: true })
+  console.log(`Copied ${src} → ${dest.replace(ROOT + '/', '')}`)
+}
+
+await mirror(join(ROOT, '../../packages/mojolicious/lib'), join(ROOT, 'lib'))
+await mirror(join(ROOT, '../shared/styles'), join(ROOT, 'dist/styles'))

--- a/examples/mojolicious/tsconfig.json
+++ b/examples/mojolicious/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types", "@cloudflare/workers-types"]
+  },
+  "include": ["*.ts", "*.tsx", "e2e/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist", "lib"]
+}

--- a/examples/mojolicious/wrangler.toml
+++ b/examples/mojolicious/wrangler.toml
@@ -1,0 +1,24 @@
+name = "barefootjs-mojolicious-example"
+main = "container.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[containers]]
+class_name = "MojoContainer"
+image = "./Dockerfile"
+max_instances = 1
+
+[[durable_objects.bindings]]
+name = "MOJO_CONTAINER"
+class_name = "MojoContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MojoContainer"]
+
+[[routes]]
+pattern = "barefootjs.dev/examples/mojolicious/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/examples/mojolicious"


### PR DESCRIPTION
## Summary

- Introduce `BASE_PATH` (defaults to `/examples/mojolicious`) and thread it through `barefoot.config.ts`, `app.pl` (routes grouped under `app->routes->under($BASE_PATH)`; `base_path` stash used by the layout template + inline index HTML), and the Playwright suite.
- Add two explicit static-forwarding routes (`/client/*asset`, `/styles/*asset`) inside the group so assets resolve correctly under the prefix — Mojolicious's built-in static serving has no URL-prefix support.
- Add `scripts/assemble-deps.ts` postbuild step that stages `packages/mojolicious/lib` into `./lib` and `examples/shared/styles` into `./dist/styles`, so the same paths work in dev and inside the container image. `use lib` in `app.pl` tries the local `lib/` first and falls back to `../../packages/mojolicious/lib`.
- Add a minimal `Dockerfile` (`perl:5.38-slim` + cpanm Mojolicious, runs as non-root, binds 0.0.0.0:8080) and a `container.ts` Worker shim exporting a `MojoContainer` Durable Object class extending `@cloudflare/containers` `Container` on port 8080.
- Add `wrangler.toml` with `[[containers]]`, the Durable Object binding, the `barefootjs.dev/examples/mojolicious/*` route, and `[vars] BASE_PATH`.
- Add a local `tsconfig.json` so `container.ts` resolves `@cloudflare/workers-types`.

## Why

Third and final PR in the barefootjs.dev examples hosting chain, stacked on top of #898 (hono Workers) and #899 (echo Container).

## Test plan

- [x] `bun run build` inside `examples/mojolicious` — clean, Perl plugin staged into `lib/`, shared styles staged into `dist/styles/`
- [x] `BASE_PATH=/examples/mojolicious perl app.pl daemon -l 'http://*:3004'` + curl smoke test — home, counter SSR, `/api/todos`, `/client/*`, `/styles/*` all 200
- [x] `bunx playwright test --workers=1` — 98 pass
- [ ] `wrangler deploy` end-to-end (requires Cloudflare account with Containers enabled)

## Notes

- `lib/` (staged Perl plugin) is gitignored; it is regenerated by `bun run build`.
- The Dockerfile assumes `bun run build` has been run on the host first (so `dist/` and `lib/` exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)