### PR TITLE
refactor(compiler): phase 4 IR visitor abstraction (IRWalker)

### DIFF
--- a/packages/jsx/src/__tests__/ir-walker.test.ts
+++ b/packages/jsx/src/__tests__/ir-walker.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import { walkIR } from '../ir-to-client-js/walker'
+import type { IRNode } from '../types'
+
+const loc = { file: 't.tsx', start: { line: 0, column: 0 }, end: { line: 0, column: 0 } } as any
+
+function elem(children: IRNode[] = [], slotId: string | null = null): IRNode {
+  return {
+    type: 'element',
+    tag: 'div',
+    attrs: [],
+    events: [],
+    ref: null,
+    children,
+    slotId,
+    needsScope: false,
+    loc,
+  }
+}
+
+function text(value: string): IRNode {
+  return { type: 'text', value, loc }
+}
+
+function expr(e: string): IRNode {
+  return { type: 'expression', expr: e, typeInfo: null, reactive: false, slotId: null, loc }
+}
+
+function cond(whenTrue: IRNode, whenFalse: IRNode): IRNode {
+  return {
+    type: 'conditional',
+    condition: 'c',
+    conditionType: null,
+    reactive: false,
+    whenTrue,
+    whenFalse,
+    slotId: null,
+    loc,
+  }
+}
+
+function loop(children: IRNode[]): IRNode {
+  return {
+    type: 'loop',
+    array: 'items',
+    arrayType: null,
+    itemType: null,
+    param: 'i',
+    index: null,
+    key: null,
+    children,
+    slotId: null,
+    loc,
+    isStaticArray: false,
+  }
+}
+
+describe('walkIR', () => {
+  test('visits all element nodes with default descent when no visitor for non-element kinds', () => {
+    const root = elem([elem([text('a'), elem()]), elem()])
+    const visited: string[] = []
+    walkIR(root, null, {
+      element: ({ node, descend }) => {
+        visited.push(`element(children=${node.children.length})`)
+        descend()
+      },
+    })
+    expect(visited).toEqual([
+      'element(children=2)',
+      'element(children=2)',
+      'element(children=0)',
+      'element(children=0)',
+    ])
+  })
+
+  test('omitting a callback still descends with the same scope', () => {
+    // No element callback → walker auto-descends into element children.
+    const root = elem([elem([expr('x')])])
+    const seen: string[] = []
+    walkIR(root, null, {
+      expression: ({ node }) => {
+        seen.push(node.expr)
+      },
+    })
+    expect(seen).toEqual(['x'])
+  })
+
+  test("returning without calling descend halts recursion for that subtree", () => {
+    const root = elem([elem([text('deep')])])
+    const visited: number[] = []
+    walkIR(root, 0, {
+      element: ({ descend, scope }) => {
+        visited.push(scope)
+        if (scope < 1) descend(scope + 1)  // only go one level in
+      },
+    })
+    expect(visited).toEqual([0, 1])
+  })
+
+  test('scope updates propagate per descent call', () => {
+    const root = elem([elem([elem()])])
+    const depths: number[] = []
+    walkIR(root, 0, {
+      element: ({ scope, descend }) => {
+        depths.push(scope)
+        descend(scope + 1)
+      },
+    })
+    expect(depths).toEqual([0, 1, 2])
+  })
+
+  test('conditional visitor can descend surgically with ctx.walk', () => {
+    const root = cond(
+      elem([expr('true-branch')]),
+      elem([expr('false-branch')]),
+    )
+    const trueOnly: string[] = []
+    walkIR(root, null, {
+      conditional: ({ node, walk }) => {
+        walk(node.whenTrue)  // skip the whenFalse branch entirely
+      },
+      expression: ({ node }) => {
+        trueOnly.push(node.expr)
+      },
+    })
+    expect(trueOnly).toEqual(['true-branch'])
+  })
+
+  test('loop default descent covers loop children', () => {
+    const root = loop([elem([expr('inside-loop')])])
+    const exprs: string[] = []
+    walkIR(root, null, {
+      expression: ({ node }) => exprs.push(node.expr),
+    })
+    expect(exprs).toEqual(['inside-loop'])
+  })
+
+  test('component visitor exposes descendJsxChildren', () => {
+    const root: IRNode = {
+      type: 'component',
+      name: 'Card',
+      props: [
+        {
+          name: 'header',
+          value: '',
+          dynamic: false,
+          jsxChildren: [expr('in-jsx-prop')],
+        } as any,
+      ],
+      propsType: null,
+      children: [text('inside-component')],
+      template: '',
+      slotId: null,
+      loc,
+    }
+    const expressions: string[] = []
+    const texts: string[] = []
+    walkIR(root, null, {
+      component: ({ descend, descendJsxChildren }) => {
+        descend()
+        descendJsxChildren()
+      },
+      expression: ({ node }) => expressions.push(node.expr),
+      text: ({ node }) => texts.push(node.value),
+    })
+    expect(texts).toEqual(['inside-component'])
+    expect(expressions).toEqual(['in-jsx-prop'])
+  })
+
+  test('exhaustive switch — unknown node kind throws', () => {
+    const bogus = { type: 'mystery' } as unknown as IRNode
+    expect(() => walkIR(bogus, null, {})).toThrow(/unhandled IRNode kind/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -8,6 +8,7 @@ import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
+import { walkIR } from './walker'
 
 /** Check if an IR node produces a DOM child element (for sibling offset counting). */
 function producesDomChild(node: IRNode): boolean {
@@ -708,34 +709,20 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
  */
 function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
   const effects: ConditionalBranchTextEffect[] = []
-  function walk(n: IRNode): void {
-    switch (n.type) {
-      case 'expression':
-        if (n.reactive && n.slotId && !n.clientOnly) {
-          effects.push({ slotId: n.slotId, expression: n.expr })
-        }
-        break
-      case 'element':
-        for (const child of n.children) walk(child)
-        break
-      case 'component':
-        for (const child of n.children) walk(child)
-        break
-      case 'fragment':
-        for (const child of n.children) walk(child)
-        break
-      // Do NOT recurse into nested conditionals — they have their own insert()
-      case 'conditional':
-        break
-      case 'if-statement':
-        break
-      case 'provider':
-      case 'async':
-        for (const child of n.children) walk(child)
-        break
-    }
-  }
-  walk(node)
+  walkIR(node, null, {
+    expression: ({ node: n }) => {
+      if (n.reactive && n.slotId && !n.clientOnly) {
+        effects.push({ slotId: n.slotId, expression: n.expr })
+      }
+    },
+    // Do NOT recurse into nested conditionals / if-statements — they have
+    // their own insert(). Loops are not inspected either; the legacy
+    // walker's switch omitted the 'loop' case entirely.
+    conditional: () => {},
+    ifStatement: () => {},
+    loop: () => {},
+    // element / fragment / component / provider / async use default descent.
+  })
   return effects
 }
 
@@ -751,100 +738,87 @@ function collectBranchLoops(
   siblingOffsets: Map<IRLoop, number>,
 ): BranchLoop[] {
   const loops: BranchLoop[] = []
-  let parentSlotId: string | null = null
   const restNames = ctx ? buildRestSpreadNames(ctx) : undefined
 
-  function walk(n: IRNode): void {
-    switch (n.type) {
-      case 'element':
-        const prevSlot = parentSlotId
-        if (n.slotId) parentSlotId = n.slotId
-        for (const child of n.children) walk(child)
-        parentSlotId = prevSlot
-        break
-      case 'loop': {
-        // parentSlotId comes from an enclosing element inside this branch;
-        // fall back to the loop's own slotId, which jsx-to-ir propagates from
-        // the nearest ancestor element when the branch itself is a fragment.
-        const containerSlot = parentSlotId ?? n.slotId
-        if (!containerSlot) break
+  walkIR<string | null>(node, null, {
+    element: ({ node: el, scope: parentSlotId, descend }) => {
+      descend(el.slotId ?? parentSlotId)
+    },
+    loop: ({ node: n, scope: parentSlotId }) => {
+      // parentSlotId comes from an enclosing element inside this branch;
+      // fall back to the loop's own slotId, which jsx-to-ir propagates from
+      // the nearest ancestor element when the branch itself is a fragment.
+      const containerSlot = parentSlotId ?? n.slotId
+      if (!containerSlot) return
 
-        // Detect composite: native element root + nested components, OR a loop
-        // with inner loops that need their own mapArray reconciliation. Mirrors
-        // the top-level `useElementReconciliation` rule so a `.map()` directly
-        // inside an outer `.map()` gets its own reactive mapArray even when
-        // the outer loop lives inside a conditional branch.
-        // Pass `undefined` for ctx to preserve the legacy branch behaviour:
-        // reactive-text collection on inner loops reached from this call path
-        // is handled at the enclosing branch-loop level below (`if (ctx)` block
-        // around `collectLoopChildReactiveTexts`), not per inner loop.
-        const { useElementReconciliation, innerLoops: innerLoopsCollected } =
-          decideLoopRendering(n, siblingOffsets, undefined)
+      // Detect composite: native element root + nested components, OR a loop
+      // with inner loops that need their own mapArray reconciliation. Mirrors
+      // the top-level `useElementReconciliation` rule so a `.map()` directly
+      // inside an outer `.map()` gets its own reactive mapArray even when
+      // the outer loop lives inside a conditional branch.
+      // Pass `undefined` for ctx to preserve the legacy branch behaviour:
+      // reactive-text collection on inner loops reached from this call path
+      // is handled at the enclosing branch-loop level below (`if (ctx)` block
+      // around `collectLoopChildReactiveTexts`), not per inner loop.
+      const { useElementReconciliation, innerLoops: innerLoopsCollected } =
+        decideLoopRendering(n, siblingOffsets, undefined)
 
-        // Build the item template from loop children.
-        // Use loopDepth=0: this loop gets its own reconcileElements (independent
-        // from the conditional's template), so items use data-key (not data-key-1).
-        // Pass loopParams so expressions reference the per-item signal accessor,
-        // keeping the template consistent with reactive effect expressions that
-        // use `param()` to read the current item value.
-        let childTemplate: string
-        if (useElementReconciliation && n.children[0]) {
-          childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0, [n.param])
-        } else {
-          childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0, [n.param])).join('')
-        }
-
-        // Collect child events, reactive texts/attrs, and conditionals for ALL
-        // branch loops — simple loops also need reactive wiring when their
-        // item body reads non-item signals (e.g., memos). Previously these
-        // were only collected for composite loops, which caused reactive
-        // reads inside simple loop bodies to silently no-op for existing items.
-        const childEvents: LoopChildEvent[] = []
-        const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
-        const childReactiveAttrs: import('./types').LoopChildReactiveAttr[] = []
-        const childConditionals: import('./types').LoopChildConditional[] = []
-        if (ctx) {
-          for (const child of n.children) {
-            childEvents.push(...collectLoopChildEventsWithNesting(child))
-            childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
-            childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
-            childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, n.param))
-          }
-        }
-
-        loops.push({
-          kind: 'branch',
-          array: n.array,
-          param: n.param,
-          index: n.index,
-          key: n.key,
-          template: childTemplate,
-          containerSlotId: containerSlot,
-          mapPreamble: n.mapPreamble ?? null,
-          nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
-          childEvents,
-          childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
-          childReactiveAttrs: childReactiveAttrs.length > 0 ? childReactiveAttrs : undefined,
-          childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
-          innerLoops: useElementReconciliation ? innerLoopsCollected : undefined,
-          useElementReconciliation: useElementReconciliation || undefined,
-        })
-        // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation
-        break
+      // Build the item template from loop children.
+      // Use loopDepth=0: this loop gets its own reconcileElements (independent
+      // from the conditional's template), so items use data-key (not data-key-1).
+      // Pass loopParams so expressions reference the per-item signal accessor,
+      // keeping the template consistent with reactive effect expressions that
+      // use `param()` to read the current item value.
+      let childTemplate: string
+      if (useElementReconciliation && n.children[0]) {
+        childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0, [n.param])
+      } else {
+        childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0, [n.param])).join('')
       }
-      case 'fragment':
-      case 'component':
-      case 'provider':
-      case 'async':
-        for (const child of n.children) walk(child)
-        break
-      // Don't recurse into nested conditionals
-      case 'conditional':
-      case 'if-statement':
-        break
-    }
-  }
-  walk(node)
+
+      // Collect child events, reactive texts/attrs, and conditionals for ALL
+      // branch loops — simple loops also need reactive wiring when their
+      // item body reads non-item signals (e.g., memos). Previously these
+      // were only collected for composite loops, which caused reactive
+      // reads inside simple loop bodies to silently no-op for existing items.
+      const childEvents: LoopChildEvent[] = []
+      const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
+      const childReactiveAttrs: import('./types').LoopChildReactiveAttr[] = []
+      const childConditionals: import('./types').LoopChildConditional[] = []
+      if (ctx) {
+        for (const child of n.children) {
+          childEvents.push(...collectLoopChildEventsWithNesting(child))
+          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
+          childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
+          childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, n.param))
+        }
+      }
+
+      loops.push({
+        kind: 'branch',
+        array: n.array,
+        param: n.param,
+        index: n.index,
+        key: n.key,
+        template: childTemplate,
+        containerSlotId: containerSlot,
+        mapPreamble: n.mapPreamble ?? null,
+        nestedComponents: useElementReconciliation ? n.nestedComponents : undefined,
+        childEvents,
+        childReactiveTexts: childReactiveTexts.length > 0 ? childReactiveTexts : undefined,
+        childReactiveAttrs: childReactiveAttrs.length > 0 ? childReactiveAttrs : undefined,
+        childConditionals: childConditionals.length > 0 ? childConditionals : undefined,
+        innerLoops: useElementReconciliation ? innerLoopsCollected : undefined,
+        useElementReconciliation: useElementReconciliation || undefined,
+      })
+      // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation.
+    },
+    // Don't recurse into nested conditionals / if-statements.
+    conditional: () => {},
+    ifStatement: () => {},
+    // fragment / component / provider / async auto-descend carrying parentSlotId.
+  })
+
   return loops
 }
 
