### PR TITLE
feat(compiler): add instrumentation counters and baseline bench harness

### DIFF
--- a/packages/jsx/bench/compiler-bench.ts
+++ b/packages/jsx/bench/compiler-bench.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env bun
+/**
+ * Compiler instrumentation benchmark.
+ *
+ * Measures the cost profile of the current analyzer + JSX->IR pipeline
+ * against a realistic corpus (site/ui components by default). Purpose:
+ * establish a baseline before migrating to type-based reactive primitive
+ * detection so we can judge whether the move is affordable.
+ *
+ * What is counted:
+ * - filesAnalyzed     — total analyzeComponent() invocations
+ * - programCreations  — ts.createProgram() calls (expensive, ~hundreds of ms each)
+ * - reactivityChecks  — containsReactiveExpression() entry-point calls
+ * - typeCheckerQueries — checker.getTypeAtLocation() calls inside the reactivity analyzer
+ * - wall time per file and aggregate
+ *
+ * Usage:
+ *   bun packages/jsx/bench/compiler-bench.ts                       # site/ui corpus (default)
+ *   bun packages/jsx/bench/compiler-bench.ts --corpus <glob-dir>   # custom corpus
+ *   bun packages/jsx/bench/compiler-bench.ts --limit 50            # process first N files
+ *   bun packages/jsx/bench/compiler-bench.ts --top 10              # print N slowest files
+ *
+ * All figures are wall-clock on the calling machine. Compare deltas, not
+ * absolute values across hosts.
+ */
+
+import { resolve, relative } from 'path'
+import { readdir, stat } from 'fs/promises'
+import {
+  compileJSXSync,
+  enableCompilerInstrumentation,
+  disableCompilerInstrumentation,
+  resetCompilerCounters,
+  getCompilerCounters,
+  type CompilerCounters,
+} from '../src/index'
+import { TestAdapter } from '../src/adapters/test-adapter'
+
+interface FileResult {
+  filePath: string
+  wallTimeMs: number
+  programCreated: boolean
+  typeCheckerQueries: number
+  reactivityChecks: number
+  errors: number
+}
+
+async function findTsxFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await findTsxFiles(full)))
+    } else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.') && !entry.name.includes('.preview.')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function parseArgs(argv: string[]): { corpus: string; limit: number; top: number } {
+  const defaultCorpus = resolve(__dirname, '../../../site/ui/components')
+  let corpus = defaultCorpus
+  let limit = Infinity
+  let top = 10
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--corpus' && argv[i + 1]) corpus = resolve(argv[++i])
+    else if (arg === '--limit' && argv[i + 1]) limit = Number(argv[++i])
+    else if (arg === '--top' && argv[i + 1]) top = Number(argv[++i])
+  }
+  return { corpus, limit, top }
+}
+
+async function main() {
+  const { corpus, limit, top } = parseArgs(process.argv)
+
+  const corpusStat = await stat(corpus).catch(() => null)
+  if (!corpusStat || !corpusStat.isDirectory()) {
+    console.error(`Corpus directory not found: ${corpus}`)
+    process.exit(1)
+  }
+
+  const allFiles = await findTsxFiles(corpus)
+  const files = allFiles.slice(0, limit)
+  if (files.length === 0) {
+    console.error(`No .tsx files found under ${corpus}`)
+    process.exit(1)
+  }
+
+  const adapter = new TestAdapter()
+  const results: FileResult[] = []
+  let totalErrors = 0
+
+  enableCompilerInstrumentation()
+  const overallStart = performance.now()
+
+  for (const filePath of files) {
+    const source = await Bun.file(filePath).text()
+
+    resetCompilerCounters()
+    const before: CompilerCounters = getCompilerCounters()
+    const t0 = performance.now()
+    let errors = 0
+    try {
+      const result = compileJSXSync(source, filePath, { adapter })
+      errors = result.errors.filter((e) => e.severity === 'error').length
+    } catch (e) {
+      errors = 1
+    }
+    const t1 = performance.now()
+    const after = getCompilerCounters()
+
+    const delta = {
+      programCreations: after.programCreations - before.programCreations,
+      typeCheckerQueries: after.typeCheckerQueries - before.typeCheckerQueries,
+      reactivityChecks: after.reactivityChecks - before.reactivityChecks,
+    }
+
+    results.push({
+      filePath,
+      wallTimeMs: t1 - t0,
+      programCreated: delta.programCreations > 0,
+      typeCheckerQueries: delta.typeCheckerQueries,
+      reactivityChecks: delta.reactivityChecks,
+      errors,
+    })
+    totalErrors += errors
+  }
+
+  const overallMs = performance.now() - overallStart
+  disableCompilerInstrumentation()
+
+  const totals = results.reduce(
+    (acc, r) => {
+      acc.wallTimeMs += r.wallTimeMs
+      acc.programsCreated += r.programCreated ? 1 : 0
+      acc.typeCheckerQueries += r.typeCheckerQueries
+      acc.reactivityChecks += r.reactivityChecks
+      return acc
+    },
+    { wallTimeMs: 0, programsCreated: 0, typeCheckerQueries: 0, reactivityChecks: 0 }
+  )
+
+  const avgMs = totals.wallTimeMs / results.length
+  const p50 = percentile(results.map((r) => r.wallTimeMs), 0.5)
+  const p95 = percentile(results.map((r) => r.wallTimeMs), 0.95)
+  const p99 = percentile(results.map((r) => r.wallTimeMs), 0.99)
+
+  console.log('=== BarefootJS Compiler Benchmark ===')
+  console.log(`Corpus:               ${corpus}`)
+  console.log(`Files compiled:       ${results.length} / ${allFiles.length} found`)
+  console.log(`Errors during build:  ${totalErrors}`)
+  console.log('')
+  console.log('--- Aggregate ---')
+  console.log(`Overall wall time:    ${overallMs.toFixed(1)} ms`)
+  console.log(`Sum of per-file time: ${totals.wallTimeMs.toFixed(1)} ms`)
+  console.log(`Avg per file:         ${avgMs.toFixed(2)} ms`)
+  console.log(`p50:                  ${p50.toFixed(2)} ms`)
+  console.log(`p95:                  ${p95.toFixed(2)} ms`)
+  console.log(`p99:                  ${p99.toFixed(2)} ms`)
+  console.log('')
+  console.log('--- Type resolution activity ---')
+  console.log(`ts.createProgram calls:        ${totals.programsCreated} files (${((totals.programsCreated / results.length) * 100).toFixed(1)}%)`)
+  console.log(`containsReactiveExpression():  ${totals.reactivityChecks} calls total`)
+  console.log(`checker.getTypeAtLocation():   ${totals.typeCheckerQueries} calls total`)
+  if (totals.reactivityChecks > 0) {
+    console.log(`Avg queries per reactivity check: ${(totals.typeCheckerQueries / totals.reactivityChecks).toFixed(1)}`)
+  }
+  console.log('')
+
+  const slowest = [...results].sort((a, b) => b.wallTimeMs - a.wallTimeMs).slice(0, top)
+  console.log(`--- Top ${top} slowest files ---`)
+  for (const r of slowest) {
+    const rel = relative(corpus, r.filePath)
+    const flags = [
+      r.programCreated ? 'Program' : '       ',
+      r.typeCheckerQueries > 0 ? `${r.typeCheckerQueries}q` : '',
+      r.reactivityChecks > 0 ? `${r.reactivityChecks}rc` : '',
+    ]
+      .filter(Boolean)
+      .join(' ')
+    console.log(`${r.wallTimeMs.toFixed(1).padStart(7)} ms  ${flags.padEnd(20)}  ${rel}`)
+  }
+  console.log('')
+
+  const programFiles = results.filter((r) => r.programCreated)
+  if (programFiles.length > 0) {
+    const programTotal = programFiles.reduce((acc, r) => acc + r.wallTimeMs, 0)
+    const programAvg = programTotal / programFiles.length
+    const noProgramTotal = totals.wallTimeMs - programTotal
+    const noProgramAvg = noProgramTotal / (results.length - programFiles.length)
+    console.log('--- Program cost isolation ---')
+    console.log(`With Program creation (n=${programFiles.length}):    avg ${programAvg.toFixed(2)} ms  (total ${programTotal.toFixed(1)} ms)`)
+    console.log(`Without Program creation (n=${results.length - programFiles.length}): avg ${noProgramAvg.toFixed(2)} ms  (total ${noProgramTotal.toFixed(1)} ms)`)
+    console.log(`Implied per-Program overhead:    ${(programAvg - noProgramAvg).toFixed(1)} ms`)
+  }
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length))
+  return sorted[idx]
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -8,6 +8,7 @@
 import ts from 'typescript'
 import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types'
 import { rewriteBarePropRefs } from './prop-rewrite'
