### PR TITLE
fix(xyflow): draw lines at tile edge (x=0, y=0) not tile center

### DIFF
--- a/packages/xyflow/src/background.ts
+++ b/packages/xyflow/src/background.ts
@@ -81,11 +81,10 @@ export function initBackground(scope: Element, props: Record<string, unknown>): 
       circle.setAttribute('cy', String(scaledGap / 2))
     } else if (variant === 'lines') {
       const path = patternContent as SVGPathElement
-      path.setAttribute('d', `M${scaledGap / 2} 0 V${scaledGap}`)
+      path.setAttribute('d', `M0 0 V${scaledGap}`)
     } else {
       const path = patternContent as SVGPathElement
-      const half = scaledGap / 2
-      path.setAttribute('d', `M${half} 0 V${scaledGap} M0 ${half} H${scaledGap}`)
+      path.setAttribute('d', `M0 0 V${scaledGap} M0 0 H${scaledGap}`)
     }
   })
 


### PR DESCRIPTION
## Problem

Lines placed at `scaledGap / 2` pass through the **center** of each cell. The conventional grid behavior is for lines to sit on **cell boundaries**, not centers.

## Fix

Place lines at the tile edge (`x=0`, `y=0`):

```ts
// lines: vertical line at left edge of tile
M0 0 V${scaledGap}

// cross: horizontal + vertical lines at top-left corner of tile
M0 0 V${scaledGap} M0 0 H${scaledGap}
```

When the pattern tiles, lines appear at `0, gap, 2*gap, ...` — forming cell boundaries rather than cell centers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)