### PR TITLE
fix(examples/echo): unblock wrangler deploy

### DIFF
--- a/examples/echo/Dockerfile
+++ b/examples/echo/Dockerfile
@@ -3,15 +3,30 @@
 # Build & runtime image for the Echo example, intended to be executed inside a
 # Cloudflare Container. Requires `bun run build` to have been run on the host
 # first so dist/ contains the generated templates, client JS and shared styles.
+#
+# Build context is the repo root (see `image_build_context` in wrangler.toml),
+# so paths below are relative to the repository root.
 
-FROM golang:1.23-alpine AS builder
+# Run the Go toolchain natively on the builder host and cross-compile to the
+# target platform. Avoids QEMU emulation, which segfaults the Go compiler when
+# building linux/amd64 on arm64 hosts (Apple Silicon).
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 WORKDIR /src
-COPY go.mod go.sum ./
+
+# Mirror the repo layout inside the image so the `replace` directive in
+# examples/echo/go.mod (`../../packages/go-template/runtime`) resolves.
+COPY packages/go-template/runtime ./packages/go-template/runtime
+COPY examples/echo/go.mod examples/echo/go.sum ./examples/echo/
+
+WORKDIR /src/examples/echo
 RUN go mod download
 
-COPY *.go ./
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/echo-server .
+COPY examples/echo/*.go ./
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/echo-server .
 
 FROM alpine:3.19
 
@@ -19,7 +34,7 @@ RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 
 COPY --from=builder /out/echo-server /app/echo-server
-COPY dist ./dist
+COPY examples/echo/dist ./dist
 
 ENV BASE_PATH=/examples/echo
 EXPOSE 8080

--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -17,6 +17,6 @@
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
-    "wrangler": "^3"
+    "wrangler": "^4"
   }
 }

--- a/examples/echo/wrangler.toml
+++ b/examples/echo/wrangler.toml
@@ -6,6 +6,9 @@ compatibility_flags = ["nodejs_compat"]
 [[containers]]
 class_name = "EchoContainer"
 image = "./Dockerfile"
+# Build from the repo root so the go.mod `replace` directive pointing at
+# ../../packages/go-template/runtime can resolve inside the image.
+image_build_context = "../.."
 max_instances = 1
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
## Summary

`bun run deploy` in `examples/echo` failed with:

```
✘ [ERROR] Processing wrangler.toml configuration:
    - "containers" should be an object, but got an array
```

Root cause was a stale `wrangler ^3` pin; `[[containers]]` (array form) and Cloudflare Containers deployment require wrangler v4. Bumping the dep surfaced a few cascading Dockerfile issues that were also fixed:

- **wrangler 3 → 4** in `examples/echo/package.json` — unlocks the `[[containers]]` schema.
- **`golang:1.23-alpine` → `golang:1.25-alpine`** — `go.mod` requires `go 1.25.6`.
- **`image_build_context = "../.."`** in `wrangler.toml` + Dockerfile paths rewritten from the repo root — so the `replace ../../packages/go-template/runtime` directive in `go.mod` resolves inside the build context.
- **`--platform=$BUILDPLATFORM` + `GOOS`/`GOARCH` cross-compile** — the Go compiler segfaulted under QEMU when building `linux/amd64` from arm64 (Apple Silicon). Running the toolchain natively and cross-compiling avoids emulation entirely.

`examples/mojolicious` has the same `[[containers]]` error but an unrelated Dockerfile bug of its own; left for a follow-up PR.

## Test plan

- [x] `wrangler deploy --dry-run` completes and produces an image locally
- [x] `bun run build` at repo root succeeds
- [x] `bun run test` — no new failures (1 pre-existing playwright failure in `packages/xyflow/e2e/flow.spec.ts` also present on `main`)
- [ ] Real `bun run deploy` against Cloudflare (owner to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)