+import { incrementCounter } from './instrumentation'
 import {
   type AnalyzerContext,
   type ConditionalReturn,
@@ -58,6 +59,7 @@ export function createProgramForFile(
   source: string,
   filePath: string
 ): { program: ts.Program; sourceFile: ts.SourceFile; checker: ts.TypeChecker } | null {
+  incrementCounter('programCreations')
   try {
     const normalizedPath = path.resolve(filePath)
 
@@ -114,6 +116,7 @@ export function analyzeComponent(
   targetComponentName?: string,
   program?: ts.Program
 ): AnalyzerContext {
+  incrementCounter('filesAnalyzed')
   // Pre-pass: inline calls to same-file reactive factory helpers so the
   // downstream analyzer sees ordinary `createSignal(...)` declarations
   // instead of `const [a, b] = customFactory(...)` (#931). Skipped when

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -167,6 +167,15 @@ export interface BuildOptions {
 // CSS Layer Prefixer
 export { applyCssLayerPrefix } from './css-layer-prefixer'
 
+// Compiler instrumentation (bench + perf debugging)
+export {
+  enableCompilerInstrumentation,
+  disableCompilerInstrumentation,
+  resetCompilerCounters,
+  getCompilerCounters,
+  type CompilerCounters,
+} from './instrumentation'
+
 // Errors
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors'
 

--- a/packages/jsx/src/instrumentation.ts
+++ b/packages/jsx/src/instrumentation.ts
@@ -1,0 +1,56 @@
+/**
+ * Compiler instrumentation counters.
+ *
+ * Off by default — the `if (_enabled)` guard is a nanosecond branch so the
+ * hot-path cost is negligible when disabled. The bench harness
+ * (packages/jsx/bench/compiler-bench.ts) toggles it on, runs a corpus
+ * through compileJSX, and reads the aggregate counters.
+ *
+ * Scope: only instrument the sites that could become Phase 2 targets of the
+ * type-based detection refactor — TypeScript Program creation, Reactive<T>
+ * checker queries, and whole-file analyze calls. Anything finer grained
+ * (individual node visits) belongs in a profiler, not here.
+ */
+
+export interface CompilerCounters {
+  /** Number of ts.createProgram() calls via createProgramForFile(). */
+  programCreations: number
+  /** Number of checker.getTypeAtLocation() calls from reactivity-checker. */
+  typeCheckerQueries: number
+  /** Number of top-level containsReactiveExpression() calls from jsx-to-ir. */
+  reactivityChecks: number
+  /** Number of analyzeComponent() invocations (one per file per target). */
+  filesAnalyzed: number
+}
+
+let _enabled = false
+let _counters: CompilerCounters = freshCounters()
+
+function freshCounters(): CompilerCounters {
+  return {
+    programCreations: 0,
+    typeCheckerQueries: 0,
+    reactivityChecks: 0,
+    filesAnalyzed: 0,
+  }
+}
+
+export function enableCompilerInstrumentation(): void {
+  _enabled = true
+}
+
+export function disableCompilerInstrumentation(): void {
+  _enabled = false
+}
+
+export function resetCompilerCounters(): void {
+  _counters = freshCounters()
+}
+
+export function getCompilerCounters(): CompilerCounters {
+  return { ..._counters }
+}
+
+export function incrementCounter(key: keyof CompilerCounters): void {
+  if (_enabled) _counters[key]++
+}

--- a/packages/jsx/src/reactivity-checker.ts
+++ b/packages/jsx/src/reactivity-checker.ts
@@ -11,8 +11,18 @@
  */
 
 import ts from 'typescript'
+import { incrementCounter } from './instrumentation'
 
 const REACTIVE_BRAND = '__reactive'
+
+/**
+ * Instrumented wrapper around checker.getTypeAtLocation so we can count
+ * query frequency when the bench harness enables instrumentation.
+ */
+function queryType(checker: ts.TypeChecker, node: ts.Node): ts.Type {
+  incrementCounter('typeCheckerQueries')
+  return checker.getTypeAtLocation(node)
+}
 
 /**
  * Check if a TypeScript type has the Reactive<T> brand.
@@ -79,7 +89,7 @@ function analyze(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis {
   // then recurse only into the object part (not the name) to avoid redundant checks.
   if (ts.isPropertyAccessExpression(node)) {
     try {
-      const type = checker.getTypeAtLocation(node)
+      const type = queryType(checker, node)
       if (isReactiveType(type)) {
         return {
           isReactive: true,
@@ -107,7 +117,7 @@ function analyze(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis {
   // Identifiers: brand is attached directly to the identifier's type.
   if (ts.isIdentifier(node)) {
     try {
-      const type = checker.getTypeAtLocation(node)
+      const type = queryType(checker, node)
       if (isReactiveType(type)) {
         return {
           isReactive: true,
@@ -123,7 +133,7 @@ function analyze(node: ts.Node, checker: ts.TypeChecker): ReactivityAnalysis {
   // Call expressions: the callee might be Reactive<() => T>.
   if (ts.isCallExpression(node)) {
     try {
-      const calleeType = checker.getTypeAtLocation(node.expression)
+      const calleeType = queryType(checker, node.expression)
       if (isReactiveType(calleeType)) {
         return {
           isReactive: true,
@@ -178,5 +188,6 @@ export function analyzeReactivity(node: ts.Node, checker: ts.TypeChecker): React
  * need the reasoning chain.
  */
 export function containsReactiveExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
+  incrementCounter('reactivityChecks')
   return brandTypeReactivityAnalyzer.analyze(node, checker).isReactive
 }


### PR DESCRIPTION
Groundwork for the planned migration from name-based to type-based reactive primitive detection. The goal is to surface the current cost profile so subsequent design decisions are driven by measurement rather than guesses.

## What this adds

### Instrumentation (opt-in, ~1ns when disabled)

Counters exposed via public API. Guarded by a boolean branch; zero hot-path cost when off.

| Counter | Meaning |
|---|---|
| \`programCreations\` | \`ts.createProgram()\` invocations via \`createProgramForFile\` |
| \`typeCheckerQueries\` | \`checker.getTypeAtLocation()\` calls inside the reactivity analyzer |
| \`reactivityChecks\` | \`containsReactiveExpression()\` entry-point calls |
| \`filesAnalyzed\` | \`analyzeComponent()\` invocations |

Public API: \`enableCompilerInstrumentation\`, \`disableCompilerInstrumentation\`, \`resetCompilerCounters\`, \`getCompilerCounters\`.

### Bench harness (\`packages/jsx/bench/compiler-bench.ts\`)

Walks a corpus of \`.tsx\` files (default: \`site/ui/components\`, 196 files), compiles each via \`compileJSXSync\` with \`TestAdapter\`, and reports aggregate + per-file stats.

\`\`\`
bun packages/jsx/bench/compiler-bench.ts
bun packages/jsx/bench/compiler-bench.ts --corpus <dir> --limit 50 --top 20
\`\`\`

## Baseline on \`site/ui/components\` (196 files, M4 Mac)

\`\`\`
Overall wall time:              1361 ms
Avg per file:                   6.55 ms
p50 / p95 / p99:                2.35 / 13.17 / 30.32 ms

ts.createProgram invocations:   1 / 196 files  (0.5%)
Per-Program overhead:           ~545 ms  (one file dominates ~40% of total)
Reactivity checks (total):      19
getTypeAtLocation queries:      10
\`\`\`

## Key finding

The existing comment in \`analyzer.ts\` claims _"~220ms overhead per file"_ for Program creation. The measured cost is **~545ms** — 2.5x the documented figure.

A naive Phase 2 rollout that ran Program for every file importing \`@barefootjs/client\` (roughly 150 of 196 files in \`site/ui\`) would push compilation from **~1.4s to ~80s** — a 60x regression.

**Implication for the type-based unification plan**: we cannot just widen the trigger condition. We need one of:

1. Eager resolution pass per file — amortize checker cost over a single walk, consume results read-only afterward.
2. Shared \`ts.Program\` across files in one build session.
3. Keep name-based as the fast path, type-based as enrichment only for unresolvable call sites.

This PR is the instrument, not the fix. It gives us the number to beat.

## Test plan

- [x] \`bun test packages/jsx\` — 717 pass, 0 fail (no regressions)
- [x] \`bun packages/jsx/bench/compiler-bench.ts\` — runs and prints report

## Out of scope

Type-based detection redesign itself. That will be a separate RFC/issue referencing these baseline numbers.