### PR TITLE
feat(compiler): recognize createSignal index-access and late-extraction patterns

### DIFF
--- a/packages/jsx/src/__tests__/analyzer.test.ts
+++ b/packages/jsx/src/__tests__/analyzer.test.ts
@@ -245,6 +245,128 @@ describe('analyzeComponent', () => {
     expect(ctx.signals[0].initialValue).toBe('[1, 2, 3]')
   })
 
+  test('extracts signal via direct index access: const count = createSignal(0)[0]', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Counter() {
+          const count = createSignal(0)[0]
+          return <div>{count()}</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].setter).toBeNull()
+    expect(ctx.signals[0].initialValue).toBe('0')
+  })
+
+  test('extracts signal via direct setter-only index access: const setCount = createSignal(0)[1]', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Counter() {
+          const setCount = createSignal(0)[1]
+          setCount(1)
+          return <div>no getter</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].setter).toBe('setCount')
+    expect(ctx.signals[0].getter.startsWith('__bf_unused_getter_')).toBe(true)
+    expect(ctx.signals[0].initialValue).toBe('0')
+  })
+
+  test('extracts signal via late extraction: const s = createSignal(0); const v = s[0]', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Counter() {
+          const s = createSignal(0)
+          const v = s[0]
+          return <div>{v()}</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('v')
+    expect(ctx.signals[0].setter).toBeNull()
+    expect(ctx.signals[0].initialValue).toBe('0')
+  })
+
+  test('extracts signal via late extraction with both getter and setter', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Counter() {
+          const s = createSignal(0)
+          const count = s[0]
+          const setCount = s[1]
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].setter).toBe('setCount')
+    expect(ctx.signals[0].initialValue).toBe('0')
+  })
+
+  test('preserves type argument across index-access patterns', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Counter() {
+          const count = createSignal<number>(0)[0]
+          return <div>{count()}</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].type.kind).toBe('primitive')
+    if (ctx.signals[0].type.kind === 'primitive') {
+      expect(ctx.signals[0].type.primitive).toBe('number')
+    }
+  })
+
+  test('does not confuse unrelated tuple-like access with signals', () => {
+    const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Things() {
+          const [count, setCount] = createSignal(0)
+          const items = [1, 2, 3]
+          const first = items[0]
+          return <div>{count()} {first}</div>
+        }
+      `
+
+    const ctx = analyzeComponent(source, 'Things.tsx')
+
+    // Only one signal (the destructured one) — `items` is an array literal,
+    // not a createSignal tuple, so items[0] must not become a signal.
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('count')
+  })
+
   test('detects export default function pattern', () => {
     const source = `
         'use client'

--- a/packages/jsx/src/__tests__/signal-index-access.test.ts
+++ b/packages/jsx/src/__tests__/signal-index-access.test.ts
@@ -1,0 +1,195 @@
+/**
+ * BarefootJS Compiler - Signal index-access and late-extraction patterns.
+ *
+ * Verifies that the analyzer + codegen recognise these alternatives to the
+ * canonical `const [getter, setter] = createSignal(init)` destructuring:
+ *
+ *   A) Direct access:    const count = createSignal(0)[0]
+ *   B) Getter-only:      const [count]  = createSignal(0)   (already covered
+ *                         by signal-partial-destructure.test.ts but retested
+ *                         here for completeness)
+ *   C) Late extraction:  const s = createSignal(0); const v = s[0]
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('signal index-access — pattern A (direct)', () => {
+  test('getter-only direct index access compiles cleanly', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const count = createSignal(42)[0]
+        return <div>{count()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Client JS must emit the canonical destructuring form so the
+    // runtime sees a real signal, not a leftover `createSignal(...)[0]`
+    // call.
+    expect(clientJs!.content).toContain('[count] = createSignal(')
+    expect(clientJs!.content).not.toContain('createSignal(42)[0]')
+  })
+
+  test('setter-only direct index access synthesizes an unused getter', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const setCount = createSignal(0)[1]
+        return <button onClick={() => setCount(1)}>bump</button>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Both getter and setter must be bound — the synthesized getter name
+    // is visible in the client JS but unused in user code.
+    expect(clientJs!.content).toMatch(/\[__bf_unused_getter_\d+, setCount\] = createSignal\(/)
+  })
+
+  test('SSR template inlines the initial value', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Display() {
+        const label = createSignal('hi')[0]
+        return <span>{label()}</span>
+      }
+    `
+    const result = compileJSXSync(source, 'Display.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const template = result.files.find((f) => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    expect(template!.content).toContain('hi')
+    expect(template!.content).not.toContain('createSignal')
+  })
+})
+
+describe('signal index-access — pattern C (late extraction)', () => {
+  test('getter-only late extraction compiles to canonical form', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const s = createSignal(7)
+        const count = s[0]
+        return <div>{count()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('[count] = createSignal(7)')
+    // The bridge identifier `s` must not leak into the output — its job
+    // ends once we know where getter/setter live.
+    expect(clientJs!.content).not.toContain('const s = createSignal')
+    expect(clientJs!.content).not.toContain('const count = s[0]')
+  })
+
+  test('both accessors resolved independently', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const s = createSignal(0)
+        const count = s[0]
+        const setCount = s[1]
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('[count, setCount] = createSignal(0)')
+  })
+
+  test('accessors declared in reverse order (setter first) still pair correctly', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const s = createSignal(0)
+        const setCount = s[1]
+        const count = s[0]
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('[count, setCount] = createSignal(0)')
+  })
+
+  test('unrelated tuple-like access is not captured as a signal', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Things() {
+        const [count] = createSignal(0)
+        const items = [10, 20, 30]
+        const first = items[0]
+        return <div>{count()} {first}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Things.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // Only one signal (the canonical destructured one); `items` must
+    // round-trip as an ordinary local array — no phantom signal.
+    const signalCount = (clientJs!.content.match(/createSignal\(/g) ?? []).length
+    expect(signalCount).toBe(1)
+  })
+})
+
+describe('signal index-access — mixed patterns in one component', () => {
+  test('canonical destructuring + direct index + late extraction coexist', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Mixed() {
+        const [a, setA] = createSignal(1)
+        const b = createSignal(2)[0]
+        const pair = createSignal(3)
+        const c = pair[0]
+        return <div>{a()} {b()} {c()} <button onClick={() => setA(a() + 1)}>+</button></div>
+      }
+    `
+    const result = compileJSXSync(source, 'Mixed.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+    expect(js).toContain('[a, setA] = createSignal(1)')
+    expect(js).toContain('[b] = createSignal(2)')
+    expect(js).toContain('[c] = createSignal(3)')
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -33,6 +33,24 @@ export interface PropsDestructuringInfo {
 }
 
 /**
+ * Pending signal tuple reference used for the "late extraction" pattern:
+ *   const s = createSignal(0)
+ *   const v = s[0]
+ *
+ * On seeing the first line we register `s` in AnalyzerContext.signalTupleRefs;
+ * on seeing the second line we set `getter` (or `setter` for `[1]`). Resolved
+ * entries are flushed into `signals` after visitComponentBody completes.
+ */
+export interface PendingSignalTuple {
+  initialValue: string
+  typedInitialValue?: string
+  type: TypeInfo
+  loc: SourceLocation
+  getter: string | null
+  setter: string | null
+}
+
+/**
  * Represents an if statement with a JSX return in a component function.
  */
 export interface ConditionalReturn {
@@ -85,6 +103,11 @@ export interface AnalyzerContext {
    * `createSignal` declarations.
    */
   reactiveFactories: Map<string, ReactiveFactoryInfo>
+  /**
+   * Intermediate `const s = createSignal(...)` tuples awaiting `s[0]`/`s[1]`
+   * extraction. Flushed into `signals` at the end of visitComponentBody.
+   */
+  signalTupleRefs: Map<string, PendingSignalTuple>
 
   // Props
   propsType: TypeInfo | null
@@ -160,6 +183,7 @@ export function createAnalyzerContext(
     jsxConstants: new Map(),
     jsxFunctions: new Map(),
     reactiveFactories: new Map(),
+    signalTupleRefs: new Map(),
 
     propsType: null,
     propsParams: [],

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -449,6 +449,10 @@ function analyzeComponentBody(
     }
 
     visitComponentBody(body, ctx)
+    // Fold any resolved `const s = createSignal(...); const v = s[0]`
+    // pairs into regular SignalInfo entries. Must run after visit so
+    // accessors declared later in the body are visible.
+    flushPendingSignalTuples(ctx)
     ctx.componentBodyBlock = null
   }
 }
@@ -474,9 +478,26 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
     for (const decl of node.declarationList.declarations) {
       if (isSignalDeclaration(decl, ctx)) {
         collectSignal(decl, ctx)
-      } else if (isMemoDeclaration(decl)) {
+        continue
+      }
+      // Index-access patterns must be checked before the tuple-ref form so
+      // a chained expression like `const s = createSignal(0)[0]` — parsed
+      // with the element access at the root — does not fall through to
+      // isSignalTupleDeclaration (which only matches a bare call).
+      const indexMatch = isSignalIndexAccess(decl, ctx)
+      if (indexMatch) {
+        collectSignalFromIndexAccess(decl, indexMatch, ctx)
+        continue
+      }
+      if (isSignalTupleDeclaration(decl)) {
+        collectSignalTupleRef(decl, ctx)
+        continue
+      }
+      if (isMemoDeclaration(decl)) {
         collectMemo(decl, ctx)
-      } else if (ts.isIdentifier(decl.name)) {
+        continue
+      }
+      if (ts.isIdentifier(decl.name)) {
         const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
         collectConstant(decl, ctx, false, isLet ? 'let' : 'const')
       }
@@ -849,6 +870,181 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
+}
+
+/**
+ * Detects `const s = createSignal(...)` — the tuple is stored in an
+ * Identifier rather than destructured. The accessor(s) appear in later
+ * declarations as `const v = s[0]` / `const sv = s[1]`. The declaration
+ * itself is registered as a pending tuple ref and resolved later.
+ */
+function isSignalTupleDeclaration(node: ts.VariableDeclaration): boolean {
+  if (!ts.isIdentifier(node.name)) return false
+  if (!node.initializer || !ts.isCallExpression(node.initializer)) return false
+  const callExpr = node.initializer
+  return (
+    ts.isIdentifier(callExpr.expression) &&
+    callExpr.expression.text === 'createSignal'
+  )
+}
+
+type SignalIndexAccessMatch =
+  | { kind: 'direct'; index: 0 | 1; callExpr: ts.CallExpression }
+  | { kind: 'tupleRef'; index: 0 | 1; tupleName: string }
+
+/**
+ * Detects two index-access patterns:
+ *   Pattern A (direct)    — `const v = createSignal(...)[N]`
+ *   Pattern C (tuple ref) — `const v = s[N]` where `s` is a known tuple ref
+ *
+ * N must be the numeric literal `0` (getter) or `1` (setter).
+ */
+function isSignalIndexAccess(
+  node: ts.VariableDeclaration,
+  ctx: AnalyzerContext
+): SignalIndexAccessMatch | null {
+  if (!ts.isIdentifier(node.name)) return null
+  if (!node.initializer || !ts.isElementAccessExpression(node.initializer)) return null
+  const access = node.initializer
+  if (!ts.isNumericLiteral(access.argumentExpression)) return null
+  const indexValue = Number(access.argumentExpression.text)
+  if (indexValue !== 0 && indexValue !== 1) return null
+  const index = indexValue as 0 | 1
+
+  // Pattern A: createSignal(...)[N]
+  if (ts.isCallExpression(access.expression)) {
+    const call = access.expression
+    if (
+      ts.isIdentifier(call.expression) &&
+      call.expression.text === 'createSignal'
+    ) {
+      return { kind: 'direct', index, callExpr: call }
+    }
+    return null
+  }
+
+  // Pattern C: s[N] where s is a known tuple ref
+  if (ts.isIdentifier(access.expression)) {
+    const tupleName = access.expression.text
+    if (ctx.signalTupleRefs.has(tupleName)) {
+      return { kind: 'tupleRef', index, tupleName }
+    }
+    return null
+  }
+
+  return null
+}
+
+function collectSignalTupleRef(
+  node: ts.VariableDeclaration,
+  ctx: AnalyzerContext
+): void {
+  const name = (node.name as ts.Identifier).text
+  const callExpr = node.initializer as ts.CallExpression
+
+  const initialValue = callExpr.arguments[0] ? ctx.getJS(callExpr.arguments[0]) : ''
+  const typedInitialValue = callExpr.arguments[0]
+    ? callExpr.arguments[0].getText(ctx.sourceFile)
+    : undefined
+
+  let type: TypeInfo = { kind: 'unknown', raw: 'unknown' }
+  if (callExpr.typeArguments && callExpr.typeArguments.length > 0) {
+    type = typeNodeToTypeInfo(callExpr.typeArguments[0], ctx.sourceFile) ?? type
+  } else {
+    type = inferTypeFromValue(initialValue)
+  }
+
+  ctx.signalTupleRefs.set(name, {
+    initialValue,
+    typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
+    type,
+    loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    getter: null,
+    setter: null,
+  })
+}
+
+function collectSignalFromIndexAccess(
+  node: ts.VariableDeclaration,
+  match: SignalIndexAccessMatch,
+  ctx: AnalyzerContext
+): void {
+  const varName = (node.name as ts.Identifier).text
+
+  if (match.kind === 'direct') {
+    // Pattern A — each declaration is a standalone signal. Pair [0] -> getter
+    // or [1] -> setter; the missing half stays null.
+    const callExpr = match.callExpr
+    const initialValue = callExpr.arguments[0] ? ctx.getJS(callExpr.arguments[0]) : ''
+    const typedInitialValue = callExpr.arguments[0]
+      ? callExpr.arguments[0].getText(ctx.sourceFile)
+      : undefined
+
+    let type: TypeInfo = { kind: 'unknown', raw: 'unknown' }
+    if (callExpr.typeArguments && callExpr.typeArguments.length > 0) {
+      type = typeNodeToTypeInfo(callExpr.typeArguments[0], ctx.sourceFile) ?? type
+    } else {
+      type = inferTypeFromValue(initialValue)
+    }
+
+    const loc = getSourceLocation(node, ctx.sourceFile, ctx.filePath)
+    if (match.index === 0) {
+      ctx.signals.push({
+        getter: varName,
+        setter: null,
+        initialValue,
+        typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
+        type,
+        loc,
+      })
+    } else {
+      // Setter-only access: emission requires a getter name. Synthesize one
+      // so the `const [g, s] = createSignal(init)` shape stays valid; the
+      // synthesized getter is unreferenced in user code.
+      ctx.signals.push({
+        getter: `__bf_unused_getter_${ctx.signals.length}`,
+        setter: varName,
+        initialValue,
+        typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
+        type,
+        loc,
+      })
+    }
+    return
+  }
+
+  // Pattern C — fold accessor into the pending tuple ref. If the same index
+  // is claimed twice, keep the first binding (matches how destructuring
+  // would collide at the language level).
+  const pending = ctx.signalTupleRefs.get(match.tupleName)
+  if (!pending) return
+  if (match.index === 0) {
+    if (!pending.getter) pending.getter = varName
+  } else {
+    if (!pending.setter) pending.setter = varName
+  }
+}
+
+/**
+ * Flush resolved signal tuple refs into ctx.signals. Entries without at
+ * least one accessor are ignored (no DOM-observable effect) and leave
+ * the original `const s = createSignal(...)` line unresolved — callers
+ * that care can surface a diagnostic, but silently skipping matches the
+ * "compile as if nothing special happened" contract for orphan refs.
+ */
+function flushPendingSignalTuples(ctx: AnalyzerContext): void {
+  for (const pending of ctx.signalTupleRefs.values()) {
+    if (!pending.getter && !pending.setter) continue
+    ctx.signals.push({
+      getter: pending.getter ?? `__bf_unused_getter_${ctx.signals.length}`,
+      setter: pending.setter,
+      initialValue: pending.initialValue,
+      typedInitialValue: pending.typedInitialValue,
+      type: pending.type,
+      loc: pending.loc,
+    })
+  }
+  ctx.signalTupleRefs.clear()
 }
 
 // =============================================================================
@@ -1372,8 +1568,13 @@ function collectConstant(
 ): void {
   if (!ts.isIdentifier(node.name)) return
 
-  // Skip if it's a signal or memo
+  // Skip if it's a signal or memo. The index-access and tuple-ref forms
+  // are caught in visitComponentBody before this function is reached, but
+  // the belt-and-suspenders check guards direct callers (e.g., the
+  // module-level path at line 366) from double-collecting a signal.
   if (isSignalDeclaration(node, ctx) || isMemoDeclaration(node)) return
+  if (isSignalTupleDeclaration(node)) return
+  if (isSignalIndexAccess(node, ctx) !== null) return
 
   const isModule = _isModule
   const name = node.name.text


### PR DESCRIPTION
## Summary

Teaches the analyzer three new ways to bind a `createSignal()` result that previously slipped past signal detection and produced a `createSignal is not defined` ReferenceError in the SSR template. The canonical destructuring form is unchanged.

Now recognized, in addition to the existing `const [getter, setter] = createSignal(init)`:

| Pattern | Example |
|---|---|
| Getter-only destructure *(was already supported)* | \`const [get] = createSignal(0)\` |
| **Direct index access (new)** | \`const count = createSignal(0)[0]\` |
| **Direct setter-only access (new)** | \`const setCount = createSignal(0)[1]\` |
| **Late extraction via tuple ref (new)** | \`const s = createSignal(0); const v = s[0]\` |
| Late extraction, both halves (new) | \`const s = createSignal(0); const a = s[0]; const b = s[1]\` |

All forms compile down to the canonical `const [getter, setter?] = createSignal(init)` shape in the emitted client JS, so the emitter, IR schema, and runtime are unchanged.

## Why

Surfaced while porting the login form for #929 — the author wanted a read-only shorthand (\`const selectedPlan = createSignal(readSelectedPlan())[0]\`) but the compiler silently kept the raw call in the SSR template and the page blew up at render time. Three similar shorthands that SolidJS accepts were falling through.

## Implementation

- New \`PendingSignalTuple\` map on \`AnalyzerContext\` tracks intermediate \`const s = createSignal(...)\` bindings. Accessors can appear in any order and are folded in before \`visitComponentBody\` completes.
- \`visitComponentBody\` checks the index-access pattern before the tuple-ref pattern so \`const s = createSignal(0)[0]\` (element access at the root) is not mis-classified as a bridge identifier.
- Setter-only direct access synthesizes an \`__bf_unused_getter_N\` name to keep the canonical \`[getter, setter]\` emission shape; the synthesized binding is unreferenced in user code.
- \`collectConstant\` guards extended to skip the new patterns — defense in depth against callers outside \`visitComponentBody\`.

## Non-goals

- No change to the IR schema, emitter, or runtime — all three new patterns reduce to the existing canonical form before codegen.
- Orphan tuple refs (\`const s = createSignal(0)\` with no accessor) are still silently ignored. A diagnostic for that could follow; the behavior is no worse than today.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/analyzer.test.ts\` — 28 pass (6 new)
- [x] \`bun test packages/jsx/src/__tests__/signal-index-access.test.ts\` — 8 pass (new file)
- [x] \`bun test\` — 2928 pass (+14 vs main, no regressions; the 128 pre-existing failures are unrelated)
- [x] \`site/ui\` clean build
- [x] \`site/ui\` SaaS gallery E2E — 18/18 pass