### PR TITLE
fix(compiler): preserve top-level ternary return in "use client" components (#968)

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -13,6 +13,7 @@ import { fixture as nestedElements } from './nested-elements'
 // Priority 3: Conditionals
 import { fixture as ternary } from './ternary'
 import { fixture as nestedTernary } from './nested-ternary'
+import { fixture as topLevelTernary } from './top-level-ternary'
 import { fixture as logicalAnd } from './logical-and'
 import { fixture as conditionalClass } from './conditional-class'
 import { fixture as ifStatement } from './if-statement'
@@ -66,6 +67,7 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 3: Conditionals
   ternary,
   nestedTernary,
+  topLevelTernary,
   logicalAnd,
   conditionalClass,
   ifStatement,

--- a/packages/adapter-tests/fixtures/top-level-ternary.ts
+++ b/packages/adapter-tests/fixtures/top-level-ternary.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Top-level ternary return (#968).
+ *
+ * Regression fixture: `return cond ? <A/> : null` at the root of a
+ * `"use client"` component previously dropped the conditional — the SSR
+ * template always rendered the truthy branch. The compiler now wraps the
+ * root in a synthetic `<div style="display:contents">` scope anchor and
+ * emits standard `bf-cond-start:sN` / `bf-cond-end:sN` markers for the
+ * null branch.
+ */
+export const fixture = createFixture({
+  id: 'top-level-ternary',
+  description: 'Top-level ternary return preserves conditional (#968)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function TopTernaryDemo() {
+  const [count, setCount] = createSignal(0)
+  return count() > 0 ? <span>{count()}</span> : null
+}
+`,
+  expectedHtml: `
+    <div style="display:contents" bf-s="test"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -29,6 +29,9 @@ describe('CSR Conformance Tests', () => {
     // Static style object is converted at compile time — no runtime needed.
     // Attribute ordering differs between SSR (style first) and CSR injection (bf-s first).
     'style-object-static',
+    // Synthetic scope wrapper has style="display:contents" before bf-s (#968).
+    // Same attribute-ordering divergence as style-object-static/-dynamic.
+    'top-level-ternary',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
+++ b/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
@@ -68,7 +68,8 @@ function extractCondMarkers(html: string): string[] {
 }
 
 // Stateless fixtures have no client JS — skip.
-// if-statement: SSR renders one branch but client JS references markers from all branches.
+// if-statement, top-level-ternary: SSR renders one branch but client JS
+// references markers from all branches.
 const statelessFixtures = new Set([
   'props-static',
   'nested-elements',
@@ -80,6 +81,7 @@ const statelessFixtures = new Set([
   'child-component',
   'static-array-children',
   'if-statement',
+  'top-level-ternary',
 ])
 
 describe('SSR-Hydration Contract', () => {

--- a/packages/jsx/src/__tests__/ir-conditional-return.test.ts
+++ b/packages/jsx/src/__tests__/ir-conditional-return.test.ts
@@ -85,3 +85,81 @@ describe('conditional JSX returns (if-statement)', () => {
     expect(clientJs?.content).toContain('initChild')
   })
 })
+
+describe('top-level ternary return (#968)', () => {
+  // Regression test for #968: previously, a component whose top-level return
+  // was a ternary expression dropped the conditional entirely — the SSR
+  // template always rendered the truthy branch, and the client reconciler
+  // never swapped branches.
+  test('preserves conditional when top-level return is `cond ? <A/> : null`', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function BadgeDemo() {
+        const [count, setCount] = createSignal(0)
+        return count() > 0 ? <span>{count()}</span> : null
+      }
+    `
+
+    const result = compileJSXSync(source, 'BadgeDemo.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+
+    const marked = result.files.find(f => f.type === 'markedTemplate')
+    expect(marked).toBeDefined()
+    // Conditional must survive to the SSR template — both ternary operator
+    // and the cond-start/end comment markers for the falsy branch.
+    expect(marked?.content).toContain('count() > 0 ?')
+    // Synthetic scope wrapper so findScope() has a bf-s anchor for the
+    // comment-only (falsy) branch.
+    expect(marked?.content).toContain('display:contents')
+    expect(marked?.content).toContain('bf-s={__scopeId}')
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Client reconciler must call insert() so the truthy branch appears
+    // only when count() > 0.
+    expect(clientJs?.content).toContain("insert(__scope, 's0', () => count() > 0")
+    expect(clientJs?.content).toContain('bf-cond-start:s0')
+    expect(clientJs?.content).toContain('bf-cond-end:s0')
+  })
+
+  test('preserves conditional when both branches are JSX', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggle() {
+        const [on, setOn] = createSignal(false)
+        return on() ? <span>ON</span> : <span>OFF</span>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs?.content).toContain('insert(__scope')
+    expect(clientJs?.content).toContain('<span bf-c="s0">ON</span>')
+    expect(clientJs?.content).toContain('<span bf-c="s0">OFF</span>')
+  })
+
+  test('handles parenthesized top-level ternary', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Paren() {
+        const [on, setOn] = createSignal(false)
+        return (on() ? <span>A</span> : <span>B</span>)
+      }
+    `
+
+    const result = compileJSXSync(source, 'Paren.tsx', { adapter })
+
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs?.content).toContain("insert(__scope, 's0', () => on()")
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -96,8 +96,14 @@ export interface AnalyzerContext {
   /** Deferred BF043 info; emitted only for stateful components in validateContext() */
   propsDestructuring: PropsDestructuringInfo | null
 
-  // JSX return
-  jsxReturn: ts.JsxElement | ts.JsxFragment | ts.JsxSelfClosingElement | null
+  // JSX return — also allows top-level `cond ? <A/> : <B/>` conditional expressions
+  // so root-level ternaries compile into IRConditional (#968).
+  jsxReturn:
+    | ts.JsxElement
+    | ts.JsxFragment
+    | ts.JsxSelfClosingElement
+    | ts.ConditionalExpression
+    | null
 
   // Conditional returns (if statements with JSX returns)
   conditionalReturns: ConditionalReturn[]

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -538,22 +538,24 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
     return
   }
 
-  // Return statement with JSX
+  // Return statement with JSX (or a top-level ternary, #968)
   if (ts.isReturnStatement(node) && node.expression) {
     if (
       ts.isJsxElement(node.expression) ||
       ts.isJsxFragment(node.expression) ||
-      ts.isJsxSelfClosingElement(node.expression)
+      ts.isJsxSelfClosingElement(node.expression) ||
+      ts.isConditionalExpression(node.expression)
     ) {
       ctx.jsxReturn = node.expression
     }
-    // Handle parenthesized JSX: return ( <div>...</div> )
+    // Handle parenthesized JSX / ternary: return ( <div>...</div> )
     if (ts.isParenthesizedExpression(node.expression)) {
       const inner = node.expression.expression
       if (
         ts.isJsxElement(inner) ||
         ts.isJsxFragment(inner) ||
-        ts.isJsxSelfClosingElement(inner)
+        ts.isJsxSelfClosingElement(inner) ||
+        ts.isConditionalExpression(inner)
       ) {
         ctx.jsxReturn = inner
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -188,6 +188,19 @@ export function jsxToIR(analyzer: AnalyzerContext): IRNode | null {
   if (!analyzer.jsxReturn) return null
 
   const ctx = createTransformContext(analyzer)
+
+  // Top-level ternary return (#968): `return cond ? <A/> : <B/>`.
+  // The ConditionalExpression isn't a JSX node, so transformNode won't
+  // handle it — dispatch directly to transformConditional and wrap in a
+  // synthetic scope element so hydration can locate __scope via bf-s.
+  // The wrapper carries the scope, so clear ctx.isRoot to avoid also
+  // marking the truthy branch's root element as a scope anchor.
+  if (ts.isConditionalExpression(analyzer.jsxReturn)) {
+    ctx.isRoot = false
+    const conditional = transformConditional(analyzer.jsxReturn, ctx)
+    return wrapInScopeElement(conditional)
+  }
+
   const ir = transformNode(analyzer.jsxReturn, ctx)
 
   // Auto-generate scope wrapper for provider-only roots that lack a scope element.
@@ -298,6 +311,14 @@ function transformNode(node: ts.Node, ctx: TransformContext): IRNode | null {
   // Expression: {expr}
   if (ts.isJsxExpression(node)) {
     return transformExpression(node, ctx)
+  }
+
+  // Top-level ternary return: `return cond ? <A/> : <B/>` (#968).
+  // Used when reached via `transformNode(analyzer.jsxReturn, ...)` from
+  // buildIfStatementChain. jsxToIR's main path handles the scope wrapper
+  // and calls transformConditional directly.
+  if (ts.isConditionalExpression(node)) {
+    return transformConditional(node, ctx)
   }
 
   return null


### PR DESCRIPTION
## Summary
- Compiler dropped the conditional when a `"use client"` component's top-level return was a ternary (`return cond ? <A/> : null`) — SSR always rendered the truthy branch and the client reconciler never swapped. Fixes #968.
- Root cause: the analyzer only recognized JSX element / fragment nodes as `jsxReturn`, so a `ConditionalExpression` return was ignored and the tree walk later latched onto the truthy branch's JSX, silently replacing the conditional with one of its branches.
- Fix widens `jsxReturn` to accept `ts.ConditionalExpression`, dispatches the top-level case to the existing `transformConditional`, and wraps the resulting `IRConditional` in a synthetic `<div style="display:contents">` scope anchor so hydration can locate `__scope` via `bf-s`.

## Changes
**`packages/jsx/src/`**
- `analyzer-context.ts`: widen `jsxReturn` type to include `ts.ConditionalExpression`.
- `analyzer.ts`: recognize `ConditionalExpression` (and parenthesized form) as a valid top-level return.
- `jsx-to-ir.ts`: dispatch to `transformConditional` + `wrapInScopeElement` in `jsxToIR`; clear `ctx.isRoot` first to avoid double-anchoring the truthy branch's root element. Add a safety branch in `transformNode` for the if-chain path.

**Tests**
- `packages/jsx/src/__tests__/ir-conditional-return.test.ts`: 3 new regression tests (ternary with null falsy branch / both JSX branches / parenthesized).
- `packages/adapter-tests/fixtures/top-level-ternary.ts`: new adapter conformance fixture. Added to CSR skip list (attribute-order divergence — same reason as `style-object-static/-dynamic`) and to the SSR-hydration contract skip list (SSR renders only one branch but client JS references markers from both — same as `if-statement`).

## Compiled output (before → after)
**Before** — conditional dropped, `<span>` always rendered:
```tsx
<span bf-s={__scopeId} bf="s1">{bfText("s0")}{count()}{bfTextEnd()}</span>
```
**After** — conditional preserved with cond-markers for the null branch:
```tsx
<div style="display:contents" bf-s={__scopeId}>
  {count() > 0
    ? <span bf-c="s0" bf="s2">{bfText("s1")}{count()}{bfTextEnd()}</span>
    : <>{bfComment("cond-start:s0")}{bfComment("cond-end:s0")}</>}
</div>
```
Client JS now emits a proper `insert(__scope, 's0', () => count() > 0, { ... }, { ... })` reconciler.

The `ShopCartBadge` workaround (`<span className="contents">` wrapper mentioned in the issue) is no longer required, though the existing component is left as-is in this PR.

## Test plan
- [x] `bun test packages/jsx` — 709 pass (3 new)
- [x] `bun test packages/adapter-tests` — 179 pass (+1 fixture)
- [x] `bun test packages/jsx packages/adapter-tests packages/dom packages/hono packages/go-template packages/client packages/cli` — 1540 pass, 0 fail
- [x] `bun run build` in `packages/jsx` — clean
- [ ] CI green