### PR TITLE
style(integrations/todo): rewrite todo-app.css on shared dark-mode tokens

### DIFF
--- a/integrations/shared/styles/todo-app.css
+++ b/integrations/shared/styles/todo-app.css
@@ -1,403 +1,404 @@
 @charset 'utf-8';
 
 /**
- * TodoMVC Base Styles (from todomvc-common/base.css)
+ * TodoApp styles for BarefootJS integration demos.
  *
- * Scoped to pages that host a .todoapp so the shared layout body styles
- * (padding-top for the fixed header etc.) remain effective everywhere else.
+ * Inspired by TodoMVC but rewritten on top of the shared design tokens in
+ * tokens.css so the demo sits naturally inside the dark-mode integration
+ * site instead of flashing to a white background mid-navigation.
+ *
+ * Scoped under `.todoapp` (and `body:has(.todoapp)`) so non-todo pages keep
+ * the default layout untouched.
  */
+
 body:has(.todoapp) {
-	margin: 0 auto;
-	padding: 0;
-	padding-top: var(--header-height);
-	background: #f5f5f5;
-	font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	line-height: 1.4em;
-	color: #111111;
-	min-width: 230px;
-	max-width: 550px;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	font-weight: 300;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.4em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
 }
 
-/**
- * TodoMVC App CSS (based on todomvc-app-css@2.4.3)
- * https://github.com/nicoquant/Todomvc/master/todomvc-app-css
- *
- * Modified: Removed body max-width to coexist with existing layout
- */
+body:has(.todoapp) > :not(.bf-header):not(script) {
+  max-width: 550px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+}
 
