### PR TITLE
feat(gallery): Productivity Suite — mail / files / board / calendar (#929)

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -233,4 +233,99 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
     expect(bindEventsMatch![1]).toContain('qsa(__branchScope')
     expect(bindEventsMatch![1]).not.toContain('$(__branchScope')
   })
+
+  test('child component inside nested conditional is only initialized once (#929)', () => {
+    // Regression: The file browser pattern has a Checkbox inside a
+    // `child.type === 'folder' ? <folder-branch> : <file-branch>` conditional,
+    // itself inside a nested `node.children.map(child => ...)`. Before the fix,
+    // `collectConditionalBranchChildComponents` recursed into conditional
+    // branches even when collecting the inner loop's direct child components,
+    // causing the same Checkbox to be emitted by both the outer ssr path and
+    // the insert() bindEvents. The two initChild() calls wired up two click
+    // handlers, and two `onCheckedChange` invocations per click cancelled
+    // each other out, leaving the nested checkbox visually unresponsive.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Checkbox } from '@ui/components/ui/checkbox'
+
+      type TreeNode = { id: number; name: string; type: 'file' | 'folder'; selected: boolean; children: TreeNode[] }
+
+      export function FileBrowser() {
+        const [tree, setTree] = createSignal<TreeNode[]>([])
+        const toggle = (id: number) => {
+          setTree(prev => prev.map(n => n.id === id ? { ...n, selected: !n.selected } : n))
+        }
+        return (
+          <div>
+            {tree().map(node => (
+              <div key={node.id}>
+                {node.children.map(child => (
+                  <div key={child.id}>
+                    {child.type === 'folder' ? (
+                      <div>
+                        <Checkbox checked={child.selected} onCheckedChange={() => toggle(child.id)} />
+                        <span>{child.name}</span>
+                      </div>
+                    ) : (
+                      <div>
+                        <Checkbox checked={child.selected} onCheckedChange={() => toggle(child.id)} />
+                        <span>{child.name}</span>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'FileBrowser.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Locate the nested mapArray callback body — the second mapArray in the file
+    // is the inner `node.children.map(child => ...)`.
+    const mapCalls = content.match(/mapArray\([\s\S]*?\}\)\s*\}/g)
+    expect(mapCalls).not.toBeNull()
+    expect(mapCalls!.length).toBeGreaterThanOrEqual(2)
+
+    // Pick the inner mapArray. It references `child.id` as the key function.
+    const innerMapArray = mapCalls!.find(m => /\(child\)\s*=>\s*String\(child\.id\)/.test(m))
+    expect(innerMapArray).toBeDefined()
+
+    // Count initChild('Checkbox', ...) occurrences inside the inner callback,
+    // but exclude those inside `bindEvents:` (insert branches), which handle
+    // the conditional separately.
+    const body = innerMapArray!
+    const bindEventsRegions: string[] = []
+    const bindEventsRe = /bindEvents:\s*\(__branchScope\)\s*=>\s*\{/g
+    let m: RegExpExecArray | null
+    while ((m = bindEventsRe.exec(body)) !== null) {
+      let depth = 1
+      let i = m.index + m[0].length
+      const start = i
+      while (i < body.length && depth > 0) {
+        if (body[i] === '{') depth++
+        else if (body[i] === '}') depth--
+        i++
+      }
+      bindEventsRegions.push(body.slice(start, i - 1))
+    }
+    // Body outside bindEvents: replace each bindEvents region with a marker.
+    let outsideBody = body
+    for (const region of bindEventsRegions) {
+      outsideBody = outsideBody.replace(region, '/*BINDEVENTS*/')
+    }
+    const outsideInitChildCount = (outsideBody.match(/initChild\('Checkbox'/g) || []).length
+
+    // The outer-level ssr path should NOT emit initChild('Checkbox', ...)
+    // for the Checkbox that lives inside the conditional. It is handled by
+    // the insert() bindEvents (which runs once per branch activation).
+    expect(outsideInitChildCount).toBe(0)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -1042,8 +1042,14 @@ function buildDepthLevels(
   childEvents: LoopChildEvent[],
 ): DepthLevel[] {
   return innerLoops.map(loop => ({
+    // Exclude components that sit inside a conditional branch of the loop
+    // body. Those are handled by the conditional's `insert()` bindEvents
+    // and must not be re-initialized here, otherwise `initChild` runs twice
+    // and double-wires event handlers (#929).
     comps: nestedComps.filter(c =>
-      (c.loopDepth ?? 0) === loop.depth && c.innerLoopArray === loop.array
+      (c.loopDepth ?? 0) === loop.depth
+      && c.innerLoopArray === loop.array
+      && !c.insideConditional
     ),
     events: childEvents.filter(ev => {
       if (ev.nestedLoops.length === 0) return false

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -288,18 +288,27 @@ export function collectLoopChildEventsWithNesting(
 /**
  * Collect child component nodes from a conditional branch for use with insert().
  * These components will be re-initialized via initChild() in the branch's bindEvents callback.
+ *
+ * @param node - The root IR node to traverse.
+ * @param skipConditionals - When true, do not descend into nested `conditional`
+ *   branches. Used when the caller collects those conditionals separately
+ *   (e.g., inner-loop direct children vs. `childConditionals`), avoiding the
+ *   double-initialization bug where the same component is emitted by both the
+ *   outer path and the `insert()` bindEvents path (#929).
  */
 export function collectConditionalBranchChildComponents(
   node: IRNode,
+  skipConditionals = false,
 ): Array<{ name: string; slotId: string | null; props: IRProp[]; children: IRNode[] }> {
   const components: Array<{ name: string; slotId: string | null; props: IRProp[]; children: IRNode[] }> = []
-  traverseForComponents(node, components)
+  traverseForComponents(node, components, skipConditionals)
   return components
 }
 
 function traverseForComponents(
   node: IRNode,
   components: Array<{ name: string; slotId: string | null; props: IRProp[]; children: IRNode[] }>,
+  skipConditionals = false,
 ): void {
   switch (node.type) {
     case 'element':
@@ -307,7 +316,7 @@ function traverseForComponents(
     case 'provider':
     case 'async':
       for (const child of node.children) {
-        traverseForComponents(child, components)
+        traverseForComponents(child, components, skipConditionals)
       }
       break
     case 'component':
@@ -319,17 +328,19 @@ function traverseForComponents(
       })
       // Recurse into JSX children passed to this component
       for (const child of node.children) {
-        traverseForComponents(child, components)
+        traverseForComponents(child, components, skipConditionals)
       }
       break
     case 'conditional':
-      traverseForComponents(node.whenTrue, components)
-      traverseForComponents(node.whenFalse, components)
+      if (skipConditionals) return
+      traverseForComponents(node.whenTrue, components, skipConditionals)
+      traverseForComponents(node.whenFalse, components, skipConditionals)
       break
     case 'if-statement':
-      traverseForComponents(node.consequent, components)
+      if (skipConditionals) return
+      traverseForComponents(node.consequent, components, skipConditionals)
       if (node.alternate) {
-        traverseForComponents(node.alternate, components)
+        traverseForComponents(node.alternate, components, skipConditionals)
       }
       break
   }
@@ -468,11 +479,17 @@ function collectBranchInnerLoops(
           reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
         }
       }
-      // Collect child components and events inside inner loop items
-      // Walk loop body children (not the loop node itself, which traverseForComponents skips)
+      // Collect child components and events inside inner loop items.
+      // Walk loop body children (not the loop node itself, which traverseForComponents skips).
+      // `skipConditionals=true`: components inside conditional branches are
+      // collected separately as `childConditionals[i].whenTrueComponents`
+      // below. Including them here too would cause `initChild` to be emitted
+      // twice (once in the outer ssr path, once in the insert() bindEvents),
+      // which double-wires the click handler and makes the two `onCheckedChange`
+      // calls cancel each other out (#929).
       const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }> = []
       for (const child of n.children) {
-        rawComps.push(...collectConditionalBranchChildComponents(child))
+        rawComps.push(...collectConditionalBranchChildComponents(child, true))
       }
       const childComponents = rawComps.map(c => ({
         name: c.name,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1907,7 +1907,7 @@ function transformMapCall(
 function collectNestedComponents(nodes: IRNode[]): IRLoopChildComponent[] {
   const result: IRLoopChildComponent[] = []
 
-  function traverse(node: IRNode, loopDepth: number, innerLoopArray?: string): void {
+  function traverse(node: IRNode, loopDepth: number, innerLoopArray: string | undefined, insideConditional: boolean): void {
     if (node.type === 'component') {
       result.push({
         name: node.name,
@@ -1924,29 +1924,39 @@ function collectNestedComponents(nodes: IRNode[]): IRLoopChildComponent[] {
         children: node.children,
         loopDepth,
         innerLoopArray,
+        insideConditional: insideConditional || undefined,
       })
       // Also traverse component children to find deeply nested components
       if (node.children) {
-        node.children.forEach(c => traverse(c, loopDepth, innerLoopArray))
+        node.children.forEach(c => traverse(c, loopDepth, innerLoopArray, insideConditional))
       }
     }
     if (node.type === 'element' && node.children) {
-      node.children.forEach(c => traverse(c, loopDepth, innerLoopArray))
+      node.children.forEach(c => traverse(c, loopDepth, innerLoopArray, insideConditional))
     }
     if (node.type === 'fragment' && node.children) {
-      node.children.forEach(c => traverse(c, loopDepth, innerLoopArray))
+      node.children.forEach(c => traverse(c, loopDepth, innerLoopArray, insideConditional))
     }
     if (node.type === 'loop' && node.children) {
-      // Entering an inner loop — increment depth, record array expression
-      node.children.forEach(c => traverse(c, loopDepth + 1, node.array))
+      // Entering an inner loop — increment depth, record array expression.
+      // Reset `insideConditional`: the loop body starts a fresh scope and its
+      // own body-level conditionals are tracked by the inner loop's own
+      // collection path.
+      node.children.forEach(c => traverse(c, loopDepth + 1, node.array, false))
     }
     if (node.type === 'conditional') {
-      traverse(node.whenTrue, loopDepth, innerLoopArray)
-      traverse(node.whenFalse, loopDepth, innerLoopArray)
+      traverse(node.whenTrue, loopDepth, innerLoopArray, true)
+      traverse(node.whenFalse, loopDepth, innerLoopArray, true)
+    }
+    if (node.type === 'if-statement') {
+      traverse(node.consequent, loopDepth, innerLoopArray, true)
+      if (node.alternate) {
+        traverse(node.alternate, loopDepth, innerLoopArray, true)
+      }
     }
   }
 
-  nodes.forEach(n => traverse(n, 0))
+  nodes.forEach(n => traverse(n, 0, undefined, false))
   return result
 }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -158,6 +158,11 @@ export interface IRLoopChildComponent {
   children: IRNode[] // Child nodes for nested component rendering
   loopDepth?: number // 0 = direct child of outer loop, 1+ = inside nested inner loops
   innerLoopArray?: string // Array expression of the innermost enclosing loop (for disambiguation)
+  // True when this component sits inside a `conditional` / `if-statement` branch
+  // below the enclosing loop body. Such components are initialized by the
+  // conditional's `insert()` bindEvents at runtime; emitting them again from
+  // the outer initializer would double-wire event handlers (#929).
+  insideConditional?: boolean
 }
 
 export interface IRLoop {

--- a/site/ui/components/gallery/productivity/board-demo.tsx
+++ b/site/ui/components/gallery/productivity/board-demo.tsx
@@ -1,0 +1,212 @@
+"use client"
+/**
+ * ProductivityBoardDemo
+ *
+ * Adapted KanbanDemo for /gallery/productivity/board.
+ *
+ * Compiler stress targets (inherited):
+ * - Nested .map(): columns().map(col => ... col.tasks.map(task => ...))
+ * - Dynamic nested array mutation (move task between columns)
+ * - Conditional rendering inside nested loop (add task form)
+ * - Module-level constants in nested loop (priorityVariant)
+ * - Derived values per column (task count)
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Badge, type BadgeVariant } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Input } from '@ui/components/ui/input'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+
+const priorityVariant: Record<string, string> = {
+  high: 'destructive',
+  medium: 'secondary',
+  low: 'outline',
+}
+
+type Task = { id: number; title: string; priority: 'high' | 'medium' | 'low' }
+type Column = { id: string; title: string; tasks: Task[] }
+
+const initialColumns: Column[] = [
+  {
+    id: 'todo',
+    title: 'To Do',
+    tasks: [
+      { id: 1, title: 'Design landing page', priority: 'high' },
+      { id: 2, title: 'Write unit tests', priority: 'medium' },
+      { id: 3, title: 'Update docs', priority: 'low' },
+    ],
+  },
+  {
+    id: 'progress',
+    title: 'In Progress',
+    tasks: [
+      { id: 4, title: 'Build API endpoint', priority: 'high' },
+      { id: 5, title: 'Code review', priority: 'medium' },
+    ],
+  },
+  {
+    id: 'done',
+    title: 'Done',
+    tasks: [
+      { id: 6, title: 'Setup CI pipeline', priority: 'medium' },
+    ],
+  },
+]
+
+export function ProductivityBoardDemo() {
+  const [columns, setColumns] = createSignal<Column[]>(initialColumns)
+  const [newTaskTitle, setNewTaskTitle] = createSignal('')
+  const [addingToColumn, setAddingToColumn] = createSignal<string | null>(null)
+  const [nextId, setNextId] = createSignal(7)
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  const totalTasks = createMemo(() =>
+    columns().reduce((sum, col) => sum + col.tasks.length, 0)
+  )
+
+  const showToast = (message: string) => {
+    setToastMessage(message)
+    setToastOpen(true)
+    setTimeout(() => setToastOpen(false), 3000)
+  }
+
+  const moveTask = (taskId: number, fromColId: string, direction: 'left' | 'right') => {
+    setColumns(prev => {
+      const fromIdx = prev.findIndex(c => c.id === fromColId)
+      const toIdx = direction === 'left' ? fromIdx - 1 : fromIdx + 1
+      if (toIdx < 0 || toIdx >= prev.length) return prev
+      const task = prev[fromIdx].tasks.find(t => t.id === taskId)
+      if (!task) return prev
+      return prev.map((col, i) => {
+        if (i === fromIdx) return { ...col, tasks: col.tasks.filter(t => t.id !== taskId) }
+        if (i === toIdx) return { ...col, tasks: [...col.tasks, task] }
+        return col
+      })
+    })
+    showToast('Task moved')
+  }
+
+  const addTask = (colId: string) => {
+    const title = newTaskTitle().trim()
+    if (!title) return
+    const id = nextId()
+    setNextId(id + 1)
+    setColumns(prev => prev.map(col => {
+      if (col.id !== colId) return col
+      return { ...col, tasks: [...col.tasks, { id, title, priority: 'medium' as const }] }
+    }))
+    setNewTaskTitle('')
+    setAddingToColumn(null)
+    showToast('Task added')
+  }
+
+  const deleteTask = (taskId: number, colId: string) => {
+    setColumns(prev => prev.map(col => {
+      if (col.id !== colId) return col
+      return { ...col, tasks: col.tasks.filter(t => t.id !== taskId) }
+    }))
+    showToast('Task deleted')
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">Task Board</h2>
+        <span className="task-total text-sm text-muted-foreground">{totalTasks()} tasks</span>
+      </div>
+
+      <div className="kanban-columns flex gap-4 overflow-x-auto pb-4">
+        {columns().map(col => (
+          <div key={col.id} className="kanban-column flex-1 min-w-[250px]">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <h3 className="column-title text-sm font-semibold">{col.title}</h3>
+                <Badge variant="secondary" className="task-count">{col.tasks.length}</Badge>
+              </div>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                className="add-task-btn"
+                onClick={() => setAddingToColumn(addingToColumn() === col.id ? null : col.id)}
+              >
+                +
+              </Button>
+            </div>
+
+            {addingToColumn() === col.id ? (
+              <div className="add-task-form flex gap-2 mb-3">
+                <Input
+                  placeholder="Task title"
+                  value={newTaskTitle()}
+                  onInput={(e) => setNewTaskTitle(e.target.value)}
+                  ref={(el) => requestAnimationFrame(() => el.focus())}
+                  className="h-8"
+                />
+                <Button size="sm" onClick={() => addTask(col.id)}>
+                  Add
+                </Button>
+              </div>
+            ) : null}
+
+            <div className="space-y-2">
+              {col.tasks.map(task => (
+                <div key={task.id} className="task-card rounded-xl border bg-card p-3 space-y-2 shadow-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="task-title text-sm font-medium">{task.title}</p>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="delete-task text-muted-foreground hover:text-destructive"
+                      onClick={() => deleteTask(task.id, col.id)}
+                    >
+                      ×
+                    </Button>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Badge variant={priorityVariant[task.priority] as BadgeVariant} className="task-priority text-xs">{task.priority}</Badge>
+                    <div className="flex gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="move-left"
+                        onClick={() => moveTask(task.id, col.id, 'left')}
+                      >
+                        ←
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="move-right"
+                        onClick={() => moveTask(task.id, col.id, 'right')}
+                      >
+                        →
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={toastOpen()}>
+          <div className="flex-1">
+            <ToastTitle>Done</ToastTitle>
+            <ToastDescription className="toast-message">{toastMessage()}</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setToastOpen(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/productivity/calendar-demo.tsx
+++ b/site/ui/components/gallery/productivity/calendar-demo.tsx
@@ -1,0 +1,578 @@
+"use client"
+/**
+ * ProductivityCalendarDemo
+ *
+ * Adapted CalendarSchedulerDemo for /gallery/productivity/calendar.
+ *
+ * Compiler stress targets (inherited):
+ * - View mode toggle changes loop structure entirely (month vs week)
+ * - Per-cell complex conditionals inside .map() body
+ * - Multi-level memo chain for week-view overlap layout (4 levels)
+ * - Outer-loop param capture in handlers (data-key / data-key-1)
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+type ViewMode = 'month' | 'week'
+type EventColor = 'blue' | 'green' | 'red' | 'purple' | 'orange'
+
+type CalendarEvent = {
+  id: number
+  title: string
+  date: string
+  startHour: number
+  duration: number
+  color: EventColor
+}
+
+const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+const HOUR_PX = 48
+
+const COLOR_CLASSES: Record<EventColor, string> = {
+  blue: 'bg-blue-100 border-blue-400 text-blue-800 dark:bg-blue-900/30 dark:border-blue-500 dark:text-blue-300',
+  green: 'bg-emerald-100 border-emerald-400 text-emerald-800 dark:bg-emerald-900/30 dark:border-emerald-500 dark:text-emerald-300',
+  red: 'bg-rose-100 border-rose-400 text-rose-800 dark:bg-rose-900/30 dark:border-rose-500 dark:text-rose-300',
+  purple: 'bg-purple-100 border-purple-400 text-purple-800 dark:bg-purple-900/30 dark:border-purple-500 dark:text-purple-300',
+  orange: 'bg-orange-100 border-orange-400 text-orange-800 dark:bg-orange-900/30 dark:border-orange-500 dark:text-orange-300',
+}
+
+const COLOR_OPTIONS: EventColor[] = ['blue', 'green', 'red', 'purple', 'orange']
+
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d)
+  r.setDate(r.getDate() + n)
+  return r
+}
+
+function getWeekStart(d: Date): Date {
+  const r = new Date(d)
+  r.setDate(d.getDate() - d.getDay())
+  r.setHours(0, 0, 0, 0)
+  return r
+}
+
+function formatHour(h: number): string {
+  if (h === 0) return '12 AM'
+  if (h < 12) return `${h} AM`
+  if (h === 12) return '12 PM'
+  return `${h - 12} PM`
+}
+
+function formatMonthYear(d: Date): string {
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+}
+
+function formatWeekRange(start: Date): string {
+  const end = addDays(start, 6)
+  return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+}
+
+let _nextId = 100
+function nextId(): number { return _nextId++ }
+
+const TODAY = new Date()
+const TODAY_KEY = toDateKey(TODAY)
+
+function dayOffset(n: number): string { return toDateKey(addDays(TODAY, n)) }
+
+const initialEvents: CalendarEvent[] = [
+  { id: 1, title: 'Team Standup', date: TODAY_KEY, startHour: 9, duration: 1, color: 'blue' },
+  { id: 2, title: 'Design Review', date: TODAY_KEY, startHour: 10, duration: 2, color: 'purple' },
+  { id: 3, title: 'Lunch with Client', date: TODAY_KEY, startHour: 12, duration: 1, color: 'green' },
+  { id: 4, title: 'Sprint Planning', date: dayOffset(1), startHour: 10, duration: 2, color: 'blue' },
+  { id: 5, title: 'Architecture Review', date: dayOffset(1), startHour: 10, duration: 3, color: 'purple' },
+  { id: 6, title: 'Release Prep', date: dayOffset(1), startHour: 14, duration: 1, color: 'orange' },
+  { id: 7, title: 'All Hands', date: dayOffset(2), startHour: 11, duration: 1, color: 'red' },
+  { id: 8, title: 'Code Review', date: dayOffset(3), startHour: 15, duration: 2, color: 'blue' },
+  { id: 9, title: 'Product Demo', date: dayOffset(5), startHour: 13, duration: 1, color: 'green' },
+  { id: 10, title: 'Weekly Report', date: dayOffset(-1), startHour: 16, duration: 1, color: 'orange' },
+]
+
+export function ProductivityCalendarDemo() {
+  const [viewMode, setViewMode] = createSignal<ViewMode>('month')
+  const [currentDate, setCurrentDate] = createSignal(new Date())
+  const [events, setEvents] = createSignal<CalendarEvent[]>(initialEvents)
+  const [selectedEventId, setSelectedEventId] = createSignal<number | null>(null)
+  const [selectedDate, setSelectedDate] = createSignal<string | null>(null)
+  const [newTitle, setNewTitle] = createSignal('')
+  const [newColor, setNewColor] = createSignal<EventColor>('blue')
+  const [creatingForHour, setCreatingForHour] = createSignal<number>(9)
+  const [showCreateForm, setShowCreateForm] = createSignal(false)
+
+  const monthLabel = createMemo(() => formatMonthYear(currentDate()))
+
+  const calendarDays = createMemo(() => {
+    const d = currentDate()
+    const monthStart = new Date(d.getFullYear(), d.getMonth(), 1)
+    const monthEnd = new Date(d.getFullYear(), d.getMonth() + 1, 0)
+    const leadingDow = monthStart.getDay()
+    const days: { date: Date; key: string; isCurrentMonth: boolean }[] = []
+
+    for (let i = leadingDow - 1; i >= 0; i--) {
+      const day = addDays(monthStart, -i - 1)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: false })
+    }
+    for (let n = 1; n <= monthEnd.getDate(); n++) {
+      const day = new Date(d.getFullYear(), d.getMonth(), n)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: true })
+    }
+    const trailing = (7 - (days.length % 7)) % 7
+    for (let i = 1; i <= trailing; i++) {
+      const day = addDays(monthEnd, i)
+      days.push({ date: day, key: toDateKey(day), isCurrentMonth: false })
+    }
+    return days
+  })
+
+  const eventsByDate = createMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {}
+    for (const evt of events()) {
+      if (!map[evt.date]) map[evt.date] = []
+      map[evt.date].push(evt)
+    }
+    return map
+  })
+
+  const dayPanelEvents = createMemo(() => {
+    const date = selectedDate()
+    if (!date) return []
+    return eventsByDate()[date] ?? []
+  })
+
+  const weekStart = createMemo(() => getWeekStart(currentDate()))
+  const weekLabel = createMemo(() => formatWeekRange(weekStart()))
+
+  const weekDays = createMemo(() =>
+    Array.from({ length: 7 }, (_, i) => {
+      const d = addDays(weekStart(), i)
+      return { date: d, key: toDateKey(d) }
+    })
+  )
+
+  const weekEvents = createMemo(() => {
+    const keys = new Set(weekDays().map(d => d.key))
+    return events().filter(e => keys.has(e.date))
+  })
+
+  const weekEventsByDay = createMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {}
+    for (const evt of weekEvents()) {
+      if (!map[evt.date]) map[evt.date] = []
+      map[evt.date].push(evt)
+    }
+    return map
+  })
+
+  const overlapGroups = createMemo(() => {
+    const result: Record<string, CalendarEvent[][]> = {}
+    for (const [dayKey, dayEvts] of Object.entries(weekEventsByDay())) {
+      const sorted = [...dayEvts].sort((a, b) => a.startHour - b.startHour)
+      const groups: CalendarEvent[][] = []
+      let group: CalendarEvent[] = []
+      let maxEnd = -1
+
+      for (const evt of sorted) {
+        if (group.length > 0 && evt.startHour < maxEnd) {
+          group.push(evt)
+          maxEnd = Math.max(maxEnd, evt.startHour + evt.duration)
+        } else {
+          if (group.length > 0) groups.push(group)
+          group = [evt]
+          maxEnd = evt.startHour + evt.duration
+        }
+      }
+      if (group.length > 0) groups.push(group)
+      result[dayKey] = groups
+    }
+    return result
+  })
+
+  const eventPositions = createMemo(() => {
+    const positions: Record<number, { top: number; height: number; left: number; width: number }> = {}
+    for (const [, groups] of Object.entries(overlapGroups())) {
+      for (const group of groups) {
+        const count = group.length
+        group.forEach((evt, idx) => {
+          positions[evt.id] = {
+            top: evt.startHour * HOUR_PX,
+            height: evt.duration * HOUR_PX - 2,
+            left: (idx / count) * 100,
+            width: (1 / count) * 100,
+          }
+        })
+      }
+    }
+    return positions
+  })
+
+  const selectedEvent = createMemo(() => {
+    const id = selectedEventId()
+    if (id === null) return null
+    return events().find(e => e.id === id) ?? null
+  })
+
+  const headerLabel = createMemo(() =>
+    viewMode() === 'month' ? monthLabel() : weekLabel()
+  )
+
+  function navigatePrev() {
+    const d = currentDate()
+    if (viewMode() === 'month') {
+      setCurrentDate(new Date(d.getFullYear(), d.getMonth() - 1, 1))
+    } else {
+      setCurrentDate(addDays(d, -7))
+    }
+    setSelectedDate(null)
+    setSelectedEventId(null)
+  }
+
+  function navigateNext() {
+    const d = currentDate()
+    if (viewMode() === 'month') {
+      setCurrentDate(new Date(d.getFullYear(), d.getMonth() + 1, 1))
+    } else {
+      setCurrentDate(addDays(d, 7))
+    }
+    setSelectedDate(null)
+    setSelectedEventId(null)
+  }
+
+  function selectDay(dateKey: string) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(null)
+    setShowCreateForm(false)
+  }
+
+  function openAddEvent() {
+    setShowCreateForm(true)
+    setCreatingForHour(9)
+    setNewTitle('')
+    setNewColor('blue')
+    setSelectedEventId(null)
+  }
+
+  function selectEvent(id: number) {
+    setSelectedEventId(id)
+    setShowCreateForm(false)
+  }
+
+  function openCreateInWeek(dateKey: string, hour: number) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(null)
+    setCreatingForHour(hour)
+    setNewTitle('')
+    setNewColor('blue')
+    setShowCreateForm(true)
+  }
+
+  function selectWeekEvent(dateKey: string, id: number) {
+    setSelectedDate(dateKey)
+    setSelectedEventId(id)
+    setShowCreateForm(false)
+  }
+
+  function confirmCreate() {
+    const title = newTitle().trim()
+    const date = selectedDate()
+    if (!title || !date) return
+    setEvents(prev => [...prev, {
+      id: nextId(),
+      title,
+      date,
+      startHour: creatingForHour(),
+      duration: 1,
+      color: newColor(),
+    }])
+    setShowCreateForm(false)
+  }
+
+  function cancelCreate() {
+    setShowCreateForm(false)
+  }
+
+  function removeEvent(id: number) {
+    setEvents(prev => prev.filter(e => e.id !== id))
+    setSelectedEventId(null)
+  }
+
+  function closeDayPanel() {
+    setSelectedDate(null)
+    setSelectedEventId(null)
+    setShowCreateForm(false)
+  }
+
+  return (
+    <div className="calendar-scheduler-demo w-full space-y-4">
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            className="today-btn h-8 px-3 text-sm border border-input rounded-md bg-background hover:bg-accent"
+            onClick={() => { setCurrentDate(new Date()); setSelectedDate(null); setSelectedEventId(null) }}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            className="prev-btn h-8 w-8 flex items-center justify-center rounded-md border border-input bg-background hover:bg-accent text-base leading-none"
+            onClick={navigatePrev}
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            className="next-btn h-8 w-8 flex items-center justify-center rounded-md border border-input bg-background hover:bg-accent text-base leading-none"
+            onClick={navigateNext}
+          >
+            ›
+          </button>
+          <span className="calendar-header-label text-sm font-semibold">
+            {headerLabel()}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="event-count text-xs text-muted-foreground">
+            {events().length} events
+          </span>
+          <div className="view-toggle flex overflow-hidden rounded-md border border-input">
+            <button
+              type="button"
+              className={`month-view-btn h-8 px-3 text-sm ${viewMode() === 'month' ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-accent'}`}
+              onClick={() => setViewMode('month')}
+            >
+              Month
+            </button>
+            <button
+              type="button"
+              className={`week-view-btn h-8 px-3 text-sm border-l border-input ${viewMode() === 'week' ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-accent'}`}
+              onClick={() => setViewMode('week')}
+            >
+              Week
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Day Panel */}
+      {selectedDate() ? (
+        <div className="day-panel rounded-md border border-border bg-card p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="day-panel-date text-sm font-semibold">{selectedDate()}</span>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                className="add-event-btn h-7 px-2 text-xs rounded-md border border-input bg-background hover:bg-accent"
+                onClick={openAddEvent}
+              >
+                + Add event
+              </button>
+              <button
+                type="button"
+                className="close-day-panel-btn h-7 w-7 flex items-center justify-center rounded border border-input text-xs"
+                onClick={closeDayPanel}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+
+          {showCreateForm() ? (
+            <div className="event-create-form flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-2 py-2">
+              <input
+                className="new-event-title-input h-8 flex-1 rounded-md border border-input bg-background px-2 text-sm min-w-32"
+                placeholder="Event title…"
+                value={newTitle()}
+                onInput={(e) => setNewTitle((e.target as HTMLInputElement).value)}
+              />
+              <select
+                className="new-event-color-select h-8 rounded-md border border-input bg-background px-2 text-sm"
+                value={newColor()}
+                onChange={(e) => setNewColor((e.target as HTMLSelectElement).value as EventColor)}
+              >
+                {COLOR_OPTIONS.map(c => (
+                  <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="create-confirm-btn h-8 rounded-md bg-primary px-3 text-sm text-primary-foreground"
+                onClick={confirmCreate}
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                className="create-cancel-btn h-8 rounded-md border border-input bg-background px-3 text-sm"
+                onClick={cancelCreate}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : null}
+
+          {dayPanelEvents().length > 0 ? (
+            <div className="day-event-list space-y-1">
+              {dayPanelEvents().map(evt => (
+                <button
+                  key={String(evt.id)}
+                  type="button"
+                  className={`day-event-item w-full text-left rounded border-l-2 px-2 py-1 text-xs cursor-pointer hover:opacity-80 ${COLOR_CLASSES[evt.color]}`}
+                  onClick={() => selectEvent(evt.id)}
+                >
+                  <span className="font-medium">{evt.title}</span>
+                  <span className="ml-1 opacity-75">{formatHour(evt.startHour)}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          {dayPanelEvents().length === 0 && !showCreateForm() ? (
+            <p className="day-empty-msg text-xs text-muted-foreground">No events. Click "+ Add event" to create one.</p>
+          ) : null}
+
+          {selectedEvent() ? (
+            <div className="selected-event-detail rounded-md border p-2">
+              <div className={`flex items-center justify-between rounded px-2 py-1 ${COLOR_CLASSES[selectedEvent()!.color]}`}>
+                <div>
+                  <span className="font-medium text-sm">{selectedEvent()!.title}</span>
+                  <span className="ml-2 text-xs opacity-75">
+                    {formatHour(selectedEvent()!.startHour)}–{formatHour(selectedEvent()!.startHour + selectedEvent()!.duration)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 ml-2">
+                  <button
+                    type="button"
+                    className="delete-event-btn h-6 rounded px-2 text-xs border opacity-70 hover:opacity-100"
+                    onClick={() => removeEvent(selectedEvent()!.id)}
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    className="close-detail-btn h-6 w-6 flex items-center justify-center rounded border text-xs"
+                    onClick={() => setSelectedEventId(null)}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* MONTH VIEW */}
+      {viewMode() === 'month' ? (
+        <div className="month-view overflow-hidden rounded-md border border-border">
+          <div className="grid grid-cols-7 border-b border-border">
+            {DAYS_OF_WEEK.map(dow => (
+              <div key={dow} className="py-2 text-center text-xs font-medium text-muted-foreground">
+                {dow}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7">
+            {calendarDays().map(cell => (
+              <button
+                key={cell.key}
+                type="button"
+                className={`month-day-cell min-h-24 border-b border-r border-border p-1 text-left hover:bg-accent/40 ${cell.isCurrentMonth ? '' : 'opacity-40'}`}
+                onClick={() => selectDay(cell.key)}
+              >
+                <div
+                  className={`mb-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${cell.key === TODAY_KEY ? 'today-marker bg-primary text-primary-foreground' : 'text-foreground'}`}
+                >
+                  {cell.date.getDate()}
+                </div>
+                {(eventsByDate()[cell.key]?.length ?? 0) > 0 ? (
+                  <div className="event-dot-count text-xs text-muted-foreground">
+                    {eventsByDate()[cell.key].length} event{eventsByDate()[cell.key].length > 1 ? 's' : ''}
+                  </div>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* WEEK VIEW */}
+      {viewMode() === 'week' ? (
+        <div className="week-view overflow-hidden rounded-md border border-border">
+          <div className="flex border-b border-border">
+            <div className="w-14 flex-none" />
+            {weekDays().map(d => (
+              <div
+                key={d.key}
+                className={`flex-1 py-2 text-center text-xs font-medium ${d.key === TODAY_KEY ? 'text-primary' : 'text-muted-foreground'}`}
+              >
+                <div>{DAYS_OF_WEEK[d.date.getDay()]}</div>
+                <div
+                  className={`mx-auto mt-0.5 flex h-6 w-6 items-center justify-center rounded-full text-sm font-semibold ${d.key === TODAY_KEY ? 'week-today-marker bg-primary text-primary-foreground' : ''}`}
+                >
+                  {d.date.getDate()}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="week-time-grid overflow-y-auto" style="max-height: 480px">
+            <div className="flex">
+              <div className="week-hour-labels w-14 flex-none">
+                {HOURS.map(h => (
+                  <div
+                    key={String(h)}
+                    className="flex items-start justify-end border-b border-border pr-2 pt-0.5 text-xs text-muted-foreground"
+                    style={`height: ${HOUR_PX}px`}
+                  >
+                    {h > 0 ? formatHour(h) : ''}
+                  </div>
+                ))}
+              </div>
+
+              {weekDays().map(d => (
+                <div
+                  key={d.key}
+                  className="week-day-col relative flex-1 border-l border-border"
+                  style={`height: ${24 * HOUR_PX}px`}
+                >
+                  {HOURS.map(h => (
+                    <div
+                      key={String(h)}
+                      className="week-hour-slot absolute w-full border-b border-border cursor-pointer hover:bg-accent/30"
+                      style={`top: ${h * HOUR_PX}px; height: ${HOUR_PX}px`}
+                      onClick={() => openCreateInWeek(d.key, h)}
+                    />
+                  ))}
+
+                  {(weekEventsByDay()[d.key] ?? []).map(evt => {
+                    const pos = eventPositions()[evt.id]
+                    if (!pos) return null
+                    return (
+                      <div
+                        key={String(evt.id)}
+                        className={`week-event absolute overflow-hidden rounded border px-1 py-0.5 text-xs cursor-pointer hover:opacity-80 ${COLOR_CLASSES[evt.color]}`}
+                        style={`top: ${pos.top}px; height: ${pos.height}px; left: ${pos.left}%; width: ${pos.width}%; z-index: 1`}
+                        onClick={() => selectWeekEvent(d.key, evt.id)}
+                      >
+                        <div className="font-medium truncate">{evt.title}</div>
+                        <div className="opacity-75">{formatHour(evt.startHour)}</div>
+                      </div>
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/site/ui/components/gallery/productivity/files-demo.tsx
+++ b/site/ui/components/gallery/productivity/files-demo.tsx
@@ -1,0 +1,288 @@
+"use client"
+/**
+ * ProductivityFilesDemo
+ *
+ * Adapted FileBrowserDemo for /gallery/productivity/files.
+ *
+ * Compiler stress targets (inherited):
+ * - Nested loops with conditionals (folder expand/collapse)
+ * - Recursive data structure rendering
+ * - Selection state propagation
+ * - Dynamic list updates (create/delete)
+ * - Derived state (selected count, total size)
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Input } from '@ui/components/ui/input'
+import { Separator } from '@ui/components/ui/separator'
+
+type FileItem = {
+  id: number
+  name: string
+  type: 'file'
+  size: number
+  selected: boolean
+}
+
+type FolderItem = {
+  id: number
+  name: string
+  type: 'folder'
+  expanded: boolean
+  selected: boolean
+  children: TreeNode[]
+}
+
+type TreeNode = FileItem | FolderItem
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function countFiles(nodes: TreeNode[]): number {
+  let count = 0
+  for (const node of nodes) {
+    if (node.type === 'file') count++
+    else count += countFiles(node.children)
+  }
+  return count
+}
+
+function totalSize(nodes: TreeNode[]): number {
+  let size = 0
+  for (const node of nodes) {
+    if (node.type === 'file') size += node.size
+    else size += totalSize(node.children)
+  }
+  return size
+}
+
+function countSelected(nodes: TreeNode[]): number {
+  let count = 0
+  for (const node of nodes) {
+    if (node.selected) count++
+    if (node.type === 'folder') count += countSelected(node.children)
+  }
+  return count
+}
+
+const initialTree: TreeNode[] = [
+  {
+    id: 1, name: 'src', type: 'folder', expanded: true, selected: false,
+    children: [
+      {
+        id: 2, name: 'components', type: 'folder', expanded: true, selected: false,
+        children: [
+          { id: 3, name: 'Button.tsx', type: 'file', size: 2048, selected: false },
+          { id: 4, name: 'Input.tsx', type: 'file', size: 1536, selected: false },
+          { id: 5, name: 'Dialog.tsx', type: 'file', size: 3200, selected: false },
+        ],
+      },
+      {
+        id: 6, name: 'utils', type: 'folder', expanded: false, selected: false,
+        children: [
+          { id: 7, name: 'format.ts', type: 'file', size: 512, selected: false },
+          { id: 8, name: 'cn.ts', type: 'file', size: 256, selected: false },
+        ],
+      },
+      { id: 9, name: 'index.ts', type: 'file', size: 128, selected: false },
+    ],
+  },
+  {
+    id: 10, name: 'public', type: 'folder', expanded: false, selected: false,
+    children: [
+      { id: 11, name: 'favicon.ico', type: 'file', size: 4096, selected: false },
+      { id: 12, name: 'robots.txt', type: 'file', size: 64, selected: false },
+    ],
+  },
+  { id: 13, name: 'package.json', type: 'file', size: 1024, selected: false },
+  { id: 14, name: 'tsconfig.json', type: 'file', size: 384, selected: false },
+  { id: 15, name: 'README.md', type: 'file', size: 2560, selected: false },
+]
+
+let nextId = 100
+
+export function ProductivityFilesDemo() {
+  const [tree, setTree] = createSignal<TreeNode[]>(initialTree)
+
+  const fileCount = createMemo(() => countFiles(tree()))
+  const totalBytes = createMemo(() => totalSize(tree()))
+  const selectedCount = createMemo(() => countSelected(tree()))
+
+  const updateNode = (nodes: TreeNode[], id: number, updater: (node: TreeNode) => TreeNode): TreeNode[] => {
+    return nodes.map(node => {
+      if (node.id === id) return updater(node)
+      if (node.type === 'folder') {
+        return { ...node, children: updateNode(node.children, id, updater) }
+      }
+      return node
+    })
+  }
+
+  const toggleExpand = (id: number) => {
+    setTree(prev => updateNode(prev, id, node =>
+      node.type === 'folder' ? { ...node, expanded: !node.expanded } : node
+    ))
+  }
+
+  const toggleSelect = (id: number) => {
+    setTree(prev => updateNode(prev, id, node => ({ ...node, selected: !node.selected })))
+  }
+
+  const deleteSelected = () => {
+    const removeSelected = (nodes: TreeNode[]): TreeNode[] =>
+      nodes
+        .filter(n => !n.selected)
+        .map(n => n.type === 'folder' ? { ...n, children: removeSelected(n.children) } : n)
+    setTree(removeSelected)
+  }
+
+  const addFile = (folderId: number, name: string) => {
+    if (!name.trim()) return
+    const newFile: FileItem = {
+      id: nextId++,
+      name: name.trim(),
+      type: 'file',
+      size: Math.floor(Math.random() * 4096) + 128,
+      selected: false,
+    }
+    setTree(prev => updateNode(prev, folderId, node =>
+      node.type === 'folder' ? { ...node, children: [...node.children, newFile], expanded: true } : node
+    ))
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-4">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 rounded-lg border p-3">
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{fileCount()}</span> files
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{formatSize(totalBytes())}</span>
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">{selectedCount()}</span> selected
+        </div>
+        <div className="flex-1" />
+        <Button variant="destructive" size="sm" disabled={selectedCount() === 0} onClick={() => deleteSelected()}>
+          Delete selected
+        </Button>
+      </div>
+
+      {/* Tree */}
+      <div className="rounded-lg border">
+        <div className="p-2">
+          {tree().map(node => (
+            <div key={node.id}>
+              {node.type === 'folder' ? (
+                <div>
+                  <div className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50">
+                    <Checkbox checked={node.selected} onCheckedChange={() => toggleSelect(node.id)} />
+                    <button
+                      className="flex items-center gap-1 text-sm font-medium flex-1 text-left"
+                      onClick={() => toggleExpand(node.id)}
+                    >
+                      <span className="w-4 text-center text-muted-foreground">{node.expanded ? '▼' : '▶'}</span>
+                      <span>📁</span>
+                      <span>{node.name}</span>
+                      <Badge variant="secondary" className="ml-auto text-xs">{node.children.length}</Badge>
+                    </button>
+                  </div>
+                  {node.expanded ? (
+                    <div className="ml-6 border-l pl-2">
+                      {node.children.map(child => (
+                        <div key={child.id}>
+                          {child.type === 'folder' ? (
+                            <div>
+                              <div className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50">
+                                <Checkbox checked={child.selected} onCheckedChange={() => toggleSelect(child.id)} />
+                                <button
+                                  className="flex items-center gap-1 text-sm font-medium flex-1 text-left"
+                                  onClick={() => toggleExpand(child.id)}
+                                >
+                                  <span className="w-4 text-center text-muted-foreground">{child.expanded ? '▼' : '▶'}</span>
+                                  <span>📁</span>
+                                  <span>{child.name}</span>
+                                  <Badge variant="secondary" className="ml-auto text-xs">{child.children.length}</Badge>
+                                </button>
+                              </div>
+                              {child.expanded ? (
+                                <div className="ml-6 border-l pl-2">
+                                  {child.children.map(grandchild => (
+                                    <div key={grandchild.id} className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50">
+                                      <Checkbox checked={grandchild.selected} onCheckedChange={() => toggleSelect(grandchild.id)} />
+                                      <span className="w-4" />
+                                      <span className="text-sm">📄</span>
+                                      <span className="text-sm flex-1">{grandchild.name}</span>
+                                      <span className="text-xs text-muted-foreground">{grandchild.type === 'file' ? formatSize(grandchild.size) : ''}</span>
+                                    </div>
+                                  ))}
+                                  <div className="flex items-center gap-2 px-2 py-1">
+                                    <span className="w-4" />
+                                    <Input
+                                      placeholder="New file..."
+                                      className="flex-1 h-6 text-xs"
+                                      onKeyDown={(e: KeyboardEvent) => {
+                                        if (e.key === 'Enter') {
+                                          const input = e.target as HTMLInputElement
+                                          addFile(child.id, input.value)
+                                          input.value = ''
+                                        }
+                                      }}
+                                    />
+                                  </div>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : (
+                            <div className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50">
+                              <Checkbox checked={child.selected} onCheckedChange={() => toggleSelect(child.id)} />
+                              <span className="w-4" />
+                              <span className="text-sm">📄</span>
+                              <span className="text-sm flex-1">{child.name}</span>
+                              <span className="text-xs text-muted-foreground">{child.type === 'file' ? formatSize(child.size) : ''}</span>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                      <div className="flex items-center gap-2 px-2 py-1">
+                        <span className="w-4" />
+                        <Input
+                          placeholder="New file..."
+                          className="flex-1 h-6 text-xs"
+                          onKeyDown={(e: KeyboardEvent) => {
+                            if (e.key === 'Enter') {
+                              const input = e.target as HTMLInputElement
+                              addFile(node.id, input.value)
+                              input.value = ''
+                            }
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 rounded px-2 py-1 hover:bg-muted/50">
+                  <Checkbox checked={node.selected} onCheckedChange={() => toggleSelect(node.id)} />
+                  <span className="w-4" />
+                  <span className="text-sm">📄</span>
+                  <span className="text-sm flex-1">{node.name}</span>
+                  <span className="text-xs text-muted-foreground">{node.type === 'file' ? formatSize(node.size) : ''}</span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/productivity/mail-demo.tsx
+++ b/site/ui/components/gallery/productivity/mail-demo.tsx
@@ -1,0 +1,371 @@
+"use client"
+/**
+ * ProductivityMailDemo
+ *
+ * Adapted MailInboxDemo for /gallery/productivity/mail. Additions over the
+ * standalone block:
+ * - Writes unread mail count to sessionStorage so ProductivityUnreadBadge
+ *   stays in sync across full-page navigation.
+ *
+ * Compiler stress targets (inherited + new):
+ * - Dynamic array signal (add/delete), state toggles inside loops
+ * - AlertDialog/portal from loop context, filter+map chains, derived memos
+ * - createEffect writing memo value to sessionStorage (cross-page state)
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@ui/components/ui/card'
+import { Badge } from '@ui/components/ui/badge'
+import { Input } from '@ui/components/ui/input'
+import { Button } from '@ui/components/ui/button'
+import { Checkbox } from '@ui/components/ui/checkbox'
+import { Separator } from '@ui/components/ui/separator'
+import {
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@ui/components/ui/alert-dialog'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+import { writeUnreadMailCount } from '../../shared/gallery-productivity-storage'
+
+type Mail = {
+  id: number
+  from: string
+  subject: string
+  preview: string
+  body: string
+  date: string
+  read: boolean
+  starred: boolean
+  selected: boolean
+}
+
+const initialMails: Mail[] = [
+  {
+    id: 1,
+    from: 'Alice Johnson',
+    subject: 'Q4 Planning Meeting',
+    preview: 'Let\'s discuss the Q4 roadmap and key milestones...',
+    body: 'Hi team,\n\nLet\'s discuss the Q4 roadmap and key milestones for the upcoming quarter. Please review the attached document before the meeting.\n\nBest regards,\nAlice',
+    date: 'Oct 22',
+    read: false,
+    starred: true,
+    selected: false,
+  },
+  {
+    id: 2,
+    from: 'Bob Smith',
+    subject: 'Design Review Feedback',
+    preview: 'Great work on the new dashboard design. A few notes...',
+    body: 'Great work on the new dashboard design. A few notes:\n\n1. The color scheme looks solid\n2. Consider adding more whitespace in the sidebar\n3. The responsive breakpoints need adjustment\n\nLet me know if you have questions.',
+    date: 'Oct 21',
+    read: true,
+    starred: false,
+    selected: false,
+  },
+  {
+    id: 3,
+    from: 'Carol White',
+    subject: 'Invoice #1234 Approved',
+    preview: 'Your invoice has been approved and payment is...',
+    body: 'Your invoice #1234 has been approved and payment is scheduled for processing within 5 business days. Please reach out to accounting if you have any questions.',
+    date: 'Oct 20',
+    read: false,
+    starred: false,
+    selected: false,
+  },
+  {
+    id: 4,
+    from: 'David Brown',
+    subject: 'Team Outing This Friday',
+    preview: 'Reminder: team outing this Friday at 3pm...',
+    body: 'Reminder: team outing this Friday at 3pm. We\'ll be going to the park for some outdoor activities. Please RSVP by Wednesday so we can plan accordingly.\n\nLooking forward to it!',
+    date: 'Oct 19',
+    read: true,
+    starred: true,
+    selected: false,
+  },
+  {
+    id: 5,
+    from: 'Eve Davis',
+    subject: 'Security Alert: New Login',
+    preview: 'A new login was detected from an unrecognized device...',
+    body: 'A new login was detected from an unrecognized device.\n\nDevice: Chrome on macOS\nLocation: San Francisco, CA\nTime: Oct 18, 2024 at 2:30 PM\n\nIf this wasn\'t you, please change your password immediately.',
+    date: 'Oct 18',
+    read: false,
+    starred: false,
+    selected: false,
+  },
+  {
+    id: 6,
+    from: 'Frank Wilson',
+    subject: 'Project Deadline Extended',
+    preview: 'Good news — the client has agreed to extend...',
+    body: 'Good news — the client has agreed to extend the project deadline by two weeks. This gives us more time to polish the deliverables and run additional testing.\n\nUpdated timeline will be shared tomorrow.',
+    date: 'Oct 17',
+    read: true,
+    starred: false,
+    selected: false,
+  },
+]
+
+export function ProductivityMailDemo() {
+  const [mails, setMails] = createSignal<Mail[]>(initialMails.map(m => ({ ...m })))
+  const [selectedId, setSelectedId] = createSignal<number | null>(null)
+  const [searchQuery, setSearchQuery] = createSignal('')
+  const [deleteDialogOpen, setDeleteDialogOpen] = createSignal(false)
+  const [deleteTargetId, setDeleteTargetId] = createSignal<number | null>(null)
+  const [toastOpen, setToastOpen] = createSignal(false)
+  const [toastMessage, setToastMessage] = createSignal('')
+
+  const filteredMails = createMemo(() =>
+    mails().filter((m) => {
+      const query = searchQuery().toLowerCase()
+      if (query === '') return true
+      return m.from.toLowerCase().includes(query) ||
+        m.subject.toLowerCase().includes(query) ||
+        m.preview.toLowerCase().includes(query)
+    })
+  )
+
+  const selectedMail = createMemo(() =>
+    mails().find((m) => m.id === selectedId())
+  )
+
+  const selectedCount = createMemo(() =>
+    mails().filter((m) => m.selected).length
+  )
+
+  const isAllSelected = createMemo(() => {
+    const filtered = filteredMails()
+    if (filtered.length === 0) return false
+    return filtered.every((m) => m.selected)
+  })
+
+  const unreadCount = createMemo(() =>
+    mails().filter((m) => !m.read).length
+  )
+
+  // Cross-page state: keep sidebar badge in sync after navigation
+  createEffect(() => {
+    writeUnreadMailCount(unreadCount())
+  })
+
+  const showToast = (message: string) => {
+    setToastMessage(message)
+    setToastOpen(true)
+    setTimeout(() => setToastOpen(false), 3000)
+  }
+
+  const handleSelectMail = (id: number) => {
+    setSelectedId(id)
+    setMails(mails().map(m => m.id === id ? { ...m, read: true } : m))
+  }
+
+  const handleToggleStar = (id: number) => {
+    setMails(mails().map(m => m.id === id ? { ...m, starred: !m.starred } : m))
+  }
+
+  const handleToggleSelect = (id: number) => {
+    setMails(mails().map(m => m.id === id ? { ...m, selected: !m.selected } : m))
+  }
+
+  const handleToggleAll = (value: boolean) => {
+    const filteredIds = filteredMails().map(m => m.id)
+    setMails(mails().map(m => filteredIds.includes(m.id) ? { ...m, selected: value } : m))
+  }
+
+  const handleToggleRead = () => {
+    const mail = selectedMail()
+    if (!mail) return
+    setMails(mails().map(m => m.id === mail.id ? { ...m, read: !m.read } : m))
+  }
+
+  const handleDeleteClick = (id: number) => {
+    setDeleteTargetId(id)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    const targetId = deleteTargetId()
+    if (targetId === null) return
+    setMails(mails().filter(m => m.id !== targetId))
+    if (selectedId() === targetId) {
+      setSelectedId(null)
+    }
+    setDeleteDialogOpen(false)
+    setDeleteTargetId(null)
+    showToast('Email deleted successfully')
+  }
+
+  const handleDeleteSelected = () => {
+    const selectedIds = mails().filter(m => m.selected).map(m => m.id)
+    setMails(mails().filter(m => !m.selected))
+    if (selectedId() !== null && selectedIds.includes(selectedId()!)) {
+      setSelectedId(null)
+    }
+    showToast(`${selectedIds.length} email(s) deleted`)
+  }
+
+  return (
+    <div className="w-full max-w-5xl">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Inbox</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {/* Toolbar */}
+          <div className="flex items-center gap-3 px-4 py-2 border-b">
+            <Checkbox
+              checked={isAllSelected()}
+              onCheckedChange={handleToggleAll}
+            />
+            <Input
+              placeholder="Search mail..."
+              value={searchQuery()}
+              onInput={(e) => setSearchQuery(e.target.value)}
+              className="max-w-xs h-8 text-sm"
+            />
+            <span className="mail-count text-sm text-muted-foreground whitespace-nowrap">
+              {filteredMails().length} of {mails().length}
+            </span>
+            {selectedCount() > 0 ? (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDeleteSelected}
+              >
+                Delete selected
+              </Button>
+            ) : null}
+          </div>
+
+          {/* Two-panel layout */}
+          <div className="flex min-h-[400px]">
+            {/* Mail list (left panel) */}
+            <div className="w-2/5 border-r overflow-y-auto">
+              {filteredMails().map((mail) => (
+                <div
+                  key={mail.id}
+                  className={`mail-row flex items-start gap-2 px-3 py-3 border-b cursor-pointer hover:bg-muted/50 ${mail.id === selectedId() ? 'bg-muted' : ''}`}
+                >
+                  <div className="pt-0.5">
+                    <Checkbox
+                      checked={mail.selected}
+                      onCheckedChange={() => handleToggleSelect(mail.id)}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    className={`star-button shrink-0 pt-0.5 text-sm bg-transparent border-none cursor-pointer p-0 ${mail.starred ? 'text-yellow-500' : 'text-muted-foreground'}`}
+                    onClick={() => handleToggleStar(mail.id)}
+                  >
+                    {mail.starred ? '★' : '☆'}
+                  </button>
+                  <div className="mail-content flex-1 min-w-0" onClick={() => handleSelectMail(mail.id)}>
+                    <div className="flex items-center justify-between gap-2">
+                      <span className={`mail-from text-sm truncate ${!mail.read ? 'font-semibold' : ''}`}>{mail.from}</span>
+                      <span className="text-xs text-muted-foreground shrink-0">{mail.date}</span>
+                    </div>
+                    <p className={`mail-subject text-sm truncate ${!mail.read ? 'font-medium' : 'text-muted-foreground'}`}>{mail.subject}</p>
+                    <p className="text-xs text-muted-foreground truncate">{mail.preview}</p>
+                    <div className="flex gap-1 mt-1">
+                      {!mail.read ? <Badge variant="default" className="text-[10px] px-1.5 py-0">New</Badge> : null}
+                      {mail.starred ? <Badge variant="outline" className="text-[10px] px-1.5 py-0">Starred</Badge> : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Mail detail (right panel) */}
+            <div className="w-3/5 overflow-y-auto">
+              {selectedMail() ? (
+                <div className="mail-detail p-4 space-y-4">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h3 className="mail-detail-subject text-lg font-semibold">{selectedMail()!.subject}</h3>
+                      <p className="mail-detail-from text-sm text-muted-foreground">From: {selectedMail()!.from}</p>
+                      <p className="text-xs text-muted-foreground">{selectedMail()!.date}</p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleToggleRead}
+                      >
+                        <span className="read-toggle-text">{selectedMail()!.read ? 'Mark unread' : 'Mark read'}</span>
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDeleteClick(selectedMail()!.id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+
+                  <Separator />
+
+                  <div className="mail-body text-sm whitespace-pre-line">{selectedMail()!.body}</div>
+                </div>
+              ) : (
+                <div className="mail-empty flex items-center justify-center h-full text-muted-foreground text-sm">
+                  Select an email to read
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* AlertDialog for delete confirmation */}
+      <AlertDialog open={deleteDialogOpen()} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogOverlay />
+        <AlertDialogContent
+          ariaLabelledby="delete-mail-title"
+          ariaDescribedby="delete-mail-desc"
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle id="delete-mail-title">Delete Email</AlertDialogTitle>
+            <AlertDialogDescription id="delete-mail-desc">
+              Are you sure you want to delete this email? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteConfirm}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <ToastProvider position="bottom-right">
+        <Toast variant="success" open={toastOpen()}>
+          <div className="flex-1">
+            <ToastTitle>Success</ToastTitle>
+            <ToastDescription className="toast-message">{toastMessage()}</ToastDescription>
+          </div>
+          <ToastClose onClick={() => setToastOpen(false)} />
+        </Toast>
+      </ToastProvider>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/productivity/productivity-shell.tsx
+++ b/site/ui/components/gallery/productivity/productivity-shell.tsx
@@ -1,0 +1,178 @@
+/**
+ * ProductivityShell
+ *
+ * Shared layout primitive for /gallery/productivity/* pages. SSR-only chrome
+ * (sidebar + header frame); the unread-mail badge island lives in a sibling
+ * "use client" component (ProductivityUnreadBadge).
+ *
+ * Compiler stress targets:
+ * - Shared layout wrapping per-route reactive content (each page mounts
+ *   its own signal scope inside this shell).
+ * - Active-route class on sidebar items derived from currentRoute prop.
+ * - Cross-page persistent state: unread mail count written by the mail page,
+ *   read by all pages via sessionStorage (see gallery-productivity-storage.ts).
+ */
+
+import type { Child } from 'hono/jsx'
+import { ProductivityUnreadBadge } from './productivity-unread-badge'
+
+export type ProductivityRouteKey = 'mail' | 'files' | 'board' | 'calendar'
+
+interface NavItem {
+  key: ProductivityRouteKey
+  href: string
+  label: string
+  icon: string
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'mail', href: '/gallery/productivity/mail', label: 'Mail', icon: 'mail' },
+  { key: 'files', href: '/gallery/productivity/files', label: 'Files', icon: 'files' },
+  { key: 'board', href: '/gallery/productivity/board', label: 'Board', icon: 'board' },
+  { key: 'calendar', href: '/gallery/productivity/calendar', label: 'Calendar', icon: 'calendar' },
+]
+
+const PAGE_TITLES: Record<ProductivityRouteKey, string> = {
+  mail: 'Mail',
+  files: 'Files',
+  board: 'Board',
+  calendar: 'Calendar',
+}
+
+function NavIcon({ name }: { name: string }) {
+  switch (name) {
+    case 'mail':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="20" height="16" x="2" y="4" rx="2" />
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+        </svg>
+      )
+    case 'files':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+        </svg>
+      )
+    case 'board':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <line x1="9" y1="3" x2="9" y2="21" />
+          <line x1="15" y1="3" x2="15" y2="21" />
+        </svg>
+      )
+    case 'calendar':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+      )
+    default:
+      return null
+  }
+}
+
+interface ProductivityShellProps {
+  currentRoute: ProductivityRouteKey
+  children?: Child
+}
+
+export function ProductivityShell({ currentRoute, children }: ProductivityShellProps) {
+  return (
+    <div className="productivity-shell flex min-h-[calc(100vh-8rem)] w-full rounded-xl border bg-card overflow-hidden">
+      {/* Sidebar */}
+      <aside
+        data-productivity-sidebar=""
+        className="hidden md:flex w-56 flex-col border-r bg-muted/30"
+        aria-label="Productivity navigation"
+      >
+        <div className="flex items-center gap-2 px-4 py-4 border-b">
+          <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold">
+            P
+          </div>
+          <span className="text-sm font-semibold">Workspace</span>
+        </div>
+        <nav className="flex flex-col gap-0.5 p-2">
+          {NAV_ITEMS.map((item) => {
+            const active = item.key === currentRoute
+            return (
+              <a
+                href={item.href}
+                data-productivity-nav-item={item.key}
+                data-active={active ? 'true' : 'false'}
+                aria-current={active ? 'page' : undefined}
+                className={`productivity-nav-link flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors no-underline ${
+                  active
+                    ? 'bg-primary text-primary-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                }`}
+              >
+                <NavIcon name={item.icon} />
+                <span>{item.label}</span>
+                {item.key === 'mail' ? <ProductivityUnreadBadge /> : null}
+              </a>
+            )
+          })}
+        </nav>
+        <div className="mt-auto border-t px-4 py-3">
+          <div className="flex items-center gap-2">
+            <div className="size-7 rounded-full bg-muted" />
+            <div className="flex flex-col leading-tight">
+              <span className="text-xs font-medium">Alex Worker</span>
+              <span className="text-[10px] text-muted-foreground">alex@workspace.app</span>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      {/* Main column */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header
+          data-productivity-header=""
+          className="flex items-center justify-between gap-3 border-b px-4 py-3 bg-background/60"
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            <h1 className="productivity-page-title text-base font-semibold truncate">
+              {PAGE_TITLES[currentRoute]}
+            </h1>
+          </div>
+        </header>
+
+        {/* Mobile nav strip */}
+        <nav
+          data-productivity-mobile-nav=""
+          className="md:hidden flex overflow-x-auto gap-1 border-b px-3 py-2 bg-background/60"
+          aria-label="Productivity navigation (mobile)"
+        >
+          {NAV_ITEMS.map((item) => {
+            const active = item.key === currentRoute
+            return (
+              <a
+                href={item.href}
+                data-productivity-mobile-nav-item={item.key}
+                data-active={active ? 'true' : 'false'}
+                aria-current={active ? 'page' : undefined}
+                className={`productivity-mobile-nav-link shrink-0 flex items-center gap-1 rounded-md px-3 py-1.5 text-xs transition-colors no-underline ${
+                  active
+                    ? 'bg-primary text-primary-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                }`}
+              >
+                {item.label}
+                {item.key === 'mail' ? <ProductivityUnreadBadge /> : null}
+              </a>
+            )
+          })}
+        </nav>
+
+        <div className="productivity-page flex-1 overflow-x-auto p-4 sm:p-6">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/productivity/productivity-unread-badge.tsx
+++ b/site/ui/components/gallery/productivity/productivity-unread-badge.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { createSignal } from '@barefootjs/client'
+import { readUnreadMailCount } from '../../shared/gallery-productivity-storage'
+
+// Compiler constraint: top-level conditional returns in "use client" components
+// are not preserved by the compiler (SSR always renders the truthy branch).
+// Workaround: wrap in a `contents` container so the conditional is an inner
+// child expression — matching the AdminUnreadBadge pattern.
+export function ProductivityUnreadBadge() {
+  const [count, setCount] = createSignal<number>(readUnreadMailCount())
+
+  // Each productivity route is a full page navigation so listeners don't
+  // accumulate — no onCleanup needed (same pattern as AdminUnreadBadge).
+  if (typeof window !== 'undefined') {
+    window.addEventListener('barefoot:productivity-storage', () => setCount(readUnreadMailCount()))
+  }
+
+  return (
+    <span className="contents" aria-live="polite">
+      {count() > 0 ? (
+        <span
+          data-unread-count={count()}
+          className="productivity-unread-count inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground"
+        >
+          {count()}
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/site/ui/components/shared/gallery-productivity-storage.ts
+++ b/site/ui/components/shared/gallery-productivity-storage.ts
@@ -1,0 +1,41 @@
+// Shared session-storage helpers for the /gallery/productivity app.
+//
+// Reactive primitives must stay in each consuming component — the compiler
+// only recognizes createSignal / createEffect at the source call site. These
+// are pure read/write helpers; components keep their own signal pairs inline.
+
+const NAMESPACE = 'barefoot.gallery.productivity'
+
+function storageKey(key: string): string {
+  return `${NAMESPACE}.${key}`
+}
+
+function readRaw(key: string): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage.getItem(storageKey(key))
+  } catch {
+    return null
+  }
+}
+
+function writeRaw(key: string, value: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(storageKey(key), value)
+    window.dispatchEvent(new CustomEvent('barefoot:productivity-storage', { detail: { key } }))
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+export function readUnreadMailCount(fallback = 0): number {
+  const raw = readRaw('unreadMailCount')
+  if (raw == null) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : fallback
+}
+
+export function writeUnreadMailCount(value: number): void {
+  writeRaw('unreadMailCount', String(value))
+}

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -106,6 +106,7 @@ export const navSections: NavSection[] = [
         links: [
           { title: 'Admin Dashboard', href: '/gallery/admin' },
           { title: 'E-Commerce Shop', href: '/gallery/shop' },
+          { title: 'Productivity Suite', href: '/gallery/productivity' },
         ],
         matchPath: (p) => p.startsWith('/gallery/'),
       },

--- a/site/ui/pages/gallery/productivity/board.tsx
+++ b/site/ui/pages/gallery/productivity/board.tsx
@@ -1,0 +1,14 @@
+import { ProductivityShell } from '@/components/gallery/productivity/productivity-shell'
+import { ProductivityBoardDemo } from '@/components/gallery/productivity/board-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ProductivityBoardPage() {
+  return (
+    <>
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <ProductivityShell currentRoute="board">
+        <ProductivityBoardDemo />
+      </ProductivityShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/productivity/calendar.tsx
+++ b/site/ui/pages/gallery/productivity/calendar.tsx
@@ -1,0 +1,14 @@
+import { ProductivityShell } from '@/components/gallery/productivity/productivity-shell'
+import { ProductivityCalendarDemo } from '@/components/gallery/productivity/calendar-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ProductivityCalendarPage() {
+  return (
+    <>
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <ProductivityShell currentRoute="calendar">
+        <ProductivityCalendarDemo />
+      </ProductivityShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/productivity/files.tsx
+++ b/site/ui/pages/gallery/productivity/files.tsx
@@ -1,0 +1,14 @@
+import { ProductivityShell } from '@/components/gallery/productivity/productivity-shell'
+import { ProductivityFilesDemo } from '@/components/gallery/productivity/files-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ProductivityFilesPage() {
+  return (
+    <>
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <ProductivityShell currentRoute="files">
+        <ProductivityFilesDemo />
+      </ProductivityShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/productivity/mail.tsx
+++ b/site/ui/pages/gallery/productivity/mail.tsx
@@ -1,0 +1,14 @@
+import { ProductivityShell } from '@/components/gallery/productivity/productivity-shell'
+import { ProductivityMailDemo } from '@/components/gallery/productivity/mail-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function ProductivityMailPage() {
+  return (
+    <>
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <ProductivityShell currentRoute="mail">
+        <ProductivityMailDemo />
+      </ProductivityShell>
+    </>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -117,6 +117,10 @@ import { AdminSettingsPage } from './pages/gallery/admin/settings'
 import { ShopCatalogPage } from './pages/gallery/shop/index'
 import { ShopCartPage } from './pages/gallery/shop/cart'
 import { ShopCheckoutPage } from './pages/gallery/shop/checkout'
+import { ProductivityMailPage } from './pages/gallery/productivity/mail'
+import { ProductivityFilesPage } from './pages/gallery/productivity/files'
+import { ProductivityBoardPage } from './pages/gallery/productivity/board'
+import { ProductivityCalendarPage } from './pages/gallery/productivity/calendar'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -632,6 +636,27 @@ export function createApp() {
 
   app.get('/gallery/shop/checkout', (c) => {
     return c.render(<ShopCheckoutPage />)
+  })
+
+  // Gallery — Productivity app (Phase 9)
+  app.get('/gallery/productivity', (c) => {
+    return c.render(<ProductivityMailPage />)
+  })
+
+  app.get('/gallery/productivity/mail', (c) => {
+    return c.render(<ProductivityMailPage />)
+  })
+
+  app.get('/gallery/productivity/files', (c) => {
+    return c.render(<ProductivityFilesPage />)
+  })
+
+  app.get('/gallery/productivity/board', (c) => {
+    return c.render(<ProductivityBoardPage />)
+  })
+
+  app.get('/gallery/productivity/calendar', (c) => {
+    return c.render(<ProductivityCalendarPage />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
## Summary

- Implements `/gallery/productivity/*` from Phase 2 of #929 (Productivity Suite)
- Four routes under a shared `ProductivityShell` sidebar layout: mail, files, board, calendar
- Cross-page state: unread mail count written by the mail page via `createEffect` → sessionStorage; `ProductivityUnreadBadge` reads it and stays in sync across full-page navigations

## Routes

| Route | Demo adapted from |
|-------|-------------------|
| `/gallery/productivity` | → mail (default) |
| `/gallery/productivity/mail` | `MailInboxDemo` |
| `/gallery/productivity/files` | `FileBrowserDemo` |
| `/gallery/productivity/board` | `KanbanDemo` |
| `/gallery/productivity/calendar` | `CalendarSchedulerDemo` |

## New files

- `components/shared/gallery-productivity-storage.ts` — sessionStorage I/O helpers (unread mail count)
- `components/gallery/productivity/productivity-shell.tsx` — SSR sidebar layout (mirrors AdminShell pattern)
- `components/gallery/productivity/productivity-unread-badge.tsx` — `"use client"` badge island
- `components/gallery/productivity/{mail,files,board,calendar}-demo.tsx` — demo components
- `pages/gallery/productivity/{mail,files,board,calendar}.tsx` — page entry points

## Compiler stress targets exercised

- Shared layout wrapping per-route reactive content (each page mounts its own signal scope)
- Active-route class on sidebar items derived from `currentRoute` prop (SSR loop with conditional class)
- `createEffect` writing a `createMemo` value to sessionStorage (cross-page state, same pattern as AdminUnreadBadge / ShopCartBadge)
- All stress targets inherited from the original standalone blocks (nested loops, 4-level memo chain in calendar, recursive tree in files, etc.)

## Test plan

- [ ] Navigate to `/gallery/productivity` → Mail page loads with unread badge showing count
- [ ] Navigate to each sub-route (files, board, calendar) → correct page loads, active sidebar item highlighted
- [ ] Open some mails (mark as read) → unread badge count decreases
- [ ] Navigate away to Files then back to Mail → unread count is still correct in sidebar badge

Closes #929 (Phase 2 — Productivity Suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)