### PR TITLE
Unify site nav data + fix two compiler bugs the refactor exposed

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -154,6 +154,43 @@ console.log('still works')
     expect(result).toContain("console.log('still works')")
   })
 
+  test('recursively inlines transitive .ts imports', async () => {
+    // Leaf module — depended on by the middle layer
+    writeFileSync(resolve(COMPONENTS_DIR, 'leaf.ts'), `
+export const FRUITS = ['apple', 'banana']
+`)
+    // Middle module — references the leaf at module-load time
+    writeFileSync(resolve(COMPONENTS_DIR, 'middle.ts'), `
+import { FRUITS } from './leaf'
+export const COUNT = FRUITS.length
+`)
+    // Client JS imports middle but not leaf
+    const clientJs = `import { COUNT } from './middle'
+console.log(COUNT)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-trans.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/Comp-trans.js', markedTemplate: 'components/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-trans.js')).text()
+    // Both leaf and middle should be inlined, with leaf's declaration first
+    // so that middle's reference to FRUITS resolves at module init.
+    expect(result).toContain('FRUITS')
+    expect(result).toContain('COUNT')
+    expect(result).not.toContain("from './middle'")
+    expect(result).not.toContain("from './leaf'")
+    const fruitsIdx = result.indexOf("const FRUITS")
+    const countIdx = result.indexOf("const COUNT")
+    expect(fruitsIdx).toBeGreaterThan(-1)
+    expect(countIdx).toBeGreaterThan(fruitsIdx)
+    // No stray `{ FRUITS, ... }` block statement left over from the export.
+    expect(result).not.toMatch(/^\s*\{\s*FRUITS\s*\}/m)
+  })
+
   test('resolves from sourceDirs when not found relative to client JS', async () => {
     // Module exists in SOURCE_DIR, not in COMPONENTS_DIR
     writeFileSync(resolve(SOURCE_DIR, 'helpers.ts'), `

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -17,11 +17,84 @@ export interface ResolveRelativeImportsOptions {
   sourceDirs?: string[]
 }
 
+async function resolveSourceFile(importPath: string, searchDirs: string[]): Promise<string> {
+  for (const dir of searchDirs) {
+    const basePath = resolve(dir, importPath)
+    for (const ext of ['.ts', '.tsx', '.js']) {
+      if (await fileExists(basePath + ext)) return basePath + ext
+    }
+  }
+  return ''
+}
+
+/**
+ * Process a single file's relative imports, mutating `content` in place.
+ * Recurses into transitively-imported `.ts` modules so that, e.g.,
+ * `client.tsx → nav-data.ts → component-registry.ts` all end up inlined
+ * in the right declaration order.
+ */
+async function inlineRelativeImports(
+  content: string,
+  searchDirs: string[],
+  inlinedPaths: Set<string>,
+  loggingPath: string
+): Promise<string> {
+  const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
+  const matches = [...content.matchAll(re)]
+  if (matches.length === 0) return content
+
+  for (const match of matches) {
+    const importPath = match[1]
+    const fullMatch = match[0]
+    const sourceFile = await resolveSourceFile(importPath, searchDirs)
+
+    if (!sourceFile || inlinedPaths.has(sourceFile)) {
+      content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+      continue
+    }
+
+    if (sourceFile.endsWith('.tsx')) {
+      content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+      console.log(`Stripped server component import: ${importPath} from ${loggingPath}`)
+      continue
+    }
+
+    inlinedPaths.add(sourceFile)
+    const sourceContent = await readText(sourceFile)
+    let jsCode = transpile(sourceContent, { loader: 'ts' })
+
+    // Recursively resolve relative imports inside the inlined module before
+    // stripping its import lines. Resolution is anchored to the source file's
+    // own directory so transitive paths (e.g. './component-registry') resolve
+    // correctly regardless of where the parent client JS lives.
+    jsCode = await inlineRelativeImports(
+      jsCode,
+      [dirname(sourceFile), ...searchDirs.slice(1)],
+      inlinedPaths,
+      loggingPath,
+    )
+
+    // Convert exports/imports of the inlined module to plain declarations.
+    // Also drop bare `export { foo, bar };` blocks emitted by the transpiler —
+    // stripping just the `export` keyword leaves a stray block statement.
+    jsCode = jsCode
+      .replace(/^import\s+.*$/gm, '')
+      .replace(/^export\s*\{[^}]*\}\s*;?\s*$/gm, '')
+      .replace(/^export\s+/gm, '')
+      .trim()
+
+    content = content.replace(fullMatch, jsCode)
+    console.log(`Inlined: ${importPath} into ${loggingPath}`)
+  }
+
+  return content
+}
+
 /**
  * Resolve relative imports in compiled client JS files.
  *
  * For each client JS file in the manifest:
- * - `.ts` imports: transpile and inline the code
+ * - `.ts` imports: transpile and inline the code (recursively for transitive `.ts` deps)
  * - `.tsx` imports: strip (server component, already rendered at SSR time)
  * - Not found / already inlined: strip
  */
@@ -38,61 +111,16 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       continue
     }
 
