### PR TITLE
feat(site/core): dark-mode playground with LP-aligned header

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -269,6 +269,15 @@ if (await Bun.file(icon64).exists()) {
   console.log('Copied: dist/icon-64.png, dist/static/icon-64.png')
 }
 
+for (const name of ['logo.svg', 'logo-for-dark.svg', 'logo-for-light.svg']) {
+  const src = resolve(IMAGES_DIR, name)
+  if (await Bun.file(src).exists()) {
+    await Bun.write(resolve(DIST_DIR, name), Bun.file(src))
+    await Bun.write(resolve(DIST_STATIC_DIR, name), Bun.file(src))
+    console.log(`Copied: dist/${name}, dist/static/${name}`)
+  }
+}
+
 // ── 7. Copy .ts modules from landing/components (non-component modules) ──
 async function copyTsModules(srcDir: string, destDir: string): Promise<void> {
   const entries = await readdir(srcDir, { withFileTypes: true }).catch(() => [])

--- a/site/core/playground/page-script.ts
+++ b/site/core/playground/page-script.ts
@@ -58,16 +58,16 @@ function buildIframeSrcdoc(opts: {
     <meta charset="UTF-8" />
     <script type="importmap">${importMap}</script>
     <style>
-      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
-      body { margin: 0; padding: 16px; }
+      :root { color-scheme: dark; font-family: system-ui, sans-serif; background: oklch(0.145 0 0); color: oklch(0.985 0 0); }
+      body { margin: 0; padding: 16px; background: oklch(0.145 0 0); color: oklch(0.985 0 0); }
       #app:empty::before {
         content: 'Preview is empty — did your component return JSX?';
-        color: #888;
+        color: oklch(0.708 0 0);
         font-size: 13px;
       }
       #playground-error {
         position: fixed; inset: 0; padding: 16px;
-        background: #fff5f5; color: #a00;
+        background: oklch(0.25 0.05 22); color: oklch(0.85 0.15 22);
         font: 12px/1.4 ui-monospace, monospace;
         white-space: pre-wrap; overflow: auto;
         display: none;
@@ -177,6 +177,7 @@ async function main() {
   }
   setTab('preview')
 
+  statusEl.dataset.state = 'working'
   statusEl.textContent = 'Loading editor…'
   const monaco = await loadMonaco()
 
@@ -228,9 +229,7 @@ async function main() {
   )
   const editor = monaco.editor.create(editorEl, {
     model,
-    theme: matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'vs-dark'
-      : 'vs',
+    theme: 'vs-dark',
     automaticLayout: true,
     minimap: { enabled: false },
     fontSize: 13,
@@ -239,12 +238,19 @@ async function main() {
   })
 
   statusEl.textContent = 'Starting compiler…'
+  statusEl.dataset.state = 'working'
   const worker = new Worker(window.PLAYGROUND_WORKER_URL, { type: 'module' })
 
   let nextId = 1
   let ready = false
   let pendingSource: string | null = null
   let debounceHandle: number | null = null
+
+  type StatusState = 'working' | 'ready' | 'error'
+  function setStatus(label: string, state: StatusState) {
+    statusEl.textContent = label
+    statusEl.dataset.state = state
+  }
 
   function showErrors(errors: { severity: string; message: string }[]) {
     errorEl.hidden = false
@@ -262,7 +268,7 @@ async function main() {
       pendingSource = source
       return
     }
-    statusEl.textContent = 'Compiling…'
+    setStatus('Compiling…', 'working')
     worker.postMessage({ id: nextId++, source })
   }
 
@@ -270,7 +276,7 @@ async function main() {
     const msg = event.data
     if (msg && msg.ready === true) {
       ready = true
-      statusEl.textContent = 'Ready'
+      setStatus('Ready', 'ready')
       if (pendingSource !== null) {
         const src = pendingSource
         pendingSource = null
@@ -283,14 +289,18 @@ async function main() {
 
     if (msg.ok === false) {
       showErrors(msg.errors)
-      statusEl.textContent = 'Errors'
+      setStatus('Build failed', 'error')
       return
     }
 
     clearErrors()
-    statusEl.textContent = msg.warnings?.length
-      ? `Compiled (${msg.warnings.length} warning${msg.warnings.length === 1 ? '' : 's'})`
-      : 'Compiled'
+    const warnings = msg.warnings?.length ?? 0
+    setStatus(
+      warnings > 0
+        ? `Preview up to date · ${warnings} warning${warnings === 1 ? '' : 's'}`
+        : 'Preview up to date',
+      'ready',
+    )
 
     clientJsPanel.textContent = msg.clientJs
     irPanel.textContent = JSON.stringify(msg.ir, null, 2)
@@ -305,6 +315,7 @@ async function main() {
     showErrors([
       { severity: 'error', message: `Worker crashed: ${e.message}` },
     ])
+    setStatus('Build failed', 'error')
   })
 
   function scheduleCompile() {
@@ -318,7 +329,10 @@ async function main() {
 
 main().catch((err) => {
   const status = document.getElementById('pg-status')
-  if (status) status.textContent = 'Failed to initialise'
+  if (status) {
+    status.textContent = 'Failed to initialise'
+    status.dataset.state = 'error'
+  }
   const errorEl = document.getElementById('pg-error')
   if (errorEl) {
     errorEl.hidden = false

--- a/site/core/playground/routes.tsx
+++ b/site/core/playground/routes.tsx
@@ -32,42 +32,52 @@ export function createPlaygroundApp() {
 
   app.get('/', (c) => {
     const html = `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Playground — Barefoot.js</title>
   <meta name="description" content="In-browser playground for BarefootJS: edit JSX, see the compiled output, and preview live." />
+  <meta name="color-scheme" content="dark" />
   <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png" />
   <link rel="stylesheet" href="/static/globals.css" />
   <link rel="stylesheet" href="/static/uno.css" />
   <style>
     html, body { height: 100%; margin: 0; }
-    body { font-family: var(--font-sans, system-ui, sans-serif); background: var(--background, #fff); color: var(--foreground, #111); display: flex; flex-direction: column; }
-    .pg-header { padding: 10px 16px; border-bottom: 1px solid var(--border, #e5e7eb); display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
-    .pg-header a { color: inherit; text-decoration: none; font-weight: 600; }
-    .pg-status { margin-left: auto; font: 12px ui-monospace, monospace; color: var(--muted-foreground, #666); }
+    body { font-family: var(--font-sans, system-ui, sans-serif); background: var(--background); color: var(--foreground); display: flex; flex-direction: column; }
+    .pg-header { height: var(--header-height, 52px); padding: 0 16px; border-bottom: 1px solid var(--border); background: var(--background); display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+    @media (min-width: 640px) { .pg-header { padding: 0 24px; gap: 24px; } }
+    .pg-header a { color: inherit; text-decoration: none; font-weight: 600; display: inline-flex; align-items: center; }
+    .pg-logo { height: 1.65rem; width: auto; display: block; }
+    .pg-sep { display: none; width: 1px; height: 20px; background: var(--border); }
+    @media (min-width: 640px) { .pg-sep { display: block; } }
+    .pg-status { margin-left: auto; font: 12px ui-monospace, monospace; color: var(--muted-foreground); display: inline-flex; align-items: center; gap: 6px; }
+    .pg-status::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+    .pg-status[data-state="ready"] { color: oklch(0.75 0.14 150); }
+    .pg-status[data-state="working"] { color: oklch(0.75 0.12 80); }
+    .pg-status[data-state="error"] { color: oklch(0.70 0.19 22); }
     .pg-main { flex: 1; display: grid; grid-template-columns: 1fr 1fr; min-height: 0; }
     @media (max-width: 900px) { .pg-main { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; } }
-    .pg-pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-right: 1px solid var(--border, #e5e7eb); }
+    .pg-pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-right: 1px solid var(--border); }
     .pg-pane:last-child { border-right: none; }
-    .pg-pane-header { padding: 6px 12px; font: 12px ui-monospace, monospace; color: var(--muted-foreground, #666); border-bottom: 1px solid var(--border, #e5e7eb); display: flex; gap: 4px; align-items: center; }
+    .pg-pane-header { padding: 6px 12px; font: 12px ui-monospace, monospace; color: var(--muted-foreground); border-bottom: 1px solid var(--border); display: flex; gap: 4px; align-items: center; }
     .pg-editor { flex: 1; min-height: 0; }
     .pg-tab { background: transparent; border: 1px solid transparent; padding: 3px 10px; border-radius: 4px; font: inherit; color: inherit; cursor: pointer; }
-    .pg-tab[aria-selected="true"] { border-color: var(--border, #e5e7eb); background: var(--muted, #f5f5f5); }
-    .pg-tab-body { flex: 1; min-height: 0; overflow: auto; }
+    .pg-tab[aria-selected="true"] { border-color: var(--border); background: var(--muted); color: var(--foreground); }
+    .pg-tab-body { flex: 1; min-height: 0; overflow: auto; background: var(--background); }
     .pg-tab-body[hidden] { display: none; }
-    #pg-preview { width: 100%; height: 100%; border: 0; background: #fff; display: block; }
-    .pg-code { margin: 0; padding: 12px; font: 12px/1.5 ui-monospace, monospace; white-space: pre; background: var(--muted, #f5f5f5); height: 100%; box-sizing: border-box; }
-    #pg-error { margin: 0; padding: 10px 16px; font: 12px/1.4 ui-monospace, monospace; color: #c00; background: #fff5f5; border-top: 1px solid #fcc; white-space: pre-wrap; flex-shrink: 0; }
+    #pg-preview { width: 100%; height: 100%; border: 0; background: var(--background); display: block; color-scheme: dark; }
+    .pg-code { margin: 0; padding: 12px; font: 12px/1.5 ui-monospace, monospace; white-space: pre; background: var(--muted); color: var(--foreground); height: 100%; box-sizing: border-box; }
+    #pg-error { margin: 0; padding: 10px 16px; font: 12px/1.4 ui-monospace, monospace; color: oklch(0.80 0.15 22); background: oklch(0.25 0.05 22); border-top: 1px solid oklch(0.40 0.12 22); white-space: pre-wrap; flex-shrink: 0; }
     #pg-error[hidden] { display: none; }
   </style>
 </head>
 <body>
   <header class="pg-header">
-    <a href="/">← Barefoot.js</a>
-    <span style="color: var(--muted-foreground, #666); font-size: 14px;">Playground</span>
-    <span id="pg-status" class="pg-status">Loading…</span>
+    <a href="/" aria-label="Barefoot.js home"><img class="pg-logo" src="/static/logo-for-dark.svg" alt="Barefoot.js" /></a>
+    <span class="pg-sep" aria-hidden="true"></span>
+    <span style="color: var(--muted-foreground); font-size: 14px;">Playground</span>
+    <span id="pg-status" class="pg-status" data-state="working">Loading…</span>
   </header>
   <div class="pg-main">
     <section class="pg-pane">


### PR DESCRIPTION
## Summary

- Force the `/playground` page into dark mode so the header, IR, and Client JS panels stop rendering on white and pick up the shared design tokens.
- Replace the `← Barefoot.js` text with the BarefootJS word mark (`logo-for-dark.svg`) and match the landing-page header's sizing (`var(--header-height)`, 16/24px gutters, separator) so the brand position is consistent.
- Rename the compiler status from `Compiled` to `Preview up to date`, add a colored status dot for ready/working/error states, and route build failures through the same helper.
- Dark-theme the preview iframe shell and its default body so the preview chrome matches the page, while leaving user-authored component styles untouched.
- Copy the BarefootJS word-mark SVGs into `dist/static/` during the build so the playground (and future pages) can reference them directly.

## Test plan

- [ ] `bun run build` in `site/core/` succeeds and emits `dist/static/logo*.svg` and the updated playground bundle.
- [ ] Visit `/playground`: header/IR/Client JS panes render on the dark background, the word mark replaces the text link, and its left gutter matches the landing page.
- [ ] Toggle Preview/IR/Client JS tabs — all panels use dark surfaces; the preview iframe body is dark by default.
- [ ] Edit the default component: status shows `Compiling…` → `Preview up to date`; introduce a syntax error to confirm `Build failed` with the red indicator.