### PR TITLE
fix(hono): forward externals and externalsBasePath in createConfig

### DIFF
--- a/packages/hono/src/__tests__/build.test.ts
+++ b/packages/hono/src/__tests__/build.test.ts
@@ -135,4 +135,20 @@ export function Counter() {
     expect(config.contentHash).toBe(true)
     expect(config.clientOnly).toBe(true)
   })
+
+  test('passes through externals and externalsBasePath', () => {
+    const externals = { react: { url: 'https://cdn.example.com/react.js' } }
+    const config = createConfig({
+      externals,
+      externalsBasePath: '/cdn/',
+    })
+    expect(config.externals).toBe(externals)
+    expect(config.externalsBasePath).toBe('/cdn/')
+  })
+
+  test('externals and externalsBasePath default to undefined', () => {
+    const config = createConfig()
+    expect(config.externals).toBeUndefined()
+    expect(config.externalsBasePath).toBeUndefined()
+  })
 })

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -29,6 +29,8 @@ export function createConfig(options: HonoBuildOptions = {}) {
     minify: options.minify,
     contentHash: options.contentHash,
     clientOnly: options.clientOnly,
+    externals: options.externals,
+    externalsBasePath: options.externalsBasePath,
     transformMarkedTemplate: useScriptCollection
       ? (content: string, componentId: string, clientJsPath: string) =>
           addScriptCollection(content, componentId, clientJsPath, options.scriptBasePath)


### PR DESCRIPTION
## Summary

`createConfig` in `packages/hono/src/build.ts` was not forwarding the `externals` and `externalsBasePath` fields that were added to `BuildOptions` in #958. As a result, Hono adapter users had to apply a spread workaround to pass these options through to the build pipeline.

- Add `externals: options.externals` and `externalsBasePath: options.externalsBasePath` to the return value of `createConfig`
- Add two tests to `packages/hono/src/__tests__/build.test.ts` covering pass-through and undefined defaults

## Test plan

- [ ] `bun test packages/hono` — existing tests still pass; new tests for `externals` / `externalsBasePath` pass-through pass
- [ ] Manually verify that a Hono project using `createConfig({ externals: { ... } })` no longer needs a spread workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)