### PR TITLE
fix(cli): warn when externals chunk resolves via import/main fallback

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -410,6 +410,84 @@ describe('processExternals', () => {
       rmSync(outDir, { recursive: true, force: true })
     }
   })
+
+  test('chunk with only import/main entry emits a warning', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      // Create a fake package that has only an `import` field (no umd/unpkg/jsdelivr).
+      const pkgDir = resolve(projectDir, 'node_modules', 'fake-pkg')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'fake-pkg', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(resolve(pkgDir, 'index.mjs'), `import { something } from 'lib0/observable'\nexport const x = 1`)
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'fake-pkg': true as const },
+      })
+
+      const warnCalls: string[] = []
+      const originalWarn = console.warn
+      console.warn = (...args: unknown[]) => { warnCalls.push(args.join(' ')) }
+      try {
+        await processExternals(config, 'components', outDir)
+      } finally {
+        console.warn = originalWarn
+      }
+
+      const warningMsg = warnCalls.find(m =>
+        m.includes('fake-pkg') && m.includes('import/main entry')
+      )
+      expect(warningMsg).toBeDefined()
+      expect(warningMsg).toContain('no umd/unpkg/jsdelivr found')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('chunk with umd entry does NOT emit an import/main fallback warning', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      // Create a fake package that has an explicit `umd` field.
+      const pkgDir = resolve(projectDir, 'node_modules', 'fake-umd-pkg')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'fake-umd-pkg',
+          version: '1.0.0',
+          exports: { '.': { umd: './dist/index.umd.js', import: './dist/index.mjs' } },
+        })
+      )
+      mkdirSync(resolve(pkgDir, 'dist'), { recursive: true })
+      writeFileSync(resolve(pkgDir, 'dist/index.umd.js'), 'var fakePkg = (function(){return {}})();')
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'fake-umd-pkg': true as const },
+      })
+
+      const warnCalls: string[] = []
+      const originalWarn = console.warn
+      console.warn = (...args: unknown[]) => { warnCalls.push(args.join(' ')) }
+      try {
+        await processExternals(config, 'components', outDir)
+      } finally {
+        console.warn = originalWarn
+      }
+
+      const fallbackWarning = warnCalls.find(m =>
+        m.includes('fake-umd-pkg') && m.includes('import/main entry')
+      )
+      expect(fallbackWarning).toBeUndefined()
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
 })
 
 // ── minification ────────────────────────────────────────────────────────

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -591,25 +591,50 @@ export function vendorChunkFilename(pkgName: string): string {
   return `${base}.js`
 }
 
+interface PkgBrowserEntry {
+  /** Absolute path to the resolved file. */
+  path: string
+  /**
+   * True when the file was resolved via a browser-ready field (`umd`, `unpkg`,
+   * or `jsdelivr`). False when we fell back to `exports["."].import` or `main`,
+   * which may still contain bare external imports that are not browser-ready.
+   */
+  isBrowserReady: boolean
+}
+
 /**
  * Locate the browser-ready entry for a package.
  * Preference order: `exports["."].umd` → `unpkg` → `jsdelivr` → `exports["."].import` → `main`.
+ * Returns `isBrowserReady: false` when the resolved file came from an
+ * `import`/`main` fallback rather than an explicit browser field.
  */
-async function resolvePkgBrowserEntry(pkgDir: string): Promise<string | null> {
+async function resolvePkgBrowserEntry(pkgDir: string): Promise<PkgBrowserEntry | null> {
   const pkgJsonPath = resolve(pkgDir, 'package.json')
   if (!(await fileExists(pkgJsonPath))) return null
   const pkg = JSON.parse(await readText(pkgJsonPath))
-  const candidates = [
+
+  // Browser-ready candidates: these fields are intended for direct browser use.
+  const browserCandidates = [
     pkg.exports?.['.']?.umd,
     pkg.unpkg,
     pkg.jsdelivr,
+  ].filter((v): v is string => typeof v === 'string')
+  for (const rel of browserCandidates) {
+    const abs = resolve(pkgDir, rel)
+    if (await fileExists(abs)) return { path: abs, isBrowserReady: true }
+  }
+
+  // Fallback candidates: may contain bare external imports not suitable for
+  // direct browser loading without a bundler or importmap.
+  const fallbackCandidates = [
     pkg.exports?.['.']?.import,
     pkg.main,
   ].filter((v): v is string => typeof v === 'string')
-  for (const rel of candidates) {
+  for (const rel of fallbackCandidates) {
     const abs = resolve(pkgDir, rel)
-    if (await fileExists(abs)) return abs
+    if (await fileExists(abs)) return { path: abs, isBrowserReady: false }
   }
+
   return null
 }
 
@@ -654,12 +679,23 @@ export async function processExternals(
 
     if (isChunk) {
       const pkgDir = resolve(config.projectDir, 'node_modules', pkgName)
-      const srcFile = await resolvePkgBrowserEntry(pkgDir)
-      if (!srcFile) {
+      const entry = await resolvePkgBrowserEntry(pkgDir)
+      if (!entry) {
         console.warn(`Warning: externals — could not resolve browser entry for "${pkgName}". Skipping.`)
         continue
       }
 
+      // Warn when the resolved file came from an import/main fallback. These
+      // files may contain bare external imports (e.g. "lib0/observable") that
+      // the browser cannot resolve without a bundler or a matching importmap.
+      if (!entry.isBrowserReady) {
+        console.warn(
+          `Warning: externals — "${pkgName}" resolved via import/main entry (no umd/unpkg/jsdelivr found). ` +
+          `The copied file may contain external imports that are not browser-ready.`
+        )
+      }
+
+      const srcFile = entry.path
       const filename = vendorChunkFilename(pkgName)
       const destPath = resolve(runtimeOutDir, filename)
       let content: string | Uint8Array = await readBytes(srcFile)


### PR DESCRIPTION
## Summary

- `resolvePkgBrowserEntry` now returns `{ path: string, isBrowserReady: boolean }` instead of a bare `string | null`
- `isBrowserReady` is `true` when the file was found via a `umd`, `unpkg`, or `jsdelivr` field (i.e., explicitly intended for direct browser use)
- `isBrowserReady` is `false` when the resolver fell back to `exports["."].import` or `main`, which may contain bare external imports like `lib0/observable` that the browser cannot resolve without a bundler or matching importmap entry
- `processExternals` now calls `console.warn` when `isBrowserReady` is `false`, surfacing the problem that was previously silent

Example warning:
```
Warning: externals — "@barefootjs/xyflow" resolved via import/main entry (no umd/unpkg/jsdelivr found). The copied file may contain external imports that are not browser-ready.
```

## Test plan

- [x] `bun test packages/cli/src/__tests__/build.test.ts` — 41 pass, 1 pre-existing failure (esbuild platform binary absent in test env, unrelated to this change)
- [x] New test: `chunk with only import/main entry emits a warning` — verifies warning is emitted when package has no browser-ready field
- [x] New test: `chunk with umd entry does NOT emit an import/main fallback warning` — verifies no spurious warning when `umd` field is present
- [x] All pre-existing `processExternals` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)