### PR TITLE
Change html lang from ja to en in example apps

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -86,7 +86,7 @@ func defaultLayout(ctx *bf.RenderContext) string {
 	}
 
 	return fmt.Sprintf(`<!DOCTYPE html>
-<html lang="ja" class="dark">
+<html lang="en" class="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -285,7 +285,7 @@ func indexHandler(c echo.Context) error {
     </ul>`, basePath, basePath, basePath, basePath, basePath)
 
 	return c.HTML(http.StatusOK, fmt.Sprintf(`<!DOCTYPE html>
-<html lang="ja" class="dark">
+<html lang="en" class="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/hono/renderer.tsx
+++ b/examples/hono/renderer.tsx
@@ -36,7 +36,7 @@ function SiteHeader() {
 export const renderer = jsxRenderer(
   ({ children }) => {
     return (
-      <html lang="ja" className="dark">
+      <html lang="en" className="dark">
         <head>
           <meta charset="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/examples/mojolicious/app.pl
+++ b/examples/mojolicious/app.pl
@@ -426,7 +426,7 @@ __DATA__
 @@ layouts/default.html.ep
 % my $bp = stash('base_path') // '';
 <!DOCTYPE html>
-<html lang="ja" class="dark">
+<html lang="en" class="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- Switch the `<html lang="ja">` attribute to `lang="en"` in the example apps so they render as English by default.

## Files changed
- `examples/hono/renderer.tsx`
- `examples/echo/main.go` (2 occurrences)
- `examples/mojolicious/app.pl`

Note: `site/ui/components/dropdown-menu-demo.tsx` has a `value="ja"` radio option inside a language-selector demo — left untouched since it represents a selectable language choice, not the document language.

## Test plan
- [ ] Run each example locally and confirm the rendered `<html>` tag uses `lang="en"`.
