### PR TITLE
feat(build): add bunBuild config to bundle plain TS entries with esbuild

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -315,7 +315,7 @@ describe('processExternals', () => {
   test('returns false and emits nothing when externals is empty', async () => {
     const outDir = makeTmpDir()
     try {
-      const changed = await processExternals(makeConfig(outDir, outDir), 'components', outDir)
+      const { changed } = await processExternals(makeConfig(outDir, outDir), 'components', outDir)
       expect(changed).toBe(false)
       expect(require('fs').existsSync(resolve(outDir, 'barefoot-externals.json'))).toBe(false)
     } finally {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,7 +1,7 @@
 // Core build module: shared pipeline for `barefoot build`.
 
 import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
-import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BunBundleEntry } from '@barefootjs/jsx'
+import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry } from '@barefootjs/jsx'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { resolve, basename, relative, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -49,7 +49,7 @@ export interface BuildConfig {
   /** URL base path for vendor chunks in the emitted importmap (default: /<runtimeSubdir>/) */
   externalsBasePath?: string
   /** Additional entry points to bundle with esbuild, with config.externals auto-applied */
-  bunBuild?: BunBundleEntry[]
+  bundleEntries?: BundleEntry[]
 }
 
 export interface BuildResult {
@@ -146,7 +146,7 @@ export function generateHash(content: string): string {
  */
 export function resolveBuildConfigFromTs(
   projectDir: string,
-  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bunBuild?: BunBundleEntry[] },
+  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bundleEntries?: BundleEntry[] },
   overrides?: { minify?: boolean }
 ): BuildConfig {
   const componentDirs = (tsConfig.components ?? ['components']).map(
@@ -167,7 +167,7 @@ export function resolveBuildConfigFromTs(
     postBuild: tsConfig.postBuild,
     externals: tsConfig.externals,
     externalsBasePath: tsConfig.externalsBasePath,
-    bunBuild: tsConfig.bunBuild?.map(e => ({
+    bundleEntries: tsConfig.bundleEntries?.map(e => ({
       entry: resolve(projectDir, e.entry),
       outfile: e.outfile,
       externals: e.externals,
@@ -310,7 +310,7 @@ export async function build(
   const { changed: externalsChanged, allExternals } = await processExternals(config, runtimeSubdir, runtimeOutDir)
   if (externalsChanged) anyOutputChanged = true
 
-  // 1c. bunBuild entries — bundle with esbuild using auto-applied externals
+  // 1c. bundleEntries entries — bundle with esbuild using auto-applied externals
   if (await processBunBuild(config, clientJsOutDir, clientJsSubdir, allExternals)) {
     anyOutputChanged = true
   }
@@ -770,7 +770,7 @@ export async function processExternals(
 }
 
 /**
- * Bundle entries listed in `config.bunBuild` directly with esbuild.
+ * Bundle entries listed in `config.bundleEntries` directly with esbuild.
  * Each entry is compiled as an ESM bundle with all externals from
  * `config.externals` (plus any per-entry overrides) excluded from the bundle.
  */
@@ -780,10 +780,10 @@ async function processBunBuild(
   clientJsSubdir: string,
   allExternals: string[],
 ): Promise<boolean> {
-  if (!config.bunBuild || config.bunBuild.length === 0) return false
+  if (!config.bundleEntries || config.bundleEntries.length === 0) return false
 
   let anyChanged = false
-  for (const entry of config.bunBuild) {
+  for (const entry of config.bundleEntries) {
     const entryExternals = [...allExternals, ...(entry.externals ?? [])]
     const outfilePath = resolve(clientJsOutDir, entry.outfile)
     await esbuildBuild({

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,7 +1,7 @@
 // Core build module: shared pipeline for `barefoot build`.
 
 import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
-import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec } from '@barefootjs/jsx'
+import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BunBundleEntry } from '@barefootjs/jsx'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { resolve, basename, relative, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -48,6 +48,8 @@ export interface BuildConfig {
   externals?: Record<string, ExternalSpec>
   /** URL base path for vendor chunks in the emitted importmap (default: /<runtimeSubdir>/) */
   externalsBasePath?: string
+  /** Additional entry points to bundle with esbuild, with config.externals auto-applied */
+  bunBuild?: BunBundleEntry[]
 }
 
 export interface BuildResult {
@@ -144,7 +146,7 @@ export function generateHash(content: string): string {
  */
 export function resolveBuildConfigFromTs(
   projectDir: string,
-  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string },
+  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bunBuild?: BunBundleEntry[] },
   overrides?: { minify?: boolean }
 ): BuildConfig {
   const componentDirs = (tsConfig.components ?? ['components']).map(
@@ -165,6 +167,11 @@ export function resolveBuildConfigFromTs(
     postBuild: tsConfig.postBuild,
     externals: tsConfig.externals,
     externalsBasePath: tsConfig.externalsBasePath,
+    bunBuild: tsConfig.bunBuild?.map(e => ({
+      entry: resolve(projectDir, e.entry),
+      outfile: e.outfile,
+      externals: e.externals,
+    })),
   }
 }
 
@@ -300,7 +307,11 @@ export async function build(
   }
 
   // 1b. Externals — copy vendor chunks, emit importmap + barefoot-externals.json
-  if (await processExternals(config, runtimeSubdir, runtimeOutDir)) {
+  const { changed: externalsChanged, allExternals } = await processExternals(config, runtimeSubdir, runtimeOutDir)
+  if (externalsChanged) anyOutputChanged = true
+
+  // 1c. bunBuild entries — bundle with esbuild using auto-applied externals
+  if (await processBunBuild(config, clientJsOutDir, clientJsSubdir, allExternals)) {
     anyOutputChanged = true
   }
 
@@ -651,13 +662,14 @@ export interface ExternalsManifest {
 /**
  * Process the `externals` config: copy vendor chunks to outDir, build the
  * importmap JSON, and write `barefoot-externals.json`.
+ * Returns whether any output file changed and the full list of external package names.
  */
 export async function processExternals(
   config: BuildConfig,
   runtimeSubdir: string,
   runtimeOutDir: string,
-): Promise<boolean> {
-  if (!config.externals || Object.keys(config.externals).length === 0) return false
+): Promise<{ changed: boolean; allExternals: string[] }> {
+  if (!config.externals || Object.keys(config.externals).length === 0) return { changed: false, allExternals: [] }
 
   const basePath = config.externalsBasePath ?? `/${runtimeSubdir}/`
   const base = basePath.endsWith('/') ? basePath : basePath + '/'
@@ -754,6 +766,37 @@ export async function processExternals(
     console.log('Generated: barefoot-externals.json')
   }
 
+  return { changed: anyChanged, allExternals }
+}
+
+/**
+ * Bundle entries listed in `config.bunBuild` directly with esbuild.
+ * Each entry is compiled as an ESM bundle with all externals from
+ * `config.externals` (plus any per-entry overrides) excluded from the bundle.
+ */
+async function processBunBuild(
+  config: BuildConfig,
+  clientJsOutDir: string,
+  clientJsSubdir: string,
+  allExternals: string[],
+): Promise<boolean> {
+  if (!config.bunBuild || config.bunBuild.length === 0) return false
+
+  let anyChanged = false
+  for (const entry of config.bunBuild) {
+    const entryExternals = [...allExternals, ...(entry.externals ?? [])]
+    const outfilePath = resolve(clientJsOutDir, entry.outfile)
+    await esbuildBuild({
+      entryPoints: [entry.entry],
+      outfile: outfilePath,
+      format: 'esm',
+      bundle: true,
+      minify: config.minify,
+      external: entryExternals,
+    })
+    anyChanged = true
+    console.log(`Generated (bun-build): ${clientJsSubdir}/${entry.outfile}`)
+  }
   return anyChanged
 }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -116,7 +116,7 @@ export type ExternalSpec =
  * Use this for modules that are not barefoot components (e.g. plain TS entry
  * points that import external vendor packages).
  */
-export interface BunBundleEntry {
+export interface BundleEntry {
   /** Entry file path relative to the config file */
   entry: string
   /** Output filename placed in the client JS output directory */
@@ -161,7 +161,7 @@ export interface BuildOptions {
    * init entry points) that import vendor packages listed in `externals`.
    * Each entry is bundled as ESM with all `externals` automatically excluded.
    */
-  bunBuild?: BunBundleEntry[]
+  bundleEntries?: BundleEntry[]
 }
 
 // CSS Layer Prefixer

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -110,6 +110,21 @@ export type ExternalSpec =
   | { chunk?: true; preload?: boolean; rebundle?: boolean }
   | { url: string; preload?: boolean }
 
+/**
+ * An entry point to bundle directly with esbuild.
+ * Externals declared in `BuildOptions.externals` are applied automatically.
+ * Use this for modules that are not barefoot components (e.g. plain TS entry
+ * points that import external vendor packages).
+ */
+export interface BunBundleEntry {
+  /** Entry file path relative to the config file */
+  entry: string
+  /** Output filename placed in the client JS output directory */
+  outfile: string
+  /** Additional packages to mark as external beyond those in `externals` */
+  externals?: string[]
+}
+
 export interface BuildOptions {
   /** Source component directories relative to config file */
   components?: string[]
@@ -140,6 +155,13 @@ export interface BuildOptions {
    * Defaults to `/<runtimeSubdir>/` (e.g., `/static/components/`).
    */
   externalsBasePath?: string
+  /**
+   * Additional entry points to bundle with esbuild directly, bypassing the
+   * barefoot component compiler. Useful for plain TS/TSX modules (e.g. canvas
+   * init entry points) that import vendor packages listed in `externals`.
+   * Each entry is bundled as ESM with all `externals` automatically excluded.
+   */
+  bunBuild?: BunBundleEntry[]
 }
 
 // CSS Layer Prefixer


### PR DESCRIPTION
## Problem

When a project contains entry points that are **not** barefoot components — for example, a canvas initializer module that transitively imports vendor packages like `yjs` or `@barefootjs/xyflow` — `barefoot build` skips them (the barefoot compiler produces no output for plain TS modules). Users currently have to hand-craft a separate `bun build ... --external ...` invocation after `barefoot build`, reading the external list from `barefoot-externals.json` themselves:

```bash
# current workaround in package.json scripts
EXTERNALS=$(bun -e "const m=require('./dist/static/barefoot-externals.json'); \
  process.stdout.write(m.externals.map(e=>'--external '+e).join(' '))")
bun build worker/components/canvas/DeskCanvas.tsx \
  --outdir dist/static/components --format esm \
  --outfile DeskCanvas.client.js --minify $EXTERNALS
```

## Solution

Add a `bunBuild` option to `BuildOptions` / `BuildConfig`.  Each entry is bundled by esbuild directly (ESM, `bundle: true`) with all packages from `config.externals` automatically excluded — no manual `--external` flags needed.

```ts
// barefoot.config.ts
export default createConfig({
  components: ['worker/components'],
  outDir: 'dist/static',
  externals: {
    '@barefootjs/xyflow': { preload: true },
    yjs: { preload: true, rebundle: true },
  },
  bunBuild: [
    {
      entry: 'worker/components/canvas/DeskCanvas.tsx',
      outfile: 'DeskCanvas.client.js',
      // externals from config.externals applied automatically
    },
  ],
})
```

## Changes

- **`packages/jsx/src/index.ts`**: new `BunBundleEntry` interface + `bunBuild` field on `BuildOptions`
- **`packages/cli/src/lib/build.ts`**:
  - `BunBundleEntry` imported and added to `BuildConfig`
  - `resolveBuildConfigFromTs` maps relative `entry` paths to absolute
  - `processExternals` return type extended to `{ changed: boolean; allExternals: string[] }` so callers don't have to re-derive the list
  - New `processBunBuild()` helper (step 1c in `build()`) runs esbuild with the derived external list

## Minimal reproduction

```ts
// barefoot.config.ts
export default createConfig({
  components: ['src/components'],
  outDir: 'dist',
  externals: { yjs: { preload: true } },
  bunBuild: [
    { entry: 'src/canvas.ts', outfile: 'canvas.client.js' },
  ],
})
```

```ts
// src/canvas.ts  — NOT a barefoot component, uses yjs directly
import * as Y from 'yjs'
export function initCanvas(el: HTMLElement) {
  const doc = new Y.Doc()
  // ...
}
```

Before this PR: `barefoot build` silently skips `canvas.ts`; users must run a separate `bun build` command.  
After this PR: `barefoot build` bundles `canvas.ts` → `dist/components/canvas.client.js` with `yjs` excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)