### PR TITLE
xyflow: fix strict-mode issues in source

### DIFF
--- a/packages/xyflow/src/connection.ts
+++ b/packages/xyflow/src/connection.ts
@@ -56,7 +56,7 @@ export function attachConnectionHandler<
   nodeId: string,
   handleType: 'source' | 'target',
   container: HTMLElement,
-  edgesSvg: SVGSVGElement,
+  _edgesSvg: SVGSVGElement,
   store: FlowStore<NodeType, EdgeType>,
 ): void {
   handleEl.addEventListener('mousedown', (e) => {

--- a/packages/xyflow/src/node-wrapper.ts
+++ b/packages/xyflow/src/node-wrapper.ts
@@ -247,7 +247,7 @@ export function createNodeWrapper<NodeType extends NodeBase>(
 
           const containerBounds = container.getBoundingClientRect()
           const mousePos = { x: lastMouseX - containerBounds.left, y: lastMouseY - containerBounds.top }
-          const [xMovement, yMovement] = calcAutoPan(mousePos, containerBounds)
+          const [xMovement = 0, yMovement = 0] = calcAutoPan(mousePos, containerBounds)
 
           if (xMovement !== 0 || yMovement !== 0) {
             const [, , scale] = store.getTransform()


### PR DESCRIPTION
## Summary

Fix two small issues in `packages/xyflow/src` that surface when a downstream consumer builds `@barefootjs/xyflow` from source with `noUncheckedIndexedAccess` / `noUnusedLocals` enabled. The upstream `packages/xyflow` tsconfig is unchanged and `bunx tsc --noEmit` remains clean.

## Changes

- **`connection.ts`** — `attachConnectionHandler` takes an `edgesSvg: SVGSVGElement` parameter that is never read. The sibling `attachReconnectionHandler` does use its own `edgesSvg` argument, so the shape needs to stay. Renamed the unused one to `_edgesSvg` to signal intent and satisfy `noUnusedParameters` without breaking positional callers (`handle.ts:68`, `node-wrapper.ts:375`).
- **`node-wrapper.ts`** — `calcAutoPan` from `@xyflow/system` is typed as returning `number[]`, so `const [xMovement, yMovement] = calcAutoPan(...)` yields `number | undefined` for each component under `noUncheckedIndexedAccess`. Added `= 0` defaults to the destructuring. The existing `!== 0` guard below handles the default correctly.

No behavior change.

## Context

Surfaced in `piconic-ai/desk`, which maps `@barefootjs/xyflow` to source via tsconfig `paths` and typechecks under `noUncheckedIndexedAccess: true`. Without this fix, that downstream had to filter `node_modules/` diagnostics out of their typecheck step.

## Test plan

- [x] `bunx tsc --noEmit` in `packages/xyflow` (upstream config) — passes
- [x] `bunx tsc --noEmit --noUncheckedIndexedAccess --noUnusedLocals --noUnusedParameters` on `packages/xyflow/src/**` — passes
- [x] `bun test` — pre-existing test environment issues are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)