### PR TITLE
fix(core): update examples → integrations import in site/core

### DIFF
--- a/site/core/app.tsx
+++ b/site/core/app.tsx
@@ -11,7 +11,7 @@ import { Hono } from 'hono'
 import { createDocsApp } from './docs-app'
 import { createLandingApp } from './landing/routes'
 import { createPlaygroundApp } from './playground/routes'
-import { createExamplesApp } from './examples/routes'
+import { createIntegrationsApp } from './integrations/routes'
 import type { Page, ContentMap } from './lib/content'
 
 /**
@@ -34,9 +34,9 @@ export async function createApp(content: ContentMap, pages: Page[]): Promise<Hon
   // Playground (GET /playground)
   app.route('/playground', createPlaygroundApp())
 
-  // Examples adapter index (GET /integrations). The adapter demos themselves
+  // Integrations adapter index (GET /integrations). The adapter demos themselves
   // live on separate services, so this is just the catalog page.
-  app.route('/integrations', createExamplesApp())
+  app.route('/integrations', createIntegrationsApp())
 
   return app
 }

--- a/site/core/uno.config.ts
+++ b/site/core/uno.config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
     filesystem: [
       './renderer.tsx',
       './landing/**/*.tsx',
-      './examples/**/*.tsx',
+      './integrations/**/*.tsx',
       './components/**/*.tsx',
       '../shared/components/**/*.tsx',
       './dist/**/*.tsx',


### PR DESCRIPTION
## Summary

PR #917 renamed `examples/` → `integrations/` but missed two stale references in `site/core/`. This broke the [deploy-core CI job](https://github.com/barefootjs/barefootjs/actions/runs/24642281911/job/72048240980) on `main`:

```
✘ [ERROR] Could not resolve "./examples/routes"

    app.tsx:14:34:
      14 │ import { createExamplesApp } from './examples/routes'
```

## Changes

- `site/core/app.tsx` — import `createIntegrationsApp` from `./integrations/routes` (the rename also changed the exported function name)
- `site/core/uno.config.ts` — update filesystem glob from `./examples/**/*.tsx` to `./integrations/**/*.tsx`

## Test plan

- [x] Local `bun run build` (root) succeeds
- [x] `site/core/` builds with `bun run build`
- [x] `bunx wrangler deploy --dry-run` succeeds (previously failed at esbuild resolve step)
- [x] `bun test packages/` — same pass/fail count as `main` (the one pre-existing xyflow e2e failure is unrelated)