### PR TITLE
fix(compiler): wrap-by-default fallback for JSX attribute bindings (#940)

### DIFF
--- a/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for #940: Solid-style wrap-by-default fallback for JSX
+ * attribute bindings. Follow-up to #937 (architecture) and #939 (text
+ * interpolation pilot).
+ *
+ * Before this change, `collect-elements.ts` gated `reactiveAttrs` on
+ * `needsEffectWrapper(...)`, an allow-list that only recognises known signal
+ * getters, memos, and props. Any attribute expression the analyzer couldn't
+ * statically prove reactive — e.g. `class={format(label)}` where `format`
+ * is imported — was silently dropped from `reactiveAttrs`. At SSR the
+ * attribute was evaluated once; the client never re-evaluated it, so the
+ * attribute stayed frozen.
+ *
+ * The fix widens the gate to also wrap when the expanded expression contains
+ * a function call (`/\b\w+\s*\(/`). Over-wrapping a pure call that
+ * subscribes to nothing is harmless (one closure at init time, no rerun);
+ * under-wrapping a reactive read is the bug class we're closing. Pure static
+ * literals and bare identifiers without calls stay un-wrapped.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
+  test('known signal getter in attribute still wraps (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function classFor(n) { return n % 2 === 0 ? 'even' : 'odd' }
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button class={classFor(count())} onClick={() => setCount(c => c + 1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Counter.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('classFor(count())')
+  })
+
+  test('unrecognised call in attribute now wraps in createEffect', () => {
+    // `format` is an imported helper the analyzer can't prove reactive;
+    // `label` is a local const, not a signal/memo/prop. Before the fix, this
+    // expression produced no entry in reactiveAttrs (silent drop). With
+    // wrap-by-default, the function-call shape alone is enough to wrap.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+
+      export function Tag() {
+        const [, setFoo] = createSignal(0)
+        const label = 'hi'
+        return <button class={format(label)} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Tag.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('format(')
+  })
+
+  test('call with no reactive source still wraps (harmless over-wrap)', () => {
+    // `Date.now()` isn't reactive, but the analyzer can't prove it
+    // non-reactive either. Under wrap-by-default we emit a createEffect
+    // rather than freeze the SSR value. The effect subscribes to nothing
+    // and runs exactly once at init.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Clock() {
+        const [, setFoo] = createSignal(0)
+        return <button data-x={Date.now()} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Clock.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('Date.now()')
+  })
+
+  test('static string literal attribute stays un-wrapped (optimisation preserved)', () => {
+    // Static literals have attr.dynamic === false, so they never reach the
+    // reactive-attr path. The component's only signal is read-only in the
+    // event handler, so no createEffect should be emitted at all.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Greeting() {
+        const [, setFoo] = createSignal(0)
+        return <button class="static" onClick={() => setFoo(1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Greeting.tsx')
+    expect(clientJs).not.toContain('createEffect')
+  })
+
+  test('bare identifier attribute (no calls) stays un-wrapped', () => {
+    // A local const without function calls expands to a string with no call
+    // shape (`\`btn-\${size}\``). Neither needsEffectWrapper nor the
+    // regex-based fallback fires, so the attribute value is left frozen in
+    // SSR output — which is correct, nothing to track.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Label() {
+        const [, setFoo] = createSignal(0)
+        const size = 'md'
+        const cls = \`btn-\${size}\`
+        return <button class={cls} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Label.tsx')
+    // No attribute-update createEffect. Guard against over-wrap regression.
+    expect(clientJs).not.toMatch(/setAttribute\(\s*['"]class['"]/)
+    expect(clientJs).not.toMatch(/className\s*=\s*[^;]*cls/)
+  })
+
+  test('spread-expanded prop whose expansion contains a call wraps', () => {
+    // `classes` is a local const whose value contains a call
+    // (`format(variant)`). expandConstantForReactivity inlines the reference
+    // before the gate runs, so the expanded string matches the call regex
+    // and the attribute wraps. This protects the same silent-drop case for
+    // code that factors class construction into a local variable.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+
+      export function Tag() {
+        const [, setFoo] = createSignal(0)
+        const base = 'btn'
+        const variant = 'primary'
+        const classes = \`\${base} \${format(variant)}\`
+        return <button class={classes} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Tag.tsx')
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain('format(')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -540,7 +540,19 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
         // e.g., `classes` → `` `${baseClasses} ${variantClasses[variant]} ${className}` ``
         const expandedValueStr = expandConstantForReactivity(valueStr, ctx)
 
-        if (needsEffectWrapper(expandedValueStr, ctx)) {
+        // Solid-style wrap-by-default fallback (#940, follow-up to #937/#939):
+        // wrap attribute bindings in createEffect not only for statically-proven
+        // reactive expressions, but also for any expression the analyzer can't
+        // prove non-reactive — i.e. anything that contains a function call.
+        // Pure static literals and bare identifiers (no calls) stay un-wrapped
+        // because their SSR value is already in the DOM.
+        //
+        // False positive (extra createEffect that subscribes to nothing) is
+        // harmless; false negative (silent drop of a reactive read) is the
+        // bug class this gate closes. Phase 2 has no AST access, so a cheap
+        // regex over the expanded expression is sufficient here.
+        const hasFunctionCall = /\b\w+\s*\(/.test(expandedValueStr)
+        if (needsEffectWrapper(expandedValueStr, ctx) || hasFunctionCall) {
           ctx.reactiveAttrs.push({
             slotId: element.slotId,
             attrName: attr.name,


### PR DESCRIPTION
## Summary

Follow-up to #937. Carries the Solid-style wrap-by-default fallback landed in #939 (text interpolation) to **JSX attribute bindings** — `<div class={expr}>`, `<button disabled={expr}>`, etc. Closes #940.

Before this change, the `reactiveAttrs` gate in `collect-elements.ts` relied solely on `needsEffectWrapper` — an allow-list that only recognises known signal getters, memos, and props. Any attribute expression the analyzer couldn't statically prove reactive — e.g. `class={format(label)}` where `format` is imported — was silently dropped from `reactiveAttrs`. SSR evaluated the value once; the client never re-evaluated it, so the attribute stayed frozen after hydration.

The fix widens the gate to also wrap when the expanded expression contains a function call. Over-wrap (createEffect that subscribes to nothing) is harmless — one closure at init time; under-wrap is the silent-drop bug this closes.

## Changes

- `packages/jsx/src/ir-to-client-js/collect-elements.ts` — widened the attribute gate at line 543. A cheap `/\b\w+\s*\(/` regex on the expanded expression decides the fallback; Phase 2 has no AST access. No `needsSlot` update required (per the issue, the slotId for attribute-bearing elements is already allocated via events / reactive children / refs).
- `packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts` — 6 regression cases mirroring `runtime-fallback-wrap.test.ts` from #939:
  1. Known signal getter in `class={classFor(count())}` still wraps (regression guard).
  2. Unrecognised call in `class={format(label)}` now wraps (new behaviour).
  3. Pure call `data-x={Date.now()}` with no reactive source still wraps (harmless over-wrap).
  4. Static literal `class=\"static\"` stays un-wrapped (optimisation preserved).
  5. Bare identifier `class={cls}` without calls stays un-wrapped.
  6. Spread-expanded prop `class={classes}` where `const classes = \`\${base} \${format(variant)}\`` wraps.

## Fixture sweep

Baseline: `site/ui/dist/components/**/*.js` on `main`. After rebuild, **9 of 181 distinct components differ (~5 %)** — well under the 30 % rollback threshold from #937. Each delta adds a correct `createEffect` for an attribute that was previously silently dropped:

- `chat-demo`, `scroll-area-demo`, `scroll-area-playground`, `music-player-demo`, `studio-canvas` — `data-state={vBarVisible() ? 'visible' : 'hidden'}` now updates reactively
- `dialog-demo` — `disabled={!isConfirmed()}` now updates reactively
- `input-otp-demo`, `input-otp-playground`, `input-otp-usage-demo` — `value={String(getValue())}` now updates reactively

## Scope (non-goals)

- Did **not** change `needsEffectWrapper`'s signature or other consumers (e.g. the loop-child reactive-attr collector, or the `reactiveChildProps` collector at line 416 for child-component prop bindings — that is #942).
- Did **not** touch conditional bindings (#941) or loop bodies (#943).
- Did **not** add opt-out syntax (Solid-style `/*@once*/`) — out of scope until wrap-by-default rolls out across all four gates.

## Test plan

- [x] `bun test packages/jsx` — 668 tests pass (6 new, 662 pre-existing).
- [x] `bun test packages/{dom,cli,client,hono,go-template,adapter-tests}` — 802 tests pass.
- [x] Clean `bun run build` succeeds.
- [x] Fixture sweep: 9 / 181 components gain new reactive-attr wraps, all correct.

## References

- Architecture rationale: #937
- Pilot (text interpolation): #939
- Sibling follow-ups: #941 (conditionals), #942 (child-component prop bindings), #943 (loops)