### PR TITLE
fix(cli): cache bundleEntries builds to avoid unconditional rebuilds

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -7,8 +7,10 @@ import {
   collectRelativeImportDeps,
   vendorChunkFilename,
   processExternals,
+  processBunBuild,
 } from '../lib/build'
-import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { emptyCache, type BuildCache, type CacheEntry } from '../lib/build-cache'
+import { mkdirSync, writeFileSync, rmSync, existsSync, statSync, readFileSync, realpathSync } from 'fs'
 import { resolve } from 'path'
 import { tmpdir } from 'os'
 
@@ -586,5 +588,210 @@ export function __bf_init_Counter(el, props) {
     expect(result).toContain('counter')
     // Hydration hook identifier must survive minification
     expect(result).toContain('__bf_init_Counter')
+  })
+})
+
+// ── processBunBuild ──────────────────────────────────────────────────────
+
+describe('processBunBuild', () => {
+  const mockAdapter = { name: 'mock', extension: '.mock' } as any
+
+  function makeTmpDir(label = 'bun-build') {
+    const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    mkdirSync(dir, { recursive: true })
+    // Resolve symlinks (e.g. /tmp → /private/tmp on macOS) so paths match
+    // what esbuild's metafile reports.
+    return realpathSync(dir)
+  }
+
+  function makeConfig(projectDir: string, outDir: string, extra: Record<string, any> = {}) {
+    return {
+      projectDir,
+      adapter: mockAdapter,
+      componentDirs: [],
+      outDir,
+      minify: false,
+      contentHash: false,
+      clientOnly: false,
+      ...extra,
+    } as any
+  }
+
+  test('returns false and writes nothing when bundleEntries is empty', async () => {
+    const outDir = makeTmpDir()
+    try {
+      const config = makeConfig(outDir, outDir)
+      const cache: BuildCache = emptyCache('global-hash')
+      const nextEntries: Record<string, CacheEntry> = {}
+      const changed = await processBunBuild(config, outDir, 'components', [], cache, nextEntries, false)
+      expect(changed).toBe(false)
+      expect(Object.keys(nextEntries).length).toBe(0)
+    } finally {
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('first build: emits output and records cache entry with deps', async () => {
+    const projectDir = makeTmpDir('src')
+    const outDir = makeTmpDir('out')
+    try {
+      const helperPath = resolve(projectDir, 'helper.ts')
+      const entryPath = resolve(projectDir, 'entry.ts')
+      writeFileSync(helperPath, 'export const FOO = 1\n')
+      writeFileSync(entryPath, `import { FOO } from './helper'\nexport const X = FOO + 1\n`)
+
+      const config = makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: entryPath, outfile: 'entry.js' }],
+      })
+      const cache: BuildCache = emptyCache('global-hash')
+      const nextEntries: Record<string, CacheEntry> = {}
+
+      const changed = await processBunBuild(config, outDir, 'components', [], cache, nextEntries, false)
+      expect(changed).toBe(true)
+
+      const outPath = resolve(outDir, 'entry.js')
+      expect(existsSync(outPath)).toBe(true)
+      const outContent = readFileSync(outPath, 'utf8')
+      // helper.ts should be inlined
+      expect(outContent).toContain('FOO')
+
+      const cacheKey = `bundle:${entryPath}`
+      expect(nextEntries[cacheKey]).toBeDefined()
+      // Entry source + helper should both be tracked as deps.
+      expect(nextEntries[cacheKey].deps[entryPath]).toBeDefined()
+      expect(nextEntries[cacheKey].deps[helperPath]).toBeDefined()
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cache hit: skips rebuild when source and deps unchanged', async () => {
+    const projectDir = makeTmpDir('src')
+    const outDir = makeTmpDir('out')
+    try {
+      const entryPath = resolve(projectDir, 'entry.ts')
+      writeFileSync(entryPath, 'export const X = 1\n')
+
+      const config = makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: entryPath, outfile: 'entry.js' }],
+      })
+
+      // First build populates the cache.
+      const cache1: BuildCache = emptyCache('global-hash')
+      const entries1: Record<string, CacheEntry> = {}
+      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+
+      const outPath = resolve(outDir, 'entry.js')
+      const mtime1 = statSync(outPath).mtimeMs
+
+      // Second run with the populated cache and no source change should reuse.
+      const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
+      const entries2: Record<string, CacheEntry> = {}
+      await new Promise((r) => setTimeout(r, 20)) // ensure a distinguishable mtime if rebuilt
+      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+
+      expect(changed).toBe(false)
+      const mtime2 = statSync(outPath).mtimeMs
+      expect(mtime2).toBe(mtime1)
+      // Cache entry carried forward.
+      const cacheKey = `bundle:${entryPath}`
+      expect(entries2[cacheKey]).toBe(entries1[cacheKey])
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cache miss: dep change invalidates cache and rebuilds', async () => {
+    const projectDir = makeTmpDir('src')
+    const outDir = makeTmpDir('out')
+    try {
+      const helperPath = resolve(projectDir, 'helper.ts')
+      const entryPath = resolve(projectDir, 'entry.ts')
+      writeFileSync(helperPath, 'export const MSG = "original"\n')
+      writeFileSync(entryPath, `import { MSG } from './helper'\nexport const X = MSG\n`)
+
+      const config = makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: entryPath, outfile: 'entry.js' }],
+      })
+
+      // First build.
+      const cache1: BuildCache = emptyCache('global-hash')
+      const entries1: Record<string, CacheEntry> = {}
+      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+      const outBefore = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
+      expect(outBefore).toContain('original')
+
+      // Change a transitive dep, not the entry itself.
+      writeFileSync(helperPath, 'export const MSG = "updated"\n')
+
+      const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
+      const entries2: Record<string, CacheEntry> = {}
+      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+      expect(changed).toBe(true)
+
+      const outAfter = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
+      expect(outAfter).toContain('updated')
+      expect(outAfter).not.toContain('original')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cache miss: rebuilds when output file is missing even if cache says fresh', async () => {
+    const projectDir = makeTmpDir('src')
+    const outDir = makeTmpDir('out')
+    try {
+      const entryPath = resolve(projectDir, 'entry.ts')
+      writeFileSync(entryPath, 'export const X = 1\n')
+
+      const config = makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: entryPath, outfile: 'entry.js' }],
+      })
+
+      // First build.
+      const cache1: BuildCache = emptyCache('global-hash')
+      const entries1: Record<string, CacheEntry> = {}
+      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+
+      // Simulate a user deleting the output — cache is fresh, file is gone.
+      rmSync(resolve(outDir, 'entry.js'))
+
+      const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
+      const entries2: Record<string, CacheEntry> = {}
+      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+      expect(changed).toBe(true)
+      expect(existsSync(resolve(outDir, 'entry.js'))).toBe(true)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('force: true rebuilds everything regardless of cache', async () => {
+    const projectDir = makeTmpDir('src')
+    const outDir = makeTmpDir('out')
+    try {
+      const entryPath = resolve(projectDir, 'entry.ts')
+      writeFileSync(entryPath, 'export const X = 1\n')
+
+      const config = makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: entryPath, outfile: 'entry.js' }],
+      })
+
+      const cache1: BuildCache = emptyCache('global-hash')
+      const entries1: Record<string, CacheEntry> = {}
+      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+
+      const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
+      const entries2: Record<string, CacheEntry> = {}
+      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, true)
+      expect(changed).toBe(true)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -7,7 +7,7 @@ import {
   collectRelativeImportDeps,
   vendorChunkFilename,
   processExternals,
-  processBunBuild,
+  processBundleEntries,
 } from '../lib/build'
 import { emptyCache, type BuildCache, type CacheEntry } from '../lib/build-cache'
 import { mkdirSync, writeFileSync, rmSync, existsSync, statSync, readFileSync, realpathSync } from 'fs'
