### PR TITLE
fix(xyflow): import reactive APIs from @barefootjs/client/runtime

### DIFF
--- a/packages/xyflow/src/__tests__/compat.test.ts
+++ b/packages/xyflow/src/__tests__/compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { createRoot } from '@barefootjs/client'
+import { createRoot } from '@barefootjs/client/runtime'
 import { createFlowStore } from '../store'
 
 /**

--- a/packages/xyflow/src/__tests__/edge-renderer.test.ts
+++ b/packages/xyflow/src/__tests__/edge-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { createRoot } from '@barefootjs/client'
+import { createRoot } from '@barefootjs/client/runtime'
 import { createFlowStore } from '../store'
 
 describe('Edge processing in store', () => {

--- a/packages/xyflow/src/__tests__/store.test.ts
+++ b/packages/xyflow/src/__tests__/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { createEffect, createRoot } from '@barefootjs/client'
+import { createEffect, createRoot } from '@barefootjs/client/runtime'
 import { createFlowStore } from '../store'
 
 describe('createFlowStore', () => {

--- a/packages/xyflow/src/background.ts
+++ b/packages/xyflow/src/background.ts
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup } from '@barefootjs/client'
+import { createEffect, onCleanup } from '@barefootjs/client/runtime'
 import { useFlow } from './hooks'
 import { SVG_NS } from './constants'
 import type { FlowStore } from './types'

--- a/packages/xyflow/src/compat.ts
+++ b/packages/xyflow/src/compat.ts
@@ -5,7 +5,7 @@
  * desk components can be ported with minimal changes.
  */
 
-import { untrack } from '@barefootjs/client'
+import { untrack } from '@barefootjs/client/runtime'
 import { addEdge as addEdgeUtil, reconnectEdge as reconnectEdgeUtil, pointToRendererPoint } from '@xyflow/system'
 import { useFlow } from './hooks'
 import type { NodeBase, EdgeBase, Viewport, XYPosition } from './types'

--- a/packages/xyflow/src/connection.ts
+++ b/packages/xyflow/src/connection.ts
@@ -1,4 +1,4 @@
-import { untrack } from '@barefootjs/client'
+import { untrack } from '@barefootjs/client/runtime'
 import { getSmoothStepPath, Position, reconnectEdge as reconnectEdgeUtil } from '@xyflow/system'
 import type { FlowStore, NodeBase, EdgeBase, Connection } from './types'
 import { SVG_NS } from './constants'

