### PR TITLE
refactor(nav): move Charts to Patterns, flatten Gallery under Patterns

### DIFF
--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -106,9 +106,7 @@ export const componentEntries: ComponentEntry[] = [
 export const blockEntries: BlockEntry[] = [
   { slug: 'file-upload', title: 'File Upload', description: 'File upload manager with drag & drop, progress simulation, and effect cleanup' },
   { slug: 'music-player', title: 'Music Player', description: 'Media player with timer, effect cleanup, and slider binding' },
-  { slug: 'multi-step-form', title: 'Multi-Step Form', description: 'Wizard form with step validation, cross-step state, and review' },
-  { slug: 'inventory-manager', title: 'Inventory Manager', description: 'CRUD inventory table with inline editing, undo/redo, search/filter, and validation' },
-  { slug: 'spreadsheet', title: 'Spreadsheet', description: 'Spreadsheet grid with cell editing, formula evaluation, selection, and 2D nested loops' },
+{ slug: 'spreadsheet', title: 'Spreadsheet', description: 'Spreadsheet grid with cell editing, formula evaluation, selection, and 2D nested loops' },
   { slug: 'permission-matrix', title: 'Permission Matrix', description: 'Role x Permission grid with inheritance cascade, diamond memo dependencies, and bulk operations' },
   { slug: 'form-builder', title: 'Form Builder', description: 'Signal-driven form builder with heterogeneous loop, dynamic field type switching, nested groups, and conditional visibility' },
   { slug: 'pivot-table', title: 'Pivot Table', description: 'Dynamic row/column grouping with multi-level aggregation, drag axis config, and expand/collapse groups' },

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -54,19 +54,6 @@ export const navSections: NavSection[] = [
         })),
         matchPath: (p) => getComponentsByCategory(category).some((e) => p === `/components/${e.slug}`),
       })),
-      {
-        key: 'charts',
-        title: 'Charts',
-        links: [
-          { title: 'Area Chart', href: '/charts/area-chart' },
-          { title: 'Bar Chart', href: '/charts/bar-chart' },
-          { title: 'Line Chart', href: '/charts/line-chart' },
-          { title: 'Pie Chart', href: '/charts/pie-chart' },
-          { title: 'Radar Chart', href: '/charts/radar-chart' },
-          { title: 'Radial Chart', href: '/charts/radial-chart' },
-        ],
-        matchPath: (p) => p.startsWith('/charts/'),
-      },
     ],
   },
   {
@@ -85,6 +72,19 @@ export const navSections: NavSection[] = [
         matchPath: (p) => p.startsWith('/docs/forms'),
       },
       {
+        key: 'charts',
+        title: 'Charts',
+        links: [
+          { title: 'Area Chart', href: '/charts/area-chart' },
+          { title: 'Bar Chart', href: '/charts/bar-chart' },
+          { title: 'Line Chart', href: '/charts/line-chart' },
+          { title: 'Pie Chart', href: '/charts/pie-chart' },
+          { title: 'Radar Chart', href: '/charts/radar-chart' },
+          { title: 'Radial Chart', href: '/charts/radial-chart' },
+        ],
+        matchPath: (p) => p.startsWith('/charts/'),
+      },
+      {
         key: 'blocks',
         title: 'Blocks',
         defaultOpen: false,
@@ -94,14 +94,9 @@ export const navSections: NavSection[] = [
         })),
         matchPath: (p) => blockEntries.some((e) => p === `/components/${e.slug}`),
       },
-    ],
-  },
-  {
-    heading: 'Gallery',
-    entries: [
       {
-        key: 'gallery-apps',
-        title: 'Apps',
+        key: 'gallery',
+        title: 'Gallery',
         defaultOpen: false,
         links: [
           { title: 'Admin Dashboard', href: '/gallery/admin' },


### PR DESCRIPTION
## Summary

- Move **Charts** from the Components section to Patterns (sits between Forms and Blocks)
- Remove the standalone **Gallery** section (with its "Apps" wrapper); Gallery is now a direct group under Patterns — making it a sibling of Forms / Charts / Blocks
- Remove **Multi-Step Form** and **Inventory Manager** from `blockEntries` — their patterns are covered by the remaining 8 blocks and the Gallery apps

Final Patterns structure:
```
Patterns
  Forms
  Charts
  Blocks  (8 entries: File Upload, Music Player, Spreadsheet, …)
  Gallery (Admin Dashboard, E-Commerce Shop, Productivity Suite, SaaS Marketing, Social App)
```

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] Sidebar shows Charts under Patterns, not Components
- [ ] Gallery appears as a flat group under Patterns (no "Apps" sub-heading)
- [ ] Multi-Step Form and Inventory Manager are no longer listed in the sidebar