### PR TITLE
feat(blocks): add State Machine Playground block

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -1,0 +1,139 @@
+/**
+ * BarefootJS Compiler — Plain nested loops without a conditional wrapper
+ *
+ * Sibling case of nested-loop-conditional.test.ts, which covers
+ * `outer.map(n => { n.cond ? { inner.map(...) } : null })` (an inner
+ * loop wrapped in a conditional).
+ *
+ * This file covers the bug surfaced while building the State Machine
+ * Playground block (Phase 9 blocks, issue #135): a direct inner
+ * `.map()` inside the outer `.map()` callback body — with no
+ * conditional wrapping the inner — is not emitted as a nested
+ * `mapArray()` when the outer loop itself lives inside a reactive
+ * conditional branch.
+ *
+ * Shape that breaks:
+ *
+ *   {show() ? null : (
+ *     <ul>
+ *       {groups().map(g => (
+ *         <div>
+ *           <ul>
+ *             {g.entries.map(e => <li>{e.text}</li>)}   // no mapArray emitted
+ *           </ul>
+ *         </div>
+ *       ))}
+ *     </ul>
+ *   )}
+ *
+ * Observed output: one `mapArray()` for `groups()` inside the
+ * conditional branch's `bindEvents`. The inner `g.entries.map()` is
+ * only present as a static `.map().join('')` inside the outer item's
+ * `template()` innerHTML. When the outer mapArray reuses an existing
+ * element (group key unchanged), the inner list never re-renders — so
+ * entries appended to an existing group never appear in the DOM.
+ *
+ * Expected: every inner `.map()` whose source is an outer-param-derived
+ * expression should be wired as a nested `mapArray()`, regardless of
+ * whether the outer loop sits at the top level or inside a conditional
+ * branch.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('plain nested loops without conditional wrapper', () => {
+  test('baseline: inner .map() directly inside outer .map() at top level wires nested mapArray', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      type Entry = { id: number; text: string }
+      type Group = { key: string; entries: Entry[] }
+
+      export function GroupedList() {
+        const [entries, setEntries] = createSignal<Entry[]>([])
+        const groups = createMemo<Group[]>(() => [{ key: 'all', entries: entries() }])
+
+        return (
+          <div>
+            {groups().map((g: Group) => (
+              <div key={g.key}>
+                <ul>
+                  {g.entries.map((e: Entry) => (
+                    <li key={String(e.id)}>{e.text}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'GroupedList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // 2 mapArrays expected: groups(), g.entries.
+    const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
+    expect(mapArrayCount).toBeGreaterThanOrEqual(2)
+  })
+
+  test('regression: inner .map() inside outer .map() inside a conditional branch wires nested mapArray', () => {
+    // Same shape as the State Machine Playground's history rendering:
+    //   { count() === 0 ? <p>empty</p> : <ul>{groups().map(g => <div><ul>{g.entries.map(...)}</ul></div>)}</ul> }
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      type Entry = { id: number; text: string }
+      type Group = { key: string; entries: Entry[] }
+
+      export function GroupedList() {
+        const [entries, setEntries] = createSignal<Entry[]>([])
+        const groups = createMemo<Group[]>(() => [{ key: 'all', entries: entries() }])
+        const count = createMemo(() => entries().length)
+
+        return (
+          <div>
+            {count() === 0 ? (
+              <p>empty</p>
+            ) : (
+              <ul>
+                {groups().map((g: Group) => (
+                  <div key={g.key}>
+                    <ul>
+                      {g.entries.map((e: Entry) => (
+                        <li key={String(e.id)}>{e.text}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'GroupedList.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    // 2 mapArrays expected: groups() inside the conditional branch, and
+    // g.entries inside each group.
+    // Bug: only groups() gets a mapArray; g.entries is baked into
+    // static innerHTML. So entries added to an existing group do not
+    // render on the client.
+    const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
+    expect(mapArrayCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -599,9 +599,20 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
         const containerSlot = parentSlotId ?? n.slotId
         if (!containerSlot) break
 
-        // Detect composite: native element root + nested components
+        // Detect composite: native element root + nested components, OR a loop
+        // with inner loops that need their own mapArray reconciliation. Mirrors
+        // the top-level `useElementReconciliation` rule (collect-elements.ts
+        // around line 283) so a `.map()` directly inside an outer `.map()` gets
+        // its own reactive mapArray even when the outer loop lives inside a
+        // conditional branch.
         const hasNestedComps = (n.nestedComponents?.length ?? 0) > 0
-        const useElementReconciliation = !n.childComponent && !n.isStaticArray && hasNestedComps
+        const innerLoopsCollected = !n.childComponent
+          ? collectInnerLoops(n.children, n.param)
+          : undefined
+        const hasInnerLoops = (innerLoopsCollected?.length ?? 0) > 0
+        const useElementReconciliation = !n.childComponent
+          && !n.isStaticArray
+          && (hasNestedComps || hasInnerLoops)
 
         // Build the item template from loop children.
         // Use loopDepth=0: this loop gets its own reconcileElements (independent
@@ -647,7 +658,7 @@ function collectBranchLoops(node: IRNode, ctx?: ClientJsContext): ConditionalBra
           childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
           childReactiveAttrs: childReactiveAttrs.length > 0 ? childReactiveAttrs : undefined,
           childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
-          innerLoops: useElementReconciliation ? collectInnerLoops(n.children, n.param) : undefined,
+          innerLoops: useElementReconciliation ? innerLoopsCollected : undefined,
           useElementReconciliation: useElementReconciliation || undefined,
         })
         // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -86,8 +86,11 @@ function emitBranchBindings(
       const cv = varSlotId(loop.containerSlotId)
       lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
 
-      if (loop.useElementReconciliation && loop.nestedComponents?.length) {
-        // Composite loop: items contain child components — use createComponent in renderItem.
+      if (loop.useElementReconciliation && (loop.nestedComponents?.length || loop.innerLoops?.length)) {
+        // Composite loop: items contain child components OR inner loops that
+        // require their own mapArray reconciliation — use the composite
+        // renderItem path (createComponent for nested components, emitInnerLoopSetup
+        // for inner loops).
         emitCompositeBranchLoop(lines, loop, cv)
       } else {
         const keyFn = loop.key

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -131,6 +131,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'pivot-table', title: 'Pivot Table', description: 'Dynamic row/column grouping with multi-level aggregation, drag axis config, and expand/collapse groups' },
   { slug: 'dashboard-builder', title: 'Dashboard Builder', description: 'Dynamic widget composition with per-widget signal isolation, dynamic component switching per item, and layout memo driven by widget count' },
   { slug: 'calendar-scheduler', title: 'Calendar Scheduler', description: '2D grid calendar with month/week view toggle, 4-level overlap layout memo chain, per-cell complex conditionals, and deep nested event handlers' },
+  { slug: 'state-machine-playground', title: 'State Machine Playground', description: 'Interactive state machine explorer with preset workflows, per-state multi-conditional classes flipping together on transition, a reactive transitions loop source, and a history filter/group memo chain' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/components/state-machine-playground-demo.tsx
+++ b/site/ui/components/state-machine-playground-demo.tsx
@@ -1,0 +1,477 @@
+"use client"
+/**
+ * StateMachinePlaygroundDemo
+ *
+ * Interactive state machine explorer with preset machines, live transitions,
+ * and a filtered/grouped history log.
+ *
+ * Compiler stress targets:
+ * - Many conditionals switching simultaneously on state change: every state
+ *   node in the states loop evaluates three independent conditional classes
+ *   (isCurrent / isReachableFromCurrent / isVisited). Firing one transition
+ *   flips all three conditionals for multiple list items at once.
+ * - Dynamic transition list: the transitions loop is either the full
+ *   transitions array or the filtered possibleTransitions() array depending
+ *   on a toggle — the loop source itself is reactive.
+ * - Per-item reactive disabled attribute: each transition button's `disabled`
+ *   is wired to `t.from === currentState()`, exercising attribute binding
+ *   inside a list whose source may itself change.
+ * - Machine switching reshapes loop structure entirely: picking a different
+ *   preset swaps the states, transitions, and initial state at once, so
+ *   every loop's length and content changes simultaneously.
+ * - Derived views: history() → historyFiltered() (by search) →
+ *   historyGroups() (by event/target) forms a 3-level memo chain that
+ *   feeds a top-level loop-of-loops. The outer group loop is reactive
+ *   (keys change as grouping mode changes); each group's inner entries
+ *   loop is also reactive. (Exercises the compiler path fixed by
+ *   "wire nested mapArray for inner .map() inside conditional-branch
+ *   loops" — an inner `.map()` directly inside an outer `.map()` that
+ *   lives inside a reactive conditional branch must also be emitted as
+ *   a nested mapArray, or entries appended to an existing group will
+ *   not appear on the client.)
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+// --- Types ---
+
+type StateKind = 'initial' | 'final' | 'error' | 'normal'
+
+type StateNode = {
+  id: string
+  label: string
+  kind: StateKind
+  description: string
+}
+
+type Transition = {
+  id: string
+  from: string
+  to: string
+  event: string
+}
+
+type Machine = {
+  id: string
+  name: string
+  description: string
+  initial: string
+  states: StateNode[]
+  transitions: Transition[]
+}
+
+type HistoryEntry = {
+  id: number
+  ts: number
+  from: string
+  to: string
+  event: string
+  machineId: string
+}
+
+type GroupBy = 'none' | 'event' | 'target'
+
+type HistoryGroup = {
+  key: string
+  entries: HistoryEntry[]
+}
+
+// --- Preset machines ---
+
+const TRAFFIC_LIGHT: Machine = {
+  id: 'traffic-light',
+  name: 'Traffic Light',
+  description: 'A classic three-state loop with a maintenance detour.',
+  initial: 'red',
+  states: [
+    { id: 'red', label: 'Red', kind: 'initial', description: 'Stop. No cross traffic.' },
+    { id: 'green', label: 'Green', kind: 'normal', description: 'Go. Intersection open.' },
+    { id: 'yellow', label: 'Yellow', kind: 'normal', description: 'Slow. Prepare to stop.' },
+    { id: 'flashing', label: 'Flashing', kind: 'error', description: 'Maintenance mode.' },
+  ],
+  transitions: [
+    { id: 'tl-go', from: 'red', to: 'green', event: 'GO' },
+    { id: 'tl-slow', from: 'green', to: 'yellow', event: 'SLOW' },
+    { id: 'tl-stop', from: 'yellow', to: 'red', event: 'STOP' },
+    { id: 'tl-fail-r', from: 'red', to: 'flashing', event: 'FAIL' },
+    { id: 'tl-fail-g', from: 'green', to: 'flashing', event: 'FAIL' },
+    { id: 'tl-fail-y', from: 'yellow', to: 'flashing', event: 'FAIL' },
+    { id: 'tl-repair', from: 'flashing', to: 'red', event: 'REPAIR' },
+  ],
+}
+
+const ORDER_WORKFLOW: Machine = {
+  id: 'order-workflow',
+  name: 'Order Workflow',
+  description: 'E-commerce order lifecycle with cancel and refund branches.',
+  initial: 'pending',
+  states: [
+    { id: 'pending', label: 'Pending', kind: 'initial', description: 'Order submitted, awaiting payment.' },
+    { id: 'processing', label: 'Processing', kind: 'normal', description: 'Payment captured, preparing shipment.' },
+    { id: 'shipped', label: 'Shipped', kind: 'normal', description: 'In transit to customer.' },
+    { id: 'delivered', label: 'Delivered', kind: 'final', description: 'Received by customer.' },
+    { id: 'cancelled', label: 'Cancelled', kind: 'final', description: 'Order cancelled.' },
+    { id: 'refunded', label: 'Refunded', kind: 'final', description: 'Payment returned.' },
+  ],
+  transitions: [
+    { id: 'ow-pay', from: 'pending', to: 'processing', event: 'PAY' },
+    { id: 'ow-ship', from: 'processing', to: 'shipped', event: 'SHIP' },
+    { id: 'ow-deliver', from: 'shipped', to: 'delivered', event: 'DELIVER' },
+    { id: 'ow-cancel-p', from: 'pending', to: 'cancelled', event: 'CANCEL' },
+    { id: 'ow-cancel-pr', from: 'processing', to: 'cancelled', event: 'CANCEL' },
+    { id: 'ow-refund-c', from: 'cancelled', to: 'refunded', event: 'REFUND' },
+    { id: 'ow-refund-d', from: 'delivered', to: 'refunded', event: 'REFUND' },
+  ],
+}
+
+const DOCUMENT_REVIEW: Machine = {
+  id: 'document-review',
+  name: 'Document Review',
+  description: 'Editorial workflow with revision loop.',
+  initial: 'draft',
+  states: [
+    { id: 'draft', label: 'Draft', kind: 'initial', description: 'Author is writing.' },
+    { id: 'review', label: 'In Review', kind: 'normal', description: 'Awaiting editor feedback.' },
+    { id: 'revision', label: 'Revision', kind: 'normal', description: 'Author making edits.' },
+    { id: 'approved', label: 'Approved', kind: 'normal', description: 'Ready to publish.' },
+    { id: 'published', label: 'Published', kind: 'final', description: 'Live.' },
+    { id: 'archived', label: 'Archived', kind: 'final', description: 'Pulled offline.' },
+  ],
+  transitions: [
+    { id: 'dr-submit', from: 'draft', to: 'review', event: 'SUBMIT' },
+    { id: 'dr-request', from: 'review', to: 'revision', event: 'REQUEST_CHANGES' },
+    { id: 'dr-resubmit', from: 'revision', to: 'review', event: 'RESUBMIT' },
+    { id: 'dr-approve', from: 'review', to: 'approved', event: 'APPROVE' },
+    { id: 'dr-publish', from: 'approved', to: 'published', event: 'PUBLISH' },
+    { id: 'dr-archive', from: 'published', to: 'archived', event: 'ARCHIVE' },
+    { id: 'dr-retract', from: 'approved', to: 'revision', event: 'RETRACT' },
+  ],
+}
+
+const MACHINES: Machine[] = [TRAFFIC_LIGHT, ORDER_WORKFLOW, DOCUMENT_REVIEW]
+
+const KIND_BADGE: Record<StateKind, string> = {
+  initial: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  final: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+  error: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300',
+  normal: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+}
+
+const KIND_LABEL: Record<StateKind, string> = {
+  initial: 'initial',
+  final: 'final',
+  error: 'error',
+  normal: 'state',
+}
+
+let _nextHistoryId = 1
+function nextHistoryId(): number { return _nextHistoryId++ }
+
+function getMachine(id: string): Machine {
+  return MACHINES.find(m => m.id === id) ?? MACHINES[0]
+}
+
+function formatTs(ts: number): string {
+  const d = new Date(ts)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
+}
+
+export function StateMachinePlaygroundDemo() {
+  const [machineId, setMachineId] = createSignal<string>(TRAFFIC_LIGHT.id)
+  const [currentState, setCurrentState] = createSignal<string>(TRAFFIC_LIGHT.initial)
+  const [history, setHistory] = createSignal<HistoryEntry[]>([])
+  const [visitedIds, setVisitedIds] = createSignal<string[]>([TRAFFIC_LIGHT.initial])
+  const [historySearch, setHistorySearch] = createSignal('')
+  const [groupBy, setGroupBy] = createSignal<GroupBy>('none')
+  const [onlyPossible, setOnlyPossible] = createSignal(false)
+
+  const machine = createMemo(() => getMachine(machineId()))
+
+  const currentStateDef = createMemo(() => {
+    const m = machine()
+    return m.states.find(s => s.id === currentState()) ?? m.states[0]
+  })
+
+  // Transitions outgoing from the current state — drives "possible" highlight and filter mode.
+  const possibleTransitions = createMemo(() =>
+    machine().transitions.filter(t => t.from === currentState())
+  )
+
+  const possibleTargetIds = createMemo(() => {
+    const set: Record<string, true> = {}
+    for (const t of possibleTransitions()) set[t.to] = true
+    return set
+  })
+
+  const visitedSet = createMemo(() => {
+    const set: Record<string, true> = {}
+    for (const id of visitedIds()) set[id] = true
+    return set
+  })
+
+  // Visible transitions: either all or only those from the current state.
+  // Changing `onlyPossible` swaps the loop source entirely.
+  const visibleTransitions = createMemo(() =>
+    onlyPossible() ? possibleTransitions() : machine().transitions
+  )
+
+  // History filter chain: raw → filtered → grouped.
+  const historyFiltered = createMemo(() => {
+    const q = historySearch().trim().toLowerCase()
+    const all = history()
+    if (!q) return all
+    return all.filter(h =>
+      h.event.toLowerCase().includes(q) ||
+      h.from.toLowerCase().includes(q) ||
+      h.to.toLowerCase().includes(q)
+    )
+  })
+
+  const historyGroups = createMemo<HistoryGroup[]>(() => {
+    const mode = groupBy()
+    const entries = historyFiltered()
+    if (mode === 'none') {
+      return [{ key: 'All transitions', entries }]
+    }
+    const map: Record<string, HistoryEntry[]> = {}
+    const order: string[] = []
+    for (const e of entries) {
+      const key = mode === 'event' ? e.event : e.to
+      if (!map[key]) {
+        map[key] = []
+        order.push(key)
+      }
+      map[key].push(e)
+    }
+    return order.map(key => ({ key, entries: map[key] }))
+  })
+
+  const historyCount = createMemo(() => history().length)
+  const visitedCount = createMemo(() => visitedIds().length)
+  const totalStates = createMemo(() => machine().states.length)
+  const possibleCount = createMemo(() => possibleTransitions().length)
+
+  function fireTransition(transition: Transition) {
+    if (transition.from !== currentState()) return
+    const entry: HistoryEntry = {
+      id: nextHistoryId(),
+      ts: Date.now(),
+      from: transition.from,
+      to: transition.to,
+      event: transition.event,
+      machineId: machineId(),
+    }
+    setCurrentState(transition.to)
+    setHistory(prev => [...prev, entry])
+    setVisitedIds(prev => prev.includes(transition.to) ? prev : [...prev, transition.to])
+  }
+
+  function selectMachine(id: string) {
+    const m = getMachine(id)
+    setMachineId(id)
+    setCurrentState(m.initial)
+    setHistory([])
+    setVisitedIds([m.initial])
+    setHistorySearch('')
+  }
+
+  function reset() {
+    const m = machine()
+    setCurrentState(m.initial)
+    setHistory([])
+    setVisitedIds([m.initial])
+    setHistorySearch('')
+  }
+
+  return (
+    <div className="state-machine-playground-demo w-full space-y-4">
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-card p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-xs font-medium text-muted-foreground" for="sm-machine-select">
+            Machine
+          </label>
+          <select
+            id="sm-machine-select"
+            className="machine-select h-8 rounded-md border border-input bg-background px-2 text-sm"
+            value={machineId()}
+            onChange={(e) => selectMachine((e.target as HTMLSelectElement).value)}
+          >
+            {MACHINES.map(m => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+          <span className="machine-description text-xs text-muted-foreground">
+            {machine().description}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="current-state-label text-sm">
+            Current: <span className="font-semibold">{currentStateDef().label}</span>
+          </span>
+          <button
+            type="button"
+            className="reset-btn h-8 px-3 text-sm rounded-md border border-input bg-background hover:bg-accent"
+            onClick={reset}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Stats strip */}
+      <div className="stats-strip grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <div className="rounded-md border border-border bg-card px-3 py-2">
+          <div className="text-xs text-muted-foreground">Current</div>
+          <div className="current-state-name text-sm font-semibold">{currentStateDef().label}</div>
+        </div>
+        <div className="rounded-md border border-border bg-card px-3 py-2">
+          <div className="text-xs text-muted-foreground">Visited</div>
+          <div className="visited-count text-sm font-semibold">{visitedCount()} / {totalStates()}</div>
+        </div>
+        <div className="rounded-md border border-border bg-card px-3 py-2">
+          <div className="text-xs text-muted-foreground">Possible now</div>
+          <div className="possible-count text-sm font-semibold">{possibleCount()}</div>
+        </div>
+        <div className="rounded-md border border-border bg-card px-3 py-2">
+          <div className="text-xs text-muted-foreground">Events fired</div>
+          <div className="history-count text-sm font-semibold">{historyCount()}</div>
+        </div>
+      </div>
+
+      {/* 3-column layout */}
+      <div className="grid gap-3 lg:grid-cols-3">
+
+        {/* States column — each state evaluates 3 simultaneous conditional classes */}
+        <div className="states-column rounded-md border border-border bg-card p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">States</h3>
+            <span className="text-xs text-muted-foreground">{totalStates()} total</span>
+          </div>
+          <div className="states-list space-y-1.5">
+            {machine().states.map((s: StateNode) => (
+              <button
+                key={s.id}
+                type="button"
+                data-state-id={s.id}
+                className={`state-node w-full rounded-md border px-3 py-2 text-left transition-colors${s.id === currentState() ? ' state-current border-primary bg-primary/10' : ''}${possibleTargetIds()[s.id] ? ' state-reachable ring-1 ring-primary/40' : ''}${visitedSet()[s.id] && s.id !== currentState() ? ' state-visited bg-accent/40' : ''}${!visitedSet()[s.id] && s.id !== currentState() ? ' border-border' : ''}`}
+                onClick={() => setCurrentState(s.id)}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="state-node-label text-sm font-medium">{s.label}</span>
+                  <span className={`state-node-kind rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${KIND_BADGE[s.kind]}`}>
+                    {KIND_LABEL[s.kind]}
+                  </span>
+                </div>
+                <p className="state-node-desc mt-0.5 text-xs text-muted-foreground">
+                  {s.description}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Transitions column — loop source itself is reactive */}
+        <div className="transitions-column rounded-md border border-border bg-card p-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold">Transitions</h3>
+            <label className="flex items-center gap-1 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                className="only-possible-toggle h-3 w-3"
+                checked={onlyPossible()}
+                onChange={(e) => setOnlyPossible((e.target as HTMLInputElement).checked)}
+              />
+              Only possible
+            </label>
+          </div>
+          {visibleTransitions().length > 0 ? (
+            <div className="transitions-list space-y-1">
+              {visibleTransitions().map((t: Transition) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  data-transition-id={t.id}
+                  className={`transition-item flex w-full items-center justify-between rounded border px-2.5 py-1.5 text-xs transition-opacity${t.from === currentState() ? ' transition-enabled border-primary/40 bg-primary/5 hover:bg-primary/10' : ' transition-disabled opacity-50 border-border'}`}
+                  disabled={t.from !== currentState()}
+                  onClick={() => fireTransition(t)}
+                >
+                  <span className="transition-event font-mono font-semibold">{t.event}</span>
+                  <span className="transition-arrow text-muted-foreground">
+                    {t.from} → {t.to}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="transitions-empty-msg text-xs text-muted-foreground">
+              No transitions {onlyPossible() ? 'available from current state' : 'defined'}.
+            </p>
+          )}
+        </div>
+
+        {/* History column — 3-level memo chain feeds a loop-of-loops */}
+        <div className="history-column rounded-md border border-border bg-card p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">History</h3>
+            <span className="text-xs text-muted-foreground">{historyCount()} events</span>
+          </div>
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <input
+              type="text"
+              className="history-search h-8 flex-1 min-w-24 rounded-md border border-input bg-background px-2 text-xs"
+              placeholder="Filter…"
+              value={historySearch()}
+              onInput={(e) => setHistorySearch((e.target as HTMLInputElement).value)}
+            />
+            <select
+              className="history-group-select h-8 rounded-md border border-input bg-background px-2 text-xs"
+              value={groupBy()}
+              onChange={(e) => setGroupBy((e.target as HTMLSelectElement).value as GroupBy)}
+            >
+              <option value="none">No group</option>
+              <option value="event">By event</option>
+              <option value="target">By target</option>
+            </select>
+          </div>
+          {historyCount() === 0 ? (
+            <p className="history-empty-msg text-xs text-muted-foreground">
+              No transitions yet. Click a transition to fire it.
+            </p>
+          ) : (
+            <div className="history-groups space-y-2">
+              {historyGroups().map((g: HistoryGroup) => (
+                <div key={g.key} className="history-group">
+                  {groupBy() !== 'none' ? (
+                    <div className="history-group-header mb-1 flex items-center justify-between">
+                      <span className="history-group-key text-xs font-semibold">{g.key}</span>
+                      <span className="text-[10px] text-muted-foreground">{g.entries.length}</span>
+                    </div>
+                  ) : null}
+                  <ul className="history-entries space-y-0.5">
+                    {g.entries.map((e: HistoryEntry) => (
+                      <li
+                        key={String(e.id)}
+                        className="history-entry flex items-center justify-between rounded border border-border/60 px-2 py-1 text-[11px]"
+                      >
+                        <span className="history-entry-event font-mono font-semibold">{e.event}</span>
+                        <span className="history-entry-path text-muted-foreground">
+                          {e.from} → {e.to}
+                        </span>
+                        <span className="history-entry-ts text-[10px] text-muted-foreground">
+                          {formatTs(e.ts)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/site/ui/e2e/state-machine-playground.spec.ts
+++ b/site/ui/e2e/state-machine-playground.spec.ts
@@ -1,0 +1,322 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('State Machine Playground Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/state-machine-playground')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="StateMachinePlaygroundDemo_"]:not([data-slot])').first()
+
+  // --- Initial Render ---
+
+  test.describe('Initial Render', () => {
+    test('renders with traffic-light machine selected', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.machine-select')).toHaveValue('traffic-light')
+      await expect(s.locator('.machine-description')).toContainText('three-state')
+    })
+
+    test('renders four traffic-light states', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.state-node')).toHaveCount(4)
+      await expect(s.locator('[data-state-id="red"]')).toBeVisible()
+      await expect(s.locator('[data-state-id="green"]')).toBeVisible()
+      await expect(s.locator('[data-state-id="yellow"]')).toBeVisible()
+      await expect(s.locator('[data-state-id="flashing"]')).toBeVisible()
+    })
+
+    test('initial state (red) is marked current', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('[data-state-id="red"]')).toHaveClass(/state-current/)
+      await expect(s.locator('.current-state-name').first()).toHaveText('Red')
+    })
+
+    test('reachable states are highlighted from the initial state', async ({ page }) => {
+      const s = section(page)
+      // From red: GO → green, FAIL → flashing (both reachable).
+      await expect(s.locator('[data-state-id="green"]')).toHaveClass(/state-reachable/)
+      await expect(s.locator('[data-state-id="flashing"]')).toHaveClass(/state-reachable/)
+      // yellow is not reachable directly from red.
+      await expect(s.locator('[data-state-id="yellow"]')).not.toHaveClass(/state-reachable/)
+    })
+
+    test('renders all 7 traffic-light transitions', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.transition-item')).toHaveCount(7)
+    })
+
+    test('only transitions from the current state are enabled', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('[data-transition-id="tl-go"]')).toBeEnabled()
+      await expect(s.locator('[data-transition-id="tl-fail-r"]')).toBeEnabled()
+      await expect(s.locator('[data-transition-id="tl-slow"]')).toBeDisabled()
+      await expect(s.locator('[data-transition-id="tl-stop"]')).toBeDisabled()
+    })
+
+    test('stats strip shows initial values', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.visited-count')).toHaveText('1 / 4')
+      await expect(s.locator('.possible-count')).toHaveText('2')
+      await expect(s.locator('.history-count')).toHaveText('0')
+    })
+
+    test('history is empty initially', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.history-empty-msg')).toBeVisible()
+      await expect(s.locator('.history-entry')).toHaveCount(0)
+    })
+  })
+
+  // --- Per-State Multi-Conditional Classes ---
+  //
+  // Firing one transition flips three independent classes on multiple
+  // state nodes at once. These tests verify the compiler wires reactive
+  // className bindings for every item in the states loop.
+
+  test.describe('Per-State Multi-Conditional Classes', () => {
+    test('firing a transition updates current, visited, and reachable classes together', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+
+      // red: was current → now visited
+      await expect(s.locator('[data-state-id="red"]')).not.toHaveClass(/state-current/)
+      await expect(s.locator('[data-state-id="red"]')).toHaveClass(/state-visited/)
+
+      // green: was reachable → now current
+      await expect(s.locator('[data-state-id="green"]')).toHaveClass(/state-current/)
+      await expect(s.locator('[data-state-id="green"]')).not.toHaveClass(/state-reachable/)
+
+      // yellow: was not reachable → now reachable (SLOW is from green)
+      await expect(s.locator('[data-state-id="yellow"]')).toHaveClass(/state-reachable/)
+
+      // flashing: was reachable from red → still reachable from green (FAIL)
+      await expect(s.locator('[data-state-id="flashing"]')).toHaveClass(/state-reachable/)
+    })
+
+    test('current state name updates in header and stats strip', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await expect(s.locator('.current-state-label')).toContainText('Green')
+      await expect(s.locator('.current-state-name').first()).toHaveText('Green')
+    })
+
+    test('visited count grows as new states are entered', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await expect(s.locator('.visited-count')).toHaveText('2 / 4')
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await expect(s.locator('.visited-count')).toHaveText('3 / 4')
+    })
+
+    test('clicking a state node sets it as current without firing a transition', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-state-id="yellow"]').click()
+      await expect(s.locator('[data-state-id="yellow"]')).toHaveClass(/state-current/)
+      // History should NOT record anything.
+      await expect(s.locator('.history-count')).toHaveText('0')
+    })
+  })
+
+  // --- Transition Button Behavior ---
+
+  test.describe('Transition Button Behavior', () => {
+    test('clicking a disabled transition does not change state', async ({ page }) => {
+      const s = section(page)
+      const before = await s.locator('.current-state-name').first().textContent()
+      // Force a click via JS since the browser would normally block it.
+      await s.locator('[data-transition-id="tl-slow"]').dispatchEvent('click')
+      const after = await s.locator('.current-state-name').first().textContent()
+      expect(after).toBe(before)
+    })
+
+    test('transitions update their enabled state when current state changes', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await expect(s.locator('[data-transition-id="tl-go"]')).toBeDisabled()
+      await expect(s.locator('[data-transition-id="tl-slow"]')).toBeEnabled()
+      await expect(s.locator('[data-transition-id="tl-fail-g"]')).toBeEnabled()
+      await expect(s.locator('[data-transition-id="tl-fail-r"]')).toBeDisabled()
+    })
+  })
+
+  // --- Dynamic Transition List (reactive loop source) ---
+
+  test.describe('Dynamic Transition List', () => {
+    test('only-possible toggle shrinks the transitions list', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.transition-item')).toHaveCount(7)
+      await s.locator('.only-possible-toggle').check()
+      await expect(s.locator('.transition-item')).toHaveCount(2)
+    })
+
+    test('only-possible list tracks the current state', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.only-possible-toggle').check()
+      await expect(s.locator('.transition-item')).toHaveCount(2)
+      // Fire GO → now at green → SLOW and FAIL are possible.
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await expect(s.locator('.transition-item')).toHaveCount(2)
+      await expect(s.locator('[data-transition-id="tl-slow"]')).toBeVisible()
+      await expect(s.locator('[data-transition-id="tl-fail-g"]')).toBeVisible()
+    })
+
+    test('unchecking restores the full transitions list', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.only-possible-toggle').check()
+      await expect(s.locator('.transition-item')).toHaveCount(2)
+      await s.locator('.only-possible-toggle').uncheck()
+      await expect(s.locator('.transition-item')).toHaveCount(7)
+    })
+  })
+
+  // --- History Memo Chain ---
+
+  test.describe('History Memo Chain', () => {
+    test('firing transitions appends history entries', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await expect(s.locator('.history-count')).toHaveText('2')
+      await expect(s.locator('.history-entry')).toHaveCount(2)
+    })
+
+    test('search input filters the history', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click() // GO
+      await s.locator('[data-transition-id="tl-slow"]').click() // SLOW
+      await s.locator('.history-search').fill('slow')
+      await expect(s.locator('.history-entry')).toHaveCount(1)
+      await expect(s.locator('.history-entry').first()).toContainText('SLOW')
+    })
+
+    test('search clears restore the full history', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await s.locator('.history-search').fill('slow')
+      await expect(s.locator('.history-entry')).toHaveCount(1)
+      await s.locator('.history-search').fill('')
+      await expect(s.locator('.history-entry')).toHaveCount(2)
+    })
+
+    test('group by event splits history into event-named groups', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click() // GO
+      await s.locator('[data-transition-id="tl-fail-g"]').click() // FAIL
+      await s.locator('[data-transition-id="tl-repair"]').click() // REPAIR
+      await s.locator('[data-transition-id="tl-fail-r"]').click() // FAIL
+      await s.locator('.history-group-select').selectOption('event')
+      const headers = s.locator('.history-group-key')
+      await expect(headers).toHaveCount(3) // GO / FAIL / REPAIR
+      await expect(headers.nth(0)).toHaveText('GO')
+      await expect(headers.nth(1)).toHaveText('FAIL')
+      await expect(headers.nth(2)).toHaveText('REPAIR')
+      // 4 transitions fired → 4 entries rendered across 3 groups.
+      await expect(s.locator('.history-entry')).toHaveCount(4)
+    })
+
+    test('group by target splits history into target-state groups', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await s.locator('.history-group-select').selectOption('target')
+      const headers = s.locator('.history-group-key')
+      await expect(headers).toHaveCount(2)
+      await expect(headers.nth(0)).toHaveText('green')
+      await expect(headers.nth(1)).toHaveText('yellow')
+    })
+
+    test('group headers disappear when grouping is none', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('.history-group-select').selectOption('event')
+      await expect(s.locator('.history-group-key')).toHaveCount(1)
+      await s.locator('.history-group-select').selectOption('none')
+      await expect(s.locator('.history-group-key')).toHaveCount(0)
+      await expect(s.locator('.history-entry')).toHaveCount(1)
+    })
+
+    test('filter + grouping compose correctly (3-level memo chain)', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-fail-g"]').click()
+      await s.locator('[data-transition-id="tl-repair"]').click()
+      await s.locator('.history-group-select').selectOption('event')
+      await s.locator('.history-search').fill('FAIL')
+      const headers = s.locator('.history-group-key')
+      await expect(headers).toHaveCount(1)
+      await expect(headers.first()).toHaveText('FAIL')
+      await expect(s.locator('.history-entry')).toHaveCount(1)
+    })
+  })
+
+  // --- Machine Switching (reshapes loop structure) ---
+
+  test.describe('Machine Switching', () => {
+    test('switching machines replaces states and transitions entirely', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.machine-select').selectOption('order-workflow')
+      await expect(s.locator('.state-node')).toHaveCount(6)
+      await expect(s.locator('.transition-item')).toHaveCount(7)
+      await expect(s.locator('[data-state-id="pending"]')).toBeVisible()
+      await expect(s.locator('[data-state-id="red"]')).toHaveCount(0)
+    })
+
+    test('switching sets current to the new initial state', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.machine-select').selectOption('order-workflow')
+      await expect(s.locator('.current-state-name').first()).toHaveText('Pending')
+      await expect(s.locator('[data-state-id="pending"]')).toHaveClass(/state-current/)
+    })
+
+    test('switching resets history and visited counters', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await expect(s.locator('.history-count')).toHaveText('2')
+      await s.locator('.machine-select').selectOption('document-review')
+      await expect(s.locator('.history-count')).toHaveText('0')
+      await expect(s.locator('.visited-count')).toHaveText('1 / 6')
+    })
+
+    test('document-review workflow fires end-to-end', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.machine-select').selectOption('document-review')
+      await s.locator('[data-transition-id="dr-submit"]').click()
+      await expect(s.locator('.current-state-name').first()).toHaveText('In Review')
+      await s.locator('[data-transition-id="dr-approve"]').click()
+      await expect(s.locator('.current-state-name').first()).toHaveText('Approved')
+      await s.locator('[data-transition-id="dr-publish"]').click()
+      await expect(s.locator('.current-state-name').first()).toHaveText('Published')
+      await expect(s.locator('.history-count')).toHaveText('3')
+    })
+  })
+
+  // --- Reset ---
+
+  test.describe('Reset', () => {
+    test('reset returns to the initial state and clears history', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-transition-id="tl-go"]').click()
+      await s.locator('[data-transition-id="tl-slow"]').click()
+      await expect(s.locator('.history-count')).toHaveText('2')
+      await s.locator('.reset-btn').click()
+      await expect(s.locator('.current-state-name').first()).toHaveText('Red')
+      await expect(s.locator('.history-count')).toHaveText('0')
+      await expect(s.locator('.visited-count')).toHaveText('1 / 4')
+    })
+
+    test('reset preserves the selected machine', async ({ page }) => {
+      const s = section(page)
+      await s.locator('.machine-select').selectOption('order-workflow')
+      await s.locator('[data-transition-id="ow-pay"]').click()
+      await s.locator('.reset-btn').click()
+      await expect(s.locator('.machine-select')).toHaveValue('order-workflow')
+      await expect(s.locator('.current-state-name').first()).toHaveText('Pending')
+    })
+  })
+})