@@ -902,30 +876,18 @@ function collectBranchConditionals(
   siblingOffsets: Map<IRLoop, number>,
 ): ConditionalElement[] {
   const result: ConditionalElement[] = []
-
-  function walk(n: IRNode): void {
-    switch (n.type) {
-      case 'conditional':
-        // Wrap-by-default fallback (#941) — mirror the top-level gate in
-        // `case 'conditional'` at collectElements().
-        if (n.slotId && decideWrapFromAstFlags(n).wrap) {
-          result.push(buildConditionalMetadata(n, ctx, siblingOffsets))
-        }
-        // Don't recurse further — the nested conditional handles its own branches
-        break
-      case 'element':
-      case 'fragment':
-      case 'component':
-      case 'provider':
-      case 'async':
-        for (const child of n.children) walk(child)
-        break
-      // Don't recurse into loops (they handle their own reconciliation)
-      case 'loop':
-      case 'if-statement':
-        break
-    }
-  }
-  walk(node)
+  walkIR(node, null, {
+    conditional: ({ node: n }) => {
+      // Wrap-by-default fallback (#941) — mirror the top-level gate in
+      // `case 'conditional'` at collectElements().
+      if (n.slotId && decideWrapFromAstFlags(n).wrap) {
+        result.push(buildConditionalMetadata(n, ctx, siblingOffsets))
+      }
+      // Don't recurse further — the nested conditional handles its own branches.
+    },
+    // Don't recurse into loops / if-statements — they have their own reconciliation paths.
+    loop: () => {},
+    ifStatement: () => {},
+  })
   return result
 }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -133,23 +133,34 @@ export function collectInnerLoops(
   ctx?: ClientJsContext,
   options?: CollectInnerLoopsOptions,
 ): NestedLoop[] {
+  type Scope = {
+    parentSlotId: string | null
+    depth: number
+    insideCond: boolean
+  }
   const result: NestedLoop[] = []
   const flat = options?.flatBranchMode === true
   const fixedDepth = options?.templateDepth
   const collectBindings = options?.collectItemBindings === true
-  let depth = 0
-  let insideCond = false
+  const initialScope: Scope = { parentSlotId: null, depth: 0, insideCond: false }
 
-  function walk(n: IRNode, parentSlotId: string | null): void {
-    switch (n.type) {
-      case 'element': {
-        const mySlotId = n.slotId ?? parentSlotId
-        for (const child of n.children) walk(child, mySlotId)
-        break
-      }
-      case 'loop': {
-        depth++
-        const emitDepth = fixedDepth ?? depth
+  for (const root of nodes) {
+    walkIR<Scope>(root, initialScope, {
+      element: ({ node: el, scope, descend }) => {
+        descend({ ...scope, parentSlotId: el.slotId ?? scope.parentSlotId })
+      },
+      component: ({ node: c, scope, descend }) => {
+        // Use the component's own slotId as the container for inner loops,
+        // so loops inside child components (e.g., SelectContent) use that
+        // component's element as the mapArray container instead of __branchScope.
+        descend({ ...scope, parentSlotId: c.slotId ?? scope.parentSlotId })
+      },
+      conditional: ({ scope, descend }) => {
+        if (flat) return
+        descend({ ...scope, insideCond: true })
+      },
+      loop: ({ node: n, scope, descend }) => {
+        const emitDepth = fixedDepth ?? scope.depth + 1
         // Generate item template for CSR rendering in mapArray.
         // Pass loopParams so expressions are wrapped at generation time (not post-hoc regex).
         const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
@@ -158,7 +169,7 @@ export function collectInnerLoops(
         const refsOuter = outerLoopParam
           ? new RegExp(`\\b${outerLoopParam}\\b`).test(n.array)
           : false
-        // Collect reactive text expressions inside inner loop items
+        // Collect reactive text expressions inside inner loop items.
         const innerReactiveTexts: Array<{ slotId: string; expression: string }> = []
         if (refsOuter && ctx) {
           for (const child of n.children) {
@@ -219,49 +230,24 @@ export function collectInnerLoops(
           array: n.array,
           param: n.param,
           key: n.key,
-          containerSlotId: parentSlotId,
+          containerSlotId: scope.parentSlotId,
           template,
           refsOuterParam: refsOuter,
           childReactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
           childComponents,
           childEvents,
           childConditionals,
-          insideConditional: !flat && insideCond ? true : undefined,
+          insideConditional: !flat && scope.insideCond ? true : undefined,
           siblingOffset: flat ? undefined : (siblingOffsets.get(n) || undefined),
         })
         // Branch-mode callers handle deeper nesting via their own collection paths.
         if (!flat) {
-          for (const child of n.children) walk(child, parentSlotId)
+          descend({ ...scope, depth: scope.depth + 1 })
         }
-        depth--
-        break
-      }
-      case 'fragment':
-      case 'provider':
-      case 'async':
-        for (const child of n.children) walk(child, parentSlotId)
-        break
-      case 'component': {
-        // Use the component's own slotId as the container for inner loops,
-        // so loops inside child components (e.g., SelectContent) use that
-        // component's element as the mapArray container instead of __branchScope.
-        const mySlotId = n.slotId ?? parentSlotId
-        for (const child of n.children) walk(child, mySlotId)
-        break
-      }
-      case 'conditional': {
-        if (flat) break
-        const prev = insideCond
-        insideCond = true
-        walk(n.whenTrue, parentSlotId)
-        walk(n.whenFalse, parentSlotId)
-        insideCond = prev
-        break
-      }
-    }
+      },
+      // fragment / provider / async auto-descend with the same scope.
+    })
   }
-
-  nodes.forEach(n => walk(n, null))
   return result
 }
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,9 +3,9 @@
  */
 
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchConditional, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
+import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
 import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
-import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEvents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
+import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 import { walkIR } from './walker'
@@ -30,40 +30,22 @@ function producesDomChild(node: IRNode): boolean {
  */
 export function computeLoopSiblingOffsets(root: IRNode): Map<IRLoop, number> {
   const offsets = new Map<IRLoop, number>()
-
-  function walk(n: IRNode): void {
-    switch (n.type) {
-      case 'element': {
-        let nonLoopCount = 0
-        for (const child of n.children) {
-          if (child.type === 'loop') {
-            if (nonLoopCount > 0) offsets.set(child, nonLoopCount)
-          } else if (producesDomChild(child)) {
-            nonLoopCount++
-          }
+  walkIR(root, null, {
+    element: ({ node: el, descend }) => {
+      let nonLoopCount = 0
+      for (const child of el.children) {
+        if (child.type === 'loop') {
+          if (nonLoopCount > 0) offsets.set(child, nonLoopCount)
+        } else if (producesDomChild(child)) {
+          nonLoopCount++
         }
-        for (const child of n.children) walk(child)
-        break
       }
-      case 'fragment':
-      case 'component':
-      case 'provider':
-      case 'async':
-      case 'loop':
-        for (const child of n.children) walk(child)
-        break
-      case 'conditional':
-        walk(n.whenTrue)
-        walk(n.whenFalse)
-        break
-      case 'if-statement':
-        walk(n.consequent)
-        if (n.alternate) walk(n.alternate)
-        break
-    }
-  }
-
-  walk(root)
+      descend()
+    },
+    // All container kinds (fragment / component / provider / async / loop /
+    // conditional / if-statement) rely on walkIR's default descent with the
+    // same scope. Leaves (text / expression / slot) are no-ops.
+  })
   return offsets
 }
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -386,158 +386,154 @@ function buildBranchChildComponents(
   }))
 }
 
-/** Recursively walk the IR tree and populate ctx with interactive/dynamic/loop/conditional elements. */
+/**
+ * Walk the IR tree and populate `ctx` with every interactive / dynamic /
+ * loop / conditional element that needs client-side wiring. Implemented
+ * on top of `walkIR` — the per-kind visitor directly encodes this pass's
+ * stop rules (loops are terminal because their body uses loop-scoped
+ * variables; conditional branches flip the `insideConditional` scope flag
+ * so text effects and conditional pushes gate correctly).
+ */
 export function collectElements(
   node: IRNode,
   ctx: ClientJsContext,
   siblingOffsets: Map<IRLoop, number>,
   insideConditional = false,
 ): void {
-  switch (node.type) {
-    case 'element':
-      collectFromElement(node, ctx, insideConditional)
-      for (const child of node.children) {
-        collectElements(child, ctx, siblingOffsets, insideConditional)
+  walkIR<boolean>(node, insideConditional, {
+    element: ({ node: el, scope: inCond, descend }) => {
+      collectFromElement(el, ctx, inCond)
+      descend()
+    },
+    expression: ({ node: ex, scope: inCond }) => {
+      if (ex.clientOnly && ex.slotId) {
+        ctx.clientOnlyElements.push({ slotId: ex.slotId, expression: ex.expr })
+        return
       }
-      break
-
-    case 'expression':
-      if (node.clientOnly && node.slotId) {
-        ctx.clientOnlyElements.push({
-          slotId: node.slotId,
-          expression: node.expr,
+      if (!ex.slotId || inCond) return
+      // Solid-style wrap-by-default fallback (#937): wrap in createEffect not
+      // only for statically-proven-reactive expressions, but also for any
+      // expression the analyzer can't prove non-reactive — i.e. anything
+      // that contains a function call or a signal-getter call. Pure static
+      // literals and bare identifiers (no calls) stay un-wrapped because
+      // their SSR value is already in the DOM.
+      //
+      // False positive (extra createEffect that subscribes to nothing) is
+      // harmless; false negative (silent drop of a reactive read) is the
+      // bug class this gate closes — see #931, #932.
+      //
+      // Only collect as a top-level dynamic element when NOT inside a
+      // conditional. Conditional text effects are collected per-branch and
+      // emitted inside bindEvents.
+      if (decideWrapFromAstFlags(ex).wrap) {
+        ctx.dynamicElements.push({
+          slotId: ex.slotId,
+          expression: ex.expr,
+          insideConditional: false,
         })
-      } else if (node.slotId && !insideConditional) {
-        // Solid-style wrap-by-default fallback (#937): wrap in createEffect not
-        // only for statically-proven-reactive expressions, but also for any
-        // expression the analyzer can't prove non-reactive — i.e. anything
-        // that contains a function call or a signal-getter call. Pure static
-        // literals and bare identifiers (no calls) stay un-wrapped because
-        // their SSR value is already in the DOM.
-        //
-        // False positive (extra createEffect that subscribes to nothing) is
-        // harmless; false negative (silent drop of a reactive read) is the
-        // bug class this gate closes — see #931, #932.
-        //
-        // Only collect as a top-level dynamic element when NOT inside a
-        // conditional. Conditional text effects are collected per-branch and
-        // emitted inside bindEvents.
-        if (decideWrapFromAstFlags(node).wrap) {
-          ctx.dynamicElements.push({
-            slotId: node.slotId,
-            expression: node.expr,
-            insideConditional: false,
-          })
-        }
       }
-      break
-
-    case 'conditional':
-      if (node.clientOnly && node.slotId) {
-        ctx.clientOnlyConditionals.push(buildConditionalMetadata(node, ctx, siblingOffsets))
-      } else if (node.slotId) {
+    },
+    conditional: ({ node: c, scope: inCond, descend }) => {
+      if (c.clientOnly && c.slotId) {
+        ctx.clientOnlyConditionals.push(buildConditionalMetadata(c, ctx, siblingOffsets))
+      } else if (c.slotId) {
         // Solid-style wrap-by-default fallback (#941, follow-up to #937/#939).
         // Wrap not only statically-proven-reactive conditions, but also any
         // condition containing a function call — otherwise the silent-drop
         // failure class freezes the branch at its SSR-time value.
-        if (decideWrapFromAstFlags(node).wrap) {
-          if (insideConditional) {
-            // Nested conditionals are collected by the parent via collectBranchConditionals.
-            // Don't push to ctx.conditionalElements — they'll be emitted inside the parent's bindEvents.
-          } else {
-            ctx.conditionalElements.push(buildConditionalMetadata(node, ctx, siblingOffsets))
-          }
+        if (decideWrapFromAstFlags(c).wrap && !inCond) {
+          // Top-level reactive conditional. Nested conditionals (inCond=true)
+          // are collected by the enclosing conditional via `collectBranchConditionals`
+          // and emitted inside that conditional's bindEvents.
+          ctx.conditionalElements.push(buildConditionalMetadata(c, ctx, siblingOffsets))
         }
       }
-      // Recurse into conditional branches with insideConditional = true
-      // to collect nested conditionals, events, refs, child components, and reactive attrs
-      collectElements(node.whenTrue, ctx, siblingOffsets, true)
-      collectElements(node.whenFalse, ctx, siblingOffsets, true)
-      break
+      // Recurse into both branches with insideConditional = true so
+      // nested conditionals / events / refs / child components / reactive
+      // attrs get collected under the parent's bindEvents path.
+      descend(true)
+    },
+    loop: ({ node: l, scope: inCond }) => {
+      // Loops inside conditionals are handled by the conditional template's inline
+      // .map() expression. Don't collect them separately — insert() re-renders the
+      // branch when template output changes (tracked via signal reads in the template
+      // function). Loop body is also never descended into from this pass: loop-scoped
+      // variables are only available inside the iteration. Event handler identifiers
+      // are extracted explicitly below for the closure capture set.
+      if (!l.slotId || inCond) return
 
-    case 'loop':
-      // Loops inside conditionals are handled by the conditional template's inline .map()
-      // expression. Don't collect them separately — insert() re-renders the branch when
-      // template output changes (tracked via signal reads in the template function).
-      if (node.slotId && !insideConditional) {
-        const childHandlers: string[] = []
-        const childEvents: LoopChildEvent[] = []
-        const childReactiveAttrs: LoopChildReactiveAttr[] = []
-        const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
-        const childConditionals: import('./types').LoopChildConditional[] = []
-        for (const child of node.children) {
-          childHandlers.push(...collectEventHandlersFromIR(child))
-          childEvents.push(...collectLoopChildEventsWithNesting(child))
-          childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, node.param))
-          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, node.param))
-          childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, node.param))
-        }
-
-        if (node.childComponent) {
-          for (const prop of node.childComponent.props) {
-            if (prop.isEventHandler) {
-              childHandlers.push(prop.value)
-            }
-          }
-        }
-
-        // Determine rendering strategy for dynamic arrays:
-        // Use element reconciliation when the loop body has nested components,
-        // or when inner loops need their own mapArray for events/reactive text.
-        const { useElementReconciliation, innerLoops } = decideLoopRendering(node, siblingOffsets, ctx)
-
-        let template = ''
-        if (node.childComponent) {
-          template = '' // childComponent path uses createComponent directly
-        } else if (node.children[0]) {
-          // Pass loopParams so expressions are wrapped at generation time,
-          // avoiding post-hoc regex wrapping that corrupts literal attribute values.
-          template = useElementReconciliation
-            ? irToPlaceholderTemplate(node.children[0], buildRestSpreadNames(ctx), 0, [node.param])
-            : irToHtmlTemplate(node.children[0], buildRestSpreadNames(ctx), 0, [node.param])
-        }
-
-        ctx.loopElements.push({
-          kind: 'top-level',
-          slotId: node.slotId,
-          array: node.array,
-          param: node.param,
-          index: node.index,
-          key: node.key,
-          template,
-          childEventHandlers: childHandlers,
-          childEvents,
-          childReactiveAttrs,
-          childReactiveTexts,
-          childConditionals,
-          childComponent: node.childComponent,
-          nestedComponents: node.nestedComponents,
-          isStaticArray: node.isStaticArray,
-          useElementReconciliation,
-          innerLoops: (useElementReconciliation || (node.isStaticArray && innerLoops?.length)) ? innerLoops : undefined,
-          siblingOffset: siblingOffsets.get(node) || undefined,
-          filterPredicate: node.filterPredicate ? {
-            param: node.filterPredicate.param,
-            raw: node.filterPredicate.raw,
-          } : undefined,
-          sortComparator: node.sortComparator ? {
-            paramA: node.sortComparator.paramA,
-            paramB: node.sortComparator.paramB,
-            raw: node.sortComparator.raw,
-          } : undefined,
-          chainOrder: node.chainOrder,
-          mapPreamble: node.mapPreamble,
-        })
+      const childHandlers: string[] = []
+      const childEvents: LoopChildEvent[] = []
+      const childReactiveAttrs: LoopChildReactiveAttr[] = []
+      const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
+      const childConditionals: import('./types').LoopChildConditional[] = []
+      for (const child of l.children) {
+        childHandlers.push(...collectEventHandlersFromIR(child))
+        childEvents.push(...collectLoopChildEventsWithNesting(child))
+        childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, l.param))
+        childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, l.param))
+        childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, l.param))
       }
-      // Don't traverse into loop children for interactive elements collection
-      // (they use loop variables that are only available inside the loop iteration).
-      // But we DO extract event handler identifiers above for function inclusion.
-      break
 
-    case 'component':
-      if (node.slotId) {
-        // Reactive props need effects to update the element when values change
-        for (const prop of node.props) {
+      if (l.childComponent) {
+        for (const prop of l.childComponent.props) {
+          if (prop.isEventHandler) childHandlers.push(prop.value)
+        }
+      }
+
+      // Determine rendering strategy for dynamic arrays:
+      // Use element reconciliation when the loop body has nested components,
+      // or when inner loops need their own mapArray for events/reactive text.
+      const { useElementReconciliation, innerLoops } = decideLoopRendering(l, siblingOffsets, ctx)
+
+      let template = ''
+      if (l.childComponent) {
+        template = '' // childComponent path uses createComponent directly
+      } else if (l.children[0]) {
+        // Pass loopParams so expressions are wrapped at generation time,
+        // avoiding post-hoc regex wrapping that corrupts literal attribute values.
+        template = useElementReconciliation
+          ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0, [l.param])
+          : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0, [l.param])
+      }
+
+      ctx.loopElements.push({
+        kind: 'top-level',
+        slotId: l.slotId,
+        array: l.array,
+        param: l.param,
+        index: l.index,
+        key: l.key,
+        template,
+        childEventHandlers: childHandlers,
+        childEvents,
+        childReactiveAttrs,
+        childReactiveTexts,
+        childConditionals,
+        childComponent: l.childComponent,
+        nestedComponents: l.nestedComponents,
+        isStaticArray: l.isStaticArray,
+        useElementReconciliation,
+        innerLoops: (useElementReconciliation || (l.isStaticArray && innerLoops?.length)) ? innerLoops : undefined,
+        siblingOffset: siblingOffsets.get(l) || undefined,
+        filterPredicate: l.filterPredicate ? {
+          param: l.filterPredicate.param,
+          raw: l.filterPredicate.raw,
+        } : undefined,
+        sortComparator: l.sortComparator ? {
+          paramA: l.sortComparator.paramA,
+          paramB: l.sortComparator.paramB,
+          raw: l.sortComparator.raw,
+        } : undefined,
+        chainOrder: l.chainOrder,
+        mapPreamble: l.mapPreamble,
+      })
+      // Don't descend — loop-scoped variables are only available inside the iteration.
+    },
+    component: ({ node: c, descend, descendJsxChildren }) => {
+      if (c.slotId) {
+        // Reactive props need effects to update the element when values change.
+        for (const prop of c.props) {
           if (prop.jsxChildren) continue
           if (prop.name.startsWith('on') && prop.name.length > 2) continue
           const value = prop.value
@@ -547,67 +543,39 @@ export function collectElements(
             const isSignalGetter = ctx.signals.some((s) => s.getter === fnName)
             if (isMemo || isSignalGetter) {
               ctx.reactiveProps.push({
-                slotId: node.slotId,
+                slotId: c.slotId,
                 propName: prop.name,
                 expression: fnName,
-                componentName: node.name,
+                componentName: c.name,
               })
             }
           }
         }
       }
 
-      collectReactiveChildProps(node, ctx)
+      collectReactiveChildProps(c, ctx)
 
       ctx.childInits.push({
-        name: node.name,
-        slotId: node.slotId,
-        propsExpr: buildComponentPropsExpr(node.props, ctx),
+        name: c.name,
+        slotId: c.slotId,
+        propsExpr: buildComponentPropsExpr(c.props, ctx),
       })
-      for (const child of node.children) {
-        collectElements(child, ctx, siblingOffsets, insideConditional)
-      }
-      // Traverse JSX prop children so events, reactive expressions,
-      // and nested components inside JSX props are collected
-      for (const prop of node.props) {
-        if (prop.jsxChildren) {
-          for (const child of prop.jsxChildren) {
-            collectElements(child, ctx, siblingOffsets, insideConditional)
-          }
-        }
-      }
-      break
 
-    case 'fragment':
-      for (const child of node.children) {
-        collectElements(child, ctx, siblingOffsets, insideConditional)
-      }
-      break
-
-    case 'if-statement':
-      collectElements(node.consequent, ctx, siblingOffsets, insideConditional)
-      if (node.alternate) {
-        collectElements(node.alternate, ctx, siblingOffsets, insideConditional)
-      }
-      break
-
-    case 'provider':
+      descend()
+      // Traverse JSX prop children so events, reactive expressions, and nested
+      // components inside JSX props are collected.
+      descendJsxChildren()
+    },
+    provider: ({ node: p, descend }) => {
       ctx.providerSetups.push({
-        contextName: node.contextName,
-        valueExpr: node.valueProp.value,
+        contextName: p.contextName,
+        valueExpr: p.valueProp.value,
       })
-      for (const child of node.children) {
-        collectElements(child, ctx, siblingOffsets, insideConditional)
-      }
-      break
-
-    case 'async':
-      // Async boundaries are transparent for client JS — just traverse children
-      for (const child of node.children) {
-        collectElements(child, ctx, siblingOffsets, insideConditional)
-      }
-      break
-  }
+      descend()
+    },
+    // fragment / if-statement / async use the walker's default auto-descent
+    // with the same scope (insideConditional flag unchanged).
+  })
 }
 
 /** Extract events, refs, and reactive attributes from a single IR element into ctx. */

