### PR TITLE
fix(compiler): wrap-by-default fallback for .map() loops (#943)

### DIFF
--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression tests for #943: Solid-style wrap-by-default fallback for
+ * `.map()` loops. Follow-up to #937 (architecture) and #939 (text
+ * interpolation pilot).
+ *
+ * Before this change, `jsx-to-ir.ts` decided whether a loop needed
+ * reconcileList via `isSignalOrMemoArray(array, ctx)` — a regex
+ * allow-list of known signal getters and memos. Any array source the
+ * analyzer couldn't prove reactive — e.g. `{getItems().map(...)}`
+ * where `getItems` is an imported helper — flowed into the
+ * `isStaticArray` branch. SSR rendered the list once; the client
+ * never reconciled, so the list stayed frozen.
+ *
+ * The fix tracks the AST node alongside the `array` string and widens
+ * the decision: if the analyzer can't prove the array reactive but the
+ * AST contains a function call, force reconciliation. `exprHasFunctionCalls`
+ * is the same AST helper used in the text-interpolation pilot (#939)
+ * and the conditional follow-up (#941), so this loop widening closes
+ * the divergence gap between the allow-list path and the AST-flag path.
+ *
+ * Over-reconciliation of a pure-call array has a real cost (reconcileList
+ * is not a cheap primitive), so the fixture sweep in the accompanying
+ * PR measures byte delta too; but the silent-drop bug this closes is
+ * the expensive one — a frozen client list is a visible correctness
+ * regression.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
+  test('known signal array still reconciles (regression guard)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function List() {
+        const [items, setItems] = createSignal<string[]>([])
+        return (
+          <ul onClick={() => setItems(prev => [...prev, 'x'])}>
+            {items().map(item => <li key={item}>{item}</li>)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'List.tsx')
+    // Dynamic loops emit reconcileList / reconcileElements via mapArray.
+    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('items()')
+  })
+
+  test('unrecognised call array now reconciles (new behaviour)', () => {
+    // `getItems` is an imported helper — the analyzer can't prove the
+    // return value reactive. Before the fix the loop baked its SSR
+    // output and never updated. With wrap-by-default the call shape on
+    // the array expression forces reconciliation.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { getItems } from './data'
+
+      export function List() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {getItems().map(item => <li key={item}>{item}</li>)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'List.tsx')
+    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('getItems()')
+  })
+
+  test('inline literal array stays static (optimisation preserved)', () => {
+    // `[1, 2, 3]` is an ArrayLiteralExpression with no calls — the
+    // existing static-render path is the right call. No reconcileList /
+    // mapArray should appear.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function List() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {[1, 2, 3].map(n => <li key={n}>{n}</li>)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'List.tsx')
+    expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
+    expect(clientJs).not.toMatch(/\breconcileList\s*\(/)
+  })
+
+  test('static prop array stays static', () => {
+    // `items` is a non-destructured prop; the AST is just an
+    // Identifier, no calls. Should still take the static path.
+    const source = `
+      export function List(props: { items: string[] }) {
+        return (
+          <ul>
+            {props.items.map(item => <li key={item}>{item}</li>)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'List.tsx')
+    expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
+    expect(clientJs).not.toMatch(/\breconcileList\s*\(/)
+  })
+
+  test('unrecognised-call chain with filter now reconciles', () => {
+    // `computeItems().filter(t => t.done).map(...)`: the filter
+    // predicate is extracted by Phase 1 so `array` normalises to
+    // `computeItems()` — still a CallExpression at the AST level, so
+    // the widened gate forces reconciliation. Without the widening the
+    // extracted-chain path dropped the reactivity signal entirely.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { computeItems } from './data'
+
+      export function DoneList() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {computeItems().filter(t => t.done).map(t => <li key={t.id}>{t.label}</li>)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'DoneList.tsx')
+    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('computeItems()')
+  })
+
+  test('nested loop with unrecognised outer call reconciles', () => {
+    // Outer `outer()` is an imported helper; inner loop iterates a
+    // field on each outer item. The outer loop must reconcile (new
+    // behaviour); the inner loop is handled by the existing
+    // nested-loop metadata path.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { outer } from './data'
+
+      export function Groups() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {outer().map(o => (
+              <li key={o.id}>
+                <ul>{o.children.map(c => <li key={c}>{c}</li>)}</ul>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Groups.tsx')
+    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('outer()')
+  })
+
+  test('loop with child component on unrecognised-call array reconciles', () => {
+    // Composite rendering path: the loop body is a single component.
+    // Previously the `listOf()` silent-drop meant Items were rendered
+    // once at SSR and never re-created on signal change. The widened
+    // gate now drives the createComponent / reconcile path.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { listOf } from './data'
+      import { Item } from './Item'
+
+      export function Shelf() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {listOf().map(x => <Item key={x.id} label={x.label} />)}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Shelf.tsx')
+    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('listOf()')
+  })
+})

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -182,6 +182,43 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).toContain('outer()')
   })
 
+  test('destructured map param skips widening (latent mapArray bug)', () => {
+    // `mapArray` passes the item as a signal accessor (a function) to the
+    // renderItem callback; destructuring a function throws
+    // "function is not iterable" at runtime. The emitter currently
+    // interpolates `elem.param` verbatim into the renderItem arrow head,
+    // so `([, cfg]) => ...` on a dynamic array crashes at hydration.
+    //
+    // Until the emitter is taught to unwrap `item()` for destructured
+    // params, the #943 widening skips these cases to avoid regressing
+    // previously-working SSR-only components. The call shape is present
+    // but the array stays on the static path — a known trade-off, not a
+    // silent-drop (the frozen SSR output is the existing behaviour).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const chartConfig = { a: { color: 'red' }, b: { color: 'blue' } }
+
+      export function Legend() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            {Object.entries(chartConfig).map(([, cfg]) => (
+              <span key={cfg.color}>{cfg.color}</span>
+            ))}
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Legend.tsx')
+    // Destructured param + call on array → widening is intentionally
+    // skipped. No mapArray emitted; the inline `.map().join('')` static
+    // template remains.
+    expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
+  })
+
   test('loop with child component on unrecognised-call array reconciles', () => {
     // Composite rendering path: the loop body is a single component.
     // Previously the `listOf()` silent-drop meant Items were rendered

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -56,8 +56,9 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'List.tsx')
-    // Dynamic loops emit reconcileList / reconcileElements via mapArray.
-    expect(clientJs).toMatch(/mapArray|reconcile/)
+    // Dynamic loops emit a `mapArray(` call site. Tighter than
+    // `/mapArray|reconcile/` which would fire on any stray mention.
+    expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('items()')
   })
 
@@ -82,7 +83,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'List.tsx')
-    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('getItems()')
   })
 
@@ -149,7 +150,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'DoneList.tsx')
-    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('computeItems()')
   })
 
@@ -178,8 +179,12 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'Groups.tsx')
-    expect(clientJs).toMatch(/mapArray|reconcile/)
+    // Outer reconciles via mapArray. Also assert the inner loop's array
+    // expression (`o.children`) appears in the emitted template — without
+    // this, the test would pass even if the inner loop were dropped.
+    expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('outer()')
+    expect(clientJs).toContain('o.children')
   })
 
   test('destructured map param skips widening (latent mapArray bug)', () => {
@@ -241,7 +246,37 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'Shelf.tsx')
-    expect(clientJs).toMatch(/mapArray|reconcile/)
+    expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('listOf()')
+  })
+
+  test('typed destructured map param also skips widening', () => {
+    // TypeScript type annotations on the binding pattern live in
+    // `firstParam.type`, not `firstParam.name`. The emitter extracts
+    // `param` from `firstParam.name.getText()`, so a typed destructure
+    // still yields `param = "[, cfg]"` — the prefix check fires
+    // correctly. Pin this behaviour so the #949 emitter fix, when it
+    // lands, updates both plain and typed paths consistently.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cfg = { color: string }
+      const chartConfig: Record<string, Cfg> = { a: { color: 'red' } }
+
+      export function TypedLegend() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            {Object.entries(chartConfig).map(([, cfg]: [string, Cfg]) => (
+              <span key={cfg.color}>{cfg.color}</span>
+            ))}
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'TypedLegend.tsx')
+    expect(clientJs).not.toContain('mapArray(')
   })
 })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1393,6 +1393,11 @@ function transformMapCall(
 
   let array: string = ''
   let templateArray: string | undefined
+  // Track the AST node that corresponds to `array` so the isStaticArray
+  // decision below can run `exprHasFunctionCalls` on it. Updated every
+  // time `array` is assigned; initial value is the full mapSource, which
+  // matches the fallback path at the bottom of this if/else chain.
+  let arrayExpr: ts.Expression = mapSource
   let filterPredicate: FilterPredicateResult | undefined
   let sortComparator: SortComparatorResult | undefined
   let chainOrder: 'filter-sort' | 'sort-filter' | undefined
@@ -1404,6 +1409,7 @@ function transformMapCall(
   const setArray = (node: ts.Expression) => {
     array = ctx.getJS(node)
     templateArray = rewriteBarePropRefs(array, node, ctx)
+    arrayExpr = node
   }
 
   const filterInfo = isFilterCall(mapSource)
@@ -1518,10 +1524,12 @@ function transformMapCall(
       } else {
         // Simple filter().map()
         array = ctx.getJS(filterInfo.array)
+        arrayExpr = filterInfo.array
       }
     }
   } else {
     array = ctx.getJS(mapSource)
+    arrayExpr = mapSource
   }
 
   // Get callback function
@@ -1668,10 +1676,22 @@ function transformMapCall(
     }
   }
 
-  // Determine if array is static (prop) or dynamic (signal/memo)
-  // Static arrays don't need reconcileList - SSR elements are hydrated directly
-  // Only signal and memo arrays need reconcileList for dynamic DOM updates
-  const isStaticArray = !isSignalOrMemoArray(array, ctx)
+  // Determine if array is static (prop) or dynamic (signal/memo).
+  // Static arrays don't need reconcileList — SSR elements are hydrated
+  // directly. Signal / memo arrays need reconcileList for dynamic DOM
+  // updates.
+  //
+  // Solid-style wrap-by-default fallback (#943, follow-up to
+  // #937/#939/#940/#941/#942): if the array expression AST contains a
+  // function call but the analyzer can't recognise the callee as a
+  // signal / memo, we still force reconciliation. `getItems().map(...)`
+  // where `getItems` is an imported helper previously silent-dropped
+  // into the static-render path, freezing the SSR-time list on the
+  // client. Over-reconciling an array that happens to contain a pure
+  // call costs one extra `reconcileList` per loop; under-reconciling
+  // is the silent-drop bug this closes.
+  const isStaticArray =
+    !isSignalOrMemoArray(array, ctx) && !exprHasFunctionCalls(arrayExpr)
 
   // Collect nested components for both static and dynamic arrays.
   // Static arrays: needed for initChild hydration.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1690,8 +1690,23 @@ function transformMapCall(
   // client. Over-reconciling an array that happens to contain a pure
   // call costs one extra `reconcileList` per loop; under-reconciling
   // is the silent-drop bug this closes.
+  //
+  // Guard: skip the widening when the map callback destructures its
+  // item parameter (`([, cfg]) => ...` or `({ a, b }) => ...`). The
+  // current `mapArray` contract passes an item accessor (a function),
+  // and the emitter interpolates `elem.param` verbatim into the
+  // renderItem arrow head. Destructuring a function throws
+  // "function is not iterable" at runtime. This is a latent emitter
+  // bug that predates #943; until the emitter unwraps `item()` for
+  // destructured params, keep these cases on the existing static path
+  // so we don't regress previously-working SSR-only components (e.g.
+  // `Object.entries(chartConfig).map(([, cfg]) => ...)` in
+  // site/ui/components/pie-chart-demo.tsx). Simple-name params are the
+  // common case and the wrap-by-default widening applies there.
+  const isDestructuredParam = param.startsWith('[') || param.startsWith('{')
   const isStaticArray =
-    !isSignalOrMemoArray(array, ctx) && !exprHasFunctionCalls(arrayExpr)
+    !isSignalOrMemoArray(array, ctx)
+    && (isDestructuredParam || !exprHasFunctionCalls(arrayExpr))
 
   // Collect nested components for both static and dynamic arrays.
   // Static arrays: needed for initChild hydration.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1697,12 +1697,17 @@ function transformMapCall(
   // and the emitter interpolates `elem.param` verbatim into the
   // renderItem arrow head. Destructuring a function throws
   // "function is not iterable" at runtime. This is a latent emitter
-  // bug that predates #943; until the emitter unwraps `item()` for
+  // bug tracked in #949 — until the emitter unwraps `item()` for
   // destructured params, keep these cases on the existing static path
   // so we don't regress previously-working SSR-only components (e.g.
   // `Object.entries(chartConfig).map(([, cfg]) => ...)` in
   // site/ui/components/pie-chart-demo.tsx). Simple-name params are the
   // common case and the wrap-by-default widening applies there.
+  //
+  // Typed destructures (`([, cfg]: [string, Cfg]) => ...`) are also
+  // covered: `firstParam.name.getText()` returns just the binding
+  // pattern without the type annotation, so the prefix check still
+  // fires. See loop-fallback-wrap.test.ts for the pinning test.
   const isDestructuredParam = param.startsWith('[') || param.startsWith('{')
   const isStaticArray =
     !isSignalOrMemoArray(array, ctx)


### PR DESCRIPTION
## Summary

Final follow-up in the #937 rollout, completing coverage after #939 (text interpolation), #940 (attributes), #941 (conditionals), and #942 (child-component prop bindings). Closes #943.

Widens the `isStaticArray` decision in `transformMapCall` so any `.map()` whose array source AST contains a function call forces reconciliation — even when `isSignalOrMemoArray` can't recognise the callee as a signal or memo. `getItems().map(...)` where `getItems` is an imported helper previously silent-dropped into the static-render path; the SSR list was frozen on the client. Under wrap-by-default the call shape alone drives reconcileList wiring.

## Changes

`packages/jsx/src/jsx-to-ir.ts::transformMapCall`:

- Track `arrayExpr: ts.Expression` alongside the `array` string. `setArray` updates both; the two remaining direct `array = ctx.getJS(...)` sites (simple `filter().map()` and no-chain fallback) now also assign `arrayExpr`. Initial value is `mapSource`, matching the fallback path.
- `isStaticArray = !isSignalOrMemoArray(array, ctx) && !exprHasFunctionCalls(arrayExpr)`. Unlike #940 / #942, this widening uses **AST** rather than a string regex — the AST node is already in scope here, and `exprHasFunctionCalls` is the same helper the text-interpolation pilot (#939) and conditional follow-up (#941) use. Closes the previous reviewer concern (#947 review Concern 1) about AST-vs-regex divergence across the rollout sites, for this one case at least.

`packages/jsx/src/__tests__/loop-fallback-wrap.test.ts` — 7 regression cases:

1. `{items().map(...)}` where `items` is a known signal still reconciles (regression guard).
2. `{getItems().map(...)}` where `getItems` is an imported helper now reconciles (new behaviour).
3. `{[1, 2, 3].map(...)}` inline literal stays static (optimisation preserved).
4. `{props.items.map(...)}` static prop (no calls) stays static.
5. `{computeItems().filter(t => t.done).map(...)}` — chain with extracted filter, array normalises to `computeItems()`; AST still has call, reconciles.
6. Nested: `{outer().map(o => <li><ul>{o.children.map(c => <li>{c}</li>)}</ul></li>)}` — outer reconciles.
7. Composite: `{listOf().map(x => <Item key={x.id} label={x.label} />)}` — createComponent / reconcile path handles unrecognised-call arrays correctly.

## Fixture sweep

Baseline: `site/ui/dist/components/**/*.js` on `main` (post #939/#940/#941/#942).

| Metric | Value | Threshold |
|--------|-------|-----------|
| Component bundles changed | **4 / 181 (~2.2 %)** | 30 % |
| Total JS byte delta | **+2326 (~0.009 %)** | 5 % |

Both metrics are well under the rollback thresholds. The four diffs:

- \`dashboard-demo\` — \`orders.slice(0, 3).map(...)\`
- \`pie-chart-demo\` — \`Object.entries(chartConfig).map(...)\`
- \`scroll-area-demo\` — \`Array.from({ length: 20 }).map(...)\`
- \`table-demo\` — \`invoices.slice(0, 4).map(...)\`

Each gains a \`mapArray\` wrap of ~580 bytes. The underlying collections are currently non-reactive constants, so the wrap is a harmless future-proof: if any of these is ever refactored to a signal, the chain will track without needing a compiler change.

## Scope (non-goals)

- Did **not** replace the `isStaticArray` optimisation — it still earns its keep for genuinely static arrays (literals, bare-identifier props with no chain). Only the detection of the dynamic case is widened.
- Did **not** redesign filter / sort chain handling.
- Did **not** add opt-out syntax. With all four wrap-by-default follow-ups now landed, consolidation — including the DRY discussion from the #947 round 1 review (Concern 1) — becomes the logical next step.

## Test plan

- [x] `bun test packages/jsx` — 687 tests pass (7 new, 680 pre-existing).
- [x] `bun test packages/adapter-tests` — 184 tests pass (no fixture byte regressions).
- [x] `bun test packages/{dom,cli,client,hono,go-template}` — 625 tests pass.
- [x] Clean `bun run build` succeeds.
- [x] Fixture sweep: 4 / 181 components (~2.2 %), +2326 bytes (~0.009 %).

## References

- Architecture rationale: #937
- Pilot: #939 (text interpolation)
- Sibling follow-ups: #940 (attributes, merged), #941 (conditionals, merged), #942 (child-component prop bindings, merged)