### PR TITLE
refactor(compiler): widen jsxReturn to ts.Expression, remove recursion discriminator (#971)

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -44,6 +44,10 @@ import { fixture as nullishCoalescingJsx } from './nullish-coalescing-jsx'
 import { fixture as logicalOrJsx } from './logical-or-jsx'
 import { fixture as branchSelfClosing } from './branch-self-closing'
 import { fixture as branchMap } from './branch-map'
+import { fixture as returnLogicalAnd } from './return-logical-and'
+import { fixture as returnLogicalOr } from './return-logical-or'
+import { fixture as returnNullishCoalescing } from './return-nullish-coalescing'
+import { fixture as returnMap } from './return-map'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
 import { fixture as multipleInstances } from './multiple-instances'
@@ -102,6 +106,10 @@ export const jsxFixtures: JSXFixture[] = [
   logicalOrJsx,
   branchSelfClosing,
   branchMap,
+  returnLogicalAnd,
+  returnLogicalOr,
+  returnNullishCoalescing,
+  returnMap,
   // Priority 7: Multi-file composition
   childComponent,
   multipleInstances,

--- a/packages/adapter-tests/fixtures/return-logical-and.ts
+++ b/packages/adapter-tests/fixtures/return-logical-and.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Top-level `return cond && <span/>` — BinaryExpression with `&&` at return
+ * root. Pre-refactor (before #971 PR 5) the analyzer's recursion-fallback
+ * silently picked the JSX on the right and dropped the `&&`, rendering
+ * `<span>Shown</span>` unconditionally. The dispatcher unification gives
+ * the same semantics as `{cond && <span/>}` in JSX-child position: an
+ * `IRConditional` wrapped in a synthetic `<div style="display:contents">`
+ * scope anchor. Initial SSR render takes the falsy branch so only the
+ * comment markers appear.
+ */
+export const fixture = createFixture({
+  id: 'return-logical-and',
+  description: 'Top-level return of logical AND renders conditional, not the JSX unconditionally',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReturnLogicalAnd() {
+  const [show, setShow] = createSignal(false)
+  return show() && <span>Shown</span>
+}
+`,
+  expectedHtml: `
+    <div style="display:contents" bf-s="test"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/return-logical-or.ts
+++ b/packages/adapter-tests/fixtures/return-logical-or.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Top-level `return prop || <Fallback/>` — BinaryExpression with `||` at
+ * return root, JSX on the right. Pairs with `return-nullish-coalescing`
+ * and `return-logical-and` to cover all three operator-gated forms at
+ * return position. Mirrors JSX-child `logical-or-jsx` semantics: an
+ * `IRConditional` wrapped in a synthetic scope anchor. With the default
+ * props (no `label`), SSR takes the falsy branch and renders the
+ * `<span>Fallback</span>` through the `bf-c` marker.
+ */
+export const fixture = createFixture({
+  id: 'return-logical-or',
+  description: 'Top-level return of logical OR with JSX fallback',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReturnLogicalOr(props: { label?: string }) {
+  const [count, setCount] = createSignal(0)
+  return props.label || <span>Fallback</span>
+}
+`,
+  props: {},
+  expectedHtml: `
+    <div style="display:contents" bf-s="test"><span bf-c="s0">Fallback</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/return-map.ts
+++ b/packages/adapter-tests/fixtures/return-map.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Top-level `return items().map(n => <li/>)` — CallExpression at return
+ * root. Pre-refactor the analyzer's recursion-fallback *skipped* the
+ * map callback's arrow-function body (it explicitly does not recurse
+ * into function bodies), so `jsxReturn` stayed unset and compilation
+ * failed with "No marked template in compile output". The dispatcher
+ * unification routes the CallExpression through `transformMapCall` the
+ * same way JSX-child position does, producing an `IRLoop` wrapped in a
+ * synthetic scope anchor.
+ */
+export const fixture = createFixture({
+  id: 'return-map',
+  description: 'Top-level return of .map produces a loop instead of failing to compile',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReturnMap() {
+  const [items, setItems] = createSignal<string[]>(['a', 'b'])
+  return items().map(n => <li key={n}>{n}</li>)
+}
+`,
+  expectedHtml: `
+    <div style="display:contents" bf-s="test"><li data-key="a"><!--bf:s0-->a<!--/--></li><li data-key="b"><!--bf:s0-->b<!--/--></li></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/return-map.ts
+++ b/packages/adapter-tests/fixtures/return-map.ts
@@ -22,6 +22,9 @@ export function ReturnMap() {
 }
 `,
   expectedHtml: `
-    <div style="display:contents" bf-s="test"><li data-key="a"><!--bf:s0-->a<!--/--></li><li data-key="b"><!--bf:s0-->b<!--/--></li></div>
+    <div style="display:contents" bf-s="test">
+      <li data-key="a"><!--bf:s0-->a<!--/--></li>
+      <li data-key="b"><!--bf:s0-->b<!--/--></li>
+    </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/return-nullish-coalescing.ts
+++ b/packages/adapter-tests/fixtures/return-nullish-coalescing.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Top-level `return prop ?? <Default/>` — BinaryExpression with `??` at
+ * return root, JSX on the right. Mirror of `nullish-coalescing-jsx` but
+ * at return position. Pre-refactor the analyzer's recursion-fallback
+ * silently registered the `<span>Default</span>` as `jsxReturn`, dropping
+ * the `??` and the left operand — identical failure mode to #968.
+ */
+export const fixture = createFixture({
+  id: 'return-nullish-coalescing',
+  description: 'Top-level return of nullish coalescing with JSX default',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ReturnNullishCoalescing(props: { banner?: any }) {
+  const [count, setCount] = createSignal(0)
+  return props.banner ?? <span>Default</span>
+}
+`,
+  props: {},
+  expectedHtml: `
+    <div style="display:contents" bf-s="test"><span bf-c="s0">Default</span></div>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -32,6 +32,12 @@ describe('CSR Conformance Tests', () => {
     // Synthetic scope wrapper has style="display:contents" before bf-s (#968).
     // Same attribute-ordering divergence as style-object-static/-dynamic.
     'top-level-ternary',
+    // Same synthetic-wrapper attribute-order divergence as top-level-ternary
+    // (#971 PR 5 uses the identical wrapper for non-JSX-direct returns).
+    'return-logical-and',
+    'return-logical-or',
+    'return-nullish-coalescing',
+    'return-map',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/go-template/src/__tests__/go-template-adapter.test.ts
@@ -35,6 +35,13 @@ runJSXConformanceTests({
     'style-object-dynamic',
     'branch-self-closing',
     'nullish-coalescing-jsx',
+    // Same conditional-marker / data-key divergences at return position.
+    // `return-nullish-coalescing` hits the same `bf-c` vs comment-marker
+    // split as `nullish-coalescing-jsx`. `return-map` uses the
+    // `data-key` serialisation that differs between Hono (runtime helper)
+    // and Go (template variable).
+    'return-nullish-coalescing',
+    'return-map',
   ],
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {

--- a/packages/jsx/src/__tests__/ir-conditional-return.test.ts
+++ b/packages/jsx/src/__tests__/ir-conditional-return.test.ts
@@ -163,3 +163,94 @@ describe('top-level ternary return (#968)', () => {
     expect(clientJs?.content).toContain("insert(__scope, 's0', () => on()")
   })
 })
+
+describe('return-position dispatcher unification (#971)', () => {
+  // The #968 ConditionalExpression special-case and the #971 PR 5 refactor
+  // converge on the same behaviour: the analyzer captures the whole return
+  // expression (any `ts.Expression`) and the Phase 1 dispatcher core decides
+  // how to lower it. These tests verify that the refactor eliminates the
+  // last silent-drop classes — top-level `&&`, `||`, `??` with JSX, and
+  // `.map` returning JSX — all of which previously tripped the
+  // recursion-as-discriminator fallback in `visitComponentBody`.
+
+  test('top-level `return cond && <span/>` renders a conditional, not the JSX unconditionally', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Guard() {
+        const [show, setShow] = createSignal(false)
+        return show() && <span>Shown</span>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Guard.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const marked = result.files.find(f => f.type === 'markedTemplate')
+    // Synthetic scope wrapper provides the bf-s anchor; the conditional
+    // itself is emitted in the template as `{cond ? <A/> : null}` —
+    // transformLogicalAnd lowers `&&` into an IRConditional with whenFalse=null.
+    // If the analyzer were still silently picking the JSX on the right,
+    // the template would contain a bare `<span>Shown</span>` root with no
+    // ternary — that was the pre-refactor #968-class failure mode.
+    expect(marked?.content).toContain('display:contents')
+    expect(marked?.content).toContain('show() ?')
+    expect(marked?.content).toContain('<span>Shown</span>')
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs?.content).toContain("insert(__scope, 's0', () => show()")
+  })
+
+  test('top-level `return prop ?? <Default/>` renders the JSX through a conditional', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Banner(props: { label?: string }) {
+        const [count, setCount] = createSignal(0)
+        return props.label ?? <span>Default</span>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Banner.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const marked = result.files.find(f => f.type === 'markedTemplate')
+    expect(marked?.content).toContain('display:contents')
+    // ?? desugars to `left != null`; the conditional reconciler must see
+    // the left operand's value — not silently render the fallback.
+    expect(marked?.content).toContain('!= null')
+  })
+
+  test('top-level `return items().map(n => <li/>)` compiles to a loop instead of failing', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function List() {
+        const [items, setItems] = createSignal<string[]>(['a'])
+        return items().map(n => <li key={n}>{n}</li>)
+      }
+    `
+
+    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    // Pre-refactor this threw "No marked template in compile output" because
+    // the analyzer's recursion-fallback explicitly skips function bodies, so
+    // `jsxReturn` never saw the `<li/>` inside the map callback. The
+    // dispatcher unification handles it the same way `.map` is handled in
+    // JSX-child position (#783).
+    expect(result.errors).toHaveLength(0)
+
+    const marked = result.files.find(f => f.type === 'markedTemplate')
+    expect(marked).toBeDefined()
+    expect(marked?.content).toContain('display:contents')
+    // The `.map` call survives to the template inside the synthetic wrapper —
+    // if the analyzer were still silently walking into the callback and
+    // picking up the `<li/>`, the template would contain a bare `<li/>`
+    // root with no map. Same IRLoop emission path as `map-basic` at
+    // JSX-child position (#783).
+    expect(marked?.content).toContain('items().map')
+    expect(marked?.content).toContain('<li key=')
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -96,14 +96,16 @@ export interface AnalyzerContext {
   /** Deferred BF043 info; emitted only for stateful components in validateContext() */
   propsDestructuring: PropsDestructuringInfo | null
 
-  // JSX return — also allows top-level `cond ? <A/> : <B/>` conditional expressions
-  // so root-level ternaries compile into IRConditional (#968).
-  jsxReturn:
-    | ts.JsxElement
-    | ts.JsxFragment
-    | ts.JsxSelfClosingElement
-    | ts.ConditionalExpression
-    | null
+  // JSX return — widened to any `ts.Expression` so the Phase 1 dispatcher
+  // core (`transformJsxExpression`) is the single source of truth for
+  // what a component can return. Non-JSX-structural returns (plain scalar
+  // values, forbidden kinds, unrecognized shapes) route through the same
+  // dispatcher and produce `null`, which `jsxToIR` treats as "no IR" —
+  // same as pre-refactor. The recursion-as-discriminator capture path in
+  // `visitComponentBody` is gone with #971 PR 5, so this field is only
+  // ever set by the explicit `return` handler or the arrow-shorthand
+  // capture — no silent-drop surface.
+  jsxReturn: ts.Expression | null
 
   // Conditional returns (if statements with JSX returns)
   conditionalReturns: ConditionalReturn[]

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -429,6 +429,22 @@ function analyzeComponentBody(
     // (signal/memo/effect/onMount/function/JSX-return/conditional-return)
     // is preserved as an InitStatementInfo so it runs at init time. See #930.
     ctx.componentBodyBlock = ts.isBlock(body) ? body : null
+
+    // Arrow shorthand body (`() => <expr>`): the body *is* the JSX return
+    // expression. Capture it directly here so `visitComponentBody` does
+    // not have to rediscover it via recursion — the recursion-fallback
+    // path was the #968 silent-drop mechanism and is removed in #971 PR 5.
+    // ParenthesizedExpression is stripped so `() => (<div/>)` captures the
+    // inner `<div/>` (equivalent to the pre-refactor `return (<div/>)`
+    // unwrap at the block level).
+    if (!ctx.componentBodyBlock) {
+      let shorthand = body as ts.Expression
+      while (ts.isParenthesizedExpression(shorthand)) {
+        shorthand = shorthand.expression
+      }
+      ctx.jsxReturn = shorthand
+    }
+
     visitComponentBody(body, ctx)
     ctx.componentBodyBlock = null
   }
@@ -538,38 +554,31 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
     return
   }
 
-  // Return statement with JSX (or a top-level ternary, #968)
+  // Return statement: capture whatever expression is returned. The Phase 1
+  // dispatcher core (`transformJsxExpression`) is the single arbiter of
+  // whether the return expression yields IR — it classifies every
+  // `ts.SyntaxKind` per spec `Appendix A`. Non-JSX-structural returns
+  // (scalar literals, forbidden kinds, etc.) yield `null` and `jsxToIR`
+  // treats that as "no IR emitted", matching pre-refactor behaviour.
+  //
+  // `ParenthesizedExpression` is stripped so `return (<div/>)` captures the
+  // inner `<div/>` directly — same semantics as the pre-refactor explicit
+  // unwrap, and avoids an extra synthetic scope wrapper at the root.
+  //
+  // The recursion-as-discriminator path (previously at lines 566-587 of this
+  // file: an "arrow function with implicit return" block plus a generic
+  // descent) was the #968 silent-drop mechanism — it registered the first
+  // nested JSX descendant as `jsxReturn`, so `return cond && <A/>`
+  // silently became `<A/>`. With the explicit return / arrow-shorthand
+  // paths now covering every legitimate capture site, the recursion no
+  // longer touches `jsxReturn`; it retains its other job (walking through
+  // statements to collect signals / memos / effects / functions).
   if (ts.isReturnStatement(node) && node.expression) {
-    if (
-      ts.isJsxElement(node.expression) ||
-      ts.isJsxFragment(node.expression) ||
-      ts.isJsxSelfClosingElement(node.expression) ||
-      ts.isConditionalExpression(node.expression)
-    ) {
-      ctx.jsxReturn = node.expression
+    let retExpr = node.expression
+    while (ts.isParenthesizedExpression(retExpr)) {
+      retExpr = retExpr.expression
     }
-    // Handle parenthesized JSX / ternary: return ( <div>...</div> )
-    if (ts.isParenthesizedExpression(node.expression)) {
-      const inner = node.expression.expression
-      if (
-        ts.isJsxElement(inner) ||
-        ts.isJsxFragment(inner) ||
-        ts.isJsxSelfClosingElement(inner) ||
-        ts.isConditionalExpression(inner)
-      ) {
-        ctx.jsxReturn = inner
-      }
-    }
-  }
-
-  // Arrow function with implicit return (JSX body)
-  if (
-    (ts.isJsxElement(node) ||
-      ts.isJsxFragment(node) ||
-      ts.isJsxSelfClosingElement(node)) &&
-    !ctx.jsxReturn
-  ) {
-    ctx.jsxReturn = node
+    ctx.jsxReturn = retExpr
   }
 
   // Skip recursion into function bodies (arrow functions, function expressions, function declarations)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -188,30 +188,45 @@ export function jsxToIR(analyzer: AnalyzerContext): IRNode | null {
   if (!analyzer.jsxReturn) return null
 
   const ctx = createTransformContext(analyzer)
+  const jsxReturn = analyzer.jsxReturn
 
-  // Top-level ternary return (#968): `return cond ? <A/> : <B/>`.
-  // The ConditionalExpression isn't a JSX node, so transformNode won't
-  // handle it — dispatch directly to transformConditional and wrap in a
-  // synthetic scope element so hydration can locate __scope via bf-s.
-  // The wrapper carries the scope, so clear ctx.isRoot to avoid also
-  // marking the truthy branch's root element as a scope anchor.
-  if (ts.isConditionalExpression(analyzer.jsxReturn)) {
-    ctx.isRoot = false
-    const conditional = transformConditional(analyzer.jsxReturn, ctx)
-    return wrapInScopeElement(conditional)
+  // Direct JSX return — the IR root is an `IRElement` / `IRFragment` that
+  // already carries its own scope anchor (unless it's a Provider-only root,
+  // which needs the synthetic-wrapper fallback below).
+  if (
+    ts.isJsxElement(jsxReturn) ||
+    ts.isJsxSelfClosingElement(jsxReturn) ||
+    ts.isJsxFragment(jsxReturn)
+  ) {
+    const ir = transformNode(jsxReturn, ctx)
+
+    // Auto-generate scope wrapper for provider-only roots that lack a scope
+    // element. When a component returns only a Provider wrapping children
+    // (no native HTML element), `findScope()` would return null during
+    // hydration. Wrapping in a synthetic `<div style="display:contents">`
+    // provides the necessary bf-s anchor.
+    if (ir && needsScopeWrapper(ir)) {
+      return wrapInScopeElement(ir)
+    }
+
+    return ir
   }
 
-  const ir = transformNode(analyzer.jsxReturn, ctx)
-
-  // Auto-generate scope wrapper for provider-only roots that lack a scope element.
-  // When a component returns only a Provider wrapping children (no native HTML element),
-  // findScope() would return null during hydration. Wrapping in a synthetic
-  // <div style="display:contents"> provides the necessary bf-s anchor.
-  if (ir && needsScopeWrapper(ir)) {
-    return wrapInScopeElement(ir)
-  }
-
-  return ir
+  // Non-JSX-direct return — delegate to the `transformJsxExpression` core
+  // (#971) and wrap in a synthetic scope element. This single path covers
+  // `ConditionalExpression` (#968 — `return cond ? <A/> : <B/>`),
+  // `BinaryExpression` with JSX right (`return cond && <A/>`,
+  // `return a ?? <A/>`, `return a || <A/>`), and `CallExpression` for
+  // `.map` / inline JSX helper (`return items.map(n => <li/>)`). If the
+  // dispatcher returns `null` (scalar or forbidden kind), the component
+  // produces no IR — same as the pre-refactor "return 42" path.
+  //
+  // `ctx.isRoot` is cleared because the synthetic wrapper carries the
+  // scope; the inner IR must not double-mark a nested element as root.
+  ctx.isRoot = false
+  const ir = transformJsxExpression(jsxReturn, ctx)
+  if (ir === null) return null
+  return wrapInScopeElement(ir)
 }
 
 // =============================================================================

--- a/packages/mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -32,6 +32,13 @@ runJSXConformanceTests({
     'logical-or-jsx',
     'nullish-coalescing-jsx',
     'branch-map',
+    // Return-position variants of the same bare-prop / loop-variable
+    // Perl-scoping divergence — `return-logical-or` / `return-nullish-coalescing`
+    // reference `$label` / `$banner` directly; `return-map` iterates over
+    // `$items` without a `my` declaration. Out of scope for the #971 refactor.
+    'return-logical-or',
+    'return-nullish-coalescing',
+    'return-map',
   ],
   onRenderError: (err, id) => {
     if (err instanceof PerlNotAvailableError) {


### PR DESCRIPTION
## Summary

Final production-code change of the #971 series. Eliminates the last silent-drop surface by widening `AnalyzerContext.jsxReturn` to any `ts.Expression` and routing non-JSX-direct returns through the dispatcher core (`transformJsxExpression`, #976). The recursion-as-discriminator fallback that caused #968 is removed.

## What changed

### Analyzer

\`packages/jsx/src/analyzer-context.ts\` — \`jsxReturn\` goes from a bespoke 4-kind union to \`ts.Expression | null\`. The core is now the single source of truth for what's renderable.

\`packages/jsx/src/analyzer.ts\`:

- \`analyzeComponentBody\` captures arrow-shorthand bodies (\`() => <expr>\`) directly, with \`ParenthesizedExpression\` stripped. Moved here because \`visitComponentBody\`'s old capture path was too permissive.
- \`visitComponentBody\`'s \`ReturnStatement\` handler now always assigns \`ctx.jsxReturn = node.expression\` (with \`ParenthesizedExpression\` unwrapping). No shape-specific gate.
- **Deleted** the \"Arrow function with implicit return (JSX body)\" block (pre-refactor lines 566–572). That block fired for *any* JSX descendant during recursion — the exact mechanism that registered the JSX on the right of \`cond && <A/>\` and discarded the \`&&\`. The recursion at lines 577–587 stays for signal/memo/effect/function collection; it no longer touches \`jsxReturn\`.

### Dispatcher entry

\`packages/jsx/src/jsx-to-ir.ts\` — \`jsxToIR\` splits on shape:

- JSX-direct (\`JsxElement\` / \`JsxFragment\` / \`JsxSelfClosingElement\`) — \`transformNode\` path, plus the existing Provider-only-root auto-wrapper (\`needsScopeWrapper\`). Same as pre-refactor.
- Everything else — \`transformJsxExpression\` with \`ctx.isRoot = false\`, wrapped in the synthetic \`<div style=\"display:contents\">\` scope anchor. This single path now covers \`ConditionalExpression\` (#968), \`BinaryExpression\` with JSX (\`&&\` / \`||\` / \`??\`), \`CallExpression\` for \`.map\` / inline-JSX helper, and Transparent unwrapping. \`null\` from the core means no IR — same as pre-refactor \`return 42\`.

## Before vs. after on the P1 gap cells

Probe results against the current branch (Hono adapter):

| Source | Pre-refactor | Post-refactor |
|---|---|---|
| \`return show() && <span/>\` | \`<span bf-s=\"test\">Shown</span>\` — unconditional | \`<div style=\"display:contents\" bf-s=\"test\"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>\` |
| \`return prop ?? <Default/>\` | \`<span bf-s=\"test\">Default</span>\` — unconditional | \`<div style=\"display:contents\" bf-s=\"test\"><span bf-c=\"s0\">Default</span></div>\` |
| \`return prop || <Fallback/>\` | \`<span bf-s=\"test\">Fallback</span>\` — unconditional | \`<div style=\"display:contents\" bf-s=\"test\"><span bf-c=\"s0\">Fallback</span></div>\` |
| \`return items().map(n => <li/>)\` | **compile error** \"No marked template in compile output\" | \`<div style=\"display:contents\" bf-s=\"test\"><li ...>a</li><li ...>b</li></div>\` |

## New fixtures and tests

**Adapter fixtures** (`packages/adapter-tests/fixtures/`):

- `return-logical-and`, `return-logical-or`, `return-nullish-coalescing`, `return-map`. Each documents its specific pre-refactor failure mode in the file docstring.

**Compiler unit tests** (`packages/jsx/src/__tests__/ir-conditional-return.test.ts` — new \`describe\` block \"return-position dispatcher unification (#971)\"):

- Asserts \`return cond && <span/>\` emits a ternary in the marked template and \`insert(__scope, 's0', () => show()...)\` in the client JS.
- Asserts \`return prop ?? <span/>\` emits \`!= null\` (\`??\` desugaring).
- Asserts \`return items().map(n => <li/>)\` compiles without \"No marked template\" error and preserves \`.map\` in the template.

These cover the prompt's \"prove the refactor is the sole mechanism\" requirement: the analyzer's explicit \`ConditionalExpression\` case (added by #970) is no longer load-bearing — the widened \`jsxReturn\` type + dispatcher routing cover the entire space.

## Adapter skip-list additions (same divergence classes as existing)

- **CSR conformance**: all four \`return-*\` fixtures. Same synthetic-wrapper attribute-ordering divergence that already skips \`top-level-ternary\` and \`style-object-static\` (\`style=\"display:contents\"\` emitted before vs. after \`bf-s\`).
- **Go-template**: \`return-nullish-coalescing\` and \`return-map\`. Same \`bf-c\` vs. comment-marker divergence as \`nullish-coalescing-jsx\` and \`branch-self-closing\`; \`data-key\` serialization differs for map loops.
- **Mojolicious**: \`return-logical-or\`, \`return-nullish-coalescing\`, \`return-map\`. Same bare-Perl-variable scoping gap (\`\$label\` / \`\$items\` without \`my\` declaration) that already skips \`logical-or-jsx\` / \`branch-map\`.

Hono passes all four return-position fixtures.

## Test plan

- [x] \`cd packages/jsx && bun run build\` — clean (tsgo passes).
- [x] \`bun test packages/jsx packages/adapter-tests\` — clean.
- [x] \`bun test packages/jsx packages/adapter-tests packages/dom packages/hono packages/go-template packages/client packages/cli packages/mojolicious\` — **1642 pass, 0 fail** (+26 from the post-#977 1616 baseline: 4 new fixtures × multiple adapters/CSR + 3 compiler unit tests).
- [x] Exhaustiveness guarantee from #976 is unchanged (\`default: assertNever(node)\` still fires \`TS2345\` on any removed \`case\`).
- [ ] CI passes on the same scope.

## #971 progress

- [x] PR 1 — #973 spec Appendix A.
- [x] PR 2 — #974 fixture matrix (surfaced these P1 gaps).
- [x] PR 3 — #976 extract \`transformJsxExpression\`, route branch path.
- [x] PR 4 — #977 route \`transformExpression\` through the core.
- [x] PR 5 — this PR — widen \`jsxReturn\`, remove recursion discriminator.
- [ ] PR 6 — CI-enforced exhaustiveness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)