### PR TITLE
feat(gallery): add /gallery/saas suite (landing / pricing / login / blog)

### DIFF
--- a/site/ui/components/gallery/saas/blog-data.tsx
+++ b/site/ui/components/gallery/saas/blog-data.tsx
@@ -1,0 +1,104 @@
+// Static blog post data for the /gallery/saas/blog demo.
+// All content is SSR-rendered; no signals needed.
+
+export interface BlogPost {
+  slug: string
+  title: string
+  excerpt: string
+  author: string
+  authorRole: string
+  authorInitials: string
+  date: string
+  readMinutes: number
+  category: string
+  tags: string[]
+  content: string[]
+}
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: 'edge-deployments-explained',
+    title: 'Edge Deployments Explained: Why Your Users Will Thank You',
+    excerpt:
+      'Moving compute closer to your users cuts latency by orders of magnitude. Here is what changes — and what does not — when you deploy to the edge.',
+    author: 'Lena Fischer',
+    authorRole: 'Staff Engineer',
+    authorInitials: 'LF',
+    date: 'April 18, 2025',
+    readMinutes: 6,
+    category: 'Engineering',
+    tags: ['Edge', 'Performance', 'Architecture'],
+    content: [
+      'When a user in Tokyo hits an endpoint deployed in us-east-1, they are paying a ~150ms round-trip tax before your application code even runs. Edge deployments eliminate this tax by running your code in a datacenter geographically close to each request.',
+      'The shift is not just topological. Edge runtimes are typically V8-isolate-based (Cloudflare Workers, Deno Deploy) rather than Node.js processes, which means cold-start overhead drops from seconds to under a millisecond. You get a fundamentally different latency profile.',
+      'The trade-off is runtime constraints: no filesystem access, limited CPU time per request, and a smaller subset of Node.js APIs. For most HTTP handlers — routing, authentication, SSR, API proxying — these constraints are invisible. For heavy CPU work or legacy Node.js dependencies, you will need a hybrid strategy.',
+      'At Barefoot we run every deploy preview on the edge by default. Production traffic is automatically routed to the nearest region. The result: median TTFB under 40ms globally, without any application-level changes from our customers.',
+      'Getting started is straightforward. Annotate your handlers with `@edge` or set `runtime: "edge"` in your config. Barefoot handles region rollout, health checks, and failover automatically. If an edge region degrades, traffic silently reroutes to the next nearest healthy node.',
+    ],
+  },
+  {
+    slug: 'zero-downtime-deploys',
+    title: 'Zero-Downtime Deploys: A Practical Guide',
+    excerpt:
+      'Rolling updates, blue-green, and canary releases each solve different problems. Learn which strategy fits your team and how to implement it in under an hour.',
+    author: 'Marcus Webb',
+    authorRole: 'Platform Engineer',
+    authorInitials: 'MW',
+    date: 'April 10, 2025',
+    readMinutes: 8,
+    category: 'DevOps',
+    tags: ['Deploy', 'Reliability', 'CI/CD'],
+    content: [
+      'The goal of zero-downtime deploys is simple: update your production application without any request receiving an error response. In practice there are three distinct strategies, each with its own complexity budget.',
+      'Rolling updates replace instances one by one, keeping the cluster partially available throughout. They are the lowest-overhead option and work well when your new version is backward-compatible with the old one — i.e., you have not changed database schemas or API contracts in breaking ways.',
+      'Blue-green deploys maintain two identical environments. Traffic flips atomically from blue to green at the DNS or load-balancer level. Rollback is instant — just flip back. The cost is double the infrastructure during the transition window.',
+      'Canary releases send a small percentage of traffic (say 5%) to the new version, monitor error rates and latency, then gradually shift more traffic if metrics stay healthy. This is the highest-confidence strategy for risky changes, but requires observability tooling to be effective.',
+      'Barefoot supports all three out of the box. Configure your strategy in `barefoot.config.ts`. Canary releases automatically pause and alert if p99 latency increases more than 20% or error rate crosses 0.5%.',
+    ],
+  },
+  {
+    slug: 'signals-and-ssr',
+    title: 'Signals and SSR: How BarefootJS Bridges the Gap',
+    excerpt:
+      'Fine-grained reactivity and server-side rendering have historically been at odds. BarefootJS compiles signal-reactive components into SSR-safe marked templates with minimal client JS.',
+    author: 'Yuki Tanaka',
+    authorRole: 'Open Source Maintainer',
+    authorInitials: 'YT',
+    date: 'March 28, 2025',
+    readMinutes: 10,
+    category: 'Framework',
+    tags: ['BarefootJS', 'Signals', 'SSR'],
+    content: [
+      'Traditional SPA frameworks send a large JavaScript bundle to the browser and re-render the entire page on the client. SSR frameworks render HTML on the server but then hydrate the whole tree — doubling the work.',
+      'BarefootJS takes a different path. The compiler statically analyzes which parts of your component tree depend on signals, and emits only the minimal DOM operations needed to update those parts. Everything else stays as static HTML.',
+      'The compilation happens in two phases. Phase 1 (JSX to IR) extracts the reactive dependency graph. Phase 2 (IR to Client JS) emits event bindings and DOM patches keyed to specific nodes using data-bf-* markers. The server renders the full HTML; the client attaches fine-grained effects to the marked nodes.',
+      'The result is a drastically smaller client payload. A typical page with a few interactive islands ships 2-4 KB of client JS rather than 50-200 KB for a full framework bundle. Pages that have no reactive islands ship zero client JS.',
+      'This architecture is particularly well-suited to marketing sites, documentation, and content-heavy applications — exactly the pages where SSR matters most for SEO and initial load performance.',
+    ],
+  },
+  {
+    slug: 'monitoring-your-first-week',
+    title: 'Monitoring Your First Week in Production',
+    excerpt:
+      'The first week after a major deploy is the most dangerous. Here are the five dashboards you should build before you ship.',
+    author: 'Priya Nair',
+    authorRole: 'SRE Lead',
+    authorInitials: 'PN',
+    date: 'March 15, 2025',
+    readMinutes: 5,
+    category: 'Operations',
+    tags: ['Observability', 'Monitoring', 'SRE'],
+    content: [
+      'Most incidents in production happen within the first 48 hours of a deploy. Not because engineers are careless, but because production traffic exposes edge cases that staging never will. Good observability is your early-warning system.',
+      'Start with error rate by endpoint. A spike in 5xx errors on a specific route tells you exactly where the regression is. Set an alert threshold at 2x your baseline error rate and page your on-call when it fires.',
+      'Second, track p50, p95, and p99 latency. p50 tells you what most users experience. p99 tells you about your worst-case tail. A widening gap between p50 and p99 often indicates a resource contention problem or an N+1 query.',
+      'Third, watch memory and CPU per instance. Gradual memory growth (a leak) and sustained high CPU (a hot loop) both manifest slowly and are missed by simple error-rate monitors.',
+      'Fourth, track your downstream dependencies: database query times, external API p99s, cache hit rates. Your application may be healthy while a dependency is quietly degrading.',
+      'Fifth — and most often skipped — monitor your business metrics. Order completion rate, sign-up funnel conversion, and checkout success are lagging indicators, but they catch regressions that pure infrastructure metrics miss.',
+    ],
+  },
+]
+
+export function getPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((p) => p.slug === slug)
+}

