### PR TITLE
ci: parallelize site/ui E2E with matrix sharding and dedupe workflows

### DIFF
--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -86,8 +86,20 @@ jobs:
       - name: Download Go dependencies
         run: cd integrations/echo && go mod download
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: Run integrations/echo E2E tests
         run: cd integrations/echo && bun run test:e2e

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -72,8 +72,20 @@ jobs:
       - name: Build integrations/hono
         run: cd integrations/hono && bun run build
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: Run integrations/hono E2E tests
         run: cd integrations/hono && bun run test:e2e
@@ -84,44 +96,4 @@ jobs:
         with:
           name: playwright-report-integrations-hono
           path: integrations/hono/playwright-report/
-          retention-days: 30
-
-  e2e-site-ui:
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build packages
-        run: |
-          bun run --filter '@barefootjs/client' build
-          bun run --filter '@barefootjs/jsx' build
-          bun run --filter '@barefootjs/form' build
-          bun run --filter '@barefootjs/chart' build
-          bun run --filter '@barefootjs/hono' build
-
-      - name: Build site/ui
-        run: cd site/ui && bun run build
-
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
-
-      - name: Run site/ui E2E tests
-        run: cd site/ui && bun run test:e2e
-
-      - name: Upload Playwright report (site/ui)
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report-site-ui
-          path: site/ui/playwright-report/
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - 'packages/chart/**'
       - 'packages/xyflow/**'
       - 'packages/adapter-tests/**'
+      # site/ui is the Hono adapter's end-to-end target, so Hono changes must
+      # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
+      - 'packages/hono/**'
       - 'ui/**'
       - 'site/ui/**'
       - '.github/workflows/ci.yml'
@@ -24,6 +27,9 @@ on:
       - 'packages/chart/**'
       - 'packages/xyflow/**'
       - 'packages/adapter-tests/**'
+      # site/ui is the Hono adapter's end-to-end target, so Hono changes must
+      # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
+      - 'packages/hono/**'
       - 'ui/**'
       - 'site/ui/**'
       - '.github/workflows/ci.yml'
@@ -76,6 +82,10 @@ jobs:
   e2e-site-ui:
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v6
@@ -99,17 +109,29 @@ jobs:
       - name: Build site/ui
         run: cd site/ui && bun run build
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
 
-      - name: Run site/ui E2E tests
-        run: cd site/ui && bun run test:e2e
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Run site/ui E2E tests (shard ${{ matrix.shard }}/4)
+        run: cd site/ui && bunx playwright test --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report (site/ui)
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-site-ui
+          name: playwright-report-site-ui-shard-${{ matrix.shard }}
           path: site/ui/playwright-report/
           retention-days: 30
 
@@ -145,8 +167,20 @@ jobs:
       - name: Download Go dependencies
         run: cd integrations/echo && go mod download
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: Run integrations/echo E2E tests
         run: cd integrations/echo && bun run test:e2e

--- a/site/ui/playwright.config.ts
+++ b/site/ui/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 0,
-  workers: undefined,
+  workers: process.env.CI ? '100%' : undefined,
   reporter: 'html',
   use: {
     baseURL,


### PR DESCRIPTION
## Summary

- Split `site/ui` Playwright run across 4 matrix shards (`fail-fast: false`) — ~1400 tests distributed 347/347/347/346 per shard.
- Remove the duplicate `e2e-site-ui` job from `ci-hono.yml`. It was identical to the one in `ci.yml` and ran the same 7-minute job twice on any PR touching `site/ui` or `packages/hono`. Added `packages/hono/**` (with a comment) to `ci.yml`'s `paths` so hono changes still trigger site/ui E2E.
- Cache Playwright browser binaries (`~/.cache/ms-playwright`) via `actions/cache` keyed on `bun.lock` — applied to every workflow that runs Playwright (`ci.yml`, `ci-hono.yml`, `ci-go-template.yml`). Saves ~25s per job on cache hits.
- Set `workers: process.env.CI ? '100%' : undefined` in `site/ui/playwright.config.ts` so shards use all 4 vCPU on `ubuntu-latest` instead of the default 2.

## Expected impact

- **site/ui E2E wall time: ~7 min → ~2 min** (each shard runs ~1.5 min of tests + ~55s fixed setup).
- hono-touching PRs no longer run the same 7-minute E2E twice.

## Test plan

- [ ] CI: `ci.yml` — `e2e-site-ui` matrix runs (shards 1–4), all green.
- [ ] CI: `ci.yml` — `e2e-echo` still passes with Playwright cache.
- [ ] CI: `ci-hono.yml` — `e2e-hono` still passes with Playwright cache; `e2e-site-ui` no longer appears.
- [ ] CI: `ci-go-template.yml` — `e2e-echo` still passes with Playwright cache.
- [ ] Confirm total `e2e-site-ui` wall time is substantially lower than the ~7 min baseline.
- [ ] Verify a `packages/hono/**` change triggers `ci.yml` e2e-site-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)