### PR TITLE
feat(site/core/playground): wire @barefootjs/hono/jsx types into Monaco

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -384,6 +384,43 @@ console.log('Generated: dist/playground/page.js (+ static copy)')
 // error reporting against @barefootjs/hono/jsx (used as the JSX source) and
 // @barefootjs/client (signals API).
 const PKG_DIR = resolve(ROOT_DIR, '../../packages')
+
+// Ensure @barefootjs/client has its .d.ts built (step 2 builds the runtime
+// JS if missing, but we also need the declarations here).
+const clientDtsFile = resolve(PKG_DIR, 'client/dist/index.d.ts')
+if (!(await Bun.file(clientDtsFile).exists())) {
+  console.log('Building @barefootjs/client declarations for playground types…')
+  const proc = Bun.spawn(['bun', 'run', 'build:types'], {
+    cwd: resolve(PKG_DIR, 'client'),
+  })
+  await proc.exited
+  if (!(await Bun.file(clientDtsFile).exists())) {
+    throw new Error(
+      'Failed to build @barefootjs/client declarations (dist/index.d.ts missing)',
+    )
+  }
+}
+
+// Minimal shims for the \`hono/jsx\` + \`hono/jsx/jsx-runtime\` modules the
+// @barefootjs/hono declarations reference. Without these Monaco would emit
+// "Cannot find module 'hono/jsx…'" diagnostics once semantic validation is
+// on. We only need the shapes used by the JSX namespace surface.
+const HONO_JSX_SHIM = `declare module 'hono/jsx' {
+  export namespace JSX {
+    type Element = unknown
+  }
+}
+`
+const HONO_JSX_RUNTIME_SHIM = `declare module 'hono/jsx/jsx-runtime' {
+  export const jsx: any
+  export const jsxs: any
+  export const Fragment: any
+  export const jsxAttr: any
+  export const jsxEscape: any
+  export const jsxTemplate: any
+}
+`
+
 const typeBundle: Record<string, string> = {
   'file:///node_modules/@barefootjs/hono/jsx/jsx-runtime/index.d.ts':
     await Bun.file(resolve(PKG_DIR, 'hono/src/jsx/jsx-runtime/index.d.ts')).text(),
@@ -392,16 +429,11 @@ const typeBundle: Record<string, string> = {
   'file:///node_modules/@barefootjs/jsx/html-types.d.ts':
     await Bun.file(resolve(PKG_DIR, 'jsx/src/html-types.ts')).text(),
   'file:///node_modules/@barefootjs/client/index.d.ts':
-    await Bun.file(resolve(PKG_DIR, 'client/dist/index.d.ts')).text(),
+    await Bun.file(clientDtsFile).text(),
+  'file:///node_modules/hono/jsx/index.d.ts': HONO_JSX_SHIM,
+  'file:///node_modules/hono/jsx/jsx-runtime/index.d.ts': HONO_JSX_RUNTIME_SHIM,
 }
-await Bun.write(
-  resolve(PLAYGROUND_DIST_DIR, 'types-bundle.json'),
-  JSON.stringify(typeBundle),
-)
-await Bun.write(
-  resolve(PLAYGROUND_STATIC_DIR, 'types-bundle.json'),
-  Bun.file(resolve(PLAYGROUND_DIST_DIR, 'types-bundle.json')),
-)
+await writePlaygroundAsset('types-bundle.json', new Blob([JSON.stringify(typeBundle)]))
 console.log('Generated: dist/playground/types-bundle.json (+ static copy)')
 
 // ── 9c. Write _headers for Cloudflare Workers static assets ──────

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -412,12 +412,16 @@ const HONO_JSX_SHIM = `declare module 'hono/jsx' {
 }
 `
 const HONO_JSX_RUNTIME_SHIM = `declare module 'hono/jsx/jsx-runtime' {
-  export const jsx: any
-  export const jsxs: any
-  export const Fragment: any
-  export const jsxAttr: any
-  export const jsxEscape: any
-  export const jsxTemplate: any
+  type Props = Record<string, unknown>
+  export function jsx(tag: string | Function, props: Props, key?: string): unknown
+  export const jsxs: typeof jsx
+  export function Fragment(props: { children?: unknown }): unknown
+  export function jsxAttr(name: string, value: unknown): string
+  export function jsxEscape(value: unknown): string
+  export function jsxTemplate(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): unknown
 }
 `
 

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -380,6 +380,30 @@ for (const output of playgroundPage.outputs) {
 }
 console.log('Generated: dist/playground/page.js (+ static copy)')
 
+// Type bundle for Monaco — gives the editor real autocomplete + accurate
+// error reporting against @barefootjs/hono/jsx (used as the JSX source) and
+// @barefootjs/client (signals API).
+const PKG_DIR = resolve(ROOT_DIR, '../../packages')
+const typeBundle: Record<string, string> = {
+  'file:///node_modules/@barefootjs/hono/jsx/jsx-runtime/index.d.ts':
+    await Bun.file(resolve(PKG_DIR, 'hono/src/jsx/jsx-runtime/index.d.ts')).text(),
+  'file:///node_modules/@barefootjs/jsx/jsx-runtime/index.d.ts':
+    await Bun.file(resolve(PKG_DIR, 'jsx/src/jsx-runtime/index.d.ts')).text(),
+  'file:///node_modules/@barefootjs/jsx/html-types.d.ts':
+    await Bun.file(resolve(PKG_DIR, 'jsx/src/html-types.ts')).text(),
+  'file:///node_modules/@barefootjs/client/index.d.ts':
+    await Bun.file(resolve(PKG_DIR, 'client/dist/index.d.ts')).text(),
+}
+await Bun.write(
+  resolve(PLAYGROUND_DIST_DIR, 'types-bundle.json'),
+  JSON.stringify(typeBundle),
+)
+await Bun.write(
+  resolve(PLAYGROUND_STATIC_DIR, 'types-bundle.json'),
+  Bun.file(resolve(PLAYGROUND_DIST_DIR, 'types-bundle.json')),
+)
+console.log('Generated: dist/playground/types-bundle.json (+ static copy)')
+
 // ── 9c. Write _headers for Cloudflare Workers static assets ──────
 // The playground iframe runs as `sandbox="allow-scripts"` (no
 // allow-same-origin), so its origin is opaque ("null"). When it imports

--- a/site/core/playground/page-script.ts
+++ b/site/core/playground/page-script.ts
@@ -184,14 +184,20 @@ async function main() {
   // editor so Monaco's TS service can resolve them on first parse.
   try {
     const res = await fetch('/static/playground/types-bundle.json')
-    if (res.ok) {
-      const bundle = (await res.json()) as Record<string, string>
-      for (const [path, contents] of Object.entries(bundle)) {
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(contents, path)
-      }
+    if (!res.ok) {
+      throw new Error(`types-bundle.json responded ${res.status}`)
     }
-  } catch {
-    // Non-fatal: editor still works, just without typed JSX.
+    const bundle = (await res.json()) as Record<string, string>
+    for (const [path, contents] of Object.entries(bundle)) {
+      monaco.languages.typescript.typescriptDefaults.addExtraLib(contents, path)
+    }
+  } catch (error) {
+    // Non-fatal: editor still works, just without typed JSX. Surface it so
+    // broken type loading is debuggable from the browser devtools.
+    console.warn(
+      'Failed to load playground type bundle; JSX typings may be unavailable.',
+      error,
+    )
   }
 
   monaco.languages.typescript.typescriptDefaults.setCompilerOptions({

--- a/site/core/playground/page-script.ts
+++ b/site/core/playground/page-script.ts
@@ -180,9 +180,48 @@ async function main() {
   statusEl.textContent = 'Loading editor…'
   const monaco = await loadMonaco()
 
+  // Load the BarefootJS type bundle (JSX + signals) before creating the
+  // editor so Monaco's TS service can resolve them on first parse.
+  try {
+    const res = await fetch('/static/playground/types-bundle.json')
+    if (res.ok) {
+      const bundle = (await res.json()) as Record<string, string>
+      for (const [path, contents] of Object.entries(bundle)) {
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(contents, path)
+      }
+    }
+  } catch {
+    // Non-fatal: editor still works, just without typed JSX.
+  }
+
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ESNext,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
+    jsxImportSource: '@barefootjs/hono/jsx',
+    allowNonTsExtensions: true,
+    allowJs: true,
+    noEmit: true,
+    isolatedModules: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+  })
+  monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+    noSemanticValidation: false,
+    noSyntaxValidation: false,
+    noSuggestionDiagnostics: true,
+  })
+
+  // Use a virtual .tsx URI so Monaco's TS service treats the buffer as TSX
+  // (otherwise JSX nodes get reported as syntax errors).
+  const model = monaco.editor.createModel(
+    window.PLAYGROUND_INITIAL_SOURCE,
+    'typescript',
+    monaco.Uri.parse('file:///playground/component.tsx'),
+  )
   const editor = monaco.editor.create(editorEl, {
-    value: window.PLAYGROUND_INITIAL_SOURCE,
-    language: 'typescript',
+    model,
     theme: matchMedia('(prefers-color-scheme: dark)').matches
       ? 'vs-dark'
       : 'vs',
@@ -191,19 +230,6 @@ async function main() {
     fontSize: 13,
     tabSize: 2,
     scrollBeyondLastLine: false,
-  })
-
-  // Let Monaco treat the buffer as TSX.
-  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-    jsx: monaco.languages.typescript.JsxEmit.Preserve,
-    target: monaco.languages.typescript.ScriptTarget.ESNext,
-    allowNonTsExtensions: true,
-    noEmit: true,
-  })
-  // Suppress cross-file diagnostics (we have no real project here).
-  monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
-    noSemanticValidation: true,
-    noSyntaxValidation: false,
   })
 
   statusEl.textContent = 'Starting compiler…'


