### PR TITLE
feat(cli): barefoot why-wrap — surface fallback-wrapped expressions (#944)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,9 @@ Use the `barefoot` CLI (`bun run barefoot`) to look up component APIs, framework
 - `barefoot search <query>` — Find components and docs by name/category/tags
 - `barefoot ui <component>` — Component reference (props, examples, a11y)
 - `barefoot core <topic>` — Core docs (signals, compiler constraints, error codes, etc.)
-- `barefoot inspect <component>` — Show signal dependency graph (signals, memos, DOM bindings)
+- `barefoot inspect <component>` — Show signal dependency graph (signals, memos, DOM bindings). Bindings wrapped by the Solid-style fallback (#937) are prefixed with `~`.
 - `barefoot why-update <component> <signal>` — Trace update propagation path from a signal to DOM
+- `barefoot why-wrap <component>` — List fallback-wrapped expressions (#937). Each is a candidate for `createMemo` refactor — the runtime effect subscribes to whatever it reads at runtime, possibly nothing.
 - `barefoot test --debug <component>` — Show signal initialization trace and effect bindings
 
 Before editing a stateful component (`"use client"`), run `barefoot inspect` first to understand its reactive structure. All inspection commands support `--json` for machine-readable output.

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -38,6 +38,7 @@ barefoot test:template Button                        # Generate IR test from exi
 # Inspect reactive structure
 barefoot inspect Counter             # Signal dependency graph
 barefoot why-update Counter count    # Trace update path: signal → DOM
+barefoot why-wrap AnalyticsDemo      # List Solid-style wrap-by-default fallback bindings
 ```
 
 Both humans and AI agents use these commands to generate and debug components without reading source files.

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -38,7 +38,7 @@ barefoot test:template Button                        # Generate IR test from exi
 # Inspect reactive structure
 barefoot inspect Counter             # Signal dependency graph
 barefoot why-update Counter count    # Trace update path: signal → DOM
-barefoot why-wrap AnalyticsDemo      # List Solid-style wrap-by-default fallback bindings
+barefoot why-wrap calendar           # List Solid-style wrap-by-default fallback bindings
 ```
 
 Both humans and AI agents use these commands to generate and debug components without reading source files.

--- a/packages/cli/src/__tests__/why-wrap.test.ts
+++ b/packages/cli/src/__tests__/why-wrap.test.ts
@@ -82,6 +82,9 @@ describe('barefoot why-wrap', () => {
       // The text binding's slotId appears in the report line.
       expect(output).toMatch(/text "s\d+"/)
       expect(output).toContain('~')
+      // The actual expression text is printed so users can locate the
+      // binding in their source without running `inspect` separately.
+      expect(output).toContain('formatTitle(page)')
       // Guidance footer — helps the user know what to do next.
       expect(output).toContain('createMemo')
     } finally {
@@ -112,7 +115,7 @@ describe('barefoot why-wrap', () => {
       const parsed = JSON.parse(output) as {
         componentName: string
         sourceFile: string
-        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string }>
+        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string; expression?: string }>
       }
       expect(parsed.componentName).toBe('Tag')
       expect(parsed.fallbacks.length).toBeGreaterThan(0)
@@ -124,6 +127,7 @@ describe('barefoot why-wrap', () => {
       expect(attrFallback).toBeDefined()
       expect(attrFallback!.label).toBe('class')
       expect(attrFallback!.deps).toEqual([])
+      expect(attrFallback!.expression).toBe('format(label)')
     } finally {
       logSpy.mockRestore()
       rmSync(path.dirname(file), { recursive: true, force: true })
@@ -137,7 +141,7 @@ describe('barefoot why-wrap', () => {
     const errSpy = spyOn(console, 'error').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/why-wrap')
-      expect(run(['NoSuchComponent12345'], makeCtx(false))).rejects.toThrow('exit 1')
+      await expect(run(['NoSuchComponent12345'], makeCtx(false))).rejects.toThrow('exit 1')
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot find'))
     } finally {
       exitSpy.mockRestore()
@@ -152,7 +156,7 @@ describe('barefoot why-wrap', () => {
     const errSpy = spyOn(console, 'error').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/why-wrap')
-      expect(run([], makeCtx(false))).rejects.toThrow('exit 1')
+      await expect(run([], makeCtx(false))).rejects.toThrow('exit 1')
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Component name required'))
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'))
     } finally {

--- a/packages/cli/src/__tests__/why-wrap.test.ts
+++ b/packages/cli/src/__tests__/why-wrap.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for `barefoot why-wrap <component>` — surface fallback-wrapped
+ * expressions emitted by Solid-style wrap-by-default (#937).
+ *
+ * Fallback wraps are harmless but invisible in the source: the compiler
+ * chose `createEffect` because it couldn't statically prove the
+ * expression is (or isn't) reactive. This CLI is the opt-in channel users
+ * rely on to find candidates for `createMemo` refactor; regressing its
+ * filter or its JSON shape silently hides the whole reactive footprint.
+ */
+
+import { describe, test, expect, spyOn } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import type { CliContext } from '../context'
+
+function makeCtx(jsonFlag: boolean): CliContext {
+  // Minimal context — `resolveComponentSource` only needs `root`, `config`,
+  // `projectDir` to resolve a bare name; we always pass an absolute .tsx
+  // path below, so those fall back fields are irrelevant for this suite.
+  return {
+    root: process.cwd(),
+    metaDir: '',
+    jsonFlag,
+    config: null,
+    projectDir: null,
+  }
+}
+
+function tmpComponent(source: string, name = 'Demo.tsx'): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'barefoot-why-wrap-'))
+  const file = path.join(dir, name)
+  writeFileSync(file, source)
+  return file
+}
+
+describe('barefoot why-wrap', () => {
+  test('reactive-only component reports no fallbacks', async () => {
+    // Counter reads a signal — emitter wraps it but classification is
+    // 'reactive'. why-wrap's filter drops it; output is the "none" line.
+    const file = tmpComponent(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(c => c + 1)}>{count()}</button>
+      }
+    `)
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/why-wrap')
+      await run([file], makeCtx(false))
+      const output = logSpy.mock.calls.map(c => c[0]).join('\n')
+      expect(output).toContain('no fallback-wrapped expression')
+      expect(output).not.toContain('~')
+    } finally {
+      logSpy.mockRestore()
+      rmSync(path.dirname(file), { recursive: true, force: true })
+    }
+  })
+
+  test('component with fallback-wrapped text binding lists it', async () => {
+    // `formatTitle(page)` is the #939 canonical fallback shape — opaque
+    // call on a non-reactive argument.
+    const file = tmpComponent(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+      }
+    `)
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/why-wrap')
+      await run([file], makeCtx(false))
+      const output = logSpy.mock.calls.map(c => c[0]).join('\n')
+      expect(output).toContain('1 fallback-wrapped expression')
+      // The text binding's slotId appears in the report line.
+      expect(output).toMatch(/text "s\d+"/)
+      expect(output).toContain('~')
+      // Guidance footer — helps the user know what to do next.
+      expect(output).toContain('createMemo')
+    } finally {
+      logSpy.mockRestore()
+      rmSync(path.dirname(file), { recursive: true, force: true })
+    }
+  })
+
+  test('--json emits machine-readable shape with classification', async () => {
+    // Editor integrations and CI scripts depend on the JSON shape.
+    // Lock in: componentName, sourceFile, fallbacks[].classification,
+    // fallbacks[].type, fallbacks[].slotId, fallbacks[].deps.
+    const file = tmpComponent(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+      export function Tag() {
+        const [, setFoo] = createSignal(0)
+        const label = 'hi'
+        return <button class={format(label)} onClick={() => setFoo(1)}>x</button>
+      }
+    `)
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/why-wrap')
+      await run([file], makeCtx(true))
+      const output = logSpy.mock.calls.map(c => c[0]).join('\n')
+      const parsed = JSON.parse(output) as {
+        componentName: string
+        sourceFile: string
+        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string }>
+      }
+      expect(parsed.componentName).toBe('Tag')
+      expect(parsed.fallbacks.length).toBeGreaterThan(0)
+      // All entries must be fallbacks — reactive bindings are filtered out.
+      for (const f of parsed.fallbacks) {
+        expect(f.classification).toBe('fallback')
+      }
+      const attrFallback = parsed.fallbacks.find(f => f.type === 'attribute')
+      expect(attrFallback).toBeDefined()
+      expect(attrFallback!.label).toBe('class')
+      expect(attrFallback!.deps).toEqual([])
+    } finally {
+      logSpy.mockRestore()
+      rmSync(path.dirname(file), { recursive: true, force: true })
+    }
+  })
+
+  test('errors on unknown component', async () => {
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`)
+    }) as never)
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/why-wrap')
+      expect(run(['NoSuchComponent12345'], makeCtx(false))).rejects.toThrow('exit 1')
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot find'))
+    } finally {
+      exitSpy.mockRestore()
+      errSpy.mockRestore()
+    }
+  })
+
+  test('errors with usage when no component argument', async () => {
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`)
+    }) as never)
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/why-wrap')
+      expect(run([], makeCtx(false))).rejects.toThrow('exit 1')
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Component name required'))
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'))
+    } finally {
+      exitSpy.mockRestore()
+      errSpy.mockRestore()
+    }
+  })
+})

--- a/packages/cli/src/commands/why-wrap.ts
+++ b/packages/cli/src/commands/why-wrap.ts
@@ -47,6 +47,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         deps: f.deps,
         type: f.type,
         classification: f.classification,
+        ...(f.expression !== undefined && { expression: f.expression }),
       })),
     }, null, 2))
     return
@@ -58,11 +59,17 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   }
 
   console.log(`${graph.componentName} — ${fallbacks.length} fallback-wrapped expression(s)`)
-  for (const f of fallbacks) {
+  // Column-align the `~ expression` column so the eye scans down the
+  // expressions rather than the labels. Width covers the longest
+  // `type "id"` cell across this component's fallbacks.
+  const cells = fallbacks.map(f => {
     const id = f.type === 'attribute' ? f.label : f.slotId
-    console.log(`  ${f.type} "${id}"  ~ (wrapped by Solid-style fallback)`)
-    console.log(`    The analyzer couldn't prove this expression's reactivity from a`)
-    console.log(`    signal/memo/prop read, so a createEffect is emitted to be safe.`)
+    return { f, cell: `${f.type} "${id}"` }
+  })
+  const width = cells.reduce((w, c) => Math.max(w, c.cell.length), 0)
+  for (const { f, cell } of cells) {
+    const expr = f.expression ?? '(expression not captured)'
+    console.log(`  ${cell.padEnd(width)}  ~ ${expr}`)
   }
   console.log()
   console.log('Fallback wraps run one createEffect per expression. Each subscribes to')

--- a/packages/cli/src/commands/why-wrap.ts
+++ b/packages/cli/src/commands/why-wrap.ts
@@ -1,0 +1,72 @@
+// barefoot why-wrap <component> — Surface fallback-wrapped expressions.
+//
+// Lists every DOM binding whose `createEffect` came from the Solid-style
+// wrap-by-default fallback (#937) rather than from statically-proven
+// reactivity. These expressions are harmless — the effect runs once at init
+// and subscribes to whatever signals it happens to read at runtime, possibly
+// none — but they are candidates for optimisation: rewriting as
+// `createMemo` or inlining a known-reactive source makes the dependency
+// static and lets the emitter skip the fallback wrap entirely.
+//
+// Output parallels `barefoot why-update`: short human-readable report by
+// default, full JSON under `--json`. Exits 0 even when no fallbacks are
+// found (an empty list is a useful signal on its own).
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: barefoot why-wrap <component> [--json]')
+    process.exit(1)
+  }
+
+  const { buildComponentGraph } = await import('@barefootjs/jsx')
+
+  const resolved = resolveComponentSource(componentName, ctx)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+  const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback')
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify({
+      componentName: graph.componentName,
+      sourceFile: graph.sourceFile,
+      fallbacks: fallbacks.map(f => ({
+        label: f.label,
+        slotId: f.slotId,
+        deps: f.deps,
+        type: f.type,
+        classification: f.classification,
+      })),
+    }, null, 2))
+    return
+  }
+
+  if (fallbacks.length === 0) {
+    console.log(`${graph.componentName} — no fallback-wrapped expressions.`)
+    return
+  }
+
+  console.log(`${graph.componentName} — ${fallbacks.length} fallback-wrapped expression(s)`)
+  for (const f of fallbacks) {
+    const id = f.type === 'attribute' ? f.label : f.slotId
+    console.log(`  ${f.type} "${id}"  ~ (wrapped by Solid-style fallback)`)
+    console.log(`    The analyzer couldn't prove this expression's reactivity from a`)
+    console.log(`    signal/memo/prop read, so a createEffect is emitted to be safe.`)
+  }
+  console.log()
+  console.log('Fallback wraps run one createEffect per expression. Each subscribes to')
+  console.log('whatever signals it happens to read at runtime (possibly none).')
+  console.log('Rewrite the expression as a createMemo to make the dependency static,')
+  console.log('or inline a known-reactive source so the emitter can prove it.')
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ Commands:
   meta:extract                Extract metadata from ui/components/ui/*.tsx
   inspect <component>         Show signal dependency graph from IR
   why-update <comp> <signal>  Show update propagation path for a signal/memo
+  why-wrap <component>        Show Solid-style wrap-by-default fallback bindings (#937)
 
 Options:
   --json                      Output in JSON format
@@ -141,6 +142,12 @@ switch (command) {
 
   case 'why-update': {
     const { run } = await import('./commands/why-update')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'why-wrap': {
+    const { run } = await import('./commands/why-wrap')
     await run(commandArgs, ctx)
     break
   }

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -446,6 +446,129 @@ describe('DomBinding classification (#944)', () => {
     expect(loop!.deps).toContain('items')
   })
 
+  test('opaque call in child-component prop is fallback (#944 concern 1)', () => {
+    // `<Card title={formatTitle(page)} />` — the #942 motivating example.
+    // The child-prop emitter wraps this in a reactive child-prop entry via
+    // `prop.callsReactiveGetters || prop.hasFunctionCalls`, but before the
+    // review fix `collectDomBindings` had no `case 'component'` branch, so
+    // the binding silently missed the graph — under-reporting in a CLI
+    // whose purpose is to surface exactly these.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+      import { Card } from './Card'
+
+      export function Dashboard() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title={formatTitle(page)} />
+          </div>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'Dashboard.tsx')
+    const cardProp = graph.domBindings.find(d => d.label === 'Card.title')
+    expect(cardProp).toBeDefined()
+    expect(cardProp!.classification).toBe('fallback')
+    expect(cardProp!.type).toBe('attribute')
+    expect(cardProp!.expression).toBe('formatTitle(page)')
+  })
+
+  test('props.xxx in child-component prop is reactive (#944 concern 1)', () => {
+    // The `hasPropsRef` branch in the emitter gate — direct `props.title`
+    // read is reactive, not fallback. Guard the debug-side approximation
+    // (`propValue.includes('props.')`) so this case doesn't get demoted
+    // to fallback by accident.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Dashboard(props: { title: string }) {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            <Card title={props.title} />
+          </div>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'Dashboard.tsx')
+    const cardProp = graph.domBindings.find(d => d.label === 'Card.title')
+    expect(cardProp).toBeDefined()
+    expect(cardProp!.classification).toBe('reactive')
+  })
+
+  test('fallback inside child-component subtree is still collected (#944 concern 1)', () => {
+    // The previous silent-fall-through also skipped recursion into
+    // `node.children`, so any fallback reached only through a component
+    // subtree was doubly invisible. Pin the recursion.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+      import { Dialog } from './Dialog'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return (
+          <Dialog>
+            <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+          </Dialog>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const text = graph.domBindings.find(d => d.type === 'text')
+    expect(text).toBeDefined()
+    expect(text!.classification).toBe('fallback')
+  })
+
+  test('domBindings carry expression text for non-event sites (#944 concern 2)', () => {
+    // why-wrap relies on the expression field to print something a human
+    // can locate in source. Pin the field on every non-event site so the
+    // CLI output doesn't silently degrade to slotId-only labels.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle, getStyle, shouldShow, getItems } from './helpers'
+      import { Card } from './Card'
+
+      export function Everything() {
+        const [, setFoo] = createSignal(0)
+        const mode = 'draft'
+        return (
+          <div onClick={() => setFoo(1)}>
+            <h1 style={getStyle(mode)}>{formatTitle(mode)}</h1>
+            {shouldShow(mode) ? <span>on</span> : <span>off</span>}
+            <ul>{getItems().map(i => <li>{i}</li>)}</ul>
+            <Card title={formatTitle(mode)} />
+          </div>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'Everything.tsx')
+    const byType = (t: string) => graph.domBindings.filter(d => d.type === t)
+    const text = byType('text').find(d => d.classification === 'fallback')
+    const attr = byType('attribute').find(d => d.classification === 'fallback' && d.label === 'style')
+    const cond = byType('conditional').find(d => d.classification === 'fallback')
+    const loop = byType('loop').find(d => d.classification === 'fallback')
+    const childProp = graph.domBindings.find(d => d.label === 'Card.title')
+    expect(text?.expression).toContain('formatTitle')
+    expect(attr?.expression).toContain('getStyle')
+    expect(cond?.expression).toContain('shouldShow')
+    expect(loop?.expression).toContain('getItems')
+    expect(childProp?.expression).toContain('formatTitle')
+    // Event handlers: no expression field — rationale in DomBinding doc.
+    const event = graph.domBindings.find(d => d.type === 'event')
+    expect(event).toBeDefined()
+    expect(event!.expression).toBeUndefined()
+  })
+
   test('formatComponentGraph marks fallback bindings with ~ prefix', () => {
     // The visual marker is the primary UX for `barefoot inspect`.
     // Guard the prefix format so `why-wrap` output doesn't silently drift.

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -296,4 +296,181 @@ describe('graphToJSON', () => {
     expect(json).toHaveProperty('effects')
     expect(json).toHaveProperty('domBindings')
   })
+
+  test('domBindings entries carry classification', () => {
+    // #944: JSON consumers (tooling, editor integrations) rely on the
+    // classification field to filter fallbacks without re-running static
+    // analysis. Guard against accidental regression in graphToJSON.
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const json = graphToJSON(graph) as { domBindings: Array<{ classification: string }> }
+    expect(json.domBindings.length).toBeGreaterThan(0)
+    for (const d of json.domBindings) {
+      expect(d).toHaveProperty('classification')
+      expect(['reactive', 'fallback']).toContain(d.classification)
+    }
+  })
+})
+
+// =============================================================================
+// #944: classification — reactive vs fallback-wrapped DOM bindings
+// =============================================================================
+
+describe('DomBinding classification (#944)', () => {
+  test('signal getter in text interpolation is reactive', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const textBindings = graph.domBindings.filter(d => d.type === 'text')
+    expect(textBindings.length).toBeGreaterThan(0)
+    for (const b of textBindings) {
+      expect(b.classification).toBe('reactive')
+      expect(b.deps).toContain('count')
+    }
+  })
+
+  test('event handler is always reactive (not subject to wrap-by-default)', () => {
+    // Handlers bind once; they aren't re-evaluated per signal change, so
+    // the wrap-by-default gate doesn't apply. They should never show up
+    // as fallback.
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const eventBindings = graph.domBindings.filter(d => d.type === 'event')
+    expect(eventBindings.length).toBeGreaterThan(0)
+    for (const b of eventBindings) {
+      expect(b.classification).toBe('reactive')
+    }
+  })
+
+  test('opaque call in text interpolation is fallback', () => {
+    // `formatTitle(page)` is an imported helper; `page` is a local const.
+    // Neither is a signal/memo/prop. #939 widened the emitter to wrap
+    // these so the DOM updates match runtime reads; #944 surfaces them
+    // here as `classification: 'fallback'` so users can find candidates.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const text = graph.domBindings.find(d => d.type === 'text')
+    expect(text).toBeDefined()
+    expect(text!.classification).toBe('fallback')
+    // Fallback bindings typically have empty deps — the effect subscribes
+    // to whatever it happens to read at runtime, possibly nothing.
+    expect(text!.deps).toEqual([])
+  })
+
+  test('opaque call in attribute is fallback', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+
+      export function Tag() {
+        const [, setFoo] = createSignal(0)
+        const label = 'hi'
+        return <button class={format(label)} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Tag.tsx')
+    const attr = graph.domBindings.find(d => d.type === 'attribute')
+    expect(attr).toBeDefined()
+    expect(attr!.classification).toBe('fallback')
+    expect(attr!.label).toBe('class')
+  })
+
+  test('opaque call in conditional is fallback', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { shouldShow } from './rules'
+
+      export function Panel() {
+        const [, setFoo] = createSignal(0)
+        const mode = 'draft'
+        return <div onClick={() => setFoo(1)}>{shouldShow(mode) ? <span>on</span> : <span>off</span>}</div>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Panel.tsx')
+    const cond = graph.domBindings.find(d => d.type === 'conditional')
+    expect(cond).toBeDefined()
+    expect(cond!.classification).toBe('fallback')
+  })
+
+  test('opaque call producing loop array is fallback', () => {
+    // `getItems()` is an imported helper — the analyzer can't prove it
+    // reactive, but it has calls so the emitter routes it through
+    // `!isStaticArray` (mapArray) to match runtime reads. #944 marks it
+    // as fallback so users can find the candidate for refactor.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { getItems } from './items'
+
+      export function List() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <ul onClick={() => setFoo(1)}>
+            {getItems().map(item => <li>{item}</li>)}
+          </ul>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'List.tsx')
+    const loop = graph.domBindings.find(d => d.type === 'loop')
+    expect(loop).toBeDefined()
+    expect(loop!.classification).toBe('fallback')
+  })
+
+  test('signal-driven loop array is reactive', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function List() {
+        const [items, setItems] = createSignal([1, 2, 3])
+        return (
+          <ul onClick={() => setItems(i => [...i, i.length])}>
+            {items().map(item => <li>{item}</li>)}
+          </ul>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'List.tsx')
+    const loop = graph.domBindings.find(d => d.type === 'loop')
+    expect(loop).toBeDefined()
+    expect(loop!.classification).toBe('reactive')
+    expect(loop!.deps).toContain('items')
+  })
+
+  test('formatComponentGraph marks fallback bindings with ~ prefix', () => {
+    // The visual marker is the primary UX for `barefoot inspect`.
+    // Guard the prefix format so `why-wrap` output doesn't silently drift.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [count, setCount] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setCount(c => c + 1)}>{formatTitle(page)} {count()}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const output = formatComponentGraph(graph)
+    // Fallback text binding for formatTitle(page) — marked with '~'.
+    expect(output).toMatch(/~ text "/)
+    // Reactive text binding for count() — marked with two leading spaces
+    // (no tilde). The exact prefix matters: it's the visual diff.
+    expect(output).toMatch(/dom bindings:[\s\S]*?text "/)
+    // No fallback marker on the reactive binding's line.
+    const lines = output.split('\n')
+    const countLine = lines.find(l => l.includes('count') && l.includes('text'))
+    expect(countLine).toBeDefined()
+    expect(countLine!).not.toMatch(/~ text/)
+  })
 })

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -71,6 +71,16 @@ export interface DomBinding {
    * to the wrap-by-default gate (handlers are bound, not re-evaluated).
    */
   classification: 'reactive' | 'fallback'
+  /**
+   * Source expression text for the binding, when available. Populated for
+   * text / attribute / conditional / loop / child-prop bindings so
+   * `barefoot why-wrap` can print the expression alongside the slotId —
+   * users locate bindings by expression, not by internal slot label.
+   *
+   * Omitted for event handlers (whose body is already surfaced by
+   * `why-update`) and for cases where the IR lacks a flat string form.
+   */
+  expression?: string
 }
 
 export interface ComponentGraph {
@@ -419,6 +429,7 @@ export function graphToJSON(graph: ComponentGraph): object {
       deps: d.deps,
       type: d.type,
       classification: d.classification,
+      ...(d.expression !== undefined && { expression: d.expression }),
     })),
   }
 }
@@ -550,6 +561,7 @@ function collectDomBindings(
             deps,
             type: 'attribute',
             classification: isReactive ? 'reactive' : 'fallback',
+            expression: expr,
           })
         }
       }
@@ -585,6 +597,7 @@ function collectDomBindings(
           deps,
           type: 'text',
           classification: isReactive ? 'reactive' : 'fallback',
+          expression: node.expr,
         })
       }
       break
@@ -601,6 +614,7 @@ function collectDomBindings(
           deps,
           type: 'conditional',
           classification: isReactive ? 'reactive' : 'fallback',
+          expression: node.condition,
         })
       }
       collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames)
@@ -625,6 +639,52 @@ function collectDomBindings(
             deps,
             type: 'loop',
             classification: isReactive ? 'reactive' : 'fallback',
+            expression: node.array,
+          })
+        }
+      }
+      for (const child of node.children) {
+        collectDomBindings(child, bindings, signalGetters, memoNames)
+      }
+      break
+    }
+    case 'component': {
+      // Child-component prop bindings (#942 DRY-consolidated in #952).
+      // Emitter gate in collect-elements.ts:442 is
+      // `hasPropsRef || needsEffectWrapper(expandedValue) || prop.callsReactiveGetters || prop.hasFunctionCalls`.
+      // `deps.length > 0` + `prop.value.includes('props.')` together
+      // approximate the first two branches (statically-proven reactive);
+      // the AST flags cover the fallback case.
+      //
+      // Before #944 this case fell through silently, so fallback-wrapped
+      // child props like `<Card title={formatTitle(page)} />` — the exact
+      // motivating example for #942 — never reached `why-wrap`'s output.
+      // The switch now iterates props and recurses into children, mirroring
+      // the `case 'element'` structure.
+      //
+      // Label uses `"ComponentName.propName"` so output distinguishes
+      // native-element attributes from child-component props without
+      // introducing a new `DomBinding.type` variant (keeps the existing
+      // type union stable for consumers).
+      for (const prop of node.props) {
+        if (prop.name === '...' || prop.name.startsWith('...')) continue
+        if (!prop.dynamic) continue
+        if (prop.jsxChildren) continue // JSX-as-prop handled via child traversal
+        const propValue = typeof prop.value === 'string' ? prop.value : ''
+        if (!propValue) continue
+        const deps = extractReactiveDeps(propValue, signalGetters, memoNames)
+        const hasPropsRef = propValue.includes('props.')
+        const isReactive = deps.length > 0 || hasPropsRef
+        const isFallback = !isReactive && (prop.callsReactiveGetters || prop.hasFunctionCalls)
+        if (isReactive || isFallback) {
+          bindings.push({
+            kind: 'dom',
+            label: `${node.name}.${prop.name}`,
+            slotId: node.slotId ?? '?',
+            deps,
+            type: 'attribute',
+            classification: isReactive ? 'reactive' : 'fallback',
+            expression: propValue,
           })
         }
       }

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -58,6 +58,19 @@ export interface DomBinding {
   slotId: string
   deps: string[]
   type: 'text' | 'event' | 'conditional' | 'loop' | 'attribute'
+  /**
+   * Classification inherited from the emitter's wrap decision (#944):
+   *  - 'reactive': static analysis proved the binding reads a signal, memo,
+   *    or reactive prop. `deps` is populated from those proven sources.
+   *  - 'fallback': Solid-style wrap-by-default (#937) wrapped it because
+   *    the expression contains a call the analyzer can't prove pure.
+   *    `deps` may be empty — the effect subscribes to whatever signals it
+   *    happens to read at runtime, possibly none.
+   *
+   * Event handlers are always classified 'reactive' — they are not subject
+   * to the wrap-by-default gate (handlers are bound, not re-evaluated).
+   */
+  classification: 'reactive' | 'fallback'
 }
 
 export interface ComponentGraph {
@@ -320,7 +333,10 @@ export function formatComponentGraph(graph: ComponentGraph): string {
     }
   }
 
-  // DOM bindings
+  // DOM bindings. Fallback-wrapped expressions (#937 Solid-style
+  // wrap-by-default) are marked with a leading `~` so users can spot
+  // expressions whose reactivity couldn't be statically proven — these
+  // are the candidates `barefoot why-wrap` surfaces for optimisation.
   if (graph.domBindings.length > 0) {
     lines.push(`  dom bindings:`)
     for (const d of graph.domBindings) {
@@ -328,7 +344,8 @@ export function formatComponentGraph(graph: ComponentGraph): string {
       const depStr = d.deps.join(', ')
       // For attribute bindings use the attr name; for others use slotId
       const id = d.type === 'attribute' ? `"${d.label}"` : `"${d.slotId}"`
-      lines.push(`    ${d.type} ${id}${arrow} ${depStr}`)
+      const marker = d.classification === 'fallback' ? '~ ' : '  '
+      lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}`)
     }
   }
 
@@ -401,6 +418,7 @@ export function graphToJSON(graph: ComponentGraph): object {
       slotId: d.slotId,
       deps: d.deps,
       type: d.type,
+      classification: d.classification,
     })),
   }
 }
