### PR TITLE
feat(compiler): inline same-file reactive factory helpers + BF110 diagnostic (#931)

### DIFF
--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression tests for #931: user-authored reactive-factory helpers.
+ *
+ * Context: wrapping `createSignal` / `createMemo` in a same-file helper
+ * used to silently break — the analyzer only matched the literal
+ * `createSignal` callee, so `const [x, setX] = myHelper(0)` produced
+ * client JS without any signal declaration. Fix: inline the factory
+ * body at the destructured call site so downstream signal/memo
+ * collection sees ordinary `createSignal(...)` calls, and emit BF110
+ * for destructures of non-recognised factory shapes.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('Reactive factory inlining (#931)', () => {
+  test('function-declaration factory: single signal [get, set] is inlined', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [c, s] = createSignal(initial)
+        return [c, s] as const
+      }
+
+      export function Counter() {
+        const [count, setCount] = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    // Inlining rewrites the destructure into an ordinary signal declaration
+    // whose getter is `count` and setter is `setCount`.
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].setter).toBe('setCount')
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+    expect(clientJs!.content).toContain('count')
+    expect(clientJs!.content).toContain('setCount')
+  })
+
+  test('factory with custom setter wrapper is inlined verbatim', () => {
+    // Matches the createPersistentSignal shape from PR #930.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createStoredSignal(key: string, initial: string) {
+        const [v, setV] = createSignal(initial)
+        const setAndStore = (next: string) => {
+          setV(next)
+          localStorage.setItem(key, next)
+        }
+        return [v, setAndStore] as const
+      }
+
+      export function Store() {
+        const [value, setValue] = createStoredSignal('k', 'hello')
+        return <button onClick={() => setValue('world')}>{value()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Store.tsx')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('value')
+
+    const result = compileJSXSync(source, 'Store.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The body's custom setter should be emitted as a regular constant
+    // inside the init function (suffix-renamed to avoid collisions).
+    expect(clientJs).toContain('createSignal')
+    expect(clientJs).toContain("localStorage.setItem('k'")
+  })
+
+  test('factory called twice in the same component — identifier hygiene', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [c, s] = createSignal(initial)
+        return [c, s] as const
+      }
+
+      export function Pair() {
+        const [a, setA] = createCounter(0)
+        const [b, setB] = createCounter(10)
+        return <p>{a()} {b()}</p>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Pair.tsx')
+    expect(ctx.signals.length).toBe(2)
+    const getters = ctx.signals.map(s => s.getter).sort()
+    expect(getters).toEqual(['a', 'b'])
+
+    const result = compileJSXSync(source, 'Pair.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // Both destructures should resolve to independent signals.
+    expect(clientJs.match(/createSignal\(/g)?.length).toBe(2)
+  })
+
+  test('factory parameters are substituted at the call site', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [c, s] = createSignal(initial)
+        return [c, s] as const
+      }
+
+      export function Counter() {
+        const [count, setCount] = createCounter(42)
+        return <span>{count()}</span>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The argument expression must flow into the createSignal call.
+    expect(clientJs).toMatch(/createSignal\(\s*42\s*\)/)
+  })
+
+  test('BF110: tuple destructure of an unknown callee emits a diagnostic', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { useExternal } from './external'
+
+      export function Gadget() {
+        const [value, setValue] = useExternal('key', 'hello')
+        return <button onClick={() => setValue('x')}>{value()}</button>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Gadget.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('useExternal')
+  })
+
+  test('BF110 is NOT emitted when the factory shape is recognised and inlined', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [c, s] = createSignal(initial)
+        return [c, s] as const
+      }
+
+      export function Counter() {
+        const [count, setCount] = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeUndefined()
+  })
+
+  test('non-tuple single-value destructure is NOT treated as a factory call', () => {
+    // Guard against false positives: `const { x } = obj()` should be left alone.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Comp() {
+        const [count, setCount] = createSignal(0)
+        return <p>{count()}</p>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Comp.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeUndefined()
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -19,6 +19,7 @@ import type {
   CompilerError,
   SourceLocation,
   ParamInfo,
+  ReactiveFactoryInfo,
 } from './types'
 import { type ExcludeRange, collectAllTypeRanges, reconstructWithoutTypes } from './strip-types'
 
@@ -74,6 +75,16 @@ export interface AnalyzerContext {
     jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
     params: string[]
   }>
+  /**
+   * Maps function names to reactive-factory info (#931). A reactive factory
+   * is a same-file helper whose body declares reactive primitives and
+   * returns a tuple of identifiers, e.g.
+   *   `function createCounter(initial) { const [c,s] = createSignal(initial); return [c, s] as const }`.
+   * When a component destructures the result of a factory call, the factory
+   * body is inlined at the call site so the compiler sees ordinary
+   * `createSignal` declarations.
+   */
+  reactiveFactories: Map<string, ReactiveFactoryInfo>
 
   // Props
   propsType: TypeInfo | null
@@ -140,6 +151,7 @@ export function createAnalyzerContext(
     typeDefinitions: [],
     jsxConstants: new Map(),
     jsxFunctions: new Map(),
+    reactiveFactories: new Map(),
 
     propsType: null,
     propsParams: [],

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -6,7 +6,7 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo } from './types'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types'
 import { rewriteBarePropRefs } from './prop-rewrite'
 import {
   type AnalyzerContext,
@@ -114,6 +114,23 @@ export function analyzeComponent(
   targetComponentName?: string,
   program?: ts.Program
 ): AnalyzerContext {
+  // Pre-pass: inline calls to same-file reactive factory helpers so the
+  // downstream analyzer sees ordinary `createSignal(...)` declarations
+  // instead of `const [a, b] = customFactory(...)` (#931). Skipped when
+  // no recognisable factories are present, so it is a no-op for the
+  // common case.
+  const prescan = prescanReactiveFactoriesInSource(source, filePath)
+  const rewritten = prescan.factories.size > 0
+    ? rewriteFactoryCallsInSource(source, prescan)
+    : null
+  if (rewritten) {
+    source = rewritten
+    // The pre-built ts.Program (if any) references the original source,
+    // so discard it — the analyzer will rebuild a fresh program if
+    // type-based detection is needed.
+    program = undefined
+  }
+
   let sourceFile: ts.SourceFile | undefined
   let checker: ts.TypeChecker | null = null
 
@@ -1558,6 +1575,10 @@ function validateContext(ctx: AnalyzerContext): void {
   // declaration cause a ReferenceError in ESM strict mode. Flag them
   // at compile time instead of shipping broken client JS. (#933)
   validateInitStatementReferences(ctx)
+
+  // BF110: flag tuple-destructures that would have been silent runtime
+  // failures before factory inlining landed (#931).
+  validateReactiveFactoryCalls(ctx)
 }
 
 function validateInitStatementReferences(ctx: AnalyzerContext): void {
@@ -1668,6 +1689,340 @@ export function listComponentFunctions(
   ts.forEachChild(sourceFile, collectComponents)
 
   return componentNames
+}
+
+// =============================================================================
+// Reactive Factory Pre-pass (#931)
+// =============================================================================
+
+// Names of reactive primitives that a factory body must contain for the
+// factory to qualify for inlining. Identifier resolution happens at the
+// source text level, so these are matched as bare identifiers.
+const REACTIVE_PRIMITIVES = new Set([
+  'createSignal', 'createMemo', 'createEffect',
+  'createDisposableEffect', 'onMount', 'onCleanup',
+])
+
+interface PrescanResult {
+  factories: Map<string, ReactiveFactoryInfo>
+  sourceFile: ts.SourceFile
+}
+
+/**
+ * Scan a source string for module-level function declarations that match
+ * the reactive-factory shape (single `return [a, b, ...]` exit + at least
+ * one reactive primitive call in the body). Returns a map from factory
+ * name to its metadata, and the parsed source file for call-site rewriting.
+ */
+function prescanReactiveFactoriesInSource(
+  source: string,
+  filePath: string
+): PrescanResult {
+  const sourceFile = ts.createSourceFile(
+    filePath + '.prescan',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const factories = new Map<string, ReactiveFactoryInfo>()
+
+  function visitTop(node: ts.Node): void {
+    if (ts.isFunctionDeclaration(node) && node.name && node.body) {
+      const info = detectReactiveFactory(node, sourceFile, filePath)
+      if (info) factories.set(node.name.text, info)
+    }
+    // Not recursing into function bodies: factory helpers are at module
+    // scope only for this round (issue #931 "In scope" §1).
+  }
+
+  ts.forEachChild(sourceFile, visitTop)
+
+  return { factories, sourceFile }
+}
+
+function detectReactiveFactory(
+  node: ts.FunctionDeclaration,
+  sourceFile: ts.SourceFile,
+  filePath: string
+): ReactiveFactoryInfo | null {
+  if (!node.body || !node.name) return null
+
+  // Require: exactly one top-level `return` whose argument is an array
+  // literal of plain identifiers (optionally wrapped in `as const` / parens).
+  let tupleReturn: ts.ArrayLiteralExpression | null = null
+  let returnCount = 0
+  for (const stmt of node.body.statements) {
+    if (!ts.isReturnStatement(stmt)) continue
+    returnCount++
+    if (!stmt.expression) return null
+    let expr: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+    // Accept `... as const` / `<const>...`
+    if (ts.isAsExpression(expr)) expr = expr.expression
+    if (ts.isTypeAssertionExpression(expr)) expr = expr.expression
+    if (!ts.isArrayLiteralExpression(expr)) return null
+    tupleReturn = expr
+  }
+  if (returnCount !== 1 || !tupleReturn) return null
+
+  // Every element must be a plain identifier (no spreads, computed,
+  // call expressions). Otherwise the caller-side rename would not be sound.
+  const returnTupleIdentifiers: string[] = []
+  for (const el of tupleReturn.elements) {
+    if (!ts.isIdentifier(el)) return null
+    returnTupleIdentifiers.push(el.text)
+  }
+  if (returnTupleIdentifiers.length === 0) return null
+
+  // Body must contain at least one reactive primitive call so that the
+  // factory is actually the right thing to inline (not just a tuple-returning
+  // helper that happens to look similar).
+  let hasReactiveCall = false
+  function checkForReactive(n: ts.Node): void {
+    if (hasReactiveCall) return
+    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression) &&
+        REACTIVE_PRIMITIVES.has(n.expression.text)) {
+      hasReactiveCall = true
+      return
+    }
+    ts.forEachChild(n, checkForReactive)
+  }
+  checkForReactive(node.body)
+  if (!hasReactiveCall) return null
+
+  // Collect local bindings in the factory body for identifier hygiene at
+  // inlining time. Only direct-child declarations of the block are
+  // considered — good enough for the typical helper shape.
+  const localBindings: string[] = []
+  for (const stmt of node.body.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        addBindingNames(decl.name, localBindings)
+      }
+    } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      localBindings.push(stmt.name.text)
+    }
+  }
+
+  // Serialize the body without the outer braces and without the return
+  // statement — the return tuple is dissolved into caller-named identifiers.
+  const bodyStatements = node.body.statements
+    .filter(s => !ts.isReturnStatement(s))
+    .map(s => s.getText(sourceFile))
+    .join('\n')
+
+  const params = node.parameters.map(p => {
+    if (ts.isIdentifier(p.name)) return p.name.text
+    // Destructured params are uncommon for this helper shape and out of
+    // initial scope; return a placeholder so we can skip the factory.
+    return ''
+  })
+  if (params.some(p => p === '')) return null
+
+  return {
+    params,
+    bodySource: bodyStatements,
+    returnTupleIdentifiers,
+    localBindings,
+    loc: getSourceLocation(node, sourceFile, filePath),
+  }
+}
+
+function addBindingNames(name: ts.BindingName, out: string[]): void {
+  if (ts.isIdentifier(name)) {
+    out.push(name.text)
+    return
+  }
+  if (ts.isObjectBindingPattern(name)) {
+    for (const el of name.elements) addBindingNames(el.name, out)
+    return
+  }
+  if (ts.isArrayBindingPattern(name)) {
+    for (const el of name.elements) {
+      if (ts.isOmittedExpression(el)) continue
+      addBindingNames(el.name, out)
+    }
+  }
+}
+
+/**
+ * Rewrite a source string by replacing each `const [a, b, ...] = factory(args)`
+ * call at the source level with the inlined factory body — params
+ * substituted with argument expressions, return tuple identifiers renamed
+ * to caller destructure names, other local bindings suffix-renamed for
+ * per-call uniqueness.
+ *
+ * Returns the rewritten source, or the original string if no inlining
+ * applies (e.g., factory arity mismatch — those are left alone so the
+ * analyzer can emit BF110 with an accurate source location).
+ */
+function rewriteFactoryCallsInSource(
+  source: string,
+  prescan: PrescanResult
+): string {
+  const { factories, sourceFile } = prescan
+
+  // Collect edits: { start, end, replacement } tuples.
+  type Edit = { start: number; end: number; replacement: string }
+  const edits: Edit[] = []
+  let callSiteIndex = 0
+
+  function visitStmt(node: ts.Node, inComponent: boolean): void {
+    if (ts.isVariableStatement(node) && inComponent) {
+      for (const decl of node.declarationList.declarations) {
+        maybeRewriteDecl(node, decl)
+      }
+    }
+    ts.forEachChild(node, (child) => {
+      // Recurse into function bodies so destructured factory calls in
+      // nested scopes (e.g. inside a component function) are picked up,
+      // but do not descend into other module-level helper bodies — their
+      // own factory calls (recursive factory definitions) are out of
+      // scope for this round.
+      if (ts.isFunctionDeclaration(child) && child.name && factories.has(child.name.text)) return
+      visitStmt(child, inComponent || isPascalCaseComponentFn(child))
+    })
+  }
+
+  function maybeRewriteDecl(stmt: ts.VariableStatement, decl: ts.VariableDeclaration): void {
+    if (!ts.isArrayBindingPattern(decl.name)) return
+    if (!decl.initializer || !ts.isCallExpression(decl.initializer)) return
+    if (!ts.isIdentifier(decl.initializer.expression)) return
+    const factoryName = decl.initializer.expression.text
+    const factory = factories.get(factoryName)
+    if (!factory) return
+
+    // Arity check — bail out on mismatch so the analyzer can report BF110
+    // on the untouched source.
+    const elements = decl.name.elements
+    if (elements.length !== factory.returnTupleIdentifiers.length) return
+
+    // Caller-side identifier names (one per tuple slot). Omitted slots
+    // and nested destructure patterns are out of scope — bail out so the
+    // analyzer can emit BF110.
+    const callerNames: string[] = []
+    for (const el of elements) {
+      if (ts.isOmittedExpression(el) || !ts.isIdentifier(el.name)) return
+      callerNames.push(el.name.text)
+    }
+
+    const argTexts = decl.initializer.arguments.map(a => a.getText(sourceFile))
+    const thisCallIndex = callSiteIndex++
+    const suffix = `_bf${thisCallIndex}`
+
+    // Apply renames to the factory body source.
+    let body = factory.bodySource
+    // 1. Suffix-rename internal bindings (exclude params + return tuple
+    //    + caller names to avoid collisions).
+    const internalRenames = new Set<string>(factory.localBindings)
+    for (const p of factory.params) internalRenames.delete(p)
+    for (const r of factory.returnTupleIdentifiers) internalRenames.delete(r)
+    for (const name of internalRenames) {
+      body = body.replace(new RegExp(`\\b${escapeRegex(name)}\\b`, 'g'), name + suffix)
+    }
+    // 2. Parameters → argument expressions. Atomic arguments (bare
+    //    identifiers, numeric literals, string literals) are spliced
+    //    directly; anything more complex is wrapped in parens to preserve
+    //    operator precedence at the splice site.
+    const atomicArg = /^(?:[\w$.]+|'[^'\\]*'|"[^"\\]*"|-?\d+(?:\.\d+)?)$/
+    for (let i = 0; i < factory.params.length; i++) {
+      const p = factory.params[i]
+      const a = argTexts[i] ?? 'undefined'
+      const wrapped = atomicArg.test(a.trim()) ? a.trim() : `(${a})`
+      body = body.replace(new RegExp(`\\b${escapeRegex(p)}\\b`, 'g'), wrapped)
+    }
+    // 3. Return tuple identifiers → caller destructure names.
+    for (let i = 0; i < factory.returnTupleIdentifiers.length; i++) {
+      const n = factory.returnTupleIdentifiers[i]
+      const caller = callerNames[i]
+      body = body.replace(new RegExp(`\\b${escapeRegex(n)}\\b`, 'g'), caller)
+    }
+
+    edits.push({
+      start: stmt.getStart(sourceFile),
+      end: stmt.getEnd(),
+      replacement: body,
+    })
+  }
+
+  visitStmt(sourceFile, false)
+
+  if (edits.length === 0) return source
+
+  // Apply edits from bottom to top so earlier offsets stay valid.
+  edits.sort((a, b) => b.start - a.start)
+  let out = source
+  for (const e of edits) {
+    out = out.slice(0, e.start) + e.replacement + out.slice(e.end)
+  }
+  return out
+}
+
+function isPascalCaseComponentFn(node: ts.Node): boolean {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return /^[A-Z]/.test(node.name.text)
+  }
+  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer && ts.isArrowFunction(node.initializer)) {
+    return /^[A-Z]/.test(node.name.text)
+  }
+  return false
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// =============================================================================
+// BF110 diagnostic (#931)
+// =============================================================================
+
+/**
+ * Scan a compiled component context for tuple-destructures whose callee is
+ * neither `createSignal` / `createMemo` nor an inlinable reactive factory.
+ * These are the silent-failure shapes that produced broken client JS prior
+ * to factory inlining — emit BF110 so users get a clear message instead.
+ */
+export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
+  if (!ctx.componentNode) return
+  const body = ts.isFunctionDeclaration(ctx.componentNode)
+    ? ctx.componentNode.body
+    : (ts.isBlock(ctx.componentNode.body) ? ctx.componentNode.body : null)
+  if (!body) return
+
+  for (const stmt of body.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isArrayBindingPattern(decl.name)) continue
+      if (!decl.initializer || !ts.isCallExpression(decl.initializer)) continue
+      if (!ts.isIdentifier(decl.initializer.expression)) continue
+      const callee = decl.initializer.expression.text
+      if (callee === 'createSignal' || callee === 'createMemo') continue
+      // Inlined factories were rewritten away before this analysis, so
+      // anything still matching the shape is a destructure of an
+      // unrecognised callee (imported helper, ad-hoc tuple fn, factory
+      // with arity mismatch).
+      ctx.errors.push(
+        createError(
+          ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY,
+          getSourceLocation(stmt, ctx.sourceFile, ctx.filePath),
+          {
+            severity: 'error',
+            message:
+              `Tuple destructuring of '${callee}(...)': this helper is not a ` +
+              `recognised reactive factory (createSignal / createMemo / a ` +
+              `same-file helper that wraps them with a single \`return [a, b, ...]\`).`,
+            suggestion: {
+              message:
+                `Inline the createSignal call at the call site, or move the ` +
+                `helper into this file as a function that returns a tuple of ` +
+                `identifiers at its single exit point.`,
+            },
+          }
+        )
+      )
+    }
+  }
 }
 
 // =============================================================================

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -50,6 +50,9 @@ export const ErrorCodes = {
 
   // Init statement errors (BF052)
   UNDECLARED_INIT_STATEMENT_REFERENCE: 'BF052',
+
+  // Reactive factory errors (BF110-BF119)
+  UNRECOGNIZED_REACTIVE_FACTORY: 'BF110',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -98,6 +101,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.UNDECLARED_INIT_STATEMENT_REFERENCE]:
     'Init statement references an undeclared identifier. Declare it at module scope, inside the component, or import it — otherwise ESM strict mode throws ReferenceError at runtime.',
