### PR TITLE
refactor(compiler): unify attribute wrap-by-default on AST flags (#940 DRY)

### DIFF
--- a/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
@@ -11,11 +11,14 @@
  * attribute was evaluated once; the client never re-evaluated it, so the
  * attribute stayed frozen.
  *
- * The fix widens the gate to also wrap when the expanded expression contains
- * a function call (`/\b\w+\s*\(/`). Over-wrapping a pure call that
- * subscribes to nothing is harmless (one closure at init time, no rerun);
- * under-wrapping a reactive read is the bug class we're closing. Pure static
- * literals and bare identifiers without calls stay un-wrapped.
+ * #940 originally closed this by adding a regex fallback
+ * (`/\b\w+\s*\(/`) with quote-strip on the expanded value. The DRY
+ * consolidation (follow-up to #952 for `IRProp`) replaced that
+ * post-expansion regex with AST flags computed Phase 1 on the source
+ * JSX expression — matching the shape #939 / #941 / #942 / #943 already
+ * use. Over-wrap (extra createEffect that subscribes to nothing) stays
+ * harmless; under-wrap (silent drop of a reactive attribute read) stays
+ * the class of bug we're closing.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -134,12 +137,27 @@ describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
     expect(clientJs).not.toMatch(/className\s*=\s*[^;]*cls/)
   })
 
