### PR TITLE
chore: migrate type-checking to @typescript/native-preview (tsgo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@happy-dom/global-registrator": "^20.0.11",
     "@playwright/test": "^1.57.0",
     "@types/bun": "latest",
+    "@types/node": "^22.10.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "concurrently": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "setup": "bun install && bun run --filter 'barefootjs-echo-example' setup",
     "build": "bun run --filter '@barefootjs/client' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' build && bun run --filter '*' build",
-    "test": "bun test --cwd . packages/",
+    "test": "bun test --cwd . __tests__",
     "test:e2e": "bun run --filter '*' test:e2e",
     "clean": "bun run --filter '*' clean",
     "dev": "docker compose up",
@@ -38,6 +38,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "solid-js": "^1.9.12",
+    "@typescript/native-preview": "beta",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/chart/tsconfig.json
+++ b/packages/chart/tsconfig.json
@@ -14,5 +14,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -12,7 +12,6 @@
     "skipLibCheck": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "baseUrl": ".",
     "paths": {
       "@barefootjs/client/reactive": ["./src/reactive.ts"]
     }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/go-template/package.json
+++ b/packages/go-template/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/go-template/tsconfig.json
+++ b/packages/go-template/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["bun", "node"],
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -77,7 +77,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/hono/tsconfig.json
+++ b/packages/hono/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "skipLibCheck": true,
+    "types": ["bun", "node"],
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external typescript",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/jsx/tsconfig.json
+++ b/packages/jsx/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/mojolicious/package.json
+++ b/packages/mojolicious/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/mojolicious/tsconfig.json
+++ b/packages/mojolicious/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["bun", "node"],
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
   },

--- a/packages/test/src/render.ts
+++ b/packages/test/src/render.ts
@@ -94,6 +94,7 @@ function buildMetadata(
     templateImports: ctx.imports.filter((imp) => !['@barefootjs/client', '@barefootjs/client'].includes(imp.source)),
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
+    initStatements: ctx.initStatements,
   }
 }
 

--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -22,7 +22,7 @@
     "build": "bun run build:js && bun run build:browser && bun run build:types",
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
     "build:browser": "bun build ./src/index.ts --outdir ./dist --entry-naming 'xyflow.browser.min.[ext]' --format esm --minify --sourcemap --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
-    "build:types": "tsc --emitDeclarationOnly --outDir ./dist",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test src/",
     "test:e2e": "bunx playwright test",
     "clean": "rm -rf dist"

--- a/packages/xyflow/tsconfig.json
+++ b/packages/xyflow/tsconfig.json
@@ -14,5 +14,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Switch all `build:types` scripts across 9 packages from `tsc` to `tsgo` (the Go-native type-checker shipped as `@typescript/native-preview@beta` in [TypeScript 7.0 beta](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/))
- Fix tsconfig incompatibilities tsgo surfaces: remove deprecated `baseUrl`, add explicit `types: [node]` / `types: [bun, node]` where needed (tsgo no longer auto-includes every `@types/*` from `node_modules`)
- `typescript@5.9.3` is kept as a devDependency — `packages/jsx` imports the TS compiler JS API (`import ts from 'typescript'`) for AST manipulation, and `@typescript/native-preview` does not yet ship a stable programmatic API (planned for TS 7.1+)

### Drive-by fixes surfaced during migration

- **`packages/test/src/render.ts`**: missing `initStatements` in the `IRMetadata` builder — a real type error that `tsc` had been flagging too (regression from commit `acfdb74f`)
- **Root `test` script**: was scoped to `packages/`, which pulled `packages/xyflow/e2e/flow.spec.ts` (a Playwright test) into `bun test` and produced a spurious `test.beforeEach()` error on every run. Narrowed the filter to `__tests__` so bun test only scans unit-test directories (adds `site/shared/tokens/__tests__` coverage as a side benefit)

## Test plan

- [x] `bun run clean && bun run build` — clean build passes
- [x] `bun run test` — 1686 pass / 0 fail (up from 1680/1 fail previously due to the xyflow/e2e false-positive)
- [x] `bun run --filter '*' build:types` — all 9 packages type-check under tsgo
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)