### PR TITLE
refactor(compiler): route transformExpression through transformJsxExpression core (#971)

### DIFF
--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -814,62 +814,16 @@ function transformExpression(
   checkBareSignalOrMemoIdentifier(expr, ctx)
 
   // Check for @client directive in prefix style: {/* @client */ expr}
-  // getFullText() includes leading trivia (comments, whitespace)
+  // getFullText() includes leading trivia (comments, whitespace). This is a
+  // JsxExpression-level concern — the core dispatcher never sees the comment —
+  // so detection and post-processing stay in the wrapper.
   const fullText = node.getFullText(ctx.sourceFile)
   const isClientOnly = fullText.includes('@client')
 
-  // Ternary expression: {cond ? a : b}
-  if (ts.isConditionalExpression(expr)) {
-    const result = transformConditional(expr, ctx)
-    if (isClientOnly) {
-      result.clientOnly = true
-      // Ensure slotId is assigned for client-only expressions
-      if (!result.slotId) {
-        result.slotId = generateSlotId(ctx)
-      }
-    }
-    return result
-  }
-
-  // Logical AND: {cond && <Component />}
-  if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-    const result = transformLogicalAnd(expr, ctx)
-    if (isClientOnly) {
-      result.clientOnly = true
-      if (!result.slotId) {
-        result.slotId = generateSlotId(ctx)
-      }
-    }
-    return result
-  }
-
-  // Nullish coalescing / logical OR with JSX: {children ?? <Icon />}, {label || <Fallback />}
-  if (
-    ts.isBinaryExpression(expr) &&
-    (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
-      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) &&
-    containsJsxInExpression(expr.right)
-  ) {
-    const result = transformNullishCoalescing(expr, ctx)
-    if (isClientOnly) {
-      result.clientOnly = true
-      if (!result.slotId) {
-        result.slotId = generateSlotId(ctx)
-      }
-    }
-    return result
-  }
-
-  // Array map: {items.map(item => <li>{item}</li>)}
-  if (ts.isCallExpression(expr) && isMapCall(expr)) {
-    const mapResult = transformMapCall(expr, ctx, isClientOnly)
-    if (mapResult) {
-      return mapResult
-    }
-    // Callback body is not JSX (e.g., function call). Fall through to expression handling.
-  }
-
-  // Inline JSX constants at the IR level (#547)
+  // #547: Inline a JSX constant referenced by identifier. Unique to JSX-child
+  // position — conditional branches and return position don't resolve
+  // Identifier to JSX. Keep outside the core so the core's Identifier case
+  // stays classified as Scalar leaf per spec Appendix A.
   if (ts.isIdentifier(expr)) {
     const jsxNode = ctx.analyzer.jsxConstants.get(expr.text)
     if (jsxNode) {
@@ -877,18 +831,27 @@ function transformExpression(
     }
   }
 
-  // Inline JSX function calls at the IR level (#569)
-  if (ts.isCallExpression(expr)) {
-    const callee = expr.expression
-    if (ts.isIdentifier(callee)) {
-      const jsxFunc = ctx.analyzer.jsxFunctions.get(callee.text)
-      if (jsxFunc) {
-        return transformJsxFunctionCall(expr, jsxFunc, ctx, isClientOnly)
+  // Delegate all other JSX-structural dispatch to the shared core (#971).
+  // The core handles ConditionalExpression / BinaryExpression (`&&`, `||`,
+  // `??` with JSX right) / CallExpression (`.map`, inline JSX helper), plus
+  // Transparent unwrapping and Scalar-leaf → null.
+  const ir = transformJsxExpression(expr, ctx, isClientOnly)
+  if (ir !== null) {
+    // The pre-refactor behaviour only applied clientOnly/slotId post-processing
+    // to IRConditional results (from the ternary / `&&` / `||` / `??` paths).
+    // IRLoop handles `isClientOnly` internally via `transformMapCall`; other
+    // shapes (IRElement / IRFragment / IRLoop / IRComponent from inline JSX
+    // helpers) are unchanged. Mirror that exactly here.
+    if (isClientOnly && ir.type === 'conditional') {
+      ir.clientOnly = true
+      if (!ir.slotId) {
+        ir.slotId = generateSlotId(ctx)
       }
     }
+    return ir
   }
 
-  // Regular expression
+  // Scalar fallback — unchanged from pre-refactor.
   const exprText = ctx.getJS(expr)
   const reactive = isReactiveExpression(exprText, ctx, expr)
   // @client expressions always need slotId and are treated as reactive for client-side evaluation
@@ -1219,6 +1182,7 @@ function assertNever(expr: never): never {
 function transformJsxExpression(
   expr: ts.Expression,
   ctx: TransformContext,
+  isClientOnly = false,
 ): IRNode | null {
   const node: JsxEmbeddableExpression = expr as JsxEmbeddableExpression
   switch (node.kind) {
@@ -1229,7 +1193,7 @@ function transformJsxExpression(
     case ts.SyntaxKind.NonNullExpression:
     case ts.SyntaxKind.TypeAssertionExpression:
     case ts.SyntaxKind.PartiallyEmittedExpression:
-      return transformJsxExpression(node.expression, ctx)
+      return transformJsxExpression(node.expression, ctx, isClientOnly)
 
     // --- JSX-structural: delegate to shape transformer ---
     case ts.SyntaxKind.JsxElement:
@@ -1257,14 +1221,17 @@ function transformJsxExpression(
     }
     case ts.SyntaxKind.CallExpression: {
       if (isMapCall(node)) {
-        const mapResult = transformMapCall(node, ctx)
+        // `isClientOnly` gates sort/filter extraction inside transformMapCall
+        // (client-only loops keep the map callback verbatim). Thread through
+        // so JSX-child position preserves pre-refactor behaviour.
+        const mapResult = transformMapCall(node, ctx, isClientOnly)
         if (mapResult) return mapResult
       }
       const callee = node.expression
       if (ts.isIdentifier(callee)) {
         const jsxFunc = ctx.analyzer.jsxFunctions.get(callee.text)
         if (jsxFunc) {
-          return transformJsxFunctionCall(node, jsxFunc, ctx, false)
+          return transformJsxFunctionCall(node, jsxFunc, ctx, isClientOnly)
         }
       }
       return null


### PR DESCRIPTION
## Summary

PR 4 in the #971 series. Migrates the second caller — `transformExpression`, the JSX-child `{expr}` dispatcher — through the exhaustive `transformJsxExpression` core introduced in #976. Pure refactor, −33 net lines, 1616 pass / 0 fail unchanged from the post-#976 baseline.

## What moved into the core vs. stayed in the wrapper

The wrapper (`transformExpression`) keeps every concern unique to JSX-child position:

| Concern | Location | Why it stays outside the core |
|---|---|---|
| **BF044** bare signal/memo identifier check | Wrapper | Diagnostic side-effect on the inner expression; runs regardless of dispatch outcome. |
| **`@client` directive detection** via `node.getFullText()` | Wrapper | The comment is leading trivia on `ts.JsxExpression`, not on the inner `ts.Expression`. The core receives only the unwrapped expression and cannot see the comment. |
| **#547** `Identifier` → registered `jsxConstants` → inline JSX | Wrapper | The spec's Appendix A classifies `Identifier` as Scalar leaf. Resolving it to JSX is specific to JSX-child position; introducing it in the core would be a semantics change for conditional-branch and (future) return-position callers. |
| **IRConditional post-processing** — `clientOnly=true` + slotId assignment | Wrapper | Pre-refactor only applied for ConditionalExpression / LogicalAnd / NullishCoalescing results. `.map` handles `isClientOnly` internally inside `transformMapCall`; other shapes (IRElement, IRFragment, inline JSX helper IRComponent) got no post-processing. The wrapper preserves this by gating on `ir.type === 'conditional'`. |
| **Scalar fallback** with reactive detection, loop-param references, wrap-by-default slot allocation | Wrapper | Position-specific: scalar expressions in JSX-child position need slotId for fine-grained effects that target text content. |

What moved into the core:

| Kind | Core dispatch | Note |
|---|---|---|
| `ConditionalExpression` | `transformConditional` | unchanged |
| `BinaryExpression(\&\&)` | `transformLogicalAnd` | unchanged |
| `BinaryExpression(\|\|/??)` + JSX right | `transformNullishCoalescing` | unchanged |
| `CallExpression(.map)` | `transformMapCall(node, ctx, isClientOnly)` | `isClientOnly` now threaded into the core |
| `CallExpression(inline JSX helper)` | `transformJsxFunctionCall(node, jsxFunc, ctx, isClientOnly)` | `isClientOnly` threaded (helper currently ignores it) |

## Core signature change

`transformJsxExpression(expr, ctx)` → `transformJsxExpression(expr, ctx, isClientOnly = false)`. Optional third parameter, default `false`. `transformConditionalBranch` (the #976 caller) continues to use the default — identical behaviour. `transformExpression` passes the `@client`-detected value so `transformMapCall`'s sort/filter-extraction gate still fires at JSX-child position.

## Scope guardrails respected

- **No semantics change**: conformance fixtures (including `logical-and`, `nullish-coalescing-text`, `nullish-coalescing-jsx`, `logical-or-jsx`, `branch-map`, `map-*`, `ternary`, `nested-ternary`) render the same HTML as pre-refactor.
- **No new BF codes**: BF050 / BF051 stay reserved for PR 5.
- **No change to return-position dispatch**: PR 5 migrates `analyzer.jsxReturn` + `jsxToIR` and deletes the `visitComponentBody` recursion fallback. Return-position gap fixtures (\`return a \&\& <A/>\`, \`return items.map(...)\`) land there with the fix.
- **No touch to the exhaustiveness infrastructure**: the `JsxEmbeddableExpression` union, `assertNever`, and the switch body are identical to #976.

## Test plan

- [x] \`cd packages/jsx && bun run build\` — clean (tsgo passes).
- [x] \`bun test packages/jsx packages/adapter-tests\` — clean.
- [x] \`bun test packages/jsx packages/adapter-tests packages/dom packages/hono packages/go-template packages/client packages/cli packages/mojolicious\` — **1616 pass, 0 fail**. Same as post-#976 baseline.
- [ ] CI passes on the same scope.

## Next in the #971 series

- **PR 5** — widen \`AnalyzerContext.jsxReturn\` to \`ts.Expression | null\`, route \`jsxToIR\` through the core, delete the `visitComponentBody` recursion fallback. The four P1 gap cells (return-position BinaryExpression + CallExpression) get their fixtures and become green.
- **PR 6** — CI-enforced type-level exhaustiveness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)