### PR TITLE
refactor(compiler): normalise NestedLoopInfo field names and key nullability

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -55,7 +55,7 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
         // Generate item template for CSR rendering in mapArray.
         // Pass loopParams so expressions are wrapped at generation time (not post-hoc regex).
         const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
-        const itemTemplate = n.children.map(c => irToPlaceholderTemplate(c, undefined, depth, loopParamsForTemplate)).join('')
+        const template = n.children.map(c => irToPlaceholderTemplate(c, undefined, depth, loopParamsForTemplate)).join('')
         // Check if array expression references the outer loop param
         const refsOuter = outerLoopParam
           ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
@@ -71,11 +71,11 @@ function collectInnerLoops(nodes: IRNode[], outerLoopParam?: string, ctx?: Clien
           depth,
           array: n.array,
           param: n.param,
-          key: n.key ?? '',
+          key: n.key,
           containerSlotId: parentSlotId,
-          itemTemplate,
+          template,
           refsOuterParam: refsOuter,
-          reactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
+          childReactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
           insideConditional: insideCond || undefined,
           siblingOffset: loopSiblingOffsets.get(n) || undefined,
         })

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -4,7 +4,7 @@
  * and event delegation within loop containers.
  */
 
-import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, ConditionalBranchLoop, ConditionalBranchConditional, LoopChildEvent, LoopChildConditional, LoopChildReactiveText, LoopElement, NestedLoopInfo } from './types'
+import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, ConditionalBranchLoop, ConditionalBranchConditional, LoopChildEvent, LoopChildConditional, LoopElement, NestedLoopInfo } from './types'
 import type { IRLoopChildComponent } from '../types'
 import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