### PR DESCRIPTION
## Summary

Fixes the type errors visible in the playground editor (`style={{...}}`, `onClick`, closing braces all underlined as errors).

Monaco was treating the buffer as plain TypeScript with no JSX namespace, so valid TSX got reported as syntax/type errors. This PR wires the editor up against the same JSX surface the project itself uses (`@barefootjs/hono/jsx`).

### Changes

- `build.ts` — bundle the `.d.ts` files Monaco needs into `dist/playground/types-bundle.json`:
  - `@barefootjs/hono/jsx/jsx-runtime` — JSX runtime + Element type
  - `@barefootjs/jsx/jsx-runtime` — `JSX.IntrinsicElements` namespace
  - `@barefootjs/jsx/html-types` — HTML attribute types referenced by the namespace
  - `@barefootjs/client` — `createSignal` / `createEffect` / etc.
- `page-script.ts`:
  - Fetch the bundle and register each entry via `monaco.languages.typescript.typescriptDefaults.addExtraLib()` at the expected `node_modules/...` paths
  - Set `jsxImportSource: '@barefootjs/hono/jsx'`, `jsx: ReactJSX`, `module: ESNext`, `moduleResolution: NodeJs`, `skipLibCheck: true`
  - Create the editor model with a `file:///playground/component.tsx` URI so the TS service enables JSX parsing
  - Re-enable semantic + syntax diagnostics

Bundle size: ~24 KB.

## Test plan

- [ ] `cd site/core && bun run build && PORT=3010 bun run dev`
- [ ] Open `http://localhost:3010/playground` — default Counter renders cleanly with no editor squigglies on `style`, `onClick`, closing braces.
- [ ] Hover `createSignal` → tooltip shows `Signal<T>` types from `@barefootjs/client`.
- [ ] Type a deliberate type error (e.g. `setCount('foo')`) → red squiggly appears with a real TS message.
- [ ] Component still compiles + previews live.

https://claude.ai/code/session_01PXSbW85Ci92xQRwAfTg6xt