### PR TITLE
fix(examples/mojolicious): unblock wrangler deploy

### DIFF
--- a/examples/mojolicious/Dockerfile
+++ b/examples/mojolicious/Dockerfile
@@ -9,15 +9,17 @@ FROM perl:5.38-slim AS deps
 RUN apt-get update \
  && apt-get install -y --no-install-recommends make gcc libc-dev \
  && rm -rf /var/lib/apt/lists/*
-RUN cpanm --notest Mojolicious
+# Install CPAN deps into a self-contained prefix so the runtime stage can copy
+# a single directory instead of guessing which /usr/local/... paths exist.
+RUN cpanm --notest --local-lib=/opt/perl-deps Mojolicious
 
 FROM perl:5.38-slim
 RUN useradd -m -r -s /bin/false app
 WORKDIR /app
 
-COPY --from=deps /usr/local/lib/perl5 /usr/local/lib/perl5
-COPY --from=deps /usr/local/share/perl /usr/local/share/perl
-COPY --from=deps /usr/local/bin /usr/local/bin
+COPY --from=deps /opt/perl-deps /opt/perl-deps
+ENV PERL5LIB=/opt/perl-deps/lib/perl5
+ENV PATH=/opt/perl-deps/bin:$PATH
 
 COPY app.pl ./
 COPY lib ./lib

--- a/examples/mojolicious/package.json
+++ b/examples/mojolicious/package.json
@@ -16,6 +16,6 @@
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
-    "wrangler": "^3"
+    "wrangler": "^4"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #911 for the Mojolicious example. `bun run deploy` previously failed the same way:

```
✘ [ERROR] Processing wrangler.toml configuration:
    - "containers" should be an object, but got an array
```

Bumping wrangler surfaced a pre-existing Dockerfile bug that had to be fixed before the image would build at all:

- **wrangler 3 → 4** — the `[[containers]]` array schema is a v4 feature.
- **`cpanm --local-lib=/opt/perl-deps`** — previous Dockerfile copied `/usr/local/share/perl` from the builder stage, but that path does not exist in `perl:5.38-slim` (cpanm writes to `/usr/local/lib/perl5/` and `/usr/local/share/perl5/`). Installing into a self-contained prefix avoids the guesswork and lets the runtime stage copy a single directory.
- **`PERL5LIB` + `PATH`** — point Perl at `/opt/perl-deps/lib/perl5` so Mojolicious resolves.

## Test plan

- [x] `wrangler deploy --dry-run` builds an image
- [x] `docker run` on that image starts Mojolicious and returns HTTP 200 on `/examples/mojolicious/`
- [x] `bun run build` at repo root succeeds
- [ ] Real `bun run deploy` against Cloudflare (owner to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)