### PR TITLE
feat(cli): surface WrapReason in barefoot why-wrap output

### DIFF
--- a/packages/cli/src/__tests__/why-wrap.test.ts
+++ b/packages/cli/src/__tests__/why-wrap.test.ts
@@ -85,6 +85,12 @@ describe('barefoot why-wrap', () => {
       // The actual expression text is printed so users can locate the
       // binding in their source without running `inspect` separately.
       expect(output).toContain('formatTitle(page)')
+      // `formatTitle(page)` triggers the AST-level `hasFunctionCalls` flag
+      // but not `callsReactiveGetters` (formatTitle isn't a known signal),
+      // so the emitter's wrap reason is `fallback-function-calls`. Surface
+      // that in the report so users can distinguish it from other fallback
+      // shapes (e.g., signal-like calls on non-reactive sources).
+      expect(output).toContain('[fallback-function-calls]')
       // Guidance footer — helps the user know what to do next.
       expect(output).toContain('createMemo')
     } finally {
@@ -115,7 +121,7 @@ describe('barefoot why-wrap', () => {
       const parsed = JSON.parse(output) as {
         componentName: string
         sourceFile: string
-        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string; expression?: string }>
+        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string; expression?: string; wrapReason?: string }>
       }
       expect(parsed.componentName).toBe('Tag')
       expect(parsed.fallbacks.length).toBeGreaterThan(0)
@@ -128,6 +134,11 @@ describe('barefoot why-wrap', () => {
       expect(attrFallback!.label).toBe('class')
       expect(attrFallback!.deps).toEqual([])
       expect(attrFallback!.expression).toBe('format(label)')
+      // `format(label)` is an opaque call — AST flag `hasFunctionCalls` is
+      // set but `callsReactiveGetters` is not. Lock in the `wrapReason`
+      // vocabulary so editor integrations can switch on the enum without
+      // re-deriving it from the expression.
+      expect(attrFallback!.wrapReason).toBe('fallback-function-calls')
     } finally {
       logSpy.mockRestore()
       rmSync(path.dirname(file), { recursive: true, force: true })

--- a/packages/cli/src/commands/why-wrap.ts
+++ b/packages/cli/src/commands/why-wrap.ts
@@ -48,6 +48,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         type: f.type,
         classification: f.classification,
         ...(f.expression !== undefined && { expression: f.expression }),
+        ...(f.wrapReason !== undefined && { wrapReason: f.wrapReason }),
       })),
     }, null, 2))
     return
@@ -69,7 +70,11 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const width = cells.reduce((w, c) => Math.max(w, c.cell.length), 0)
   for (const { f, cell } of cells) {
     const expr = f.expression ?? '(expression not captured)'
-    console.log(`  ${cell.padEnd(width)}  ~ ${expr}`)
+    // Reason is appended at EOL so the `~ expression` column stays aligned
+    // for the eye-scan case; debuggers who care about *why* the wrap fired
+    // can read the bracketed tag on the right.
+    const reason = f.wrapReason ? `  [${f.wrapReason}]` : ''
+    console.log(`  ${cell.padEnd(width)}  ~ ${expr}${reason}`)
   }
   console.log()
   console.log('Fallback wraps run one createEffect per expression. Each subscribes to')

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -21,6 +21,8 @@ import { analyzeComponent, listComponentFunctions } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { buildMetadata } from './compiler'
 import { analyzeClientNeeds } from './ir-to-client-js'
+import type { WrapReason } from './ir-to-client-js/reactivity'
+import { decideWrapFromAstFlags } from './ir-to-client-js/reactivity'
 
 // =============================================================================
 // Types
@@ -81,6 +83,16 @@ export interface DomBinding {
    * `why-update`) and for cases where the IR lacks a flat string form.
    */
   expression?: string