-  test('spread-expanded prop whose expansion contains a call wraps', () => {
-    // `classes` is a local const whose value contains a call
-    // (`format(variant)`). expandConstantForReactivity inlines the reference
-    // before the gate runs, so the expanded string matches the call regex
-    // and the attribute wraps. This protects the same silent-drop case for
-    // code that factors class construction into a local variable.
+  test('local-const identifier attribute stays un-wrapped (DRY source-level vs post-expansion guard)', () => {
+    // DRY consolidation replaced the post-expansion regex gate with AST
+    // flags computed on the attribute's source expression. This changes
+    // behaviour for a specific shape: a local-const identifier whose
+    // initializer contains a call, used as an attribute value.
+    //
+    // Source: `class={classes}` where
+    // `const classes = \`\${base} \${format(variant)}\``. The old regex
+    // expanded `classes` first, then matched `format(` on the expansion
+    // — forcing wrap. The AST flags see only the source identifier
+    // `classes` (no CallExpression), so `hasFunctionCalls` is false.
+    // `needsEffectWrapper` on the expanded text also stays false
+    // because `base`, `format`, and `variant` aren't registered as
+    // reactive (no signals/memos/props match). The attribute stays
+    // un-wrapped.
+    //
+    // That is the correct semantic under #937: wrap based on what the
+    // attribute's source expression *does*, not on what its transitive
+    // inlining happens to contain. The SSR-rendered attribute is
+    // already frozen into the DOM and none of the transitive reads are
+    // reactive, so the previous wrap was dead weight.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -155,7 +173,33 @@ describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
     `
 
     const clientJs = getClientJs(source, 'Tag.tsx')
-    expect(clientJs).toContain('createEffect')
-    expect(clientJs).toContain('format(')
+    expect(clientJs).not.toContain('createEffect')
+  })
+
+  test('string-literal-only function-like pattern stays un-wrapped (AST-flag structural check)', () => {
+    // Before DRY consolidation, collect-elements.ts scanned the expanded
+    // attribute value with /\b\w+\s*\(/ after stripping quoted strings.
+    // A structural regex over stripped text is still a regex — any future
+    // regression in the strip step would silently re-introduce hsl / rgb
+    // / url / etc. false positives. The AST flag approach can't be fooled
+    // this way: `{ color: 'hsl(221 83% 53%)' }` is an object literal with
+    // a StringLiteral value, not a CallExpression, so `hasFunctionCalls`
+    // is structurally false.
+    //
+    // The enclosing expression has no reactive source (no signal, no
+    // memo, no \`props.\`), so the attribute must NOT appear in
+    // reactiveAttrs.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Palette() {
+        const [, setFoo] = createSignal(0)
+        return <div style={{ color: 'hsl(221 83% 53%)' }} onClick={() => setFoo(1)}>x</div>
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Palette.tsx')
+    expect(clientJs).not.toContain('createEffect')
   })
 })

--- a/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
@@ -137,7 +137,7 @@ describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
     expect(clientJs).not.toMatch(/className\s*=\s*[^;]*cls/)
   })
 
-  test('local-const identifier attribute stays un-wrapped (DRY source-level vs post-expansion guard)', () => {
+  test('local-const identifier attribute stays un-wrapped (#953 source-level vs post-expansion guard)', () => {
     // DRY consolidation replaced the post-expansion regex gate with AST
     // flags computed on the attribute's source expression. This changes
     // behaviour for a specific shape: a local-const identifier whose
@@ -173,10 +173,19 @@ describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
     `
 
     const clientJs = getClientJs(source, 'Tag.tsx')
-    expect(clientJs).not.toContain('createEffect')
+    // Narrowed from `not.toContain('createEffect')` so a future optimisation
+    // that happens to wrap something else in this component doesn't fail
+    // this test for the wrong reason. The thing we actually pin is that
+    // the `class` attribute is not re-bound via a reactive-attrs entry:
+    // `// Reactive attributes` is the emitter-stable section header for
+    // that block in collect-elements.ts, and `class` is the only
+    // attribute in `Tag` that could regress into it.
+    expect(clientJs).not.toContain('Reactive attributes')
+    expect(clientJs).not.toMatch(/setAttribute\(\s*['"]class['"]/)
+    expect(clientJs).not.toMatch(/\.className\s*=/)
   })
 
-  test('string-literal-only function-like pattern stays un-wrapped (AST-flag structural check)', () => {
+  test('string-literal-only function-like pattern stays un-wrapped (#953 AST-flag structural check)', () => {
     // Before DRY consolidation, collect-elements.ts scanned the expanded
     // attribute value with /\b\w+\s*\(/ after stripping quoted strings.
     // A structural regex over stripped text is still a regex — any future
@@ -200,6 +209,11 @@ describe('Solid-style wrap-by-default fallback for attributes (#940)', () => {
     `
 
     const clientJs = getClientJs(source, 'Palette.tsx')
-    expect(clientJs).not.toContain('createEffect')
+    // Pin the `style` attribute specifically, not the whole module — see
+    // the comment on the previous test for the rationale. Palette has no
+    // other attribute that could regress into reactive-attrs, so this is
+    // a tight structural guard.
+    expect(clientJs).not.toContain('Reactive attributes')
+    expect(clientJs).not.toMatch(/setAttribute\(\s*['"]style['"]/)
   })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -565,19 +565,29 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
         // e.g., `classes` → `` `${baseClasses} ${variantClasses[variant]} ${className}` ``
         const expandedValueStr = expandConstantForReactivity(valueStr, ctx)
 
-        // Solid-style wrap-by-default fallback (#940, follow-up to #937/#939):
-        // wrap attribute bindings in createEffect not only for statically-proven
-        // reactive expressions, but also for any expression the analyzer can't
-        // prove non-reactive — i.e. anything that contains a function call.
-        // Pure static literals and bare identifiers (no calls) stay un-wrapped
-        // because their SSR value is already in the DOM.
+        // Solid-style wrap-by-default fallback (#940, DRY-consolidated
+        // with #939/#941/#942/#943 via IRAttribute AST flags). Wrap
+        // attribute bindings in createEffect not only for
+        // statically-proven reactive expressions, but also for any
+        // expression the analyzer can't prove non-reactive — AST flags
+        // carry that signal from Phase 1. Pure literals and bare
+        // identifiers (no calls) stay un-wrapped because their SSR value
+        // is already in the DOM.
         //
-        // False positive (extra createEffect that subscribes to nothing) is
-        // harmless; false negative (silent drop of a reactive read) is the
-        // bug class this gate closes. Phase 2 has no AST access, so a cheap
-        // regex over the expanded expression is sufficient here.
-        const hasFunctionCall = /\b\w+\s*\(/.test(expandedValueStr)
-        if (needsEffectWrapper(expandedValueStr, ctx) || hasFunctionCall) {
+        // `needsEffectWrapper(expandedValueStr, ctx)` stays as a
+        // string-level check because it recognises known signal getters,
+        // memos, and prop names inside expanded local-const references
+        // (e.g. `const classes = \`btn \${count()}\`; <div class={classes}>`).
+        // `attr.callsReactiveGetters` / `attr.hasFunctionCalls` are
+        // computed structurally from the AST of the source expression, so
+        // they can't false-match call-like substrings inside string
+        // literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and
+        // don't depend on the expansion order of local constants.
+        if (
+          needsEffectWrapper(expandedValueStr, ctx)
+          || attr.callsReactiveGetters
+          || attr.hasFunctionCalls
+        ) {
           ctx.reactiveAttrs.push({
             slotId: element.slotId,
             attrName: attr.name,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1870,6 +1870,22 @@ function processAttributes(
     if (dynamic && typeof value === 'string' && attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
       templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
     }
+
+    // AST-derived reactivity flags for Solid-style wrap-by-default fallback
+    // (#940 DRY consolidation). Lets collect-elements.ts decide wrapping
+    // structurally instead of regex-scanning the expanded value string —
+    // a regex can false-match call-like substrings inside string literals
+    // (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and is forced to
+    // re-strip quotes every time. Flags are computed on the source JSX
+    // expression before local-const expansion, matching the structural
+    // guarantee #942 / #952 established for `IRProp`.
+    let callsReactive = false
+    let hasCalls = false
+    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+      callsReactive = exprCallsReactiveGetters(attr.initializer.expression, ctx)
+      hasCalls = exprHasFunctionCalls(attr.initializer.expression)
+    }
+
     attrs.push({
       name,
       value,
@@ -1877,6 +1893,8 @@ function processAttributes(
       dynamic,
       isLiteral,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
+      callsReactiveGetters: callsReactive || undefined,
+      hasFunctionCalls: hasCalls || undefined,
       ...pickAttrMeta(attrResult),
     })
   }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -373,6 +373,10 @@ export interface IRAttribute extends AttrMeta {
   dynamic: boolean
   isLiteral: boolean // true if value came from a string literal attribute
   loc: SourceLocation
+  /** When true, attr expression calls signal getters or memos (computed from AST). (#940 DRY consolidation) */
+  callsReactiveGetters?: boolean
+  /** When true, attr expression contains any `identifier()` pattern (computed from AST). (#940 DRY consolidation) */
+  hasFunctionCalls?: boolean
 }
 
 export interface IREvent {


### PR DESCRIPTION
## Summary

- Close the last regex-based outlier in the #937 Solid-style wrap-by-default rollout: JSX attribute bindings (#940) now gate on `IRAttribute.callsReactiveGetters` / `IRAttribute.hasFunctionCalls`, the same AST-derived flags #939 / #941 / #942 / #943 already use on `IRExpression`, `IRConditional`, and `IRProp` (after #952).
- Remove the `/\b\w+\s*\(/` regex from `collect-elements.ts`. AST flags are computed Phase 1 on the attribute's source JSX expression, so they can't false-match call-like substrings inside string literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and don't depend on the expansion order of local constants.
- Add a structural pinning test: `style={{ color: 'hsl(221 83% 53%)' }}` stays un-wrapped because `hsl(...)` is a `StringLiteral` inside an `ObjectLiteralExpression`, not a `CallExpression`.

## Context

Prep for #944 (`barefoot why-wrap` CLI). Once #944's `collectDomBindings` widens to surface fallback-wrapped expressions, it benefits from every emit site reading the same flag shape — one gate, one code path. This PR is the last stand-alone DRY refactor before #944; no CLI changes here.

`needsEffectWrapper(expandedValueStr, ctx)` stays as the string-level check against expanded text, matching what #952 kept for `IRProp`. It still catches known signal getters / memos / props inside transitively-inlined local-const references like `const classes = \`btn \${count()}\`; <div class={classes}>`. The AST flags live on the source expression; the expanded check lives on post-expansion text. Both branches are needed for full coverage.

## Behaviour change

Local-const identifiers whose initializers contain calls but no reactive reads (e.g. `const classes = \`\${base} \${fmt(v)}\`; <div class={classes}>`) no longer wrap. The source AST sees only the identifier `classes` (no `CallExpression`), and the expansion has no reactive source — so the attribute stays frozen in SSR, which is correct: nothing to track.

This is the attribute-side analogue of the `formatDate={fmtDate}` shift in #952. The existing `spread-expanded prop whose expansion contains a call wraps` test locked in the old post-expansion wrap; renamed to `local-const identifier attribute stays un-wrapped` and flipped to assert the new semantic, consistent with #952's `local-const arrow binding stays un-wrapped` child-prop pinning test.

## Fixture sweep (site/ui/dist/components)

508 files total, **0 changed** (total bytes identical main vs PR: 28078189). No site/ui component currently hits the behaviour-change shape (local-const template-literal-with-call used as an HTML attribute value, without any reactive source). The regression surface is covered by unit tests.

## Test plan

- [x] `bun test packages/jsx` — 693 pass (all 5 fallback-wrap suites + new hsl pinning + renamed local-const test)
- [x] `bun test --cwd . packages/` — 1649 pass; remaining 1 fail / 1 error is the pre-existing `packages/xyflow/e2e/flow.spec.ts` Playwright `beforeEach` issue present on main (same state as #952)
- [x] `bun run build` — clean
- [x] Fixture sweep — 0 files changed, total bytes identical

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>