### PR TITLE
feat(cli): add rebundle option to externals for self-contained ESM output

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -442,6 +442,7 @@ describe('processExternals', () => {
       )
       expect(warningMsg).toBeDefined()
       expect(warningMsg).toContain('no umd/unpkg/jsdelivr found')
+      expect(warningMsg).toContain('rebundle: true')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
       rmSync(outDir, { recursive: true, force: true })
@@ -481,6 +482,78 @@ describe('processExternals', () => {
 
       const fallbackWarning = warnCalls.find(m =>
         m.includes('fake-umd-pkg') && m.includes('import/main entry')
+      )
+      expect(fallbackWarning).toBeUndefined()
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rebundle: true produces self-contained ESM without bare external imports', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      // dep-pkg: a simple dependency that will be inlined
+      const depDir = resolve(projectDir, 'node_modules', 'dep-pkg')
+      mkdirSync(depDir, { recursive: true })
+      writeFileSync(resolve(depDir, 'package.json'), JSON.stringify({ name: 'dep-pkg', version: '1.0.0', main: './index.js' }))
+      writeFileSync(resolve(depDir, 'index.js'), `export const INLINED = 'from-dep-pkg'`)
+
+      // needs-rebundle: imports from dep-pkg (bare external that browsers can't resolve)
+      const pkgDir = resolve(projectDir, 'node_modules', 'needs-rebundle')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'needs-rebundle', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(resolve(pkgDir, 'index.mjs'), `import { INLINED } from 'dep-pkg'\nexport const value = INLINED`)
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'needs-rebundle': { rebundle: true } as const },
+      })
+
+      await processExternals(config, 'components', outDir)
+
+      const outFile = resolve(outDir, 'needs-rebundle.js')
+      expect(require('fs').existsSync(outFile)).toBe(true)
+      const content = require('fs').readFileSync(outFile, 'utf8')
+      // dep-pkg code must be inlined — no bare 'dep-pkg' import should remain
+      expect(content).toContain('from-dep-pkg')
+      expect(content).not.toMatch(/from ['"]dep-pkg['"]/)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rebundle: true does NOT emit import/main fallback warning', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      const pkgDir = resolve(projectDir, 'node_modules', 'rebundle-pkg')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'rebundle-pkg', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(resolve(pkgDir, 'index.mjs'), `export const x = 1`)
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'rebundle-pkg': { rebundle: true } as const },
+      })
+
+      const warnCalls: string[] = []
+      const originalWarn = console.warn
+      console.warn = (...args: unknown[]) => { warnCalls.push(args.join(' ')) }
+      try {
+        await processExternals(config, 'components', outDir)
+      } finally {
+        console.warn = originalWarn
+      }
+
+      const fallbackWarning = warnCalls.find(m =>
+        m.includes('rebundle-pkg') && m.includes('import/main entry')
       )
       expect(fallbackWarning).toBeUndefined()
     } finally {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -17,6 +17,7 @@ import {
 } from './build-cache'
 import { writeIfChanged } from './fs-utils'
 import { fileExists, readBytes, readText, transpile } from './runtime'
+import { build as esbuildBuild } from 'esbuild'
 
 export { resolveRelativeImports } from './resolve-imports'
 
@@ -685,26 +686,42 @@ export async function processExternals(
         continue
       }
 
-      // Warn when the resolved file came from an import/main fallback. These
-      // files may contain bare external imports (e.g. "lib0/observable") that
-      // the browser cannot resolve without a bundler or a matching importmap.
-      if (!entry.isBrowserReady) {
+      const wantRebundle = typeof spec === 'object' && !('url' in spec) && spec.rebundle === true
+
+      // Warn when the resolved file came from an import/main fallback and rebundle is not set.
+      // These files may contain bare external imports (e.g. "lib0/observable") that the browser
+      // cannot resolve without a bundler or importmap. Set rebundle: true to inline them.
+      if (!entry.isBrowserReady && !wantRebundle) {
         console.warn(
           `Warning: externals — "${pkgName}" resolved via import/main entry (no umd/unpkg/jsdelivr found). ` +
-          `The copied file may contain external imports that are not browser-ready.`
+          `The copied file may contain external imports that are not browser-ready. ` +
+          `Set rebundle: true to re-bundle it into a self-contained ESM file.`
         )
       }
 
       const srcFile = entry.path
       const filename = vendorChunkFilename(pkgName)
       const destPath = resolve(runtimeOutDir, filename)
-      let content: string | Uint8Array = await readBytes(srcFile)
-      if (config.minify) {
-        content = transpile(content instanceof Uint8Array ? new TextDecoder().decode(content) : content, { loader: 'js', minify: true })
-      }
-      if (await writeIfChanged(destPath, content)) {
+
+      if (wantRebundle) {
+        await esbuildBuild({
+          entryPoints: [srcFile],
+          outfile: destPath,
+          format: 'esm',
+          bundle: true,
+          minify: config.minify ?? false,
+        })
         anyChanged = true
-        console.log(`Generated: ${runtimeSubdir}/${filename}`)
+        console.log(`Generated (bundled): ${runtimeSubdir}/${filename}`)
+      } else {
+        let content: string | Uint8Array = await readBytes(srcFile)
+        if (config.minify) {
+          content = transpile(content instanceof Uint8Array ? new TextDecoder().decode(content) : content, { loader: 'js', minify: true })
+        }
+        if (await writeIfChanged(destPath, content)) {
+          anyChanged = true
+          console.log(`Generated: ${runtimeSubdir}/${filename}`)
+        }
       }
 
       const url = `${base}${filename}`

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -101,10 +101,13 @@ export interface PostBuildContext {
  *   (umd → unpkg → jsdelivr → import condition) and copy it to the output dir.
  * - `{ url }` — CDN passthrough: skip local copy, use the URL as-is in the importmap.
  * - `preload: true` — emit a `<link rel="modulepreload">` hint for this entry.
+ * - `rebundle: true` — re-bundle the resolved entry with esbuild into a self-contained
+ *   ESM file, inlining all dependencies. Useful for packages (e.g. `yjs`) whose
+ *   `dist/*.mjs` files still contain bare external imports that browsers cannot resolve.
  */
 export type ExternalSpec =
   | true
-  | { chunk?: true; preload?: boolean }
+  | { chunk?: true; preload?: boolean; rebundle?: boolean }
   | { url: string; preload?: boolean }
 
 export interface BuildOptions {


### PR DESCRIPTION
## Problem

Packages like `yjs` ship their `dist/` as ESM with bare external imports:

```js
import { Observable } from 'lib0/observable'
```

When `processExternals` copies these files as-is, the browser fails to load them:

```
Uncaught TypeError: Failed to resolve module specifier "lib0/observable"
```

The existing warning (`import/main entry`) already flags this, but leaves the user to work around it manually (e.g. via a `postBuild` hook that re-runs `bun build`).

## Solution

Add `rebundle: true` to `ExternalSpec`. When set, `processExternals` uses esbuild with `bundle: true` to inline all transitive dependencies into a single self-contained ESM file, instead of copying the source as-is.

```ts
// barefoot.config.ts
export default createConfig({
  externals: {
    yjs: { preload: true, rebundle: true },
  },
})
```

The import/main fallback warning is also updated to suggest `rebundle: true` as the fix.

## Changes

- `packages/jsx/src/index.ts` — add `rebundle?: boolean` to the chunk variant of `ExternalSpec`
- `packages/cli/src/lib/build.ts` — call `esbuild.build({ bundle: true })` when `rebundle: true`; update fallback warning text
- `packages/cli/src/__tests__/build.test.ts` — two new tests: output is self-contained, no fallback warning emitted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)