### PR TITLE
fix(compiler): preserve multi-return JSX helpers in marked-template output (#932)

### DIFF
--- a/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
+++ b/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
@@ -141,4 +141,43 @@ describe('Multi-return JSX helper preservation (#932)', () => {
     // reach the template output somewhere.
     expect(markedTemplate).toMatch(/PackageIcon|<svg|<path/)
   })
+
+  test('exported-via-named-export multi-return component stays a component', () => {
+    // Regression guard (#932): shadcn-style stateless components like
+    // `ButtonGroupText` have two JSX returns (asChild / default branches)
+    // and are re-exported via `export { Name }` at the bottom of the file.
+    // They must NOT be reclassified as helpers — other files import them
+    // as components and expect compiled component output.
+    const source = `
+      function ButtonGroupText({ asChild, children }: { asChild?: boolean, children?: unknown }) {
+        if (asChild) {
+          return <span className="as-child">{children}</span>
+        }
+        return <div className="default">{children}</div>
+      }
+
+      export { ButtonGroupText }
+    `
+    const result = compileJSXSync(source, 'button-group.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
+    expect(markedTemplate).toBeDefined()
+    expect(markedTemplate!.content).toMatch(/ButtonGroupText/)
+  })
+
+  test('inline `export function` multi-return component stays a component', () => {
+    const source = `
+      export function ButtonGroupText({ asChild, children }: { asChild?: boolean, children?: unknown }) {
+        if (asChild) {
+          return <span>{children}</span>
+        }
+        return <div>{children}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'button-group.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
+    expect(markedTemplate).toBeDefined()
+    expect(markedTemplate!.content).toMatch(/ButtonGroupText/)
+  })
 })

--- a/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
+++ b/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for #932: module-level JSX helper functions with
+ * multiple `return` statements (switch / if-else chain) must be
+ * preserved in the marked-template output so SSR does not throw
+ * `ReferenceError: HelperName is not defined`.
+ *
+ * Context: `extractSingleJsxReturn` in the analyzer only marks a helper
+ * `isJsxFunction = true` when the body has exactly one JSX-returning
+ * `return`. Multi-return shapes slipped through both the inlining path
+ * and the emitter path, surfacing as a silent hydration/SSR break (see
+ * `ui/components/gallery/admin/admin-shell.tsx`'s NavIcon workaround).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('Multi-return JSX helper preservation (#932)', () => {
+  test('switch-return helper is preserved in the marked template', () => {
+    const source = `
+      function NavIcon({ name }: { name: string }) {
+        switch (name) {
+          case 'home':  return <svg><path d="m1 1" /></svg>
+          case 'chart': return <svg><path d="m2 2" /></svg>
+          default:      return null
+        }
+      }
+
+      export function Shell() {
+        return (
+          <nav>
+            <NavIcon name="home" />
+            <NavIcon name="chart" />
+          </nav>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'Shell.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
+    expect(markedTemplate).toBeDefined()
+    // The helper body must land in the template file so SSR can resolve it.
+    expect(markedTemplate!.content).toContain('function NavIcon')
+    expect(markedTemplate!.content).toContain("case 'home'")
+    expect(markedTemplate!.content).toContain("case 'chart'")
+  })
+
+  test('if-else chain returning JSX is preserved', () => {
+    const source = `
+      function Badge({ kind }: { kind: string }) {
+        if (kind === 'ok')   return <span class="ok">ok</span>
+        if (kind === 'warn') return <span class="warn">warn</span>
+        return <span class="err">err</span>
+      }
+
+      export function Panel() {
+        return (
+          <div>
+            <Badge kind="ok" />
+            <Badge kind="warn" />
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'Panel.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(markedTemplate).toContain('function Badge')
+    expect(markedTemplate).toContain("kind === 'ok'")
+    expect(markedTemplate).toContain("kind === 'warn'")
+  })
+
+  test('early-return null + JSX fallback is preserved', () => {
+    const source = `
+      function Optional({ show }: { show: boolean }) {
+        if (!show) return null
+        return <strong>shown</strong>
+      }
+
+      export function Host() {
+        return <div><Optional show={true} /></div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Host.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(markedTemplate).toContain('function Optional')
+    expect(markedTemplate).toContain('return null')
+    expect(markedTemplate).toContain('<strong>shown</strong>')
+  })
+
+  test('"use client" files keep multi-return components as components', () => {
+    // Regression guard: stateful multi-return components that rely on
+    // conditional-return handling (createSignal + onClick per branch)
+    // must NOT be reclassified as verbatim helpers.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggle(props: { asChild?: boolean }) {
+        const [open, setOpen] = createSignal(false)
+        if (props.asChild) {
+          return <span onClick={() => setOpen(!open())}>child</span>
+        }
+        return <button onClick={() => setOpen(!open())}>toggle</button>
+      }
+    `
+    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('initToggle')
+    expect(clientJs!.content).toContain("addEventListener('click'")
+  })
+
+  test('single-return helper continues to work (regression guard)', () => {
+    const source = `
+      function PackageIcon({ size }: { size: number }) {
+        return <svg width={size}><path d="m0 0" /></svg>
+      }
+
+      export function Lister() {
+        return <div><PackageIcon size={24} /></div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Lister.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
+    // Single-return helpers are inlined at call sites by #569, so the
+    // function body need not appear verbatim, but the SVG content must
+    // reach the template output somewhere.
+    expect(markedTemplate).toMatch(/PackageIcon|<svg|<path/)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -171,8 +171,15 @@ export function analyzeComponent(
     targetComponentName = findDefaultExportedComponent(sourceFile)
   }
 
+  // Pre-scan named exports (`export { Foo, Bar }`) so the multi-return
+  // JSX helper reclassifier (#932) can refuse to demote functions that
+  // other files import as components. Inline `export function Foo` is
+  // picked up via the modifier, but named-export declarations only land
+  // at the end of the file — too late for the visit.
+  const namedExports = collectNamedExports(sourceFile)
+
   // Single pass visitor
-  visit(sourceFile, ctx, targetComponentName)
+  visit(sourceFile, ctx, targetComponentName, namedExports)
 
   // Post-processing validations
   validateContext(ctx)
@@ -209,6 +216,32 @@ function findDefaultExportedComponent(sourceFile: ts.SourceFile): string | undef
   return defaultExportName
 }
 
+/**
+ * Collect the set of top-level names exported via `export { Name }` or
+ * `export { Name as Alias }`. Used by the multi-return JSX helper
+ * reclassifier (#932) to keep any PascalCase function that other files
+ * import as a component on the component-compilation path.
+ */
+function collectNamedExports(sourceFile: ts.SourceFile): Set<string> {
+  const exported = new Set<string>()
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isExportDeclaration(stmt) &&
+      stmt.exportClause &&
+      ts.isNamedExports(stmt.exportClause)
+    ) {
+      for (const spec of stmt.exportClause.elements) {
+        // `export { LocalName as ExternalName }` — the declaration we
+        // care about is identified by the local (`propertyName`) or, if
+        // no alias, `name`.
+        const local = (spec.propertyName ?? spec.name).text
+        exported.add(local)
+      }
+    }
+  }
+  return exported
+}
+
 // =============================================================================
 // Single Pass Visitor
 // =============================================================================
@@ -216,7 +249,8 @@ function findDefaultExportedComponent(sourceFile: ts.SourceFile): string | undef
 function visit(
   node: ts.Node,
   ctx: AnalyzerContext,
-  targetComponentName?: string
+  targetComponentName?: string,
+  namedExports?: Set<string>
 ): void {
   // Check for 'use client' directive at module level
   if (ts.isExpressionStatement(node) && ts.isStringLiteral(node.expression)) {
@@ -249,9 +283,15 @@ function visit(
   // helper so the marked-template emitter can include it in any
   // component that references it (<HelperName />).
   //
-  // `"use client"` files are left alone — their multi-return components
-  // are legitimately stateful (createSignal + onClick branches per
-  // variant) and rely on `conditionalReturns` handling at IR time.
+  // Reclassification only applies to *internal* helpers — functions that
+  // aren't exported (inline `export function` or trailing `export { X }`).
+  // Exported PascalCase functions are part of this file's public API and
+  // other files import them as components; demoting them would break
+  // cross-file consumers.
+  //
+  // `"use client"` files are also left alone — their multi-return
+  // components are legitimately stateful (createSignal + onClick branches
+  // per variant) and rely on `conditionalReturns` handling at IR time.
   if (
     !ctx.hasUseClientDirective &&
     ts.isFunctionDeclaration(node) &&
@@ -259,9 +299,12 @@ function visit(
     node.body &&
     isMultiReturnJsxFunctionBody(node.body)
   ) {
-    const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
-    collectFunction(node, ctx, true, isExported)
-    return
+    const hasInlineExport = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+    const hasNamedExport = namedExports?.has(node.name.text) ?? false
+    if (!hasInlineExport && !hasNamedExport) {
+      collectFunction(node, ctx, true, false)
+      return
+    }
   }
 
   // Component function
@@ -356,7 +399,7 @@ function visit(
     }
   }
 
-  ts.forEachChild(node, (child) => visit(child, ctx, targetComponentName))
+  ts.forEachChild(node, (child) => visit(child, ctx, targetComponentName, namedExports))
 }
 
 // =============================================================================
@@ -1745,6 +1788,7 @@ export function listComponentFunctions(
     ts.isStringLiteral(stmt.expression) &&
     (stmt.expression.text === 'use client' || stmt.expression.text === "'use client'")
   )
+  const namedExports = collectNamedExports(sourceFile)
 
   function collectComponents(node: ts.Node): void {
     // Exported function declaration
@@ -1754,8 +1798,18 @@ export function listComponentFunctions(
       // verbatim as helpers rather than compiled as standalone components
       // (see #932 — the component pipeline drops their body). Skip them
       // here so `compileMultipleComponents` does not emit a broken file
-      // for them.
-      if (!hasUseClient && node.body && isMultiReturnJsxFunctionBody(node.body)) {
+      // for them. Only applies to *internal* helpers; anything exported
+      // (inline or via `export { Name }`) is part of the file's public
+      // API and must stay on the component-compilation path.
+      const hasInlineExport = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+      const hasNamedExport = namedExports.has(node.name.text)
+      const isExported = hasInlineExport || hasNamedExport
+      if (
+        !hasUseClient &&
+        !isExported &&
+        node.body &&
+        isMultiReturnJsxFunctionBody(node.body)
+      ) {
         // fall through to forEachChild
       } else {
         componentNames.push(node.name.text)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -241,6 +241,29 @@ function visit(
     collectTypeAliasDefinition(node, ctx)
   }
 
+  // Module-level multi-return JSX helper (#932): a PascalCase function
+  // whose body is a switch / if-else chain where every exit returns JSX
+  // or null. In non-`"use client"` files the component pipeline collapses
+  // such bodies into an empty output (conditional-returns machinery only
+  // runs on the target component); preserve the function verbatim as a
+  // helper so the marked-template emitter can include it in any
+  // component that references it (<HelperName />).
+  //
+  // `"use client"` files are left alone — their multi-return components
+  // are legitimately stateful (createSignal + onClick branches per
+  // variant) and rely on `conditionalReturns` handling at IR time.
+  if (
+    !ctx.hasUseClientDirective &&
+    ts.isFunctionDeclaration(node) &&
+    node.name &&
+    node.body &&
+    isMultiReturnJsxFunctionBody(node.body)
+  ) {
+    const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+    collectFunction(node, ctx, true, isExported)
+    return
+  }
+
   // Component function
   if (isComponentFunction(node)) {
     if (!targetComponentName || node.name.text === targetComponentName) {
@@ -970,6 +993,48 @@ function extractSingleJsxReturn(
   return jsxReturn
 }
 
+/**
+ * Detect a multi-return JSX helper: every top-level exit point is a
+ * `return <jsx>` or `return null`, and at least one return is JSX. Used
+ * to reclassify module-level PascalCase functions with a `switch` / if-else
+ * chain body as verbatim helpers rather than components — otherwise the
+ * component pipeline collapses multi-branch bodies into an empty output
+ * and SSR throws `ReferenceError: <Name> is not defined`. (#932)
+ *
+ * Does not descend into nested function/arrow bodies.
+ */
+export function isMultiReturnJsxFunctionBody(body: ts.Block): boolean {
+  let returnCount = 0
+  let hasJsxReturn = false
+  let allReturnsAreJsxOrNull = true
+
+  function visit(node: ts.Node): void {
+    if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node)) return
+    if (ts.isReturnStatement(node)) {
+      returnCount++
+      if (!node.expression) {
+        allReturnsAreJsxOrNull = false
+        return
+      }
+      let expr: ts.Expression = node.expression
+      while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+      const isJsx =
+        ts.isJsxElement(expr) ||
+        ts.isJsxSelfClosingElement(expr) ||
+        ts.isJsxFragment(expr)
+      const isNull = expr.kind === ts.SyntaxKind.NullKeyword
+      if (isJsx) hasJsxReturn = true
+      if (!isJsx && !isNull) allReturnsAreJsxOrNull = false
+      return
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(body, visit)
+
+  return returnCount > 1 && hasJsxReturn && allReturnsAreJsxOrNull
+}
+
 function collectFunction(
   node: ts.FunctionDeclaration,
   ctx: AnalyzerContext,
@@ -1672,10 +1737,29 @@ export function listComponentFunctions(
 
   const componentNames: string[] = []
 
+  // 'use client' directive detection (controls whether multi-return JSX
+  // PascalCase functions are treated as components or as verbatim helpers).
+  // See #932.
+  const hasUseClient = sourceFile.statements.some(stmt =>
+    ts.isExpressionStatement(stmt) &&
+    ts.isStringLiteral(stmt.expression) &&
+    (stmt.expression.text === 'use client' || stmt.expression.text === "'use client'")
+  )
+
   function collectComponents(node: ts.Node): void {
     // Exported function declaration
     if (isComponentFunction(node)) {
-      componentNames.push(node.name.text)
+      // In non-"use client" files, PascalCase functions whose body is a
+      // multi-return JSX dispatch (switch / if-else chain) are preserved
+      // verbatim as helpers rather than compiled as standalone components
+      // (see #932 — the component pipeline drops their body). Skip them
+      // here so `compileMultipleComponents` does not emit a broken file
+      // for them.
+      if (!hasUseClient && node.body && isMultiReturnJsxFunctionBody(node.body)) {
+        // fall through to forEachChild
+      } else {
+        componentNames.push(node.name.text)
+      }
     }
 
     // Exported arrow function component

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -303,6 +303,11 @@ function visit(
     const hasNamedExport = namedExports?.has(node.name.text) ?? false
     if (!hasInlineExport && !hasNamedExport) {
       collectFunction(node, ctx, true, false)
+      // Mark as a multi-return JSX helper so downstream emission (client JS)
+      // can distinguish it from ordinary module-level helpers whose `body`
+      // happens to contain JSX-like characters inside string literals.
+      const fn = ctx.localFunctions.find(f => f.name === node.name!.text)
+      if (fn) fn.isMultiReturnJsxHelper = true
       return
     }
   }

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -221,6 +221,13 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   const moduleLevelFunctions: FunctionInfo[] = []
   for (const fn of ctx.localFunctions) {
     if (fn.isJsxFunction) continue  // Inlined at call sites (#569)
+    // Multi-return JSX helpers (#932) have `containsJsx: true` but no
+    // `isJsxFunction` — they are preserved verbatim for the SSR marked
+    // template, but their body contains raw JSX syntax that is not valid
+    // JavaScript. Skip them here so client JS stays parseable; hydration
+    // of the referencing component does not need the helper at runtime
+    // (the SVG / JSX was already rendered by SSR).
+    if (fn.containsJsx) continue
     if (!usedIdentifiers.has(fn.name)) continue
     if (fn.isModule && !bodyReferencesComponentScope(fn.body, componentScopeNames)) {
       moduleLevelFunctions.push(fn)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -221,13 +221,15 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   const moduleLevelFunctions: FunctionInfo[] = []
   for (const fn of ctx.localFunctions) {
     if (fn.isJsxFunction) continue  // Inlined at call sites (#569)
-    // Multi-return JSX helpers (#932) have `containsJsx: true` but no
-    // `isJsxFunction` — they are preserved verbatim for the SSR marked
-    // template, but their body contains raw JSX syntax that is not valid
-    // JavaScript. Skip them here so client JS stays parseable; hydration
-    // of the referencing component does not need the helper at runtime
-    // (the SVG / JSX was already rendered by SSR).
-    if (fn.containsJsx) continue
+    // Multi-return JSX helpers (#932) are preserved verbatim for the SSR
+    // marked template, but their body contains raw JSX syntax that is
+    // not valid JavaScript. Skip them here so client JS stays parseable;
+    // hydration of the referencing component does not need the helper at
+    // runtime (the SVG / JSX was already rendered by SSR). Do NOT rely on
+    // `containsJsx` — that regex flag also matches helpers whose body has
+    // JSX-like strings inside string literals (e.g. a code-snippet
+    // builder), and skipping those would regress real client-side logic.
+    if (fn.isMultiReturnJsxHelper) continue
     if (!usedIdentifiers.has(fn.name)) continue
     if (fn.isModule && !bodyReferencesComponentScope(fn.body, componentScopeNames)) {
       moduleLevelFunctions.push(fn)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -512,6 +512,13 @@ export interface FunctionInfo {
   isModule?: boolean
   /** When true, this function returns JSX and is inlined at call sites (#569). */
   isJsxFunction?: boolean
+  /**
+   * When true, this is a module-level multi-return JSX helper reclassified
+   * from the component path (#932). The body is preserved verbatim for the
+   * SSR marked template but MUST be skipped from client-JS emission — the
+   * body contains actual JSX syntax, not just JSX-like string literals.
+   */
+  isMultiReturnJsxHelper?: boolean
   loc: SourceLocation
 }
 

--- a/site/ui/components/gallery/admin/admin-shell.tsx
+++ b/site/ui/components/gallery/admin/admin-shell.tsx
@@ -43,63 +43,50 @@ const PAGE_TITLES: Record<AdminRouteKey, string> = {
   settings: 'Settings',
 }
 
-// NavIcon uses a single-return JSX body with conditional children rather
-// than a multi-return switch. The compiler's sibling-function inlining
-// (`extractSingleJsxReturn` in packages/jsx/src/analyzer.ts) only matches
-// helpers with a single JSX return; a switch-with-multiple-returns was
-// silently dropped from the emitted marked template, causing
-// `ReferenceError: NavIcon is not defined` at SSR. Tracked as a separate
-// compiler issue — remove this workaround once multi-return helpers are
-// preserved in marked-template output.
 function NavIcon({ name }: { name: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      {name === 'home' ? (
-        <>
+  switch (name) {
+    case 'home':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
           <polyline points="9 22 9 12 15 12 15 22" />
-        </>
-      ) : null}
-      {name === 'chart' ? (
-        <>
+        </svg>
+      )
+    case 'chart':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M3 3v18h18" />
           <path d="M7 14l4-4 4 4 5-5" />
-        </>
-      ) : null}
-      {name === 'list' ? (
-        <>
+        </svg>
+      )
+    case 'list':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M8 6h13" />
           <path d="M8 12h13" />
           <path d="M8 18h13" />
           <circle cx="4" cy="6" r="1" />
           <circle cx="4" cy="12" r="1" />
           <circle cx="4" cy="18" r="1" />
-        </>
-      ) : null}
-      {name === 'bell' ? (
-        <>
+        </svg>
+      )
+    case 'bell':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
           <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-        </>
-      ) : null}
-      {name === 'cog' ? (
-        <>
+        </svg>
+      )
+    case 'cog':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="3" />
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-        </>
-      ) : null}
-    </svg>
-  )
+        </svg>
+      )
+    default:
+      return null
+  }
 }
 
 interface AdminShellProps {


### PR DESCRIPTION
## Summary

Closes #932.

- A PascalCase module-level helper whose body is a `switch` / if-else chain with multiple JSX-returning `return` statements was silently dropped from the marked-template file. `extractSingleJsxReturn` rejected multi-return bodies, the component pipeline collapsed the body into an empty output, and SSR threw `ReferenceError: <Name> is not defined` (originally surfaced as `NavIcon is not defined` in the admin-gallery E2E).
- Detect such helpers in non-\`\"use client\"\` files via new `isMultiReturnJsxFunctionBody` and route them through `collectFunction` as verbatim module-level helpers — matching how single-return helpers (`#569`) are already preserved.
- `listComponentFunctions` excludes them from `componentNames` so `compileMultipleComponents` no longer tries (and fails) to emit a broken standalone component file for them.
- `\"use client\"` files are deliberately untouched — their multi-return components are legitimately stateful (`createSignal` + onClick branches per variant) and continue to flow through the existing `conditionalReturns` machinery.
- Revert the `NavIcon` single-return workaround in `site/ui/components/gallery/admin/admin-shell.tsx` (introduced by `a432061d`) so the original switch-based source compiles cleanly.

## Test plan

- [x] `bun test packages/jsx` — 640 tests pass. No existing `if-return` component regressions (covered by `ir-conditional-return.test.ts`).
- [x] New tests in `multi-return-jsx-helper.test.ts`:
  - switch-return helper preserved in marked template
  - if-else chain returning JSX preserved
  - early-return null + JSX fallback preserved
  - \`\"use client\"\` + stateful multi-return component stays as component (regression guard)
  - single-return helper still inlined (no regression)
- [x] `bun run build` — full monorepo, admin-shell compiled marked template now contains `function NavIcon` with all switch cases verbatim.
- [ ] Playwright `admin-gallery.spec.ts` — recommend running against the reverted source to confirm the original repro is fixed at runtime. (Not run in this environment; local green can be verified via `bun --filter barefootjs-site-ui test:e2e`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)