+  /**
+   * Structural trigger that decided the emitter's wrap-by-default call
+   * (#937, DRY-consolidated in PR #991). Mirrors the `WrapReason` enum on
+   * `WrapDecision` in `ir-to-client-js/reactivity.ts` so users debugging
+   * `why-wrap` see the same vocabulary the compiler uses internally.
+   *
+   * Populated for text / attribute / conditional / loop / child-prop
+   * bindings; omitted for event handlers (not subject to the wrap gate).
+   */
+  wrapReason?: WrapReason
 }
 
 export interface ComponentGraph {
@@ -520,6 +532,25 @@ export function formatSignalTrace(traces: SignalTrace[]): string {
 // =============================================================================
 
 /**
+ * Derive a `WrapReason` for bindings that mix string-level evidence (known
+ * signal/memo/prop names in the expression → `deps.length > 0`, or a
+ * `props.xxx` reference) with the AST flags the analyzer attaches to each
+ * attribute/prop/loop. Mirrors `decideWrapForAttr` / `decideWrapForChildProp`
+ * in `ir-to-client-js/reactivity.ts` but uses `deps` as the stand-in for the
+ * string-level `needsEffectWrapper` check (debug.ts has no `ClientJsContext`).
+ */
+function inferWrapReasonForAttrLike(
+  hasStringReactive: boolean,
+  hasPropsRef: boolean,
+  flags: { callsReactiveGetters?: boolean; hasFunctionCalls?: boolean },
+): WrapReason | undefined {
+  if (hasPropsRef) return 'props-access'
+  if (hasStringReactive) return 'string-reactive'
+  const decision = decideWrapFromAstFlags(flags)
+  return decision.wrap ? decision.reason : undefined
+}
+
+/**
  * Collect DOM bindings (text updates, event handlers, etc.) from the IR tree.
  *
  * Emits one `DomBinding` per expression the emitter wraps in `createEffect` at
@@ -552,8 +583,8 @@ function collectDomBindings(
         if (!expr) continue
         const deps = extractReactiveDeps(expr, signalGetters, memoNames)
         const isReactive = deps.length > 0
-        const isFallback = !isReactive && (attr.callsReactiveGetters || attr.hasFunctionCalls)
-        if (isReactive || isFallback) {
+        const wrapReason = inferWrapReasonForAttrLike(isReactive, false, attr)
+        if (wrapReason) {
           bindings.push({
             kind: 'dom',
             label: attr.name,
@@ -562,6 +593,7 @@ function collectDomBindings(
             type: 'attribute',
             classification: isReactive ? 'reactive' : 'fallback',
             expression: expr,
+            wrapReason,
           })
         }
       }
@@ -586,9 +618,8 @@ function collectDomBindings(
     case 'expression': {
       // Widened to match emitter gate in collect-elements.ts:
       // `node.reactive || node.callsReactiveGetters || node.hasFunctionCalls`.
-      const isReactive = node.reactive
-      const isFallback = !isReactive && (node.callsReactiveGetters || node.hasFunctionCalls)
-      if ((isReactive || isFallback) && node.slotId) {
+      const decision = decideWrapFromAstFlags(node)
+      if (decision.wrap && node.slotId) {
         const deps = extractReactiveDeps(node.expr, signalGetters, memoNames)
         bindings.push({
           kind: 'dom',
@@ -596,16 +627,16 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'text',
-          classification: isReactive ? 'reactive' : 'fallback',
+          classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
           expression: node.expr,
+          wrapReason: decision.reason,
         })
       }
       break
     }
     case 'conditional': {
-      const isReactive = node.reactive
-      const isFallback = !isReactive && (node.callsReactiveGetters || node.hasFunctionCalls)
-      if ((isReactive || isFallback) && node.slotId) {
+      const decision = decideWrapFromAstFlags(node)
+      if (decision.wrap && node.slotId) {
         const deps = extractReactiveDeps(node.condition, signalGetters, memoNames)
         bindings.push({
           kind: 'dom',
@@ -613,8 +644,9 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'conditional',
-          classification: isReactive ? 'reactive' : 'fallback',
+          classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
           expression: node.condition,
+          wrapReason: decision.reason,
         })
       }
       collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames)
@@ -632,6 +664,17 @@ function collectDomBindings(
         const isReactive = deps.length > 0 || node.callsReactiveGetters === true
         const isFallback = !isReactive && node.hasFunctionCalls === true
         if (isReactive || isFallback) {
+          // IRLoop has no `.reactive` flag (unlike IRExpression/IRConditional),
+          // so we derive the WrapReason inline rather than via
+          // `inferWrapReasonForAttrLike`: a loop whose array calls a signal
+          // getter (`items()` where `items` is a signal) is proven-reactive,
+          // not fallback — flip the string evidence before handing the AST
+          // flags to the helper.
+          const wrapReason: WrapReason = deps.length > 0
+            ? 'string-reactive'
+            : node.callsReactiveGetters
+              ? 'proven-reactive'
+              : 'fallback-function-calls'
           bindings.push({
             kind: 'dom',
             label: `loop "${node.slotId}"`,
@@ -640,6 +683,7 @@ function collectDomBindings(
             type: 'loop',
             classification: isReactive ? 'reactive' : 'fallback',
             expression: node.array,
+            wrapReason,
           })
         }
       }
@@ -675,8 +719,8 @@ function collectDomBindings(
         const deps = extractReactiveDeps(propValue, signalGetters, memoNames)
         const hasPropsRef = propValue.includes('props.')
         const isReactive = deps.length > 0 || hasPropsRef
-        const isFallback = !isReactive && (prop.callsReactiveGetters || prop.hasFunctionCalls)
-        if (isReactive || isFallback) {
+        const wrapReason = inferWrapReasonForAttrLike(deps.length > 0, hasPropsRef, prop)
+        if (wrapReason) {
           bindings.push({
             kind: 'dom',
             label: `${node.name}.${prop.name}`,
@@ -685,6 +729,7 @@ function collectDomBindings(
             type: 'attribute',
             classification: isReactive ? 'reactive' : 'fallback',
             expression: propValue,
+            wrapReason,
           })
         }
       }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -196,6 +196,7 @@ export {
   graphToJSON,
 } from './debug'
 export type { ComponentGraph, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace } from './debug'
+export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'


### PR DESCRIPTION
## Summary
Follow-up to #991. The `WrapDecision` ADT now carries a `WrapReason` discriminator, but `why-wrap` was throwing it away — users could see *that* a binding was wrapped as a fallback, but not *which* AST-level trigger fired.

- Thread `wrapReason` through `DomBinding` → both output modes:
  - **Human**: ``text "s0"  ~ formatTitle(page)  [fallback-function-calls]``
  - **JSON**: ``"wrapReason": "fallback-function-calls"``
- `debug.ts::collectDomBindings` had an independent copy of the wrap-classification logic; route it through `decideWrapFromAstFlags` + a small `inferWrapReasonForAttrLike` helper so `collect-elements.ts` and `debug.ts` share the same vocabulary.
- Re-export `WrapReason` from `@barefootjs/jsx` so editor integrations can switch on the enum without re-deriving it from the expression string.

## Test plan
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/cli` — 1497 pass / 0 fail
- [x] `bun test ui/components/` — 1157 pass / 0 fail
- [x] Smoke test: `bun run barefoot why-wrap <fixture>` shows `[fallback-function-calls]` suffix; `--json` carries the field
- [x] `@barefootjs/jsx` build (incl. `tsgo --emitDeclarationOnly`) regenerates `.d.ts` with the new field and re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)