### PR TITLE
fix(playground): eliminate white-flash on preview iframe load

### DIFF
--- a/site/core/playground/routes.tsx
+++ b/site/core/playground/routes.tsx
@@ -90,7 +90,7 @@ export function createPlaygroundApp() {
         <button id="pg-tab-button-ir" class="pg-tab" data-pg-tab="ir" role="tab" aria-selected="false" aria-controls="pg-tab-ir">IR</button>
         <button id="pg-tab-button-clientjs" class="pg-tab" data-pg-tab="clientJs" role="tab" aria-selected="false" aria-controls="pg-tab-clientjs">Client JS</button>
       </div>
-      <div class="pg-tab-body" id="pg-tab-preview" role="tabpanel" aria-labelledby="pg-tab-button-preview"><iframe id="pg-preview" sandbox="allow-scripts" title="Preview"></iframe></div>
+      <div class="pg-tab-body" id="pg-tab-preview" role="tabpanel" aria-labelledby="pg-tab-button-preview"><iframe id="pg-preview" sandbox="allow-scripts" title="Preview" srcdoc='<!DOCTYPE html><html><head><meta name="color-scheme" content="dark"><style>:root{color-scheme:dark;background:oklch(0.145 0 0)}html,body{margin:0;background:oklch(0.145 0 0)}</style></head><body></body></html>'></iframe></div>
       <div class="pg-tab-body" id="pg-tab-ir" role="tabpanel" aria-labelledby="pg-tab-button-ir" hidden><pre id="pg-ir" class="pg-code"></pre></div>
       <div class="pg-tab-body" id="pg-tab-clientjs" role="tabpanel" aria-labelledby="pg-tab-button-clientjs" hidden><pre id="pg-clientjs" class="pg-code"></pre></div>
     </section>


### PR DESCRIPTION
## Summary
- The Playground preview iframe briefly flashed white on page load before switching to the dark theme.
- Root cause: the iframe had no initial \`srcdoc\`, so browsers rendered their default white document until the first compile completed and assigned a new \`srcdoc\`.
- Fix: give the iframe a minimal dark-background \`srcdoc\` inline (matches the same \`oklch(0.145 0 0)\` used by \`buildIframeSrcdoc()\` after compile), so the first paint is already dark and the hand-off is seamless.

## Test plan
- [ ] Open \`/playground\` with a cold cache and confirm no white flash before the preview renders.
- [ ] Compile a component and confirm the preview still renders correctly after srcdoc replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)