### PR TITLE
refactor(compiler): phase 3 BranchSummary ADT

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -866,18 +866,29 @@ function buildConditionalMetadata(
     condition: node.condition,
     whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames, -1),
     whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames, -1),
-    whenTrueEvents: collectConditionalBranchEvents(node.whenTrue),
-    whenFalseEvents: collectConditionalBranchEvents(node.whenFalse),
-    whenTrueRefs: collectConditionalBranchRefs(node.whenTrue),
-    whenFalseRefs: collectConditionalBranchRefs(node.whenFalse),
-    whenTrueChildComponents: buildBranchChildComponents(collectConditionalBranchChildComponents(node.whenTrue), ctx),
-    whenFalseChildComponents: buildBranchChildComponents(collectConditionalBranchChildComponents(node.whenFalse), ctx),
-    whenTrueTextEffects: collectBranchTextEffects(node.whenTrue),
-    whenFalseTextEffects: collectBranchTextEffects(node.whenFalse),
-    whenTrueLoops: collectBranchLoops(node.whenTrue, ctx, siblingOffsets),
-    whenFalseLoops: collectBranchLoops(node.whenFalse, ctx, siblingOffsets),
-    whenTrueConditionals: collectBranchConditionals(node.whenTrue, ctx, siblingOffsets),
-    whenFalseConditionals: collectBranchConditionals(node.whenFalse, ctx, siblingOffsets),
+    whenTrue: summarizeBranch(node.whenTrue, ctx, siblingOffsets),
+    whenFalse: summarizeBranch(node.whenFalse, ctx, siblingOffsets),
+  }
+}
+
+/**
+ * Bundle every reactive entity collected from a single conditional branch
+ * subtree into a `BranchSummary`. One call replaces the six parallel
+ * `collectBranch*` calls that used to populate the flat `whenTrueXxx` /
+ * `whenFalseXxx` fields on `ConditionalElement`.
+ */
+function summarizeBranch(
+  node: IRNode,
+  ctx: ClientJsContext,
+  siblingOffsets: Map<IRLoop, number>,
+): import('./types').BranchSummary {
+  return {
+    events: collectConditionalBranchEvents(node),
+    refs: collectConditionalBranchRefs(node),
+    childComponents: buildBranchChildComponents(collectConditionalBranchChildComponents(node), ctx),
+    textEffects: collectBranchTextEffects(node),
+    loops: collectBranchLoops(node, ctx, siblingOffsets),
+    conditionals: collectBranchConditionals(node, ctx, siblingOffsets),
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -4,7 +4,7 @@
  * and event delegation within loop containers.
  */
 
-import type { ClientJsContext, ConditionalBranchEvent, ConditionalBranchRef, ConditionalBranchChildComponent, ConditionalBranchTextEffect, BranchLoop, ConditionalBranchConditional, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
+import type { ClientJsContext, ConditionalBranchEvent, BranchLoop, BranchSummary, ConditionalElement, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
 import type { IRLoopChildComponent } from '../types'
 import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
@@ -68,14 +68,10 @@ function destructureLoopParam(param: string): { head: string; unwrap: string } {
  */
 function emitBranchBindings(
   lines: string[],
-  events: ConditionalBranchEvent[],
-  refs: ConditionalBranchRef[],
-  childComponents: ConditionalBranchChildComponent[],
+  branch: BranchSummary,
   eventNameFn: (eventName: string) => string,
-  textEffects: ConditionalBranchTextEffect[] = [],
-  branchLoops: BranchLoop[] = [],
-  branchConditionals: ConditionalBranchConditional[] = []
 ): void {
+  const { events, refs, childComponents, textEffects, loops: branchLoops, conditionals: branchConditionals } = branch
   const allSlotIds = new Set<string>()
   for (const event of events) allSlotIds.add(event.slotId)
   for (const ref of refs) allSlotIds.add(ref.slotId)
@@ -208,7 +204,7 @@ function emitBranchBindings(
  */
 function emitNestedBranchConditional(
   lines: string[],
-  elem: ConditionalBranchConditional,
+  elem: ConditionalElement,
   eventNameFn: (eventName: string) => string,
 ): void {
   const whenTrueWithCond = addCondAttrToTemplate(elem.whenTrueHtml, elem.slotId)
@@ -217,12 +213,12 @@ function emitNestedBranchConditional(
   lines.push(`      insert(__branchScope, '${elem.slotId}', () => ${elem.condition}, {`)
   lines.push(`        template: () => \`${whenTrueWithCond}\`,`)
   lines.push(`        bindEvents: (__branchScope) => {`)
-  emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, eventNameFn, elem.whenTrueTextEffects, elem.whenTrueLoops, elem.whenTrueConditionals)
+  emitBranchBindings(lines, elem.whenTrue, eventNameFn)
   lines.push(`        }`)
   lines.push(`      }, {`)
   lines.push(`        template: () => \`${whenFalseWithCond}\`,`)
   lines.push(`        bindEvents: (__branchScope) => {`)
-  emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, eventNameFn, elem.whenFalseTextEffects, elem.whenFalseLoops, elem.whenFalseConditionals)
+  emitBranchBindings(lines, elem.whenFalse, eventNameFn)
   lines.push(`        }`)
   lines.push(`      })`)
 }
@@ -289,12 +285,12 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, toDomEventName, elem.whenTrueTextEffects, elem.whenTrueLoops, elem.whenTrueConditionals)
+    emitBranchBindings(lines, elem.whenTrue, toDomEventName)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, toDomEventName, elem.whenFalseTextEffects, elem.whenFalseLoops, elem.whenFalseConditionals)
+    emitBranchBindings(lines, elem.whenFalse, toDomEventName)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')
@@ -312,12 +308,12 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
     lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
     lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrueEvents, elem.whenTrueRefs, elem.whenTrueChildComponents, rawEventName, elem.whenTrueTextEffects, elem.whenTrueLoops, elem.whenTrueConditionals)
+    emitBranchBindings(lines, elem.whenTrue, rawEventName)
     lines.push(`    }`)
     lines.push(`  }, {`)
     lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalseEvents, elem.whenFalseRefs, elem.whenFalseChildComponents, rawEventName, elem.whenFalseTextEffects, elem.whenFalseLoops, elem.whenFalseConditionals)
+    emitBranchBindings(lines, elem.whenFalse, rawEventName)
     lines.push(`    }`)
     lines.push(`  })`)
     lines.push('')

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -19,16 +19,16 @@ import { inferDefaultValue, toDomEventName, wrapHandlerInBlock, varSlotId, quote
 export function collectConditionalSlotIds(ctx: ClientJsContext): Set<string> {
   const conditionalSlotIds = new Set<string>()
   for (const cond of ctx.conditionalElements) {
-    for (const event of cond.whenTrueEvents) {
+    for (const event of cond.whenTrue.events) {
       conditionalSlotIds.add(event.slotId)
     }
-    for (const event of cond.whenFalseEvents) {
+    for (const event of cond.whenFalse.events) {
       conditionalSlotIds.add(event.slotId)
     }
-    for (const ref of cond.whenTrueRefs) {
+    for (const ref of cond.whenTrue.refs) {
       conditionalSlotIds.add(ref.slotId)
     }
-    for (const ref of cond.whenFalseRefs) {
+    for (const ref of cond.whenFalse.refs) {
       conditionalSlotIds.add(ref.slotId)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ComponentIR, ConstantInfo, FunctionInfo, IRNode } from '../types'
-import type { ClientJsContext, ConditionalBranchConditional, BranchLoop } from './types'
+import type { ClientJsContext, ConditionalElement } from './types'
 import { varSlotId, bodyReferencesComponentScope, PROPS_PARAM } from './utils'
 import { collectUsedIdentifiers, collectUsedFunctions, collectIdentifiersFromIRTree } from './identifiers'
 import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
@@ -510,15 +510,15 @@ export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>)
  * composite loops within conditional branches (e.g., Badge inside a branch loop).
  */
 function collectChildNamesFromBranches(
-  cond: { whenTrueLoops: BranchLoop[]; whenFalseLoops: BranchLoop[]; whenTrueConditionals?: ConditionalBranchConditional[]; whenFalseConditionals?: ConditionalBranchConditional[] },
+  cond: Pick<ConditionalElement, 'whenTrue' | 'whenFalse'>,
   names: Set<string>,
 ): void {
-  for (const loop of [...cond.whenTrueLoops, ...cond.whenFalseLoops]) {
+  for (const loop of [...cond.whenTrue.loops, ...cond.whenFalse.loops]) {
     if (loop.nestedComponents) {
       for (const comp of loop.nestedComponents) names.add(comp.name)
     }
   }
-  for (const nested of [...(cond.whenTrueConditionals ?? []), ...(cond.whenFalseConditionals ?? [])]) {
+  for (const nested of [...cond.whenTrue.conditionals, ...cond.whenFalse.conditionals]) {
     collectChildNamesFromBranches(nested, names)
   }
 }

--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -95,10 +95,10 @@ export function collectUsedIdentifiers(ctx: ClientJsContext): Set<string> {
     extractIdentifiers(elem.condition, used)
     extractTemplateIdentifiers(elem.whenTrueHtml, used)
     extractTemplateIdentifiers(elem.whenFalseHtml, used)
-    for (const event of elem.whenTrueEvents) {
+    for (const event of elem.whenTrue.events) {
       extractIdentifiers(event.handler, used)
     }
-    for (const event of elem.whenFalseEvents) {
+    for (const event of elem.whenFalse.events) {
       extractIdentifiers(event.handler, used)
     }
   }
@@ -154,19 +154,19 @@ export function collectUsedIdentifiers(ctx: ClientJsContext): Set<string> {
   }
 
   for (const elem of ctx.conditionalElements) {
-    for (const ref of elem.whenTrueRefs) {
+    for (const ref of elem.whenTrue.refs) {
       extractIdentifiers(ref.callback, used)
     }
-    for (const ref of elem.whenFalseRefs) {
+    for (const ref of elem.whenFalse.refs) {
       extractIdentifiers(ref.callback, used)
     }
   }
 
   for (const elem of ctx.clientOnlyConditionals) {
-    for (const ref of elem.whenTrueRefs) {
+    for (const ref of elem.whenTrue.refs) {
       extractIdentifiers(ref.callback, used)
     }
-    for (const ref of elem.whenFalseRefs) {
+    for (const ref of elem.whenFalse.refs) {
       extractIdentifiers(ref.callback, used)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -42,7 +42,7 @@ export interface ClientJsContext {
   reactiveChildProps: ReactiveChildProp[]
   reactiveAttrs: ReactiveAttribute[]
   clientOnlyElements: ClientOnlyElement[]
-  clientOnlyConditionals: ClientOnlyConditional[]
+  clientOnlyConditionals: ConditionalElement[]
   providerSetups: Array<{ contextName: string; valueExpr: string }>
   /** HTML elements with unresolved spread attrs (open types, need applyRestAttrs at runtime) */
   restAttrElements: RestAttrElement[]
@@ -139,7 +139,8 @@ export interface BranchLoop extends LoopCore {
  * — events, refs, child components, text effects, nested loops, and nested
  * conditionals. Replaces the six parallel `whenTrueXxx` / `whenFalseXxx`
  * field pairs that used to live directly on `ConditionalElement` and
- * `ClientOnlyConditional` (pre-Phase 3 shape).
+ * `ConditionalElement` (pre-Phase 3 shape; `ClientOnlyConditional` was a
+ * structurally-identical sibling type, now replaced by `ConditionalElement`).
  */
 export interface BranchSummary {
   events: ConditionalBranchEvent[]
@@ -291,14 +292,6 @@ export interface ClientOnlyElement {
   expression: string
 }
 
-export interface ClientOnlyConditional {
-  slotId: string
-  condition: string
-  whenTrueHtml: string
-  whenFalseHtml: string
-  whenTrue: BranchSummary
-  whenFalse: BranchSummary
-}
 
 export interface RestAttrElement {
   slotId: string

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -134,23 +134,29 @@ export interface BranchLoop extends LoopCore {
   useElementReconciliation?: boolean
 }
 
+/**
+ * All reactive entities collected from one branch of a reactive conditional
+ * — events, refs, child components, text effects, nested loops, and nested
+ * conditionals. Replaces the six parallel `whenTrueXxx` / `whenFalseXxx`
+ * field pairs that used to live directly on `ConditionalElement` and
+ * `ClientOnlyConditional` (pre-Phase 3 shape).
+ */
+export interface BranchSummary {
+  events: ConditionalBranchEvent[]
+  refs: ConditionalBranchRef[]
+  childComponents: ConditionalBranchChildComponent[]
+  textEffects: ConditionalBranchTextEffect[]
+  loops: BranchLoop[]
+  conditionals: ConditionalElement[]
+}
+
 export interface ConditionalElement {
   slotId: string
   condition: string
   whenTrueHtml: string
   whenFalseHtml: string
-  whenTrueEvents: ConditionalBranchEvent[]
-  whenFalseEvents: ConditionalBranchEvent[]
-  whenTrueRefs: ConditionalBranchRef[]
-  whenFalseRefs: ConditionalBranchRef[]
-  whenTrueChildComponents: ConditionalBranchChildComponent[]
-  whenFalseChildComponents: ConditionalBranchChildComponent[]
-  whenTrueTextEffects: ConditionalBranchTextEffect[]
-  whenFalseTextEffects: ConditionalBranchTextEffect[]
-  whenTrueLoops: BranchLoop[]
-  whenFalseLoops: BranchLoop[]
-  whenTrueConditionals: ConditionalBranchConditional[]
-  whenFalseConditionals: ConditionalBranchConditional[]
+  whenTrue: BranchSummary
+  whenFalse: BranchSummary
 }
 
 /**
@@ -290,18 +296,8 @@ export interface ClientOnlyConditional {
   condition: string
   whenTrueHtml: string
   whenFalseHtml: string
-  whenTrueEvents: ConditionalBranchEvent[]
-  whenFalseEvents: ConditionalBranchEvent[]
-  whenTrueRefs: ConditionalBranchRef[]
-  whenFalseRefs: ConditionalBranchRef[]
-  whenTrueChildComponents: ConditionalBranchChildComponent[]
-  whenFalseChildComponents: ConditionalBranchChildComponent[]
-  whenTrueTextEffects: ConditionalBranchTextEffect[]
-  whenFalseTextEffects: ConditionalBranchTextEffect[]
-  whenTrueLoops: BranchLoop[]
-  whenFalseLoops: BranchLoop[]
-  whenTrueConditionals: ConditionalBranchConditional[]
-  whenFalseConditionals: ConditionalBranchConditional[]
+  whenTrue: BranchSummary
+  whenFalse: BranchSummary
 }
 
 export interface RestAttrElement {


### PR DESCRIPTION
## Summary

Phase 3 of the collectElements modularization epic (#999). Collapses the 14 parallel `whenTrueXxx` / `whenFalseXxx` fields on `ConditionalElement` (and its structural twin `ClientOnlyConditional`) into a single `{ whenTrue: BranchSummary; whenFalse: BranchSummary }` shape.

### Commit 1 — introduce `BranchSummary`

Before: every new per-branch collection category required editing four loosely-coupled places (type definition, builder in `buildConditionalMetadata`, consumer at each read site, and often the type again for the client-only sibling). After: one `BranchSummary` bundles events / refs / childComponents / textEffects / loops / conditionals; one `summarizeBranch(node, ctx, siblingOffsets)` populates it; `emitBranchBindings(lines, branch, eventNameFn)` reads it with three args instead of eight.

Consumer migrations (all straight read-path renames):
- ``identifiers.ts`` — ``elem.whenTrueEvents`` → ``elem.whenTrue.events`` etc.
- ``emit-init-sections.ts`` — same, in ``collectConditionalSlotIds``.
- ``emit-control-flow.ts`` — ``emitBranchBindings`` signature shrunk from 8 args to 3; three call sites simplified accordingly.
- ``generate-init.ts`` — ``collectChildNamesFromBranches`` now takes ``Pick<ConditionalElement, 'whenTrue' \| 'whenFalse'>``.

### Commit 2 — drop `ClientOnlyConditional`

After the BranchSummary collapse, ``ClientOnlyConditional`` and ``ConditionalElement`` became byte-identical interfaces with the same builder. The distinction lived only in emit strategy (``toDomEventName`` vs raw event name), which is a per-call-site choice. Remove the redundant interface; ``ctx.clientOnlyConditionals`` is now ``ConditionalElement[]``.

## Test plan

- [x] ``bun test packages/jsx`` — 743 pass, 0 fail
- [x] ``bun test packages/adapter-tests`` — 214 pass, 0 fail (adapter conformance + CSR conformance fixtures byte-identical)
- [x] Clean ``bun run clean && bun run build`` green

## Non-goals preserved

- ``LoopChildConditional`` keeps its own ``whenTrueEvents`` / ``whenFalseEvents`` / etc. fields (different runtime path — per-item ``insert()``). Explicitly out of scope per the phase 3 issue.

## Related

- Epic: #999
- Phase 3 issue: #1003
- Depends on: phase 1 (merged) + phase 2 (merged)
- Unblocks: #1004 (phase 4 — IR visitor abstraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)