### PR TITLE
feat: /gallery/shop — E-Commerce Shop gallery (Phase 9)

### DIFF
--- a/site/ui/components/gallery/shop/cart-demo.tsx
+++ b/site/ui/components/gallery/shop/cart-demo.tsx
@@ -1,0 +1,163 @@
+"use client"
+/**
+ * ShopCartDemo
+ *
+ * Gallery-specific cart for /gallery/shop/cart. Identical to CartDemo
+ * except the Checkout button is an anchor to /gallery/shop/checkout,
+ * completing the catalog → cart → checkout navigation flow.
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Separator } from '@ui/components/ui/separator'
+
+type CartItem = {
+  id: number
+  name: string
+  price: number
+  quantity: number
+  image: string
+}
+
+const formatPrice = (cents: number): string =>
+  `$${(cents / 100).toFixed(2)}`
+
+const initialItems: CartItem[] = [
+  { id: 1, name: 'Wireless Headphones', price: 7999, quantity: 1, image: '🎧' },
+  { id: 2, name: 'USB-C Hub Adapter', price: 3499, quantity: 2, image: '🔌' },
+  { id: 3, name: 'Mechanical Keyboard', price: 12999, quantity: 1, image: '⌨️' },
+  { id: 4, name: 'Laptop Stand', price: 4999, quantity: 1, image: '💻' },
+]
+
+const DISCOUNT_THRESHOLD = 20000
+const DISCOUNT_RATE = 0.1
+const TAX_RATE = 0.08
+
+export function ShopCartDemo() {
+  const [items, setItems] = createSignal<CartItem[]>(initialItems)
+
+  const subtotal = createMemo(() =>
+    items().reduce((sum, item) => sum + item.price * item.quantity, 0)
+  )
+
+  const discount = createMemo(() =>
+    subtotal() >= DISCOUNT_THRESHOLD ? Math.round(subtotal() * DISCOUNT_RATE) : 0
+  )
+
+  const taxableAmount = createMemo(() => subtotal() - discount())
+
+  const tax = createMemo(() => Math.round(taxableAmount() * TAX_RATE))
+
+  const total = createMemo(() => taxableAmount() + tax())
+
+  const itemCount = createMemo(() =>
+    items().reduce((sum, item) => sum + item.quantity, 0)
+  )
+
+  const updateQuantity = (id: number, delta: number) => {
+    setItems(prev => prev.map(item =>
+      item.id === id
+        ? { ...item, quantity: Math.max(1, item.quantity + delta) }
+        : item
+    ))
+  }
+
+  const removeItem = (id: number) => {
+    setItems(prev => prev.filter(item => item.id !== id))
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Shopping Cart</h3>
+        <Badge variant="secondary">{itemCount()} items</Badge>
+      </div>
+
+      {items().length > 0 ? (
+        <div className="space-y-4">
+          <div className="rounded-lg border divide-y">
+            {items().map(item => (
+              <div key={item.id} className="flex items-center gap-3 p-3">
+                <span className="text-2xl">{item.image}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{item.name}</p>
+                  <p className="text-sm text-muted-foreground">{formatPrice(item.price)} each</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, -1)}
+                  >
+                    −
+                  </Button>
+                  <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => updateQuantity(item.id, 1)}
+                  >
+                    +
+                  </Button>
+                </div>
+                <p className="text-sm font-semibold w-16 text-right">
+                  {formatPrice(item.price * item.quantity)}
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => removeItem(item.id)}
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+          </div>
+          <div className="space-y-3">
+            <div className="rounded-lg border p-4 space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <span>{formatPrice(subtotal())}</span>
+              </div>
+              {discount() > 0 ? (
+                <div className="flex justify-between text-sm text-green-600">
+                  <span>Discount (10%)</span>
+                  <span>−{formatPrice(discount())}</span>
+                </div>
+              ) : null}
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Tax (8%)</span>
+                <span>{formatPrice(tax())}</span>
+              </div>
+              <Separator />
+              <div className="flex justify-between font-semibold">
+                <span>Total</span>
+                <span>{formatPrice(total())}</span>
+              </div>
+              {discount() === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Add {formatPrice(DISCOUNT_THRESHOLD - subtotal())} more for 10% off
+                </p>
+              ) : null}
+            </div>
+            <a
+              href="/gallery/shop/checkout"
+              className="flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors"
+            >
+              Checkout — {formatPrice(total())}
+            </a>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border p-8 text-center">
+          <p className="text-2xl mb-2">🛒</p>
+          <p className="text-sm text-muted-foreground">Your cart is empty</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/ui/components/gallery/shop/catalog-demo.tsx
+++ b/site/ui/components/gallery/shop/catalog-demo.tsx
@@ -1,0 +1,334 @@
+"use client"
+/**
+ * ShopCatalogDemo
+ *
+ * Adapted ProductCardsDemo for /gallery/shop/catalog. Additions over the
+ * standalone block:
+ * - Writes cart count to sessionStorage so ShopCartBadge stays in sync
+ *   across the full-page navigation boundary.
+ * - Cart sidebar footer links to /gallery/shop/cart.
+ *
+ * Compiler stress targets (inherited + new):
+ * - Derived state from 3 signals (search + category + priceRange)
+ * - Dynamic CSS class from signal (viewMode → grid layout)
+ * - Per-item cart operations (add/remove/quantity)
+ * - Computed total from array signal (cartItems reduce)
+ * - Toast notification triggered by action
+ * - Inner loops (tags.map inside products.map)
+ * - Badge variants from data (category, "Sale")
+ * - Empty state conditional
+ * - createEffect writing memo value to sessionStorage (cross-page state)
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+import { Card, CardHeader, CardTitle, CardContent, CardDescription, CardFooter } from '@ui/components/ui/card'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
+import { Separator } from '@ui/components/ui/separator'
+import { Slider } from '@ui/components/ui/slider'
+import { ToastProvider, Toast, ToastTitle, ToastDescription, ToastClose } from '@ui/components/ui/toast'
+import { writeCartCount } from '../../shared/gallery-shop-storage'
+
+// --- Types ---
+
+type Category = 'electronics' | 'accessories' | 'wearables' | 'home'
+
+type Product = {
+  id: number
+  name: string
+  description: string
+  price: number
+  originalPrice: number
+  category: Category
+  rating: number
+  reviewCount: number
+  tags: string[]
+  image: string
+  inStock: boolean
+}
+
+type CartItem = {
+  product: Product
+  quantity: number
+}
+
+// --- Constants ---
+
+const PRICE_MAX = 300
+const FREE_SHIPPING_THRESHOLD = 10000
+
+const categoryBadgeVariant = {
+  electronics: 'default',
+  accessories: 'secondary',
+  wearables: 'outline',
+  home: 'secondary',
+} as const
+
+// --- Mock Data ---
+
+const allProducts: Product[] = [
+  { id: 1, name: 'Wireless Headphones', description: 'Premium noise-cancelling over-ear headphones', price: 19900, originalPrice: 24900, category: 'electronics', rating: 5, reviewCount: 342, tags: ['bluetooth', 'noise-cancelling'], image: '🎧', inStock: true },
+  { id: 2, name: 'Smart Watch Pro', description: 'Fitness tracker with heart rate and GPS', price: 29900, originalPrice: 29900, category: 'wearables', rating: 4, reviewCount: 215, tags: ['fitness', 'gps'], image: '⌚', inStock: true },
+  { id: 3, name: 'USB-C Hub', description: '7-in-1 multiport adapter for laptops', price: 4900, originalPrice: 5900, category: 'accessories', rating: 4, reviewCount: 178, tags: ['usb-c', 'adapter'], image: '🔌', inStock: true },
+  { id: 4, name: 'Mechanical Keyboard', description: 'RGB backlit with Cherry MX switches', price: 12900, originalPrice: 12900, category: 'electronics', rating: 5, reviewCount: 567, tags: ['rgb', 'cherry-mx'], image: '⌨️', inStock: true },
+  { id: 5, name: 'Desk Lamp', description: 'LED desk lamp with adjustable color temperature', price: 3900, originalPrice: 4900, category: 'home', rating: 4, reviewCount: 89, tags: ['led', 'adjustable'], image: '💡', inStock: true },
+  { id: 6, name: 'Phone Case', description: 'Slim protective case with MagSafe support', price: 2900, originalPrice: 2900, category: 'accessories', rating: 3, reviewCount: 445, tags: ['magsafe', 'slim'], image: '📱', inStock: true },
+  { id: 7, name: 'Fitness Band', description: 'Lightweight activity tracker with sleep monitoring', price: 7900, originalPrice: 9900, category: 'wearables', rating: 4, reviewCount: 312, tags: ['fitness', 'sleep'], image: '💪', inStock: false },
+  { id: 8, name: 'Wireless Charger', description: 'Fast wireless charging pad for Qi devices', price: 2400, originalPrice: 2400, category: 'electronics', rating: 4, reviewCount: 201, tags: ['wireless', 'fast-charge'], image: '🔋', inStock: true },
+  { id: 9, name: 'Standing Desk Mat', description: 'Anti-fatigue mat for standing desks', price: 4500, originalPrice: 5500, category: 'home', rating: 5, reviewCount: 156, tags: ['ergonomic'], image: '🧘', inStock: true },
+  { id: 10, name: 'Camera Strap', description: 'Adjustable woven camera neck strap', price: 1900, originalPrice: 1900, category: 'accessories', rating: 4, reviewCount: 67, tags: ['adjustable'], image: '📷', inStock: true },
+  { id: 11, name: 'Smart Speaker', description: 'Voice assistant with premium sound', price: 9900, originalPrice: 12900, category: 'electronics', rating: 4, reviewCount: 423, tags: ['voice', 'speaker'], image: '🔊', inStock: true },
+  { id: 12, name: 'Yoga Mat', description: 'Non-slip exercise mat with carrying strap', price: 3400, originalPrice: 3400, category: 'home', rating: 5, reviewCount: 289, tags: ['exercise', 'non-slip'], image: '🧘‍♀️', inStock: true },
+]
+
+// --- Helpers ---
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+function stars(rating: number): string {
+  return '★'.repeat(rating) + '☆'.repeat(5 - rating)
+}
+
+// --- Component ---
+
+export function ShopCatalogDemo() {
+  // Signals
+  const [searchQuery, setSearchQuery] = createSignal('')
+  const [categoryFilter, setCategoryFilter] = createSignal('all')
+  const [priceRange, setPriceRange] = createSignal(PRICE_MAX)
+  const [viewMode, setViewMode] = createSignal<'grid' | 'list'>('grid')
+  const [cartItems, setCartItems] = createSignal<CartItem[]>([])
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  // 3-signal derived memo
+  const filteredProducts = createMemo(() => {
+    const query = searchQuery().toLowerCase()
+    const category = categoryFilter()
+    const maxPrice = priceRange() * 100
+    return allProducts.filter(p => {
+      if (category !== 'all' && p.category !== category) return false
+      if (p.price > maxPrice) return false
+      if (query && !p.name.toLowerCase().includes(query) && !p.tags.some(t => t.includes(query))) return false
+      return true
+    })
+  })
+
+  // Cart memos
+  const cartTotal = createMemo(() => cartItems().reduce((sum, item) => sum + item.product.price * item.quantity, 0))
+  const cartCount = createMemo(() => cartItems().reduce((sum, item) => sum + item.quantity, 0))
+
+  // Sync cart count to sessionStorage for ShopCartBadge cross-page state
+  createEffect(() => {
+    writeCartCount(cartCount())
+  })
+
+  // Cart handlers
+  const addToCart = (product: Product) => {
+    setCartItems(prev => {
+      const existing = prev.find(item => item.product.id === product.id)
+      if (existing) {
+        return prev.map(item => item.product.id === product.id ? { ...item, quantity: item.quantity + 1 } : item)
+      }
+      return [...prev, { product, quantity: 1 }]
+    })
+    setToastMessage(`${product.name} added to cart`)
+    setToastOpen(true)
+  }
+
+  const removeFromCart = (productId: number) => {
+    setCartItems(prev => prev.filter(item => item.product.id !== productId))
+  }
+
+  const updateQuantity = (productId: number, delta: number) => {
+    setCartItems(prev => prev.map(item => {
+      if (item.product.id !== productId) return item
+      const newQty = Math.max(1, item.quantity + delta)
+      return { ...item, quantity: newQty }
+    }))
+  }
+
+  return (
+    <div className="w-full min-w-0 space-y-6">
+
+      {/* === FILTER BAR === */}
+      <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+        <Input
+          value={searchQuery()}
+          onInput={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search products..."
+          className="product-search flex-1 max-w-xs"
+        />
+        <Select value={categoryFilter()} onValueChange={setCategoryFilter}>
+          <SelectTrigger className="category-filter w-[160px]">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Categories</SelectItem>
+            <SelectItem value="electronics">Electronics</SelectItem>
+            <SelectItem value="accessories">Accessories</SelectItem>
+            <SelectItem value="wearables">Wearables</SelectItem>
+            <SelectItem value="home">Home</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground whitespace-nowrap">Max: {formatPrice(priceRange() * 100)}</span>
+          <Slider
+            value={priceRange()}
+            min={0}
+            max={PRICE_MAX}
+            onValueChange={setPriceRange}
+            className="price-slider w-32"
+          />
+        </div>
+        <Button
+          variant={viewMode() === 'list' ? 'default' : 'outline'}
+          size="sm"
+          className="view-toggle"
+          onClick={() => setViewMode(viewMode() === 'grid' ? 'list' : 'grid')}
+        >
+          {viewMode() === 'grid' ? '☰ List' : '⊞ Grid'}
+        </Button>
+      </div>
+
+      {/* Results count */}
+      <p className="product-count text-sm text-muted-foreground">{filteredProducts().length} products</p>
+
+      {/* === MAIN CONTENT === */}
+      <div className="flex flex-col lg:flex-row gap-6">
+
+        {/* --- Product Grid/List --- */}
+        <div className="flex-1 min-w-0">
+          {/* Dynamic CSS class from signal */}
+          <div className={viewMode() === 'grid'
+            ? 'product-grid grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4'
+            : 'product-grid grid grid-cols-1 gap-3'}>
+            {filteredProducts().map(product => (
+              <Card key={product.id} className="product-card">
+                <CardHeader className="pb-2">
+                  <div className="text-4xl mb-2">{product.image}</div>
+                  <div className="flex items-center gap-2">
+                    <CardTitle className="product-name text-sm">{product.name}</CardTitle>
+                    {product.originalPrice > product.price ? (
+                      <Badge variant="destructive" className="sale-badge text-xs">Sale</Badge>
+                    ) : null}
+                  </div>
+                  <CardDescription className="text-xs">{product.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="flex flex-wrap gap-1">
+                    <Badge variant={categoryBadgeVariant[product.category]} className="category-badge text-xs">{product.category}</Badge>
+                    {/* Inner loop: tags */}
+                    {product.tags.map(tag => (
+                      <Badge key={tag} variant="outline" className="tag-badge text-xs">{tag}</Badge>
+                    ))}
+                  </div>
+                  <div className="flex items-baseline gap-2">
+                    <span className="product-price font-bold">{formatPrice(product.price)}</span>
+                    {product.originalPrice > product.price ? (
+                      <span className="text-xs text-muted-foreground line-through">{formatPrice(product.originalPrice)}</span>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs">
+                    <span className="product-rating text-amber-500">{stars(product.rating)}</span>
+                    <span className="text-muted-foreground">({product.reviewCount})</span>
+                  </div>
+                </CardContent>
+                <CardFooter className="gap-2">
+                  <Button
+                    size="sm"
+                    className="add-to-cart-btn"
+                    disabled={!product.inStock}
+                    onClick={() => addToCart(product)}
+                  >
+                    {product.inStock ? 'Add to Cart' : 'Out of Stock'}
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+
+          {/* Empty state */}
+          {filteredProducts().length === 0 ? (
+            <div className="product-empty text-center py-12 text-muted-foreground">
+              <p className="text-lg">No products match your filters</p>
+              <p className="text-sm mt-1">Try adjusting your search or filters</p>
+            </div>
+          ) : null}
+        </div>
+
+        {/* --- Cart Sidebar --- */}
+        <div className="w-full lg:w-80 shrink-0">
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">Cart</CardTitle>
+                <Badge variant="secondary" className="cart-count">{cartCount()} items</Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {cartItems().length === 0 ? (
+                <p className="cart-empty text-sm text-muted-foreground text-center py-4">Your cart is empty</p>
+              ) : null}
+
+              <div className="cart-items space-y-2">
+              {cartItems().map(item => (
+                <div key={item.product.id} className="cart-item flex items-center gap-2">
+                  <span className="text-xl">{item.product.image}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="cart-item-name text-sm font-medium truncate">{item.product.name}</p>
+                    <p className="text-xs text-muted-foreground">{formatPrice(item.product.price)}</p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button variant="outline" size="sm" className="h-6 w-6 p-0 qty-minus" onClick={() => updateQuantity(item.product.id, -1)}>-</Button>
+                    <span className="cart-item-qty text-sm w-6 text-center">{item.quantity}</span>
+                    <Button variant="outline" size="sm" className="h-6 w-6 p-0 qty-plus" onClick={() => updateQuantity(item.product.id, 1)}>+</Button>
+                  </div>
+                  <Button variant="ghost" size="sm" className="h-6 px-1 text-xs text-destructive remove-btn" onClick={() => removeFromCart(item.product.id)}>×</Button>
+                </div>
+              ))}
+              </div>
+            </CardContent>
+            {cartItems().length > 0 ? (
+              <div>
+                <Separator />
+                <CardFooter className="flex-col items-stretch gap-2 pt-4">
+                  <div className="flex justify-between">
+                    <span className="text-sm font-medium">Subtotal</span>
+                    <span className="cart-total text-sm font-bold">{formatPrice(cartTotal())}</span>
+                  </div>
+                  {cartTotal() >= FREE_SHIPPING_THRESHOLD ? (
+                    <Badge variant="default" className="free-shipping self-start">Free Shipping</Badge>
+                  ) : (
+                    <p className="shipping-message text-xs text-muted-foreground">
+                      Add {formatPrice(FREE_SHIPPING_THRESHOLD - cartTotal())} more for free shipping
+                    </p>
+                  )}
+                  <a
+                    href="/gallery/shop/cart"
+                    className="inline-flex items-center justify-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors"
+                  >
+                    Go to Cart →
+                  </a>
+                </CardFooter>
+              </div>
+            ) : null}
+          </Card>
+        </div>
+      </div>
+
+      {/* === TOAST === */}
+      <ToastProvider position="bottom-right">
+        <Toast open={toastOpen()} onOpenChange={setToastOpen} variant="default" duration={3000}>
+          <ToastTitle>Added to Cart</ToastTitle>
+          <ToastDescription>{toastMessage()}</ToastDescription>
+          <ToastClose />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/shop/shop-cart-badge.tsx
+++ b/site/ui/components/gallery/shop/shop-cart-badge.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { createSignal } from '@barefootjs/client'
+import { readCartCount } from '../../shared/gallery-shop-storage'
+
+// Compiler constraint: top-level conditional returns in "use client" components
+// are not preserved by the compiler (SSR always renders the truthy branch).
+// Workaround: wrap in a `contents` container so the conditional is an inner
+// child expression — matching the AdminUnreadBadge pattern.
+export function ShopCartBadge() {
+  const [count, setCount] = createSignal<number>(readCartCount())
+
+  // Each shop route is a full page navigation so listeners don't accumulate —
+  // no onCleanup needed (same pattern as AdminUnreadBadge).
+  if (typeof window !== 'undefined') {
+    window.addEventListener('barefoot:shop-storage', () => setCount(readCartCount()))
+  }
+
+  return (
+    <span className="contents" aria-live="polite">
+      {count() > 0 ? (
+        <span
+          data-cart-count={count()}
+          className="shop-cart-count inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground"
+        >
+          {count()}
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/site/ui/components/gallery/shop/shop-shell.tsx
+++ b/site/ui/components/gallery/shop/shop-shell.tsx
@@ -1,0 +1,88 @@
+/**
+ * ShopShell
+ *
+ * Shared layout for /gallery/shop/* pages. SSR-only chrome (top nav bar);
+ * the cart count island (ShopCartBadge) lives in a sibling "use client" component.
+ *
+ * Top nav contrasts with AdminShell's sidebar — demonstrates two layout
+ * archetypes in the same gallery.
+ *
+ * Compiler stress targets:
+ * - Shared layout wrapping per-route reactive content (each page mounts
+ *   its own signal scope inside this shell).
+ * - Active-route class on nav items derived from currentRoute prop.
+ */
+
+import type { Child } from 'hono/jsx'
+import { ShopCartBadge } from './shop-cart-badge'
+
+export type ShopRouteKey = 'catalog' | 'cart' | 'checkout'
+
+interface NavItem {
+  key: ShopRouteKey
+  href: string
+  label: string
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'catalog', href: '/gallery/shop', label: 'Catalog' },
+  { key: 'cart', href: '/gallery/shop/cart', label: 'Cart' },
+  { key: 'checkout', href: '/gallery/shop/checkout', label: 'Checkout' },
+]
+
+interface ShopShellProps {
+  currentRoute: ShopRouteKey
+  children?: Child
+}
+
+export function ShopShell({ currentRoute, children }: ShopShellProps) {
+  return (
+    <div className="shop-shell flex min-h-[calc(100vh-8rem)] w-full flex-col rounded-xl border bg-card overflow-hidden">
+      {/* Top nav */}
+      <header
+        data-shop-header=""
+        className="flex items-center gap-4 border-b px-4 py-3 bg-background/60"
+      >
+        {/* Logo */}
+        <div className="flex items-center gap-2 shrink-0">
+          <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold">
+            S
+          </div>
+          <span className="text-sm font-semibold">Shop</span>
+        </div>
+
+        {/* Nav links */}
+        <nav
+          data-shop-nav=""
+          className="flex items-center gap-1 overflow-x-auto"
+          aria-label="Shop navigation"
+        >
+          {NAV_ITEMS.map((item) => {
+            const active = item.key === currentRoute
+            return (
+              <a
+                href={item.href}
+                data-shop-nav-item={item.key}
+                data-active={active ? 'true' : 'false'}
+                aria-current={active ? 'page' : undefined}
+                className={`shop-nav-link flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors no-underline whitespace-nowrap ${
+                  active
+                    ? 'bg-primary text-primary-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                }`}
+              >
+                {item.label}
+                {item.key === 'cart' ? <ShopCartBadge /> : null}
+              </a>
+            )
+          })}
+        </nav>
+      </header>
+
+      {/* Page content */}
+      <div className="shop-page flex-1 overflow-x-auto p-4 sm:p-6">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/shared/gallery-shop-storage.ts
+++ b/site/ui/components/shared/gallery-shop-storage.ts
@@ -1,0 +1,41 @@
+// Shared session-storage helpers for the /gallery/shop app.
+//
+// Reactive primitives must stay in each consuming component — the compiler
+// only recognizes createSignal / createEffect at the source call site. These
+// are pure read/write helpers; components keep their own signal pairs inline.
+
+const NAMESPACE = 'barefoot.gallery.shop'
+
+function storageKey(key: string): string {
+  return `${NAMESPACE}.${key}`
+}
+
+function readRaw(key: string): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage.getItem(storageKey(key))
+  } catch {
+    return null
+  }
+}
+
+function writeRaw(key: string, value: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(storageKey(key), value)
+    window.dispatchEvent(new CustomEvent('barefoot:shop-storage', { detail: { key } }))
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+export function readCartCount(fallback = 0): number {
+  const raw = readRaw('cartCount')
+  if (raw == null) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : fallback
+}
+
+export function writeCartCount(value: number): void {
+  writeRaw('cartCount', String(value))
+}

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -103,7 +103,10 @@ export const navSections: NavSection[] = [
         key: 'gallery-apps',
         title: 'Apps',
         defaultOpen: false,
-        links: [{ title: 'Admin Dashboard', href: '/gallery/admin' }],
+        links: [
+          { title: 'Admin Dashboard', href: '/gallery/admin' },
+          { title: 'E-Commerce Shop', href: '/gallery/shop' },
+        ],
         matchPath: (p) => p.startsWith('/gallery/'),
       },
     ],

--- a/site/ui/e2e/admin-gallery.spec.ts
+++ b/site/ui/e2e/admin-gallery.spec.ts
@@ -112,11 +112,11 @@ test.describe('Gallery: Admin app', () => {
 
     test('gallery meta link is outside the admin shell', async ({ page }) => {
       await page.goto('/gallery/admin')
-      const githubLinks = page.locator('a[href*="issues/929"]')
+      const githubLinks = page.locator('a[href*="components/gallery/admin"]')
       await expect(githubLinks).toHaveCount(1)
       // The link must be a sibling of (not descendant of) the admin shell.
       const insideShell = await page
-        .locator('.admin-shell a[href*="issues/929"]')
+        .locator('.admin-shell a[href*="components/gallery/admin"]')
         .count()
       expect(insideShell).toBe(0)
     })

--- a/site/ui/pages/gallery/admin/analytics.tsx
+++ b/site/ui/pages/gallery/admin/analytics.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminAnalyticsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" issueNumber={929} />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="analytics">
         <AdminAnalyticsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/gallery-meta.tsx
+++ b/site/ui/pages/gallery/admin/gallery-meta.tsx
@@ -1,37 +1,19 @@
-/**
- * Small meta strip for every `/gallery/admin/*` page — shown above the
- * admin app shell. Intentionally kept outside AdminShell because it's
- * gallery chrome (about the demo site), not part of the Acme admin UI.
- */
-
 interface GalleryMetaProps {
   appName: string
-  issueNumber: number
+  sourceHref: string
 }
 
-export function GalleryMeta({ appName, issueNumber }: GalleryMetaProps) {
+export function GalleryMeta({ appName, sourceHref }: GalleryMetaProps) {
   return (
     <div className="flex items-center justify-between text-xs text-muted-foreground mb-3 px-1">
-      <span>
-        <span className="font-medium text-foreground">{appName}</span>
-        {' '}— a multi-page gallery demo built with BarefootJS (
-        <a
-          href="https://github.com/barefootjs/barefootjs/issues/135"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-foreground"
-        >
-          Phase 9 Blocks
-        </a>
-        )
-      </span>
+      <span className="font-medium text-foreground">{appName}</span>
       <a
-        href={`https://github.com/barefootjs/barefootjs/issues/${issueNumber}`}
+        href={sourceHref}
         target="_blank"
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1 hover:text-foreground"
       >
-        View on GitHub
+        View source
         <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M7 7h10v10" />
           <path d="M7 17 17 7" />

--- a/site/ui/pages/gallery/admin/index.tsx
+++ b/site/ui/pages/gallery/admin/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminOverviewPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" issueNumber={929} />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="overview">
         <AdminOverviewDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/notifications.tsx
+++ b/site/ui/pages/gallery/admin/notifications.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminNotificationsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" issueNumber={929} />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="notifications">
         <AdminNotificationsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/orders.tsx
+++ b/site/ui/pages/gallery/admin/orders.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminOrdersPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" issueNumber={929} />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="orders">
         <AdminOrdersDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/settings.tsx
+++ b/site/ui/pages/gallery/admin/settings.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminSettingsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" issueNumber={929} />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="settings">
         <AdminSettingsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/shop/cart.tsx
+++ b/site/ui/pages/gallery/shop/cart.tsx
@@ -1,5 +1,5 @@
 import { ShopShell } from '@/components/gallery/shop/shop-shell'
-import { CartDemo } from '@/components/cart-demo'
+import { ShopCartDemo } from '@/components/gallery/shop/cart-demo'
 import { GalleryMeta } from '../admin/gallery-meta'
 
 export function ShopCartPage() {
@@ -7,7 +7,7 @@ export function ShopCartPage() {
     <>
       <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
       <ShopShell currentRoute="cart">
-        <CartDemo />
+        <ShopCartDemo />
       </ShopShell>
     </>
   )

--- a/site/ui/pages/gallery/shop/cart.tsx
+++ b/site/ui/pages/gallery/shop/cart.tsx
@@ -1,0 +1,14 @@
+import { ShopShell } from '@/components/gallery/shop/shop-shell'
+import { CartDemo } from '@/components/cart-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ShopCartPage() {
+  return (
+    <>
+      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <ShopShell currentRoute="cart">
+        <CartDemo />
+      </ShopShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/shop/cart.tsx
+++ b/site/ui/pages/gallery/shop/cart.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCartPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="cart">
         <ShopCartDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/shop/checkout.tsx
+++ b/site/ui/pages/gallery/shop/checkout.tsx
@@ -1,0 +1,14 @@
+import { ShopShell } from '@/components/gallery/shop/shop-shell'
+import { CheckoutDemo } from '@/components/checkout-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ShopCheckoutPage() {
+  return (
+    <>
+      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <ShopShell currentRoute="checkout">
+        <CheckoutDemo />
+      </ShopShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/shop/checkout.tsx
+++ b/site/ui/pages/gallery/shop/checkout.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCheckoutPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="checkout">
         <CheckoutDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/shop/index.tsx
+++ b/site/ui/pages/gallery/shop/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCatalogPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="catalog">
         <ShopCatalogDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/shop/index.tsx
+++ b/site/ui/pages/gallery/shop/index.tsx
@@ -1,0 +1,14 @@
+import { ShopShell } from '@/components/gallery/shop/shop-shell'
+import { ShopCatalogDemo } from '@/components/gallery/shop/catalog-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ShopCatalogPage() {
+  return (
+    <>
+      <GalleryMeta appName="E-Commerce Shop" issueNumber={929} />
+      <ShopShell currentRoute="catalog">
+        <ShopCatalogDemo />
+      </ShopShell>
+    </>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -114,6 +114,9 @@ import { AdminAnalyticsPage } from './pages/gallery/admin/analytics'
 import { AdminOrdersPage } from './pages/gallery/admin/orders'
 import { AdminNotificationsPage } from './pages/gallery/admin/notifications'
 import { AdminSettingsPage } from './pages/gallery/admin/settings'
+import { ShopCatalogPage } from './pages/gallery/shop/index'
+import { ShopCartPage } from './pages/gallery/shop/cart'
+import { ShopCheckoutPage } from './pages/gallery/shop/checkout'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -616,6 +619,19 @@ export function createApp() {
 
   app.get('/gallery/admin/settings', (c) => {
     return c.render(<AdminSettingsPage />)
+  })
+
+  // Gallery — Shop app (Phase 9)
+  app.get('/gallery/shop', (c) => {
+    return c.render(<ShopCatalogPage />)
+  })
+
+  app.get('/gallery/shop/cart', (c) => {
+    return c.render(<ShopCartPage />)
+  })
+
+  app.get('/gallery/shop/checkout', (c) => {
+    return c.render(<ShopCheckoutPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

- Adds `/gallery/shop` E-Commerce Shop gallery, implementing Phase 2 of issue #929 (Gallery Site for Blocks)
- Three interconnected pages sharing a persistent `ShopShell` layout with top navigation
- Cross-page cart count via sessionStorage + custom event (same pattern as admin's unread badge)
- Reuses existing `CartDemo` and `CheckoutDemo` blocks; adapts `ProductCardsDemo` for the gallery

## Pages

| Route | Content | Key compiler tests |
|-------|---------|-------------------|
| `/gallery/shop` | `ShopCatalogDemo` | 3-signal derived memo, dynamic CSS class, inner loops, cart ops |
| `/gallery/shop/cart` | `CartDemo` | Derived state chain: subtotal → discount → tax → total |
| `/gallery/shop/checkout` | `CheckoutDemo` | Multi-branch conditional, composite loop inside conditional (#724) |

## Compiler Bug Found — #968

**Top-level conditional return in `"use client"` component drops the conditional.**

`return count() > 0 ? <span>...</span> : null` compiles to an unconditional `<span>` in SSR — the ternary is ignored. Workaround applied in `ShopCartBadge`: wrap in `<span className="contents">` so the conditional is a child expression rather than the root return, matching the existing `AdminUnreadBadge` pattern.

## New Files

- `site/ui/components/shared/gallery-shop-storage.ts` — sessionStorage read/write helpers
- `site/ui/components/gallery/shop/shop-shell.tsx` — SSR-only top-nav layout shell
- `site/ui/components/gallery/shop/shop-cart-badge.tsx` — "use client" cart count badge
- `site/ui/components/gallery/shop/catalog-demo.tsx` — adapted ProductCardsDemo (writes sessionStorage)
- `site/ui/pages/gallery/shop/{index,cart,checkout}.tsx` — route page components

## Modified Files

- `site/ui/routes.tsx` — 3 new shop routes
- `site/ui/components/shared/nav-data.ts` — "E-Commerce Shop" added to Gallery sidebar section

## Test plan

- [x] `/gallery/shop` renders catalog with 12 products, filters, cart sidebar
- [x] Add to Cart → cart sidebar updates, "Cart N" badge appears in nav header
- [x] Navigate to `/gallery/shop/cart` → cart badge count persists (sessionStorage)
- [x] Navigate to `/gallery/shop/checkout` → 3-step form renders, badge count persists
- [x] Existing E2E tests pass (1308/1310; 2 pre-existing `form-builder` failures unrelated)
- [x] Build succeeds: `bun run build` — all 3 shop components compiled to `dist/components/gallery/shop/`

Closes part of #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)