### PR TITLE
refactor(compiler): consolidate createEffect wrap decision into WrapDecision ADT

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,7 +5,7 @@
 import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchConditional, ConditionalBranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildEvent, LoopChildReactiveAttr, NestedLoopInfo } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
-import { needsEffectWrapper, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
+import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 
@@ -233,11 +233,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         // Only collect as a top-level dynamic element when NOT inside a
         // conditional. Conditional text effects are collected per-branch and
         // emitted inside bindEvents.
-        const shouldWrap =
-          node.reactive ||
-          node.callsReactiveGetters ||
-          node.hasFunctionCalls
-        if (shouldWrap) {
+        if (decideWrapFromAstFlags(node).wrap) {
           ctx.dynamicElements.push({
             slotId: node.slotId,
             expression: node.expr,
@@ -255,11 +251,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
         // Wrap not only statically-proven-reactive conditions, but also any
         // condition containing a function call — otherwise the silent-drop
         // failure class freezes the branch at its SSR-time value.
-        const shouldWrap =
-          node.reactive ||
-          node.callsReactiveGetters ||
-          node.hasFunctionCalls
-        if (shouldWrap) {
+        if (decideWrapFromAstFlags(node).wrap) {
           if (insideConditional) {
             // Nested conditionals are collected by the parent via collectBranchConditionals.
             // Don't push to ctx.conditionalElements — they'll be emitted inside the parent's bindEvents.
@@ -437,9 +429,7 @@ export function collectElements(node: IRNode, ctx: ClientJsContext, insideCondit
           // `prop.hasFunctionCalls` are computed structurally from the AST
           // so they can't false-match call-like substrings inside string
           // literals (e.g. `{ color: 'hsl(221 83% 53%)' }`).
-          const hasPropsRef = expandedValue.includes('props.')
-          const hasReactiveExpr = needsEffectWrapper(expandedValue, ctx)
-          if (hasPropsRef || hasReactiveExpr || prop.callsReactiveGetters || prop.hasFunctionCalls) {
+          if (decideWrapForChildProp(expandedValue, ctx, prop).wrap) {
             const attrName = prop.name === 'className' ? 'class' : prop.name
             ctx.reactiveChildProps.push({
               componentName: node.name,
@@ -583,11 +573,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
         // they can't false-match call-like substrings inside string
         // literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and
         // don't depend on the expansion order of local constants.
-        if (
-          needsEffectWrapper(expandedValueStr, ctx)
-          || attr.callsReactiveGetters
-          || attr.hasFunctionCalls
-        ) {
+        if (decideWrapForAttr(expandedValueStr, ctx, attr).wrap) {
           ctx.reactiveAttrs.push({
             slotId: element.slotId,
             attrName: attr.name,
@@ -786,7 +772,7 @@ function collectBranchConditionals(node: IRNode, ctx: ClientJsContext): Conditio
       case 'conditional':
         // Wrap-by-default fallback (#941) — mirror the top-level gate in
         // `case 'conditional'` at collectElements().
-        if (n.slotId && (n.reactive || n.callsReactiveGetters || n.hasFunctionCalls)) {
+        if (n.slotId && decideWrapFromAstFlags(n).wrap) {
           result.push(buildConditionalMetadata(n, ctx))
         }
         // Don't recurse further — the nested conditional handles its own branches

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -29,6 +29,79 @@ import { expandConstantForReactivity } from './prop-handling'
  * - Skips `children` props because children are server-rendered and should not
  *   trigger `createEffect` wrapping on the client
  */
+/**
+ * Decision about whether an expression should be wrapped in `createEffect`
+ * for client-side reactivity. The `reason` field surfaces *why* the wrap
+ * was chosen (proven reactive vs Solid-style fallback) so the wrap-by-default
+ * gates (#937 / #939–#943) stay debuggable rather than collapsing into a
+ * single boolean.
+ */
+export type WrapDecision =
+  | { wrap: false }
+  | { wrap: true; reason: WrapReason }
+
+export type WrapReason =
+  /** Phase 1 analyzer proved the expression reads a signal/memo/prop. */
+  | 'proven-reactive'
+  /** Expression contains a call that looks like a signal getter / memo (AST flag). */
+  | 'fallback-getter-calls'
+  /** Expression contains an arbitrary `identifier()` call (AST flag — Solid-style fallback). */
+  | 'fallback-function-calls'
+  /** String-level `needsEffectWrapper` matched (signal getter / memo / prop name in expanded value). */
+  | 'string-reactive'
+  /** Expanded child-component prop value contains a `props.xxx` reference. */
+  | 'props-access'
+
+/**
+ * AST-flag based wrap decision for IRExpression / IRConditional / nested
+ * IRConditional nodes. Replaces the duplicated
+ * `node.reactive || node.callsReactiveGetters || node.hasFunctionCalls`
+ * predicate (#937 / #941). Pure literals and bare identifiers (no calls)
+ * stay un-wrapped because their SSR value is already in the DOM.
+ */
+export function decideWrapFromAstFlags(node: {
+  reactive?: boolean
+  callsReactiveGetters?: boolean
+  hasFunctionCalls?: boolean
+}): WrapDecision {
+  if (node.reactive) return { wrap: true, reason: 'proven-reactive' }
+  if (node.callsReactiveGetters) return { wrap: true, reason: 'fallback-getter-calls' }
+  if (node.hasFunctionCalls) return { wrap: true, reason: 'fallback-function-calls' }
+  return { wrap: false }
+}
+
+/**
+ * Wrap decision for native-element reactive attributes (#940). Combines the
+ * string-level `needsEffectWrapper` check (recognises signal getters / memos /
+ * prop names inside expanded local-const references) with the AST flags from
+ * the source attribute expression.
+ */
+export function decideWrapForAttr(
+  expandedValue: string,
+  ctx: ClientJsContext,
+  attr: { callsReactiveGetters?: boolean; hasFunctionCalls?: boolean },
+): WrapDecision {
+  if (needsEffectWrapper(expandedValue, ctx)) return { wrap: true, reason: 'string-reactive' }
+  if (attr.callsReactiveGetters) return { wrap: true, reason: 'fallback-getter-calls' }
+  if (attr.hasFunctionCalls) return { wrap: true, reason: 'fallback-function-calls' }
+  return { wrap: false }
+}
+
+/**
+ * Wrap decision for child-component reactive props (#942). Adds a `props.xxx`
+ * substring check on top of the attr decision: when the parent's prop is
+ * forwarded into a child component, the child needs to re-read it through
+ * createEffect so parent re-renders propagate.
+ */
+export function decideWrapForChildProp(
+  expandedValue: string,
+  ctx: ClientJsContext,
+  prop: { callsReactiveGetters?: boolean; hasFunctionCalls?: boolean },
+): WrapDecision {
+  if (expandedValue.includes('props.')) return { wrap: true, reason: 'props-access' }
+  return decideWrapForAttr(expandedValue, ctx, prop)
+}
+
 export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean {
   for (const signal of ctx.signals) {
     if (new RegExp(`\\b${signal.getter}\\s*\\(`).test(expr)) {


### PR DESCRIPTION
## Summary
- Extract the 5x duplicated wrap-by-default predicate (#937, #939–#943) from `collect-elements.ts` into a single `WrapDecision` ADT with a `WrapReason` discriminator.
- Add 3 helpers in `reactivity.ts`: `decideWrapFromAstFlags` (expression / conditional — AST flags only), `decideWrapForAttr` (element attr — AST flags + `needsEffectWrapper`), `decideWrapForChildProp` (child component prop — adds `props.xxx` check on top).
- Route all 5 call sites (expression, top-level conditional, nested-branch conditional, element attr, child-component prop) through the helpers.

No behavior change — the predicates stay identical. The `reason` is now a first-class value, ready to surface in `barefoot why-wrap` output in a follow-up.

## Test plan
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests` — 1181 pass / 0 fail
- [x] `bun test ui/components/` — 1157 pass / 0 fail
- [x] `bun run --filter '@barefootjs/client' build` & `bun run --filter '@barefootjs/jsx' build` (including `tsgo --emitDeclarationOnly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)