### PR TITLE
fix(toast): add setTimeout fallback so exit state finalizes without transitionend

### DIFF
--- a/ui/components/ui/toast/index.tsx
+++ b/ui/components/ui/toast/index.tsx
@@ -217,7 +217,8 @@ function Toast(props: ToastProps) {
     let exitTimer: ReturnType<typeof setTimeout> | null = null
 
     // Transition to hidden after exit animation completes
-    el.addEventListener('transitionend', () => {
+    el.addEventListener('transitionend', (e) => {
+      if (e.target !== el) return
       if (el.dataset.state === 'exiting') {
         if (exitTimer) { clearTimeout(exitTimer); exitTimer = null }
         el.dataset.state = 'hidden'

--- a/ui/components/ui/toast/index.tsx
+++ b/ui/components/ui/toast/index.tsx
@@ -214,10 +214,12 @@ function Toast(props: ToastProps) {
   const handleMount = (el: HTMLElement) => {
     const providerEl = el.closest('[data-slot="toast-provider"]') as HTMLElement
     let dismissTimer: ReturnType<typeof setTimeout> | null = null
+    let exitTimer: ReturnType<typeof setTimeout> | null = null
 
     // Transition to hidden after exit animation completes
     el.addEventListener('transitionend', () => {
       if (el.dataset.state === 'exiting') {
+        if (exitTimer) { clearTimeout(exitTimer); exitTimer = null }
         el.dataset.state = 'hidden'
         el.className = `hidden ${toastBaseClasses} ${toastVariantClass} ${className}`
       }
@@ -232,6 +234,7 @@ function Toast(props: ToastProps) {
       if (isOpen) {
         // Clear dismiss timer when entering
         if (dismissTimer) { clearTimeout(dismissTimer); dismissTimer = null }
+        if (exitTimer)    { clearTimeout(exitTimer);    exitTimer    = null }
 
         // Entering state
         el.dataset.state = 'entering'
@@ -253,12 +256,22 @@ function Toast(props: ToastProps) {
         }
       } else {
         if (dismissTimer) { clearTimeout(dismissTimer); dismissTimer = null }
+        if (exitTimer)    { clearTimeout(exitTimer);    exitTimer    = null }
 
         const currentState = el.dataset.state
         if (currentState === 'visible' || currentState === 'entering') {
-          // Exiting state — transitionend listener handles the rest
           el.dataset.state = 'exiting'
           el.className = `${stateClasses.exiting} ${toastBaseClasses} ${toastVariantClass} ${className}`
+
+          // Fallback: if transitionend is dropped (CI load, backgrounded tab, etc.),
+          // still finalize exit. Idempotent with the transitionend listener.
+          exitTimer = setTimeout(() => {
+            exitTimer = null
+            if (el.dataset.state === 'exiting') {
+              el.dataset.state = 'hidden'
+              el.className = `hidden ${toastBaseClasses} ${toastVariantClass} ${className}`
+            }
+          }, 1000) // duration-slow (300ms) + generous buffer
         }
       }
     })


### PR DESCRIPTION
## Summary

Fixes #979 — `toast.spec.ts:21` ("closes toast when close button is clicked") was flaking in CI because `data-state="exiting" → "hidden"` was gated solely on a `transitionend` event. Under CI load, headless Chromium can drop `transitionend` for short transitions (`duration-slow` = 300ms), leaving the component stuck at `exiting` and causing the 5s Playwright assertion to time out.

**Root cause**: `handleMount` in `ui/components/ui/toast/index.tsx` relied on `transitionend` as the only path to `hidden`. If the event does not fire, the toast stays at `exiting` indefinitely.

**Fix**: add a 1-second `exitTimer` fallback alongside the existing `transitionend` listener. Whichever fires first wins; the loser's `if (el.dataset.state === 'exiting')` guard is already in place and rejects the duplicate write. This is the same belt-and-braces idiom used by Radix UI and shadcn/ui for the same class of problem.

Changes:
- `ui/components/ui/toast/index.tsx` — add `exitTimer` handle, arm it in the exit branch, and clear it in three places (on re-open, inside `transitionend`, and at the start of the else branch) to prevent stale timer snaps.

This is **not a regression from #971** — toast source last changed in `ba24ef9a`, well before the #971 compiler series.

## Test plan

- [x] `bun test ui/components/ui/toast` — 18/18 pass (IR-level tests unchanged)
- [x] `bun run build` — clean build passes
- [ ] CI: `site/ui/e2e/toast.spec.ts` should now pass without flaking (verify on next 2 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)