### PR TITLE
feat(site/core/landing): drop GitHub CTA from hero

### DIFF
--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -201,12 +201,6 @@ export async function Hero() {
             >
               Open Playground
             </a>
-            <a
-              href="https://github.com/barefootjs/barefootjs"
-              className="btn-secondary"
-            >
-              GitHub
-            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

On narrow viewports the three hero CTAs (Get Started / Open Playground / GitHub) wrapped and GitHub dropped to its own line, breaking the visual rhythm. GitHub is already reachable from the header icon, so drop it from the hero — leaves Get Started + Open Playground, which fit on one line on mobile.

## Test plan

- [ ] Landing page on a narrow viewport (≤ ~400 px) — CTAs stay on a single row.
- [ ] Header still has the GitHub icon.

https://claude.ai/code/session_01PXSbW85Ci92xQRwAfTg6xt