### PR TITLE
test(compiler): verify transformJsxExpression exhaustiveness at compile time (#971)

### DIFF
--- a/packages/jsx/src/__tests__/dispatcher-exhaustiveness.test.ts
+++ b/packages/jsx/src/__tests__/dispatcher-exhaustiveness.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const jsxToIrSource = readFileSync(
+  join(import.meta.dir, '..', 'jsx-to-ir.ts'),
+  'utf8',
+)
+
+// Pinned to `typescript@5.9.3` typescript.d.ts — the source of truth for
+// spec/compiler.md Appendix A. If a TypeScript upgrade renames a kind or
+// splits one into two, this list and the dispatcher's switch must be
+// updated together. See A.4 for the verification workflow.
+const appendixAKinds = [
+  // Transparent
+  'ParenthesizedExpression',
+  'AsExpression',
+  'SatisfiesExpression',
+  'NonNullExpression',
+  'TypeAssertionExpression',
+  'PartiallyEmittedExpression',
+  // JSX-structural
+  'JsxElement',
+  'JsxFragment',
+  'JsxSelfClosingElement',
+  'ConditionalExpression',
+  'BinaryExpression',
+  'CallExpression',
+  // Scalar leaf
+  'Identifier',
+  'StringLiteral',
+  'NumericLiteral',
+  'BigIntLiteral',
+  'RegularExpressionLiteral',
+  'NoSubstitutionTemplateLiteral',
+  'TemplateExpression',
+  'TaggedTemplateExpression',
+  'TrueKeyword',
+  'FalseKeyword',
+  'NullKeyword',
+  'ThisKeyword',
+  'SuperKeyword',
+  'ImportKeyword',
+  'PropertyAccessExpression',
+  'ElementAccessExpression',
+  'PrefixUnaryExpression',
+  'PostfixUnaryExpression',
+  'TypeOfExpression',
+  'VoidExpression',
+  'DeleteExpression',
+  'NewExpression',
+  'ObjectLiteralExpression',
+  'ArrowFunction',
+  'FunctionExpression',
+  'ClassExpression',
+  'MetaProperty',
+  'ExpressionWithTypeArguments',
+  'CommaListExpression',
+  'SyntheticExpression',
+  'ArrayLiteralExpression',
+  // Forbidden
+  'AwaitExpression',
+  'YieldExpression',
+  // Unreachable
+  'SpreadElement',
+  'OmittedExpression',
+  'JsxExpression',
+  'JsxOpeningElement',
+  'JsxOpeningFragment',
+  'JsxClosingFragment',
+  'JsxAttributes',
+  'MissingDeclaration',
+]
+
+/**
+ * Regression coverage for the #971 dispatcher-unification guarantee.
+ *
+ * The *real* exhaustiveness check is enforced by `tsgo` during the package
+ * build (`cd packages/jsx && bun run build` — part of CI): removing a
+ * `case` from `transformJsxExpression` makes its `default` branch receive a
+ * non-`never` type, and `assertNever(expr: never): never` fails to type-check
+ * with `TS2345: Argument of type 'X' is not assignable to parameter of type
+ * 'never'`. That alone is enough to catch accidental removals.
+ *
+ * These tests protect against the *next* failure mode: someone weakening the
+ * guarantee without realising. If `assertNever` is called with an `as never`
+ * cast, or a case is deleted from both the `JsxEmbeddableExpression` union
+ * *and* the switch at the same time, `tsgo` stays green but the silent-drop
+ * surface reappears. This suite fails fast in that case.
+ */
+describe('transformJsxExpression dispatcher exhaustiveness (#971)', () => {
+  test('`assertNever` helper takes a `never` parameter', () => {
+    expect(jsxToIrSource).toContain('function assertNever(expr: never): never')
+  })
+
+  test('dispatcher calls `assertNever` in the `default` branch without a type cast', () => {
+    expect(jsxToIrSource).toMatch(/default:\s*\n\s*return assertNever\(node\)/)
+    // No `as never`, `as any`, or `!`-assertion escape hatches — those would
+    // pass tsgo regardless of how many cases are missing.
+    expect(jsxToIrSource).not.toMatch(/return assertNever\(node as /)
+    expect(jsxToIrSource).not.toMatch(/return assertNever\(node!/)
+  })
+
+  test('`JsxEmbeddableExpression` union lists every ts.SyntaxKind in spec Appendix A', () => {
+    // The switch's exhaustiveness is only as strong as the union it narrows
+    // over. If someone shrinks the union, tsgo keeps passing but the
+    // dispatcher silently stops handling whichever kinds were removed.
+    // Pin both here and in Appendix A.2 so the two stay in sync.
+    const unionBlock = jsxToIrSource.match(
+      /type JsxEmbeddableExpression =[\s\S]+?(?=\n\nfunction )/,
+    )?.[0]
+    expect(unionBlock).toBeDefined()
+    for (const kind of appendixAKinds) {
+      // Each kind appears once in the union type alias as `ts.KindName`.
+      expect(unionBlock!).toContain(`ts.${ensureUnionMemberName(kind)}`)
+    }
+  })
+
+  test('dispatcher switch has a `case` per ts.SyntaxKind in spec Appendix A', () => {
+    // Appendix A is the source of truth; if a kind is in the appendix but
+    // not in the dispatcher, a future refactor could narrow the union and
+    // re-enable silent drops undetected.
+    for (const kind of appendixAKinds) {
+      expect(jsxToIrSource).toContain(`case ts.SyntaxKind.${kind}:`)
+    }
+  })
+})
+
+/**
+ * Translate a `ts.SyntaxKind` name to the corresponding interface name used
+ * in `typescript.d.ts` type declarations. Most kinds use the same name, but
+ * a few rename (e.g., `SyntaxKind.TypeAssertionExpression` →
+ * `interface TypeAssertion`, keyword literals → `FooLiteral`).
+ */
+function ensureUnionMemberName(kindName: string): string {
+  const map: Record<string, string> = {
+    TypeAssertionExpression: 'TypeAssertion',
+    TrueKeyword: 'TrueLiteral',
+    FalseKeyword: 'FalseLiteral',
+    NullKeyword: 'NullLiteral',
+    ThisKeyword: 'ThisExpression',
+    SuperKeyword: 'SuperExpression',
+    ImportKeyword: 'ImportExpression',
+  }
+  return map[kindName] ?? kindName
+}

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -745,10 +745,27 @@ Ruling: **Forbidden**. Emit `BF051 — YieldExpression not allowed in render pos
 
 ### A.4 Verification
 
-The classification table above is the source of truth for `transformJsxExpression`. Verification path:
+The classification table above is the source of truth for `transformJsxExpression`. Verification is layered:
 
-1. The dispatcher's `switch (expr.kind)` has one `case` label per Transparent / JSX-structural / Scalar leaf / Forbidden / Unreachable entry.
-2. The `default` branch calls `assertNever(expr)` with the `expr: never` type check, which fails at `tsc` compile time if any enumerated kind is missing.
-3. A compile-time regression test (added in a later PR of the #971 series) deliberately omits one `case` to assert that `tsc` reports an error — this prevents the exhaustiveness check from being silently weakened by a future edit.
+1. **Dispatcher structure.** The dispatcher's `switch (expr.kind)` has one `case` label per Transparent / JSX-structural / Scalar leaf / Forbidden / Unreachable entry. The local narrowing cast `const node: JsxEmbeddableExpression = expr as JsxEmbeddableExpression` makes the switch operate over a union where each kind is a literal type, so TypeScript can perform exhaustiveness inference.
 
-When TypeScript upstream adds a new `ts.Expression`-valued `SyntaxKind`, the expected workflow is: (a) the next `tsc` run fails on `transformJsxExpression`, (b) the author classifies the new kind using this appendix's five-class rubric, (c) the appendix and the `switch` are updated in the same PR.
+2. **Compile-time exhaustiveness via `assertNever`.** The `default` branch calls `assertNever(expr: never): never` with the narrowed `node`. If any case is missing from the switch, `node` in the `default` branch is not `never` and `tsgo` fails with:
+   ```
+   Argument of type '<KindName>' is not assignable to parameter of type 'never'. (TS2345)
+   ```
+   This is the #971 single-source-of-truth guarantee: adding or removing a renderable shape must pass through this switch to even build.
+
+3. **CI gate.** `cd packages/jsx && bun run build` runs `tsgo --emitDeclarationOnly` as part of CI. Removing a `case` is therefore a red build, not a silent runtime drop. Every package-local test workflow depends on this build step, so the gate covers every adapter and the documentation site as well.
+
+4. **Manual verification.** To reproduce the compile error locally:
+   ```sh
+   # In packages/jsx/src/jsx-to-ir.ts, comment out any one case — e.g.:
+   # // case ts.SyntaxKind.TaggedTemplateExpression:
+   cd packages/jsx && bun run build
+   # Expect: tsgo error TS2345 on the assertNever(node) call.
+   # Uncomment the case to restore.
+   ```
+
+5. **Contract regression test.** `packages/jsx/src/__tests__/dispatcher-exhaustiveness.test.ts` asserts that (a) the helper stays `assertNever(expr: never): never`, (b) the dispatcher's `default` branch calls it without an `as`-cast or `!`-assertion escape hatch, (c) the `JsxEmbeddableExpression` union and the switch both list every kind in this appendix. These runtime checks catch the failure mode where the *union* is shrunk in lockstep with the switch — in that case `tsgo` stays green but the silent-drop surface reappears.
+
+When TypeScript upstream adds a new `ts.Expression`-valued `SyntaxKind`, the expected workflow is: (a) the next `tsgo` run fails on `transformJsxExpression`, (b) the author classifies the new kind using this appendix's five-class rubric, (c) the appendix table, the `JsxEmbeddableExpression` union, and the `switch` are updated in the same PR. The dispatcher-exhaustiveness test fails until the appendix is updated, surfacing the requirement.


### PR DESCRIPTION
## Summary

Final PR of the #971 series. Locks down the dispatcher's single-source-of-truth guarantee from two sides:

1. **spec/compiler.md Appendix A.4** — rewritten to be the authoritative verification document: dispatcher structure, compile-time `assertNever` gate, CI gate, manual-verification recipe, and TypeScript-upgrade workflow.
2. **`packages/jsx/src/__tests__/dispatcher-exhaustiveness.test.ts`** — four regression tests that fail fast if someone weakens the guarantee in a way `tsgo` can't catch on its own.

Closes the work originally planned as step 6 of the #971 migration plan.

## Why a test in addition to tsgo?

`tsgo`'s compile-time exhaustiveness check fires when a single \`case\` is removed from the dispatcher's \`switch\` while the \`JsxEmbeddableExpression\` union stays wide. Two other regression modes bypass it:

- **Same union, cast escape hatch** — e.g. someone \"fixes\" a compile error by changing \`return assertNever(node)\` to \`return assertNever(node as never)\`. `tsgo` stays green; every missing case silently returns \`null\`. The silent-drop surface is fully reconstituted.
- **Union shrunk in lockstep with the switch** — if both the union and the switch lose the same kind, \`tsgo\` still passes (the narrowed union no longer contains the removed kind), but the dispatcher now handles strictly fewer shapes than Appendix A documents.

The four new assertions explicitly cover both:

1. \`assertNever\` helper signature stays \`(expr: never): never\`.
2. The \`default\` branch calls \`assertNever(node)\` with no \`as\`-cast or \`!\`-assertion escape hatch.
3. The \`JsxEmbeddableExpression\` union contains every \`ts.Expression\` subtype in Appendix A (the union is pinned to \`typescript@5.9.3\`).
4. The dispatcher's \`switch\` has a \`case\` for every \`ts.SyntaxKind\` in Appendix A.

Sanity-checked by flipping \`return assertNever(node)\` → \`return assertNever(node as never)\` in \`jsx-to-ir.ts\`: test #2 fails. Restoring the file makes all 4 pass.

## spec/compiler.md — Appendix A.4 rewrite

Replaces the previous 3-step sketch with 5 explicit layers:

1. **Dispatcher structure** — documents the \`const node: JsxEmbeddableExpression = expr as JsxEmbeddableExpression\` narrowing that makes \`switch (node.kind)\` exhaustiveness-checkable.
2. **Compile-time \`assertNever\`** — names the \`TS2345: Argument of type 'X' is not assignable to parameter of type 'never'\` error a missing case produces.
3. **CI gate** — points at \`cd packages/jsx && bun run build\` running \`tsgo\`, which every downstream test workflow depends on. Missing case = red CI.
4. **Manual verification recipe** — one-paragraph reproduction: comment out a case, run the build, expect the \`TS2345\`, uncomment to restore.
5. **Contract regression test** — pointer to this PR's test file.

The TypeScript-upgrade workflow (end of A.4) is expanded to require appendix + union + switch to move together in one PR; the dispatcher-exhaustiveness test fails until the appendix is updated.

## Test plan

- [x] \`cd packages/jsx && bun run build\` — clean (tsgo exhaustiveness still enforced end-to-end, unchanged).
- [x] \`bun test packages/jsx/src/__tests__/dispatcher-exhaustiveness.test.ts\` — 4 pass.
- [x] \`bun test packages/jsx packages/adapter-tests packages/dom packages/hono packages/go-template packages/client packages/cli packages/mojolicious\` — **1646 pass, 0 fail** (+4 from the 1642 baseline after #978, matching exactly the four new assertions).
- [x] Sanity: \`assertNever(node)\` → \`assertNever(node as never)\` makes test #2 fail with a clear mismatch; restoring passes.
- [ ] CI passes on the same scope.

## #971 series

All six PRs merged with this one:

| PR | Purpose |
|---|---|
| #973 | spec Appendix A (ts.SyntaxKind classification) |
| #974 | Fixture matrix (surfaced the P1 return-position gaps) |
| #976 | Extract \`transformJsxExpression\`, route branch path |
| #977 | Route \`transformExpression\` through the core |
| #978 | Widen \`jsxReturn\` to \`ts.Expression\`, remove recursion discriminator |
| this PR | CI-enforced exhaustiveness + regression coverage |

Issue #971 can close with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)