### PR TITLE
fix(compiler): wrap-by-default fallback for child-component prop bindings (#942)

### DIFF
--- a/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for #942: Solid-style wrap-by-default fallback for
+ * prop bindings on child components — `<Card title={expr} />`. Follow-up
+ * to #937 (architecture) and #939 (text interpolation pilot).
+ *
+ * Before this change, `collect-elements.ts` gated `reactiveChildProps`
+ * on `hasPropsRef || needsEffectWrapper(...)`. The latter is an
+ * allow-list that only recognises known signal getters, memos, and
+ * prop parameter names. Any child-component prop expression the
+ * analyzer couldn't prove reactive — e.g. `<Card title={formatTitle(
+ * page)} />` where `formatTitle` is imported — was silently dropped.
+ * At SSR the prop was evaluated once; the child component's DOM stayed
+ * frozen at its initial render on the client.
+ *
+ * The fix adds a third branch to the OR gate: `/\b\w+\s*\(/.test(
+ * expandedValue)`. Over-wrap (extra createEffect that subscribes to
+ * nothing) is harmless — one closure at init time. Under-wrap is the
+ * silent-drop bug we're closing.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('Solid-style wrap-by-default fallback for child-component props (#942)', () => {
+  test('known signal getter in child prop still wraps (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Dashboard() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <div onClick={() => setCount(c => c + 1)}>
+            <Card title={count()} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Dashboard.tsx')
+    // Reactive child props emit a `// Reactive child component props`
+    // block containing a createEffect that refreshes the child element's
+    // attributes when the signal changes.
+    expect(clientJs).toContain('Reactive child component props')
+    expect(clientJs).toContain('count()')
+  })
+
+  test('unrecognised call in child prop now wraps (new behaviour)', () => {
+    // `formatTitle` is an imported helper the analyzer can't prove
+    // reactive; `page` is a local const. Before the fix, this was
+    // silently dropped from reactiveChildProps. With wrap-by-default the
+    // function-call shape alone triggers the fallback.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+      import { Card } from './Card'
+
+      export function Dashboard() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title={formatTitle(page)} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Dashboard.tsx')
+    expect(clientJs).toContain('Reactive child component props')
+    expect(clientJs).toContain('formatTitle(')
+  })
+
+  test('call with no recognised reactive source wraps (harmless over-wrap)', () => {
+    // `variantFor(status)` is a pure call: neither signal, memo, nor
+    // prop appears. Under wrap-by-default we emit a createEffect that
+    // subscribes to nothing and runs exactly once. Cheaper than the
+    // silent-drop risk.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { variantFor } from './variants'
+      import { Badge } from './Badge'
+
+      export function Label() {
+        const [, setFoo] = createSignal(0)
+        const status = 'active'
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Badge variant={variantFor(status)} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Label.tsx')
+    expect(clientJs).toContain('Reactive child component props')
+    expect(clientJs).toContain('variantFor(')
+  })
+
+  test('string literal prop stays un-wrapped', () => {
+    // Static literal props have attr.dynamic === false and take the
+    // `prop.isLiteral` branch of the if/else — they never reach the
+    // reactiveChildProps gate at all.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Dashboard() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title="Static" />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Dashboard.tsx')
+    expect(clientJs).not.toContain('Reactive child component props')
+  })
+
+  test('bare identifier child prop (no calls, no props ref) stays un-wrapped', () => {
+    // `label` is a local const with no function calls and no `props.`
+    // reference. None of the three OR branches fires, so no
+    // createEffect is emitted for the child prop binding.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Dashboard() {
+        const [, setFoo] = createSignal(0)
+        const label = 'hi'
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title={label} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Dashboard.tsx')
+    expect(clientJs).not.toContain('Reactive child component props')
+  })
+
+  test('props.xxx access in child prop still wraps (hasPropsRef regression guard)', () => {
+    // The existing `hasPropsRef` branch remains — `props.title` is a
+    // direct prop reference even though it contains no function call.
+    // Ensures the widening didn't accidentally displace the existing
+    // path.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Dashboard(props: { title: string }) {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title={props.title} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Dashboard.tsx')
+    expect(clientJs).toContain('Reactive child component props')
+    // The emitted code rewrites `props.xxx` to the internal props-param
+    // name (`_p.xxx`) via rewriteDestructuredPropsInExpr. Assert on the
+    // emitted form — the gate's `expandedValue.includes('props.')` check
+    // still runs against the source expression before rewriting.
+    expect(clientJs).toMatch(/__v\s*=\s*_p\.title/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -422,9 +422,31 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           const expandedValue = expandDynamicPropValue(prop.value, ctx)
           propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
 
+          // Solid-style wrap-by-default fallback (#942, follow-up to
+          // #937/#939/#940/#941). Wrap child-component prop bindings in
+          // createEffect not only for statically-proven-reactive values,
+          // but also for any expression the analyzer can't prove
+          // non-reactive — anything containing a function call. Pure
+          // literals and bare identifiers (no calls) stay un-wrapped via
+          // the other branches of this if/else.
+          //
+          // False positive (extra createEffect that subscribes to nothing)
+          // is harmless; false negative (silent drop of a reactive read in
+          // a child prop like `<Card title={format(x)} />`) is the bug
+          // class this closes. Phase 2 has no AST access here, so a cheap
+          // regex on the expanded expression is sufficient.
+          //
+          // Single- and double-quoted strings are stripped before the
+          // regex runs, to avoid false positives on object-literal prop
+          // values like `{ color: 'hsl(221 83% 53%)' }`. Template literals
+          // are left intact because `${calls()}` inside them is live code.
           const hasPropsRef = expandedValue.includes('props.')
           const hasReactiveExpr = needsEffectWrapper(expandedValue, ctx)
-          if (hasPropsRef || hasReactiveExpr) {
+          const withoutStringLiterals = expandedValue
+            .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+            .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+          const hasAnyCall = /\b\w+\s*\(/.test(withoutStringLiterals)
+          if (hasPropsRef || hasReactiveExpr || hasAnyCall) {
             const attrName = prop.name === 'className' ? 'class' : prop.name
             ctx.reactiveChildProps.push({
               componentName: node.name,

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -438,15 +438,19 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           //
           // Single- and double-quoted strings are stripped before the
           // regex runs, to avoid false positives on object-literal prop
-          // values like `{ color: 'hsl(221 83% 53%)' }`. Template literals
-          // are left intact because `${calls()}` inside them is live code.
+          // values like `{ color: 'hsl(221 83% 53%)' }`. A single
+          // alternation regex handles both quote kinds in one pass, so
+          // there is no order dependency for inputs that mix them
+          // (e.g. `"It's fine"`). Template literals are left intact
+          // because `${calls()}` inside them is live code.
           const hasPropsRef = expandedValue.includes('props.')
           const hasReactiveExpr = needsEffectWrapper(expandedValue, ctx)
-          const withoutStringLiterals = expandedValue
-            .replace(/'(?:[^'\\]|\\.)*'/g, "''")
-            .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-          const hasAnyCall = /\b\w+\s*\(/.test(withoutStringLiterals)
-          if (hasPropsRef || hasReactiveExpr || hasAnyCall) {
+          const withoutStringLiterals = expandedValue.replace(
+            /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
+            '',
+          )
+          const hasCallOutsideString = /\b\w+\s*\(/.test(withoutStringLiterals)
+          if (hasPropsRef || hasReactiveExpr || hasCallOutsideString) {
             const attrName = prop.name === 'className' ? 'class' : prop.name
             ctx.reactiveChildProps.push({
               componentName: node.name,


### PR DESCRIPTION
## Summary

Follow-up to #937. Carries the Solid-style wrap-by-default fallback landed in #939 (text interpolation), #940 (attributes), and #941 (conditionals) to **prop bindings on child components** — `<Card title={expr} />`, `<Badge variant={expr} />`, etc. Closes #942.

Before this change, the `reactiveChildProps` gate in `collect-elements.ts` fired on `hasPropsRef || needsEffectWrapper(...)`. The latter is an allow-list that only recognises known signal getters, memos, and prop parameter names. Any child-component prop expression the analyzer couldn't statically prove reactive — e.g. `<Card title={formatTitle(page)} />` where `formatTitle` is imported — was silently dropped. SSR evaluated the prop once; the client never re-evaluated it, so the child component's DOM stayed frozen.

## Changes

`packages/jsx/src/ir-to-client-js/collect-elements.ts`:

The gate now ORs three conditions:

- `hasPropsRef` — direct `props.xxx` access (existing path).
- `hasReactiveExpr` — `needsEffectWrapper`'s allow-list match (existing path).
- `hasAnyCall` — **new regex fallback**: `/\b\w+\s*\(/` on the expanded value, applied **after stripping single- and double-quoted string literals**. The strip avoids false positives on object-literal prop values like `{ color: 'hsl(221 83% 53%)' }` — the `hsl(` inside the literal would otherwise trigger a spurious wrap. Template literals are left intact because `${calls()}` interpolations are live code.

Over-wrap (extra createEffect that subscribes to nothing) is harmless: one closure at init time, sets the child component DOM attribute once. Under-wrap is the silent-drop bug this closes.

`packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts` — 6 regression cases mirroring `runtime-fallback-wrap.test.ts` from #939:

1. Known signal in `<Card title={count()} />` still wraps (regression guard).
2. Unrecognised call in `<Card title={formatTitle(page)} />` now wraps (new behaviour).
3. Pure call `<Badge variant={variantFor(status)} />` with no recognised reactive source wraps (harmless over-wrap).
4. String literal prop `<Card title=\"Static\" />` stays un-wrapped.
5. Bare identifier `<Card title={label} />` without calls or `props.` stays un-wrapped.
6. `<Card title={props.title} />` — existing `hasPropsRef` path still wraps.

## Fixture sweep

Baseline: `site/ui/dist/components/**/*.js` on `main` (post #939/#940/#941). After rebuild, **52 / 181 distinct components differ (~28.7 %)**, just under the 30 % rollback threshold from #937.

Bulk of the diffs trace to a single source pattern: \`<CopyButton code={plainJsxTree(tree())} />\` in every playground component. \`tree()\` is a signal but the outer \`plainJsxTree\` call blocked \`needsEffectWrapper\` from recognising the signal read — a genuine silent-drop fix now reactively refreshing the playground's copy-to-clipboard source.

The remaining diffs add harmless over-wraps for inline arrow-function props (\`(v) => v.slice(0, 3)\`) and constructor calls (\`new Date()\`). The child component receives each prop stably via \`initChild()\`; the extra DOM \`setAttribute\` on the component element is a one-shot at hydration and matches the SSR-rendered attribute.

Initial attempt without the string-literal strip produced 60 / 181 = 33 %, just over threshold, because chart demos use inline \`config={{ color: 'hsl(221 83% 53%)' }}\` — the \`hsl(\` inside the string was matching the naive regex. Stripping single/double-quoted strings before the regex drops those spurious matches.

## Scope (non-goals)

- Did **not** change `forwardProps()` semantics or spread-prop reactivity.
- Did **not** change the JSX-children getter path.
- Did **not** deduplicate the now four-site `hasAnyCall` regex into a shared helper — same DRY discussion as #941, worth revisiting after #943 lands.

## Test plan

- [x] `bun test packages/jsx` — 680 tests pass (6 new, 674 pre-existing).
- [x] `bun test packages/{dom,cli,client,hono,go-template,adapter-tests}` — 802 tests pass.
- [x] Clean `bun run build` succeeds.
- [x] Fixture sweep: 52 / 181 components gain correct new \`createEffect\` for child-component prop updates.

## References

- Architecture rationale: #937
- Pilot: #939 (text interpolation)
- Sibling follow-ups: #940 (attributes, merged), #941 (conditionals, merged), #943 (loops)