-    // Reset the global regex for each file
-    const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
-    const matches = [...content.matchAll(re)]
-    if (matches.length === 0) continue
-
     const inlinedPaths = new Set<string>()
+    const next = await inlineRelativeImports(
+      content,
+      [dirname(filePath), ...sourceDirs],
+      inlinedPaths,
+      entry.clientJs,
+    )
 
-    for (const match of matches) {
-      const importPath = match[1]
-      const fullMatch = match[0]
-
-      // Try to resolve source file: first relative to client JS, then sourceDirs
-      const searchDirs = [dirname(filePath), ...sourceDirs]
-      let sourceFile = ''
-      for (const dir of searchDirs) {
-        const basePath = resolve(dir, importPath)
-        for (const ext of ['.ts', '.tsx', '.js']) {
-          if (await fileExists(basePath + ext)) {
-            sourceFile = basePath + ext
-            break
-          }
-        }
-        if (sourceFile) break
-      }
-
-      if (!sourceFile || inlinedPaths.has(sourceFile)) {
-        // Already inlined or not found — strip the import
-        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-        continue
-      }
-
-      // Only inline pure TS modules (no JSX). TSX files with JSX are server
-      // components whose rendering was already done at SSR time — their imports
-      // in client JS are for component name matching only, not runtime execution.
-      if (sourceFile.endsWith('.tsx')) {
-        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-        console.log(`Stripped server component import: ${importPath} from ${entry.clientJs}`)
-        continue
-      }
-
-      // Transpile and inline pure TS utility modules
-      const sourceContent = await readText(sourceFile)
-      let jsCode = transpile(sourceContent, { loader: 'ts' })
-
-      // Convert exports to plain declarations for inlining
-      jsCode = jsCode
-        .replace(/^import\s+.*$/gm, '')
-        .replace(/^export\s+/gm, '')
-        .trim()
-
-      content = content.replace(fullMatch, jsCode)
-      inlinedPaths.add(sourceFile)
-      console.log(`Inlined: ${importPath} into ${entry.clientJs}`)
+    if (next !== content) {
+      await writeText(filePath, next)
     }
-
-    await writeText(filePath, content)
   }
 }

