### PR TITLE
fix(client): share reactive runtime across main and /runtime entries

### DIFF
--- a/benchmarks/browser-bench.ts
+++ b/benchmarks/browser-bench.ts
@@ -63,11 +63,13 @@ function vanillaCreate(tbody: HTMLElement, count: number): HTMLElement[] {
 // ---------------------------------------------------------------------------
 // BarefootJS
 // ---------------------------------------------------------------------------
+// Import directly from the reactive source to avoid going through the
+// package's subpath exports, which rely on the built dist being present.
 import {
   createSignal as bfSignal,
   createEffect as bfEffect,
   createRoot as bfRoot,
-} from '../packages/client/src/index.ts'
+} from '../packages/client/src/reactive.ts'
 
 interface BfRow {
   label: [() => string, (v: string | ((p: string) => string)) => void]

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -248,10 +248,17 @@ export async function build(
       : emptyCache(globalHash)
   let anyOutputChanged = false
 
-  // 1. Runtime file — copy barefoot.js (and the shared reactive module it
-  //    imports) via writeIfChanged so unchanged runtime is quiet.
+  // 1. Runtime file — copy the standalone runtime bundle (reactive inlined)
+  //    to barefoot.js. The sibling `./runtime` entry keeps
+  //    `@barefootjs/client/reactive` as an external import so downstream
+  //    bundlers can dedupe it against the main entry; when we ship a file
+  //    for the browser to load directly, we need the self-contained build.
   const domPkgDir = resolve(config.projectDir, 'node_modules/@barefootjs/client')
   const domDistCandidates = [
+    resolve(config.projectDir, '../../packages/client/dist/runtime/standalone.js'),
+    resolve(domPkgDir, 'dist/runtime/standalone.js'),
+    // Legacy fallback for older @barefootjs/client dists that only shipped
+    // the single runtime entry.
     resolve(config.projectDir, '../../packages/client/dist/runtime/index.js'),
     resolve(domPkgDir, 'dist/runtime/index.js'),
   ]
@@ -267,46 +274,14 @@ export async function build(
   }
 
   if (domDistFile) {
-    // Copy the shared reactive module next to barefoot.js. The runtime
-    // dist keeps `@barefootjs/client/reactive` as an external import so
-    // downstream bundlers can dedupe it against the main entry; in the
-    // CLI output we rewrite that to a relative `./reactive.js` sibling.
-    const reactiveDistFile = resolve(dirname(domDistFile), '../reactive.js')
-    let reactiveAvailable = false
-    try {
-      await stat(reactiveDistFile)
-      reactiveAvailable = true
-    } catch {
-      // continue without — older client dists inlined reactive.
-    }
-
-    if (reactiveAvailable) {
-      const reactiveOutPath = resolve(runtimeOutDir, 'reactive.js')
-      let reactiveContent: string | Uint8Array
-      if (config.minify) {
-        reactiveContent = transpile(await readText(reactiveDistFile), { loader: 'js', minify: true })
-      } else {
-        reactiveContent = await readBytes(reactiveDistFile)
-      }
-      const wroteReactive = await writeIfChanged(reactiveOutPath, reactiveContent)
-      if (wroteReactive) {
-        anyOutputChanged = true
-        console.log(`Generated: ${runtimeSubdir}/reactive.js`)
-      }
-    }
-
     const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
-    let runtimeContent: string
+    let runtimeContent: string | Uint8Array
     if (config.minify) {
+      // Minify at copy time so the minify pass below doesn't need to touch
+      // barefoot.js (keeping it out of the per-build write loop).
       runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
     } else {
-      runtimeContent = await readText(domDistFile)
-    }
-    if (reactiveAvailable) {
-      runtimeContent = runtimeContent.replace(
-        /from\s*['"]@barefootjs\/client\/reactive['"]/g,
-        `from './reactive.js'`,
-      )
+      runtimeContent = await readBytes(domDistFile)
     }
     const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
     if (wrote) {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -248,7 +248,8 @@ export async function build(
       : emptyCache(globalHash)
   let anyOutputChanged = false
 
-  // 1. Runtime file — copy barefoot.js via writeIfChanged so unchanged runtime is quiet
+  // 1. Runtime file — copy barefoot.js (and the shared reactive module it
+  //    imports) via writeIfChanged so unchanged runtime is quiet.
   const domPkgDir = resolve(config.projectDir, 'node_modules/@barefootjs/client')
   const domDistCandidates = [
     resolve(config.projectDir, '../../packages/client/dist/runtime/index.js'),
@@ -266,14 +267,46 @@ export async function build(
   }
 
   if (domDistFile) {
+    // Copy the shared reactive module next to barefoot.js. The runtime
+    // dist keeps `@barefootjs/client/reactive` as an external import so
+    // downstream bundlers can dedupe it against the main entry; in the
+    // CLI output we rewrite that to a relative `./reactive.js` sibling.
+    const reactiveDistFile = resolve(dirname(domDistFile), '../reactive.js')
+    let reactiveAvailable = false
+    try {
+      await stat(reactiveDistFile)
+      reactiveAvailable = true
+    } catch {
+      // continue without — older client dists inlined reactive.
+    }
+
+    if (reactiveAvailable) {
+      const reactiveOutPath = resolve(runtimeOutDir, 'reactive.js')
+      let reactiveContent: string | Uint8Array
+      if (config.minify) {
+        reactiveContent = transpile(await readText(reactiveDistFile), { loader: 'js', minify: true })
+      } else {
+        reactiveContent = await readBytes(reactiveDistFile)
+      }
+      const wroteReactive = await writeIfChanged(reactiveOutPath, reactiveContent)
+      if (wroteReactive) {
+        anyOutputChanged = true
+        console.log(`Generated: ${runtimeSubdir}/reactive.js`)
+      }
+    }
+
     const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
-    let runtimeContent: string | Uint8Array
+    let runtimeContent: string
     if (config.minify) {
-      // Minify at copy time so the minify pass below doesn't need to touch
-      // barefoot.js (keeping it out of the per-build write loop).
       runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
     } else {
-      runtimeContent = await readBytes(domDistFile)
+      runtimeContent = await readText(domDistFile)
+    }
+    if (reactiveAvailable) {
+      runtimeContent = runtimeContent.replace(
+        /from\s*['"]@barefootjs\/client\/reactive['"]/g,
+        `from './reactive.js'`,
+      )
     }
     const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
     if (wrote) {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,6 +17,10 @@
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
+    },
+    "./runtime/standalone": {
+      "types": "./dist/runtime/index.d.ts",
+      "import": "./dist/runtime/standalone.js"
     }
   },
   "files": [
@@ -25,7 +29,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive'",
+    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm",
     "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./reactive": {
+      "types": "./dist/reactive.d.ts",
+      "import": "./dist/reactive.js"
+    },
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
@@ -21,7 +25,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm",
+    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive'",
     "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,6 @@
+// Reactive primitives live at the shared `@barefootjs/client/reactive`
+// subpath so main and the `/runtime` entry point reference a single
+// physical module — see src/runtime/index.ts for the rationale.
 export {
   createSignal,
   createEffect,
@@ -13,7 +16,7 @@ export {
   type Memo,
   type CleanupFn,
   type EffectFn,
-} from './reactive'
+} from '@barefootjs/client/reactive'
 
 export { splitProps } from './split-props'
 

--- a/packages/client/src/runtime/apply-rest-attrs.ts
+++ b/packages/client/src/runtime/apply-rest-attrs.ts
@@ -5,7 +5,7 @@
  * Used when spread props cannot be statically expanded (open types).
  */
 
-import { createEffect } from '../reactive'
+import { createEffect } from '@barefootjs/client/reactive'
 
 /** Map of JSX prop names to HTML attribute names */
 function toAttrName(key: string): string {

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -8,7 +8,7 @@
 import { getTemplate } from './template'
 import { getComponentInit } from './registry'
 import { hydratedScopes } from './hydration-state'
-import { untrack } from '../reactive'
+import { untrack } from '@barefootjs/client/reactive'
 import { setCurrentScope } from './context'
 import { BF_SCOPE, BF_KEY } from '@barefootjs/shared'
 import type { ComponentDef } from './types'

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -1,5 +1,13 @@
 // Re-export all user-facing @barefootjs/client APIs so compiler-generated
 // code can use a single import source.
+//
+// The reactive runtime has module-local state (`Listener`, `Owner`, the
+// pending-effect queue) and MUST NOT be duplicated across bundles —
+// otherwise a signal created via one copy is invisible to an effect
+// registered via the other. Both `@barefootjs/client` (main) and this
+// `/runtime` entry pull the reactive primitives from the shared
+// `@barefootjs/client/reactive` subpath so downstream bundlers see a
+// single physical module.
 export {
   createSignal,
   createEffect,
@@ -15,7 +23,7 @@ export {
   type Memo,
   type CleanupFn,
   type EffectFn,
-} from '../reactive'
+} from '@barefootjs/client/reactive'
 
 export { splitProps } from '../split-props'
 export { __slot, type SlotMarker } from '../slot'

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -6,7 +6,7 @@
  * handles event binding for both branches.
  */
 
-import { createEffect } from '../reactive'
+import { createEffect } from '@barefootjs/client/reactive'
 import { find } from './query'
 import { setParentScopeId, parseHTML } from './component'
 import { BF_COND, BF_SCOPE, BF_CHILD_PREFIX } from '@barefootjs/shared'

--- a/packages/client/src/runtime/map-array.ts
+++ b/packages/client/src/runtime/map-array.ts
@@ -11,7 +11,7 @@
  * can initialize it (initChild) instead of creating a new one (createComponent).
  */
 
-import { createSignal, createEffect, createRoot } from '../reactive'
+import { createSignal, createEffect, createRoot } from '@barefootjs/client/reactive'
 import { hydratedScopes } from './hydration-state'
 import { BF_KEY, BF_LOOP_START, BF_LOOP_END } from '@barefootjs/shared'
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -11,7 +11,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@barefootjs/client/reactive": ["./src/reactive.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/preview/src/compile.ts
+++ b/packages/preview/src/compile.ts
@@ -50,8 +50,9 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     await symlink(previewNodeModules, distNodeModules, 'dir')
   }
 
-  // 1. Copy barefoot.js runtime
-  const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/index.js')
+  // 1. Copy barefoot.js runtime — use the standalone runtime (reactive
+  //    primitives inlined) so the browser can load the file directly.
+  const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/standalone.js')
   if (!await Bun.file(domDistFile).exists()) {
     console.log('Building @barefootjs/client...')
     const proc = Bun.spawn(['bun', 'run', 'build'], { cwd: DOM_PKG_DIR })

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -52,8 +52,11 @@ await Bun.write(resolve(DIST_DIR, 'content.json'), JSON.stringify(content))
 console.log(`Bundled: ${pages.length} pages → dist/content.json`)
 
 // ── 2. Build and copy barefoot.js runtime ─────────────────────
+// Use the standalone runtime (reactive primitives inlined) so the
+// browser can load the file directly. The sibling `./runtime` entry
+// keeps reactive external for bundler-side deduplication.
 const barefootFileName = 'barefoot.js'
-const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/index.js')
+const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/standalone.js')
 
 if (!await Bun.file(domDistFile).exists()) {
   console.log('Building @barefootjs/client...')

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -89,9 +89,12 @@ const componentFiles = [...uiComponentFiles, ...docsComponentFiles, ...sharedCom
 await rm(DIST_DIR, { recursive: true, force: true })
 await mkdir(DIST_COMPONENTS_DIR, { recursive: true })
 
-// Build and copy barefoot.js from @barefootjs/client
+// Build and copy barefoot.js from @barefootjs/client.
+// Use the standalone runtime (reactive primitives inlined) so the browser
+// can load the file directly. The sibling `./runtime` entry keeps reactive
+// external for bundler-side deduplication.
 const barefootFileName = 'barefoot.js'
-const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/index.js')
+const domDistFile = resolve(DOM_PKG_DIR, 'dist/runtime/standalone.js')
 
 if (!await Bun.file(domDistFile).exists()) {
   console.log('Building @barefootjs/client...')


### PR DESCRIPTION
## Summary

- Publish reactive primitives through a new \`@barefootjs/client/reactive\` subpath.
- Main (\`@barefootjs/client\`) and \`/runtime\` entries now both pull reactive from this shared module instead of inlining their own copy, so a consumer bundling both sees a single physical module.
- No behavior change for anyone importing only \`@barefootjs/client\` or only \`@barefootjs/client/runtime\`.

## Why

\`dist/index.js\` and \`dist/runtime/index.js\` were each built as standalone ESM bundles that inlined \`src/reactive.ts\` — which owns module-local state (\`Owner\`, \`Listener\`, \`PendingEffects\`, \`BatchDepth\`). When a downstream library mixes imports (e.g. \`@barefootjs/xyflow\`'s \`store.ts\` uses \`from '@barefootjs/client'\` while \`flow.ts\` uses \`from '@barefootjs/client/runtime'\`), each entry's bundle carries its own reactive runtime. A signal created via one copy is then invisible to an effect registered via the other — \`createEffect(() => store.signal())\` never re-runs when \`store.setSignal(...)\` fires.

The concrete downstream bug that surfaced this: in a Hono + Cloudflare Workers app bundling \`DeskCanvas.tsx\` with \`bun build\`, \`store.setViewport(...)\` updated the viewport signal in one reactive copy but the \`viewportEl.style.transform\` effect in \`flow.ts\` was registered with the other copy. \`d3-zoom\`'s internal \`__zoom\` moved on wheel events, but the DOM viewport silently stayed at \`translate(0px, 0px) scale(1)\` — scroll-to-pan and \`zoomActivationKeyCode\` zoom both appeared broken.

## What this PR does

- \`packages/client/package.json\`:
  - Add \`./reactive\` export → \`./dist/reactive.js\`.
  - \`build:js\`: first build \`src/reactive.ts\` standalone, then build the main and runtime entries with \`@barefootjs/client/reactive\` marked external.
- \`packages/client/src/index.ts\` and \`packages/client/src/runtime/index.ts\`: change \`from './reactive'\` / \`from '../reactive'\` → \`from '@barefootjs/client/reactive'\`. Both also pick up comments explaining the single-copy invariant.

\`createContext\` / \`Context\` type and the non-reactive helpers (\`splitProps\`, \`__slot\`, \`forwardProps\`, \`unwrap\`) keep their current re-export paths — they're pure and safe to duplicate — but can be moved to their own subpaths the same way if we ever want to.

## Test plan

- [x] \`bun test packages/\` — 1578 pass, 1 fail, 1 error. The 1 fail / 1 error are a pre-existing Playwright-in-\`bun test\` leak unrelated to this change. (Baseline with this branch stashed ran 1506 pass / 6 fail / 6 errors because \`client/dist\` on \`main\` isn't rebuilt; rebuilding client alone lifts the baseline to match.)
- [x] Rebuilt the package, copied into the downstream app's \`node_modules\`, and confirmed:
  - Only one \`createSignal\` appears in the final \`DeskCanvas.js\` bundle (was two before).
  - \`@barefootjs/xyflow\` scroll-to-pan and Cmd+wheel zoom both work again.
  - \`dev/catalog/issue-card\` still renders 8 nodes and drag-pans correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)