### PR TITLE
refactor(compiler): phase 2 unify inner-loop collectors

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -67,17 +67,75 @@ export function computeLoopSiblingOffsets(root: IRNode): Map<IRLoop, number> {
 }
 
 /**
- * Collect inner loop metadata from an IR subtree.
- * Returns NestedLoop for each loop node found within the tree,
- * tracking the nearest ancestor element's slotId as container.
+ * Options controlling `collectInnerLoops` traversal and payload collection.
+ *
+ * The "general" traversal (default) descends into every subtree finding
+ * every inner loop, tracking depth; the "branch" traversal (all three
+ * options set, produced by `branchInnerLoopOptions()`) is used by
+ * `collectLoopChildConditionals` to gather 1-level inner loops within a
+ * conditional branch, where deeper loops and nested conditionals are
+ * handled by the caller's separate collection paths (avoiding the
+ * double-initialization bug fixed in #929).
  */
-function collectInnerLoops(
+export interface CollectInnerLoopsOptions {
+  /**
+   * Collect per-item `childComponents` / `childEvents` / `childConditionals`
+   * on each emitted NestedLoop. Used by branch callers whose `insert()`
+   * bindEvents must wire each inner-loop item's event handlers, components,
+   * and nested conditionals at runtime.
+   */
+  collectItemBindings?: boolean
+  /**
+   * Fixed template placeholder depth. When set, `irToPlaceholderTemplate`
+   * uses this value instead of the tracked depth counter. Branch callers
+   * always operate at depth 1 (loops inside a conditional inside a loop
+   * item), independent of the general counter.
+   */
+  templateDepth?: number
+  /**
+   * Flat traversal: do NOT recurse into loop-body children or into
+   * conditional branches. Branch callers need this because nested loops
+   * have their own mapArray reconciliation and nested conditionals are
+   * collected via `childConditionals` in the enclosing
+   * `collectLoopChildConditionals` walk — descending here would
+   * double-emit their metadata.
+   */
+  flatBranchMode?: boolean
+}
+
+/** Options preset for the "branch inner loops" use case. */
+export const branchInnerLoopOptions: CollectInnerLoopsOptions = {
+  collectItemBindings: true,
+  templateDepth: 1,
+  flatBranchMode: true,
+}
+
+/**
+ * Collect inner-loop metadata from an IR subtree. Returns one `NestedLoop`
+ * per `IRLoop` node found in the tree, using the nearest ancestor element's
+ * slot id as the mapArray container.
+ *
+ * This is the unified collector shared by:
+ *   - `collectElements` case 'loop' (via `decideLoopRendering`)
+ *   - `collectBranchLoops` (via `decideLoopRendering`, branch-of-conditional loops)
+ *   - `collectLoopChildConditionals` (with `branchInnerLoopOptions`, inner loops
+ *     inside a conditional branch of a loop item — #830 Path A)
+ *
+ * Before Phase 2 (#1001), the third call site lived in `reactivity.ts` as
+ * `collectBranchInnerLoops`; see that history for why the option preset
+ * hard-codes `templateDepth: 1` and `flatBranchMode: true`.
+ */
+export function collectInnerLoops(
   nodes: IRNode[],
   siblingOffsets: Map<IRLoop, number>,
   outerLoopParam?: string,
   ctx?: ClientJsContext,
+  options?: CollectInnerLoopsOptions,
 ): NestedLoop[] {
   const result: NestedLoop[] = []
+  const flat = options?.flatBranchMode === true
+  const fixedDepth = options?.templateDepth
+  const collectBindings = options?.collectItemBindings === true
   let depth = 0
   let insideCond = false
 
@@ -90,10 +148,11 @@ function collectInnerLoops(
       }
       case 'loop': {
         depth++
+        const emitDepth = fixedDepth ?? depth
         // Generate item template for CSR rendering in mapArray.
         // Pass loopParams so expressions are wrapped at generation time (not post-hoc regex).
         const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
-        const template = n.children.map(c => irToPlaceholderTemplate(c, undefined, depth, loopParamsForTemplate)).join('')
+        const template = n.children.map(c => irToPlaceholderTemplate(c, undefined, emitDepth, loopParamsForTemplate)).join('')
         // Check if array expression references the outer loop param
         const refsOuter = outerLoopParam
           ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
@@ -105,9 +164,57 @@ function collectInnerLoops(
             innerReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
           }
         }
+
+        // Per-item bindings for branch-mode callers (child components,
+        // events, nested conditionals) — matches the pre-Phase 2
+        // `collectBranchInnerLoops` behaviour.
+        let childComponents: import('../types').IRLoopChildComponent[] | undefined
+        let childEvents: LoopChildEvent[] | undefined
+        let childConditionals: import('./types').LoopChildConditional[] | undefined
+        if (collectBindings) {
+          // skipConditionals=true: components inside conditional branches
+          // are collected separately via `childConditionals[i].whenTrueComponents`
+          // (below). Including them here would double-init event handlers.
+          const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: IRNode[] }> = []
+          for (const child of n.children) {
+            rawComps.push(...collectConditionalBranchChildComponents(child, true))
+          }
+          if (rawComps.length > 0) {
+            childComponents = rawComps.map(c => ({
+              name: c.name,
+              slotId: c.slotId,
+              props: c.props.map(p => ({
+                name: p.name,
+                value: p.value,
+                dynamic: p.dynamic ?? false,
+                isLiteral: p.isLiteral ?? false,
+                isEventHandler: p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase(),
+              })),
+              children: c.children,
+              loopDepth: emitDepth,
+            }))
+          }
+
+          const evs: LoopChildEvent[] = []
+          for (const child of n.children) {
+            evs.push(...collectLoopChildEventsWithNesting(child))
+          }
+          if (evs.length > 0) childEvents = evs
+
+          if (ctx) {
+            const conds = collectLoopChildConditionals(
+              { type: 'fragment', children: n.children, loc: n.loc } as unknown as IRNode,
+              ctx,
+              siblingOffsets,
+              n.param,
+            )
+            if (conds.length > 0) childConditionals = conds
+          }
+        }
+
         result.push({
           kind: 'nested',
-          depth,
+          depth: emitDepth,
           array: n.array,
           param: n.param,
           key: n.key,
@@ -115,10 +222,16 @@ function collectInnerLoops(
           template,
           refsOuterParam: refsOuter,
           childReactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
-          insideConditional: insideCond || undefined,
-          siblingOffset: siblingOffsets.get(n) || undefined,
+          childComponents,
+          childEvents,
+          childConditionals,
+          insideConditional: !flat && insideCond ? true : undefined,
+          siblingOffset: flat ? undefined : (siblingOffsets.get(n) || undefined),
         })
-        for (const child of n.children) walk(child, parentSlotId)
+        // Branch-mode callers handle deeper nesting via their own collection paths.
+        if (!flat) {
+          for (const child of n.children) walk(child, parentSlotId)
+        }
         depth--
         break
       }
@@ -136,6 +249,7 @@ function collectInnerLoops(
         break
       }
       case 'conditional': {
+        if (flat) break
         const prev = insideCond
         insideCond = true
         walk(n.whenTrue, parentSlotId)
@@ -369,7 +483,7 @@ export function collectElements(
           childEvents.push(...collectLoopChildEventsWithNesting(child))
           childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, node.param))
           childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, node.param))
