### PR TITLE
fix(compiler): unwrap accessor for destructured .map() params (#949)

### DIFF
--- a/packages/client/__tests__/runtime/map-array.test.ts
+++ b/packages/client/__tests__/runtime/map-array.test.ts
@@ -390,9 +390,9 @@ describe('mapArray', () => {
   // at first render. mapArray skips renderItem for same-key setItem
   // updates, which means the locals freeze — fine-grained reactivity
   // through destructured bindings needs Option 3 (template-time
-  // rewriting to `__bfItem().path`). This test locks that behaviour
-  // in so a future Option 3 PR turns a red test green rather than
-  // silently changing semantics.
+  // rewriting to `__bfItem().path`), tracked in #951. This test locks
+  // the current behaviour in so the Option 3 PR must consciously flip
+  // it from green to red rather than silently changing semantics.
   test('destructured locals captured once — frozen on same-key update (known limitation)', () => {
     const [items, setItems] = createSignal<[string, string][]>([['1', 'A']])
 

--- a/packages/client/__tests__/runtime/map-array.test.ts
+++ b/packages/client/__tests__/runtime/map-array.test.ts
@@ -301,4 +301,86 @@ describe('mapArray', () => {
     expect(renderCount).toBe(1)
     expect(container.children[0].textContent).toBe('B')
   })
+
+  // Regression: #949. The emitter (see destructureLoopParam in
+  // emit-control-flow.ts) now renames the renderItem param to a synthetic
+  // accessor and unwraps once at body entry. This shape — "function-typed
+  // param unwrapped via __loopItem()" — is what the compiled output
+  // produces for `signalArr().map(([a, b]) => ...)`. The test exercises
+  // the contract directly against the runtime so the fix doesn't silently
+  // regress on the client side.
+  test('destructuring via accessor unwrap works for array-pattern params', () => {
+    const [items, setItems] = createSignal<[string, string][]>([
+      ['1', 'A'],
+      ['2', 'B'],
+    ])
+
+    mapArray(
+      items,
+      container,
+      (item, _i) => item[0],
+      // Shape matches compiled output: synthetic __loopItem, unwrap at entry.
+      (__loopItem) => {
+        const [a, b] = __loopItem()
+        const li = document.createElement('li')
+        li.setAttribute('data-a', a)
+        li.textContent = b
+        return li
+      },
+    )
+
+    expect(container.children.length).toBe(2)
+    expect(container.children[0].getAttribute('data-a')).toBe('1')
+    expect(container.children[0].textContent).toBe('A')
+    expect(container.children[1].getAttribute('data-a')).toBe('2')
+    expect(container.children[1].textContent).toBe('B')
+
+    // Array-level update: add + reorder must update DOM.
+    setItems([
+      ['3', 'C'],
+      ['1', 'A'],
+      ['2', 'B'],
+    ])
+
+    expect(container.children.length).toBe(3)
+    expect(container.children[0].getAttribute('data-a')).toBe('3')
+    expect(container.children[1].getAttribute('data-a')).toBe('1')
+    expect(container.children[2].getAttribute('data-a')).toBe('2')
+
+    // Remove one.
+    setItems([['1', 'A']])
+    expect(container.children.length).toBe(1)
+    expect(container.children[0].getAttribute('data-a')).toBe('1')
+  })
+
+  test('destructuring via accessor unwrap works for object-pattern params', () => {
+    const [items, setItems] = createSignal([
+      { id: '1', label: 'A' },
+      { id: '2', label: 'B' },
+    ])
+
+    mapArray(
+      items,
+      container,
+      (item) => item.id,
+      (__loopItem) => {
+        const { id, label } = __loopItem()
+        const li = document.createElement('li')
+        li.setAttribute('data-id', id)
+        li.textContent = label
+        return li
+      },
+    )
+
+    expect(container.children.length).toBe(2)
+    expect(container.children[0].getAttribute('data-id')).toBe('1')
+    expect(container.children[0].textContent).toBe('A')
+
+    setItems([{ id: '2', label: 'B' }, { id: '3', label: 'C' }])
+
+    expect(container.children.length).toBe(2)
+    expect(container.children[0].getAttribute('data-id')).toBe('2')
+    expect(container.children[1].getAttribute('data-id')).toBe('3')
+    expect(container.children[1].textContent).toBe('C')
+  })
 })

--- a/packages/client/__tests__/runtime/map-array.test.ts
+++ b/packages/client/__tests__/runtime/map-array.test.ts
@@ -305,7 +305,7 @@ describe('mapArray', () => {
   // Regression: #949. The emitter (see destructureLoopParam in
   // emit-control-flow.ts) now renames the renderItem param to a synthetic
   // accessor and unwraps once at body entry. This shape — "function-typed
-  // param unwrapped via __loopItem()" — is what the compiled output
+  // param unwrapped via __bfItem()" — is what the compiled output
   // produces for `signalArr().map(([a, b]) => ...)`. The test exercises
   // the contract directly against the runtime so the fix doesn't silently
   // regress on the client side.
@@ -319,9 +319,9 @@ describe('mapArray', () => {
       items,
       container,
       (item, _i) => item[0],
-      // Shape matches compiled output: synthetic __loopItem, unwrap at entry.
-      (__loopItem) => {
-        const [a, b] = __loopItem()
+      // Shape matches compiled output: synthetic __bfItem, unwrap at entry.
+      (__bfItem) => {
+        const [a, b] = __bfItem()
         const li = document.createElement('li')
         li.setAttribute('data-a', a)
         li.textContent = b
@@ -363,8 +363,8 @@ describe('mapArray', () => {
       items,
       container,
       (item) => item.id,
-      (__loopItem) => {
-        const { id, label } = __loopItem()
+      (__bfItem) => {
+        const { id, label } = __bfItem()
         const li = document.createElement('li')
         li.setAttribute('data-id', id)
         li.textContent = label
@@ -382,5 +382,52 @@ describe('mapArray', () => {
     expect(container.children[0].getAttribute('data-id')).toBe('2')
     expect(container.children[1].getAttribute('data-id')).toBe('3')
     expect(container.children[1].textContent).toBe('C')
+  })
+
+  // Pinning test for the #949 known limitation. The fix (see
+  // destructureLoopParam in emit-control-flow.ts) unwraps the accessor
+  // once at renderItem body entry, so destructured locals are captured
+  // at first render. mapArray skips renderItem for same-key setItem
+  // updates, which means the locals freeze — fine-grained reactivity
+  // through destructured bindings needs Option 3 (template-time
+  // rewriting to `__bfItem().path`). This test locks that behaviour
+  // in so a future Option 3 PR turns a red test green rather than
+  // silently changing semantics.
+  test('destructured locals captured once — frozen on same-key update (known limitation)', () => {
+    const [items, setItems] = createSignal<[string, string][]>([['1', 'A']])
+
+    mapArray(
+      items,
+      container,
+      (item) => item[0],
+      (__bfItem) => {
+        const [, b] = __bfItem()
+        const li = document.createElement('li')
+        // Read `b` once — mirrors captured-semantics in compiled output.
+        li.setAttribute('data-b', b)
+        li.textContent = b
+        return li
+      },
+    )
+
+    const firstEl = container.children[0]
+    expect(firstEl.textContent).toBe('A')
+    expect(firstEl.getAttribute('data-b')).toBe('A')
+
+    // Same key '1', new inner value — mapArray fires setItem and
+    // reuses the DOM node, but `b` was captured on first render so
+    // the DOM attribute / text stay at the original value.
+    setItems([['1', 'B']])
+
+    expect(container.children[0]).toBe(firstEl)
+    expect(firstEl.textContent).toBe('A')
+    expect(firstEl.getAttribute('data-b')).toBe('A')
+
+    // Array-level update (different key) produces a fresh renderItem
+    // call, so `b` is re-captured from the new value — this path works.
+    setItems([['2', 'C']])
+
+    expect(container.children[0].getAttribute('data-b')).toBe('C')
+    expect(container.children[0].textContent).toBe('C')
   })
 })

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -187,18 +187,15 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).toContain('o.children')
   })
 
-  test('destructured map param skips widening (latent mapArray bug)', () => {
+  test('destructured map param now reconciles (#949 emitter fix)', () => {
     // `mapArray` passes the item as a signal accessor (a function) to the
-    // renderItem callback; destructuring a function throws
-    // "function is not iterable" at runtime. The emitter currently
-    // interpolates `elem.param` verbatim into the renderItem arrow head,
-    // so `([, cfg]) => ...` on a dynamic array crashes at hydration.
-    //
-    // Until the emitter is taught to unwrap `item()` for destructured
-    // params, the #943 widening skips these cases to avoid regressing
-    // previously-working SSR-only components. The call shape is present
-    // but the array stays on the static path — a known trade-off, not a
-    // silent-drop (the frozen SSR output is the existing behaviour).
+    // renderItem callback; destructuring a function would throw
+    // "function is not iterable" at runtime. Before #949 the emitter
+    // interpolated `elem.param` verbatim into the renderItem arrow head,
+    // so this path was excluded from the #943 widening to avoid the
+    // crash. With #949 the emitter renames the param to a synthetic
+    // accessor and unwraps once at body entry, so destructured-param
+    // callbacks are safe to reconcile like any other dynamic array.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -218,10 +215,11 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'Legend.tsx')
-    // Destructured param + call on array → widening is intentionally
-    // skipped. No mapArray emitted; the inline `.map().join('')` static
-    // template remains.
-    expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
+    // mapArray is emitted (widening now applies). renderItem uses the
+    // synthetic `__loopItem` param and unwraps at entry.
+    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toContain('(__loopItem, ')
+    expect(clientJs).toContain('const [, cfg] = __loopItem();')
   })
 
   test('loop with child component on unrecognised-call array reconciles', () => {
@@ -250,13 +248,12 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).toContain('listOf()')
   })
 
-  test('typed destructured map param also skips widening', () => {
+  test('typed destructured map param also reconciles (#949)', () => {
     // TypeScript type annotations on the binding pattern live in
     // `firstParam.type`, not `firstParam.name`. The emitter extracts
     // `param` from `firstParam.name.getText()`, so a typed destructure
-    // still yields `param = "[, cfg]"` — the prefix check fires
-    // correctly. Pin this behaviour so the #949 emitter fix, when it
-    // lands, updates both plain and typed paths consistently.
+    // still yields `param = "[, cfg]"`. Once #949 landed, the
+    // destructureLoopParam helper picks up both plain and typed forms.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -277,6 +274,37 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'TypedLegend.tsx')
-    expect(clientJs).not.toContain('mapArray(')
+    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toContain('(__loopItem, ')
+    expect(clientJs).toContain('const [, cfg] = __loopItem();')
+  })
+
+  test('object-destructured map param on signal array reconciles (#949)', () => {
+    // Object-pattern destructure on a signal array. Before #949 this
+    // produced `({ label, value }, __idx, __existing) =>` as the
+    // renderItem head, and mapArray's accessor contract meant the
+    // destructure tried to unpack a function at hydration. With the
+    // emitter fix, the synthetic accessor + entry unwrap keeps the
+    // destructured bindings in scope for the template body.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Fields() {
+        const [items, setItems] = createSignal([{ label: 'a', value: '1' }])
+        return (
+          <ul onClick={() => setItems(prev => [...prev, { label: 'b', value: '2' }])}>
+            {items().map(({ label, value }) => (
+              <li key={value}>{label}:{value}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Fields.tsx')
+    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).toContain('(__loopItem, ')
+    expect(clientJs).toContain('const { label, value } = __loopItem();')
   })
 })

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -216,10 +216,10 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
     const clientJs = getClientJs(source, 'Legend.tsx')
     // mapArray is emitted (widening now applies). renderItem uses the
-    // synthetic `__loopItem` param and unwraps at entry.
+    // synthetic `__bfItem` param and unwraps at entry.
     expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__loopItem, ')
-    expect(clientJs).toContain('const [, cfg] = __loopItem();')
+    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toContain('const [, cfg] = __bfItem();')
   })
 
   test('loop with child component on unrecognised-call array reconciles', () => {
@@ -275,8 +275,8 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
     const clientJs = getClientJs(source, 'TypedLegend.tsx')
     expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__loopItem, ')
-    expect(clientJs).toContain('const [, cfg] = __loopItem();')
+    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toContain('const [, cfg] = __bfItem();')
   })
 
   test('object-destructured map param on signal array reconciles (#949)', () => {
@@ -304,7 +304,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
     const clientJs = getClientJs(source, 'Fields.tsx')
     expect(clientJs).toContain('mapArray(')
-    expect(clientJs).toContain('(__loopItem, ')
-    expect(clientJs).toContain('const { label, value } = __loopItem();')
+    expect(clientJs).toContain('(__bfItem, ')
+    expect(clientJs).toContain('const { label, value } = __bfItem();')
   })
 })

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -34,9 +34,9 @@ import { emitAttrUpdate } from './emit-reactive'
  * remove / reorder / key change) work correctly because a new renderItem
  * call produces fresh locals. Same-key fine-grained reactivity through
  * destructured bindings requires template-time rewriting of binding
- * references to `__bfItem().path` — tracked as an Option 3 follow-up.
+ * references to `__bfItem().path` — tracked in #951 (Option 3 follow-up).
  * See the pinning test in `map-array.test.ts::destructured locals
- * captured once (known limitation)`.
+ * captured once — frozen on same-key update (known limitation)`.
  */
 function destructureLoopParam(param: string): { head: string; unwrap: string } {
   if (param.startsWith('[') || param.startsWith('{')) {

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -20,18 +20,29 @@ import { emitAttrUpdate } from './emit-reactive'
  * synthetic accessor name and unwrap once at body entry, so destructured
  * bindings become plain locals that the rest of the emitted body can read.
  *
+ * The `__bf_` prefix is a barefoot-reserved namespace — avoids any chance
+ * of collision if the user writes `.map(item => ...)` with a matching name.
+ *
+ * Detection relies on `param` being the trimmed output of
+ * `firstParam.name.getText()` in `jsx-to-ir.ts::transformMapCall` — no
+ * leading parens, no type annotations, no trivia whitespace. If that
+ * upstream contract changes, the prefix check must be widened in lockstep
+ * or the #949 crash resurfaces silently.
+ *
  * Known limitation: destructured locals are captured at first render and
  * will not refresh on same-key setItem updates. Array-level updates (add /
  * remove / reorder / key change) work correctly because a new renderItem
  * call produces fresh locals. Same-key fine-grained reactivity through
  * destructured bindings requires template-time rewriting of binding
- * references to `__loopItem().path` — tracked as an Option 3 follow-up.
+ * references to `__bfItem().path` — tracked as an Option 3 follow-up.
+ * See the pinning test in `map-array.test.ts::destructured locals
+ * captured once (known limitation)`.
  */
 function destructureLoopParam(param: string): { head: string; unwrap: string } {
   if (param.startsWith('[') || param.startsWith('{')) {
     return {
-      head: '__loopItem',
-      unwrap: `const ${param} = __loopItem();`,
+      head: '__bfItem',
+      unwrap: `const ${param} = __bfItem();`,
     }
   }
   return { head: param, unwrap: '' }

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -11,6 +11,33 @@ import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
 /**
+ * Compute the mapArray renderItem parameter head and any unwrap statement
+ * needed when the map callback destructures its item parameter (#949).
+ *
+ * mapArray passes the item to renderItem as a signal accessor (function).
+ * Interpolating `[a, b]` or `{ x, y }` verbatim into the arrow head crashes
+ * at hydration with "function is not iterable". We rename the param to a
+ * synthetic accessor name and unwrap once at body entry, so destructured
+ * bindings become plain locals that the rest of the emitted body can read.
+ *
+ * Known limitation: destructured locals are captured at first render and
+ * will not refresh on same-key setItem updates. Array-level updates (add /
+ * remove / reorder / key change) work correctly because a new renderItem
+ * call produces fresh locals. Same-key fine-grained reactivity through
+ * destructured bindings requires template-time rewriting of binding
+ * references to `__loopItem().path` — tracked as an Option 3 follow-up.
+ */
+function destructureLoopParam(param: string): { head: string; unwrap: string } {
+  if (param.startsWith('[') || param.startsWith('{')) {
+    return {
+      head: '__loopItem',
+      unwrap: `const ${param} = __loopItem();`,
+    }
+  }
+  return { head: param, unwrap: '' }
+}
+
+/**
  * Emit find() + event binding + ref callbacks + child component inits for a conditional branch.
  * Used by both emitConditionalUpdates and emitClientOnlyConditionals.
  */
@@ -101,20 +128,26 @@ function emitBranchBindings(
           || (loop.childReactiveTexts?.length ?? 0) > 0
           || (loop.childConditionals?.length ?? 0) > 0
 
+        const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param)
+        const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
+
         if (!hasReactiveEffects) {
           // Simple case: no reactive effects — return existing DOM as-is.
           // Template expressions use loopParam() to read the current item, so the
           // signal accessor stays intact without any unwrap.
           if (loop.mapPreamble) {
-            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
           } else {
-            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => { if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
           }
         } else {
           // Multi-line renderItem with fine-grained effects — applies to both
           // SSR (existing DOM) and CSR (freshly created) paths so reactive reads
           // of non-item signals propagate to existing items too.
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => {`)
+          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+          if (pUnwrap) {
+            lines.push(`        ${pUnwrap}`)
+          }
           if (loop.mapPreamble) {
             lines.push(`        ${loop.mapPreamble}`)
           }
@@ -212,11 +245,16 @@ function emitCompositeBranchLoop(
     ? `(${loop.param}${loop.index ? `, ${loop.index}` : ''}) => String(${loop.key})`
     : 'null'
 
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param)
+
   // Wrap everything in a disposable effect for branch cleanup
   // Clear template-generated children so mapArray creates fresh elements
   // with properly initialized components via createComponent in renderItem.
   lines.push(`      if (__loop_${cv}) getLoopChildren(__loop_${cv}).forEach(__el => __el.remove())`)
-  lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${loop.param}, ${indexParam}, __existing) => {`)
+  lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+  if (pUnwrap) {
+    lines.push(`        ${pUnwrap}`)
+  }
   emitCompositeRenderItemBody(lines, '        ', ctx)
   lines.push(`      })`)
 }
@@ -353,8 +391,13 @@ function emitBranchInnerLoops(
       ? `(${scopeVar}.querySelector('[bf="${csl}"]') ?? ${scopeVar}.querySelector('[bf-s$="_${csl}"]') ?? ${scopeVar})`
       : scopeVar
 
+    const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param)
+
     lines.push(`${indent}{ const __bic${uid} = ${containerExpr}`)
-    lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${inner.param}, __bidx${uid}, __existing) => {`)
+    lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${innerHead}, __bidx${uid}, __existing) => {`)
+    if (innerUnwrap) {
+      lines.push(`${indent}  ${innerUnwrap}`)
+    }
     lines.push(`${indent}  let __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
     if (inner.key) {
       const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
@@ -731,8 +774,12 @@ function emitComponentLoopReconciliation(lines: string[], elem: LoopElement, key
   const chainedExpr = buildChainedArrayExpr(elem)
   // Only init components at loopDepth 0 — inner-loop components are handled by their own loop
   const nestedComps = (elem.nestedComponents ?? []).filter(c => !c.loopDepth)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
 
-  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => {`)
+  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+  if (pUnwrap) {
+    lines.push(`    ${pUnwrap}`)
+  }
   if (nestedComps.length > 0) {
     // Unified renderItem: SSR hydrates nested components, CSR creates from scratch
     lines.push(`    if (__existing) {`)
@@ -831,15 +878,20 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: LoopElement, 
   const hasReactiveEffects = elem.childReactiveAttrs.length > 0
     || elem.childReactiveTexts.length > 0
     || (elem.childConditionals?.length ?? 0) > 0
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
+  const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
 
   if (!hasReactiveEffects) {
     // Simple case: no reactive effects
     // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
     const preamble = elem.mapPreamble ? `${wrap(elem.mapPreamble)}; ` : ''
-    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => { ${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
   } else {
     // Multi-line renderItem with fine-grained effects (shared for CSR and SSR)
-    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => {`)
+    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+    if (pUnwrap) {
+      lines.push(`    ${pUnwrap}`)
+    }
     if (elem.mapPreamble) {
       lines.push(`    ${wrap(elem.mapPreamble)}`)
     }
@@ -1184,9 +1236,13 @@ function emitInnerLoopSetup(
         : 'null'
       // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
       const wrappedTemplate = inner.itemTemplate!
+      const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param)
       ls.push(`${indent}// Reactive inner loop: ${inner.array}`)
       ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `qsa(${parentElVar}, ${containerSelector})` : parentElVar}`)
-      ls.push(`${indent}if (__ic${uid}) mapArray(() => ${arrayExpr} || [], __ic${uid}, ${keyFn}, (${inner.param}, __innerIdx${uid}, __existing) => {`)
+      ls.push(`${indent}if (__ic${uid}) mapArray(() => ${arrayExpr} || [], __ic${uid}, ${keyFn}, (${innerHead}, __innerIdx${uid}, __existing) => {`)
+      if (innerUnwrap) {
+        ls.push(`${indent}  ${innerUnwrap}`)
+      }
       // SSR/CSR branch
       ls.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
       if (inner.key) {
@@ -1305,7 +1361,11 @@ function emitCompositeElementReconciliation(
     depthLevels,
   }
 
-  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${elem.param}, ${indexParam}, __existing) => {`)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
+  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+  if (pUnwrap) {
+    lines.push(`    ${pUnwrap}`)
+  }
   emitCompositeRenderItemBody(lines, '    ', ctx)
   lines.push(`  })`)
 }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1691,27 +1691,14 @@ function transformMapCall(
   // call costs one extra `reconcileList` per loop; under-reconciling
   // is the silent-drop bug this closes.
   //
-  // Guard: skip the widening when the map callback destructures its
-  // item parameter (`([, cfg]) => ...` or `({ a, b }) => ...`). The
-  // current `mapArray` contract passes an item accessor (a function),
-  // and the emitter interpolates `elem.param` verbatim into the
-  // renderItem arrow head. Destructuring a function throws
-  // "function is not iterable" at runtime. This is a latent emitter
-  // bug tracked in #949 — until the emitter unwraps `item()` for
-  // destructured params, keep these cases on the existing static path
-  // so we don't regress previously-working SSR-only components (e.g.
-  // `Object.entries(chartConfig).map(([, cfg]) => ...)` in
-  // site/ui/components/pie-chart-demo.tsx). Simple-name params are the
-  // common case and the wrap-by-default widening applies there.
-  //
-  // Typed destructures (`([, cfg]: [string, Cfg]) => ...`) are also
-  // covered: `firstParam.name.getText()` returns just the binding
-  // pattern without the type annotation, so the prefix check still
-  // fires. See loop-fallback-wrap.test.ts for the pinning test.
-  const isDestructuredParam = param.startsWith('[') || param.startsWith('{')
+  // Destructured map params (`([, cfg]) => ...`, `({ a, b }) => ...`,
+  // typed forms) used to be excluded from the widening to avoid a
+  // latent crash in the `mapArray` renderItem emitter — see #949 and
+  // the emitter-side `destructureLoopParam` helper, which now unwraps
+  // the signal accessor at renderItem body entry. No more skip.
   const isStaticArray =
     !isSignalOrMemoArray(array, ctx)
-    && (isDestructuredParam || !exprHasFunctionCalls(arrayExpr))
+    && !exprHasFunctionCalls(arrayExpr)
 
   // Collect nested components for both static and dynamic arrays.
   // Static arrays: needed for initChild hydration.


### PR DESCRIPTION
## Summary

- Fixes the latent `mapArray` emitter crash for destructured `.map()` callback params (`([, cfg]) => ...`, `({ a, b }) => ...`, typed and parenthesized forms) — surfaced during the #937 wrap-by-default rollout and guarded off in #943.
- Emitter (`ir-to-client-js/emit-control-flow.ts`) now renames the renderItem arrow param to a synthetic `__bfItem` accessor and unwraps the destructuring pattern once at body entry. Applied consistently across all 10 `mapArray(...)` emission sites via a shared `destructureLoopParam` helper.
- Removes the `isDestructuredParam` skip in `jsx-to-ir.ts::transformMapCall`; signal/memo and unrecognised-call arrays with destructured callbacks now widen to `mapArray` like any other dynamic loop.

## Design decision

Issue proposed three options for the reactivity of captured destructured bindings. After re-evaluating against the existing `wrapLoopParamAsAccessor` layer:

- **Chose Option 1 (renderItem-entry unwrap)** over Option 3 (template-time rewriting). Option 3 would require making `ctx.loopParams` a path-aware map and extending the regex-based wrapper to rewrite binding references to `__bfItem().path` — a bigger change that is out of scope for this crash fix.
- **Known limitation**: destructured locals are captured at first render. Array-level updates (add / remove / reorder / key change) refresh correctly because each new key invokes a fresh `renderItem`. Same-key `setItem` updates do **not** refresh the destructured locals — tracked in **#951** as the Option 3 follow-up (includes a todo-toggle repro for user self-diagnosis).

See the `destructureLoopParam` doc comment and the updated `transformMapCall` comment for the in-code rationale. The limitation is pinned behaviourally by `map-array.test.ts::destructured locals captured once — frozen on same-key update (known limitation)` so Option 3 (#951) has to consciously flip it.

## Test plan

- [x] `bun test packages/jsx packages/adapter-tests packages/{dom,cli,client,hono,go-template}` — all green
- [x] Unit tests in `packages/jsx/src/__tests__/loop-fallback-wrap.test.ts` — inverted the two pinning tests (8th and 9th) to assert the widening now applies, asserted the emitted `__bfItem` + unwrap shape, and added a new object-pattern case on a signal array
- [x] Added runtime unit tests in `packages/client/__tests__/runtime/map-array.test.ts` (DOM update verification): array-pattern and object-pattern destructure via `__bfItem()` unwrap with add/reorder/remove, plus a pinning test for the same-key limitation (#951)
- [x] Fixture sweep (`site/ui/dist/components`): count 364 → 364 (0% change, well within 30%), bytes 30M → 30M (0% change, within 5%). Only `pie-chart-demo-*.js` hash changed — its Donut demo uses `Object.entries(chartConfig).map(([, cfg]) => ...)`, which now correctly flows through `mapArray`
- [x] E2E (`cd site/ui && bunx playwright test`): pie-chart suite 10/10 green including `Interactive > switching metric updates the chart` (the exact case that drove #943). Full suite: 1385 passed, 2 pre-existing failures in `form-builder.spec.ts` unrelated to #949 (form-builder-demo compiled JS is byte-identical on `main` and this branch — verified via worktree)

## Review round-2 follow-ups

- Renamed synthetic accessor `__loopItem` → `__bfItem` (barefoot-reserved namespace).
- Documented the `destructureLoopParam` heuristic's dependency on `firstParam.name.getText()` shape.
- Added the same-key limitation pinning test so Option 3 flip is conscious.
- Filed **#951** as the Option 3 tracker with a todo-toggle repro; linked from the code comment, the pinning test comment, and this PR description.

## Related

- Closes #949
- Follow-up: #951 (Option 3 — same-key fine-grained reactivity via `__bfItem().path` template rewriting)
- Related: #943 (pinning guard being removed), #948 (review surfaced this follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)