--- a/site/ui/pages/components/state-machine-playground.tsx
+++ b/site/ui/pages/components/state-machine-playground.tsx
@@ -1,0 +1,162 @@
+/**
+ * State Machine Playground Reference Page (/components/state-machine-playground)
+ *
+ * Block-level composition pattern: interactive state machine explorer with
+ * many-simultaneous-conditionals per list item, a reactive loop source, and
+ * a multi-level history filter/group memo chain.
+ */
+
+import { StateMachinePlaygroundDemo } from '@/components/state-machine-playground-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+// Each state node evaluates three independent conditional classes
+// (isCurrent / isReachable / isVisited). Firing a single transition
+// flips all three across multiple list items at once — the compiler
+// must wire reactive className bindings inside the states loop so
+// every affected node updates on the next microtask.
+
+function StateMachinePlayground() {
+  const [machineId, setMachineId] = createSignal('traffic-light')
+  const [currentState, setCurrentState] = createSignal(machine().initial)
+  const [history, setHistory] = createSignal<HistoryEntry[]>([])
+  const [onlyPossible, setOnlyPossible] = createSignal(false)
+  const [historySearch, setHistorySearch] = createSignal('')
+  const [groupBy, setGroupBy] = createSignal<'none' | 'event' | 'target'>('none')
+
+  const machine = createMemo(() => MACHINES.find(m => m.id === machineId())!)
+
+  // Drives the "reachable" highlight on state nodes.
+  const possibleTransitions = createMemo(() =>
+    machine().transitions.filter(t => t.from === currentState())
+  )
+
+  // The transitions loop source itself is reactive.
+  const visibleTransitions = createMemo(() =>
+    onlyPossible() ? possibleTransitions() : machine().transitions
+  )
+
+  // 3-level history memo chain: raw → filtered → grouped.
+  const historyFiltered = createMemo(() => /* filter by search */)
+  const historyGroups = createMemo(() => /* group by mode */)
+
+  return (
+    <div>
+      {/* Every state node has three conditional classes that flip together. */}
+      {machine().states.map(s => (
+        <button key={s.id}
+          className={\`state-node\${s.id === currentState() ? ' state-current' : ''}\${possibleTargetIds()[s.id] ? ' state-reachable' : ''}\${visitedSet()[s.id] ? ' state-visited' : ''}\`}
+          onClick={() => setCurrentState(s.id)}
+        >
+          {s.label}
+        </button>
+      ))}
+
+      {/* Loop source may be the full list OR the filtered one. */}
+      {visibleTransitions().map(t => (
+        <button key={t.id}
+          disabled={t.from !== currentState()}
+          onClick={() => fireTransition(t)}
+        >
+          {t.event}: {t.from} → {t.to}
+        </button>
+      ))}
+
+      {/* Loop-of-loops over the grouped history. */}
+      {historyGroups().map(g => (
+        <div key={g.key}>
+          <h4>{g.key}</h4>
+          {g.entries.map(e => (
+            <div key={String(e.id)}>{e.event}: {e.from} → {e.to}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}`
+
+export function StateMachinePlaygroundRefPage() {
+  return (
+    <DocPage slug="state-machine-playground" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="State Machine Playground"
+          description="Interactive state machine explorer with preset workflows, per-state multi-conditional classes that flip together on transition, a reactive transitions loop source, and a history memo chain that filters and groups derived views."
+          {...getNavLinks('state-machine-playground')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <StateMachinePlaygroundDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Many Conditionals Switching Simultaneously</h3>
+              <p className="text-sm text-muted-foreground">
+                Every state node evaluates three independent conditional classes —
+                <code className="mx-1 text-xs">isCurrent</code>,
+                <code className="mx-1 text-xs">isReachableFromCurrent</code>, and
+                <code className="mx-1 text-xs">isVisited</code> — inside the same
+                <code className="mx-1 text-xs">.map()</code> body. Firing one transition
+                flips all three conditions for multiple list items at once, exercising
+                reactive className binding wiring across every loop item on a single
+                signal update.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Dynamic Transition List</h3>
+              <p className="text-sm text-muted-foreground">
+                The <code className="mx-1 text-xs">&quot;Only possible&quot;</code> toggle switches the transitions
+                loop source between the full machine transition array and the
+                <code className="mx-1 text-xs">possibleTransitions()</code> filter. Toggling it
+                shrinks or grows the rendered list entirely — the compiler must
+                re-run the loop with a different source signal without stale list
+                items left behind.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">Machine Switching Reshapes Loop Structure</h3>
+              <p className="text-sm text-muted-foreground">
+                Selecting a different preset replaces the states, transitions, and
+                initial state all at once via <code className="mx-1 text-xs">selectMachine()</code>.
+                Every loop on the page (states, transitions, history) re-renders
+                against completely new source data, stressing the compiler's
+                key-based reconciliation.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">History Filter/Group Memo Chain</h3>
+              <p className="text-sm text-muted-foreground">
+                History rendering uses a three-level memo chain:
+                <code className="mx-1 text-xs">history</code> →
+                <code className="mx-1 text-xs">historyFiltered</code> (search text) →
+                <code className="mx-1 text-xs">historyGroups</code> (mode: none / event / target).
+                The outer grouped loop and each group's inner entries loop both react
+                to signal changes upstream in the chain. Group keys change as the
+                grouping mode changes, so every list item's key identity shifts.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -86,6 +86,7 @@ import { FormBuilderRefPage } from './pages/components/form-builder'
 import { PivotTableRefPage } from './pages/components/pivot-table'
 import { DashboardBuilderRefPage } from './pages/components/dashboard-builder'
 import { CalendarSchedulerRefPage } from './pages/components/calendar-scheduler'
+import { StateMachinePlaygroundRefPage } from './pages/components/state-machine-playground'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -582,6 +583,11 @@ export function createApp() {
   // Calendar Scheduler block page
   app.get('/components/calendar-scheduler', (c) => {
     return c.render(<CalendarSchedulerRefPage />)
+  })
+
+  // State Machine Playground block page
+  app.get('/components/state-machine-playground', (c) => {
+    return c.render(<StateMachinePlaygroundRefPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

- Adds the State Machine Playground block (issue #135): three preset workflows (traffic light, order workflow, document review), per-state multi-conditional classes that flip together on transition, a reactive transitions loop whose source itself changes via an "Only possible" toggle, and a history memo chain with search and grouping rendered as natural nested loops.
- Adds a failing compiler regression test `packages/jsx/src/__tests__/nested-loop-plain.test.ts` that isolates a bug found while building this block, plus the compiler fix that makes it pass.
- Adds 30 E2E tests (all passing).

## Compiler bug fixed

An inner `.map()` directly inside an outer `.map()` **that lives inside a reactive conditional branch** was not emitted as a nested `mapArray()`. The inner list was only produced as static `.map().join('')` inside the outer item's `template()` innerHTML, so entries appended to an existing group never rendered on the client.

Shape that was broken:

```jsx
{count() === 0 ? (
  <p>empty</p>
) : (
  <ul>
    {groups().map(g => (
      <div>
        <ul>
          {g.entries.map(e => <li>{e.text}</li>)}   {/* was static innerHTML */}
        </ul>
      </div>
    ))}
  </ul>
)}
```

Root cause: in `collect-elements.ts`, the branch-loop collector only enabled `useElementReconciliation` when the body contained nested child components (`hasNestedComps`), so loops whose body had only plain inner `.map()` calls fell through to the simple template path and never collected `innerLoops`. `nested-loop-conditional.test.ts` only covered inner loops wrapped in a conditional, so the plain-nested-inside-conditional path was uncovered.

Fix mirrors the top-level rule: also enable element reconciliation for branch loops when the body has inner loops, collect those inner loops, and update the emitter gate to trigger the composite `renderItem` path when either `nestedComponents` or `innerLoops` is non-empty.

## Test plan
- [x] `bun test packages/jsx/` — 630/630 pass (including the new regression test, which previously failed)
- [x] `bun test packages/client/` — 209/209 pass
- [x] `bun test packages/adapter-tests/` — 177/177 pass
- [x] `bunx playwright test state-machine-playground.spec.ts` — 30/30 pass
- [x] Dev server loads the page with no console errors; fires transitions, adds history entries, switches machines, groups/filters history — all reactive updates visible