### PR TITLE
feat(examples): scope todo state per browser session

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"container/list"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -89,27 +92,101 @@ func defaultLayout(ctx *bf.RenderContext) string {
 </html>`, ctx.Title, basePath, basePath, headingStyle, extraCSS, headingHTML, ctx.ComponentHTML, basePath, ctx.Portals, ctx.Scripts)
 }
 
-// In-memory todo storage
-var (
-	todoMutex  sync.RWMutex
-	todoNextID = 4
-	todos      = []Todo{
-		{ID: 1, Text: "Setup project", Done: false, Editing: false},
-		{ID: 2, Text: "Create components", Done: false, Editing: false},
-		{ID: 3, Text: "Write tests", Done: true, Editing: false},
-	}
+// Per-session in-memory todo storage. Each browser gets an opaque session
+// id via a cookie scoped to basePath; sessionStore keys on that id so one
+// visitor's list is never visible to another. LRU-bounded to keep memory
+// usage predictable; oldest sessions get evicted past sessionStoreMax.
+const (
+	sessionCookieName = "bf_session"
+	sessionTTLSeconds = 60 * 60 * 24 * 30 // 30d
+	sessionStoreMax   = 1000
 )
 
-// Reset todos to initial state (for testing)
-func resetTodos() {
-	todoMutex.Lock()
-	defer todoMutex.Unlock()
-	todoNextID = 4
-	todos = []Todo{
+type sessionState struct {
+	mu     sync.Mutex
+	todos  []Todo
+	nextID int
+}
+
+type sessionStoreT struct {
+	mu    sync.Mutex
+	items map[string]*list.Element // session id → list element holding (id, state)
+	order *list.List               // front = most recent, back = least recent
+}
+
+type sessionEntry struct {
+	id    string
+	state *sessionState
+}
+
+var sessionStore = &sessionStoreT{
+	items: make(map[string]*list.Element),
+	order: list.New(),
+}
+
+func seedTodos() []Todo {
+	return []Todo{
 		{ID: 1, Text: "Setup project", Done: false, Editing: false},
 		{ID: 2, Text: "Create components", Done: false, Editing: false},
 		{ID: 3, Text: "Write tests", Done: true, Editing: false},
 	}
+}
+
+func newSessionID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// getSession returns the per-session todo state for the caller, creating a
+// new session (and setting the cookie) if none exists yet.
+func getSession(c echo.Context) *sessionState {
+	var id string
+	if ck, err := c.Cookie(sessionCookieName); err == nil && ck.Value != "" {
+		id = ck.Value
+	} else {
+		newID, err := newSessionID()
+		if err != nil {
+			// Fall back to a process-local deterministic id on error; bad
+			// luck for the caller but avoids 500.
+			newID = fmt.Sprintf("fallback-%d", time.Now().UnixNano())
+		}
+		id = newID
+		c.SetCookie(&http.Cookie{
+			Name:     sessionCookieName,
+			Value:    id,
+			Path:     basePath,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   sessionTTLSeconds,
+		})
+	}
+
+	sessionStore.mu.Lock()
+	defer sessionStore.mu.Unlock()
+
+	if elem, ok := sessionStore.items[id]; ok {
+		sessionStore.order.MoveToFront(elem)
+		return elem.Value.(*sessionEntry).state
+	}
+
+	state := &sessionState{todos: seedTodos(), nextID: 4}
+	elem := sessionStore.order.PushFront(&sessionEntry{id: id, state: state})
+	sessionStore.items[id] = elem
+
+	// Evict least-recently-used sessions if we're over capacity.
+	for sessionStore.order.Len() > sessionStoreMax {
+		oldest := sessionStore.order.Back()
+		if oldest == nil {
+			break
+		}
+		sessionStore.order.Remove(oldest)
+		delete(sessionStore.items, oldest.Value.(*sessionEntry).id)
+	}
+
+	return state
 }
 
 func main() {
@@ -236,10 +313,11 @@ func toggleHandler(c echo.Context) error {
 }
 
 func todosHandler(c echo.Context) error {
-	todoMutex.RLock()
-	currentTodos := make([]Todo, len(todos))
-	copy(currentTodos, todos)
-	todoMutex.RUnlock()
+	state := getSession(c)
+	state.mu.Lock()
+	currentTodos := make([]Todo, len(state.todos))
+	copy(currentTodos, state.todos)
+	state.mu.Unlock()
 
 	// Build TodoItemProps array with ScopeID for each item
 	todoItems := make([]TodoItemProps, len(currentTodos))
@@ -318,10 +396,11 @@ func conditionalReturnLinkHandler(c echo.Context) error {
 }
 
 func todosSSRHandler(c echo.Context) error {
-	todoMutex.RLock()
-	currentTodos := make([]Todo, len(todos))
-	copy(currentTodos, todos)
-	todoMutex.RUnlock()
+	state := getSession(c)
+	state.mu.Lock()
+	currentTodos := make([]Todo, len(state.todos))
+	copy(currentTodos, state.todos)
+	state.mu.Unlock()
 
 	// Build TodoItemProps array with ScopeID for each item
 	todoItems := make([]TodoItemProps, len(currentTodos))
@@ -347,9 +426,10 @@ func todosSSRHandler(c echo.Context) error {
 
 // Todo API handlers
 func getTodosAPI(c echo.Context) error {
-	todoMutex.RLock()
-	defer todoMutex.RUnlock()
-	return c.JSON(http.StatusOK, todos)
+	state := getSession(c)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return c.JSON(http.StatusOK, state.todos)
 }
 
 func createTodoAPI(c echo.Context) error {
@@ -360,15 +440,16 @@ func createTodoAPI(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid input"})
 	}
 
-	todoMutex.Lock()
+	state := getSession(c)
+	state.mu.Lock()
 	newTodo := Todo{
-		ID:   todoNextID,
+		ID:   state.nextID,
 		Text: input.Text,
 		Done: false,
 	}
-	todoNextID++
-	todos = append(todos, newTodo)
-	todoMutex.Unlock()
+	state.nextID++
+	state.todos = append(state.todos, newTodo)
+	state.mu.Unlock()
 
 	return c.JSON(http.StatusCreated, newTodo)
 }
@@ -387,18 +468,19 @@ func updateTodoAPI(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid input"})
 	}
 
-	todoMutex.Lock()
-	defer todoMutex.Unlock()
+	state := getSession(c)
+	state.mu.Lock()
+	defer state.mu.Unlock()
 
-	for i, todo := range todos {
+	for i, todo := range state.todos {
 		if todo.ID == id {
 			if input.Text != nil {
-				todos[i].Text = *input.Text
+				state.todos[i].Text = *input.Text
 			}
 			if input.Done != nil {
-				todos[i].Done = *input.Done
+				state.todos[i].Done = *input.Done
 			}
-			return c.JSON(http.StatusOK, todos[i])
+			return c.JSON(http.StatusOK, state.todos[i])
 		}
 	}
 
@@ -411,12 +493,13 @@ func deleteTodoAPI(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid id"})
 	}
 
-	todoMutex.Lock()
-	defer todoMutex.Unlock()
+	state := getSession(c)
+	state.mu.Lock()
+	defer state.mu.Unlock()
 
-	for i, todo := range todos {
+	for i, todo := range state.todos {
 		if todo.ID == id {
-			todos = append(todos[:i], todos[i+1:]...)
+			state.todos = append(state.todos[:i], state.todos[i+1:]...)
 			return c.NoContent(http.StatusNoContent)
 		}
 	}
@@ -425,7 +508,11 @@ func deleteTodoAPI(c echo.Context) error {
 }
 
 func resetTodosAPI(c echo.Context) error {
-	resetTodos()
+	state := getSession(c)
+	state.mu.Lock()
+	state.todos = seedTodos()
+	state.nextID = 4
+	state.mu.Unlock()
 	return c.NoContent(http.StatusOK)
 }
 

--- a/examples/hono/server.tsx
+++ b/examples/hono/server.tsx
@@ -6,6 +6,8 @@
  */
 
 import { Hono } from 'hono'
+import type { Context } from 'hono'
+import { getCookie, setCookie } from 'hono/cookie'
 import { createDevReloader } from '@barefootjs/hono/dev-worker'
 import { renderer } from './renderer'
 import Counter from '@/components/Counter'
@@ -35,15 +37,68 @@ app.use(renderer)
 // No-op in production (NODE_ENV=production).
 app.get('/_bf/reload', createDevReloader())
 
-// In-memory todo storage. Workers isolates are ephemeral, so this resets
-// on cold start — acceptable for a demo.
+// Per-session in-memory todo storage. Each browser gets an opaque session
+// id via a cookie scoped to BASE_PATH; the map is keyed by that id so one
+// visitor's list is never visible to another. Workers isolates are
+// ephemeral, so every cold start resets all sessions — acceptable for a
+// demo and also a cheap way to evict stale data.
 type Todo = { id: number; text: string; done: boolean }
-let todos: Todo[] = [
-  { id: 1, text: 'Setup project', done: false },
-  { id: 2, text: 'Create components', done: false },
-  { id: 3, text: 'Write tests', done: true },
-]
-let nextId = 4
+type SessionState = { todos: Todo[]; nextId: number }
+
+const SESSION_COOKIE = 'bf_session'
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30 // 30d
+const MAX_SESSIONS = 1000
+
+const sessions = new Map<string, SessionState>()
+
+function seedTodos(): Todo[] {
+  return [
+    { id: 1, text: 'Setup project', done: false },
+    { id: 2, text: 'Create components', done: false },
+    { id: 3, text: 'Write tests', done: true },
+  ]
+}
+
+function seedSession(): SessionState {
+  return { todos: seedTodos(), nextId: 4 }
+}
+
+function touchLRU(id: string, state: SessionState) {
+  // Re-insert so Map iteration order reflects recency; the first key is
+  // always the least-recently-used session.
+  sessions.delete(id)
+  sessions.set(id, state)
+}
+
+function evictIfNeeded() {
+  while (sessions.size > MAX_SESSIONS) {
+    const oldest = sessions.keys().next().value
+    if (oldest === undefined) break
+    sessions.delete(oldest)
+  }
+}
+
+function getSession(c: Context): SessionState {
+  let id = getCookie(c, SESSION_COOKIE)
+  if (!id) {
+    id = crypto.randomUUID()
+    setCookie(c, SESSION_COOKIE, id, {
+      path: BASE_PATH,
+      httpOnly: true,
+      sameSite: 'Lax',
+      maxAge: SESSION_TTL_SECONDS,
+    })
+  }
+  let state = sessions.get(id)
+  if (!state) {
+    state = seedSession()
+    sessions.set(id, state)
+    evictIfNeeded()
+  } else {
+    touchLRU(id, state)
+  }
+  return state
+}
 
 app.get('/', (c) => {
   return c.render(
@@ -89,18 +144,20 @@ app.get('/toggle', (c) => {
 })
 
 app.get('/todos', (c) => {
+  const session = getSession(c)
   return c.render(
     <div id="app">
-      <TodoApp initialTodos={todos} />
+      <TodoApp initialTodos={session.todos} />
       <p><a href={link('/')}>← Back</a></p>
     </div>
   )
 })
 
 app.get('/todos-ssr', (c) => {
+  const session = getSession(c)
   return c.render(
     <div id="app">
-      <TodoAppSSR initialTodos={todos} />
+      <TodoAppSSR initialTodos={session.todos} />
       <p><a href={link('/')}>← Back</a></p>
     </div>
   )
@@ -204,12 +261,13 @@ app.get('/api/ai-chat', () => {
   })
 })
 
-app.get('/api/todos', (c) => c.json(todos))
+app.get('/api/todos', (c) => c.json(getSession(c).todos))
 
 app.post('/api/todos', async (c) => {
+  const session = getSession(c)
   const body = await c.req.json()
-  const newTodo: Todo = { id: nextId++, text: body.text, done: false }
-  todos.push(newTodo)
+  const newTodo: Todo = { id: session.nextId++, text: body.text, done: false }
+  session.todos.push(newTodo)
   return c.json(newTodo, 201)
 })
 
@@ -217,8 +275,9 @@ app.put('/api/todos/:id', async (c) => {
   const id = parseInt(c.req.param('id'), 10)
   if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400)
 
+  const session = getSession(c)
   const body = await c.req.json()
-  const todo = todos.find(t => t.id === id)
+  const todo = session.todos.find(t => t.id === id)
   if (!todo) return c.json({ error: 'Todo not found' }, 404)
 
   if (body.text !== undefined) todo.text = body.text
@@ -230,20 +289,18 @@ app.delete('/api/todos/:id', (c) => {
   const id = parseInt(c.req.param('id'), 10)
   if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400)
 
-  const index = todos.findIndex(t => t.id === id)
+  const session = getSession(c)
+  const index = session.todos.findIndex(t => t.id === id)
   if (index === -1) return c.json({ error: 'Todo not found' }, 404)
 
-  todos.splice(index, 1)
+  session.todos.splice(index, 1)
   return c.json({ success: true })
 })
 
 app.post('/api/todos/reset', (c) => {
-  todos = [
-    { id: 1, text: 'Setup project', done: false },
-    { id: 2, text: 'Create components', done: false },
-    { id: 3, text: 'Write tests', done: true },
-  ]
-  nextId = 4
+  const session = getSession(c)
+  session.todos = seedTodos()
+  session.nextId = 4
   return c.json({ success: true })
 })
 

--- a/examples/mojolicious/app.pl
+++ b/examples/mojolicious/app.pl
@@ -36,23 +36,73 @@ if (app->mode eq 'development') {
 }
 
 # ---------------------------------------------------------------------------
-# In-memory todo storage
+# Per-session in-memory todo storage
+#
+# Each browser gets an opaque session id via a cookie scoped to $BASE_PATH;
+# %sessions keys on that id so one visitor's list is never visible to
+# another. LRU-bounded so memory usage stays predictable.
 # ---------------------------------------------------------------------------
 
-my @todos = (
-    { id => 1, text => 'Setup project',     done => false, editing => false },
-    { id => 2, text => 'Create components', done => false, editing => false },
-    { id => 3, text => 'Write tests',       done => true,  editing => false },
-);
-my $next_id = 4;
+use constant {
+    SESSION_COOKIE     => 'bf_session',
+    SESSION_TTL_SEC    => 60 * 60 * 24 * 30, # 30d
+    SESSION_STORE_MAX  => 1000,
+};
 
-sub reset_todos {
-    @todos = (
+my %sessions;          # id => { todos => [...], next_id => N }
+my @session_order;     # ids in access order, oldest at index 0
+
+sub seed_todos {
+    return [
         { id => 1, text => 'Setup project',     done => false, editing => false },
         { id => 2, text => 'Create components', done => false, editing => false },
         { id => 3, text => 'Write tests',       done => true,  editing => false },
-    );
-    $next_id = 4;
+    ];
+}
+
+sub new_session_id {
+    # 16 bytes of /dev/urandom, hex-encoded (32 chars). Fall back to a
+    # time+rand combo if urandom is unavailable — good enough for a demo.
+    if (open my $fh, '<:raw', '/dev/urandom') {
+        read $fh, my $bytes, 16;
+        close $fh;
+        return unpack 'H*', $bytes if length $bytes == 16;
+    }
+    return sprintf '%d-%d', time, int(rand(2 ** 31));
+}
+
+sub get_session ($c) {
+    my $id = $c->cookie(SESSION_COOKIE);
+    unless (defined $id && length $id && exists $sessions{$id}) {
+        unless (defined $id && length $id) {
+            $id = new_session_id();
+            $c->cookie(
+                SESSION_COOKIE,
+                $id,
+                {
+                    path     => $BASE_PATH,
+                    httponly => 1,
+                    samesite => 'Lax',
+                    max_age  => SESSION_TTL_SEC,
+                },
+            );
+        }
+        if (!exists $sessions{$id}) {
+            $sessions{$id} = { todos => seed_todos(), next_id => 4 };
+            push @session_order, $id;
+            # Evict oldest if over capacity.
+            while (scalar @session_order > SESSION_STORE_MAX) {
+                my $oldest = shift @session_order;
+                delete $sessions{$oldest};
+            }
+        }
+    }
+    else {
+        # Touch LRU: move to back of access order.
+        @session_order = grep { $_ ne $id } @session_order;
+        push @session_order, $id;
+    }
+    return $sessions{$id};
 }
 
 # ---------------------------------------------------------------------------
@@ -227,7 +277,8 @@ $r->get('/conditional-return-link' => sub ($c) {
 });
 
 $r->get('/todos' => sub ($c) {
-    my @current_todos = map { {%$_} } @todos;  # shallow copy
+    my $session = get_session($c);
+    my @current_todos = map { {%$_} } @{ $session->{todos} };  # shallow copy
     my $done_count = scalar grep { $_->{done} } @current_todos;
 
     $c->render_component('TodoApp',
@@ -243,7 +294,8 @@ $r->get('/todos' => sub ($c) {
 });
 
 $r->get('/todos-ssr' => sub ($c) {
-    my @current_todos = map { {%$_} } @todos;
+    my $session = get_session($c);
+    my @current_todos = map { {%$_} } @{ $session->{todos} };
     my $done_count = scalar grep { $_->{done} } @current_todos;
 
     $c->render_component('TodoAppSSR',
@@ -342,25 +394,28 @@ $r->get('/api/ai-chat' => sub ($c) {
 # ---------------------------------------------------------------------------
 
 $r->get('/api/todos' => sub ($c) {
-    $c->render(json => \@todos);
+    my $session = get_session($c);
+    $c->render(json => $session->{todos});
 });
 
 $r->post('/api/todos' => sub ($c) {
+    my $session = get_session($c);
     my $input = $c->req->json;
     my $todo = {
-        id      => $next_id++,
+        id      => $session->{next_id}++,
         text    => $input->{text},
         done    => false,
         editing => false,
     };
-    push @todos, $todo;
+    push @{ $session->{todos} }, $todo;
     $c->render(json => $todo, status => 201);
 });
 
 $r->put('/api/todos/:id' => sub ($c) {
+    my $session = get_session($c);
     my $id = $c->param('id');
     my $input = $c->req->json;
-    for my $todo (@todos) {
+    for my $todo (@{ $session->{todos} }) {
         if ($todo->{id} == $id) {
             $todo->{text} = $input->{text} if exists $input->{text};
             $todo->{done} = $input->{done} ? true : false if exists $input->{done};
@@ -371,13 +426,16 @@ $r->put('/api/todos/:id' => sub ($c) {
 });
 
 $r->delete('/api/todos/:id' => sub ($c) {
+    my $session = get_session($c);
     my $id = $c->param('id');
-    @todos = grep { $_->{id} != $id } @todos;
+    $session->{todos} = [ grep { $_->{id} != $id } @{ $session->{todos} } ];
     $c->rendered(204);
 });
 
 $r->post('/api/todos/reset' => sub ($c) {
-    reset_todos();
+    my $session = get_session($c);
+    $session->{todos}   = seed_todos();
+    $session->{next_id} = 4;
     $c->rendered(200);
 });
 

--- a/examples/shared/e2e/todo-app.spec.ts
+++ b/examples/shared/e2e/todo-app.spec.ts
@@ -19,9 +19,12 @@ export function todoAppTests(baseUrl: string, todosPath: string = '/todos') {
     // Increase timeout for TodoApp tests (hydration can take time)
     test.setTimeout(30000)
 
-    test.beforeEach(async ({ page, request }) => {
-      // Reset server state before each test
-      await request.post(`${baseUrl}/api/todos/reset`)
+    test.beforeEach(async ({ page }) => {
+      // Reset server state before each test. Use `page.request` (not the
+      // standalone `request` fixture) so the reset POST shares cookies —
+      // and therefore the per-session todo list — with the page navigation
+      // that follows.
+      await page.request.post(`${baseUrl}/api/todos/reset`)
       await page.goto(`${baseUrl}${todosPath}`)
       // Wait for todoapp to be loaded
       await page.waitForSelector('.todoapp')
@@ -167,9 +170,9 @@ export function todoAppTests(baseUrl: string, todosPath: string = '/todos') {
       await expect(page.locator('.todo-list li').first()).toContainText('Write tests')
     })
 
-    test('filters on direct URL access - #/active', async ({ page, request }) => {
-      // Reset server state
-      await request.post(`${baseUrl}/api/todos/reset`)
+    test('filters on direct URL access - #/active', async ({ page }) => {
+      // Reset server state (page-bound request shares the session cookie)
+      await page.request.post(`${baseUrl}/api/todos/reset`)
 
       // Navigate directly to /todos#/active
       await page.goto(`${baseUrl}${todosPath}#/active`)
@@ -187,9 +190,9 @@ export function todoAppTests(baseUrl: string, todosPath: string = '/todos') {
       await expect(page.locator('.todo-list li')).not.toContainText(['Write tests'])
     })
 
