### PR TITLE
feat(site): link to /playground from header + landing hero

### DIFF
--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -196,6 +196,12 @@ export async function Hero() {
               Get Started
             </a>
             <a
+              href="/playground"
+              className="btn-secondary"
+            >
+              Open Playground
+            </a>
+            <a
               href="https://github.com/barefootjs/barefootjs"
               className="btn-secondary"
             >

--- a/site/core/landing/renderer.tsx
+++ b/site/core/landing/renderer.tsx
@@ -73,7 +73,7 @@ export const landingRenderer = jsxRenderer(
             <link rel="stylesheet" href="/static/uno.css" />
           </head>
           <body>
-            <Header logoHref="/" coreHref="/docs/introduction" uiHref={uiHref} searchSlot={<SearchPlaceholder />} themeSwitcher={<ThemeSwitcher />} />
+            <Header logoHref="/" coreHref="/docs/introduction" uiHref={uiHref} playgroundHref="/playground" searchSlot={<SearchPlaceholder />} themeSwitcher={<ThemeSwitcher />} />
             <main>
               {children}
             </main>

--- a/site/core/renderer.tsx
+++ b/site/core/renderer.tsx
@@ -151,6 +151,7 @@ export const renderer = jsxRenderer(
               logoHref="/"
               coreHref="/docs/introduction"
               uiHref={uiHref}
+              playgroundHref="/playground"
               searchSlot={<SearchPlaceholder />}
               themeSwitcher={<ThemeSwitcher />}
             />

--- a/site/shared/components/header.tsx
+++ b/site/shared/components/header.tsx
@@ -10,10 +10,11 @@
 import { Logo } from './logo'
 
 export interface HeaderProps {
-  activePage?: 'core' | 'ui'
+  activePage?: 'core' | 'ui' | 'playground'
   logoHref?: string
   coreHref?: string
   uiHref?: string
+  playgroundHref?: string
   searchSlot?: any
   leftSlot?: any
   themeSwitcher?: any
@@ -32,17 +33,17 @@ export function Header({
   logoHref = 'https://barefootjs.dev',
   coreHref = 'https://barefootjs.dev/docs/introduction',
   uiHref = 'https://ui.barefootjs.dev',
+  playgroundHref = 'https://barefootjs.dev/playground',
   searchSlot,
   leftSlot,
   themeSwitcher,
 }: HeaderProps) {
-  const coreClass = activePage === 'core'
-    ? 'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-foreground'
-    : 'px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50'
-
-  const uiClass = activePage === 'ui'
-    ? 'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-foreground'
-    : 'px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline text-muted-foreground hover:text-foreground hover:bg-accent/50'
+  const navLinkBase = 'relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors no-underline'
+  const navLinkActive = `${navLinkBase} text-foreground`
+  const navLinkInactive = `${navLinkBase} text-muted-foreground hover:text-foreground hover:bg-accent/50`
+  const coreClass = activePage === 'core' ? navLinkActive : navLinkInactive
+  const uiClass = activePage === 'ui' ? navLinkActive : navLinkInactive
+  const playgroundClass = activePage === 'playground' ? navLinkActive : navLinkInactive
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 h-[var(--header-height)] bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
@@ -73,6 +74,12 @@ export function Header({
             <a href={uiHref} className={uiClass}>
               UI
               {activePage === 'ui' && (
+                <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full" style="background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end))" />
+              )}
+            </a>
+            <a href={playgroundHref} className={playgroundClass}>
+              Playground
+              {activePage === 'playground' && (
                 <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full" style="background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end))" />
               )}
             </a>


### PR DESCRIPTION
## Summary

Surfaces `/playground` in two places so visitors can discover it:

- **Header nav** — `Core / UI / Playground` across landing, docs, and the UI site (via the shared header). New optional `playgroundHref` prop on `<Header>` defaults to the production URL; the core renderers override it to `/playground` so the link stays same-origin.
- **Landing hero** — `Open Playground` as a secondary CTA between `Get Started` and `GitHub`.

## Test plan

- [ ] `cd site/core && bun run build && PORT=3010 bun run dev`
- [ ] `http://localhost:3010/` — hero shows three buttons; "Open Playground" navigates to `/playground`.
- [ ] Header nav on `/` and `/docs/*` shows Core / UI / Playground links.
- [ ] The UI site (`site/ui`) still builds and its header shows Playground pointing at the production URL.

https://claude.ai/code/session_01PXSbW85Ci92xQRwAfTg6xt