### PR TITLE
feat(site/core/playground): add "Template" tab after Preview / IR / Client JS

### DIFF
--- a/site/core/playground/page-script.ts
+++ b/site/core/playground/page-script.ts
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-type Tab = 'preview' | 'ir' | 'clientJs'
+type Tab = 'preview' | 'ir' | 'clientJs' | 'template'
 
 const MONACO_CDN = 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs'
 
@@ -151,6 +151,7 @@ async function main() {
   ) as HTMLIFrameElement
   const irPanel = document.getElementById('pg-ir')!
   const clientJsPanel = document.getElementById('pg-clientjs')!
+  const templatePanel = document.getElementById('pg-template')!
   const statusEl = document.getElementById('pg-status')!
   const errorEl = document.getElementById('pg-error')!
   const tabButtons = document.querySelectorAll<HTMLButtonElement>(
@@ -160,6 +161,7 @@ async function main() {
     preview: document.getElementById('pg-tab-preview')!,
     ir: document.getElementById('pg-tab-ir')!,
     clientJs: document.getElementById('pg-tab-clientjs')!,
+    template: document.getElementById('pg-tab-template')!,
   }
 
   function setTab(tab: Tab) {
@@ -294,6 +296,7 @@ async function main() {
 
     clientJsPanel.textContent = msg.clientJs
     irPanel.textContent = JSON.stringify(msg.ir, null, 2)
+    templatePanel.textContent = msg.template ?? ''
 
     previewFrame.srcdoc = buildIframeSrcdoc({
       clientJs: msg.clientJs,

--- a/site/core/playground/routes.tsx
+++ b/site/core/playground/routes.tsx
@@ -79,10 +79,12 @@ export function createPlaygroundApp() {
         <button id="pg-tab-button-preview" class="pg-tab" data-pg-tab="preview" role="tab" aria-selected="true" aria-controls="pg-tab-preview">Preview</button>
         <button id="pg-tab-button-ir" class="pg-tab" data-pg-tab="ir" role="tab" aria-selected="false" aria-controls="pg-tab-ir">IR</button>
         <button id="pg-tab-button-clientjs" class="pg-tab" data-pg-tab="clientJs" role="tab" aria-selected="false" aria-controls="pg-tab-clientjs">Client JS</button>
+        <button id="pg-tab-button-template" class="pg-tab" data-pg-tab="template" role="tab" aria-selected="false" aria-controls="pg-tab-template">Template</button>
       </div>
       <div class="pg-tab-body" id="pg-tab-preview" role="tabpanel" aria-labelledby="pg-tab-button-preview"><iframe id="pg-preview" sandbox="allow-scripts" title="Preview"></iframe></div>
       <div class="pg-tab-body" id="pg-tab-ir" role="tabpanel" aria-labelledby="pg-tab-button-ir" hidden><pre id="pg-ir" class="pg-code"></pre></div>
       <div class="pg-tab-body" id="pg-tab-clientjs" role="tabpanel" aria-labelledby="pg-tab-button-clientjs" hidden><pre id="pg-clientjs" class="pg-code"></pre></div>
+      <div class="pg-tab-body" id="pg-tab-template" role="tabpanel" aria-labelledby="pg-tab-button-template" hidden><pre id="pg-template" class="pg-code"></pre></div>
     </section>
   </div>
   <pre id="pg-error" hidden></pre>

--- a/site/core/playground/worker.ts
+++ b/site/core/playground/worker.ts
@@ -16,6 +16,7 @@ import {
   listComponentFunctions,
   type ComponentIR,
 } from '@barefootjs/jsx'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
 
 type CompileRequest = {
   id: number
@@ -30,6 +31,7 @@ type CompileResponse =
       ok: true
       componentName: string
       clientJs: string
+      template: string
       ir: ComponentIR
       warnings: CompilerError[]
     }
@@ -40,6 +42,7 @@ type CompileResponse =
     }
 
 const VIRTUAL_PATH = '/playground/component.tsx'
+const adapter = new HonoAdapter()
 
 function compile(source: string): CompileResponse | null {
   const names = listComponentFunctions(source, VIRTUAL_PATH)
@@ -103,12 +106,21 @@ function compile(source: string): CompileResponse | null {
   componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
 
   const clientJs = generateClientJs(componentIR)
+  let template = ''
+  try {
+    template = adapter.generate(componentIR).template
+  } catch (err) {
+    template = `// Adapter failed to generate template: ${
+      err instanceof Error ? err.message : String(err)
+    }`
+  }
 
   return {
     id: 0,
     ok: true,
     componentName: entryName,
     clientJs,
+    template,
     ir: componentIR,
     warnings,
   }


### PR DESCRIPTION
## Summary

Adds a fourth tab **Template** to the playground (after Preview / IR / Client JS) showing the compiled Marked Template produced by `HonoAdapter`.

### Changes

- `worker.ts` — instantiate `HonoAdapter`, call `adapter.generate(ir)` after building Client JS, return the `template` string alongside existing fields. Wrapped in try/catch so an adapter failure doesn't hide the rest of the compile output.
- `routes.tsx` — fourth tab button + panel with matching `aria-controls` / `role="tabpanel"` wiring.
- `page-script.ts` — extend the `Tab` union, grab the new panel, write the template on every successful compile.

Smoke-tested locally with the default Counter; the tab shows the generated Hono JSX template (with `bfText` markers, scope attributes, etc.).

## Test plan

- [ ] `cd site/core && bun run build && PORT=3010 bun run dev`
- [ ] Open `/playground` — four tabs visible: Preview, IR, Client JS, Template (in that order).
- [ ] Template tab shows the `function Counter(...) { return <div bf-s=...>...</div> }` Hono JSX output.
- [ ] Editing the source re-renders all four tabs.
- [ ] Tab keyboard/screen-reader navigation still works (aria wiring preserved).

https://claude.ai/code/session_01PXSbW85Ci92xQRwAfTg6xt