### PR TITLE
feat(xyflow): ship xyflow.browser.min.js pre-bundled browser variant (#954)

### DIFF
--- a/docs/core/advanced/xyflow-browser-bundle.md
+++ b/docs/core/advanced/xyflow-browser-bundle.md
@@ -1,0 +1,69 @@
+---
+title: xyflow browser bundle
+description: How to serve @barefootjs/xyflow as a pre-built browser chunk via an importmap
+---
+
+# xyflow browser bundle
+
+`@barefootjs/xyflow` ships a pre-minified ESM variant, `dist/xyflow.browser.min.js`, with `@barefootjs/client*` left as externals. Apps that want to serve xyflow as an independently-cached static asset can copy this file instead of re-bundling.
+
+## Why a pre-built variant
+
+Bundling xyflow into a large client entry adds ~270 KB of d3 + wrapper code to every cold-visit payload. Re-bundling it manually as a separate chunk requires remembering three externals:
+
+```
+--external '@barefootjs/client'
+--external '@barefootjs/client/runtime'
+--external '@barefootjs/client/reactive'
+```
+
+Missing any one of them silently inlines a second copy of the reactive primitives, breaking signal propagation across the boundary (fitView becomes a no-op, `FlowContext` reads from the wrong owner, etc.). The pre-built variant has all three applied already.
+
+## Setup
+
+**1. Copy the file into your static output:**
+
+```sh
+cp node_modules/@barefootjs/xyflow/dist/xyflow.browser.min.js \
+   public/static/components/xyflow.js
+
+# Optional: copy the sourcemap for readable DevTools stacks
+cp node_modules/@barefootjs/xyflow/dist/xyflow.browser.min.js.map \
+   public/static/components/xyflow.js.map
+```
+
+**2. Add an importmap to your HTML:**
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@barefootjs/client":          "/static/components/barefoot.js",
+    "@barefootjs/client/runtime":  "/static/components/barefoot.js",
+    "@barefootjs/client/reactive": "/static/components/barefoot.js",
+    "@barefootjs/xyflow":          "/static/components/xyflow.js"
+  }
+}
+</script>
+```
+
+The three `@barefootjs/client*` entries all pointing at the same file is what makes the browser deduplicate them into a single module instance, so reactive primitives share one `Listener`/`Owner` global.
+
+## package.json fields
+
+The file is also exposed via the `umd` export condition and the `unpkg`/`jsdelivr` top-level fields:
+
+```json
+{
+  "exports": {
+    ".": {
+      "umd":    "./dist/xyflow.browser.min.js",
+      "import": "./dist/index.js"
+    }
+  },
+  "unpkg":    "./dist/xyflow.browser.min.js",
+  "jsdelivr": "./dist/xyflow.browser.min.js"
+}
+```
+
+CDNs like unpkg and jsDelivr resolve the top-level fields automatically, so `https://unpkg.com/@barefootjs/xyflow` serves the pre-built variant.

--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "unpkg": "./dist/xyflow.browser.min.js",
+  "jsdelivr": "./dist/xyflow.browser.min.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "umd": "./dist/xyflow.browser.min.js",
       "import": "./dist/index.js"
     }
   },
@@ -16,8 +19,9 @@
     "src"
   ],
   "scripts": {
-    "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime'",
+    "build": "bun run build:js && bun run build:browser && bun run build:types",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
+    "build:browser": "bun build ./src/index.ts --outdir ./dist --entry-naming 'xyflow.browser.min.[ext]' --format esm --minify --sourcemap --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
     "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
     "test": "bun test src/",
     "test:e2e": "bunx playwright test",


### PR DESCRIPTION
## Summary

- Add `build:browser` script to `@barefootjs/xyflow` that produces a minified ESM bundle (`dist/xyflow.browser.min.js` + `.map`) with all three `@barefootjs/client*` paths left as externals
- Expose the file via `umd` export condition and top-level `unpkg`/`jsdelivr` fields in `package.json`
- Fix `build:js` to also externalize `@barefootjs/client/reactive` (was already in the browser build but missing from the dev build, risking reactive duplication on downstream re-bundle)
- Add `docs/core/advanced/xyflow-browser-bundle.md` with the importmap recipe

## Why

Apps that want xyflow as an independently-cached static chunk currently have to re-bundle `dist/index.js` themselves with three specific `--external` flags. Missing any one of them silently inlines a second copy of the reactive primitives, breaking signal propagation (`fitView` becomes a no-op, `FlowContext` reads from the wrong owner). This pre-built variant removes that footgun.

## Test plan

- [ ] `cd packages/xyflow && bun run build` — `build:js` and `build:browser` both succeed
- [ ] `dist/xyflow.browser.min.js` and `dist/xyflow.browser.min.js.map` are generated
- [ ] Verify `dist/xyflow.browser.min.js` imports `@barefootjs/client`, `@barefootjs/client/runtime`, `@barefootjs/client/reactive` (not inlined): `grep "from '@barefootjs" dist/xyflow.browser.min.js`

Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)