-    test('filters on direct URL access - #/completed', async ({ page, request }) => {
-      // Reset server state
-      await request.post(`${baseUrl}/api/todos/reset`)
+    test('filters on direct URL access - #/completed', async ({ page }) => {
+      // Reset server state (page-bound request shares the session cookie)
+      await page.request.post(`${baseUrl}/api/todos/reset`)
 
       // Navigate directly to /todos#/completed
       await page.goto(`${baseUrl}${todosPath}#/completed`)


### PR DESCRIPTION
## Problem

The three adapter todo demos shared a single in-memory todo list across every visitor, so anything anyone typed — including offensive content — was visible to the next person who loaded `/examples/<adapter>/todos`.

## Solution

Scope the store by an opaque session cookie. One visitor's list is never visible to another. No database added.

- Cookie `bf_session` (HttpOnly, SameSite=Lax, Path=`$BASE_PATH`, 30d max-age), generated on first request.
- `Map<sessionId, { todos, nextId }>` per adapter, bounded by a 1000-entry LRU so memory usage stays predictable.
- All SSR pages and `/api/todos*` endpoints read and mutate only the caller's session state.
- `/api/todos/reset` now resets only the caller's list. (A panic button still exists implicitly: restarting any Worker / Go process / Mojolicious daemon clears everything.)

## Per-adapter details

- **hono/server.tsx** — `hono/cookie` helpers, `Map` with insertion-order LRU, `getSession(c)`.
- **echo/main.go** — `crypto/rand` for ids, `container/list` for true LRU ordering, per-session `sync.Mutex`. Drops the old global `todoMutex`.
- **mojolicious/app.pl** — `/dev/urandom` (falling back to `time + rand`) for ids, `%sessions` + `@session_order` LRU, `get_session($c)` helper.

## E2E

- `examples/shared/e2e/todo-app.spec.ts` switches from Playwright's standalone `request` fixture to `page.request`. Without this, the reset POST lands on a different session than the page's browser cookies, so tests leak state across cases.

## Test plan

- [x] Manual cookie-jar curl against each adapter: session A adds a todo, session B (fresh jar) doesn't see it.
- [x] `bunx playwright test --workers=1 --retries=2` for hono — 98 pass
- [x] Same for echo — 98 pass
- [x] Same for mojolicious — 98 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)