### PR TITLE
feat(blocks): add Calendar Scheduler block

### DIFF
--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -118,6 +118,46 @@ describe('Compiler-Runtime Contract', () => {
       expect(js).not.toContain('data-key-0')
     })
 
+    test('loop inside conditional: outer=data-key, inner=data-key-1 in SSR template', () => {
+      // Regression: SSR template for conditional branch used to generate
+      // data-key-1/data-key-2 (off-by-one), mismatching the event dispatcher
+      // which expects data-key/data-key-1. Broke click handlers on inner-loop
+      // elements inside conditional branches.
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/client'
+        export function Test() {
+          const [show] = createSignal(true)
+          const [groups] = createSignal([{id: 'g1', items: [{id: 'i1'}]}])
+          return (
+            <div>
+              {show() ? (
+                <div>
+                  {groups().map(group => (
+                    <div key={group.id}>
+                      {group.items.map(item => (
+                        <button key={item.id} onClick={() => {}}>
+                          {item.id}
+                        </button>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          )
+        }
+      `)
+      // The SSR template inside insert(..., { template: () => ... }) must use
+      // data-key for outer items and data-key-1 for inner items, matching
+      // what the event dispatcher searches for.
+      expect(js).not.toContain('data-key-2')
+      // Outer loop items must have data-key in the SSR branch template
+      expect(js).toMatch(/data-key="['"] \+ \(group\.id\)/)
+      // Inner loop items must have data-key-1 in the SSR branch template
+      expect(js).toMatch(/data-key-1="['"] \+ \(item\.id\)/)
+    })
+
     test('key in HTML template uses data-key attribute name', () => {
       const result = compileJSXSync(`
         "use client"

--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -158,6 +158,42 @@ describe('Compiler-Runtime Contract', () => {
       expect(js).toMatch(/data-key-1="['"] \+ \(item\.id\)/)
     })
 
+    test('loop inside conditional wires reactive conditionals in mapArray callback', () => {
+      // Regression: simple loops inside conditional branches used to skip
+      // reactive-effect setup and just `return __existing` for hydrated items.
+      // That meant conditionals inside the loop body that read non-item signals
+      // (e.g., memos) never re-evaluated when those signals changed.
+      const js = compileClient(`
+        "use client"
+        import { createSignal, createMemo } from '@barefootjs/client'
+        type CountMap = Record<string, number>
+        export function Test() {
+          const [show] = createSignal(true)
+          const [events] = createSignal<number[]>([])
+          const [days] = createSignal([{key: 'd1'}, {key: 'd2'}])
+          const countByDay = createMemo<CountMap>(() => ({ d1: events().length }))
+          return (
+            <div>
+              {show() ? (
+                <div>
+                  {days().map(d => (
+                    <div key={d.key}>
+                      {(countByDay()[d.key] ?? 0) > 0 ? (
+                        <span className="count">{countByDay()[d.key]}</span>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          )
+        }
+      `)
+      // The mapArray callback must set up the reactive conditional via insert()
+      // instead of short-circuiting with `if (__existing) return __existing`.
+      expect(js).toMatch(/mapArray\(\(\) => days\(\),[\s\S]+?insert\(__el,/)
+    })
+
     test('key in HTML template uses data-key attribute name', () => {
       const result = compileJSXSync(`
         "use client"

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -673,11 +673,14 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
  */
 function buildConditionalMetadata(node: IRNode & { type: 'conditional' }, ctx: ClientJsContext): ConditionalElement {
   const restNames = buildRestSpreadNames(ctx)
+  // Use loopDepth=-1 so the first loop encountered inside the branch emits
+  // data-key (depth 0) for its items, matching the mapArray item template
+  // and event dispatcher convention. Matches irToComponentTemplate/generateCsrTemplate.
   return {
     slotId: node.slotId!,
     condition: node.condition,
-    whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames),
-    whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames),
+    whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames, -1),
+    whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames, -1),
     whenTrueEvents: collectConditionalBranchEvents(node.whenTrue),
     whenFalseEvents: collectConditionalBranchEvents(node.whenFalse),
     whenTrueRefs: collectConditionalBranchRefs(node.whenTrue),

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -606,15 +606,21 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
         // Build the item template from loop children.
         // Use loopDepth=0: this loop gets its own reconcileElements (independent
         // from the conditional's template), so items use data-key (not data-key-1).
+        // Pass loopParams so expressions reference the per-item signal accessor,
+        // keeping the template consistent with reactive effect expressions that
+        // use `param()` to read the current item value.
         let childTemplate: string
         if (useElementReconciliation && n.children[0]) {
-          childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0)
+          childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0, [n.param])
         } else {
-          childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0)).join('')
+          childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0, [n.param])).join('')
         }
 
-        // Collect child events for ALL loops (needed for event delegation).
-        // Reactive fields (texts, attrs, conditionals) are composite-only.
+        // Collect child events, reactive texts/attrs, and conditionals for ALL
+        // branch loops — simple loops also need reactive wiring when their
+        // item body reads non-item signals (e.g., memos). Previously these
+        // were only collected for composite loops, which caused reactive
+        // reads inside simple loop bodies to silently no-op for existing items.
         const childEvents: LoopChildEvent[] = []
         const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
         const childReactiveAttrs: import('./types').LoopChildReactiveAttr[] = []
@@ -622,10 +628,6 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
         if (ctx) {
           for (const child of n.children) {
             childEvents.push(...collectLoopChildEventsWithNesting(child))
-          }
-        }
-        if (useElementReconciliation && ctx) {
-          for (const child of n.children) {
             childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
             childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
             childConditionals.push(...collectLoopChildConditionals(child, ctx, n.param))
@@ -642,9 +644,9 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           mapPreamble: n.mapPreamble ?? null,
           nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
           childEvents,
-          childReactiveTexts: useElementReconciliation ? childReactiveTexts : undefined,
-          childReactiveAttrs: useElementReconciliation ? childReactiveAttrs : undefined,
-          childConditionals: useElementReconciliation ? childConditionals : undefined,
+          childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
+          childReactiveAttrs: childReactiveAttrs.length > 0 ? childReactiveAttrs : undefined,
+          childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
           innerLoops: useElementReconciliation ? collectInnerLoops(n.children, n.param) : undefined,
           useElementReconciliation: useElementReconciliation || undefined,
         })

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -6,7 +6,7 @@
 
 import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, ConditionalBranchLoop, ConditionalBranchConditional, LoopChildEvent, LoopChildConditional, LoopChildReactiveText, LoopElement, NestedLoopInfo } from './types'
 import type { IRLoopChildComponent } from '../types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
@@ -82,24 +82,14 @@ function emitBranchBindings(
 
     // Emit loop reconciliation effects for loops inside this branch.
     // The loop's container is found via $() and updated reactively via reconcileElements.
-    // SSR templates use data-key-1 for loops inside conditionals (depth 1 in the
-    // inline template), but reconcileElements uses data-key (depth 0 for independent loops).
-    // Rename SSR attributes on hydration so reconcileElements can find them.
     for (const loop of branchLoops) {
       const cv = varSlotId(loop.containerSlotId)
       lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
 
       if (loop.useElementReconciliation && loop.nestedComponents?.length) {
         // Composite loop: items contain child components — use createComponent in renderItem.
-        // Do NOT rename data-key-1 → data-key here: the hydration guard inside the
-        // disposable effect checks !hasAttribute('data-key') to detect template-generated
-        // elements and initialize child components via initChild. Premature rename would
-        // skip hydration, leaving components uninitialized.
         emitCompositeBranchLoop(lines, loop, cv)
       } else {
-        // Simple loop: rename SSR data-key-1 → data-key for mapArray compatibility.
-        // Safe for simple loops (no child components to initialize).
-        lines.push(`      if (__loop_${cv}) getLoopChildren(__loop_${cv}).forEach(__el => { if (__el.hasAttribute('${DATA_KEY_PREFIX}1') && !__el.hasAttribute('${DATA_KEY}')) { __el.setAttribute('${DATA_KEY}', __el.getAttribute('${DATA_KEY_PREFIX}1')); __el.removeAttribute('${DATA_KEY_PREFIX}1') } })`)
         const keyFn = loop.key
           ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
           : 'null'

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -94,10 +94,39 @@ function emitBranchBindings(
           ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
           : 'null'
         const indexParam = loop.index || '__idx'
-        if (loop.mapPreamble) {
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; if (typeof ${loop.param} === 'function') ${loop.param} = ${loop.param}(); ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+        const hasReactiveEffects = (loop.childReactiveAttrs?.length ?? 0) > 0
+          || (loop.childReactiveTexts?.length ?? 0) > 0
+          || (loop.childConditionals?.length ?? 0) > 0
+
+        if (!hasReactiveEffects) {
+          // Simple case: no reactive effects — return existing DOM as-is.
+          // Template expressions use loopParam() to read the current item, so the
+          // signal accessor stays intact without any unwrap.
+          if (loop.mapPreamble) {
+            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+          } else {
+            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+          }
         } else {
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; if (typeof ${loop.param} === 'function') ${loop.param} = ${loop.param}(); const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+          // Multi-line renderItem with fine-grained effects — applies to both
+          // SSR (existing DOM) and CSR (freshly created) paths so reactive reads
+          // of non-item signals propagate to existing items too.
+          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => {`)
+          if (loop.mapPreamble) {
+            lines.push(`        ${loop.mapPreamble}`)
+          }
+          lines.push(`        const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
+          emitLoopChildReactiveEffects(
+            lines,
+            '        ',
+            '__el',
+            loop.childReactiveAttrs ?? [],
+            loop.childReactiveTexts ?? [],
+            loop.childConditionals,
+            loop.param,
+          )
+          lines.push(`        return __el`)
+          lines.push(`      })`)
         }
         emitBranchLoopEventDelegation(lines, loop, cv)
       }
@@ -796,7 +825,9 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: LoopElement, 
   const indexParam = elem.index || '__idx'
   const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param)
 
-  const hasReactiveEffects = elem.childReactiveAttrs.length > 0 || elem.childReactiveTexts.length > 0
+  const hasReactiveEffects = elem.childReactiveAttrs.length > 0
+    || elem.childReactiveTexts.length > 0
+    || (elem.childConditionals?.length ?? 0) > 0
 
   if (!hasReactiveEffects) {
     // Simple case: no reactive effects

--- a/site/ui/components/calendar-scheduler-demo.tsx
+++ b/site/ui/components/calendar-scheduler-demo.tsx
@@ -11,12 +11,10 @@
  *   and event count — multiple conditional branches inside a .map() body.
  * - Multi-level memo for overlap layout: weekEvents → weekEventsByDay →
  *   overlapGroups → eventPositions (4-level chain for week view).
- * - Outer-loop param capture in handlers: day-panel and week-slot handlers
- *   capture the outer loop's `d.key` / `cell.key` item (single nesting level).
- *
- * Note: Interactive event selection uses a day-panel (flat loop) rather than
- * nested-loop click handlers, working around a known compiler limitation
- * (nested-loop data-key lookup uses wrong depth for inner loop elements).
+ * - Outer-loop param capture in handlers: week-view hour-slot and event
+ *   handlers are nested inside the weekDays() outer loop, inside the
+ *   viewMode === 'week' conditional. This exercises the click dispatcher
+ *   path that resolves both outer and inner loop keys via data-key / data-key-1.
  */
 
 import { createSignal, createMemo } from '@barefootjs/client'
@@ -304,6 +302,24 @@ export function CalendarSchedulerDemo() {
     setShowCreateForm(false)
   }
 
+  // Week-view nested-loop click handlers. Each handler captures both the outer
+  // loop param (d.key) and inner loop param (h / evt.id), exercising the
+  // data-key / data-key-1 dispatcher path across the viewMode conditional branch.
+  function openCreateInWeek(dateKey: string, hour: number) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(null)
+    setCreatingForHour(hour)
+    setNewTitle('')
+    setNewColor('blue')
+    setShowCreateForm(true)
+  }
+
+  function selectWeekEvent(dateKey: string, id: number) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(id)
+    setShowCreateForm(false)
+  }
+
   function confirmCreate() {
     const title = newTitle().trim()
     const date = selectedDate()
@@ -571,31 +587,34 @@ export function CalendarSchedulerDemo() {
                 ))}
               </div>
 
-              {/* Day columns — visual only (overlap layout memo chain drives positioning) */}
+              {/* Day columns — nested loops with click handlers capturing outer (d.key)
+                  and inner (h / evt.id) params across the viewMode conditional. */}
               {weekDays().map(d => (
                 <div
                   key={d.key}
                   className="week-day-col relative flex-1 border-l border-border"
                   style={`height: ${24 * HOUR_PX}px`}
                 >
-                  {/* Hour rows (background grid) */}
+                  {/* Hour rows: click to create event at that hour */}
                   {HOURS.map(h => (
                     <div
                       key={String(h)}
-                      className="week-hour-slot absolute w-full border-b border-border"
+                      className="week-hour-slot absolute w-full border-b border-border cursor-pointer hover:bg-accent/30"
                       style={`top: ${h * HOUR_PX}px; height: ${HOUR_PX}px`}
+                      onClick={() => openCreateInWeek(d.key, h)}
                     />
                   ))}
 
-                  {/* Positioned events (visual display driven by 4-level memo chain) */}
+                  {/* Positioned events (click to select) */}
                   {(weekEventsByDay()[d.key] ?? []).map(evt => {
                     const pos = eventPositions()[evt.id]
                     if (!pos) return null
                     return (
                       <div
                         key={String(evt.id)}
-                        className={`week-event absolute overflow-hidden rounded border px-1 py-0.5 text-xs ${COLOR_CLASSES[evt.color]}`}
+                        className={`week-event absolute overflow-hidden rounded border px-1 py-0.5 text-xs cursor-pointer hover:opacity-80 ${COLOR_CLASSES[evt.color]}`}
                         style={`top: ${pos.top}px; height: ${pos.height}px; left: ${pos.left}%; width: ${pos.width}%; z-index: 1`}
+                        onClick={() => selectWeekEvent(d.key, evt.id)}
                       >
                         <div className="font-medium truncate">{evt.title}</div>
                         <div className="opacity-75">{formatHour(evt.startHour)}</div>

--- a/site/ui/components/calendar-scheduler-demo.tsx
+++ b/site/ui/components/calendar-scheduler-demo.tsx
@@ -1,0 +1,613 @@
+"use client"
+/**
+ * CalendarSchedulerDemo
+ *
+ * 2D grid calendar with month/week view toggle and overlapping event layout.
+ *
+ * Compiler stress targets:
+ * - View mode toggle changes loop structure entirely: month view renders a flat
+ *   calendarDays loop; week view renders nested weekDays × HOURS 2D grid.
+ * - Per-cell complex conditionals: each cell checks isCurrentMonth, isToday,
+ *   and event count — multiple conditional branches inside a .map() body.
+ * - Multi-level memo for overlap layout: weekEvents → weekEventsByDay →
+ *   overlapGroups → eventPositions (4-level chain for week view).
+ * - Outer-loop param capture in handlers: day-panel and week-slot handlers
+ *   capture the outer loop's `d.key` / `cell.key` item (single nesting level).
+ *
+ * Note: Interactive event selection uses a day-panel (flat loop) rather than
+ * nested-loop click handlers, working around a known compiler limitation
+ * (nested-loop data-key lookup uses wrong depth for inner loop elements).
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+// --- Types ---
+
+type ViewMode = 'month' | 'week'
+type EventColor = 'blue' | 'green' | 'red' | 'purple' | 'orange'
+
+type CalendarEvent = {
+  id: number
+  title: string
+  date: string
+  startHour: number
+  duration: number
+  color: EventColor
+}
+
+// --- Constants ---
+
+const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+const HOUR_PX = 48
+
+const COLOR_CLASSES: Record<EventColor, string> = {
+  blue: 'bg-blue-100 border-blue-400 text-blue-800 dark:bg-blue-900/30 dark:border-blue-500 dark:text-blue-300',
+  green: 'bg-emerald-100 border-emerald-400 text-emerald-800 dark:bg-emerald-900/30 dark:border-emerald-500 dark:text-emerald-300',
+  red: 'bg-rose-100 border-rose-400 text-rose-800 dark:bg-rose-900/30 dark:border-rose-500 dark:text-rose-300',
+  purple: 'bg-purple-100 border-purple-400 text-purple-800 dark:bg-purple-900/30 dark:border-purple-500 dark:text-purple-300',
+  orange: 'bg-orange-100 border-orange-400 text-orange-800 dark:bg-orange-900/30 dark:border-orange-500 dark:text-orange-300',
+}
+
+const COLOR_OPTIONS: EventColor[] = ['blue', 'green', 'red', 'purple', 'orange']
+
+// --- Pure helpers ---
+
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d)
+  r.setDate(r.getDate() + n)
+  return r
+}
+
+function getWeekStart(d: Date): Date {
+  const r = new Date(d)
+  r.setDate(d.getDate() - d.getDay())
+  r.setHours(0, 0, 0, 0)
+  return r
+}
+
+function formatHour(h: number): string {
+  if (h === 0) return '12 AM'
+  if (h < 12) return `${h} AM`
+  if (h === 12) return '12 PM'
+  return `${h - 12} PM`
+}
+
+function formatMonthYear(d: Date): string {
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+}
+
+function formatWeekRange(start: Date): string {
+  const end = addDays(start, 6)
+  return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+}
+
+let _nextId = 100
+function nextId(): number { return _nextId++ }
+
+// --- Initial data ---
+
+const TODAY = new Date()
+const TODAY_KEY = toDateKey(TODAY)
+
+function dayOffset(n: number): string { return toDateKey(addDays(TODAY, n)) }
+
+const initialEvents: CalendarEvent[] = [
+  { id: 1, title: 'Team Standup', date: TODAY_KEY, startHour: 9, duration: 1, color: 'blue' },
+  { id: 2, title: 'Design Review', date: TODAY_KEY, startHour: 10, duration: 2, color: 'purple' },
+  { id: 3, title: 'Lunch with Client', date: TODAY_KEY, startHour: 12, duration: 1, color: 'green' },
+  { id: 4, title: 'Sprint Planning', date: dayOffset(1), startHour: 10, duration: 2, color: 'blue' },
+  { id: 5, title: 'Architecture Review', date: dayOffset(1), startHour: 10, duration: 3, color: 'purple' },
+  { id: 6, title: 'Release Prep', date: dayOffset(1), startHour: 14, duration: 1, color: 'orange' },
+  { id: 7, title: 'All Hands', date: dayOffset(2), startHour: 11, duration: 1, color: 'red' },
+  { id: 8, title: 'Code Review', date: dayOffset(3), startHour: 15, duration: 2, color: 'blue' },
+  { id: 9, title: 'Product Demo', date: dayOffset(5), startHour: 13, duration: 1, color: 'green' },
+  { id: 10, title: 'Weekly Report', date: dayOffset(-1), startHour: 16, duration: 1, color: 'orange' },
+]
+
+// --- Component ---
+
+export function CalendarSchedulerDemo() {
+  const [viewMode, setViewMode] = createSignal<ViewMode>('month')
+  const [currentDate, setCurrentDate] = createSignal(new Date())
+  const [events, setEvents] = createSignal<CalendarEvent[]>(initialEvents)
+  const [selectedEventId, setSelectedEventId] = createSignal<number | null>(null)
+  const [selectedDate, setSelectedDate] = createSignal<string | null>(null)
+  const [newTitle, setNewTitle] = createSignal('')
+  const [newColor, setNewColor] = createSignal<EventColor>('blue')
+  const [creatingForHour, setCreatingForHour] = createSignal<number>(9)
+  const [showCreateForm, setShowCreateForm] = createSignal(false)
+
+  // --- Month view memos ---
+
+  const monthLabel = createMemo(() => formatMonthYear(currentDate()))
+
+  const calendarDays = createMemo(() => {
+    const d = currentDate()
+    const monthStart = new Date(d.getFullYear(), d.getMonth(), 1)
+    const monthEnd = new Date(d.getFullYear(), d.getMonth() + 1, 0)
+    const leadingDow = monthStart.getDay()
+    const days: { date: Date; key: string; isCurrentMonth: boolean }[] = []
+
+    for (let i = leadingDow - 1; i >= 0; i--) {
+      const day = addDays(monthStart, -i - 1)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: false })
+    }
+    for (let n = 1; n <= monthEnd.getDate(); n++) {
+      const day = new Date(d.getFullYear(), d.getMonth(), n)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: true })
+    }
+    const trailing = (7 - (days.length % 7)) % 7
+    for (let i = 1; i <= trailing; i++) {
+      const day = addDays(monthEnd, i)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: false })
+    }
+    return days
+  })
+
+  const eventsByDate = createMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {}
+    for (const evt of events()) {
+      if (!map[evt.date]) map[evt.date] = []
+      map[evt.date].push(evt)
+    }
+    return map
+  })
+
+  // Combined memo: calendarDays + event counts.
+  // Including count in the key forces mapArray to recreate the cell DOM when the
+  // count changes (mapArray returns __existing for unchanged keys, so reactive
+  // reads inside the cell body won't update without this).
+  const calendarDaysWithCounts = createMemo(() => {
+    const byDate = eventsByDate()
+    return calendarDays().map(cell => ({
+      ...cell,
+      count: byDate[cell.key]?.length ?? 0,
+    }))
+  })
+
+  // Day panel: flat loop of events for the selected date (avoids nested-loop click bug)
+  const dayPanelEvents = createMemo(() => {
+    const date = selectedDate()
+    if (!date) return []
+    return eventsByDate()[date] ?? []
+  })
+
+  // --- Week view memos (4-level overlap layout chain) ---
+
+  const weekStart = createMemo(() => getWeekStart(currentDate()))
+  const weekLabel = createMemo(() => formatWeekRange(weekStart()))
+
+  const weekDays = createMemo(() =>
+    Array.from({ length: 7 }, (_, i) => {
+      const d = addDays(weekStart(), i)
+      return { date: d, key: toDateKey(d) }
+    })
+  )
+
+  // Level 1: filter events for the displayed week
+  const weekEvents = createMemo(() => {
+    const keys = new Set(weekDays().map(d => d.key))
+    return events().filter(e => keys.has(e.date))
+  })
+
+  // Level 2: group by day key
+  const weekEventsByDay = createMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {}
+    for (const evt of weekEvents()) {
+      if (!map[evt.date]) map[evt.date] = []
+      map[evt.date].push(evt)
+    }
+    return map
+  })
+
+  // Level 3: compute overlap groups within each day
+  const overlapGroups = createMemo(() => {
+    const result: Record<string, CalendarEvent[][]> = {}
+    for (const [dayKey, dayEvts] of Object.entries(weekEventsByDay())) {
+      const sorted = [...dayEvts].sort((a, b) => a.startHour - b.startHour)
+      const groups: CalendarEvent[][] = []
+      let group: CalendarEvent[] = []
+      let maxEnd = -1
+
+      for (const evt of sorted) {
+        if (group.length > 0 && evt.startHour < maxEnd) {
+          group.push(evt)
+          maxEnd = Math.max(maxEnd, evt.startHour + evt.duration)
+        } else {
+          if (group.length > 0) groups.push(group)
+          group = [evt]
+          maxEnd = evt.startHour + evt.duration
+        }
+      }
+      if (group.length > 0) groups.push(group)
+      result[dayKey] = groups
+    }
+    return result
+  })
+
+  // Level 4: compute pixel position for each event
+  const eventPositions = createMemo(() => {
+    const positions: Record<number, { top: number; height: number; left: number; width: number }> = {}
+    for (const [, groups] of Object.entries(overlapGroups())) {
+      for (const group of groups) {
+        const count = group.length
+        group.forEach((evt, idx) => {
+          positions[evt.id] = {
+            top: evt.startHour * HOUR_PX,
+            height: evt.duration * HOUR_PX - 2,
+            left: (idx / count) * 100,
+            width: (1 / count) * 100,
+          }
+        })
+      }
+    }
+    return positions
+  })
+
+  // --- Derived ---
+
+  const selectedEvent = createMemo(() => {
+    const id = selectedEventId()
+    if (id === null) return null
+    return events().find(e => e.id === id) ?? null
+  })
+
+  const headerLabel = createMemo(() =>
+    viewMode() === 'month' ? monthLabel() : weekLabel()
+  )
+
+  // --- Handlers ---
+
+  function navigatePrev() {
+    const d = currentDate()
+    if (viewMode() === 'month') {
+      setCurrentDate(new Date(d.getFullYear(), d.getMonth() - 1, 1))
+    } else {
+      setCurrentDate(addDays(d, -7))
+    }
+    setSelectedDate(null)
+    setSelectedEventId(null)
+  }
+
+  function navigateNext() {
+    const d = currentDate()
+    if (viewMode() === 'month') {
+      setCurrentDate(new Date(d.getFullYear(), d.getMonth() + 1, 1))
+    } else {
+      setCurrentDate(addDays(d, 7))
+    }
+    setSelectedDate(null)
+    setSelectedEventId(null)
+  }
+
+  function selectDay(dateKey: string) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(null)
+    setShowCreateForm(false)
+  }
+
+  function openAddEvent() {
+    setShowCreateForm(true)
+    setCreatingForHour(9)
+    setNewTitle('')
+    setNewColor('blue')
+    setSelectedEventId(null)
+  }
+
+  function selectEvent(id: number) {
+    setSelectedEventId(id)
+    setShowCreateForm(false)
+  }
+
+  function confirmCreate() {
+    const title = newTitle().trim()
+    const date = selectedDate()
+    if (!title || !date) return
+    setEvents(prev => [...prev, {
+      id: nextId(),
+      title,
+      date,
+      startHour: creatingForHour(),
+      duration: 1,
+      color: newColor(),
+    }])
+    setShowCreateForm(false)
+  }
+
+  function cancelCreate() {
+    setShowCreateForm(false)
+  }
+
+  function removeEvent(id: number) {
+    setEvents(prev => prev.filter(e => e.id !== id))
+    setSelectedEventId(null)
+  }
+
+  function closeDayPanel() {
+    setSelectedDate(null)
+    setSelectedEventId(null)
+    setShowCreateForm(false)
+  }
+
+  return (
+    <div className="calendar-scheduler-demo w-full space-y-4">
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            className="today-btn h-8 px-3 text-sm border border-input rounded-md bg-background hover:bg-accent"
+            onClick={() => { setCurrentDate(new Date()); setSelectedDate(null); setSelectedEventId(null) }}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            className="prev-btn h-8 w-8 flex items-center justify-center rounded-md border border-input bg-background hover:bg-accent text-base leading-none"
+            onClick={navigatePrev}
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            className="next-btn h-8 w-8 flex items-center justify-center rounded-md border border-input bg-background hover:bg-accent text-base leading-none"
+            onClick={navigateNext}
+          >
+            ›
+          </button>
+          <span className="calendar-header-label text-sm font-semibold">
+            {headerLabel()}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="event-count text-xs text-muted-foreground">
+            {events().length} events
+          </span>
+          <div className="view-toggle flex overflow-hidden rounded-md border border-input">
+            <button
+              type="button"
+              className={`month-view-btn h-8 px-3 text-sm ${viewMode() === 'month' ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-accent'}`}
+              onClick={() => setViewMode('month')}
+            >
+              Month
+            </button>
+            <button
+              type="button"
+              className={`week-view-btn h-8 px-3 text-sm border-l border-input ${viewMode() === 'week' ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-accent'}`}
+              onClick={() => setViewMode('week')}
+            >
+              Week
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Day Panel — flat loop of events for selected date (avoids nested-loop click handler bug) */}
+      {selectedDate() ? (
+        <div className="day-panel rounded-md border border-border bg-card p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="day-panel-date text-sm font-semibold">{selectedDate()}</span>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                className="add-event-btn h-7 px-2 text-xs rounded-md border border-input bg-background hover:bg-accent"
+                onClick={openAddEvent}
+              >
+                + Add event
+              </button>
+              <button
+                type="button"
+                className="close-day-panel-btn h-7 w-7 flex items-center justify-center rounded border border-input text-xs"
+                onClick={closeDayPanel}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+
+          {/* Create form (within day panel) */}
+          {showCreateForm() ? (
+            <div className="event-create-form flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-2 py-2">
+              <input
+                className="new-event-title-input h-8 flex-1 rounded-md border border-input bg-background px-2 text-sm min-w-32"
+                placeholder="Event title…"
+                value={newTitle()}
+                onInput={(e) => setNewTitle((e.target as HTMLInputElement).value)}
+              />
+              <select
+                className="new-event-color-select h-8 rounded-md border border-input bg-background px-2 text-sm"
+                value={newColor()}
+                onChange={(e) => setNewColor((e.target as HTMLSelectElement).value as EventColor)}
+              >
+                {COLOR_OPTIONS.map(c => (
+                  <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="create-confirm-btn h-8 rounded-md bg-primary px-3 text-sm text-primary-foreground"
+                onClick={confirmCreate}
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                className="create-cancel-btn h-8 rounded-md border border-input bg-background px-3 text-sm"
+                onClick={cancelCreate}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : null}
+
+          {/* Flat list of events for selected date — single-level loop, no nesting */}
+          {dayPanelEvents().length > 0 ? (
+            <div className="day-event-list space-y-1">
+              {dayPanelEvents().map(evt => (
+                <button
+                  key={String(evt.id)}
+                  type="button"
+                  className={`day-event-item w-full text-left rounded border-l-2 px-2 py-1 text-xs cursor-pointer hover:opacity-80 ${COLOR_CLASSES[evt.color]}`}
+                  onClick={() => selectEvent(evt.id)}
+                >
+                  <span className="font-medium">{evt.title}</span>
+                  <span className="ml-1 opacity-75">{formatHour(evt.startHour)}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          {dayPanelEvents().length === 0 && !showCreateForm() ? (
+            <p className="day-empty-msg text-xs text-muted-foreground">No events. Click "+ Add event" to create one.</p>
+          ) : null}
+
+          {/* Selected event detail inside day panel */}
+          {selectedEvent() ? (
+            <div className="selected-event-detail rounded-md border p-2">
+              <div className={`flex items-center justify-between rounded px-2 py-1 ${COLOR_CLASSES[selectedEvent()!.color]}`}>
+                <div>
+                  <span className="font-medium text-sm">{selectedEvent()!.title}</span>
+                  <span className="ml-2 text-xs opacity-75">
+                    {formatHour(selectedEvent()!.startHour)}–{formatHour(selectedEvent()!.startHour + selectedEvent()!.duration)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 ml-2">
+                  <button
+                    type="button"
+                    className="delete-event-btn h-6 rounded px-2 text-xs border opacity-70 hover:opacity-100"
+                    onClick={() => removeEvent(selectedEvent()!.id)}
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    className="close-detail-btn h-6 w-6 flex items-center justify-center rounded border text-xs"
+                    onClick={() => setSelectedEventId(null)}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* MONTH VIEW */}
+      {viewMode() === 'month' ? (
+        <div className="month-view overflow-hidden rounded-md border border-border">
+          <div className="grid grid-cols-7 border-b border-border">
+            {DAYS_OF_WEEK.map(dow => (
+              <div key={dow} className="py-2 text-center text-xs font-medium text-muted-foreground">
+                {dow}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7">
+            {calendarDaysWithCounts().map(cell => (
+              <button
+                key={`${cell.key}:${cell.count}`}
+                type="button"
+                className={`month-day-cell min-h-24 border-b border-r border-border p-1 text-left hover:bg-accent/40 ${cell.isCurrentMonth ? '' : 'opacity-40'}`}
+                onClick={() => selectDay(cell.key)}
+              >
+                <div
+                  className={`mb-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${cell.key === TODAY_KEY ? 'today-marker bg-primary text-primary-foreground' : 'text-foreground'}`}
+                >
+                  {cell.date.getDate()}
+                </div>
+                {cell.count > 0 ? (
+                  <div className="event-dot-count text-xs text-muted-foreground">
+                    {cell.count} event{cell.count > 1 ? 's' : ''}
+                  </div>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* WEEK VIEW */}
+      {viewMode() === 'week' ? (
+        <div className="week-view overflow-hidden rounded-md border border-border">
+          {/* Day header row */}
+          <div className="flex border-b border-border">
+            <div className="w-14 flex-none" />
+            {weekDays().map(d => (
+              <div
+                key={d.key}
+                className={`flex-1 py-2 text-center text-xs font-medium ${d.key === TODAY_KEY ? 'text-primary' : 'text-muted-foreground'}`}
+              >
+                <div>{DAYS_OF_WEEK[d.date.getDay()]}</div>
+                <div
+                  className={`mx-auto mt-0.5 flex h-6 w-6 items-center justify-center rounded-full text-sm font-semibold ${d.key === TODAY_KEY ? 'week-today-marker bg-primary text-primary-foreground' : ''}`}
+                >
+                  {d.date.getDate()}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Scrollable time grid */}
+          <div className="week-time-grid overflow-y-auto" style="max-height: 480px">
+            <div className="flex">
+              {/* Hour label column */}
+              <div className="week-hour-labels w-14 flex-none">
+                {HOURS.map(h => (
+                  <div
+                    key={String(h)}
+                    className="flex items-start justify-end border-b border-border pr-2 pt-0.5 text-xs text-muted-foreground"
+                    style={`height: ${HOUR_PX}px`}
+                  >
+                    {h > 0 ? formatHour(h) : ''}
+                  </div>
+                ))}
+              </div>
+
+              {/* Day columns — visual only (overlap layout memo chain drives positioning) */}
+              {weekDays().map(d => (
+                <div
+                  key={d.key}
+                  className="week-day-col relative flex-1 border-l border-border"
+                  style={`height: ${24 * HOUR_PX}px`}
+                >
+                  {/* Hour rows (background grid) */}
+                  {HOURS.map(h => (
+                    <div
+                      key={String(h)}
+                      className="week-hour-slot absolute w-full border-b border-border"
+                      style={`top: ${h * HOUR_PX}px; height: ${HOUR_PX}px`}
+                    />
+                  ))}
+
+                  {/* Positioned events (visual display driven by 4-level memo chain) */}
+                  {(weekEventsByDay()[d.key] ?? []).map(evt => {
+                    const pos = eventPositions()[evt.id]
+                    if (!pos) return null
+                    return (
+                      <div
+                        key={String(evt.id)}
+                        className={`week-event absolute overflow-hidden rounded border px-1 py-0.5 text-xs ${COLOR_CLASSES[evt.color]}`}
+                        style={`top: ${pos.top}px; height: ${pos.height}px; left: ${pos.left}%; width: ${pos.width}%; z-index: 1`}
+                      >
+                        <div className="font-medium truncate">{evt.title}</div>
+                        <div className="opacity-75">{formatHour(evt.startHour)}</div>
+                      </div>
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/site/ui/components/calendar-scheduler-demo.tsx
+++ b/site/ui/components/calendar-scheduler-demo.tsx
@@ -156,18 +156,6 @@ export function CalendarSchedulerDemo() {
     return map
   })
 
-  // Combined memo: calendarDays + event counts.
-  // Including count in the key forces mapArray to recreate the cell DOM when the
-  // count changes (mapArray returns __existing for unchanged keys, so reactive
-  // reads inside the cell body won't update without this).
-  const calendarDaysWithCounts = createMemo(() => {
-    const byDate = eventsByDate()
-    return calendarDays().map(cell => ({
-      ...cell,
-      count: byDate[cell.key]?.length ?? 0,
-    }))
-  })
-
   // Day panel: flat loop of events for the selected date (avoids nested-loop click bug)
   const dayPanelEvents = createMemo(() => {
     const date = selectedDate()
@@ -527,9 +515,9 @@ export function CalendarSchedulerDemo() {
             ))}
           </div>
           <div className="grid grid-cols-7">
-            {calendarDaysWithCounts().map(cell => (
+            {calendarDays().map(cell => (
               <button
-                key={`${cell.key}:${cell.count}`}
+                key={cell.key}
                 type="button"
                 className={`month-day-cell min-h-24 border-b border-r border-border p-1 text-left hover:bg-accent/40 ${cell.isCurrentMonth ? '' : 'opacity-40'}`}
                 onClick={() => selectDay(cell.key)}
@@ -539,9 +527,9 @@ export function CalendarSchedulerDemo() {
                 >
                   {cell.date.getDate()}
                 </div>
-                {cell.count > 0 ? (
+                {(eventsByDate()[cell.key]?.length ?? 0) > 0 ? (
                   <div className="event-dot-count text-xs text-muted-foreground">
-                    {cell.count} event{cell.count > 1 ? 's' : ''}
+                    {eventsByDate()[cell.key].length} event{eventsByDate()[cell.key].length > 1 ? 's' : ''}
                   </div>
                 ) : null}
               </button>

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -130,6 +130,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'form-builder', title: 'Form Builder', description: 'Signal-driven form builder with heterogeneous loop, dynamic field type switching, nested groups, and conditional visibility' },
   { slug: 'pivot-table', title: 'Pivot Table', description: 'Dynamic row/column grouping with multi-level aggregation, drag axis config, and expand/collapse groups' },
   { slug: 'dashboard-builder', title: 'Dashboard Builder', description: 'Dynamic widget composition with per-widget signal isolation, dynamic component switching per item, and layout memo driven by widget count' },
+  { slug: 'calendar-scheduler', title: 'Calendar Scheduler', description: '2D grid calendar with month/week view toggle, 4-level overlap layout memo chain, per-cell complex conditionals, and deep nested event handlers' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/calendar-scheduler.spec.ts
+++ b/site/ui/e2e/calendar-scheduler.spec.ts
@@ -333,4 +333,50 @@ test.describe('Calendar Scheduler Block', () => {
       expect(eventCountAfter).not.toBe(eventCountBefore)
     })
   })
+
+  // --- Nested-Loop Click Handlers (week view inside viewMode conditional) ---
+  //
+  // These exercise the compiler path where click handlers are attached to
+  // elements inside nested .map() loops inside a conditional branch. Both the
+  // outer loop key (d.key via data-key) and the inner loop key (h or evt.id
+  // via data-key-1) must be resolvable by the event dispatcher.
+
+  test.describe('Week View Nested-Loop Click Handlers', () => {
+    test('clicking a week hour slot opens the day panel with that date', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const todayColIdx = new Date().getDay()
+      const col = s.locator('.week-day-col').nth(todayColIdx)
+      // Click an hour slot inside the nested loop
+      await col.locator('.week-hour-slot').nth(8).click()
+      await expect(s.locator('.day-panel')).toBeVisible()
+      await expect(s.locator('.event-create-form')).toBeVisible()
+    })
+
+    test('clicking a week event selects the event and shows its detail', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const todayColIdx = new Date().getDay()
+      const col = s.locator('.week-day-col').nth(todayColIdx)
+      const firstEvent = col.locator('.week-event').first()
+      const title = await firstEvent.locator('.font-medium').textContent()
+      await firstEvent.click()
+      await expect(s.locator('.day-panel')).toBeVisible()
+      await expect(s.locator('.selected-event-detail')).toBeVisible()
+      await expect(s.locator('.selected-event-detail')).toContainText(title!.trim())
+    })
+
+    test('clicking different columns captures the correct outer loop param', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      // Use hour 5 (5 AM) — no seeded events here, so nothing intercepts the click.
+      // Click column 0 → day panel shows column 0's date
+      await s.locator('.week-day-col').nth(0).locator('.week-hour-slot').nth(5).click()
+      const firstDate = await s.locator('.day-panel-date').textContent()
+      // Click column 2 → day panel shows column 2's date (different)
+      await s.locator('.week-day-col').nth(2).locator('.week-hour-slot').nth(5).click()
+      const secondDate = await s.locator('.day-panel-date').textContent()
+      expect(secondDate).not.toBe(firstDate)
+    })
+  })
 })

--- a/site/ui/e2e/calendar-scheduler.spec.ts
+++ b/site/ui/e2e/calendar-scheduler.spec.ts
@@ -1,0 +1,336 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Calendar Scheduler Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/calendar-scheduler')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="CalendarSchedulerDemo_"]:not([data-slot])').first()
+
+  // --- Initial Render ---
+
+  test.describe('Initial Render', () => {
+    test('renders month view by default', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.month-view')).toBeVisible()
+      await expect(s.locator('.week-view')).not.toBeVisible()
+    })
+
+    test('renders 7 day-of-week headers', async ({ page }) => {
+      const s = section(page)
+      const headers = s.locator('.month-view .grid').first().locator('div')
+      await expect(headers).toHaveCount(7)
+    })
+
+    test('renders month day cells', async ({ page }) => {
+      const s = section(page)
+      const cells = s.locator('.month-day-cell')
+      const count = await cells.count()
+      expect(count).toBeGreaterThanOrEqual(28)
+      expect(count % 7).toBe(0)
+    })
+
+    test('shows today marker in month view', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.today-marker')).toBeVisible()
+    })
+
+    test('shows event count dot on days with events', async ({ page }) => {
+      const s = section(page)
+      const dots = s.locator('.event-dot-count')
+      const count = await dots.count()
+      expect(count).toBeGreaterThan(0)
+    })
+
+    test('shows total event count in toolbar', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.event-count')).toContainText('10 events')
+    })
+
+    test('renders navigation controls', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.prev-btn')).toBeVisible()
+      await expect(s.locator('.next-btn')).toBeVisible()
+      await expect(s.locator('.today-btn')).toBeVisible()
+    })
+
+    test('renders view toggle buttons', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.month-view-btn')).toBeVisible()
+      await expect(s.locator('.week-view-btn')).toBeVisible()
+    })
+  })
+
+  // --- View Mode Toggle ---
+
+  test.describe('View Mode Toggle', () => {
+    test('switching to week replaces month view with week view', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      await expect(s.locator('.week-view')).toBeVisible()
+      await expect(s.locator('.month-view')).not.toBeVisible()
+    })
+
+    test('switching back to month replaces week view with month view', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      await s.locator('.month-view-btn').click()
+      await expect(s.locator('.month-view')).toBeVisible()
+      await expect(s.locator('.week-view')).not.toBeVisible()
+    })
+
+    test('week view renders 7 day columns', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      await expect(s.locator('.week-day-col')).toHaveCount(7)
+    })
+
+    test('week view shows today marker', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      await expect(s.locator('.week-today-marker')).toBeVisible()
+    })
+
+    test('week view renders 24 hour slots per column', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const firstCol = s.locator('.week-day-col').first()
+      await expect(firstCol.locator('.week-hour-slot')).toHaveCount(24)
+    })
+
+    test('week view shows hour labels', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      await expect(s.locator('.week-hour-labels')).toBeVisible()
+    })
+
+    test('header label changes with view mode', async ({ page }) => {
+      const s = section(page)
+      const monthLabel = await s.locator('.calendar-header-label').textContent()
+      await s.locator('.week-view-btn').click()
+      const weekLabel = await s.locator('.calendar-header-label').textContent()
+      expect(monthLabel).not.toBe(weekLabel)
+    })
+  })
+
+  // --- Navigation ---
+
+  test.describe('Navigation', () => {
+    test('next button advances the month', async ({ page }) => {
+      const s = section(page)
+      const beforeLabel = await s.locator('.calendar-header-label').textContent()
+      await s.locator('.next-btn').click()
+      const afterLabel = await s.locator('.calendar-header-label').textContent()
+      expect(afterLabel).not.toBe(beforeLabel)
+    })
+
+    test('prev button goes back a month', async ({ page }) => {
+      const s = section(page)
+      const beforeLabel = await s.locator('.calendar-header-label').textContent()
+      await s.locator('.prev-btn').click()
+      const afterLabel = await s.locator('.calendar-header-label').textContent()
+      expect(afterLabel).not.toBe(beforeLabel)
+    })
+
+    test('today button returns to current month', async ({ page }) => {
+      const s = section(page)
+      const todayLabel = await s.locator('.calendar-header-label').textContent()
+      await s.locator('.next-btn').click()
+      await s.locator('.next-btn').click()
+      await s.locator('.today-btn').click()
+      await expect(s.locator('.calendar-header-label')).toHaveText(todayLabel!)
+    })
+
+    test('week view prev/next changes week label', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const beforeLabel = await s.locator('.calendar-header-label').textContent()
+      await s.locator('.next-btn').click()
+      const afterLabel = await s.locator('.calendar-header-label').textContent()
+      expect(afterLabel).not.toBe(beforeLabel)
+    })
+  })
+
+  // --- Day Panel ---
+
+  test.describe('Day Panel', () => {
+    test('clicking a day cell opens the day panel', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await expect(s.locator('.day-panel')).toBeVisible()
+    })
+
+    test('day panel shows the selected date', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await expect(s.locator('.day-panel-date')).toBeVisible()
+    })
+
+    test('close button hides the day panel', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await expect(s.locator('.day-panel')).toBeVisible()
+      await s.locator('.close-day-panel-btn').click()
+      await expect(s.locator('.day-panel')).not.toBeVisible()
+    })
+
+    test('today cell shows events in day panel', async ({ page }) => {
+      const s = section(page)
+      // Find the today-marker cell and click it
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      await expect(s.locator('.day-event-list')).toBeVisible()
+      const items = s.locator('.day-event-item')
+      await expect(items).not.toHaveCount(0)
+    })
+
+    test('empty day shows empty message', async ({ page }) => {
+      const s = section(page)
+      // Click prev month to get to a month with no events
+      await s.locator('.next-btn').click()
+      await s.locator('.next-btn').click()
+      // Click first cell of that month
+      await s.locator('.month-day-cell').first().click()
+      await expect(s.locator('.day-empty-msg')).toBeVisible()
+    })
+
+    test('add event button opens the create form', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await s.locator('.add-event-btn').click()
+      await expect(s.locator('.event-create-form')).toBeVisible()
+    })
+
+    test('can add an event via the create form', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await s.locator('.add-event-btn').click()
+      await s.locator('.new-event-title-input').fill('Test Event')
+      await s.locator('.create-confirm-btn').click()
+      await expect(s.locator('.event-create-form')).not.toBeVisible()
+      // Event count increases
+      await expect(s.locator('.event-count')).toContainText('11 events')
+    })
+
+    test('cancel button closes the create form', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.month-day-cell').first().click()
+      await s.locator('.add-event-btn').click()
+      await s.locator('.new-event-title-input').fill('Cancelled Event')
+      await s.locator('.create-cancel-btn').click()
+      await expect(s.locator('.event-create-form')).not.toBeVisible()
+      await expect(s.locator('.event-count')).toContainText('10 events')
+    })
+  })
+
+  // --- Event Selection ---
+
+  test.describe('Event Selection', () => {
+    test('clicking an event in day panel shows event detail', async ({ page }) => {
+      const s = section(page)
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      await s.locator('.day-event-item').first().click()
+      await expect(s.locator('.selected-event-detail')).toBeVisible()
+    })
+
+    test('event detail shows the event title', async ({ page }) => {
+      const s = section(page)
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      const firstItem = s.locator('.day-event-item').first()
+      const title = await firstItem.locator('.font-medium').textContent()
+      await firstItem.click()
+      await expect(s.locator('.selected-event-detail')).toContainText(title!.trim())
+    })
+
+    test('close button hides event detail', async ({ page }) => {
+      const s = section(page)
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      await s.locator('.day-event-item').first().click()
+      await expect(s.locator('.selected-event-detail')).toBeVisible()
+      await s.locator('.close-detail-btn').click()
+      await expect(s.locator('.selected-event-detail')).not.toBeVisible()
+    })
+
+    test('delete button removes the event', async ({ page }) => {
+      const s = section(page)
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      const countBefore = await s.locator('.day-event-item').count()
+      await s.locator('.day-event-item').first().click()
+      await s.locator('.delete-event-btn').click()
+      await expect(s.locator('.selected-event-detail')).not.toBeVisible()
+      const countAfter = await s.locator('.day-event-item').count()
+      expect(countAfter).toBe(countBefore - 1)
+    })
+  })
+
+  // --- Week View Events (Overlap Layout) ---
+
+  test.describe('Week View Events (Overlap Layout)', () => {
+    test('week view shows positioned event blocks', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const count = await s.locator('.week-event').count()
+      expect(count).toBeGreaterThan(0)
+    })
+
+    test('week events show title and time', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const count = await s.locator('.week-event').count()
+      if (count > 0) {
+        const first = s.locator('.week-event').first()
+        await expect(first.locator('.font-medium')).toBeVisible()
+      }
+    })
+
+    test('today column shows multiple events', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      const todayColIdx = new Date().getDay()
+      const col = s.locator('.week-day-col').nth(todayColIdx)
+      const evts = col.locator('.week-event')
+      const count = await evts.count()
+      expect(count).toBeGreaterThan(0)
+    })
+
+    test('overlapping events are both rendered (side by side)', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.week-view-btn').click()
+      // Day +1 has two overlapping events (id 4 and 5, both startHour: 10)
+      const tomorrowIdx = (new Date().getDay() + 1) % 7
+      const col = s.locator('.week-day-col').nth(tomorrowIdx)
+      const evts = col.locator('.week-event')
+      const count = await evts.count()
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+
+    test('adding event updates week view on navigation back to same week', async ({ page }) => {
+      const s = section(page)
+      // Add an event for today via month view
+      const todayCell = s.locator('.month-day-cell:has(.today-marker)')
+      await todayCell.click()
+      const eventCountBefore = await s.locator('.event-count').textContent()
+      await s.locator('.add-event-btn').click()
+      await s.locator('.new-event-title-input').fill('New Week Event')
+      await s.locator('.create-confirm-btn').click()
+
+      // Switch to week view — should show more events
+      await s.locator('.week-view-btn').click()
+      const todayColIdx = new Date().getDay()
+      const col = s.locator('.week-day-col').nth(todayColIdx)
+      const evtsAfter = col.locator('.week-event').count()
+      expect(await evtsAfter).toBeGreaterThan(0)
+
+      const eventCountAfter = await s.locator('.event-count').textContent()
+      expect(eventCountAfter).not.toBe(eventCountBefore)
+    })
+  })
+})

--- a/site/ui/pages/components/calendar-scheduler.tsx
+++ b/site/ui/pages/components/calendar-scheduler.tsx
@@ -1,0 +1,167 @@
+/**
+ * Calendar Scheduler Reference Page (/components/calendar-scheduler)
+ *
+ * Block-level composition pattern: 2D grid calendar with month/week view
+ * toggle, overlapping event layout memo chain, and outer-loop param capture.
+ */
+
+import { CalendarSchedulerDemo } from '@/components/calendar-scheduler-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+// View mode toggle changes the entire loop structure:
+// month view → flat calendarDays loop
+// week view  → nested weekDays × HOURS 2D grid
+
+function CalendarScheduler() {
+  const [viewMode, setViewMode] = createSignal<'month' | 'week'>('month')
+  const [currentDate, setCurrentDate] = createSignal(new Date())
+  const [events, setEvents] = createSignal<CalendarEvent[]>(initialEvents)
+
+  // 4-level overlap layout memo chain (week view only):
+  const weekEvents = createMemo(() =>
+    events().filter(e => isInWeek(e.date, weekStart()))
+  )
+  const weekEventsByDay = createMemo(() => groupByDay(weekEvents()))
+  const overlapGroups = createMemo(() =>
+    computeOverlapGroups(weekEventsByDay())
+  )
+  const eventPositions = createMemo(() =>
+    computeEventPositions(overlapGroups())
+  )
+
+  return (
+    <div>
+      {/* Month view: flat loop with per-cell conditionals */}
+      {viewMode() === 'month' ? (
+        <div className="grid grid-cols-7">
+          {calendarDays().map(cell => (
+            <div key={cell.key}
+              className={\`...\${cell.isCurrentMonth ? '' : 'opacity-40'}\${cell.key === todayKey ? ' bg-primary/5' : ''}\`}
+              onClick={() => openCreate(cell.key, 9)}
+            >
+              {(eventsByDate()[cell.key] ?? []).map(evt => (
+                <div key={String(evt.id)} className={COLOR_CLASSES[evt.color]}>
+                  {evt.title}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Week view: 2D loop — weekDays outer, HOURS inner */}
+      {viewMode() === 'week' ? (
+        <div className="flex">
+          {weekDays().map(d => (
+            <div key={d.key} className="relative flex-1" style={\`height: \${24 * HOUR_PX}px\`}>
+              {HOURS.map(h => (
+                <div key={String(h)} className="absolute w-full border-b"
+                  style={\`top: \${h * HOUR_PX}px; height: \${HOUR_PX}px\`}
+                  onClick={() => openCreate(d.key, h)}
+                />
+              ))}
+              {(weekEventsByDay()[d.key] ?? []).map(evt => {
+                const pos = eventPositions()[evt.id]
+                return (
+                  <div key={String(evt.id)} className="absolute"
+                    style={\`top: \${pos.top}px; height: \${pos.height}px; left: \${pos.left}%; width: \${pos.width}%\`}
+                    onClick={() => setSelectedEventId(evt.id)}
+                  >
+                    {evt.title}
+                  </div>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}`
+
+export function CalendarSchedulerRefPage() {
+  return (
+    <DocPage slug="calendar-scheduler" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Calendar Scheduler"
+          description="Month/week calendar with view-mode toggling that changes the loop structure entirely, a 4-level overlap layout memo chain, and deep nested event handlers inside a 2D time grid."
+          {...getNavLinks('calendar-scheduler')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <CalendarSchedulerDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">View Mode Toggle Changes Loop Structure</h3>
+              <p className="text-sm text-muted-foreground">
+                Switching between Month and Week renders an entirely different DOM tree.
+                Month view iterates a flat <code className="mx-1 text-xs">calendarDays()</code> array
+                (a 1D loop producing a 7-column grid). Week view nests
+                <code className="mx-1 text-xs">weekDays().map()</code> and
+                <code className="mx-1 text-xs">HOURS.map()</code> to build a 2D time grid
+                with absolutely-positioned events. The compiler must handle both loop
+                structures behind the same <code className="mx-1 text-xs">viewMode()</code> conditional.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Per-Cell Complex Conditionals</h3>
+              <p className="text-sm text-muted-foreground">
+                Each month day cell evaluates three independent conditions:
+                <code className="mx-1 text-xs">cell.isCurrentMonth</code> (opacity),
+                <code className="mx-1 text-xs">cell.key === todayKey</code> (highlight ring), and
+                event list presence. The week header repeats similar checks per day column.
+                Multiple conditional class branches inside a single <code className="mx-1 text-xs">.map()</code> body
+                stress the compiler's per-cell IR generation.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">4-Level Memo Chain for Overlap Layout</h3>
+              <p className="text-sm text-muted-foreground">
+                Week view event positioning uses a four-level memo dependency:
+                <code className="mx-1 text-xs">weekEvents</code> (filter by week) →
+                <code className="mx-1 text-xs">weekEventsByDay</code> (group by day key) →
+                <code className="mx-1 text-xs">overlapGroups</code> (detect overlapping event clusters) →
+                <code className="mx-1 text-xs">eventPositions</code> (compute pixel top/height/left/width).
+                Adding or deleting an event cascades through all four levels to update layout.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Deep Nested Event Handlers</h3>
+              <p className="text-sm text-muted-foreground">
+                The week time grid nests three <code className="mx-1 text-xs">.map()</code> calls:
+                outer <code className="mx-1 text-xs">weekDays</code>, inner
+                <code className="mx-1 text-xs">HOURS</code>, and sibling
+                <code className="mx-1 text-xs">weekEventsByDay[d.key]</code>.
+                Click handlers in the hour slots capture <code className="mx-1 text-xs">d.key</code>
+                (outer loop parameter) and <code className="mx-1 text-xs">h</code> (inner item),
+                exercising outer-loop param accessor wrapping across two loop levels.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -85,6 +85,7 @@ import { PermissionMatrixRefPage } from './pages/components/permission-matrix'
 import { FormBuilderRefPage } from './pages/components/form-builder'
 import { PivotTableRefPage } from './pages/components/pivot-table'
 import { DashboardBuilderRefPage } from './pages/components/dashboard-builder'
+import { CalendarSchedulerRefPage } from './pages/components/calendar-scheduler'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -576,6 +577,11 @@ export function createApp() {
   // Dashboard Builder block page
   app.get('/components/dashboard-builder', (c) => {
     return c.render(<DashboardBuilderRefPage />)
+  })
+
+  // Calendar Scheduler block page
+  app.get('/components/calendar-scheduler', (c) => {
+    return c.render(<CalendarSchedulerRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

This PR combines three related changes:

### 1. Calendar Scheduler block (Phase 9 blocks, [issue #135](https://github.com/barefootjs/barefootjs/issues/135))

- Demo component, reference page (`/components/calendar-scheduler`), and E2E tests
- Registered in the component registry and routes
- Exercises 2D grid layout, 4-level memo chains (`weekEvents → weekEventsByDay → overlapGroups → eventPositions`), per-cell conditionals, and nested-loop click handlers inside a view-mode conditional

### 2. Compiler fix: `data-key-N` depth mismatch in SSR conditional branches

The SSR template for a conditional branch was generated with `loopDepth=0`, causing the loop case handler to emit `loopDepth+1=1` for the outer loop's items — producing `data-key-1` instead of `data-key`. The `mapArray` item template and event dispatcher use `data-key` (depth 0) / `data-key-1` (depth 1), so nested-loop click handlers inside conditional branches could not resolve their inner-loop keys.

**Fix**: align `buildConditionalMetadata` with `irToComponentTemplate` / `generateCsrTemplate` by passing `loopDepth=-1`. The workaround migration that renamed `data-key-1` → `data-key` on hydration is no longer needed and has been removed.

**Applied to calendar-scheduler**: the week view now attaches `onClick` directly to nested `.week-hour-slot` and `.week-event` elements (inside the `viewMode === 'week'` conditional).

### 3. Compiler fix: simple branch loops skip reactive-effect wiring

Simple loops inside conditional branches previously emitted a one-liner `mapArray` callback with `if (__existing) return __existing;` — no reactive-effect setup for hydrated items. That meant when a loop body read non-item signals (e.g., `eventsByDate()` inside the `calendarDays().map()` body), those reads never re-ran for existing DOM items. Adding/deleting events didn't update the `event-dot-count` badge on calendar cells.

**Fix**:
- `collectBranchLoops` (`collect-elements.ts`) now collects `childReactiveTexts`, `childReactiveAttrs`, and `childConditionals` for **all** branch loops, not just composite ones.
- The branch loop's item template is built with `loopParams`, so expressions reference the per-item signal accessor (`cell().key`) consistent with the reactive effect expressions.
- Branch loop emission (`emit-control-flow.ts`) uses a multi-line `renderItem` when any reactive field is non-empty, wiring `insert()` / `createEffect` for both the SSR-hydrated and CSR-constructed `__el` paths.

This removes the need for the `calendarDaysWithCounts` memo + count-in-key workaround — the calendar now reads `eventsByDate()` directly inside the loop body and updates reactively.

## Test plan

- [x] 627 compiler unit tests pass (including new tests in `compiler-runtime-contract.test.ts` for both compiler fixes)
- [x] 39 calendar-scheduler E2E tests pass (including Week View Nested-Loop Click Handlers group)
- [x] Full E2E suite: 1348 pass, 2 pre-existing form-builder failures unchanged (unrelated to this PR)
- [x] Clean build (`bun run build`)
- [x] Adding/deleting events updates `event-dot-count` badge on calendar cells (no workaround needed)
- [x] Week view hour slot click opens day panel with correct day/hour; week event click selects the event — both capture outer (`d.key`) and inner (`h` / `evt.id`) loop params