-          childConditionals.push(...collectLoopChildConditionals(child, ctx, node.param))
+          childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, node.param))
         }
 
         if (node.childComponent) {
@@ -660,10 +774,10 @@ function collectBranchLoops(
         // the top-level `useElementReconciliation` rule so a `.map()` directly
         // inside an outer `.map()` gets its own reactive mapArray even when
         // the outer loop lives inside a conditional branch.
-        // Pass `undefined` for ctx to match the pre-existing branch behavior:
-        // inner-loop reactive-text collection is handled by the separate
-        // `collectBranchInnerLoops` path in reactivity.ts, not here. Phase 2
-        // unifies those two collectors; until then preserve the split.
+        // Pass `undefined` for ctx to preserve the legacy branch behaviour:
+        // reactive-text collection on inner loops reached from this call path
+        // is handled at the enclosing branch-loop level below (`if (ctx)` block
+        // around `collectLoopChildReactiveTexts`), not per inner loop.
         const { useElementReconciliation, innerLoops: innerLoopsCollected } =
           decideLoopRendering(n, siblingOffsets, undefined)
 
@@ -694,7 +808,7 @@ function collectBranchLoops(
             childEvents.push(...collectLoopChildEventsWithNesting(child))
             childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
             childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
-            childConditionals.push(...collectLoopChildConditionals(child, ctx, n.param))
+            childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, n.param))
           }
         }
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -468,10 +468,14 @@ export function collectLoopChildReactiveTexts(
 export function collectLoopChildConditionals(
   node: IRNode,
   ctx: ClientJsContext,
+  siblingOffsets: Map<import('../types').IRLoop, number>,
   loopParam?: string,
 ): LoopChildConditional[] {
   const conditionals: LoopChildConditional[] = []
   const { irToHtmlTemplate } = require('./html-template')
+  // Lazy require avoids the collect-elements.ts ↔ reactivity.ts import
+  // cycle; same pattern as irToHtmlTemplate / irToPlaceholderTemplate above.
+  const { collectInnerLoops, branchInnerLoopOptions } = require('./collect-elements')
 
   function walk(n: IRNode): void {
     if (n.type === 'conditional' && n.slotId) {
@@ -487,6 +491,8 @@ export function collectLoopChildConditionals(
         const loopParamsForCond = loopParam ? [loopParam] : undefined
         const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
         const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
+        const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+        const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
         conditionals.push({
           slotId: n.slotId,
           condition: expanded,
@@ -494,10 +500,10 @@ export function collectLoopChildConditionals(
           whenFalseHtml,
           whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
           whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
-          whenTrueInnerLoops: collectBranchInnerLoops(n.whenTrue, loopParam, ctx),
-          whenFalseInnerLoops: collectBranchInnerLoops(n.whenFalse, loopParam, ctx),
-          whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, loopParam),
-          whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, loopParam),
+          whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
+          whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
+          whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
+          whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
           whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
           whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
         })
@@ -517,103 +523,6 @@ export function collectLoopChildConditionals(
 
   walk(node)
   return conditionals
-}
-
-/**
- * Collect inner loop info from a conditional branch IR node.
- * Used to set up mapArray inside insert() bindEvents for loops
- * that are inside conditional branches of loop items.
- */
-function collectBranchInnerLoops(
-  node: IRNode,
-  outerLoopParam?: string,
-  ctx?: ClientJsContext,
-): LoopChildConditional['whenTrueInnerLoops'] {
-  const { irToPlaceholderTemplate } = require('./html-template')
-  const loops: import('./types').NestedLoop[] = []
-
-  // Pass the current container's slotId down through the tree.
-  // A loop uses parentContainerSlotId as its container.
-  // When entering a component, its slotId becomes the container for its children,
-  // but NOT for its siblings — this prevents a sibling component's slotId from
-  // being used as the loop container.
-  function walk(n: IRNode, parentContainerSlotId: string | null = null): void {
-    if (n.type === 'element') {
-      const mySlotId = n.slotId ?? parentContainerSlotId
-      for (const child of n.children) walk(child, mySlotId)
-    } else if (n.type === 'loop') {
-      const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
-      const template = n.children.map((c: IRNode) => irToPlaceholderTemplate(c, undefined, 1, loopParamsForTemplate)).join('')
-      const refsOuter = outerLoopParam
-        ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
-        : false
-      const childReactiveTexts: Array<{ slotId: string; expression: string }> = []
-      if (refsOuter && ctx) {
-        for (const child of n.children) {
-          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
-        }
-      }
-      // Collect child components and events inside inner loop items.
-      // Walk loop body children (not the loop node itself, which traverseForComponents skips).
-      // `skipConditionals=true`: components inside conditional branches are
-      // collected separately as `childConditionals[i].whenTrueComponents`
-      // below. Including them here too would cause `initChild` to be emitted
-      // twice (once in the outer ssr path, once in the insert() bindEvents),
-      // which double-wires the click handler and makes the two `onCheckedChange`
-      // calls cancel each other out (#929).
-      const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }> = []
-      for (const child of n.children) {
-        rawComps.push(...collectConditionalBranchChildComponents(child, true))
-      }
-      const childComponents = rawComps.map(c => ({
-        name: c.name,
-        slotId: c.slotId,
-        props: c.props.map(p => ({
-          name: p.name,
-          value: p.value,
-          dynamic: p.dynamic ?? false,
-          isLiteral: p.isLiteral ?? false,
-          isEventHandler: p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase(),
-        })),
-        children: c.children,
-        loopDepth: 1,
-      }))
-      const childEvents: import('./types').LoopChildEvent[] = []
-      for (const child of n.children) {
-        childEvents.push(...collectLoopChildEventsWithNesting(child))
-      }
-      // Collect conditionals inside inner loop body (#830 Path B)
-      const childConditionals = ctx
-        ? collectLoopChildConditionals(
-            { type: 'fragment', children: n.children } as any,
-            ctx,
-            n.param,
-          )
-        : []
-      loops.push({
-        kind: 'nested',
-        depth: 1,
-        array: n.array,
-        param: n.param,
-        key: n.key,
-        containerSlotId: parentContainerSlotId,
-        template,
-        refsOuterParam: refsOuter,
-        childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
-        childComponents: childComponents.length > 0 ? childComponents : undefined,
-        childEvents: childEvents.length > 0 ? childEvents : undefined,
-        childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
-      })
-    } else if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
-      // For component nodes (e.g., SelectContent), pass slotId to children so inner loops
-      // use the component element as their container rather than the branch scope.
-      const mySlotId = (n.type === 'component' && n.slotId) ? n.slotId : parentContainerSlotId
-      for (const child of n.children) walk(child, mySlotId)
-    }
-  }
-
-  walk(node, null)
-  return loops.length > 0 ? loops : undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 of the collectElements modularization epic (#999). Merges the two near-duplicate inner-loop collectors:

- `collectInnerLoops` (was in `collect-elements.ts`, general-purpose) — tracks depth, descends into conditionals and loop children.
- `collectBranchInnerLoops` (was in `reactivity.ts`, branch-specific) — hardcodes depth=1, stops at conditionals, flat traversal, collects rich per-item bindings (childComponents/childEvents/childConditionals).

The structural walker was identical; only the payload shape, depth strategy, and stop-rules differed. Merge both onto a single `collectInnerLoops` in ``collect-elements.ts`` gated by a ``CollectInnerLoopsOptions`` record:

```ts
interface CollectInnerLoopsOptions {
  collectItemBindings?: boolean   // branch: true
  templateDepth?: number          // branch: 1 (fixed); general: tracked counter
  flatBranchMode?: boolean        // branch: skip conditionals and loop-body recursion
}

export const branchInnerLoopOptions = { collectItemBindings: true, templateDepth: 1, flatBranchMode: true }
```

``collectBranchInnerLoops`` is deleted. Its sole remaining caller (``collectLoopChildConditionals`` in ``reactivity.ts``) now invokes the unified collector with ``branchInnerLoopOptions``.

## Changes

- ``collect-elements.ts``: expand ``collectInnerLoops`` signature and body; export it + ``branchInnerLoopOptions``; thread ``siblingOffsets`` through ``collectLoopChildConditionals`` call sites.
- ``reactivity.ts``: delete ``collectBranchInnerLoops``; add ``siblingOffsets`` param to ``collectLoopChildConditionals``; use ``require('./collect-elements')`` to pull in the unified collector (mirrors the existing lazy-require pattern used for ``html-template``, avoiding the two files' import cycle).

## Test plan

- [x] ``bun test packages/jsx`` — 743 pass, 0 fail
- [x] ``bun test packages/adapter-tests`` — 214 pass, 0 fail (adapter conformance + CSR conformance fixtures byte-identical)
- [x] Clean build — ``bun run clean && bun run build`` green
- [x] ``rg 'collectBranchInnerLoops' packages/*/src/`` returns zero hits (only docstring references remain)

## Divergences preserved

``collectBranchInnerLoops`` had a latent gap that's preserved by the branch preset: it never handled ``IRAsync`` nodes, while the general walker did. Under ``flatBranchMode`` the merged walker keeps that gap — any inner loop inside ``<Async>`` inside a conditional branch of a loop body would still be skipped. No fixture currently exercises this combination; the issue will surface if/when one is added.

## Related

- Epic: #999
- Phase 2 issue: #1001
- Depends on: #1006 (phase 1, merged)
- Unblocks: #1003 (phase 3 — BranchSummary ADT)

## Note

During ``/loop`` execution the commit initially landed on an unrelated branch (``refactor/nav-reorganize``) that appeared in the working tree. The commit has been cherry-picked to ``refactor/phase2-unify-inner-loop-collectors`` (this branch). ``refactor/nav-reorganize`` still contains an SHA-duplicate of this commit on top of unrelated site-navigation work; feel free to drop it there if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)