### PR TITLE
fix(cli): ignore directories when hashing import deps

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import {
   discoverComponentFiles,
   generateHash,
   resolveBuildConfigFromTs,
+  collectRelativeImportDeps,
 } from '../lib/build'
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
 import { resolve } from 'path'
@@ -154,6 +155,91 @@ describe('resolveBuildConfigFromTs', () => {
     })
 
     expect(config.outDir).toBe('/test/project/build/output')
+  })
+})
+
+// ── collectRelativeImportDeps ───────────────────────────────────────────
+
+describe('collectRelativeImportDeps', () => {
+  const testDir = resolve(tmpdir(), `bf-test-collect-deps-${Date.now()}`)
+  const entry = resolve(testDir, 'entry.tsx')
+
+  function setup() {
+    mkdirSync(testDir, { recursive: true })
+    writeFileSync(entry, '')
+  }
+
+  function cleanup() {
+    rmSync(testDir, { recursive: true, force: true })
+  }
+
+  test('resolves `./foo` to ./foo.ts when a file exists', async () => {
+    setup()
+    writeFileSync(resolve(testDir, 'foo.ts'), 'export const x = 1')
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './foo'`)
+    expect(deps).toEqual([resolve(testDir, 'foo.ts')])
+    cleanup()
+  })
+
+  test('resolves `./foo` to ./foo.tsx when a file exists', async () => {
+    setup()
+    writeFileSync(resolve(testDir, 'foo.tsx'), 'export function X() {}')
+    const deps = await collectRelativeImportDeps(entry, `import { X } from './foo'`)
+    expect(deps).toEqual([resolve(testDir, 'foo.tsx')])
+    cleanup()
+  })
+
+  test('resolves `./dir` to ./dir/index.ts when dir exists with an index file', async () => {
+    setup()
+    mkdirSync(resolve(testDir, 'dir'))
+    writeFileSync(resolve(testDir, 'dir/index.ts'), 'export const x = 1')
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './dir'`)
+    expect(deps).toEqual([resolve(testDir, 'dir/index.ts')])
+    cleanup()
+  })
+
+  test('skips bare directory paths without an index file (regression: EISDIR on readText)', async () => {
+    setup()
+    mkdirSync(resolve(testDir, 'empty'))
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './empty'`)
+    expect(deps).toEqual([])
+    cleanup()
+  })
+
+  test('ignores bare-match directory when `/index.ts` sibling exists (no EISDIR)', async () => {
+    // The bare `./dir` path is a directory and must NOT be picked — the
+    // collector must fall through to the `/index.ts` candidate instead.
+    setup()
+    mkdirSync(resolve(testDir, 'nodes'))
+    writeFileSync(resolve(testDir, 'nodes/index.ts'), 'export const nodeTypes = {}')
+    const deps = await collectRelativeImportDeps(entry, `import { nodeTypes } from './nodes'`)
+    expect(deps).toEqual([resolve(testDir, 'nodes/index.ts')])
+    cleanup()
+  })
+
+  test('skips imports that resolve to nothing', async () => {
+    setup()
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './missing'`)
+    expect(deps).toEqual([])
+    cleanup()
+  })
+
+  test('ignores bare (non-relative) imports', async () => {
+    setup()
+    const deps = await collectRelativeImportDeps(entry, `import { x } from 'some-pkg'`)
+    expect(deps).toEqual([])
+    cleanup()
+  })
+
+  test('deduplicates repeated relative imports', async () => {
+    setup()
+    writeFileSync(resolve(testDir, 'foo.ts'), 'export const x = 1')
+    const deps = await collectRelativeImportDeps(
+      entry,
+      `import { x } from './foo'\nimport { x as y } from './foo'`,
+    )
+    expect(deps).toEqual([resolve(testDir, 'foo.ts')])
+    cleanup()
   })
 })
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -568,11 +568,18 @@ async function collectRelativeImportDeps(
     const candidates = [base, ...EXT_CANDIDATES.map((ext) => base + ext)]
     for (const cand of candidates) {
       if (seen.has(cand)) continue
-      if (await fileExists(cand)) {
-        seen.add(cand)
-        results.push(cand)
-        break
+      // Require a regular file. A bare `./dir` import resolves to a directory
+      // here, and hashing that path via readText would throw EISDIR. The
+      // `/index.ts[x]` candidates already cover the directory-as-module case.
+      try {
+        const s = await stat(cand)
+        if (!s.isFile()) continue
+      } catch {
+        continue
       }
+      seen.add(cand)
+      results.push(cand)
+      break
     }
   }
   return results

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -552,7 +552,7 @@ const RELATIVE_IMPORT_SCAN_RE = /(?:^|\n)\s*(?:import|export)\s+(?:[^'"\n]+from\
  * cache: when an imported file changes, the importer's cache entry becomes
  * stale and must be recompiled (so its combined client JS picks up the change).
  */
-async function collectRelativeImportDeps(
+export async function collectRelativeImportDeps(
   entryPath: string,
   sourceContent: string,
 ): Promise<string[]> {


### PR DESCRIPTION
## Summary
- `collectRelativeImportDeps` accepted any filesystem entry as a resolved import, including directories. When a source file had `import x from './dir'`, the bare path matched the directory before `/index.ts[x]` could be tried, and the subsequent `hashContent(await readText(cand))` threw `EISDIR` and aborted the whole build.
- Check `stat.isFile()` on the candidate so directory resolutions fall through to the `/index.ts[x]` entries.

## Repro (in piconic/desk)
With canvas sources that do `import { nodeTypes } from './nodes'` (where `./nodes/` is a directory with `index.ts`), `barefoot build` aborted after compiling 4 of the 6 eligible components with:

```
EISDIR: illegal operation on a directory, read
      fd: 5,
 syscall: "read",
   errno: -21,
    code: "EISDIR"
```

With this fix the build completes and the emitted CJs points at the actual `nodes/index.ts` file.

## Test plan
- [x] `bun test` in `packages/cli/` — 280/280 passing
- [x] Ran `barefoot build` end-to-end in piconic/desk against this branch; all 6 components compile and the `./nodes` dep resolves to `./nodes/index.ts`