--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -5,6 +5,7 @@
 import type { IRNode, IRLoopChildComponent } from '../types'
 import { attrValueToString } from './utils'
 import type { ClientJsContext } from './types'
+import { walkIR } from './walker'
 
 /** JavaScript keywords and common globals to skip during identifier extraction. */
 const KEYWORDS_AND_GLOBALS = new Set([
@@ -237,74 +238,54 @@ export function isKeywordOrGlobal(id: string): boolean {
  * miss identifiers in new/unexpected locations, this covers the entire tree.
  */
 export function collectIdentifiersFromIRTree(node: IRNode, set: Set<string>): void {
-  switch (node.type) {
-    case 'element':
-      for (const attr of node.attrs) {
+  walkIR(node, null, {
+    element: ({ node: el, descend }) => {
+      for (const attr of el.attrs) {
         if (attr.dynamic && attr.value) {
           const v = typeof attr.value === 'string' ? attr.value : attrValueToString(attr.value)
           if (v) extractIdentifiers(v, set)
         }
       }
-      for (const event of node.events) extractIdentifiers(event.handler, set)
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      break
-
-    case 'component':
-      for (const prop of node.props) {
+      for (const event of el.events) extractIdentifiers(event.handler, set)
+      descend()
+    },
+    component: ({ node: c, descend, descendJsxChildren }) => {
+      for (const prop of c.props) {
         if (prop.dynamic) extractIdentifiers(prop.value, set)
-        if (prop.jsxChildren) {
-          for (const child of prop.jsxChildren) collectIdentifiersFromIRTree(child, set)
-        }
       }
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      break
-
-    case 'expression':
-      extractIdentifiers(node.expr, set)
-      break
-
-    case 'conditional':
-      extractIdentifiers(node.condition, set)
-      collectIdentifiersFromIRTree(node.whenTrue, set)
-      collectIdentifiersFromIRTree(node.whenFalse, set)
-      break
-
-    case 'if-statement':
-      extractIdentifiers(node.condition, set)
-      for (const sv of node.scopeVariables) extractIdentifiers(sv.initializer, set)
-      collectIdentifiersFromIRTree(node.consequent, set)
-      if (node.alternate) collectIdentifiersFromIRTree(node.alternate, set)
-      break
-
-    case 'loop':
-      extractIdentifiers(node.array, set)
-      if (node.filterPredicate) extractIdentifiers(node.filterPredicate.raw, set)
-      if (node.sortComparator) extractIdentifiers(node.sortComparator.raw, set)
-      if (node.mapPreamble) extractIdentifiers(node.mapPreamble, set)
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      if (node.childComponent) collectIdentifiersFromChildComponent(node.childComponent, set)
-      if (node.nestedComponents) {
-        for (const comp of node.nestedComponents) collectIdentifiersFromChildComponent(comp, set)
+      descend()
+      descendJsxChildren()
+    },
+    expression: ({ node: ex }) => {
+      extractIdentifiers(ex.expr, set)
+    },
+    conditional: ({ node: c, descend }) => {
+      extractIdentifiers(c.condition, set)
+      descend()
+    },
+    ifStatement: ({ node: i, descend }) => {
+      extractIdentifiers(i.condition, set)
+      for (const sv of i.scopeVariables) extractIdentifiers(sv.initializer, set)
+      descend()
+    },
+    loop: ({ node: l, descend }) => {
+      extractIdentifiers(l.array, set)
+      if (l.filterPredicate) extractIdentifiers(l.filterPredicate.raw, set)
+      if (l.sortComparator) extractIdentifiers(l.sortComparator.raw, set)
+      if (l.mapPreamble) extractIdentifiers(l.mapPreamble, set)
+      descend()
+      if (l.childComponent) collectIdentifiersFromChildComponent(l.childComponent, set)
+      if (l.nestedComponents) {
+        for (const comp of l.nestedComponents) collectIdentifiersFromChildComponent(comp, set)
       }
-      break
-
-    case 'fragment':
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      break
-
-    case 'provider':
-      extractIdentifiers(node.contextName, set)
-      if (node.valueProp.dynamic) extractIdentifiers(node.valueProp.value, set)
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      break
-
-    case 'async':
-      for (const child of node.children) collectIdentifiersFromIRTree(child, set)
-      break
-
-    case 'slot':
-      break
-  }
+    },
+    provider: ({ node: p, descend }) => {
+      extractIdentifiers(p.contextName, set)
+      if (p.valueProp.dynamic) extractIdentifiers(p.valueProp.value, set)
+      descend()
+    },
+    // fragment / async use the walker's default auto-descent; slot is a leaf.
+  })
 }
 
 function collectIdentifiersFromChildComponent(comp: IRLoopChildComponent, set: Set<string>): void {
@@ -321,34 +302,16 @@ function collectIdentifiersFromChildComponent(comp: IRLoopChildComponent, set: S
  * the flattened ClientJsContext — walking them would break constant inlining.
  */
 export function addLoopSubtreeIdentifiers(node: IRNode, set: Set<string>): void {
-  switch (node.type) {
-    case 'loop':
-      // Found a loop — walk its ENTIRE subtree deeply
-      collectIdentifiersFromIRTree(node, set)
-      break
-    case 'element':
-    case 'fragment':
-      for (const child of node.children) addLoopSubtreeIdentifiers(child, set)
-      break
-    case 'component':
-      for (const child of node.children) addLoopSubtreeIdentifiers(child, set)
-      for (const prop of node.props) {
-        if (prop.jsxChildren) {
-          for (const child of prop.jsxChildren) addLoopSubtreeIdentifiers(child, set)
-        }
-      }
-      break
-    case 'conditional':
-      addLoopSubtreeIdentifiers(node.whenTrue, set)
-      addLoopSubtreeIdentifiers(node.whenFalse, set)
-      break
-    case 'if-statement':
-      addLoopSubtreeIdentifiers(node.consequent, set)
-      if (node.alternate) addLoopSubtreeIdentifiers(node.alternate, set)
-      break
-    case 'provider':
-    case 'async':
-      for (const child of node.children) addLoopSubtreeIdentifiers(child, set)
-      break
-  }
+  walkIR(node, null, {
+    loop: ({ node: l }) => {
+      // Found a loop — walk its ENTIRE subtree deeply via the identifier-extraction pass.
+      collectIdentifiersFromIRTree(l, set)
+    },
+    component: ({ descend, descendJsxChildren }) => {
+      descend()
+      descendJsxChildren()
+    },
+    // element / fragment / conditional / if-statement / provider / async rely
+    // on walkIR's default descent until they hit a loop subtree.
+  })
 }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -15,6 +15,7 @@ import type {
 } from './types'
 import { attrValueToString, exprReferencesIdent } from './utils'
 import { expandConstantForReactivity } from './prop-handling'
+import { walkIR } from './walker'
 
 /**
  * Phase 2 reactivity detection: determines if a code expression needs `createEffect`
@@ -141,54 +142,24 @@ export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean 
  */
 export function collectEventHandlersFromIR(node: IRNode): string[] {
   const handlers: string[] = []
-
-  switch (node.type) {
-    case 'element':
-      for (const event of node.events) {
-        handlers.push(event.handler)
-      }
-      for (const child of node.children) {
-        handlers.push(...collectEventHandlersFromIR(child))
-      }
-      break
-    case 'fragment':
-      for (const child of node.children) {
-        handlers.push(...collectEventHandlersFromIR(child))
-      }
-      break
-    case 'conditional':
-      handlers.push(...collectEventHandlersFromIR(node.whenTrue))
-      handlers.push(...collectEventHandlersFromIR(node.whenFalse))
-      break
-    case 'component':
+  walkIR(node, null, {
+    element: ({ node, descend }) => {
+      for (const event of node.events) handlers.push(event.handler)
+      descend()
+    },
+    component: ({ node, descend }) => {
       for (const prop of node.props) {
         if (prop.name.startsWith('on') && prop.name.length > 2) {
           handlers.push(prop.value)
         }
       }
-      for (const child of node.children) {
-        handlers.push(...collectEventHandlersFromIR(child))
-      }
-      break
-    case 'if-statement':
-      handlers.push(...collectEventHandlersFromIR(node.consequent))
-      if (node.alternate) {
-        handlers.push(...collectEventHandlersFromIR(node.alternate))
-      }
-      break
-    case 'provider':
-    case 'async':
-      for (const child of node.children) {
-        handlers.push(...collectEventHandlersFromIR(child))
-      }
-      break
-    case 'loop':
-      for (const child of node.children) {
-        handlers.push(...collectEventHandlersFromIR(child))
-      }
-      break
-  }
-
+      descend()
+    },
+    // Non-container kinds (text / expression / slot) have no children, so
+    // the walker's default no-descent behaviour is correct for them.
+    // Every other container kind (fragment / conditional / if-statement /
+    // provider / async / loop) uses the walker's default descent.
+  })
   return handlers
 }
 
@@ -196,37 +167,22 @@ export function collectEventHandlersFromIR(node: IRNode): string[] {
  * Traverse an IR tree depth-first, calling visitor for each element node.
  * Shared by collectConditionalBranchEvents, collectConditionalBranchRefs,
  * and collectLoopChildEvents to avoid duplicating the traversal logic.
+ *
+ * 'loop' is intentionally skipped. Nested .map() event delegation requires
+ * a different approach (nested data-key lookup + inner loop variable
+ * resolution) that isn't implemented yet. See memory:
+ * compiler-reconcile-templates-events.md
  */
-function traverseElements(node: IRNode, visitor: (el: IRElement, domDepth: number) => void, domDepth = 0): void {
-  switch (node.type) {
-    case 'element':
-      visitor(node, domDepth)
-      for (const child of node.children) {
-        traverseElements(child, visitor, domDepth + 1)
-      }
-      break
-    case 'fragment':
-    case 'component':
-    case 'provider':
-    case 'async':
-      for (const child of node.children) {
-        traverseElements(child, visitor, domDepth)
-      }
-      break
-    case 'conditional':
-      traverseElements(node.whenTrue, visitor, domDepth)
-      traverseElements(node.whenFalse, visitor, domDepth)
-      break
-    case 'if-statement':
-      traverseElements(node.consequent, visitor, domDepth)
-      if (node.alternate) {
-        traverseElements(node.alternate, visitor, domDepth)
-      }
-      break
-    // Note: 'loop' case is intentionally omitted. Nested .map() event delegation
-    // requires a different approach (nested data-key lookup + inner loop variable
-    // resolution) that isn't implemented yet. See memory: compiler-reconcile-templates-events.md
-  }
+function traverseElements(node: IRNode, visitor: (el: IRElement, domDepth: number) => void): void {
+  walkIR(node, 0, {
+    element: ({ node: el, scope: domDepth, descend }) => {
+      visitor(el, domDepth)
+      descend(domDepth + 1)
+    },
+    loop: () => {
+      // skip: nested-loop event delegation is handled separately
+    },
+  })
 }
 
 /**
@@ -384,40 +340,23 @@ function traverseForComponents(
   components: Array<{ name: string; slotId: string | null; props: IRProp[]; children: IRNode[] }>,
   skipConditionals = false,
 ): void {
-  switch (node.type) {
-    case 'element':
-    case 'fragment':
-    case 'provider':
-    case 'async':
-      for (const child of node.children) {
-        traverseForComponents(child, components, skipConditionals)
-      }
-      break
-    case 'component':
+  walkIR(node, null, {
+    component: ({ node, descend }) => {
       components.push({
         name: node.name,
         slotId: node.slotId,
         props: node.props,
         children: node.children,
       })
-      // Recurse into JSX children passed to this component
-      for (const child of node.children) {
-        traverseForComponents(child, components, skipConditionals)
-      }
-      break
-    case 'conditional':
-      if (skipConditionals) return
-      traverseForComponents(node.whenTrue, components, skipConditionals)
-      traverseForComponents(node.whenFalse, components, skipConditionals)
-      break
-    case 'if-statement':
-      if (skipConditionals) return
-      traverseForComponents(node.consequent, components, skipConditionals)
-      if (node.alternate) {
-        traverseForComponents(node.alternate, components, skipConditionals)
-      }
-      break
-  }
+      // Recurse into children passed to this component.
+      descend()
+    },
+    // Loops never contain collected components via this walker; halting
+    // here matches the pre-walker behaviour (no 'loop' case in the switch).
+    loop: () => {},
+    conditional: skipConditionals ? () => {} : undefined,
+    ifStatement: skipConditionals ? () => {} : undefined,
+  })
 }
 
 /**
@@ -432,31 +371,26 @@ export function collectLoopChildReactiveTexts(
   loopParam?: string,
 ): LoopChildReactiveText[] {
   const texts: LoopChildReactiveText[] = []
-
-  function walk(n: IRNode, insideConditional = false): void {
-    if (n.type === 'expression' && n.slotId) {
+  walkIR(node, false, {
+    expression: ({ node: n, scope: insideConditional }) => {
+      if (!n.slotId) return
       const expanded = expandConstantForReactivity(n.expr, ctx)
       // Include if expression reads signals OR references the loop parameter
-      // (loop param becomes a signal accessor via per-item signals)
+      // (loop param becomes a signal accessor via per-item signals).
       const isReactive = needsEffectWrapper(expanded, ctx)
       const refsLoopParam = loopParam ? exprReferencesIdent(expanded, loopParam) : false
       if (isReactive || refsLoopParam) {
         texts.push({ slotId: n.slotId, expression: expanded, insideConditional: insideConditional || undefined })
       }
-    }
-    if (n.type === 'element') {
-      for (const child of n.children) walk(child, insideConditional)
-    }
-    if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
-      for (const child of n.children) walk(child, insideConditional)
-    }
-    if (n.type === 'conditional') {
-      walk(n.whenTrue, true)
-      walk(n.whenFalse, true)
-    }
-  }
-
-  walk(node)
+    },
+    conditional: ({ descend }) => {
+      descend(true)
+    },
+    // Skip loop/async/if-statement subtrees — the original walker omitted them.
+    loop: () => {},
+    async: () => {},
+    ifStatement: () => {},
+  })
   return texts
 }
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -250,68 +250,64 @@ export function collectLoopChildEvents(node: IRNode): LoopChildEvent[] {
  */
 export function collectLoopChildEventsWithNesting(
   node: IRNode,
-  nestingStack: NestedLoop[] = [],
+  initialNestingStack: NestedLoop[] = [],
 ): LoopChildEvent[] {
-  const events: LoopChildEvent[] = []
-
-  let lastElementSlotId: string | null = null
-
-  function walk(n: IRNode, domDepth = 0): void {
-    switch (n.type) {
-      case 'element': {
-        const prevSlotId = lastElementSlotId
-        if (n.slotId) lastElementSlotId = n.slotId
-        if (n.slotId) {
-          for (const event of n.events) {
-            events.push({
-              eventName: event.name,
-              childSlotId: n.slotId,
-              handler: event.handler,
-              nestedLoops: [...nestingStack],
-              domDepth,
-            })
-          }
-        }
-        for (const child of n.children) walk(child, domDepth + 1)
-        lastElementSlotId = prevSlotId
-        break
-      }
-      case 'loop':
-        // Enter nested loop — push nesting info with container element's slotId
-        nestingStack.push({
-          kind: 'nested',
-          depth: nestingStack.length + 1,
-          array: n.array,
-          param: n.param,
-          key: n.key,
-          containerSlotId: lastElementSlotId,
-        })
-        for (const child of n.children) walk(child, domDepth)
-        nestingStack.pop()
-        break
-      case 'fragment':
-      case 'component':
-      case 'provider':
-      case 'async':
-        for (const child of n.children) walk(child, domDepth)
-        break
-      case 'conditional':
-        // Reactive conditionals (slotId set) are managed by insert() + bindEvents.
-        // Their events are collected into LoopChildConditional.whenTrue/FalseEvents
-        // and emitted inside bindEvents — not via delegation (#839).
-        if (!n.slotId) {
-          walk(n.whenTrue, domDepth)
-          walk(n.whenFalse, domDepth)
-        }
-        break
-      case 'if-statement':
-        walk(n.consequent, domDepth)
-        if (n.alternate) walk(n.alternate, domDepth)
-        break
-    }
+  type Scope = {
+    nestingStack: NestedLoop[]
+    lastElementSlotId: string | null
+    domDepth: number
   }
-
-  walk(node)
+  const events: LoopChildEvent[] = []
+  const initialScope: Scope = {
+    nestingStack: initialNestingStack,
+    lastElementSlotId: null,
+    domDepth: 0,
+  }
+  walkIR(node, initialScope, {
+    element: ({ node: el, scope, descend }) => {
+      if (el.slotId) {
+        for (const event of el.events) {
+          events.push({
+            eventName: event.name,
+            childSlotId: el.slotId,
+            handler: event.handler,
+            nestedLoops: [...scope.nestingStack],
+            domDepth: scope.domDepth,
+          })
+        }
+      }
+      descend({
+        ...scope,
+        lastElementSlotId: el.slotId ?? scope.lastElementSlotId,
+        domDepth: scope.domDepth + 1,
+      })
+    },
+    loop: ({ node: l, scope, descend }) => {
+      // Enter nested loop — push nesting info with container element's slotId.
+      descend({
+        ...scope,
+        nestingStack: [
+          ...scope.nestingStack,
+          {
+            kind: 'nested',
+            depth: scope.nestingStack.length + 1,
+            array: l.array,
+            param: l.param,
+            key: l.key,
+            containerSlotId: scope.lastElementSlotId,
+          },
+        ],
+      })
+    },
+    conditional: ({ node: c, scope, descend }) => {
+      // Reactive conditionals (slotId set) are managed by insert() + bindEvents.
+      // Their events are collected into LoopChildConditional.whenTrue/FalseEvents
+      // and emitted inside bindEvents — not via delegation (#839).
+      if (!c.slotId) descend(scope)
+    },
+    // fragment / component / provider / async / if-statement use the default
+    // auto-descent, which preserves scope (no domDepth bump, no stack push).
+  })
   return events
 }
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -407,9 +407,12 @@ export function collectLoopChildConditionals(
   // cycle; same pattern as irToHtmlTemplate / irToPlaceholderTemplate above.
   const { collectInnerLoops, branchInnerLoopOptions } = require('./collect-elements')
 
-  function walk(n: IRNode): void {
-    if (n.type === 'conditional' && n.slotId) {
-      // Include conditionals that are reactive OR reference the loop param
+  walkIR(node, null, {
+    conditional: ({ node: n }) => {
+      // Don't recurse into conditional branches — nested conditionals
+      // inside branches will be handled by insert()'s own bindEvents.
+      // Non-reactive, non-loop-param conditionals are ignored entirely.
+      if (!n.slotId) return
       const isReactive = n.reactive
       const refsLoopParam = loopParam ? exprReferencesIdent(n.condition, loopParam) : false
       if (!isReactive && !refsLoopParam) return
@@ -417,41 +420,35 @@ export function collectLoopChildConditionals(
       // Loop-param conditionals are reactive via per-item signal accessors;
       // needsEffectWrapper only knows about signals/memos/props, not loop params.
       if (!refsLoopParam && !needsEffectWrapper(expanded, ctx)) return
-      {
-        const loopParamsForCond = loopParam ? [loopParam] : undefined
-        const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
-        const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
-        const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
-        const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
-        conditionals.push({
-          slotId: n.slotId,
-          condition: expanded,
-          whenTrueHtml,
-          whenFalseHtml,
-          whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
-          whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
-          whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
-          whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
-          whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
-          whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
-          whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
-          whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
-        })
-      }
-      // Don't recurse into conditional branches — nested conditionals
-      // inside branches will be handled by insert()'s own bindEvents
-      return
-    }
-    if (n.type === 'element') {
-      for (const child of n.children) walk(child)
-    }
-    if (n.type === 'fragment' || n.type === 'component' || n.type === 'provider') {
-      for (const child of n.children) walk(child)
-    }
-    // Don't recurse into nested loops — they have their own mapArray
-  }
 
-  walk(node)
+      const loopParamsForCond = loopParam ? [loopParam] : undefined
+      const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
+      const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
+      const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+      const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+      conditionals.push({
+        slotId: n.slotId,
+        condition: expanded,
+        whenTrueHtml,
+        whenFalseHtml,
+        whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
+        whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
+        whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
+        whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
+        whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
+        whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
+        whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
+        whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
+      })
+    },
+    // element / fragment / component / provider auto-descend with same scope.
+    // loop / async / if-statement skipped — nested loops have their own
+    // mapArray, async + if-statement don't appear in loop-body conditionals.
+    loop: () => {},
+    async: () => {},
+    ifStatement: () => {},
+  })
+
   return conditionals
 }
 

--- a/packages/jsx/src/ir-to-client-js/walker.ts
+++ b/packages/jsx/src/ir-to-client-js/walker.ts
@@ -1,0 +1,295 @@
+/**
+ * Generic IR tree walker with declarative per-node-kind visitors and
+ * explicit scope threading.
+ *
+ * Purpose (Phase 4 of the collectElements modularization epic, #999):
+ * every collector in this directory used to re-implement its own
+ * `switch (node.type)` over the 10 `IRNode` kinds, each with its own
+ * stop-rule wiring. Adding a new kind (most recently `IRAsync`) required
+ * editing every walker by hand. This module centralises the fan-out so
+ * new kinds compile-check into every visitor at once via `assertNever`
+ * in the default arm.
+ *
+ * Design:
+ * - Per-kind optional callbacks on `IRVisitor<Scope>`.
+ * - When a callback is **absent**, `walkIR` descends into the node's
+ *   default children with the same scope.
+ * - When a callback is **present**, it takes full control: it receives
+ *   `descend(scope?)` (recurses into default children, optionally with
+ *   a new scope) and `walk(node, scope)` (surgical traversal of any
+ *   subtree with any scope). The visitor is responsible for calling
+ *   one of these if it wants recursion — explicit descent mirrors how
+ *   every existing walker already works.
+ * - Component `prop.jsxChildren` are NOT part of default descent.
+ *   Visitors that need them call `descendJsxChildren(scope?)` from the
+ *   component visit context. Matches the pre-Phase-4 behaviour where
+ *   only `collectElements` descended into JSX prop children.
+ *
+ * Not a goal: subsuming Phase 1 transformations (`jsx-to-ir.ts`). Scope
+ * is strictly `packages/jsx/src/ir-to-client-js/`.
+ */
+
+import type {
+  IRNode,
+  IRElement,
+  IRText,
+  IRExpression,
+  IRConditional,
+  IRLoop,
+  IRComponent,
+  IRSlot,
+  IRFragment,
+  IRIfStatement,
+  IRProvider,
+  IRAsync,
+} from '../types'
+
+/**
+ * Arguments passed to every per-kind visitor callback.
+ *
+ * `descend(nextScope?)` recurses into the node's default children with
+ * the given scope (or the current one). For `component` nodes,
+ * `descendJsxChildren(nextScope?)` additionally walks every JSX prop
+ * value's child subtree.
+ *
+ * `walk(node, scope)` escapes the default descent pattern for callers
+ * that need surgical traversal (e.g. conditional-branch collectors that
+ * descend only into `whenTrue` or only into `whenFalse`).
+ */
+export interface VisitContext<Scope, Node extends IRNode> {
+  readonly node: Node
+  readonly scope: Scope
+  descend(nextScope?: Scope): void
+  walk(node: IRNode, scope?: Scope): void
+}
+
+/** Additional affordance exposed only for `IRComponent` visitors. */
+export interface ComponentVisitContext<Scope> extends VisitContext<Scope, IRComponent> {
+  /** Walk every JSX child subtree across every `prop.jsxChildren` on this component. */
+  descendJsxChildren(nextScope?: Scope): void
+}
+
+export interface IRVisitor<Scope> {
+  element?(ctx: VisitContext<Scope, IRElement>): void
+  text?(ctx: VisitContext<Scope, IRText>): void
+  expression?(ctx: VisitContext<Scope, IRExpression>): void
+  conditional?(ctx: VisitContext<Scope, IRConditional>): void
+  loop?(ctx: VisitContext<Scope, IRLoop>): void
+  component?(ctx: ComponentVisitContext<Scope>): void
+  slot?(ctx: VisitContext<Scope, IRSlot>): void
+  fragment?(ctx: VisitContext<Scope, IRFragment>): void
+  ifStatement?(ctx: VisitContext<Scope, IRIfStatement>): void
+  provider?(ctx: VisitContext<Scope, IRProvider>): void
+  async?(ctx: VisitContext<Scope, IRAsync>): void
+}
+
+/** Recurse into the default children of `node` with the given scope. */
+function descendDefault<Scope>(
+  node: IRNode,
+  scope: Scope,
+  walk: (n: IRNode, s: Scope) => void,
+): void {
+  switch (node.type) {
+    case 'element':
+    case 'fragment':
+    case 'component':
+    case 'provider':
+    case 'async':
+    case 'loop':
+      for (const child of node.children) walk(child, scope)
+      return
+    case 'conditional':
+      walk(node.whenTrue, scope)
+      walk(node.whenFalse, scope)
+      return
+    case 'if-statement':
+      walk(node.consequent, scope)
+      if (node.alternate) walk(node.alternate, scope)
+      return
+    case 'text':
+    case 'expression':
+    case 'slot':
+      return
+    default:
+      return assertNever(node)
+  }
+}
+
+/** Walk a single node's JSX prop children (for `component` nodes only). */
+function descendComponentJsxChildren<Scope>(
+  node: IRComponent,
+  scope: Scope,
+  walk: (n: IRNode, s: Scope) => void,
+): void {
+  for (const prop of node.props) {
+    if (!prop.jsxChildren) continue
+    for (const child of prop.jsxChildren) walk(child, scope)
+  }
+}
+
+/**
+ * Walk an IR tree rooted at `root`, dispatching each node to the matching
+ * visitor callback. If a callback is missing for a kind, the walker
+ * descends into that kind's default children with the same scope.
+ *
+ * Callbacks control their own descent via `ctx.descend()` / `ctx.walk()`
+ * and (for components) `ctx.descendJsxChildren()`.
+ */
+export function walkIR<Scope>(
+  root: IRNode,
+  initialScope: Scope,
+  visitor: IRVisitor<Scope>,
+): void {
+  function walk(node: IRNode, scope: Scope): void {
+    const doDescend = (nextScope: Scope = scope) => descendDefault(node, nextScope, walk)
+
+    switch (node.type) {
+      case 'element': {
+        if (visitor.element) {
+          visitor.element({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'text': {
+        if (visitor.text) {
+          visitor.text({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        }
+        return
+      }
+      case 'expression': {
+        if (visitor.expression) {
+          visitor.expression({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        }
+        return
+      }
+      case 'conditional': {
+        if (visitor.conditional) {
+          visitor.conditional({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'loop': {
+        if (visitor.loop) {
+          visitor.loop({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'component': {
+        if (visitor.component) {
+          visitor.component({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            descendJsxChildren: (s = scope) => descendComponentJsxChildren(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'slot': {
+        if (visitor.slot) {
+          visitor.slot({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        }
+        return
+      }
+      case 'fragment': {
+        if (visitor.fragment) {
+          visitor.fragment({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'if-statement': {
+        if (visitor.ifStatement) {
+          visitor.ifStatement({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'provider': {
+        if (visitor.provider) {
+          visitor.provider({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      case 'async': {
+        if (visitor.async) {
+          visitor.async({
+            node,
+            scope,
+            descend: (s = scope) => descendDefault(node, s, walk),
+            walk: (n, s = scope) => walk(n, s),
+          })
+        } else {
+          doDescend()
+        }
+        return
+      }
+      default:
+        return assertNever(node)
+    }
+  }
+
+  walk(root, initialScope)
+}
+
+function assertNever(x: never): never {
+  throw new Error(`IRWalker: unhandled IRNode kind: ${JSON.stringify(x)}`)
+}


### PR DESCRIPTION
## Summary

Phase 4 of the collectElements modularization epic (#999). Stacked on top of #1009 (phase 3, still open pending GitHub CI backlog); the PR base will auto-update to ``main`` once phase 3 merges.

Introduces a generic IR tree walker (``walkIR``) and migrates every collector in ``packages/jsx/src/ir-to-client-js/`` onto it. Any future ``IRNode`` kind now becomes a compile-time error in walker.ts's ``assertNever`` arm instead of silently diverging across 10+ hand-written walkers.

## Commits

1. ``feat(compiler): add IRWalker infrastructure`` — new ``walker.ts`` with exhaustive switch + ``assertNever``, per-kind optional visitors, explicit ``descend(scope?)`` / ``walk(node, scope?)``, plus ``descendJsxChildren(scope?)`` on the component visit context. Unit-tested with 8 cases.
2. ``migrate read-only reactivity walkers`` — ``collectEventHandlersFromIR``, ``traverseElements``, ``traverseForComponents``, and their dependents (``collectConditionalBranchEvents``, ``collectConditionalBranchRefs``, ``collectLoopChildEvents``, ``collectLoopChildReactiveAttrs``, ``collectLoopChildReactiveTexts``).
3. ``migrate collectLoopChildEventsWithNesting`` — the richer-scope walker (``nestingStack`` + ``lastElementSlotId`` + ``domDepth``) threaded through an immutable ``Scope`` record.
4. ``migrate branch collectors`` — ``collectBranchTextEffects``, ``collectBranchLoops``, ``collectBranchConditionals``, ``collectLoopChildConditionals``.
5. ``migrate collectInnerLoops`` — the unified inner-loop collector, scope carries parentSlotId/depth/insideCond.
6. ``migrate collectElements main pass`` — the top-level 200-line switch collapses to a walkIR visitor; loop/component/conditional/provider cases encode their own stop rules explicitly.
7. ``migrate remaining walkers`` — ``computeLoopSiblingOffsets``, ``collectIdentifiersFromIRTree``, ``addLoopSubtreeIdentifiers``; drops two now-unused imports.

## Acceptance

- [x] ``bun test packages/jsx`` — 751 pass, 0 fail (adds 8 ``ir-walker.test.ts`` cases)
- [x] ``bun test packages/adapter-tests`` — 214 pass, 0 fail (adapter + CSR conformance fixtures byte-identical)
- [x] Clean ``bun run clean && bun run build`` green
- [x] ``rg 'switch\s*\(\s*[a-zA-Z_]+\.type\s*\)' packages/jsx/src/ir-to-client-js/`` hits only walker.ts and html-template.ts.

## Scope note — html-template.ts not migrated

``html-template.ts`` also contains several ``switch (node.type)`` walkers, but it belongs to a different responsibility (IR → HTML template-string generation, not reactive-metadata collection). The phase 4 issue #1004 listed only the collector walkers in ``collect-elements.ts`` / ``reactivity.ts`` / ``identifiers.ts``. The acceptance criterion ``at most 2 hits`` in the issue body was too tight; html-template.ts is an intentional follow-up candidate, not part of this PR. The actual scope reduction achieved:

- Before phase 4: 10 hand-written ``switch (node.type)`` walkers across ``collect-elements.ts`` / ``reactivity.ts`` / ``identifiers.ts``.
- After phase 4: 0. All 10 now sit on top of ``walkIR``.

## Related

- Epic: #999
- Phase 4 issue: #1004
- Based on: #1009 (phase 3, pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)