### PR TITLE
ci: add GitHub Actions workflow for CLI package tests

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -1,0 +1,42 @@
+name: CI — CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/cli/**'
+      - 'packages/client/**'
+      - 'packages/jsx/**'
+      - 'ui/**'
+      - '.github/workflows/ci-cli.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/cli/**'
+      - 'packages/client/**'
+      - 'packages/jsx/**'
+      - 'ui/**'
+      - '.github/workflows/ci-cli.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/jsx' build
+
+      - name: Run unit tests
+        run: cd packages/cli && bun test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci-cli.yml` to run `bun test` for `packages/cli` on push/PR to `main`.
- Triggers only when `packages/cli/**`, `packages/jsx/**`, `packages/client/**`, `ui/**`, or the workflow itself changes.
- Builds `@barefootjs/client` and `@barefootjs/jsx` before running tests because `packages/cli/src/lib/build.ts` imports `@barefootjs/jsx` at runtime.

## Test plan

- [ ] Verify the `CI — CLI` workflow runs on this PR and passes.
- [ ] Confirm the path filter excludes the workflow from unrelated changes.