--- a/site/ui/components/gallery/saas/blog-index-demo.tsx
+++ b/site/ui/components/gallery/saas/blog-index-demo.tsx
@@ -1,0 +1,75 @@
+/**
+ * SaasBlogIndexDemo
+ *
+ * Blog post listing page — fully SSR, no client JS.
+ *
+ * Compiler stress targets:
+ * - Static map() loop over posts array
+ * - Deep static nesting with no reactive islands
+ * - Category badge rendering from static data
+ */
+
+import { BLOG_POSTS } from './blog-data'
+
+export function SaasBlogIndexDemo() {
+  return (
+    <div className="saas-blog-index w-full max-w-3xl mx-auto px-4 sm:px-6 py-10 space-y-8">
+
+      <div className="space-y-2">
+        <h1 className="saas-blog-title text-3xl font-bold tracking-tight">Blog</h1>
+        <p className="text-muted-foreground">
+          Engineering deep-dives, product updates, and deployment best practices.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {BLOG_POSTS.map((post) => (
+          <article
+            key={post.slug}
+            className="saas-blog-card group rounded-xl border bg-card p-5 sm:p-6 space-y-3 hover:shadow-sm transition-shadow"
+          >
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="saas-blog-category inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium">
+                {post.category}
+              </span>
+              <span className="text-xs text-muted-foreground">{post.date}</span>
+              <span className="text-xs text-muted-foreground">{post.readMinutes} min read</span>
+            </div>
+
+            <h2 className="saas-blog-post-title text-lg font-semibold text-foreground leading-snug">
+              <a
+                href={`/gallery/saas/blog/${post.slug}`}
+                className="no-underline hover:text-primary transition-colors"
+              >
+                {post.title}
+              </a>
+            </h2>
+
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {post.excerpt}
+            </p>
+
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <div className="size-7 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-bold shrink-0">
+                  {post.authorInitials}
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-foreground">{post.author}</span>
+                  <span className="text-xs text-muted-foreground ml-1.5">{post.authorRole}</span>
+                </div>
+              </div>
+              <a
+                href={`/gallery/saas/blog/${post.slug}`}
+                className="saas-blog-read-more text-xs font-medium text-primary no-underline hover:underline shrink-0"
+              >
+                Read more →
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+
+    </div>
+  )
+}

--- a/site/ui/components/gallery/saas/blog-post-demo.tsx
+++ b/site/ui/components/gallery/saas/blog-post-demo.tsx
@@ -1,0 +1,139 @@
+/**
+ * SaasBlogPostDemo
+ *
+ * Single blog post view — fully SSR, no client JS.
+ * Receives a post slug as a prop; shell handles 404 fallback.
+ *
+ * Compiler stress targets:
+ * - Static content rendering with no reactive islands
+ * - Conditional 404 state from a static prop
+ * - Tag loop and paragraph loop
+ */
+
+import { BLOG_POSTS, getPost } from './blog-data'
+
+interface SaasBlogPostDemoProps {
+  slug: string
+}
+
+export function SaasBlogPostDemo({ slug }: SaasBlogPostDemoProps) {
+  const post = getPost(slug)
+
+  if (!post) {
+    return (
+      <div className="saas-blog-post-notfound flex flex-col items-center justify-center py-24 px-4 text-center space-y-4">
+        <p className="text-4xl">404</p>
+        <h1 className="text-xl font-semibold text-foreground">Post not found</h1>
+        <p className="text-muted-foreground text-sm">
+          This post does not exist or may have been moved.
+        </p>
+        <a href="/gallery/saas/blog" className="text-sm text-primary no-underline hover:underline">
+          ← Back to blog
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="saas-blog-post w-full max-w-2xl mx-auto px-4 sm:px-6 py-10 space-y-8">
+
+      {/* Back link */}
+      <a
+        href="/gallery/saas/blog"
+        className="saas-blog-back inline-flex items-center gap-1 text-sm text-muted-foreground no-underline hover:text-foreground transition-colors"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+        All posts
+      </a>
+
+      {/* Header */}
+      <header className="space-y-4">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="saas-post-category inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium">
+            {post.category}
+          </span>
+          <span className="text-xs text-muted-foreground">{post.date}</span>
+          <span className="text-xs text-muted-foreground">{post.readMinutes} min read</span>
+        </div>
+
+        <h1 className="saas-post-title text-2xl sm:text-3xl font-bold tracking-tight leading-snug text-foreground">
+          {post.title}
+        </h1>
+
+        <p className="text-muted-foreground leading-relaxed">{post.excerpt}</p>
+
+        <div className="flex items-center gap-3 pt-1">
+          <div className="size-9 rounded-full bg-primary/20 text-primary flex items-center justify-center text-sm font-bold shrink-0">
+            {post.authorInitials}
+          </div>
+          <div>
+            <p className="text-sm font-medium text-foreground">{post.author}</p>
+            <p className="text-xs text-muted-foreground">{post.authorRole}</p>
+          </div>
+        </div>
+      </header>
+
+      <hr className="border-border" />
+
+      {/* Body */}
+      <div className="saas-post-body space-y-5">
+        {post.content.map((paragraph, i) => (
+          <p key={i} className="text-foreground leading-relaxed">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+
+      {/* Tags */}
+      <div className="flex items-center gap-2 flex-wrap pt-2">
+        {post.tags.map((tag) => (
+          <span
+            key={tag}
+            className="saas-post-tag inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      {/* CTA */}
+      <div className="rounded-xl border bg-card p-5 space-y-3 text-center">
+        <p className="text-sm font-medium text-foreground">Ready to ship like this?</p>
+        <p className="text-xs text-muted-foreground">
+          Deploy to the global edge in seconds. Start free, no credit card required.
+        </p>
+        <a
+          href="/gallery/saas/pricing"
+          className="inline-flex items-center gap-1 rounded-lg bg-primary px-4 py-2 text-xs font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors"
+        >
+          See pricing
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+
+      {/* Other posts */}
+      <div className="space-y-3">
+        <h2 className="text-sm font-medium text-foreground">More from the blog</h2>
+        <div className="space-y-2">
+          {BLOG_POSTS.filter((p) => p.slug !== slug).slice(0, 3).map((p) => (
+            <a
+              key={p.slug}
+              href={`/gallery/saas/blog/${p.slug}`}
+              className="saas-related-post flex items-start gap-3 rounded-lg p-3 no-underline hover:bg-muted/50 transition-colors"
+            >
+              <div className="space-y-0.5 min-w-0">
+                <p className="text-sm font-medium text-foreground leading-snug truncate">{p.title}</p>
+                <p className="text-xs text-muted-foreground">{p.date} · {p.readMinutes} min</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/site/ui/components/gallery/saas/landing-demo.tsx
+++ b/site/ui/components/gallery/saas/landing-demo.tsx
@@ -1,0 +1,212 @@
+/**
+ * SaasLandingDemo
+ *
+ * Full-page marketing landing: hero, features, social proof, CTA.
+ * SSR-only — no "use client" directive, no signals.
+ *
+ * Compiler stress targets:
+ * - Deep static nesting (section > div > div > p)
+ * - Static map() loops (feature list, testimonials, logo strip)
+ * - Purely declarative JSX with no reactive islands
+ */
+
+const FEATURES = [
+  {
+    icon: '⚡',
+    title: 'Instant Deploy',
+    description: 'Ship from git to a global edge network in seconds. Zero config required.',
+  },
+  {
+    icon: '🔒',
+    title: 'Built-in Security',
+    description: 'TLS, DDoS protection, and WAF included on every plan. Sleep soundly.',
+  },
+  {
+    icon: '📊',
+    title: 'Real-time Analytics',
+    description: 'Traffic, errors, and performance metrics updated live. No third-party tools.',
+  },
+  {
+    icon: '🔄',
+    title: 'Auto Scaling',
+    description: 'Handle traffic spikes automatically. Pay only for what you use.',
+  },
+  {
+    icon: '🤝',
+    title: 'Team Collaboration',
+    description: 'Invite teammates, manage permissions, and review deploys together.',
+  },
+  {
+    icon: '🛠',
+    title: 'Developer First',
+    description: 'CLI, GitHub Actions, REST API. Build the workflow that fits your team.',
+  },
+]
+
+const TESTIMONIALS = [
+  {
+    quote: 'We cut our deployment pipeline from 20 minutes to under 60 seconds. Barefoot just works.',
+    author: 'Mia Chen',
+    role: 'CTO, Loopify',
+    avatar: 'MC',
+  },
+  {
+    quote: 'The analytics alone saved us three separate SaaS subscriptions. Excellent ROI.',
+    author: 'James Park',
+    role: 'Engineering Lead, Trellis',
+    avatar: 'JP',
+  },
+  {
+    quote: `Our team went from "what's deployed?" to full confidence in the release process.`,
+    author: 'Sara Okonkwo',
+    role: 'Staff Engineer, Nomad',
+    avatar: 'SO',
+  },
+]
+
+const LOGOS = ['Loopify', 'Trellis', 'Nomad', 'Petal', 'Arclight', 'Verdant']
+
+const STATS = [
+  { value: '10,000+', label: 'Projects deployed' },
+  { value: '99.99%', label: 'Uptime SLA' },
+  { value: '~50ms', label: 'Median deploy time' },
+  { value: '180+', label: 'Edge locations' },
+]
+
+export function SaasLandingDemo() {
+  return (
+    <div className="saas-landing w-full">
+
+      {/* Hero */}
+      <section className="saas-hero px-4 sm:px-8 py-16 sm:py-24 text-center max-w-4xl mx-auto">
+        <div className="inline-flex items-center gap-2 rounded-full border bg-muted/50 px-3 py-1 text-xs text-muted-foreground mb-6">
+          <span className="size-1.5 rounded-full bg-green-500" />
+          Now in public beta — join 10,000 developers
+        </div>
+        <h1 className="saas-hero-title text-4xl sm:text-5xl font-bold tracking-tight text-foreground mb-6 leading-tight">
+          Ship faster.<br />Scale effortlessly.<br />
+          <span className="text-primary">Stay in control.</span>
+        </h1>
+        <p className="saas-hero-subtitle text-lg text-muted-foreground mb-8 max-w-2xl mx-auto">
+          Barefoot is the deployment platform built for teams who move fast.
+          From a single command to global scale — no DevOps required.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <a
+            href="/gallery/saas/pricing"
+            className="saas-cta-primary inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors"
+          >
+            Start for free
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+            </svg>
+          </a>
+          <a
+            href="/gallery/saas/blog"
+            className="saas-cta-secondary inline-flex items-center gap-2 rounded-lg border px-5 py-2.5 text-sm font-medium text-foreground no-underline hover:bg-accent transition-colors"
+          >
+            Read the blog
+          </a>
+        </div>
+      </section>
+
+      {/* Logo strip */}
+      <section className="saas-logos border-y px-4 sm:px-8 py-8 bg-muted/30">
+        <p className="text-center text-xs text-muted-foreground mb-6 uppercase tracking-wider font-medium">
+          Trusted by teams at
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-6 sm:gap-10">
+          {LOGOS.map((name) => (
+            <span key={name} className="saas-logo-item text-sm font-semibold text-muted-foreground/60">
+              {name}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="saas-stats px-4 sm:px-8 py-12 max-w-4xl mx-auto">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
+          {STATS.map((stat) => (
+            <div key={stat.label} className="saas-stat-item space-y-1">
+              <p className="text-3xl font-bold text-foreground">{stat.value}</p>
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="saas-features px-4 sm:px-8 py-12 max-w-5xl mx-auto">
+        <div className="text-center mb-10">
+          <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-3">
+            Everything you need, nothing you don't
+          </h2>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            A focused set of tools that cover the full deployment lifecycle — from push to production.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {FEATURES.map((feature) => (
+            <div
+              key={feature.title}
+              className="saas-feature-card rounded-xl border bg-card p-5 space-y-3 hover:shadow-sm transition-shadow"
+            >
+              <div className="text-2xl">{feature.icon}</div>
+              <h3 className="font-semibold text-foreground">{feature.title}</h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="saas-testimonials px-4 sm:px-8 py-12 bg-muted/30">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-2xl font-bold text-center text-foreground mb-8">
+            Loved by developers
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+            {TESTIMONIALS.map((t) => (
+              <div
+                key={t.author}
+                className="saas-testimonial-card rounded-xl border bg-card p-5 space-y-4"
+              >
+                <p className="text-sm text-foreground leading-relaxed">"{t.quote}"</p>
+                <div className="flex items-center gap-3">
+                  <div className="size-8 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-bold">
+                    {t.avatar}
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{t.author}</p>
+                    <p className="text-xs text-muted-foreground">{t.role}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="saas-final-cta px-4 sm:px-8 py-16 text-center max-w-2xl mx-auto">
+        <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-4">
+          Ready to deploy with confidence?
+        </h2>
+        <p className="text-muted-foreground mb-8">
+          Start free. Upgrade when you're ready. No credit card required.
+        </p>
+        <a
+          href="/gallery/saas/pricing"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors"
+        >
+          View pricing
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+      </section>
+
+    </div>
+  )
+}

--- a/site/ui/components/gallery/saas/login-demo.tsx
+++ b/site/ui/components/gallery/saas/login-demo.tsx
@@ -1,0 +1,236 @@
+"use client"
+/**
+ * SaasLoginDemo
+ *
+ * Login/signup form with cross-page plan awareness.
+ * Reads the billing cycle and selected plan from sessionStorage
+ * (written by SaasPricingDemo) to show a contextual banner.
+ *
+ * Compiler stress targets:
+ * - createMemo chain: emailError → passwordError → isFormValid
+ * - Conditional banner based on sessionStorage (plan selected on pricing page)
+ * - Loading and success states
+ * - Signal-driven disabled / aria-invalid bindings
+ */
+
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Input } from '@ui/components/ui/input'
+import { Button } from '@ui/components/ui/button'
+import { Separator } from '@ui/components/ui/separator'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@ui/components/ui/card'
+import {
+  Field,
+  FieldLabel,
+  FieldContent,
+  FieldError,
+} from '@ui/components/ui/field'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+import {
+  readBillingCycle,
+  readSelectedPlan,
+  type SelectedPlan,
+  type BillingCycle,
+} from '../../shared/gallery-saas-storage'
+
+const PLAN_LABELS: Record<Exclude<SelectedPlan, null>, string> = {
+  free: 'Free',
+  pro: 'Pro',
+  enterprise: 'Enterprise',
+}
+
+export function SaasLoginDemo() {
+  const [email, setEmail] = createSignal('')
+  const [password, setPassword] = createSignal('')
+  const [emailTouched, setEmailTouched] = createSignal(false)
+  const [passwordTouched, setPasswordTouched] = createSignal(false)
+  const [loading, setLoading] = createSignal(false)
+  const [success, setSuccess] = createSignal(false)
+
+  const [selectedPlan, setSelectedPlan] = createSignal<SelectedPlan>(readSelectedPlan())
+  const [billingCycle, setBillingCycle] = createSignal<BillingCycle>(readBillingCycle())
+
+  // Sync from sessionStorage on mount (other tabs or same-session navigation)
+  if (typeof window !== 'undefined') {
+    window.addEventListener('barefoot:saas-storage', () => {
+      setSelectedPlan(readSelectedPlan())
+      setBillingCycle(readBillingCycle())
+    })
+  }
+
+  const emailError = createMemo(() => {
+    if (!emailTouched()) return ''
+    if (email().trim() === '') return 'Email is required'
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email())) return 'Invalid email format'
+    return ''
+  })
+
+  const passwordError = createMemo(() => {
+    if (!passwordTouched()) return ''
+    if (password() === '') return 'Password is required'
+    if (password().length < 8) return 'At least 8 characters required'
+    return ''
+  })
+
+  const isFormValid = createMemo(
+    () =>
+      emailError() === '' &&
+      passwordError() === '' &&
+      email().trim() !== '' &&
+      password() !== ''
+  )
+
+  const handleSubmit = async () => {
+    if (!isFormValid() || loading()) return
+    setLoading(true)
+    await new Promise((resolve) => setTimeout(resolve, 1200))
+    setLoading(false)
+    setSuccess(true)
+    setEmail('')
+    setPassword('')
+    setEmailTouched(false)
+    setPasswordTouched(false)
+    setTimeout(() => setSuccess(false), 3000)
+  }
+
+  return (
+    <div className="saas-login flex min-h-[480px] items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm space-y-4">
+
+        {/* Plan context banner — shown when user came from pricing page */}
+        {selectedPlan() ? (
+          <div className="saas-plan-banner rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm space-y-0.5">
+            <p className="font-medium text-foreground">
+              {PLAN_LABELS[selectedPlan()!]} plan selected
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {billingCycle() === 'annual' ? 'Billed annually — save 20%' : 'Billed monthly'}
+              . Create an account to continue.
+            </p>
+          </div>
+        ) : null}
+
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Create your account</CardTitle>
+            <CardDescription>
+              {selectedPlan()
+                ? `Get started with the ${PLAN_LABELS[selectedPlan()!]} plan`
+                : 'Deploy your first project in minutes'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+
+            {/* OAuth */}
+            <div className="grid grid-cols-2 gap-3">
+              <Button variant="outline" className="saas-oauth-google">
+                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                </svg>
+                Google
+              </Button>
+              <Button variant="outline" className="saas-oauth-github">
+                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+                </svg>
+                GitHub
+              </Button>
+            </div>
+
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <Separator />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">Or continue with</span>
+              </div>
+            </div>
+
+            <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+              <Field data-invalid={emailError() !== '' || undefined}>
+                <FieldLabel for="saas-email">Work email</FieldLabel>
+                <FieldContent>
+                  <Input
+                    id="saas-email"
+                    type="email"
+                    placeholder="you@company.com"
+                    value={email()}
+                    onInput={(e) => setEmail(e.target.value)}
+                    onBlur={() => setEmailTouched(true)}
+                    disabled={loading()}
+                    aria-invalid={emailError() !== '' || undefined}
+                  />
+                  {emailError() !== '' ? (
+                    <FieldError>{emailError()}</FieldError>
+                  ) : null}
+                </FieldContent>
+              </Field>
+
+              <Field data-invalid={passwordError() !== '' || undefined}>
+                <FieldLabel for="saas-password">Password</FieldLabel>
+                <FieldContent>
+                  <Input
+                    id="saas-password"
+                    type="password"
+                    placeholder="Min. 8 characters"
+                    value={password()}
+                    onInput={(e) => setPassword(e.target.value)}
+                    onBlur={() => setPasswordTouched(true)}
+                    disabled={loading()}
+                    aria-invalid={passwordError() !== '' || undefined}
+                  />
+                  {passwordError() !== '' ? (
+                    <FieldError>{passwordError()}</FieldError>
+                  ) : null}
+                </FieldContent>
+              </Field>
+
+              <Button
+                className="saas-submit w-full"
+                onClick={handleSubmit}
+                disabled={!isFormValid() || loading()}
+              >
+                <span className="button-text">
+                  {loading() ? 'Creating account...' : 'Create account'}
+                </span>
+              </Button>
+            </form>
+          </CardContent>
+          <CardFooter className="flex justify-center">
+            <p className="text-sm text-muted-foreground">
+              Already have an account?{' '}
+              <a href="#" className="text-primary underline-offset-4 hover:underline">
+                Sign in
+              </a>
+            </p>
+          </CardFooter>
+        </Card>
+
+        <ToastProvider position="bottom-right">
+          <Toast variant="success" open={success()}>
+            <div className="flex-1">
+              <ToastTitle>Account created!</ToastTitle>
+              <ToastDescription>Welcome to Barefoot. Your first deploy awaits.</ToastDescription>
+            </div>
+            <ToastClose onClick={() => setSuccess(false)} />
+          </Toast>
+        </ToastProvider>
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/saas/pricing-demo.tsx
+++ b/site/ui/components/gallery/saas/pricing-demo.tsx
@@ -1,0 +1,220 @@
+"use client"
+/**
+ * SaasPricingDemo
+ *
+ * SaaS pricing page with billing toggle and plan selection.
+ * Client island for the billing toggle and plan CTA clicks.
+ * Selection is persisted to sessionStorage so the login page can read it.
+ *
+ * Compiler stress targets:
+ * - Signal-driven billing toggle (isAnnual → price display)
+ * - createMemo for savings percentage
+ * - Cross-page state write: writeBillingCycle / writeSelectedPlan on plan select
+ * - Dynamic loop over plans array (displayPlans memo)
+ * - Signal-driven badge conditional ("Save 20%")
+ */
+
+import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+import { Card, CardHeader, CardTitle, CardContent, CardDescription, CardFooter } from '@ui/components/ui/card'
+import { Badge } from '@ui/components/ui/badge'
+import { Button } from '@ui/components/ui/button'
+import { Switch } from '@ui/components/ui/switch'
+import { Separator } from '@ui/components/ui/separator'
+import {
+  readBillingCycle,
+  writeBillingCycle,
+  readSelectedPlan,
+  writeSelectedPlan,
+  type SelectedPlan,
+} from '../../shared/gallery-saas-storage'
+
+type PlanTier = 'free' | 'pro' | 'enterprise'
+
+type Plan = {
+  id: PlanTier
+  name: string
+  description: string
+  monthlyPrice: number
+  annualPrice: number
+  recommended: boolean
+  cta: string
+  highlights: string[]
+}
+
+const ANNUAL_DISCOUNT = 20
+
+const PLANS: Plan[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    description: 'For side projects and experimentation',
+    monthlyPrice: 0,
+    annualPrice: 0,
+    recommended: false,
+    cta: 'Get started',
+    highlights: ['1 project', 'Basic analytics', 'Community support', '1 GB bandwidth/mo'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    description: 'For professionals and growing teams',
+    monthlyPrice: 2000,
+    annualPrice: 1600,
+    recommended: true,
+    cta: 'Start free trial',
+    highlights: [
+      'Unlimited projects',
+      'Advanced analytics',
+      'Priority support',
+      '100 GB bandwidth/mo',
+      'Custom domains',
+      'Team collaboration (up to 5)',
+    ],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    description: 'For large organizations with custom needs',
+    monthlyPrice: 8000,
+    annualPrice: 6400,
+    recommended: false,
+    cta: 'Contact sales',
+    highlights: [
+      'Everything in Pro',
+      'Unlimited teammates',
+      'SSO & SAML',
+      'Dedicated support',
+      'Unlimited bandwidth',
+      'SLA guarantee',
+      'Audit logs',
+    ],
+  },
+]
+
+function formatPrice(cents: number): string {
+  if (cents === 0) return '$0'
+  return `$${(cents / 100).toFixed(0)}`
+}
+
+export function SaasPricingDemo() {
+  const [isAnnual, setIsAnnual] = createSignal(readBillingCycle() === 'annual')
+  const [selectedPlan, setSelectedPlan] = createSignal<SelectedPlan>(readSelectedPlan())
+
+  const savingsPercent = createMemo(() => (isAnnual() ? ANNUAL_DISCOUNT : 0))
+  const displayPlans = createMemo(() => PLANS)
+
+  createEffect(() => {
+    writeBillingCycle(isAnnual() ? 'annual' : 'monthly')
+  })
+
+  createEffect(() => {
+    writeSelectedPlan(selectedPlan())
+  })
+
+  const handlePlanSelect = (tier: PlanTier) => {
+    setSelectedPlan(tier)
+    // Navigate to login with the selection persisted
+    window.location.href = '/gallery/saas/login'
+  }
+
+  return (
+    <div className="saas-pricing w-full max-w-5xl mx-auto px-4 sm:px-6 py-12 space-y-10">
+
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <h1 className="saas-pricing-title text-3xl sm:text-4xl font-bold tracking-tight">
+          Simple, transparent pricing
+        </h1>
+        <p className="text-muted-foreground text-lg">
+          Start free. Upgrade as you grow. No surprises.
+        </p>
+
+        {/* Billing toggle */}
+        <div className="saas-billing-toggle flex items-center justify-center gap-3 pt-2">
+          <span className={isAnnual() ? 'billing-label text-sm font-medium text-muted-foreground' : 'billing-label text-sm font-medium text-foreground'}>
+            Monthly
+          </span>
+          <Switch
+            checked={isAnnual()}
+            onCheckedChange={setIsAnnual}
+            aria-label="Toggle annual billing"
+          />
+          <span className={isAnnual() ? 'billing-label text-sm font-medium text-foreground' : 'billing-label text-sm font-medium text-muted-foreground'}>
+            Annual
+          </span>
+          {isAnnual() ? (
+            <Badge variant="default" className="savings-badge">Save {savingsPercent()}%</Badge>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Plan cards */}
+      <div className="saas-plan-cards grid grid-cols-1 md:grid-cols-3 gap-6">
+        {displayPlans().map((plan) => (
+          <Card
+            key={plan.id}
+            className={`saas-plan-card relative ${plan.recommended ? 'border-primary shadow-lg ring-1 ring-primary' : ''}`}
+          >
+            {plan.recommended ? (
+              <Badge variant="default" className="saas-popular-badge absolute -top-3 left-1/2 -translate-x-1/2">
+                Most popular
+              </Badge>
+            ) : null}
+
+            <CardHeader className="text-center">
+              <CardTitle className="saas-plan-name">{plan.name}</CardTitle>
+              <CardDescription>{plan.description}</CardDescription>
+              <div className="mt-4">
+                <span className="saas-price-amount text-4xl font-bold">
+                  {isAnnual() ? formatPrice(plan.annualPrice) : formatPrice(plan.monthlyPrice)}
+                </span>
+                <span className="saas-price-period text-muted-foreground text-sm ml-1">
+                  {plan.monthlyPrice === 0 ? '' : isAnnual() ? '/mo billed annually' : '/month'}
+                </span>
+              </div>
+              {isAnnual() && plan.monthlyPrice > 0 ? (
+                <p className="saas-original-price text-sm text-muted-foreground line-through">
+                  {formatPrice(plan.monthlyPrice)}/mo
+                </p>
+              ) : null}
+            </CardHeader>
+
+            <CardContent>
+              <Separator />
+              <ul className="saas-feature-list mt-4 space-y-2">
+                {plan.highlights.map((feature) => (
+                  <li key={feature} className="flex items-start gap-2 text-sm">
+                    <span className="text-primary shrink-0 mt-0.5">✓</span>
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+
+            <CardFooter>
+              <Button
+                variant={plan.recommended ? 'default' : 'outline'}
+                className="saas-plan-cta w-full"
+                data-plan={plan.id}
+                onClick={() => handlePlanSelect(plan.id)}
+              >
+                {plan.cta}
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+
+      {/* Selected plan feedback */}
+      {selectedPlan() ? (
+        <p className="saas-selected-feedback text-center text-sm text-muted-foreground">
+          Selected:{' '}
+          <span className="font-medium text-foreground saas-selected-plan-name">{selectedPlan()}</span>
+          {' — '}
+          {isAnnual() ? 'billed annually' : 'billed monthly'}
+        </p>
+      ) : null}
+
+    </div>
+  )
+}

--- a/site/ui/components/gallery/saas/saas-shell.tsx
+++ b/site/ui/components/gallery/saas/saas-shell.tsx
@@ -1,0 +1,142 @@
+/**
+ * SaasShell
+ *
+ * Shared layout primitive for /gallery/saas/* pages. SSR-only chrome
+ * (top nav + footer); interactive islands (pricing toggle, login form,
+ * plan selection badge) live in sibling "use client" components.
+ *
+ * Compiler stress targets:
+ * - Shared layout wrapping per-route SSR-heavy content (each page mounts
+ *   its own signal scope inside this shell).
+ * - Active-route class on nav items derived from currentRoute prop.
+ * - Cross-page persistent state: billing cycle and selected plan carried
+ *   from pricing page to login page via sessionStorage.
+ * - SSR-heavy workload: landing, blog index, and blog post are fully
+ *   server-rendered with no client JS at all.
+ */
+
+import type { Child } from 'hono/jsx'
+
+export type SaasRouteKey = 'landing' | 'pricing' | 'blog' | 'login'
+
+interface NavItem {
+  key: SaasRouteKey
+  href: string
+  label: string
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { key: 'landing', href: '/gallery/saas', label: 'Home' },
+  { key: 'pricing', href: '/gallery/saas/pricing', label: 'Pricing' },
+  { key: 'blog', href: '/gallery/saas/blog', label: 'Blog' },
+]
+
+interface SaasShellProps {
+  currentRoute: SaasRouteKey
+  children?: Child
+}
+
+export function SaasShell({ currentRoute, children }: SaasShellProps) {
+  return (
+    <div className="saas-shell flex min-h-[calc(100vh-8rem)] w-full flex-col rounded-xl border bg-background overflow-hidden">
+      {/* Top navigation */}
+      <header
+        data-saas-header=""
+        className="sticky top-0 z-10 flex items-center justify-between gap-4 border-b bg-background/95 backdrop-blur px-4 sm:px-6 py-3"
+      >
+        {/* Logo */}
+        <a
+          href="/gallery/saas"
+          className="flex items-center gap-2 no-underline text-foreground"
+        >
+          <div className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold">
+            B
+          </div>
+          <span className="text-sm font-semibold">Barefoot</span>
+        </a>
+
+        {/* Desktop nav */}
+        <nav
+          data-saas-nav=""
+          className="hidden sm:flex items-center gap-1"
+          aria-label="SaaS site navigation"
+        >
+          {NAV_ITEMS.map((item) => {
+            const active = item.key === currentRoute
+            return (
+              <a
+                href={item.href}
+                data-saas-nav-item={item.key}
+                data-active={active ? 'true' : 'false'}
+                aria-current={active ? 'page' : undefined}
+                className={`saas-nav-link rounded-md px-3 py-1.5 text-sm transition-colors no-underline ${
+                  active
+                    ? 'bg-accent text-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
+                }`}
+              >
+                {item.label}
+              </a>
+            )
+          })}
+        </nav>
+
+        {/* CTA */}
+        <a
+          href="/gallery/saas/login"
+          data-saas-nav-item="login"
+          data-active={currentRoute === 'login' ? 'true' : 'false'}
+          aria-current={currentRoute === 'login' ? 'page' : undefined}
+          className={`saas-cta-link rounded-md px-3 py-1.5 text-sm font-medium no-underline transition-colors ${
+            currentRoute === 'login'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-primary text-primary-foreground hover:bg-primary/90'
+          }`}
+        >
+          Sign in
+        </a>
+      </header>
+
+      {/* Mobile nav strip */}
+      <nav
+        data-saas-mobile-nav=""
+        className="sm:hidden flex overflow-x-auto gap-1 border-b px-3 py-2 bg-background/80"
+        aria-label="SaaS site navigation (mobile)"
+      >
+        {NAV_ITEMS.map((item) => {
+          const active = item.key === currentRoute
+          return (
+            <a
+              href={item.href}
+              data-saas-mobile-nav-item={item.key}
+              data-active={active ? 'true' : 'false'}
+              aria-current={active ? 'page' : undefined}
+              className={`saas-mobile-nav-link shrink-0 rounded-md px-3 py-1.5 text-xs transition-colors no-underline ${
+                active
+                  ? 'bg-accent text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'
+              }`}
+            >
+              {item.label}
+            </a>
+          )
+        })}
+      </nav>
+
+      {/* Page content */}
+      <main className="saas-page flex-1 overflow-x-auto">
+        {children}
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t px-4 sm:px-6 py-4 text-xs text-muted-foreground flex items-center justify-between gap-4">
+        <span>© 2025 Barefoot, Inc.</span>
+        <div className="flex gap-4">
+          <a href="#" className="hover:text-foreground no-underline">Privacy</a>
+          <a href="#" className="hover:text-foreground no-underline">Terms</a>
+          <a href="#" className="hover:text-foreground no-underline">Contact</a>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/site/ui/components/shared/gallery-saas-storage.ts
+++ b/site/ui/components/shared/gallery-saas-storage.ts
@@ -1,0 +1,53 @@
+// Shared session-storage helpers for the /gallery/saas app.
+//
+// Reactive primitives must stay in each consuming component — the compiler
+// only recognizes createSignal / createEffect at the source call site. These
+// are pure read/write helpers; components keep their own signal pairs inline.
+
+const NAMESPACE = 'barefoot.gallery.saas'
+
+function storageKey(key: string): string {
+  return `${NAMESPACE}.${key}`
+}
+
+function readRaw(key: string): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage.getItem(storageKey(key))
+  } catch {
+    return null
+  }
+}
+
+function writeRaw(key: string, value: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(storageKey(key), value)
+    window.dispatchEvent(new CustomEvent('barefoot:saas-storage', { detail: { key } }))
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+export type BillingCycle = 'monthly' | 'annual'
+export type SelectedPlan = 'free' | 'pro' | 'enterprise' | null
+
+export function readBillingCycle(fallback: BillingCycle = 'monthly'): BillingCycle {
+  const raw = readRaw('billingCycle')
+  if (raw === 'monthly' || raw === 'annual') return raw
+  return fallback
+}
+
+export function writeBillingCycle(value: BillingCycle): void {
+  writeRaw('billingCycle', value)
+}
+
+export function readSelectedPlan(fallback: SelectedPlan = null): SelectedPlan {
+  const raw = readRaw('selectedPlan')
+  if (raw === 'free' || raw === 'pro' || raw === 'enterprise') return raw
+  return fallback
+}
+
+export function writeSelectedPlan(value: SelectedPlan): void {
+  writeRaw('selectedPlan', value == null ? '' : value)
+}

--- a/site/ui/e2e/saas-gallery.spec.ts
+++ b/site/ui/e2e/saas-gallery.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from '@playwright/test'
+
+const navRoutes = [
+  { path: '/gallery/saas', key: 'landing', title: null },
+  { path: '/gallery/saas/pricing', key: 'pricing', title: null },
+  { path: '/gallery/saas/blog', key: 'blog', title: null },
+  { path: '/gallery/saas/login', key: 'login', title: null },
+] as const
+
+test.describe('Gallery: SaaS Marketing app', () => {
+  test.describe('Layout', () => {
+    test('each route renders the saas shell with the correct active nav item', async ({ page }) => {
+      for (const route of navRoutes) {
+        await page.goto(route.path)
+        await expect(page.locator('[data-saas-header]')).toBeVisible()
+
+        const active = page.locator(`[data-saas-nav-item="${route.key}"]`)
+        await expect(active).toHaveAttribute('data-active', 'true')
+        await expect(active).toHaveAttribute('aria-current', 'page')
+      }
+    })
+
+    test('inactive nav items are marked data-active=false', async ({ page }) => {
+      await page.goto('/gallery/saas')
+
+      // Landing is active; pricing, blog should be inactive
+      await expect(page.locator('[data-saas-nav-item="pricing"]')).toHaveAttribute('data-active', 'false')
+      await expect(page.locator('[data-saas-nav-item="blog"]')).toHaveAttribute('data-active', 'false')
+      await expect(page.locator('[data-saas-nav-item="login"]')).toHaveAttribute('data-active', 'false')
+    })
+
+    test('gallery meta link is outside the saas shell', async ({ page }) => {
+      await page.goto('/gallery/saas')
+      const githubLinks = page.locator('a[href*="components/gallery/saas"]')
+      await expect(githubLinks).toHaveCount(1)
+      const insideShell = await page
+        .locator('.saas-shell a[href*="components/gallery/saas"]')
+        .count()
+      expect(insideShell).toBe(0)
+    })
+  })
+
+  test.describe('Navigation', () => {
+    test('navigates between all routes via the top nav', async ({ page }) => {
+      await page.goto('/gallery/saas')
+
+      // To pricing
+      await page.locator('[data-saas-nav] [data-saas-nav-item="pricing"]').click()
+      await page.waitForURL('**/gallery/saas/pricing')
+      await expect(page).toHaveURL(/\/gallery\/saas\/pricing$/)
+      await expect(page.locator('[data-saas-nav-item="pricing"]')).toHaveAttribute('data-active', 'true')
+
+      // To blog
+      await page.locator('[data-saas-nav] [data-saas-nav-item="blog"]').click()
+      await page.waitForURL('**/gallery/saas/blog')
+      await expect(page).toHaveURL(/\/gallery\/saas\/blog$/)
+
+      // To login via CTA
+      await page.locator('[data-saas-nav-item="login"]').first().click()
+      await page.waitForURL('**/gallery/saas/login')
+      await expect(page).toHaveURL(/\/gallery\/saas\/login$/)
+
+      // Back to landing via logo (direct child of header, not inside nav)
+      await page.locator('[data-saas-header] > a[href="/gallery/saas"]').click()
+      await page.waitForURL('**/gallery/saas')
+      await expect(page).toHaveURL(/\/gallery\/saas$/)
+    })
+  })
+
+  test.describe('Landing page', () => {
+    test('renders hero with CTA links', async ({ page }) => {
+      await page.goto('/gallery/saas')
+      await expect(page.locator('.saas-hero')).toBeVisible()
+      await expect(page.locator('.saas-hero-title')).toBeVisible()
+      await expect(page.locator('.saas-cta-primary')).toBeVisible()
+      await expect(page.locator('.saas-features')).toBeVisible()
+      await expect(page.locator('.saas-testimonials')).toBeVisible()
+    })
+  })
+
+  test.describe('Pricing page', () => {
+    test('renders three plan cards', async ({ page }) => {
+      await page.goto('/gallery/saas/pricing')
+      await expect(page.locator('.saas-plan-card')).toHaveCount(3)
+    })
+
+    test('billing toggle switches price display', async ({ page }) => {
+      await page.goto('/gallery/saas/pricing')
+
+      // Default is monthly — no savings badge
+      await expect(page.locator('.savings-badge')).toHaveCount(0)
+
+      // Toggle to annual
+      await page.locator('.saas-billing-toggle [role="switch"]').click()
+      await expect(page.locator('.savings-badge')).toBeVisible()
+      await expect(page.locator('.savings-badge')).toContainText('20%')
+
+      // Pro plan original price strikethrough should appear
+      await expect(page.locator('.saas-original-price')).toHaveCount(2) // pro + enterprise
+    })
+
+    test('selecting a plan navigates to login', async ({ page }) => {
+      await page.goto('/gallery/saas/pricing')
+
+      // Click the Pro plan CTA
+      await page.locator('.saas-plan-card [data-plan="pro"]').click()
+      await page.waitForURL('**/gallery/saas/login')
+      await expect(page).toHaveURL(/\/gallery\/saas\/login$/)
+    })
+  })
+
+  test.describe('Cross-page state', () => {
+    test('billing cycle persists from pricing to login', async ({ page }) => {
+      await page.goto('/gallery/saas/pricing')
+
+      // Switch to annual
+      await page.locator('.saas-billing-toggle [role="switch"]').click()
+      await expect(page.locator('.savings-badge')).toBeVisible()
+
+      // Navigate to login
+      await page.locator('[data-saas-nav-item="login"]').first().click()
+      await page.waitForURL('**/gallery/saas/login')
+
+      // Monthly/annual state was written to sessionStorage — navigate back and verify it persists
+      await page.goto('/gallery/saas/pricing')
+      await expect(page.locator('.savings-badge')).toBeVisible()
+    })
+
+    test('selected plan is shown as banner on login page', async ({ page }) => {
+      await page.goto('/gallery/saas/pricing')
+
+      // Select Pro
+      await page.locator('.saas-plan-card [data-plan="pro"]').click()
+      await page.waitForURL('**/gallery/saas/login')
+
+      // Banner should show the selected plan
+      await expect(page.locator('.saas-plan-banner')).toBeVisible()
+      await expect(page.locator('.saas-plan-banner')).toContainText('Pro')
+    })
+  })
+
+  test.describe('Blog', () => {
+    test('blog index lists all posts', async ({ page }) => {
+      await page.goto('/gallery/saas/blog')
+      await expect(page.locator('.saas-blog-card')).toHaveCount(4)
+    })
+
+    test('clicking a post link navigates to the post page', async ({ page }) => {
+      await page.goto('/gallery/saas/blog')
+
+      const firstLink = page.locator('.saas-blog-read-more').first()
+      const href = await firstLink.getAttribute('href')
+      await firstLink.click()
+      await page.waitForURL(`**${href}`)
+
+      await expect(page.locator('.saas-blog-post')).toBeVisible()
+      await expect(page.locator('.saas-post-title')).toBeVisible()
+    })
+
+    test('blog post back link returns to blog index', async ({ page }) => {
+      await page.goto('/gallery/saas/blog/edge-deployments-explained')
+
+      await page.locator('.saas-blog-back').click()
+      await page.waitForURL('**/gallery/saas/blog')
+      await expect(page).toHaveURL(/\/gallery\/saas\/blog$/)
+    })
+
+    test('invalid post slug shows 404 state', async ({ page }) => {
+      await page.goto('/gallery/saas/blog/does-not-exist')
+      await expect(page.locator('.saas-blog-post-notfound')).toBeVisible()
+    })
+
+    test('blog post page has active blog nav item', async ({ page }) => {
+      await page.goto('/gallery/saas/blog/edge-deployments-explained')
+      await expect(page.locator('[data-saas-nav-item="blog"]')).toHaveAttribute('data-active', 'true')
+    })
+  })
+
+  test.describe('Login page', () => {
+    test('submit button is disabled when form is empty', async ({ page }) => {
+      await page.goto('/gallery/saas/login')
+      await expect(page.locator('.saas-submit')).toBeDisabled()
+    })
+
+    test('shows validation errors on blur', async ({ page }) => {
+      await page.goto('/gallery/saas/login')
+
+      await page.locator('#saas-email').click()
+      await page.locator('#saas-email').blur()
+      await expect(page.locator('#saas-email')).toHaveAttribute('aria-invalid', 'true')
+
+      await page.locator('#saas-password').click()
+      await page.locator('#saas-password').blur()
+      await expect(page.locator('#saas-password')).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    test('submit succeeds with valid credentials', async ({ page }) => {
+      await page.goto('/gallery/saas/login')
+
+      await page.locator('#saas-email').fill('test@example.com')
+      await page.locator('#saas-password').fill('password123')
+
+      await expect(page.locator('.saas-submit')).toBeEnabled()
+      await page.locator('.saas-submit').click()
+
+      // Loading state
+      await expect(page.locator('.button-text')).toContainText('Creating account')
+
+      // Success toast
+      await expect(page.locator('[role="status"]')).toBeVisible({ timeout: 5000 })
+    })
+  })
+})

--- a/site/ui/pages/gallery/saas/blog-post.tsx
+++ b/site/ui/pages/gallery/saas/blog-post.tsx
@@ -1,0 +1,18 @@
+import { SaasShell } from '@/components/gallery/saas/saas-shell'
+import { SaasBlogPostDemo } from '@/components/gallery/saas/blog-post-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+interface SaasBlogPostPageProps {
+  slug: string
+}
+
+export function SaasBlogPostPage({ slug }: SaasBlogPostPageProps) {
+  return (
+    <>
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <SaasShell currentRoute="blog">
+        <SaasBlogPostDemo slug={slug} />
+      </SaasShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/saas/blog.tsx
+++ b/site/ui/pages/gallery/saas/blog.tsx
@@ -1,0 +1,14 @@
+import { SaasShell } from '@/components/gallery/saas/saas-shell'
+import { SaasBlogIndexDemo } from '@/components/gallery/saas/blog-index-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function SaasBlogPage() {
+  return (
+    <>
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <SaasShell currentRoute="blog">
+        <SaasBlogIndexDemo />
+      </SaasShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/saas/index.tsx
+++ b/site/ui/pages/gallery/saas/index.tsx
@@ -1,0 +1,14 @@
+import { SaasShell } from '@/components/gallery/saas/saas-shell'
+import { SaasLandingDemo } from '@/components/gallery/saas/landing-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function SaasLandingPage() {
+  return (
+    <>
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <SaasShell currentRoute="landing">
+        <SaasLandingDemo />
+      </SaasShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/saas/login.tsx
+++ b/site/ui/pages/gallery/saas/login.tsx
@@ -1,0 +1,14 @@
+import { SaasShell } from '@/components/gallery/saas/saas-shell'
+import { SaasLoginDemo } from '@/components/gallery/saas/login-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function SaasLoginPage() {
+  return (
+    <>
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <SaasShell currentRoute="login">
+        <SaasLoginDemo />
+      </SaasShell>
+    </>
+  )
+}

--- a/site/ui/pages/gallery/saas/pricing.tsx
+++ b/site/ui/pages/gallery/saas/pricing.tsx
@@ -1,0 +1,14 @@
+import { SaasShell } from '@/components/gallery/saas/saas-shell'
+import { SaasPricingDemo } from '@/components/gallery/saas/pricing-demo'
+import { GalleryMeta } from '../admin/gallery-meta'
+
+export function SaasPricingPage() {
+  return (
+    <>
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <SaasShell currentRoute="pricing">
+        <SaasPricingDemo />
+      </SaasShell>
+    </>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -121,6 +121,11 @@ import { ProductivityMailPage } from './pages/gallery/productivity/mail'
 import { ProductivityFilesPage } from './pages/gallery/productivity/files'
 import { ProductivityBoardPage } from './pages/gallery/productivity/board'
 import { ProductivityCalendarPage } from './pages/gallery/productivity/calendar'
+import { SaasLandingPage } from './pages/gallery/saas/index'
+import { SaasPricingPage } from './pages/gallery/saas/pricing'
+import { SaasLoginPage } from './pages/gallery/saas/login'
+import { SaasBlogPage } from './pages/gallery/saas/blog'
+import { SaasBlogPostPage } from './pages/gallery/saas/blog-post'
 
 // Form pattern pages
 import { ControlledInputPage } from './pages/forms/controlled-input'
@@ -657,6 +662,28 @@ export function createApp() {
 
   app.get('/gallery/productivity/calendar', (c) => {
     return c.render(<ProductivityCalendarPage />)
+  })
+
+  // Gallery — SaaS Marketing app (Phase 9)
+  app.get('/gallery/saas', (c) => {
+    return c.render(<SaasLandingPage />)
+  })
+
+  app.get('/gallery/saas/pricing', (c) => {
+    return c.render(<SaasPricingPage />)
+  })
+
+  app.get('/gallery/saas/login', (c) => {
+    return c.render(<SaasLoginPage />)
+  })
+
+  app.get('/gallery/saas/blog', (c) => {
+    return c.render(<SaasBlogPage />)
+  })
+
+  app.get('/gallery/saas/blog/:slug', (c) => {
+    const slug = c.req.param('slug')
+    return c.render(<SaasBlogPostPage slug={slug} />)
   })
 
   // Bar Chart reference page


### PR DESCRIPTION
Closes #929 (Phase 2 — SaaS Marketing).

## Summary

- Adds 5 routes under `/gallery/saas/*`: landing, pricing, login, blog index, blog post
- SSR-heavy workload by design: landing, blog index, and blog post are **fully server-rendered with zero client JS**
- Sparse client islands: pricing toggle and login form
- Cross-page state: billing cycle + selected plan flow from pricing → login via sessionStorage
- 18 E2E tests covering layout, navigation, cross-page state, blog, and login validation

## Routes

| Route | Rendering | Notes |
|---|---|---|
| `/gallery/saas` | SSR-only | Hero, features, testimonials, stats, CTA |
| `/gallery/saas/pricing` | SSR + client island | Billing toggle, plan cards, sessionStorage write |
| `/gallery/saas/login` | SSR + client island | Form validation, plan banner from sessionStorage |
| `/gallery/saas/blog` | SSR-only | Static post listing |
| `/gallery/saas/blog/:slug` | SSR-only | Post detail + 404 fallback |

## Compiler stress targets

- Fully static SSR tree with no reactive islands (landing, blog)
- Signal-driven billing toggle (`isAnnual` → price, savings badge, original-price strikethrough)
- `createMemo` chain: `emailError → passwordError → isFormValid` (login)
- Cross-page signal init from sessionStorage (login reads plan selected on pricing page)
- Static `map()` loops with deep nesting (feature cards, testimonials, blog post list, tags, related posts)
- Conditional 404 branch from a static prop

## Test plan

- [x] `bun run build` — clean build
- [x] `bun run test:e2e --grep "Gallery: SaaS Marketing"` — 18/18 pass
- [x] `bun test packages/jsx/src/__tests__` — 717 pass (no regressions; pre-existing failures are unrelated)