@@ -591,12 +591,12 @@ export function __bf_init_Counter(el, props) {
   })
 })
 
-// ── processBunBuild ──────────────────────────────────────────────────────
+// ── processBundleEntries ──────────────────────────────────────────────────────
 
-describe('processBunBuild', () => {
+describe('processBundleEntries', () => {
   const mockAdapter = { name: 'mock', extension: '.mock' } as any
 
-  function makeTmpDir(label = 'bun-build') {
+  function makeTmpDir(label = 'bundle-entries') {
     const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
     mkdirSync(dir, { recursive: true })
     // Resolve symlinks (e.g. /tmp → /private/tmp on macOS) so paths match
@@ -623,7 +623,7 @@ describe('processBunBuild', () => {
       const config = makeConfig(outDir, outDir)
       const cache: BuildCache = emptyCache('global-hash')
       const nextEntries: Record<string, CacheEntry> = {}
-      const changed = await processBunBuild(config, outDir, 'components', [], cache, nextEntries, false)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
       expect(changed).toBe(false)
       expect(Object.keys(nextEntries).length).toBe(0)
     } finally {
@@ -646,7 +646,7 @@ describe('processBunBuild', () => {
       const cache: BuildCache = emptyCache('global-hash')
       const nextEntries: Record<string, CacheEntry> = {}
 
-      const changed = await processBunBuild(config, outDir, 'components', [], cache, nextEntries, false)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
       expect(changed).toBe(true)
 
       const outPath = resolve(outDir, 'entry.js')
@@ -680,7 +680,7 @@ describe('processBunBuild', () => {
       // First build populates the cache.
       const cache1: BuildCache = emptyCache('global-hash')
       const entries1: Record<string, CacheEntry> = {}
-      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+      await processBundleEntries(config, outDir, 'components', [], cache1, entries1, false)
 
       const outPath = resolve(outDir, 'entry.js')
       const mtime1 = statSync(outPath).mtimeMs
@@ -689,7 +689,7 @@ describe('processBunBuild', () => {
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
       await new Promise((r) => setTimeout(r, 20)) // ensure a distinguishable mtime if rebuilt
-      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
 
       expect(changed).toBe(false)
       const mtime2 = statSync(outPath).mtimeMs
@@ -719,7 +719,7 @@ describe('processBunBuild', () => {
       // First build.
       const cache1: BuildCache = emptyCache('global-hash')
       const entries1: Record<string, CacheEntry> = {}
-      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+      await processBundleEntries(config, outDir, 'components', [], cache1, entries1, false)
       const outBefore = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
       expect(outBefore).toContain('original')
 
@@ -728,7 +728,7 @@ describe('processBunBuild', () => {
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
       expect(changed).toBe(true)
 
       const outAfter = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
@@ -754,14 +754,14 @@ describe('processBunBuild', () => {
       // First build.
       const cache1: BuildCache = emptyCache('global-hash')
       const entries1: Record<string, CacheEntry> = {}
-      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+      await processBundleEntries(config, outDir, 'components', [], cache1, entries1, false)
 
       // Simulate a user deleting the output — cache is fresh, file is gone.
       rmSync(resolve(outDir, 'entry.js'))
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, false)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
       expect(changed).toBe(true)
       expect(existsSync(resolve(outDir, 'entry.js'))).toBe(true)
     } finally {
@@ -783,11 +783,11 @@ describe('processBunBuild', () => {
 
       const cache1: BuildCache = emptyCache('global-hash')
       const entries1: Record<string, CacheEntry> = {}
-      await processBunBuild(config, outDir, 'components', [], cache1, entries1, false)
+      await processBundleEntries(config, outDir, 'components', [], cache1, entries1, false)
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBunBuild(config, outDir, 'components', [], cache2, entries2, true)
+      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, true)
       expect(changed).toBe(true)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -312,7 +312,7 @@ export async function build(
   if (externalsChanged) anyOutputChanged = true
 
   // 1c. bundleEntries entries — bundle with esbuild using auto-applied externals
-  if (await processBunBuild(config, clientJsOutDir, clientJsSubdir, allExternals, cache, nextEntries, force)) {
+  if (await processBundleEntries(config, clientJsOutDir, clientJsSubdir, allExternals, cache, nextEntries, force)) {
     anyOutputChanged = true
   }
 
@@ -785,7 +785,7 @@ export async function processExternals(
  * and externals are excluded). On subsequent runs, the entry is rebuilt only
  * if the source or any dep hash has changed, or the output file is missing.
  */
-export async function processBunBuild(
+export async function processBundleEntries(
   config: BuildConfig,
   clientJsOutDir: string,
   clientJsSubdir: string,
@@ -838,7 +838,7 @@ export async function processBunBuild(
       absWorkingDir,
     })
     anyChanged = true
-    console.log(`Generated (bun-build): ${clientJsSubdir}/${entry.outfile}`)
+    console.log(`Generated (entry): ${clientJsSubdir}/${entry.outfile}`)
 
     // Harvest project-local deps from esbuild's metafile. Keys are relative
     // to absWorkingDir. Skip node_modules (versioning is pinned by the

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -260,6 +260,7 @@ export async function build(
     loadedCache && loadedCache.globalHash === globalHash
       ? loadedCache
       : emptyCache(globalHash)
+  const nextEntries: Record<string, CacheEntry> = {}
   let anyOutputChanged = false
 
   // 1. Runtime file — copy the standalone runtime bundle (reactive inlined)
@@ -311,7 +312,7 @@ export async function build(
   if (externalsChanged) anyOutputChanged = true
 
   // 1c. bundleEntries entries — bundle with esbuild using auto-applied externals
-  if (await processBunBuild(config, clientJsOutDir, clientJsSubdir, allExternals)) {
+  if (await processBunBuild(config, clientJsOutDir, clientJsSubdir, allExternals, cache, nextEntries, force)) {
     anyOutputChanged = true
   }
 
@@ -365,7 +366,6 @@ export async function build(
   }
 
   // 4. Compile each component (or reuse from cache)
-  const nextEntries: Record<string, CacheEntry> = {}
   for (const entryPath of allFiles) {
     const sourceContent = sourceContents.get(entryPath)!
     if (!hasUseClientDirective(sourceContent)) {
@@ -456,7 +456,13 @@ export async function build(
   }
 
   // 5. Prune outputs for cache entries whose source was deleted since last build.
-  const toDelete = Object.keys(cache.entries).filter((p) => !allFilesSet.has(p))
+  //    - Component entries: keyed by source path; delete if path is no longer in allFilesSet.
+  //    - Bundle entries ("bundle:" prefix): delete if no longer present in nextEntries
+  //      (i.e. removed from config.bundleEntries).
+  const toDelete = Object.keys(cache.entries).filter((key) => {
+    if (key.startsWith('bundle:')) return !(key in nextEntries)
+    return !allFilesSet.has(key)
+  })
   for (const deletedPath of toDelete) {
     const entry = cache.entries[deletedPath]
     for (const output of entry.outputs) {
@@ -773,12 +779,20 @@ export async function processExternals(
  * Bundle entries listed in `config.bundleEntries` directly with esbuild.
  * Each entry is compiled as an ESM bundle with all externals from
  * `config.externals` (plus any per-entry overrides) excluded from the bundle.
+ *
+ * Results are cached by source+deps hash. Dependencies are harvested from
+ * esbuild's metafile on first build (project-local files only — node_modules
+ * and externals are excluded). On subsequent runs, the entry is rebuilt only
+ * if the source or any dep hash has changed, or the output file is missing.
  */
-async function processBunBuild(
+export async function processBunBuild(
   config: BuildConfig,
   clientJsOutDir: string,
   clientJsSubdir: string,
   allExternals: string[],
+  cache: BuildCache,
+  nextEntries: Record<string, CacheEntry>,
+  force: boolean,
 ): Promise<boolean> {
   if (!config.bundleEntries || config.bundleEntries.length === 0) return false
 
@@ -786,16 +800,71 @@ async function processBunBuild(
   for (const entry of config.bundleEntries) {
     const entryExternals = [...allExternals, ...(entry.externals ?? [])]
     const outfilePath = resolve(clientJsOutDir, entry.outfile)
-    await esbuildBuild({
+    const absEntry = resolve(entry.entry)
+    const cacheKey = `bundle:${absEntry}`
+
+    const sourceContent = await readText(absEntry)
+    const sourceHash = hashContent(sourceContent)
+
+    // Cache lookup: reuse if source + every recorded dep still matches and the
+    // output file hasn't been removed by hand.
+    const cached = cache.entries[cacheKey]
+    if (!force && cached !== undefined && (await fileExists(outfilePath))) {
+      const depPaths = Object.keys(cached.deps)
+      const depHashes = new Map<string, string>()
+      await Promise.all(
+        depPaths.map(async (depPath) => {
+          if (await fileExists(depPath)) {
+            depHashes.set(depPath, hashContent(await readText(depPath)))
+          }
+        }),
+      )
+      const lookupDepHash = (absPath: string): string | null => depHashes.get(absPath) ?? null
+      if (isEntryFresh(cached, sourceHash, lookupDepHash)) {
+        nextEntries[cacheKey] = cached
+        continue
+      }
+    }
+
+    const absWorkingDir = process.cwd()
+    const result = await esbuildBuild({
       entryPoints: [entry.entry],
       outfile: outfilePath,
       format: 'esm',
       bundle: true,
       minify: config.minify,
       external: entryExternals,
+      metafile: true,
+      absWorkingDir,
     })
     anyChanged = true
     console.log(`Generated (bun-build): ${clientJsSubdir}/${entry.outfile}`)
+
+    // Harvest project-local deps from esbuild's metafile. Keys are relative
+    // to absWorkingDir. Skip node_modules (versioning is pinned by the
+    // lockfile / package.json, which the global cache hash covers) and any
+    // external (those aren't bundled, so their contents don't affect the output).
+    const externalsSet = new Set(entryExternals)
+    const depsMap: Record<string, string> = { [absEntry]: sourceHash }
+    const metafile = result.metafile
+    if (metafile) {
+      for (const inputPath of Object.keys(metafile.inputs)) {
+        if (externalsSet.has(inputPath)) continue
+        const abs = resolve(absWorkingDir, inputPath)
+        if (abs === absEntry) continue
+        if (abs.includes('/node_modules/')) continue
+        if (await fileExists(abs)) {
+          depsMap[abs] = hashContent(await readText(abs))
+        }
+      }
+    }
+
+    nextEntries[cacheKey] = {
+      hash: sourceHash,
+      deps: depsMap,
+      outputs: [relative(config.outDir, outfilePath)],
+      manifestKey: null,
+    }
   }
   return anyChanged
 }


### PR DESCRIPTION
## Summary

`processBunBuild` currently rebuilds every entry in `config.bundleEntries` on every `barefoot build` invocation, regardless of whether any input changed. For projects that ship a large client-rendered bundle via `bundleEntries` (e.g. a canvas app wired through `@barefootjs/xyflow`), every incremental build pays the full esbuild cost even when nothing upstream was touched.

This PR wires `bundleEntries` into the existing `BuildCache` using a `bundle:` key prefix so they participate in the same incremental-build system as components.

## Behavior

- Source + recorded dep hashes are checked against the cache. If every dep still matches **and** the output file is present on disk, the esbuild call is skipped and the previous cache entry is carried forward.
- Dependencies are harvested from esbuild's `metafile` on each real build. Only project-local files are tracked — externals and anything under `node_modules/` are excluded (version-level invalidation is already covered by the global cache hash, which includes the CLI package.json).
- If a user deletes the output file by hand, the cache is invalidated and the entry is rebuilt.
- When a bundle entry is removed from `config.bundleEntries`, its old output is pruned alongside deleted component outputs in step 5.
- `force: true` continues to bypass the cache.

## Tests

Added coverage in `packages/cli/src/__tests__/build.test.ts`:

- empty `bundleEntries` — no work, no cache entries
- first build — output emitted, deps recorded including a transitive import
- cache hit — no rebuild, output mtime preserved, cache entry carried forward
- dep invalidation — transitive change triggers a rebuild
- missing-output invalidation — fresh cache but deleted output still rebuilds
- `force: true` — rebuilds regardless of cache

All 316 tests in `packages/cli` pass.

## Verification in a real project

On a project with 12 `bundleEntries`:

```sh
# Before: every invocation runs esbuild for all 12 entries
$ bun run node_modules/barefootjs/packages/cli/src/index.ts build
Generated (bun-build): components/DeskCanvas.client.js
Generated (bun-build): components/AxisCatalog.js
...12 lines...
Build complete: 0 compiled, 6 cached, 12 skipped, 0 errors

# After: repeat invocation with no source changes
$ bun run node_modules/barefootjs/packages/cli/src/index.ts build
Build complete: 0 compiled, 6 cached, 12 skipped, 0 errors

# After: touch one source file → only the affected entry rebuilds
$ bun run node_modules/barefootjs/packages/cli/src/index.ts build
Generated (bun-build): components/DeskCanvas.client.js
Build complete: 0 compiled, 6 cached, 12 skipped, 0 errors
```

## Test plan

- [x] `cd packages/cli && bun test` — all tests pass
- [x] Confirmed on a real project with 12 `bundleEntries`: no-op builds skip all entries, single-source changes rebuild only the affected entry