### PR TITLE
fix(compiler): wrap-by-default fallback for JSX conditional expressions (#941)

### DIFF
--- a/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for #941: Solid-style wrap-by-default fallback for JSX
+ * conditional expressions used as children — `{cond ? a : b}`,
+ * `{cond && b}`, `{a ?? b}`, `{a || b}`. Follow-up to #937 (architecture)
+ * and #939 (text interpolation pilot).
+ *
+ * Before this change, `jsx-to-ir.ts` gated `IRConditional.slotId` on
+ * `isReactiveExpression(...)` (an allow-list of known signal getters,
+ * memos, and props). Any condition the analyzer couldn't statically prove
+ * reactive — e.g. `{isVisible(x) ? <A/> : <B/>}` where `isVisible` is an
+ * imported helper — was allocated no slotId. At SSR the branch was chosen
+ * once based on the condition's initial value; the client never
+ * re-evaluated it, so the rendered branch stayed frozen.
+ *
+ * The fix computes `exprHasFunctionCalls` / `exprCallsReactiveGetters` on
+ * the condition AST at each of the three sites and includes those flags
+ * in both the `needsSlot` decision and the `IRConditional` node. The
+ * collector in `collect-elements.ts` then wraps on the widened gate.
+ * Over-wrap is harmless; under-wrap is the silent-drop bug we're closing.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('Solid-style wrap-by-default fallback for conditionals (#941)', () => {
+  test('known signal in ternary still wraps (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Gate() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <button onClick={() => setCount(c => c + 1)}>
+            {count() > 0 ? <span>pos</span> : <span>zero</span>}
+          </button>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Gate.tsx')
+    // A reactive ternary emits an insert(...) call for branch switching.
+    expect(clientJs).toContain('insert')
+    expect(clientJs).toContain('count()')
+  })
+
+  test('unrecognised call in ternary now wraps in insert (new behaviour)', () => {
+    // `isVisible` is an imported helper the analyzer can't prove reactive.
+    // Before the fix, no slotId was allocated, and the branch stayed frozen
+    // at its SSR value. With wrap-by-default the call shape alone allocates
+    // a slotId and the collector emits an insert() for branch switching.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { isVisible } from './visibility'
+
+      export function Gate() {
+        const [, setFoo] = createSignal(0)
+        const x = 1
+        return (
+          <button onClick={() => setFoo(1)}>
+            {isVisible(x) ? <span>yes</span> : <span>no</span>}
+          </button>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Gate.tsx')
+    expect(clientJs).toContain('insert')
+    expect(clientJs).toContain('isVisible(')
+  })
+
+  test('logical-AND with method-call condition wraps', () => {
+    // `flags.enabled()` is a method call — neither signal, memo, nor prop.
+    // Under the old gate this was dropped; under wrap-by-default the
+    // function-call shape alone triggers the fallback.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Banner() {
+        const [, setFoo] = createSignal(0)
+        const flags = { enabled: () => true }
+        return (
+          <div onClick={() => setFoo(1)}>
+            {flags.enabled() && <span>on</span>}
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Banner.tsx')
+    expect(clientJs).toContain('insert')
+    expect(clientJs).toContain('flags.enabled()')
+  })
+
+  test('static literal-derived condition stays un-wrapped', () => {
+    // `staticValue` is a bare local const with no function calls; neither
+    // the old gate nor the new fallback fires. No insert() — the branch
+    // baked into SSR output stays as-is on the client.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Banner() {
+        const [, setFoo] = createSignal(0)
+        const staticValue = true
+        return (
+          <div onClick={() => setFoo(1)}>
+            {staticValue ? <span>a</span> : <span>b</span>}
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Banner.tsx')
+    expect(clientJs).not.toContain('insert')
+  })
+
+  test('bare identifier in nullish coalescing stays un-wrapped', () => {
+    // `a` is a bare local const with no calls. `a ?? <Fallback/>` has
+    // nothing to re-evaluate on the client. No insert() emitted.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Message() {
+        const [, setFoo] = createSignal(0)
+        const a = 'hello'
+        return (
+          <div onClick={() => setFoo(1)}>
+            {a ?? <span>fallback</span>}
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Message.tsx')
+    expect(clientJs).not.toContain('insert')
+  })
+
+  test('nested ternaries with unrecognised calls wrap at both levels', () => {
+    // `outer()` and `inner()` are imported helpers the analyzer can't
+    // prove reactive. Both conditionals must wrap so that a signal update
+    // in either layer triggers a re-render, not just the outermost.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { outer, inner } from './checks'
+
+      export function Nested() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <button onClick={() => setFoo(1)}>
+            {outer() ? (inner() ? <span>A</span> : <span>B</span>) : <span>C</span>}
+          </button>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Nested.tsx')
+    expect(clientJs).toContain('outer()')
+    expect(clientJs).toContain('inner()')
+    // Both conditionals produce insert() call sites. Two insert(...) calls
+    // for the outer + the nested inner.
+    const insertCount = (clientJs.match(/\binsert\s*\(/g) ?? []).length
+    expect(insertCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
@@ -107,8 +107,11 @@ describe('Solid-style wrap-by-default fallback for conditionals (#941)', () => {
 
   test('static literal-derived condition stays un-wrapped', () => {
     // `staticValue` is a bare local const with no function calls; neither
-    // the old gate nor the new fallback fires. No insert() — the branch
-    // baked into SSR output stays as-is on the client.
+    // the old gate nor the new fallback fires. The conditional stays baked
+    // into SSR output. Assert specifically that `staticValue` is not passed
+    // to an `insert(...)` callback — tighter than `.not.toContain('insert')`,
+    // which would flip red on any unrelated future insert() site in the
+    // same component.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -125,29 +128,30 @@ describe('Solid-style wrap-by-default fallback for conditionals (#941)', () => {
     `
 
     const clientJs = getClientJs(source, 'Banner.tsx')
-    expect(clientJs).not.toContain('insert')
+    expect(clientJs).not.toMatch(/insert\s*\([^)]*staticValue/)
   })
 
   test('bare identifier in nullish coalescing stays un-wrapped', () => {
-    // `a` is a bare local const with no calls. `a ?? <Fallback/>` has
-    // nothing to re-evaluate on the client. No insert() emitted.
+    // `greeting` is a bare local const with no calls. `greeting ??
+    // <Fallback/>` has nothing to re-evaluate on the client. Slot-scoped
+    // assertion: `greeting` must not appear inside an insert(...) callback.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
 
       export function Message() {
         const [, setFoo] = createSignal(0)
-        const a = 'hello'
+        const greeting = 'hello'
         return (
           <div onClick={() => setFoo(1)}>
-            {a ?? <span>fallback</span>}
+            {greeting ?? <span>fallback</span>}
           </div>
         )
       }
     `
 
     const clientJs = getClientJs(source, 'Message.tsx')
-    expect(clientJs).not.toContain('insert')
+    expect(clientJs).not.toMatch(/insert\s*\([^)]*greeting/)
   })
 
   test('nested ternaries with unrecognised calls wrap at both levels', () => {
@@ -172,9 +176,10 @@ describe('Solid-style wrap-by-default fallback for conditionals (#941)', () => {
     const clientJs = getClientJs(source, 'Nested.tsx')
     expect(clientJs).toContain('outer()')
     expect(clientJs).toContain('inner()')
-    // Both conditionals produce insert() call sites. Two insert(...) calls
-    // for the outer + the nested inner.
+    // Outer + nested inner conditional each get their own insert() call —
+    // exactly two. Using toBe(2) (rather than >=2) catches both the
+    // silent-drop regression *and* any accidental duplicate emission.
     const insertCount = (clientJs.match(/\binsert\s*\(/g) ?? []).length
-    expect(insertCount).toBeGreaterThanOrEqual(2)
+    expect(insertCount).toBe(2)
   })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -250,12 +250,22 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
     case 'conditional':
       if (node.clientOnly && node.slotId) {
         ctx.clientOnlyConditionals.push(buildConditionalMetadata(node, ctx))
-      } else if (node.reactive && node.slotId) {
-        if (insideConditional) {
-          // Nested conditionals are collected by the parent via collectBranchConditionals.
-          // Don't push to ctx.conditionalElements — they'll be emitted inside the parent's bindEvents.
-        } else {
-          ctx.conditionalElements.push(buildConditionalMetadata(node, ctx))
+      } else if (node.slotId) {
+        // Solid-style wrap-by-default fallback (#941, follow-up to #937/#939).
+        // Wrap not only statically-proven-reactive conditions, but also any
+        // condition containing a function call — otherwise the silent-drop
+        // failure class freezes the branch at its SSR-time value.
+        const shouldWrap =
+          node.reactive ||
+          node.callsReactiveGetters ||
+          node.hasFunctionCalls
+        if (shouldWrap) {
+          if (insideConditional) {
+            // Nested conditionals are collected by the parent via collectBranchConditionals.
+            // Don't push to ctx.conditionalElements — they'll be emitted inside the parent's bindEvents.
+          } else {
+            ctx.conditionalElements.push(buildConditionalMetadata(node, ctx))
+          }
         }
       }
       // Recurse into conditional branches with insideConditional = true
@@ -749,7 +759,9 @@ function collectBranchConditionals(node: IRNode, ctx: ClientJsContext): Conditio
   function walk(n: IRNode): void {
     switch (n.type) {
       case 'conditional':
-        if (n.reactive && n.slotId) {
+        // Wrap-by-default fallback (#941) — mirror the top-level gate in
+        // `case 'conditional'` at collectElements().
+        if (n.slotId && (n.reactive || n.callsReactiveGetters || n.hasFunctionCalls)) {
           result.push(buildConditionalMetadata(n, ctx))
         }
         // Don't recurse further — the nested conditional handles its own branches

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -970,7 +970,15 @@ function transformConditional(
   const condition = ctx.getJS(node.condition)
   const reactive = isReactiveExpression(condition, ctx, node.condition)
   const loopParamReactive = !reactive && referencesLoopParam(condition, ctx)
-  const slotId = (reactive || loopParamReactive) ? generateSlotId(ctx) : null
+  // Solid-style wrap-by-default fallback (#941, follow-up to #937/#939).
+  // A condition the analyzer can't prove reactive but that contains a
+  // function call is likely a silent-drop waiting to happen — allocate
+  // a slotId so the collector can wrap it. See `case 'conditional'` in
+  // collect-elements.ts for the matching gate.
+  const callsReactive = exprCallsReactiveGetters(node.condition, ctx)
+  const hasCalls = exprHasFunctionCalls(node.condition)
+  const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+  const slotId = needsSlot ? generateSlotId(ctx) : null
 
   // Transform both branches
   const whenTrue = transformConditionalBranch(node.whenTrue, ctx)
@@ -985,6 +993,8 @@ function transformConditional(
     whenTrue,
     whenFalse,
     slotId,
+    callsReactiveGetters: callsReactive || undefined,
+    hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -996,7 +1006,11 @@ function transformLogicalAnd(
   const condition = ctx.getJS(node.left)
   const reactive = isReactiveExpression(condition, ctx, node.left)
   const loopParamReactive = !reactive && referencesLoopParam(condition, ctx)
-  const slotId = (reactive || loopParamReactive) ? generateSlotId(ctx) : null
+  // Wrap-by-default fallback (#941) — see transformConditional.
+  const callsReactive = exprCallsReactiveGetters(node.left, ctx)
+  const hasCalls = exprHasFunctionCalls(node.left)
+  const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+  const slotId = needsSlot ? generateSlotId(ctx) : null
 
   const whenTrue = transformConditionalBranch(node.right, ctx)
   const whenFalse: IRExpression = {
@@ -1017,6 +1031,8 @@ function transformLogicalAnd(
     whenTrue,
     whenFalse,
     slotId,
+    callsReactiveGetters: callsReactive || undefined,
+    hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -1050,7 +1066,14 @@ function transformNullishCoalescing(
   const condition = isNullish ? `${leftText} != null` : leftText
   const reactive = isReactiveExpression(leftText, ctx, node.left)
   const loopParamReactive = !reactive && referencesLoopParam(leftText, ctx)
-  const slotId = (reactive || loopParamReactive) ? generateSlotId(ctx) : null
+  // Wrap-by-default fallback (#941) — see transformConditional. The call
+  // flags are computed from node.left (the operand that stands in for the
+  // condition). Hoisted here so both the IRConditional slotId decision and
+  // the whenTrue IRExpression can share the same values.
+  const callsReactive = exprCallsReactiveGetters(node.left, ctx)
+  const hasCalls = exprHasFunctionCalls(node.left)
+  const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+  const slotId = needsSlot ? generateSlotId(ctx) : null
 
   // whenTrue: the left-hand value itself
   const templateLeftText = rewriteBarePropRefs(leftText, node.left, ctx)
@@ -1061,8 +1084,8 @@ function transformNullishCoalescing(
     typeInfo: inferExpressionType(node.left, ctx),
     reactive,
     slotId: null,
-    callsReactiveGetters: exprCallsReactiveGetters(node.left, ctx) || undefined,
-    hasFunctionCalls: exprHasFunctionCalls(node.left) || undefined,
+    callsReactiveGetters: callsReactive || undefined,
+    hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node.left, ctx.sourceFile, ctx.filePath),
   }
 
@@ -1082,6 +1105,8 @@ function transformNullishCoalescing(
     whenTrue,
     whenFalse,
     slotId,
+    callsReactiveGetters: callsReactive || undefined,
+    hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -136,6 +136,10 @@ export interface IRConditional {
   loc: SourceLocation
   /** When true, condition should be evaluated on client side only */
   clientOnly?: boolean
+  /** When true, condition calls signal getters or memos (has reactive `foo()` pattern). */
+  callsReactiveGetters?: boolean
+  /** When true, condition contains function call(s) — any `identifier()` pattern (computed from AST). */
+  hasFunctionCalls?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #937. Carries the Solid-style wrap-by-default fallback landed in #939 (text interpolation) and #940 (attributes) to **conditional expressions used as JSX children** — `{cond ? a : b}`, `{cond && b}`, `{a ?? b}`, `{a || b}`. Closes #941.

Before this change, three near-identical gates in `jsx-to-ir.ts` (`transformConditional`, `transformLogicalAnd`, `transformNullishCoalescing`) allocated `IRConditional.slotId` only when `isReactiveExpression(condition)` returned true (an allow-list of known signal getters, memos, and props). Any condition the analyzer couldn't statically prove reactive — e.g. `{isVisible(x) ? <A/> : <B/>}` where `isVisible` is an imported helper — got no slotId. At SSR the branch was chosen once; the client never re-evaluated the condition, so the rendered branch stayed frozen.

The fix mirrors the pilot: compute `exprHasFunctionCalls` / `exprCallsReactiveGetters` on the condition AST at each site, widen `needsSlot` with both flags, store them on the `IRConditional`, and widen the collector gate in `collect-elements.ts` (top-level + nested branch) to wrap on `reactive || callsReactiveGetters || hasFunctionCalls`.

## Changes

- `packages/jsx/src/types.ts` — add `callsReactiveGetters?` and `hasFunctionCalls?` to `IRConditional`, mirroring `IRExpression`.
- `packages/jsx/src/jsx-to-ir.ts`:
  - `transformConditional` (line 966) — widen `needsSlot` with the two AST-derived flags; store both on the returned node.
  - `transformLogicalAnd` (line 992) — same.
  - `transformNullishCoalescing` (line 1044) — hoist the flag computation so both the `IRConditional` slotId decision and the `whenTrue` `IRExpression` share the same values (previously only the whenTrue had them).
- `packages/jsx/src/ir-to-client-js/collect-elements.ts`:
  - `case 'conditional'` in `collectElements` — widen the gate.
  - `collectBranchConditionals` — widen symmetrically for nested branches.
- `packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts` — 6 regression cases mirroring `runtime-fallback-wrap.test.ts` from #939:
  1. Known signal in ternary still wraps (regression guard).
  2. Unrecognised call in ternary now wraps (new behaviour).
  3. Logical-AND with method-call condition wraps.
  4. Static literal-derived condition stays un-wrapped.
  5. Bare identifier in nullish coalescing stays un-wrapped.
  6. Nested ternaries with unrecognised calls wrap at both levels.

## Fixture sweep

Baseline: `site/ui/dist/components/**/*.js` on `main` (includes #939 + #940). After rebuild, **6 of 181 distinct components differ (~3.3 %)** — well under the 30 % rollback threshold from #937. All diffs trace to a single source change: the Calendar component gaining a correct \`insert()\` for \`{numMonths() >= 2 && <SecondMonth />}\`, which was previously frozen to its SSR-time branch.

Affected bundles (all Calendar-bundle related):
- `calendar-demo`, `calendar-playground`, `calendar-usage-demo`
- `date-picker-demo`, `date-picker-playground` (wrap Calendar)
- `studio-canvas` (embeds Calendar)

## Scope (non-goals)

- Did **not** redesign the branch-template mechanism. Only the gate is widened.
- Did **not** widen `collectLoopChildConditionals` (loop-body conditionals) — tracked in #943.
- Did **not** deduplicate the three near-identical gates into a helper. Structural cleanup out of scope.
- Did **not** touch `IRIfStatement` (component-level \`if (cond) return <X/>\` chain) — a separate code path not relevant to JSX-inline silent-drops.

## Test plan

- [x] `bun test packages/jsx` — 674 tests pass (6 new, 668 pre-existing).
- [x] `bun test packages/{dom,cli,client,hono,go-template,adapter-tests}` — 802 tests pass.
- [x] Clean `bun run build` succeeds.
- [x] Fixture sweep: 6 / 181 components gain a correct new `insert()`.

## References

- Architecture rationale: #937
- Pilot: #939 (text interpolation)
- Sibling follow-ups: #940 (attributes, merged), #942 (child-component prop bindings), #943 (loops)