### PR TITLE
ci: fix Playwright cache misses and split --with-deps install

### DIFF
--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -99,9 +99,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install chromium
 
-      - name: Install Playwright system deps
-        run: bunx playwright install-deps chromium
-
       - name: Run integrations/echo E2E tests
         run: cd integrations/echo && bun run test:e2e
 

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -91,14 +91,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          # Key on package.json (committed, deterministic) — not bun.lock
+          # which is gitignored and re-solved per run.
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser binaries
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
 
-      - name: Install Playwright system deps only
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps
         run: bunx playwright install-deps chromium
 
       - name: Run integrations/echo E2E tests

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -83,9 +83,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install chromium
 
-      - name: Install Playwright system deps
-        run: bunx playwright install-deps chromium
-
       - name: Run integrations/hono E2E tests
         run: cd integrations/hono && bun run test:e2e
 

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -75,14 +75,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          # Key on package.json (committed, deterministic) — not bun.lock
+          # which is gitignored and re-solved per run.
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser binaries
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
 
-      - name: Install Playwright system deps only
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps
         run: bunx playwright install-deps chromium
 
       - name: Run integrations/hono E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,14 +114,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          # Key on package.json (committed, deterministic) — not bun.lock
+          # which is gitignored and re-solved per run.
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser binaries
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
 
-      - name: Install Playwright system deps only
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps
         run: bunx playwright install-deps chromium
 
       - name: Run site/ui E2E tests (shard ${{ matrix.shard }}/4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install chromium
 
-      - name: Install Playwright system deps
-        run: bunx playwright install-deps chromium
-
       - name: Run site/ui E2E tests (shard ${{ matrix.shard }}/4)
         run: cd site/ui && bunx playwright test --shard=${{ matrix.shard }}/4
 


### PR DESCRIPTION
## Summary

Two fixes to the intermittent slow setup that appeared after matrix sharding landed. Confirmed working — all 4 \`e2e-site-ui\` shards now complete within 10 seconds of each other instead of the previous 2 min / 14 min spread.

## Problem

Before this PR, the "Install Playwright browsers" step showed 20× variance across shards in a single run. On the commit that triggered the investigation (run 24758102073), the four shards took:

| shard | step breakdown | total |
|---|---|---|
| (1) | binaries 10s + install-deps **269s** + tests 80s | 6m26s |
| (2) | binaries 11s + install-deps **741s** + tests 83s | 14m24s |
| (3) | binaries 11s + install-deps 17s + tests 79s | 2m19s |
| (4) | binaries 10s + install-deps 12s + tests 76s | 2m7s |

The two root causes were independent.

## Fix 1 — Deterministic cache key

\`hashFiles('bun.lock')\` was non-deterministic: \`bun.lock\` is \`.gitignore\`d, each shard regenerates it via \`bun install\`, and tiny solve differences produced different hashes across shards. That split a single run into multiple cache keys, so some shards missed while others hit.

Switched to \`hashFiles('**/package.json')\` (committed, deterministic). Every shard in a run now looks up the same key.

## Fix 2 — Skip install-deps

With fix 1 applied, shards consistently cache-hit the browser binaries (0s). What remained was the \`install-deps\` step running apt-get on every shard — and per-runner apt mirror latency still produced the 12s/17s/269s/741s spread shown above.

GitHub Actions' \`ubuntu-latest\` (Ubuntu 24.04) image ships with all the shared libraries Playwright chromium needs (libnss3, libnspr4, libatk*, libcups2, libxkb*, libxcomposite1, libxdamage1, libxfixes3, libxrandr2, libgbm1, libpango, libcairo2, libasound2, ...). Dropped the \`install-deps\` step entirely. If a future runner image ever drops one of these, chromium launch will fail fast and we'll add a targeted \`apt-get install\` for just that lib.

Also split the cache-miss path from \`playwright install --with-deps chromium\` into \`playwright install chromium\` (browser binaries only) — this was a prerequisite of fix 2 but is kept anyway for when caches are rotated.

## Measured result (run 24760419270 on this PR)

| shard | Build site/ui | Cache lookup | Install binaries | E2E tests | **Total** |
|---|---|---|---|---|---|
| (1) | 11s | 6s | 0s (hit) | 80s | **1m52s** |
| (2) | 10s | 8s | 0s (hit) | 82s | **1m58s** |
| (3) | 11s | 5s | 0s (hit) | 78s | **1m48s** |
| (4) | 11s | 4s | 0s (hit) | 83s | **1m51s** |

- Every shard cache-hits deterministically.
- \`Install Playwright browser binaries\` takes 0s on hit (skipped).
- \`Install Playwright system deps\` step is gone.
- Shard spread compressed from 2 min / 14 min (before) to 10 seconds.
- chromium runs fine in every shard — no missing shared library.

## Changes

Applied identically to \`ci.yml\`, \`ci-hono.yml\`, \`ci-go-template.yml\`. Stale \`bun.lock\`-keyed caches were cleared out-of-band so the first run rebuilt cleanly under the new key.

## Cumulative CI history

| State | \`e2e-site-ui\` wall clock (max shard) |
|---|---|
| Pre-sharding baseline | ~7m |
| #962 (shard 4 + browser cache) | 4m8s |
| #964 (static E2E → IR test) | 1m59s |
| **#966 (this PR)** | **1m58s, stable ±5s** |

Wall clock is similar to #964, but the **variance is eliminated** — runs no longer contain 10-minute outlier shards.

## Test plan

- [x] CI on this PR: all 4 \`e2e-site-ui\` shards green, setup uniform (±5s).
- [x] \`e2e-hono\` green — same setup pattern.
- [x] \`e2e-echo\` (ci-go-template.yml) green — same setup pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)