### PR TITLE
refactor(compiler): unify child-prop wrap-by-default on AST flags (#942 DRY)

### DIFF
--- a/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
@@ -3,19 +3,26 @@
  * prop bindings on child components — `<Card title={expr} />`. Follow-up
  * to #937 (architecture) and #939 (text interpolation pilot).
  *
- * Before this change, `collect-elements.ts` gated `reactiveChildProps`
- * on `hasPropsRef || needsEffectWrapper(...)`. The latter is an
- * allow-list that only recognises known signal getters, memos, and
- * prop parameter names. Any child-component prop expression the
- * analyzer couldn't prove reactive — e.g. `<Card title={formatTitle(
- * page)} />` where `formatTitle` is imported — was silently dropped.
- * At SSR the prop was evaluated once; the child component's DOM stayed
- * frozen at its initial render on the client.
+ * Before #942, `collect-elements.ts` gated `reactiveChildProps` on
+ * `hasPropsRef || needsEffectWrapper(...)`. The latter is an allow-list
+ * that only recognises known signal getters, memos, and prop parameter
+ * names. Any child-component prop expression the analyzer couldn't
+ * prove reactive — e.g. `<Card title={formatTitle(page)} />` where
+ * `formatTitle` is imported — was silently dropped. At SSR the prop was
+ * evaluated once; the child component's DOM stayed frozen at its
+ * initial render on the client.
  *
- * The fix adds a third branch to the OR gate: `/\b\w+\s*\(/.test(
- * expandedValue)`. Over-wrap (extra createEffect that subscribes to
- * nothing) is harmless — one closure at init time. Under-wrap is the
- * silent-drop bug we're closing.
+ * #942 originally closed this by adding a third branch to the OR gate:
+ * `/\b\w+\s*\(/.test(expandedValue)` with string-literal stripping to
+ * avoid false matches on `{ color: 'hsl(...)' }`. #952 then
+ * DRY-consolidated #942 into the same AST-flag shape that #939 / #941
+ * / #943 already used: the gate now reads
+ * `prop.callsReactiveGetters || prop.hasFunctionCalls` and both flags
+ * are computed Phase 1 over the prop's source AST expression — no
+ * post-expansion string scan, no string-strip workaround. Over-wrap
+ * (extra createEffect that subscribes to nothing) stays harmless;
+ * under-wrap (silent drop of a reactive read in a child prop) stays
+ * the class of bug we're closing.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -187,6 +194,44 @@ describe('Solid-style wrap-by-default fallback for child-component props (#942)'
     `
 
     const clientJs = getClientJs(source, 'Palette.tsx')
+    expect(clientJs).not.toContain('Reactive child component props')
+  })
+
+  test('local-const arrow binding stays un-wrapped (#952 source-level vs post-expansion guard)', () => {
+    // #952 replaced the post-expansion regex gate with AST flags computed
+    // on the prop's source expression. This changes behaviour for a
+    // specific shape that the fixture sweep surfaced empirically but no
+    // unit test locked in: a child-component prop whose value is a bare
+    // identifier bound to a local const whose initializer contains a
+    // call or constructor.
+    //
+    // Source: `<DatePicker formatDate={fmtDate} />` where
+    // `const fmtDate = (d) => d.toLocaleDateString(...)`. The #942 regex
+    // expanded `fmtDate` first, then matched `toLocaleDateString(` on
+    // the expansion — forcing wrap. The #952 AST flags see only the
+    // source identifier `fmtDate` (no CallExpression), so
+    // `hasFunctionCalls` is false and the prop stays un-wrapped. That is
+    // the correct semantic under #937: wrap based on what the prop's
+    // source expression *does*, not on what its transitive inlining
+    // happens to contain. The child component still receives the
+    // function value once via `initChild`'s `get formatDate()` property.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { DatePicker } from './DatePicker'
+
+      export function Form() {
+        const [, setFoo] = createSignal(0)
+        const fmtDate = (d: Date) => d.toLocaleDateString('en-US', { month: 'short' })
+        return (
+          <div onClick={() => setFoo(1)}>
+            <DatePicker formatDate={fmtDate} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Form.tsx')
     expect(clientJs).not.toContain('Reactive child component props')
   })
 

--- a/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
@@ -158,6 +158,38 @@ describe('Solid-style wrap-by-default fallback for child-component props (#942)'
     expect(clientJs).not.toContain('Reactive child component props')
   })
 
+  test('string-literal-only function-like pattern stays un-wrapped (AST-flag structural check, #942 DRY)', () => {
+    // Before #942 DRY consolidation, collect-elements.ts scanned the
+    // expanded expression text with /\b\w+\s*\(/ after stripping quoted
+    // strings. Structural regex over stripped text is still a regex —
+    // any future regression in the strip step would silently re-introduce
+    // hsl/rgb/url/etc. false positives. The AST flag approach can't be
+    // fooled this way: `{ color: 'hsl(221 83% 53%)' }` is an object
+    // literal with a StringLiteral value, not a CallExpression, so
+    // `hasFunctionCalls` is structurally false.
+    //
+    // The enclosing expression has no reactive source (no signal, no
+    // memo, no `props.`), so none of the OR branches should fire and the
+    // prop must NOT appear in reactiveChildProps.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Palette() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card config={{ color: 'hsl(221 83% 53%)' }} />
+          </div>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Palette.tsx')
+    expect(clientJs).not.toContain('Reactive child component props')
+  })
+
   test('props.xxx access in child prop still wraps (hasPropsRef regression guard)', () => {
     // The existing `hasPropsRef` branch remains — `props.title` is a
     // direct prop reference even though it contains no function call.

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -422,35 +422,24 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           const expandedValue = expandDynamicPropValue(prop.value, ctx)
           propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
 
-          // Solid-style wrap-by-default fallback (#942, follow-up to
-          // #937/#939/#940/#941). Wrap child-component prop bindings in
-          // createEffect not only for statically-proven-reactive values,
-          // but also for any expression the analyzer can't prove
-          // non-reactive — anything containing a function call. Pure
-          // literals and bare identifiers (no calls) stay un-wrapped via
-          // the other branches of this if/else.
+          // Solid-style wrap-by-default fallback (#942, DRY-consolidated
+          // with #939/#941/#943 via IRProp AST flags). Wrap child-component
+          // prop bindings in createEffect not only for statically-proven
+          // reactive values, but also for any expression the analyzer
+          // can't prove non-reactive — AST flags carry that signal from
+          // Phase 1. Pure literals and bare identifiers (no calls) stay
+          // un-wrapped via the other branches of this if/else.
           //
-          // False positive (extra createEffect that subscribes to nothing)
-          // is harmless; false negative (silent drop of a reactive read in
-          // a child prop like `<Card title={format(x)} />`) is the bug
-          // class this closes. Phase 2 has no AST access here, so a cheap
-          // regex on the expanded expression is sufficient.
-          //
-          // Single- and double-quoted strings are stripped before the
-          // regex runs, to avoid false positives on object-literal prop
-          // values like `{ color: 'hsl(221 83% 53%)' }`. A single
-          // alternation regex handles both quote kinds in one pass, so
-          // there is no order dependency for inputs that mix them
-          // (e.g. `"It's fine"`). Template literals are left intact
-          // because `${calls()}` inside them is live code.
+          // `hasPropsRef` stays as a string-level check because the
+          // props-param rename lives in Phase 1 (IRProp.value already has
+          // `props.xxx` substituted); string-literal stripping isn't
+          // needed for it, and `prop.callsReactiveGetters` /
+          // `prop.hasFunctionCalls` are computed structurally from the AST
+          // so they can't false-match call-like substrings inside string
+          // literals (e.g. `{ color: 'hsl(221 83% 53%)' }`).
           const hasPropsRef = expandedValue.includes('props.')
           const hasReactiveExpr = needsEffectWrapper(expandedValue, ctx)
-          const withoutStringLiterals = expandedValue.replace(
-            /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g,
-            '',
-          )
-          const hasCallOutsideString = /\b\w+\s*\(/.test(withoutStringLiterals)
-          if (hasPropsRef || hasReactiveExpr || hasCallOutsideString) {
+          if (hasPropsRef || hasReactiveExpr || prop.callsReactiveGetters || prop.hasFunctionCalls) {
             const attrName = prop.name === 'className' ? 'class' : prop.name
             ctx.reactiveChildProps.push({
               componentName: node.name,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2143,6 +2143,20 @@ function processComponentProps(
       propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
     }
 
+    // AST-derived reactivity flags for Solid-style wrap-by-default fallback
+    // (#942 DRY consolidation). Lets collect-elements.ts decide wrapping
+    // structurally instead of regex-scanning the expanded string — a regex
+    // over expression text can false-match call-like substrings inside
+    // string literals (e.g. `'hsl(221 83% 53%)'`). JSX-as-prop is handled
+    // above via `jsxChildren` and string-literal attrs have no expression
+    // to analyze; only regular dynamic expression attrs carry flags.
+    let callsReactive = false
+    let hasCalls = false
+    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+      callsReactive = exprCallsReactiveGetters(attr.initializer.expression, ctx)
+      hasCalls = exprHasFunctionCalls(attr.initializer.expression)
+    }
+
     props.push({
       name,
       value: propValue,
@@ -2150,6 +2164,8 @@ function processComponentProps(
       dynamic,
       isLiteral,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
+      callsReactiveGetters: callsReactive || undefined,
+      hasFunctionCalls: hasCalls || undefined,
       ...pickAttrMeta(attrResult),
     })
   }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -392,6 +392,10 @@ export interface IRProp extends AttrMeta {
   loc: SourceLocation
   /** When the prop value is a JSX element/fragment, store the transformed IR nodes here */
   jsxChildren?: IRNode[]
+  /** When true, prop expression calls signal getters or memos (computed from AST). (#942 DRY consolidation) */
+  callsReactiveGetters?: boolean
+  /** When true, prop expression contains any `identifier()` pattern (computed from AST). (#942 DRY consolidation) */
+  hasFunctionCalls?: boolean
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Close out the last regex-based outlier in the #937 Solid-style wrap-by-default rollout: child-component prop bindings (#942) now gate on `IRProp.callsReactiveGetters` / `IRProp.hasFunctionCalls`, the same AST-derived flags #939 / #941 / #943 already use on `IRExpression` and `IRConditional`.
- Remove the `expandedValue` regex (`/\b\w+\s*\(/` with string-literal stripping) from `collect-elements.ts`. AST flags are computed Phase 1 on the attribute's source expression, so they can't false-match call-like substrings inside string literals (e.g. `{ color: 'hsl(221 83% 53%)' }`) and don't depend on the expansion order of local constants.
- Add a pinning test that an object-literal prop containing an `hsl(...)` string stays un-wrapped — a structural guarantee from the AST that the regex could only approximate.

## Context

Noted as the DRY follow-up on #937 and as concern 1 of the #948 PR review: 4 of the 5 wrap-by-default sites were already on AST flags; only #942 still diverged because Phase 2 (`collect-elements.ts`) has no AST access — the prop value has collapsed to `IRProp.value: string` by then. This PR carries the flags on `IRProp` itself so Phase 2 can consult them structurally.

## Fixture sweep (site/ui/dist/components)

181 files total, 4 changed (2.2%), -1771 bytes overall. Every diff is a reduction in redundant attribute re-sets inside an existing parent `createEffect`, where a non-reactive local-const value (e.g. `const today = new Date(); <Calendar fromDate={today} />`) was previously regex-caught after expansion. `initChild`-time initialization of those props is unchanged.

- `calendar-demo`: -601 bytes — `fromDate={today}`, `toDate={maxDate}`, `disabled={isWeekend}` no longer force re-binding on every `date()` tick
- `calendar-usage-demo`: -483 bytes — same pattern
- `command-demo`: -405 bytes — local-const arrow function prop
- `date-picker-demo`: -282 bytes — `formatDate={fmtDate}` where `fmtDate` is a local arrow const

## Test plan

- [x] `bun test packages/jsx` — 691 pass (existing 6 child-prop-fallback-wrap cases + new hsl-pinning case all green)
- [x] `bun test --cwd . packages/` — 1647 pass; the remaining 1 fail / 1 error is the pre-existing `packages/xyflow/e2e/flow.spec.ts` Playwright issue, present on main
- [x] `bun run build` — clean (pre-existing `@barefootjs/test` TS error on main is unchanged)
- [x] Fixture sweep vs main — 4/181 files changed, all reductions, all justified

🤖 Generated with [Claude Code](https://claude.com/claude-code)