--- a/packages/hono/src/adapter/hono-adapter.ts
+++ b/packages/hono/src/adapter/hono-adapter.ts
@@ -577,10 +577,16 @@ export class HonoAdapter extends JsxAdapter {
     let mapExpr: string
     // Use typed mapPreamble when available to preserve type annotations in .tsx output
     const preamble = loop.typedMapPreamble ?? loop.mapPreamble
+    // When the rendered children are a JSX expression-container (e.g. a single
+    // ternary `{cond ? <A/> : <B/>}` from renderConditional), they cannot be
+    // used directly as an arrow body — `(x) => {…}` is parsed as a block
+    // statement and the function returns undefined. Wrap with a fragment so
+    // the body is unambiguously a JSX expression.
+    const safeChildren = children.startsWith('{') ? `<>${children}</>` : children
     if (preamble) {
-      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => { ${preamble} return ${children} })}`
+      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => { ${preamble} return ${safeChildren} })}`
     } else {
-      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => ${children})}`
+      mapExpr = `{${loop.array}.map((${loop.param}${paramAnnotation}${indexParam}) => ${safeChildren})}`
     }
     // Wrap with loop boundary markers so reconciliation doesn't affect siblings.
     // bfComment is a helper that renders an HTML comment in JSX.

--- a/packages/jsx/src/__tests__/map-ternary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-ternary-body.test.ts
@@ -1,0 +1,75 @@
+/**
+ * BarefootJS Compiler — `.map()` callback whose body is a sole ternary.
+ *
+ * Regression: when a map callback returns `cond ? <A/> : <B/>`, the renderer
+ * used to emit `(item) => {cond ? <A/> : <B/>}` — a JS *block* statement with
+ * no `return`, so the function returned undefined and no items rendered.
+ *
+ * The fix wraps the body with `<>…</>` whenever the rendered children start
+ * with a `{`, turning it into a valid JSX expression body.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('.map() with ternary body', () => {
+  test('arrow body is wrapped so it is not parsed as a block statement', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function isGroup(entry: any): entry is { groupTitle: string } {
+        return 'groupTitle' in entry
+      }
+
+      export function Nav() {
+        const [entries, _setEntries] = createSignal([
+          { groupTitle: 'A' },
+          { href: '/b', linkTitle: 'B' },
+        ])
+        return (
+          <ul>
+            {entries().map((entry) =>
+              isGroup(entry) ? <li>{entry.groupTitle}</li> : <a href={entry.href}>{entry.linkTitle}</a>
+            )}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Nav.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    const out = template!.content
+
+    // Bug reproduction guard: the buggy output contained `=> {... ? ... : ...}`
+    // (a block statement). Make sure no such pattern remains for the inner map.
+    // After the fix, the body is `<>{... ? ... : ...}</>`.
+    expect(out).toMatch(/=>\s*<>\{[^]*\?[^]*:[^]*\}<\/>/)
+    expect(out).not.toMatch(/=>\s*\{[^{}]*\?[^{}]*:[^{}]*<\/li>[^{}]*\}\)/)
+  })
+
+  test('expression-only callback body (e.g. {item.name}) is also wrapped', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Names() {
+        const [items, _setItems] = createSignal([{ name: 'A' }, { name: 'B' }])
+        return (
+          <ul>
+            {items().map((item) => <li>{item.name}</li>)}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Names.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    // Sanity: still compiles. No specific shape assertion — the JSX-element
+    // body case is already valid without wrapping; this just guards against
+    // regressions in the safeguard path.
+  })
+})

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -227,8 +227,11 @@ export class TestAdapter extends JsxAdapter {
   renderLoop(loop: IRLoop): string {
     const indexParam = loop.index ? `, ${loop.index}` : ''
     const children = this.renderChildren(loop.children)
+    // Wrap with fragment when children start with `{` so the arrow body isn't
+    // parsed as a block statement (matches hono-adapter behavior).
+    const safeChildren = children.startsWith('{') ? `<>${children}</>` : children
 
-    return `{${loop.array}.map((${loop.param}${indexParam}) => ${children})}`
+    return `{${loop.array}.map((${loop.param}${indexParam}) => ${safeChildren})}`
   }
 
   renderComponent(comp: IRComponent): string {

--- a/site/ui/components/mobile-menu.tsx
+++ b/site/ui/components/mobile-menu.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createEffect } from '@barefootjs/client'
 import { XIcon, ChevronRightIcon } from '@ui/components/ui/icon'
-import { categoryOrder, categoryLabels, getComponentsByCategory, blockEntries } from './shared/component-registry'
+import { navSections, isNavGroup } from './shared/nav-data'
 
 const summaryClass = 'flex w-full items-center justify-between py-2.5 px-4 text-base font-medium text-foreground hover:bg-accent/50 rounded-md transition-colors cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden'
 const menuLinkClass = 'block py-2.5 px-4 text-base rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 no-underline'
@@ -51,27 +51,12 @@ export function MobileMenu() {
       if (details) details.open = true
     }
 
-    if (currentPath === '/') {
-      openCategory('docs')
-    } else if (currentPath.startsWith('/components/') && currentPath !== '/components') {
-      // Open the matching component category
-      for (const cat of categoryOrder) {
-        const entries = getComponentsByCategory(cat)
-        if (entries.some(e => currentPath === `/components/${e.slug}`)) {
-          openCategory(`components-${cat}`)
-          break
+    for (const section of navSections) {
+      for (const entry of section.entries) {
+        if (isNavGroup(entry) && entry.matchPath?.(currentPath)) {
+          openCategory(entry.key)
         }
       }
-      // Check blocks
-      if (blockEntries.some(e => currentPath === `/components/${e.slug}`)) {
-        openCategory('blocks')
-      }
-    } else if (currentPath.startsWith('/charts/')) {
-      openCategory('charts')
-    } else if (currentPath.startsWith('/docs/forms')) {
-      openCategory('forms')
-    } else if (currentPath.startsWith('/docs/cli') || currentPath === '/studio') {
-      openCategory('tools')
     }
 
     const openMenu = (): void => {
@@ -201,84 +186,32 @@ export function MobileMenu() {
 
           <nav className="p-4 overflow-y-auto h-[calc(100%-48px)]">
             <div className="space-y-1">
-              {/* Docs */}
-              <details data-category="docs" className="mb-2 group">
-                <summary className={summaryClass}>
-                  <span>Docs</span>
-                  <ChevronRightIcon size="sm" className={chevronClass} />
-                </summary>
-                <div className="pl-2 py-1 space-y-0.5">
-                  <a href="/" className={menuLinkClass}>Introduction</a>
-                </div>
-              </details>
-
-              {/* Components — grouped by category */}
-              <div className="pt-3 mt-3 border-t">
-                <span className="block px-4 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Components</span>
-              </div>
-              {categoryOrder.map((cat) => (
-                <details data-category={`components-${cat}`} className="mb-2 group">
-                  <summary className={summaryClass}>
-                    <span>{categoryLabels[cat]}</span>
-                    <ChevronRightIcon size="sm" className={chevronClass} />
-                  </summary>
-                  <div className="pl-2 py-1 space-y-0.5">
-                    {getComponentsByCategory(cat).map((entry) => (
-                      <a href={`/components/${entry.slug}`} className={menuLinkClass}>{entry.title}</a>
-                    ))}
-                  </div>
-                </details>
+              {navSections.map((section, sectionIndex) => (
+                <>
+                  {section.heading && (
+                    <div className={sectionIndex === 0 ? '' : 'pt-3 mt-3 border-t'}>
+                      <span className="block px-4 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">{section.heading}</span>
+                    </div>
+                  )}
+                  {section.entries.map((entry) =>
+                    isNavGroup(entry) ? (
+                      <details data-category={entry.key} className="mb-2 group" open={entry.defaultOpen}>
+                        <summary className={summaryClass}>
+                          <span>{entry.title}</span>
+                          <ChevronRightIcon size="sm" className={chevronClass} />
+                        </summary>
+                        <div className="pl-2 py-1 space-y-0.5">
+                          {entry.links.map((link) => (
+                            <a href={link.href} className={menuLinkClass}>{link.title}</a>
+                          ))}
+                        </div>
+                      </details>
+                    ) : (
+                      <a href={entry.href} className={menuLinkClass}>{entry.title}</a>
+                    )
+                  )}
+                </>
               ))}
-              <details data-category="charts" className="mb-2 group">
-                <summary className={summaryClass}>
-                  <span>Charts</span>
-                  <ChevronRightIcon size="sm" className={chevronClass} />
-                </summary>
-                <div className="pl-2 py-1 space-y-0.5">
-                  <a href="/charts/area-chart" className={menuLinkClass}>Area Chart</a>
-                  <a href="/charts/bar-chart" className={menuLinkClass}>Bar Chart</a>
-                  <a href="/charts/line-chart" className={menuLinkClass}>Line Chart</a>
-                  <a href="/charts/pie-chart" className={menuLinkClass}>Pie Chart</a>
-                  <a href="/charts/radar-chart" className={menuLinkClass}>Radar Chart</a>
-                  <a href="/charts/radial-chart" className={menuLinkClass}>Radial Chart</a>
-                </div>
-              </details>
-
-              {/* Patterns */}
-              <div className="pt-3 mt-3 border-t">
-                <span className="block px-4 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Patterns</span>
-              </div>
-              <details data-category="forms" className="mb-2 group">
-                <summary className={summaryClass}>
-                  <span>Forms</span>
-                  <ChevronRightIcon size="sm" className={chevronClass} />
-                </summary>
-                <div className="pl-2 py-1 space-y-0.5">
-                  <a href="/docs/forms/controlled-input" className={menuLinkClass}>Controlled Input</a>
-                  <a href="/docs/forms/create-form" className={menuLinkClass}>createForm</a>
-                  <a href="/docs/forms/field-arrays" className={menuLinkClass}>Field Arrays</a>
-                  <a href="/docs/forms/submit" className={menuLinkClass}>Submit</a>
-                  <a href="/docs/forms/validation" className={menuLinkClass}>Validation</a>
-                </div>
-              </details>
-              <details data-category="blocks" className="mb-2 group">
-                <summary className={summaryClass}>
-                  <span>Blocks</span>
-                  <ChevronRightIcon size="sm" className={chevronClass} />
-                </summary>
-                <div className="pl-2 py-1 space-y-0.5">
-                  {blockEntries.map((entry) => (
-                    <a href={`/components/${entry.slug}`} className={menuLinkClass}>{entry.title}</a>
-                  ))}
-                </div>
-              </details>
-
-              {/* Tools */}
-              <div className="pt-3 mt-3 border-t">
-                <span className="block px-4 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Tools</span>
-              </div>
-              <a href="/docs/cli" className={menuLinkClass}>CLI</a>
-              <a href="/studio" className={menuLinkClass}>Studio</a>
             </div>
           </nav>
         </div>

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -1,0 +1,118 @@
+/**
+ * Site Navigation — single source of truth.
+ *
+ * Both the desktop sidebar (renderer.tsx) and the mobile bottom-sheet menu
+ * (mobile-menu.tsx) read from `navSections`. Add a link in one place and it
+ * shows up in both. Without this, mobile drifts behind desktop (issue: Gallery
+ * was added to desktop only).
+ */
+
+import type { SidebarLink, SidebarGroup } from '../../../shared/components/sidebar-page-nav'
+import { categoryOrder, categoryLabels, getComponentsByCategory, blockEntries } from './component-registry'
+
+export interface NavGroup extends SidebarGroup {
+  /** Stable identity. Used by the mobile menu as `data-category` and to match auto-open. */
+  key: string
+  /** When the current path matches, the mobile menu auto-opens this group on load. */
+  matchPath?: (path: string) => boolean
+}
+
+export type NavEntry = NavGroup | SidebarLink
+
+export interface NavSection {
+  /** Optional uppercase header rendered above the entries (e.g. "Components"). */
+  heading?: string
+  entries: NavEntry[]
+}
+
+export function isNavGroup(entry: NavEntry): entry is NavGroup {
+  return 'links' in entry
+}
+
+export const navSections: NavSection[] = [
+  {
+    entries: [
+      {
+        key: 'docs',
+        title: 'Docs',
+        defaultOpen: true,
+        links: [{ title: 'Introduction', href: '/' }],
+        matchPath: (p) => p === '/',
+      },
+    ],
+  },
+  {
+    heading: 'Components',
+    entries: [
+      ...categoryOrder.map((category): NavGroup => ({
+        key: `components-${category}`,
+        title: categoryLabels[category],
+        defaultOpen: false,
+        links: getComponentsByCategory(category).map((entry) => ({
+          title: entry.title,
+          href: `/components/${entry.slug}`,
+        })),
+        matchPath: (p) => getComponentsByCategory(category).some((e) => p === `/components/${e.slug}`),
+      })),
+      {
+        key: 'charts',
+        title: 'Charts',
+        links: [
+          { title: 'Area Chart', href: '/charts/area-chart' },
+          { title: 'Bar Chart', href: '/charts/bar-chart' },
+          { title: 'Line Chart', href: '/charts/line-chart' },
+          { title: 'Pie Chart', href: '/charts/pie-chart' },
+          { title: 'Radar Chart', href: '/charts/radar-chart' },
+          { title: 'Radial Chart', href: '/charts/radial-chart' },
+        ],
+        matchPath: (p) => p.startsWith('/charts/'),
+      },
+    ],
+  },
+  {
+    heading: 'Patterns',
+    entries: [
+      {
+        key: 'forms',
+        title: 'Forms',
+        links: [
+          { title: 'Controlled Input', href: '/docs/forms/controlled-input' },
+          { title: 'createForm', href: '/docs/forms/create-form' },
+          { title: 'Field Arrays', href: '/docs/forms/field-arrays' },
+          { title: 'Submit', href: '/docs/forms/submit' },
+          { title: 'Validation', href: '/docs/forms/validation' },
+        ],
+        matchPath: (p) => p.startsWith('/docs/forms'),
+      },
+      {
+        key: 'blocks',
+        title: 'Blocks',
+        defaultOpen: false,
+        links: blockEntries.map((entry) => ({
+          title: entry.title,
+          href: `/components/${entry.slug}`,
+        })),
+        matchPath: (p) => blockEntries.some((e) => p === `/components/${e.slug}`),
+      },
+    ],
+  },
+  {
+    heading: 'Gallery',
+    entries: [
+      {
+        key: 'gallery-apps',
+        title: 'Apps',
+        defaultOpen: false,
+        links: [{ title: 'Admin Dashboard', href: '/gallery/admin' }],
+        matchPath: (p) => p.startsWith('/gallery/'),
+      },
+    ],
+  },
+  {
+    heading: 'Tools',
+    entries: [
+      { title: 'CLI', href: '/docs/cli' },
+      { title: 'Studio', href: '/studio' },
+    ],
+  },
+]

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -21,7 +21,7 @@ declare module 'hono' {
 import { BfScripts } from '../../packages/hono/src/scripts'
 import { BfPortals } from '../../packages/hono/src/portals'
 import { BfPreload, type Manifest } from '../../packages/hono/src/preload'
-import { SidebarNav, type SidebarEntry } from '../shared/components/sidebar-page-nav'
+import { SidebarNav } from '../shared/components/sidebar-page-nav'
 import { Header } from '../shared/components/header'
 import { MobileMenu } from '@/components/mobile-menu'
 import { MobilePageNav } from '../shared/components/mobile-page-nav'
@@ -59,80 +59,7 @@ function WithPredictableIds({ children }: { children: any }) {
 }
 
 import { themeInitScript } from '@barefootjs/site-shared/lib/theme-init'
-import { categoryOrder, categoryLabels, getComponentsByCategory, blockEntries } from './components/shared/component-registry'
-
-// Sidebar menu data — split into sections with visual separators
-const startEntries: SidebarEntry[] = [
-  {
-    title: 'Docs',
-    defaultOpen: true,
-    links: [
-      { title: 'Introduction', href: '/' },
-    ],
-  },
-]
-
-// Component categories + Charts generated from registry
-const componentEntries: SidebarEntry[] = [
-  ...categoryOrder.map((category) => ({
-    title: categoryLabels[category],
-    defaultOpen: false,
-    links: getComponentsByCategory(category).map((entry) => ({
-      title: entry.title,
-      href: `/components/${entry.slug}`,
-    })),
-  })),
-  {
-    title: 'Charts',
-    links: [
-      { title: 'Area Chart', href: '/charts/area-chart' },
-      { title: 'Bar Chart', href: '/charts/bar-chart' },
-      { title: 'Line Chart', href: '/charts/line-chart' },
-      { title: 'Pie Chart', href: '/charts/pie-chart' },
-      { title: 'Radar Chart', href: '/charts/radar-chart' },
-      { title: 'Radial Chart', href: '/charts/radial-chart' },
-    ],
-  },
-]
-
-// Patterns — composition guides and page-level layouts
-const patternEntries: SidebarEntry[] = [
-  {
-    title: 'Forms',
-    links: [
-      { title: 'Controlled Input', href: '/docs/forms/controlled-input' },
-      { title: 'createForm', href: '/docs/forms/create-form' },
-      { title: 'Field Arrays', href: '/docs/forms/field-arrays' },
-      { title: 'Submit', href: '/docs/forms/submit' },
-      { title: 'Validation', href: '/docs/forms/validation' },
-    ],
-  },
-  {
-    title: 'Blocks',
-    defaultOpen: false,
-    links: blockEntries.map((entry) => ({
-      title: entry.title,
-      href: `/components/${entry.slug}`,
-    })),
-  },
-]
-
-// Gallery — multi-page demo apps (see issue #929)
-const galleryEntries: SidebarEntry[] = [
-  {
-    title: 'Apps',
-    defaultOpen: false,
-    links: [
-      { title: 'Admin Dashboard', href: '/gallery/admin' },
-    ],
-  },
-]
-
-// Tools — CLI and design system utilities
-const toolEntries: SidebarEntry[] = [
-  { title: 'CLI', href: '/docs/cli' },
-  { title: 'Studio', href: '/studio' },
-]
+import { navSections } from './components/shared/nav-data'
 
 // Import map for resolving bare module specifiers in client JS
 const importMapScript = JSON.stringify({
@@ -206,23 +133,16 @@ export const renderer = jsxRenderer(
                 aria-label="Main navigation"
                 data-sidebar-menu
               >
-                <SidebarNav entries={startEntries} currentPath={currentPath} />
-                <div className="pt-3 mt-3 border-t">
-                  <span className="block px-3 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Components</span>
-                </div>
-                <SidebarNav entries={componentEntries} currentPath={currentPath} />
-                <div className="pt-3 mt-3 border-t">
-                  <span className="block px-3 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Patterns</span>
-                </div>
-                <SidebarNav entries={patternEntries} currentPath={currentPath} />
-                <div className="pt-3 mt-3 border-t">
-                  <span className="block px-3 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Gallery</span>
-                </div>
-                <SidebarNav entries={galleryEntries} currentPath={currentPath} />
-                <div className="pt-3 mt-3 border-t">
-                  <span className="block px-3 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Tools</span>
-                </div>
-                <SidebarNav entries={toolEntries} currentPath={currentPath} />
+                {navSections.map((section, i) => (
+                  <>
+                    {section.heading && (
+                      <div className={i === 0 ? '' : 'pt-3 mt-3 border-t'}>
+                        <span className="block px-3 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">{section.heading}</span>
+                      </div>
+                    )}
+                    <SidebarNav entries={section.entries} currentPath={currentPath} />
+                  </>
+                ))}
               </nav>
             )}
             <div className={isChrome ? 'sm:pl-56' : ''}>


### PR DESCRIPTION
## Summary

- **site/ui:** introduce `nav-data.ts` as the single source of truth for both the desktop sidebar (`renderer.tsx`) and the mobile bottom-sheet menu (`mobile-menu.tsx`). Adding a section/group/link now requires editing one file, eliminating the desktop-vs-mobile drift that left Gallery off mobile.
- **packages/cli:** `resolveRelativeImports` now recurses into transitive `.ts` imports. Previously, when a client component imported `nav-data.ts` which imported `component-registry.ts`, the inner import was stripped without inlining its dependency, causing a runtime `ReferenceError: categoryOrder is not defined`.
- **packages/hono / packages/jsx:** when a `.map()` callback's body is a sole ternary returning JSX, the loop renderer pasted `{cond ? <A/> : <B/>}` directly as the arrow body. JS parses that as a *block statement*, so the function returned undefined and no items rendered. Wrap such children with `<>…</>` so the body is unambiguously a JSX expression.

The two compiler fixes were each surfaced by the `nav-data` refactor — the symptoms were a runtime error on first load, then an `UNDEFINED` heading and missing `<details>` entries in the rendered mobile menu.

## Test plan

- [x] `cd packages/cli && bun test src/__tests__/resolve-imports.test.ts` (8 pass; new `recursively inlines transitive .ts imports` case)
- [x] `cd packages/jsx && bun test` (656 pass; new `map-ternary-body.test.ts`)
- [x] `cd packages/hono && bun test` (69 pass)
- [x] `cd site/ui && bun run build` succeeds; generated `mobile-menu-99c1327f.js` declares `categoryOrder` etc. before `navSections`
- [x] Playwright at 390×800 on `/gallery/admin`: console-error count = 0; mobile menu shows Docs / Components / Patterns / Gallery / Tools with no `UNDEFINED`; `Apps` auto-opens on `/gallery/*`; clicking `Input` summary expands children