--- a/packages/xyflow/src/context.ts
+++ b/packages/xyflow/src/context.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@barefootjs/client'
+import { createContext } from '@barefootjs/client/runtime'
 import type { FlowStore } from './types'
 
 /**

--- a/packages/xyflow/src/controls.ts
+++ b/packages/xyflow/src/controls.ts
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup } from '@barefootjs/client'
+import { createSignal, onCleanup } from '@barefootjs/client/runtime'
 import { useFlow } from './hooks'
 import { applyPositionStyle } from './utils'
 

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -1,7 +1,7 @@
 import {
   createEffect,
   onCleanup,
-} from '@barefootjs/client'
+} from '@barefootjs/client/runtime'
 import {
   getBezierPath,
   getSmoothStepPath,

--- a/packages/xyflow/src/minimap.ts
+++ b/packages/xyflow/src/minimap.ts
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup, untrack } from '@barefootjs/client'
+import { createEffect, onCleanup, untrack } from '@barefootjs/client/runtime'
 import { useFlow } from './hooks'
 import { SVG_NS, INFINITE_EXTENT } from './constants'
 import { applyPositionStyle } from './utils'

--- a/packages/xyflow/src/node-resizer.ts
+++ b/packages/xyflow/src/node-resizer.ts
@@ -1,4 +1,4 @@
-import { onCleanup, untrack } from '@barefootjs/client'
+import { onCleanup, untrack } from '@barefootjs/client/runtime'
 import {
   XYResizer,
   XY_RESIZER_HANDLE_POSITIONS,

--- a/packages/xyflow/src/node-wrapper.ts
+++ b/packages/xyflow/src/node-wrapper.ts
@@ -3,7 +3,7 @@ import {
   createEffect,
   onCleanup,
   untrack,
-} from '@barefootjs/client'
+} from '@barefootjs/client/runtime'
 import { updateNodeInternals, updateAbsolutePositions, calcAutoPan, clampPositionToParent } from '@xyflow/system'
 import type {
   NodeBase,

--- a/packages/xyflow/src/selection.ts
+++ b/packages/xyflow/src/selection.ts
@@ -1,4 +1,4 @@
-import { onCleanup, untrack } from '@barefootjs/client'
+import { onCleanup, untrack } from '@barefootjs/client/runtime'
 import type { NodeBase, EdgeBase, InternalNodeBase, Transform } from '@xyflow/system'
 import type { FlowStore, InternalFlowStore, SelectionMode } from './types'
 

--- a/packages/xyflow/src/store.ts
+++ b/packages/xyflow/src/store.ts
@@ -3,7 +3,7 @@ import {
   createEffect,
   createMemo,
   untrack,
-} from '@barefootjs/client'
+} from '@barefootjs/client/runtime'
 import {
   adoptUserNodes,
   updateAbsolutePositions,

--- a/packages/xyflow/src/types.ts
+++ b/packages/xyflow/src/types.ts
@@ -22,8 +22,7 @@ import type {
   ConnectionMode,
   Connection,
 } from '@xyflow/system'
-import type { Signal, Memo } from '@barefootjs/client'
-import type { ComponentDef } from '@barefootjs/client/runtime'
+import type { Signal, Memo, ComponentDef } from '@barefootjs/client/runtime'
 
 export type FitViewOptions = FitViewOptionsBase
 


### PR DESCRIPTION
## Summary

- Normalize every `@barefootjs/client` import in `packages/xyflow/src` (plus the xyflow tests) to `@barefootjs/client/runtime`, matching what `flow.ts` already does.
- Keeps the whole library on a single reactive runtime copy, which is what the existing `setViewport triggers reactive updates` test expects.

## What was broken

`xyflow/src/flow.ts` imported `createEffect` from `@barefootjs/client/runtime`, but `xyflow/src/store.ts` (and most siblings) imported `createSignal` / `createEffect` from `@barefootjs/client`. When an app bundles xyflow, each entry resolves to its own pre-built dist (`client/dist/index.js` and `client/dist/runtime/index.js`), and each dist inlines its own copy of the reactive runtime — separate `Listener` / `Owner` closures and separate subscriber sets.

The practical effect downstream (seen in a Hono + Cloudflare Workers app that bundles DeskCanvas.tsx with `bun build`): `store.setViewport(...)` updates the signal in one runtime copy, while `createEffect(() => { const vp = store.viewport(); viewportEl.style.transform = ... })` in `flow.ts` is registered with the other copy's scheduler. The DOM effect never re-runs, so:

- Scroll-to-pan (`panOnScroll: true`) never updates `viewportEl.style.transform` even though `d3-zoom`'s internal `__zoom` moves.
- Cmd+scroll (`zoomActivationKeyCode: 'Meta'`) has the same symptom — zoom applies in d3 but the viewport DOM stays at `translate(0px, 0px) scale(1)`.

## What this PR does

- `packages/xyflow/src/**/*.ts`: switch `from '@barefootjs/client'` → `from '@barefootjs/client/runtime'` for the 11 modules that import reactive / lifecycle primitives (`createSignal`, `createEffect`, `createMemo`, `onCleanup`, `untrack`, `createContext`).
- `packages/xyflow/src/types.ts`: collapse `Signal` / `Memo` / `ComponentDef` type imports into a single `/runtime` import.
- `packages/xyflow/src/__tests__/*.ts`: mirror the same change so unit tests exercise the library through the same runtime copy.

`flow.ts`, `hooks.ts`, and the existing `/runtime` imports in `node-wrapper.ts` already pointed at `/runtime`, so this PR just removes the inconsistency.

## Test plan

- [x] `bun run --filter '@barefootjs/client' build && cd packages/xyflow && bun test` — 30 pass / 1 pre-existing Playwright-in-bun failure / 1 pre-existing error (unchanged from `main`).
- [x] Reproduced the viewport-not-updating bug with a downstream app (scroll-to-pan + Cmd+zoom), confirmed both behaviors recover after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)