### PR TITLE
fix(examples/*): route /examples/<name> without trailing slash too

### DIFF
--- a/examples/echo/wrangler.toml
+++ b/examples/echo/wrangler.toml
@@ -16,6 +16,12 @@ class_name = "EchoContainer"
 tag = "v1"
 new_sqlite_classes = ["EchoContainer"]
 
+# Two patterns: `/examples/echo/*` matches /examples/echo/... but not the
+# bare /examples/echo, so add the no-slash variant explicitly.
+[[routes]]
+pattern = "barefootjs.dev/examples/echo"
+zone_name = "barefootjs.dev"
+
 [[routes]]
 pattern = "barefootjs.dev/examples/echo/*"
 zone_name = "barefootjs.dev"

--- a/examples/hono/wrangler.toml
+++ b/examples/hono/wrangler.toml
@@ -12,6 +12,14 @@ binding = "ASSETS"
 # because the Worker doesn't register those paths.
 run_worker_first = true
 
+# Two patterns because Cloudflare route globs do not match the "/*" suffix
+# as empty — `/examples/hono/*` matches /examples/hono/counter and
+# /examples/hono/, but not /examples/hono (no trailing slash), which is the
+# canonical URL served by Hono's `app.get('/')` under basePath.
+[[routes]]
+pattern = "barefootjs.dev/examples/hono"
+zone_name = "barefootjs.dev"
+
 [[routes]]
 pattern = "barefootjs.dev/examples/hono/*"
 zone_name = "barefootjs.dev"

--- a/examples/mojolicious/wrangler.toml
+++ b/examples/mojolicious/wrangler.toml
@@ -16,6 +16,13 @@ class_name = "MojoContainer"
 tag = "v1"
 new_sqlite_classes = ["MojoContainer"]
 
+# Two patterns: `/examples/mojolicious/*` matches /examples/mojolicious/...
+# but not the bare /examples/mojolicious, so add the no-slash variant
+# explicitly.
+[[routes]]
+pattern = "barefootjs.dev/examples/mojolicious"
+zone_name = "barefootjs.dev"
+
 [[routes]]
 pattern = "barefootjs.dev/examples/mojolicious/*"
 zone_name = "barefootjs.dev"


### PR DESCRIPTION
## Problem

After deploying the hono example to production, `https://barefootjs.dev/examples/hono` returns 404, while `https://barefootjs.dev/examples/hono/counter` works. Same latent issue for `/examples/echo` and `/examples/mojolicious`.

## Root cause

Cloudflare route globs do **not** treat the `/*` suffix as matching empty — `barefootjs.dev/examples/hono/*` matches `/examples/hono/` and `/examples/hono/counter`, but not the bare `/examples/hono`. Since each adapter's home handler is registered at the no-slash URL (Hono's `app.get('/')` under basePath, Echo's `g.GET("")`, Mojolicious's routes under `under($BASE_PATH)`), the canonical home URL was unreachable in production.

## Fix

Add a second `[[routes]]` entry without `/*` to each adapter's `wrangler.toml`:

```toml
[[routes]]
pattern = "barefootjs.dev/examples/hono"
zone_name = "barefootjs.dev"

[[routes]]
pattern = "barefootjs.dev/examples/hono/*"
zone_name = "barefootjs.dev"
```

The same edit is applied to `examples/echo` and `examples/mojolicious`.

## Test plan

- [ ] Redeploy each adapter (`wrangler deploy`) and verify `barefootjs.dev/examples/<adapter>` resolves to the adapter home page instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)