+
+  [ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY]:
+    'Tuple destructuring of a non-reactive factory call. The compiler only recognizes createSignal / createMemo calls and same-file helpers that wrap them with a single `return [a, b]` exit.',
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -462,6 +462,36 @@ export interface ImportInfo {
   loc: SourceLocation
 }
 
+/**
+ * Reactive factory helper metadata (#931). Collected when a same-file
+ * function matches the factory shape: exactly one top-level `return` whose
+ * argument is an array literal of identifiers, and at least one reactive
+ * primitive call (`createSignal`, `createMemo`, `createEffect`, etc.) in
+ * the body.
+ *
+ * When a component calls the factory in a tuple-destructure context, the
+ * body is inlined at the call site so downstream signal/memo collection
+ * sees an ordinary `createSignal(...)` declaration.
+ */
+export interface ReactiveFactoryInfo {
+  /** Parameter names, in declaration order. */
+  params: string[]
+  /**
+   * Raw JS source of the factory body block *without braces* and with the
+   * return tuple removed. Identifiers are renamed at the call site.
+   */
+  bodySource: string
+  /** Identifier names inside the returned array literal, in order. */
+  returnTupleIdentifiers: string[]
+  /**
+   * Names declared anywhere in the factory body (local bindings). Used by
+   * the call-site inliner to apply unique-suffix renaming and keep
+   * identifiers hygienic across repeat calls of the same factory.
+   */
+  localBindings: string[]
+  loc: SourceLocation
+}
+
 export interface ImportSpecifier {
   name: string
   alias: string | null


### PR DESCRIPTION
## Summary

Closes #931.

User-authored helpers that wrap `createSignal` / `createMemo` and return a tuple (e.g. `createPersistentSignal`, `createCounter`) used to produce silently broken client JS — the analyzer only matched a literal `createSignal` callee, so destructured factory calls emitted zero signal declarations and SSR threw `ReferenceError: <name> is not defined` with zero compiler errors or warnings.

### What this PR does

- **Pre-scan** the source file for module-level function declarations that match the reactive-factory shape: exactly one top-level `return` of an array literal of plain identifiers, at least one reactive primitive call (`createSignal` / `createMemo` / `createEffect` / `onMount` / `onCleanup`) in the body.
- **Rewrite** every `const [a, b, ...] = factory(args)` call site at the source-text level by splicing the factory body in place:
  - parameters → argument expressions (atomic literals spliced directly, complex exprs parenthesised for precedence safety),
  - return tuple identifiers → caller destructure names,
  - other local bindings → suffix-renamed (`name_bf<N>`) so repeat calls of the same factory in one component don't collide.
- Standard analysis runs on the rewritten source, sees ordinary `createSignal(...)` declarations, and wires reactivity as usual.
- **Add BF110 `UNRECOGNIZED_REACTIVE_FACTORY`**: emitted when a destructured call site still references a callee that the compiler can't inline (imported helper, arity mismatch, non-recognised shape). Replaces the prior silent-output failure with an actionable diagnostic.

### Scope

Matches the issue's "in scope" section:
- Same-file function declarations.
- Return tuples of 1 – N plain identifiers.
- Factory bodies with mixed `createSignal` / `createMemo` / `createEffect` / regular consts / wrapper functions.
- Per-call-site hygiene (Tier 1 regex suffix rename).

Explicit follow-ups:
- Arrow-function constant factories (`const createCounter = (n) => { ... }`).
- Cross-file imported factories.
- AST-level α-conversion (Tier 2) if regex renaming produces real-world false positives.

## Test plan

- [x] `bun test packages/jsx` — 643 tests pass, including 7 new cases in `reactive-factory-inlining.test.ts`:
  - function-declaration factory, single signal tuple
  - factory with custom setter wrapper (createPersistentSignal shape)
  - factory called twice in one component — hygiene/no collisions
  - parameter substitution reaches the inlined `createSignal(...)` call
  - BF110 fires for tuple destructure of an imported helper
  - BF110 does NOT fire when a factory is recognised and inlined
  - ordinary `createSignal` destructure is not misclassified as a factory
- [x] `bun run build` — full monorepo clean.
- [x] `tsc --noEmit -p packages/jsx/tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)