@@ -490,7 +508,19 @@ export function formatSignalTrace(traces: SignalTrace[]): string {
 // Helpers
 // =============================================================================
 
-/** Collect DOM bindings (text updates, event handlers, etc.) from the IR tree. */
+/**
+ * Collect DOM bindings (text updates, event handlers, etc.) from the IR tree.
+ *
+ * Emits one `DomBinding` per expression the emitter wraps in `createEffect` at
+ * client JS generation time. The gate matches `ir-to-client-js/collect-elements.ts`
+ * so `barefoot inspect` / `barefoot why-update` / `barefoot why-wrap` see the
+ * same reactive footprint the runtime sees.
+ *
+ * Each binding carries a `classification`:
+ *  - `'reactive'`: static analysis proved the expression reads a signal/memo/prop.
+ *  - `'fallback'`: Solid-style wrap-by-default (#937) wrapped it because the
+ *    expression contains a call the analyzer can't prove pure.
+ */
 function collectDomBindings(
   node: IRNode,
   bindings: DomBinding[],
@@ -500,33 +530,40 @@ function collectDomBindings(
   switch (node.type) {
     case 'element': {
       // Dynamic attribute bindings (style, class, aria-*, data-*, etc.)
+      // Widened to match the emitter's gate in collect-elements.ts:
+      // `needsEffectWrapper(...) || attr.callsReactiveGetters || attr.hasFunctionCalls`.
+      // `deps.length > 0` is the debug-side proxy for `needsEffectWrapper` —
+      // both recognise known signal / memo / prop names, so a non-empty
+      // deps list is the statically-proven-reactive case.
       for (const attr of node.attrs) {
         if (!attr.dynamic) continue
         const expr = attrValueToString(attr.value)
         if (!expr) continue
         const deps = extractReactiveDeps(expr, signalGetters, memoNames)
-        if (deps.length > 0) {
+        const isReactive = deps.length > 0
+        const isFallback = !isReactive && (attr.callsReactiveGetters || attr.hasFunctionCalls)
+        if (isReactive || isFallback) {
           bindings.push({
             kind: 'dom',
             label: attr.name,
             slotId: node.slotId ?? '?',
             deps,
             type: 'attribute',
+            classification: isReactive ? 'reactive' : 'fallback',
           })
         }
       }
-      // Event handlers
+      // Event handlers — always tracked, always 'reactive' (handlers are
+      // bound, not re-evaluated; no wrap-by-default gate applies).
       for (const event of node.events) {
-        const deps = extractReactiveDeps(event.handler, signalGetters, memoNames)
-        if (deps.length > 0 || true) {
-          bindings.push({
-            kind: 'dom',
-            label: `${event.name} handler "${node.slotId ?? '?'}"`,
-            slotId: node.slotId ?? '?',
-            deps: extractSetterRefs(event.handler, signalGetters),
-            type: 'event',
-          })
-        }
+        bindings.push({
+          kind: 'dom',
+          label: `${event.name} handler "${node.slotId ?? '?'}"`,
+          slotId: node.slotId ?? '?',
+          deps: extractSetterRefs(event.handler, signalGetters),
+          type: 'event',
+          classification: 'reactive',
+        })
       }
       // Recurse
       for (const child of node.children) {
@@ -535,7 +572,11 @@ function collectDomBindings(
       break
     }
     case 'expression': {
-      if (node.reactive && node.slotId) {
+      // Widened to match emitter gate in collect-elements.ts:
+      // `node.reactive || node.callsReactiveGetters || node.hasFunctionCalls`.
+      const isReactive = node.reactive
+      const isFallback = !isReactive && (node.callsReactiveGetters || node.hasFunctionCalls)
+      if ((isReactive || isFallback) && node.slotId) {
         const deps = extractReactiveDeps(node.expr, signalGetters, memoNames)
         bindings.push({
           kind: 'dom',
@@ -543,12 +584,15 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'text',
+          classification: isReactive ? 'reactive' : 'fallback',
         })
       }
       break
     }
     case 'conditional': {
-      if (node.reactive && node.slotId) {
+      const isReactive = node.reactive
+      const isFallback = !isReactive && (node.callsReactiveGetters || node.hasFunctionCalls)
+      if ((isReactive || isFallback) && node.slotId) {
         const deps = extractReactiveDeps(node.condition, signalGetters, memoNames)
         bindings.push({
           kind: 'dom',
@@ -556,6 +600,7 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'conditional',
+          classification: isReactive ? 'reactive' : 'fallback',
         })
       }
       collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames)
@@ -563,15 +608,23 @@ function collectDomBindings(
       break
     }
     case 'loop': {
+      // IRLoop compresses reactive/fallback behind `!isStaticArray`. We
+      // distinguish here via the dedicated flags added in #944:
+      // `callsReactiveGetters` catches `items()` where `items` is a signal;
+      // `hasFunctionCalls` without reactive-getter hit is the fallback case
+      // (e.g. `getItems().map(...)` with an opaque helper).
       if (node.slotId) {
         const deps = extractReactiveDeps(node.array, signalGetters, memoNames)
-        if (deps.length > 0) {
+        const isReactive = deps.length > 0 || node.callsReactiveGetters === true
+        const isFallback = !isReactive && node.hasFunctionCalls === true
+        if (isReactive || isFallback) {
           bindings.push({
             kind: 'dom',
             label: `loop "${node.slotId}"`,
             slotId: node.slotId,
             deps,
             type: 'loop',
+            classification: isReactive ? 'reactive' : 'fallback',
           })
         }
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1696,9 +1696,11 @@ function transformMapCall(
   // latent crash in the `mapArray` renderItem emitter — see #949 and
   // the emitter-side `destructureLoopParam` helper, which now unwraps
   // the signal accessor at renderItem body entry. No more skip.
+  const callsReactive = exprCallsReactiveGetters(arrayExpr, ctx)
+  const hasCalls = exprHasFunctionCalls(arrayExpr)
   const isStaticArray =
     !isSignalOrMemoArray(array, ctx)
-    && !exprHasFunctionCalls(arrayExpr)
+    && !hasCalls
 
   // Collect nested components for both static and dynamic arrays.
   // Static arrays: needed for initChild hydration.
@@ -1720,6 +1722,8 @@ function transformMapCall(
     // The parent element will assign its slotId to the loop after transformation
     slotId: null,
     isStaticArray,
+    callsReactiveGetters: callsReactive || undefined,
+    hasFunctionCalls: hasCalls || undefined,
     childComponent,
     nestedComponents,
     filterPredicate,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -182,6 +182,20 @@ export interface IRLoop {
   isStaticArray: boolean
 
   /**
+   * When true, array expression calls signal getters or memos (computed from AST).
+   * Derived Phase 1 so debug tooling (#944) can classify the wrap decision
+   * without re-deriving reactivity from the expression string.
+   */
+  callsReactiveGetters?: boolean
+  /**
+   * When true, array expression contains any `identifier()` pattern (computed from AST).
+   * Combined with `callsReactiveGetters` this distinguishes reactive loops
+   * (`items().map(...)` where `items` is a signal) from fallback-wrapped loops
+   * (`getItems().map(...)` where `getItems` is an opaque call).
+   */
+  hasFunctionCalls?: boolean
+
+  /**
    * When the loop body is a single component, store its info here
    * for createComponent-based rendering instead of template strings.
    * This enables proper parent-to-child prop passing (including event handlers).


### PR DESCRIPTION
## Summary

- New subcommand `barefoot why-wrap <component>` lists every DOM binding whose `createEffect` came from the Solid-style wrap-by-default fallback (#937) rather than from statically-proven reactivity — these are the optimisation candidates that were previously invisible.
- `DomBinding` gains `classification: 'reactive' | 'fallback'` and `expression?: string` so `barefoot inspect` / `why-update` / `why-wrap` all see the same reactive footprint the runtime sees, and CLI output can print the actual expression. `collectDomBindings` is widened across text (#939), attribute (#940), conditional (#941), loop (#943), **and child-component prop (#942/#952)** to match every emitter's wrap decision.
- `IRLoop` gains `callsReactiveGetters` / `hasFunctionCalls` (mirroring #939/#941/#942/#952-on-`IRProp` and #953-on-`IRAttribute`) so loop bindings classify the same way as the other four sites.
- `formatComponentGraph` prefixes fallback bindings with `~`. `--json` carries `classification` and `expression` verbatim for tooling.

Closes #944.

## Why CLI, not warnings

Decided in #937 and the `project_priorities` memory: dev-time warnings are ignored or become noise. Opt-in CLI is the visibility channel — matches the shape of existing `inspect` / `why-update` / `test --debug` tooling. `why-wrap` surfaces the information; the user decides what to rewrite.

## Manual verification

Running against `calendar` (touches text / attribute / conditional across both sub-months):

```
$ bun run barefoot why-wrap calendar
Calendar — 8 fallback-wrapped expression(s)
  attribute "className"  ~ numMonths() > 1 flex gap-4
  attribute "className"  ~ getDayClasses(day, isSelected, rangePos)
  attribute "data-date"  ~ toISODateString(day.date)
  text "s8"              ~ day.date.getDate()
  conditional "s12"      ~ numMonths() >= 2
  attribute "className"  ~ getDayClasses(day, isSelected, rangePos)
  attribute "data-date"  ~ toISODateString(day.date)
  text "s21"             ~ day.date.getDate()

Fallback wraps run one createEffect per expression. Each subscribes to
whatever signals it happens to read at runtime (possibly none).
Rewrite the expression as a createMemo to make the dependency static,
or inline a known-reactive source so the emitter can prove it.
```

Child-component prop case verified via a synthetic `<Card title={formatTitle(page)} />` component — output prints `attribute "Card.title"  ~ formatTitle(page)`, confirming the #942 motivating example now surfaces end-to-end.

`barefoot inspect calendar` shows `~` markers on the same bindings. `--json` emits `classification` and `expression` on every `domBindings` entry. `why-wrap --json` filters to fallbacks only.

## Commit-level breakdown

1. `feat(compiler): classify DomBindings as reactive vs fallback` — `DomBinding.classification` field, `collectDomBindings` gate widening across text / attribute / conditional / loop, `IRLoop` flags + `jsx-to-ir` population, `formatComponentGraph` marker, `graphToJSON` classification.
2. `test(compiler): pin DomBinding reactive/fallback classification` — 8 `debug.test.ts` cases covering text/attribute/conditional/loop × reactive/fallback, plus `formatComponentGraph` marker pinning and `graphToJSON` shape pinning.
3. `feat(cli): barefoot why-wrap` — command + dispatcher wiring + 5-case test suite.
4. `docs: document why-wrap and the ~ fallback marker` — `CLAUDE.md` + `docs/core/core-concepts/ai-native.md`.
5. `fix(debug): address PR #956 review` — adds the missing `case 'component'` branch for child-component props (concern 1), `DomBinding.expression?` with CLI output overhaul (concern 2), `await expect(...).rejects.toThrow()` on error tests (concern 3), swap non-existent `AnalyticsDemo` for real `calendar` in docs (concern 5). 4 new debug.test.ts cases lock in the new contract.

## Test plan

- [x] `bun test packages/jsx` — 706 pass (13 new cases in `debug.test.ts`)
- [x] `bun test packages/cli` — 506 pass (5 cases in `why-wrap.test.ts`, all with proper `await`)
- [x] `bun test --cwd . packages/` — 1667 pass; remaining 1 fail / 1 error is the pre-existing `packages/xyflow/e2e/flow.spec.ts` Playwright issue on main
- [x] `bun run build` — clean
- [x] Manual: `barefoot why-wrap calendar` shows 8 fallbacks with actual expression text
- [x] Manual: `barefoot why-wrap /tmp/child-prop-demo.tsx` surfaces `Card.title ~ formatTitle(page)` (concern 1 regression guard)
- [x] Manual: `barefoot why-wrap calendar --json` returns valid JSON with `classification` and `expression` on every entry
- [x] Manual: `barefoot inspect calendar` shows `~` marker on fallback bindings

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>