### PR TITLE
ci(deploy): deploy examples alongside site/core + site/ui

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'site/**'
       - 'ui/**'
       - 'docs/core/**'
+      - 'examples/**'
       - '.github/workflows/deploy.yml'
 
   # Allow manual trigger with site selection
@@ -21,6 +22,10 @@ on:
           - all
           - core
           - ui
+          - examples
+          - examples-hono
+          - examples-echo
+          - examples-mojolicious
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -87,8 +92,109 @@ jobs:
 
       - name: Build site
         run: cd site/ui && bun run build:worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Deploy to Cloudflare Workers
         run: cd site/ui && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-examples-hono:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'examples' || github.event.inputs.site == 'examples-hono')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/hono' build
+
+      - name: Build example
+        run: cd examples/hono && bun run build
+
+      - name: Deploy to Cloudflare Workers
+        run: cd examples/hono && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-examples-echo:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'examples' || github.event.inputs.site == 'examples-echo')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/go-template' build
+
+      - name: Build example
+        run: cd examples/echo && bun run build
+
+      # wrangler deploy builds the Cloudflare Container image from the
+      # example's Dockerfile, which needs Docker on the runner.
+      # ubuntu-latest ships with a running Docker daemon by default.
+      - name: Deploy to Cloudflare Workers
+        run: cd examples/echo && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-examples-mojolicious:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'examples' || github.event.inputs.site == 'examples-mojolicious')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/mojolicious' build
+
+      - name: Build example
+        run: cd examples/mojolicious && bun run build
+
+      # wrangler deploy builds the Cloudflare Container image from the
+      # example's Dockerfile, which needs Docker on the runner.
+      # ubuntu-latest ships with a running Docker daemon by default.
+      - name: Deploy to Cloudflare Workers
+        run: cd examples/mojolicious && bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Extend `.github/workflows/deploy.yml` so the three adapter examples (hono / echo / mojolicious) are deployed on the same triggers as the main sites.

- Push to `main` now also redeploys the examples when any file under `examples/**` changes (added to the existing path filter).
- `workflow_dispatch` gains targeted choices:
  - `examples` — all three
  - `examples-hono` / `examples-echo` / `examples-mojolicious`
  - `all` now covers examples too
- Each example gets its own job: checkout → bun install → build required `@barefootjs/*` packages → `bun run build` in the example → `wrangler deploy`.
- Echo and Mojolicious are Cloudflare Container workers. Their `wrangler deploy` step builds the Dockerfile image on the runner; `ubuntu-latest` already ships with a running Docker daemon, so no extra setup is needed.
- Same `production` environment and `CLOUDFLARE_API_TOKEN` secret as `deploy-core` / `deploy-ui`.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] Merge and watch the next push-to-main cycle — or manually trigger via `workflow_dispatch` with `site=examples-hono` to smoke-test one adapter before rolling out.
- [ ] Confirm `CLOUDFLARE_API_TOKEN` has sufficient permissions for Containers (image push). The existing `deploy-core` / `deploy-ui` tokens already work for plain Workers; Containers add a registry push step, so if `deploy-examples-echo` or `-mojolicious` fails on `wrangler deploy` the token needs `Workers Scripts:Edit` + `Account Settings:Read` as per Cloudflare's Containers docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)