-button {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	background: none;
-	font-size: 100%;
-	vertical-align: baseline;
-	font-family: inherit;
-	font-weight: inherit;
-	color: inherit;
-	-webkit-appearance: none;
-	appearance: none;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+.todoapp button {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font-size: 100%;
+  vertical-align: baseline;
+  font-family: inherit;
+  font-weight: inherit;
+  color: inherit;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .hidden {
-	display: none;
+  display: none;
 }
 
 .todoapp {
-	background: #fff;
-	margin: 130px 0 40px 0;
-	position: relative;
-	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2),
-	            0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  position: relative;
+  margin: 110px 0 var(--space-10) 0;
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
 }
 
-.todoapp input::-webkit-input-placeholder {
-	font-style: italic;
-	font-weight: 400;
-	color: rgba(0, 0, 0, 0.4);
-}
-
-.todoapp input::-moz-placeholder {
-	font-style: italic;
-	font-weight: 400;
-	color: rgba(0, 0, 0, 0.4);
-}
-
-.todoapp input::input-placeholder {
-	font-style: italic;
-	font-weight: 400;
-	color: rgba(0, 0, 0, 0.4);
+.todoapp input::placeholder {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--muted-foreground);
+  opacity: 0.7;
 }
 
 .todoapp h1 {
-	position: absolute;
-	top: -140px;
-	width: 100%;
-	font-size: 80px;
-	font-weight: 200;
-	text-align: center;
-	color: #b83f45;
-	-webkit-text-rendering: optimizeLegibility;
-	-moz-text-rendering: optimizeLegibility;
-	text-rendering: optimizeLegibility;
+  position: absolute;
+  top: -100px;
+  width: 100%;
+  margin: 0;
+  font-size: 72px;
+  font-weight: 200;
+  line-height: 1;
+  letter-spacing: var(--tracking-tighter);
+  text-align: center;
+  color: var(--foreground);
+  opacity: 0.9;
+  text-rendering: optimizeLegibility;
 }
 
 .new-todo,
 .edit {
-	position: relative;
-	margin: 0;
-	width: 100%;
-	font-size: 24px;
-	font-family: inherit;
-	font-weight: inherit;
-	line-height: 1.4em;
-	color: inherit;
-	padding: 6px;
-	border: 1px solid #999;
-	box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
-	box-sizing: border-box;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+  position: relative;
+  margin: 0;
+  width: 100%;
+  font-size: 20px;
+  font-family: inherit;
+  font-weight: inherit;
+  line-height: 1.4em;
+  color: var(--foreground);
+  padding: var(--space-3);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.new-todo:focus,
+.edit:focus {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring) 35%, transparent);
 }
 
 .new-todo {
-	padding: 16px 16px 16px 60px;
-	height: 65px;
-	border: none;
-	background: rgba(0, 0, 0, 0.003);
-	box-shadow: inset 0 -2px 1px rgba(0,0,0,0.03);
+  padding: var(--space-4) var(--space-4) var(--space-4) 60px;
+  height: 60px;
+  border: none;
+  border-radius: 0;
+  background: color-mix(in oklch, var(--card) 92%, var(--foreground));
+  border-bottom: 1px solid var(--border);
+}
+
+.new-todo:focus {
+  box-shadow: inset 0 -2px 0 0 var(--ring);
 }
 
 .main {
-	position: relative;
-	z-index: 2;
-	border-top: 1px solid #e6e6e6;
+  position: relative;
+  z-index: 2;
+  border-top: 1px solid var(--border);
 }
 
 .toggle-all {
-	width: 1px;
-	height: 1px;
-	border: none; /* Mobile Safari */
-	opacity: 0;
-	position: absolute;
-	right: 100%;
-	bottom: 100%;
+  width: 1px;
+  height: 1px;
+  border: none;
+  opacity: 0;
+  position: absolute;
+  right: 100%;
+  bottom: 100%;
 }
 
 .toggle-all + label {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 45px;
-	height: 65px;
-	font-size: 0;
-	position: absolute;
-	top: -65px;
-	left: -0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 45px;
+  height: 60px;
+  font-size: 0;
+  position: absolute;
+  top: -60px;
+  left: 0;
 }
 
 .toggle-all + label:before {
-	content: '❯';
-	display: inline-block;
-	font-size: 22px;
-	color: #949494;
-	padding: 10px 27px 10px 27px;
-	-webkit-transform: rotate(90deg);
-	transform: rotate(90deg);
+  content: '❯';
+  display: inline-block;
+  font-size: 20px;
+  color: var(--muted-foreground);
+  padding: 10px 27px 10px 27px;
+  transform: rotate(90deg);
+  transition: color var(--duration-fast);
 }
 
 .toggle-all:checked + label:before {
-	color: #484848;
+  color: var(--foreground);
 }
 
 .todo-list {
-	margin: 0;
-	padding: 0;
-	list-style: none;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .todo-list li {
-	position: relative;
-	font-size: 24px;
-	border-bottom: 1px solid #ededed;
+  position: relative;
+  font-size: 18px;
+  border-bottom: 1px solid var(--border);
 }
 
 .todo-list li:last-child {
-	border-bottom: none;
+  border-bottom: none;
 }
 
 .todo-list li.editing {
-	border-bottom: none;
-	padding: 0;
+  border-bottom: none;
+  padding: 0;
 }
 
 .todo-list li.editing .edit {
-	display: block;
-	width: calc(100% - 43px);
-	padding: 12px 16px;
-	margin: 0 0 0 43px;
+  display: block;
+  width: calc(100% - 43px);
+  padding: 12px var(--space-4);
+  margin: 0 0 0 43px;
+  border-radius: var(--radius-sm);
 }
 
 .todo-list li.editing .view {
-	display: none;
+  display: none;
 }
 
 .todo-list li .toggle {
-	text-align: center;
-	width: 40px;
-	/* auto, since non-WebKit browsers doesn't support input styling */
-	height: auto;
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	margin: auto 0;
-	border: none; /* Mobile Safari */
-	-webkit-appearance: none;
-	appearance: none;
+  text-align: center;
+  width: 40px;
+  height: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
+  border: none;
+  -webkit-appearance: none;
+  appearance: none;
+  opacity: 0;
+  cursor: pointer;
 }
 
-.todo-list li .toggle {
-	opacity: 0;
-}
-
+/*
+ * SVG circle + checkmark driven by `currentColor`, so the same asset adapts
+ * to the current foreground color in both light and dark modes.
+ */
 .todo-list li .toggle + label {
-	/*
-		Firefox requires `#` to be escaped - https://bugzilla.mozilla.org/show_bug.cgi?id=922433
-		IE and Edge requires *everything* to be escaped to render, so we do that instead of just the `#` - https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7157459/
-	*/
-	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23949494%22%20stroke-width%3D%223%22/%3E%3C/svg%3E');
-	background-repeat: no-repeat;
-	background-position: center left;
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2248%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%224%22%20opacity%3D%220.4%22/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: center left 4px;
+  color: var(--muted-foreground);
 }
 
 .todo-list li .toggle:checked + label {
-	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%2359A193%22%20stroke-width%3D%223%22%2F%3E%3Cpath%20fill%3D%22%233EA390%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22%2F%3E%3C%2Fsvg%3E');
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2248%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%224%22/%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
+  color: var(--foreground);
 }
 
 .todo-list li label {
-	overflow-wrap: break-word;
-	padding: 15px 15px 15px 60px;
-	display: block;
-	line-height: 1.2;
-	transition: color 0.4s;
-	font-weight: 400;
-	color: #484848;
+  overflow-wrap: break-word;
+  padding: var(--space-4) var(--space-4) var(--space-4) 60px;
+  display: block;
+  line-height: 1.2;
+  transition: color var(--duration-normal);
+  font-weight: 400;
+  color: var(--foreground);
 }
 
 .todo-list li.completed label {
-	color: #949494;
-	text-decoration: line-through;
+  color: var(--muted-foreground);
+  text-decoration: line-through;
 }
 
 .todo-list li .destroy {
-	display: none;
-	position: absolute;
-	top: 0;
-	right: 10px;
-	bottom: 0;
-	width: 40px;
-	height: 40px;
-	margin: auto 0;
-	font-size: 30px;
-	color: #949494;
-	transition: color 0.2s ease-out;
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 10px;
+  bottom: 0;
+  width: 32px;
+  height: 32px;
+  margin: auto 0;
+  font-size: 26px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color var(--duration-fast);
+  border-radius: var(--radius-sm);
 }
 
 .todo-list li .destroy:hover,
 .todo-list li .destroy:focus {
-	color: #C18585;
+  color: var(--destructive);
+  outline: none;
 }
 
 .todo-list li .destroy:after {
-	content: '×';
-	display: block;
-	height: 100%;
-	line-height: 1.1;
+  content: '×';
+  display: block;
+  height: 100%;
+  line-height: 1.1;
 }
 
 .todo-list li:hover .destroy {
-	display: block;
+  display: block;
 }
 
 .todo-list li .edit {
-	display: none;
+  display: none;
 }
 
 .todo-list li.editing:last-child {
-	margin-bottom: -1px;
+  margin-bottom: -1px;
 }
 
 .footer {
-	padding: 10px 15px;
-	height: 20px;
-	text-align: center;
-	font-size: 15px;
-	border-top: 1px solid #e6e6e6;
-}
-
-.footer:before {
-	content: '';
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: 50px;
-	overflow: hidden;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
-	            0 8px 0 -3px #f6f6f6,
-	            0 9px 1px -3px rgba(0, 0, 0, 0.2),
-	            0 16px 0 -6px #f6f6f6,
-	            0 17px 2px -6px rgba(0, 0, 0, 0.2);
+  padding: var(--space-3) var(--space-4);
+  text-align: center;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  border-top: 1px solid var(--border);
+  background: color-mix(in oklch, var(--card) 92%, var(--background));
+  position: relative;
+  min-height: 20px;
 }
 
 .todo-count {
-	float: left;
-	text-align: left;
+  float: left;
+  text-align: left;
 }
 
 .todo-count strong {
-	font-weight: 300;
+  font-weight: 600;
+  color: var(--foreground);
 }
 
 .filters {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	position: absolute;
-	right: 0;
-	left: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  position: absolute;
+  right: 0;
+  left: 0;
 }
 
 .filters li {
-	display: inline;
+  display: inline;
 }
 
 .filters li a {
-	color: inherit;
-	margin: 3px;
-	padding: 3px 7px;
-	text-decoration: none;
-	border: 1px solid transparent;
-	border-radius: 3px;
-	cursor: pointer;
+  color: var(--muted-foreground);
+  margin: 3px;
+  padding: 3px 7px;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background-color var(--duration-fast);
 }
 
 .filters li a:hover {
-	border-color: #DB7676;
+  color: var(--foreground);
+  border-color: var(--border);
+  background: color-mix(in oklch, var(--accent) 50%, transparent);
 }
 
 .filters li a.selected {
-	border-color: #CE4646;
+  color: var(--foreground);
+  border-color: var(--ring);
+  background: color-mix(in oklch, var(--accent) 70%, transparent);
 }
 
 .clear-completed,
 html .clear-completed:active {
-	float: right;
-	position: relative;
-	line-height: 19px;
-	text-decoration: none;
-	cursor: pointer;
+  float: right;
+  position: relative;
+  line-height: 19px;
+  color: var(--muted-foreground);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color var(--duration-fast);
 }
 
 .clear-completed:hover {
-	text-decoration: underline;
+  color: var(--foreground);
+  text-decoration: underline;
 }
 
 .info {
-	margin: 65px auto 0;
-	color: #4d4d4d;
-	font-size: 11px;
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-	text-align: center;
+  margin: var(--space-10) auto 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  text-align: center;
 }
 
 .info p {
-	line-height: 1;
+  line-height: 1;
 }
 
 .info a {
-	color: inherit;
-	text-decoration: none;
-	font-weight: 400;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
 }
 
 .info a:hover {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
-/*
-	Hack to remove background from Mobile Safari.
-	Can't use it globally since it destroys checkboxes in Firefox
-*/
 @media screen and (-webkit-min-device-pixel-ratio:0) {
-	.toggle-all,
-	.todo-list li .toggle {
-		background: none;
-	}
+  .toggle-all,
+  .todo-list li .toggle {
+    background: none;
+  }
 
-	.todo-list li .toggle {
-		height: 40px;
-	}
+  .todo-list li .toggle {
+    height: 40px;
+  }
 }
 
 @media (max-width: 430px) {
-	.footer {
-		height: 50px;
-	}
+  .footer {
+    height: 50px;
+  }
 
-	.filters {
-		bottom: 10px;
-	}
+  .filters {
+    bottom: var(--space-3);
+  }
 }
 
-:focus,
-.toggle:focus + label,
-.toggle-all:focus + label {
-	box-shadow: 0 0 2px 2px #CF7D7D;
-	outline: 0;
+.todoapp :focus-visible,
+.todoapp .toggle:focus-visible + label,
+.todoapp .toggle-all:focus-visible + label {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }

--- a/integrations/shared/styles/todo-app.css
+++ b/integrations/shared/styles/todo-app.css
@@ -210,19 +210,19 @@ body:has(.todoapp) > :not(.bf-header):not(script) {
 }
 
 /*
- * SVG circle + checkmark driven by `currentColor`, so the same asset adapts
- * to the current foreground color in both light and dark modes.
+ * Explicit white (#fff) rather than `currentColor` because Chrome does not
+ * resolve `currentColor` inside a `background-image: url(data:…)` SVG — the
+ * asset falls back to black and disappears against the dark card background.
+ * The integration site is pinned to dark mode, so a fixed white is safe.
  */
 .todo-list li .toggle + label {
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%225%22/%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22%23fff%22%20stroke-width%3D%225%22/%3E%3C/svg%3E');
   background-repeat: no-repeat;
   background-position: center left 4px;
-  color: var(--foreground);
 }
 
 .todo-list li .toggle:checked + label {
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%225%22/%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
-  color: var(--foreground);
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22%23fff%22%20stroke-width%3D%225%22/%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
 }
 
 .todo-list li label {

--- a/integrations/shared/styles/todo-app.css
+++ b/integrations/shared/styles/todo-app.css
@@ -99,7 +99,6 @@ body:has(.todoapp) > :not(.bf-header):not(script) {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.new-todo:focus,
 .edit:focus {
   outline: none;
   border-color: var(--ring);
@@ -116,7 +115,8 @@ body:has(.todoapp) > :not(.bf-header):not(script) {
 }
 
 .new-todo:focus {
-  box-shadow: inset 0 -2px 0 0 var(--ring);
+  outline: none;
+  box-shadow: none;
 }
 
 .main {
@@ -214,14 +214,14 @@ body:has(.todoapp) > :not(.bf-header):not(script) {
  * to the current foreground color in both light and dark modes.
  */
 .todo-list li .toggle + label {
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2248%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%224%22%20opacity%3D%220.4%22/%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%225%22/%3E%3C/svg%3E');
   background-repeat: no-repeat;
   background-position: center left 4px;
-  color: var(--muted-foreground);
+  color: var(--foreground);
 }
 
 .todo-list li .toggle:checked + label {
-  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2248%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%224%22/%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2246%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%225%22/%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
   color: var(--foreground);
 }
 


### PR DESCRIPTION
## Summary

- Replace TodoMVC light-theme defaults in `integrations/shared/styles/todo-app.css` with styles that consume the design tokens from `tokens.css`, so the demo sits naturally inside the dark-mode integration site instead of flashing to a white background on navigation.
- Switch the checkbox SVGs to `currentColor` so toggle icons track `--foreground` in either theme.
- No functional change: only CSS; the HTML structure, class names, and JS behavior are untouched.

## Before / After

Before: landing on `/todos` punched through the site's pinned dark theme (`<html class="dark">`) with `#f5f5f5` body / `#fff` card / `#b83f45` title.

After: card, borders, text, filter chips, toggle circles, "Clear completed" link, etc. all driven by `--background` / `--card` / `--foreground` / `--muted-foreground` / `--ring` / `--destructive`, matching the surrounding integration pages.

## Test plan

- [x] `bun run --cwd integrations/hono test:e2e` — 98 passed (includes the full shared TodoApp suite)
- [x] Manual visual QA on `http://localhost:8787/integrations/hono/todos` and `/todos-ssr` via Playwright: title, input, list, toggle, completed strikethrough, filters, counter, "Clear completed" all render correctly in dark mode
- [ ] Spot-check `echo` / `mojolicious` / `csr` adapters that consume the same shared CSS