### PR TITLE
fix(compiler): Solid-style wrap-by-default for text interpolation (#937)

### DIFF
--- a/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
@@ -102,10 +102,10 @@ describe('Solid-style wrap-by-default fallback (#937)', () => {
     `
 
     const clientJs = getClientJs(source, 'Greeting.tsx')
-    // No createEffect for the text — only the event handler and signal setup.
-    // We look specifically for the absence of a createEffect that writes the
-    // literal into a text node.
-    expect(clientJs).not.toMatch(/createEffect\([^)]*\)\s*=>\s*\{[^}]*['"]hello['"]/)
+    // A pure literal has no slotId and no dynamic binding — nothing to
+    // update at runtime. The only signal in this component is read-only in
+    // the event handler, so no createEffect should be emitted at all.
+    expect(clientJs).not.toContain('createEffect')
   })
 
   test('bare identifier (no calls) stays un-wrapped', () => {
@@ -124,6 +124,10 @@ describe('Solid-style wrap-by-default fallback (#937)', () => {
     `
 
     const clientJs = getClientJs(source, 'Label.tsx')
+    // Guard against the identifier being dropped entirely from the module —
+    // an over-eager regression could satisfy the negative assertion below by
+    // removing `label` altogether. We assert presence in the init scope too.
+    expect(clientJs).toContain('label')
     // No text-update createEffect should be emitted for a static bare ident.
     expect(clientJs).not.toMatch(/nodeValue\s*=\s*String\(label/)
   })

--- a/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for #937: Solid-style wrap-by-default fallback for JSX
+ * text interpolation.
+ *
+ * Before this pilot, `collect-elements.ts` gated `dynamicElements` on
+ * `node.reactive && node.slotId`. Any expression the analyzer couldn't
+ * statically prove reactive silently flowed through as a static text node —
+ * its SSR value was frozen in the DOM and never updated. That silent-drop
+ * path is the architectural gap behind #931 / #932 / and various
+ * factory-wrapping regressions.
+ *
+ * The fix widens the gate to also wrap expressions whose AST carries
+ * `hasFunctionCalls` or `callsReactiveGetters`. Over-wrapping a pure call
+ * that subscribes to nothing is harmless (one extra closure); under-wrapping
+ * a reactive read is the bug class we're closing. Pure literals and bare
+ * identifiers without calls stay un-wrapped so the optimisation the flag was
+ * originally computed for is preserved.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('Solid-style wrap-by-default fallback (#937)', () => {
+  test('known signal getter still wraps (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Counter.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('count()')
+  })
+
+  test('unrecognised call inside interpolation now wraps in createEffect', () => {
+    // `format(...)` is an imported helper the analyzer can't prove reactive.
+    // `count()` is a recognised signal getter, so the interpolation already
+    // had reactive=true. We also assert the new behaviour: even when the
+    // outer call is unrecognised, the expression is wrapped because
+    // `hasFunctionCalls` is true.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(count() + 1)}>{format(count())}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Counter.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('format(count())')
+  })
+
+  test('call expression with no known reactive source still wraps (new behaviour)', () => {
+    // `Date.now()` is not reactive, but the analyzer cannot prove it
+    // non-reactive either. Under wrap-by-default, we emit a createEffect
+    // rather than freeze the SSR value in the DOM. Over-wrapping here is
+    // harmless: the effect subscribes to nothing and runs exactly once.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Clock() {
+        const [_, setNow] = createSignal(0)
+        return <button onClick={() => setNow(Date.now())}>{Date.now()}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Clock.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('Date.now()')
+  })
+
+  test('static string literal stays un-wrapped (optimisation preserved)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Greeting() {
+        const [, setFoo] = createSignal(0)
+        return <button onClick={() => setFoo(1)}>{'hello'}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Greeting.tsx')
+    // No createEffect for the text — only the event handler and signal setup.
+    // We look specifically for the absence of a createEffect that writes the
+    // literal into a text node.
+    expect(clientJs).not.toMatch(/createEffect\([^)]*\)\s*=>\s*\{[^}]*['"]hello['"]/)
+  })
+
+  test('bare identifier (no calls) stays un-wrapped', () => {
+    // A local constant that is not a signal and contains no function calls
+    // keeps its value frozen at SSR — there is nothing for a client-side
+    // effect to track.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Label() {
+        const [, setFoo] = createSignal(0)
+        const label = 'hi'
+        return <button onClick={() => setFoo(1)}>{label}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Label.tsx')
+    // No text-update createEffect should be emitted for a static bare ident.
+    expect(clientJs).not.toMatch(/nodeValue\s*=\s*String\(label/)
+  })
+
+  test('method chain on props wraps (already reactive, but exercises the gate)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Joined(props: { items: string[] }) {
+        const [, setFoo] = createSignal(0)
+        return <button onClick={() => setFoo(1)}>{props.items.join(',')}</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Joined.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('.items.join')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -218,14 +218,32 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           slotId: node.slotId,
           expression: node.expr,
         })
-      } else if (node.reactive && node.slotId && !insideConditional) {
-        // Only collect as top-level dynamic element if NOT inside a conditional.
-        // Conditional text effects are collected per-branch and emitted inside bindEvents.
-        ctx.dynamicElements.push({
-          slotId: node.slotId,
-          expression: node.expr,
-          insideConditional: false,
-        })
+      } else if (node.slotId && !insideConditional) {
+        // Solid-style wrap-by-default fallback (#937): wrap in createEffect not
+        // only for statically-proven-reactive expressions, but also for any
+        // expression the analyzer can't prove non-reactive — i.e. anything
+        // that contains a function call or a signal-getter call. Pure static
+        // literals and bare identifiers (no calls) stay un-wrapped because
+        // their SSR value is already in the DOM.
+        //
+        // False positive (extra createEffect that subscribes to nothing) is
+        // harmless; false negative (silent drop of a reactive read) is the
+        // bug class this gate closes — see #931, #932.
+        //
+        // Only collect as a top-level dynamic element when NOT inside a
+        // conditional. Conditional text effects are collected per-branch and
+        // emitted inside bindEvents.
+        const shouldWrap =
+          node.reactive ||
+          node.callsReactiveGetters ||
+          node.hasFunctionCalls
+        if (shouldWrap) {
+          ctx.dynamicElements.push({
+            slotId: node.slotId,
+            expression: node.expr,
+            insideConditional: false,
+          })
+        }
       }
       break
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -875,12 +875,18 @@ function transformExpression(
   // so fine-grained effects can target them for per-item signal updates
   const refsLoopParam = ctx.loopParams.size > 0
     && Array.from(ctx.loopParams).some(p => new RegExp(`\\b${p}\\b`).test(exprText))
-  const needsSlot = reactive || isClientOnly || refsLoopParam
-  const slotId = needsSlot ? generateSlotId(ctx) : null
 
-  // Compute AST-derived flags for Phase 2 optimization
+  // Compute AST-derived flags. `callsReactive` recognises signal-getter / memo
+  // calls even inside deeper expressions (e.g., `format(count())`); `hasCalls`
+  // is broader — any identifier() pattern. Both serve as Solid-style
+  // wrap-by-default hints (#937): if the analyzer can't prove the expression
+  // non-reactive but it contains calls, we allocate a slotId so the client JS
+  // path can wrap the read in createEffect as a safe fallback.
   const callsReactive = exprCallsReactiveGetters(expr, ctx)
   const hasCalls = exprHasFunctionCalls(expr)
+
+  const needsSlot = reactive || isClientOnly || refsLoopParam || callsReactive || hasCalls
+  const slotId = needsSlot ? generateSlotId(ctx) : null
 
   const templateExpr = rewriteBarePropRefs(exprText, expr, ctx)
   return {


### PR DESCRIPTION
## Summary

Pilot for #937. Widen the dynamic-text gate in `collect-elements.ts` and the slot allocator in `jsx-to-ir.ts` so any JSX text interpolation with a function call or signal-getter call gets wrapped in `createEffect`, even when the analyzer cannot statically prove the expression reactive. Pure literals and bare identifiers stay un-wrapped.

This closes the silent-drop failure class behind #931 / #932 at the collector layer:

- **False positive** (extra `createEffect` that subscribes to nothing): one closure at init time, no rerun — harmless.
- **False negative** (the old behaviour): SSR value frozen in the DOM, no client-side update — the bug class we're closing.

## Changes

- `packages/jsx/src/ir-to-client-js/collect-elements.ts` — widened the `expression` case: now also wraps when `node.hasFunctionCalls` or `node.callsReactiveGetters` is true, not only when `node.reactive` is proven.
- `packages/jsx/src/jsx-to-ir.ts` — widened `needsSlot` in `transformExpression()` with the same two flags so the expression reaches the gate with a `slotId` allocated. Without this, the collect gate widening would be a no-op for the exact silent-drop cases we want to catch.
- `packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts` — 6 regression cases (known signal, unrecognised outer call, unrecognised call with no reactive source, static literal, bare identifier, method chain on props).

## Fixture diff

Baseline: `site/ui/dist/components/**/*.js` on `main`. After rebuild, **2 files of 250 differ** (≈0.8%, well under the 30% rollback threshold from the issue):

- `site/ui/dist/components/analytics-dashboard-demo-*.js`
- `site/ui/dist/components/gallery/admin/analytics-demo-*.js`

Both diffs reduce to one new harmless `createEffect` per file, for `{formatCurrency(REVENUE_TARGET)}` (a call on a module-level constant — previously a silent drop, now a no-op effect). Everything else is slot-id number shift.

## Test plan

- [x] `bun test packages/jsx` — 656 pre-existing tests pass; 6 new tests pass.
- [x] `bun test packages/{jsx,dom,cli,client,hono,go-template,adapter-tests}` — 1464 tests pass.
- [x] Clean `bun run build` succeeds on both `main` and this branch.
- [x] Site/ui Playwright E2E: 1385 pass / 2 fail — the two failures (`form-builder.spec.ts` required-toggle + bug-regression) reproduce on `main` with no changes applied, so they are pre-existing and unrelated.

## Follow-ups (out of scope for this PR)

As the issue lays out, the pattern replicates to: JSX attributes, conditionals, loops, and prop bindings on child components. Each is its own PR.