@@ -385,7 +385,7 @@ function emitBranchInnerLoops(
 
   for (let i = 0; i < innerLoops.length; i++) {
     const inner = innerLoops[i]
-    if (!inner.refsOuterParam || !inner.itemTemplate) continue
+    if (!inner.refsOuterParam || !inner.template) continue
 
     const uid = `br_${i}`
     const arrayExpr = wrapOuter(inner.array)
@@ -394,7 +394,7 @@ function emitBranchInnerLoops(
       : 'null'
     const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
     // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
-    const wrappedTemplate = inner.itemTemplate
+    const wrappedTemplate = inner.template
     // Find the container for the inner loop. Try bf= attribute (plain elements) first,
     // then bf-s$ suffix match (component scope elements like SelectContent).
     const csl = inner.containerSlotId
@@ -442,8 +442,8 @@ function emitBranchInnerLoops(
       lines.push(`${indent}  }`)
     }
     // Reactive text effects for inner loop items
-    if (inner.reactiveTexts && inner.reactiveTexts.length > 0) {
-      for (const text of inner.reactiveTexts) {
+    if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
+      for (const text of inner.childReactiveTexts) {
         const wrappedExpr = wrapBoth(text.expression)
         if (text.insideConditional) {
           // Text is inside a conditional branch: insert() may replace the DOM element,
@@ -947,7 +947,11 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: LoopElement): voi
         ls.push(`      const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
         // Resolve inner loop variables via the outer param's nested array
         for (const nested of ev.nestedLoops) {
-          const innerKeyExpr = nested.key.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+          // `nested.key` can be null for unkeyed loops; coerce to '' so the
+          // resolution silently no-ops (String('') never matches a real
+          // key), matching prior behavior when NestedLoopInfo.key was
+          // always a string defaulting to ''.
+          const innerKeyExpr = (nested.key ?? '').replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
           ls.push(`      const ${nested.param} = ${elem.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
         }
         // Guard all resolved variables
@@ -1002,7 +1006,8 @@ function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchL
         ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
         ls.push(`      const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
         for (const nested of ev.nestedLoops) {
-          const innerKeyExpr = nested.key.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+          // See sibling comment above — `nested.key` may be null.
+          const innerKeyExpr = (nested.key ?? '').replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
           ls.push(`      const ${nested.param} = ${loop.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
         }
         const allParams = [loop.param, ...ev.nestedLoops.map(n => n.param)]
@@ -1028,7 +1033,7 @@ function emitBranchLoopEventDelegation(lines: string[], loop: ConditionalBranchL
 interface DepthLevel {
   comps: (LoopElement['nestedComponents'] & {})[number][]
   events: LoopChildEvent[]
-  loopInfo: { array: string; param: string; key: string; depth: number; containerSlotId?: string | null; itemTemplate?: string; refsOuterParam?: boolean; reactiveTexts?: LoopChildReactiveText[]; insideConditional?: boolean } | null
+  loopInfo: NestedLoopInfo | null
 }
 
 /**
@@ -1245,14 +1250,14 @@ function emitInnerLoopSetup(
     const arrayExpr = wrapOuter(inner.array)
     const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
 
-    if (inner.refsOuterParam && inner.itemTemplate && outerLoopParam) {
+    if (inner.refsOuterParam && inner.template && outerLoopParam) {
       // Reactive inner loop: use mapArray for proper add/remove/update
       // Key function receives plain item value (not accessor) per mapArray contract
       const keyFn = inner.key
         ? `(${inner.param}) => String(${inner.key})`
         : 'null'
       // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
-      const wrappedTemplate = inner.itemTemplate!
+      const wrappedTemplate = inner.template!
       const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param)
       ls.push(`${indent}// Reactive inner loop: ${inner.array}`)
       ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `qsa(${parentElVar}, ${containerSelector})` : parentElVar}`)
@@ -1314,8 +1319,8 @@ function emitInnerLoopSetup(
         emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
       }
       // Reactive text effects for inner loop items
-      if (inner.reactiveTexts && inner.reactiveTexts.length > 0) {
-        for (const text of inner.reactiveTexts) {
+      if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
+        for (const text of inner.childReactiveTexts) {
           const wrappedExpr = wrapLoopParamAsAccessor(wrapOuter(text.expression), inner.param)
           if (text.insideConditional) {
             // Text is inside a conditional branch: insert() may replace the DOM element,

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -326,7 +326,7 @@ export function collectLoopChildEventsWithNesting(
           depth: nestingStack.length + 1,
           array: n.array,
           param: n.param,
-          key: n.key ?? '',
+          key: n.key,
           containerSlotId: lastElementSlotId,
         })
         for (const child of n.children) walk(child, domDepth)
@@ -542,14 +542,14 @@ function collectBranchInnerLoops(
       for (const child of n.children) walk(child, mySlotId)
     } else if (n.type === 'loop') {
       const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
-      const itemTemplate = n.children.map((c: IRNode) => irToPlaceholderTemplate(c, undefined, 1, loopParamsForTemplate)).join('')
+      const template = n.children.map((c: IRNode) => irToPlaceholderTemplate(c, undefined, 1, loopParamsForTemplate)).join('')
       const refsOuter = outerLoopParam
         ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
         : false
-      const reactiveTexts: Array<{ slotId: string; expression: string }> = []
+      const childReactiveTexts: Array<{ slotId: string; expression: string }> = []
       if (refsOuter && ctx) {
         for (const child of n.children) {
-          reactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
+          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
         }
       }
       // Collect child components and events inside inner loop items.
@@ -593,11 +593,11 @@ function collectBranchInnerLoops(
         depth: 1,
         array: n.array,
         param: n.param,
-        key: n.key ?? '',
+        key: n.key,
         containerSlotId: parentContainerSlotId,
-        itemTemplate,
+        template,
         refsOuterParam: refsOuter,
-        reactiveTexts: reactiveTexts.length > 0 ? reactiveTexts : undefined,
+        childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
         childComponents: childComponents.length > 0 ? childComponents : undefined,
         childEvents: childEvents.length > 0 ? childEvents : undefined,
         childConditionals: childConditionals.length > 0 ? childConditionals : undefined,

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -152,14 +152,21 @@ export interface NestedLoopInfo {
   depth: number    // 1 for first nesting level, 2 for second, etc.
   array: string    // Inner loop array expression (e.g., 'col.tasks')
   param: string    // Inner loop parameter name (e.g., 'task')
-  key: string      // Inner loop key expression (e.g., 'task.id')
+  // Aligned with LoopElement / ConditionalBranchLoop which already allow
+  // `null` — loops without an explicit key expression omit it rather than
+  // coerce to `''`. Makes the three loop-info types share one nullability
+  // story, a prerequisite for the planned discriminated-union unification.
+  key: string | null
   containerSlotId: string | null // Slot ID of the parent element containing the loop (for hydration)
   /** HTML template for a single inner loop item (for mapArray CSR rendering) */
-  itemTemplate?: string
+  // Field renamed from `itemTemplate` to match LoopElement/ConditionalBranchLoop.
+  template?: string
   /** Whether the inner array references the outer loop param (needs reactive mapArray) */
   refsOuterParam?: boolean
   /** Reactive text expressions inside inner loop items (slotId → expression) */
-  reactiveTexts?: LoopChildReactiveText[]
+  // Renamed from `reactiveTexts` so every loop-info type uses the same
+  // `child*` prefix for per-item reactive wiring.
+  childReactiveTexts?: LoopChildReactiveText[]
   /** Child components inside inner loop items (for initChild/createComponent) */
   childComponents?: import('../types').IRLoopChildComponent[]
   /** Event handlers inside inner loop items */


### PR DESCRIPTION
## Summary
Step A of the Loop-info unification plan. `LoopElement`, `ConditionalBranchLoop`, and `NestedLoopInfo` carry ~80% the same data but differ on three micro-inconsistencies — normalising them now makes Step B (discriminated union) a pure type refactor with no further rename churn.

Changes:
- `NestedLoopInfo.itemTemplate` → `template` (matches sibling types)
- `NestedLoopInfo.reactiveTexts` → `childReactiveTexts` (matches the `child*` prefix used elsewhere)
- `NestedLoopInfo.key: string` (default `''`) → `string | null` (matches sibling types)
- `DepthLevel.loopInfo` inline structural type → `NestedLoopInfo | null` (the inline duplicate stops paying rent once field names align)

## Behaviour preservation
The two `nested.key.replace(...)` call sites in `emit-control-flow.ts` previously relied on the `''` default. They now coerce `null → ''` locally; the downstream `String('') === realKey` comparison was already a silent no-op for unkeyed nested loops, so the observable output is unchanged.

## Test plan
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/cli` — 1497 pass / 0 fail
- [x] `bun test ui/components/` — 1157 pass / 0 fail
- [x] `bun run --filter '@barefootjs/jsx' build` (incl. `tsgo --emitDeclarationOnly`) — OK

## Next (Step B)
Lift the shared core into a base interface (`LoopCore`) and represent the three contexts as a discriminated union `CollectedLoop = TopLevelLoop | BranchLoop | NestedLoop`, forcing exhaustive handling in `emit-control-flow.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)