### PR TITLE
refactor(compiler): add stopAt walker preset for branch/loop collectors

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -8,7 +8,7 @@ import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
 import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
-import { walkIR } from './walker'
+import { walkIR, stopAt } from './walker'
 
 /** Check if an IR node produces a DOM child element (for sibling offset counting). */
 function producesDomChild(node: IRNode): boolean {
@@ -646,18 +646,16 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
 function collectBranchTextEffects(node: IRNode): ConditionalBranchTextEffect[] {
   const effects: ConditionalBranchTextEffect[] = []
   walkIR(node, null, {
+    // Do NOT recurse into nested conditionals / if-statements — they have
+    // their own insert(). Loops are not inspected either; the legacy
+    // walker's switch omitted the 'loop' case entirely.
+    // element / fragment / component / provider / async use default descent.
+    ...stopAt<null>('conditional', 'ifStatement', 'loop'),
     expression: ({ node: n }) => {
       if (n.reactive && n.slotId && !n.clientOnly) {
         effects.push({ slotId: n.slotId, expression: n.expr })
       }
     },
-    // Do NOT recurse into nested conditionals / if-statements — they have
-    // their own insert(). Loops are not inspected either; the legacy
-    // walker's switch omitted the 'loop' case entirely.
-    conditional: () => {},
-    ifStatement: () => {},
-    loop: () => {},
-    // element / fragment / component / provider / async use default descent.
   })
   return effects
 }
@@ -677,6 +675,9 @@ function collectBranchLoops(
   const restNames = ctx ? buildRestSpreadNames(ctx) : undefined
 
   walkIR<string | null>(node, null, {
+    // Don't recurse into nested conditionals / if-statements.
+    // fragment / component / provider / async auto-descend carrying parentSlotId.
+    ...stopAt<string | null>('conditional', 'ifStatement'),
     element: ({ node: el, scope: parentSlotId, descend }) => {
       descend(el.slotId ?? parentSlotId)
     },
@@ -749,10 +750,6 @@ function collectBranchLoops(
       })
       // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation.
     },
-    // Don't recurse into nested conditionals / if-statements.
-    conditional: () => {},
-    ifStatement: () => {},
-    // fragment / component / provider / async auto-descend carrying parentSlotId.
   })
 
   return loops
@@ -813,6 +810,8 @@ function collectBranchConditionals(
 ): ConditionalElement[] {
   const result: ConditionalElement[] = []
   walkIR(node, null, {
+    // Don't recurse into loops / if-statements — they have their own reconciliation paths.
+    ...stopAt<null>('loop', 'ifStatement'),
     conditional: ({ node: n }) => {
       // Wrap-by-default fallback (#941) — mirror the top-level gate in
       // `case 'conditional'` at collectElements().
@@ -821,9 +820,6 @@ function collectBranchConditionals(
       }
       // Don't recurse further — the nested conditional handles its own branches.
     },
-    // Don't recurse into loops / if-statements — they have their own reconciliation paths.
-    loop: () => {},
-    ifStatement: () => {},
   })
   return result
 }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -15,7 +15,7 @@ import type {
 } from './types'
 import { attrValueToString, exprReferencesIdent } from './utils'
 import { expandConstantForReactivity } from './prop-handling'
-import { walkIR } from './walker'
+import { walkIR, stopAt } from './walker'
 
 /**
  * Phase 2 reactivity detection: determines if a code expression needs `createEffect`
@@ -379,7 +379,14 @@ function traverseForComponents(
   components: Array<{ name: string; slotId: string | null; props: IRProp[]; children: IRNode[] }>,
   skipConditionals = false,
 ): void {
+  // Loops never contain collected components via this walker; halting there
+  // matches the pre-walker behaviour (no 'loop' case in the switch).
+  // skipConditionals also halts at nested conditionals / if-statements.
+  const stops = skipConditionals
+    ? stopAt<null>('loop', 'conditional', 'ifStatement')
+    : stopAt<null>('loop')
   walkIR(node, null, {
+    ...stops,
     component: ({ node, descend }) => {
       components.push({
         name: node.name,
@@ -390,11 +397,6 @@ function traverseForComponents(
       // Recurse into children passed to this component.
       descend()
     },
-    // Loops never contain collected components via this walker; halting
-    // here matches the pre-walker behaviour (no 'loop' case in the switch).
-    loop: () => {},
-    conditional: skipConditionals ? () => {} : undefined,
-    ifStatement: skipConditionals ? () => {} : undefined,
   })
 }
 
@@ -411,6 +413,10 @@ export function collectLoopChildReactiveTexts(
 ): LoopChildReactiveText[] {
   const texts: LoopChildReactiveText[] = []
   walkIR(node, false, {
+    // Skip loop/async/if-statement subtrees — the original walker omitted
+    // them; they have their own scopes (inner-loop reconciliation, async
+    // boundaries, statement-level control flow).
+    ...stopAt<boolean>('loop', 'async', 'ifStatement'),
     expression: ({ node: n, scope: insideConditional }) => {
       if (!n.slotId) return
       const expanded = expandConstantForReactivity(n.expr, ctx)
@@ -422,10 +428,6 @@ export function collectLoopChildReactiveTexts(
     conditional: ({ descend }) => {
       descend(true)
     },
-    // Skip loop/async/if-statement subtrees — the original walker omitted them.
-    loop: () => {},
-    async: () => {},
-    ifStatement: () => {},
   })
   return texts
 }
@@ -448,6 +450,10 @@ export function collectLoopChildConditionals(
   const { collectInnerLoops, branchInnerLoopOptions } = require('./collect-elements')
 
   walkIR(node, null, {
+    // element / fragment / component / provider auto-descend with same scope.
+    // loop / async / if-statement skipped — nested loops have their own
+    // mapArray, async + if-statement don't appear in loop-body conditionals.
+    ...stopAt<null>('loop', 'async', 'ifStatement'),
     conditional: ({ node: n }) => {
       // Don't recurse into conditional branches — nested conditionals
       // inside branches will be handled by insert()'s own bindEvents.
@@ -482,12 +488,6 @@ export function collectLoopChildConditionals(
         whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
       })
     },
-    // element / fragment / component / provider auto-descend with same scope.
-    // loop / async / if-statement skipped — nested loops have their own
-    // mapArray, async + if-statement don't appear in loop-body conditionals.
-    loop: () => {},
-    async: () => {},
-    ifStatement: () => {},
   })
 
   return conditionals

--- a/packages/jsx/src/ir-to-client-js/walker.ts
+++ b/packages/jsx/src/ir-to-client-js/walker.ts
@@ -293,3 +293,36 @@ export function walkIR<Scope>(
 function assertNever(x: never): never {
   throw new Error(`IRWalker: unhandled IRNode kind: ${JSON.stringify(x)}`)
 }
+
+/**
+ * Build a partial visitor that halts descent at the given IR node kinds.
+ *
+ * Each listed kind is wired to a no-op callback. Because a present callback
+ * takes full control of descent (see `walkIR`), omitting `descend()` inside
+ * the no-op means the walker stops at that kind without traversing its
+ * children. Spreads into a larger visitor:
+ *
+ *     walkIR(root, scope, {
+ *       ...stopAt('loop', 'async', 'ifStatement'),
+ *       expression: (...) => { ... },
+ *     })
+ *
+ * Declarative alternative to scattering `kind: () => {}` empty callbacks
+ * across every branch/loop-scoped collector. Collectors inside this
+ * directory share a small set of "where to stop" recipes — loops have
+ * their own reconciliation path, `async` boundaries suspend traversal,
+ * `if-statement` is statement-level control flow, and nested conditionals
+ * inside a branch own their own `insert()` call — so expressing those
+ * stop rules uniformly keeps the intent in one place and makes new
+ * collectors pick the right recipe by name rather than by copy-paste.
+ */
+export function stopAt<Scope>(
+  ...kinds: Array<keyof IRVisitor<Scope>>
+): Partial<IRVisitor<Scope>> {
+  const visitor: Partial<IRVisitor<Scope>> = {}
+  const noop = () => {}
+  for (const kind of kinds) {
+    ;(visitor as Record<string, () => void>)[kind as string] = noop
+  }
+  return visitor
+}


### PR DESCRIPTION
## Summary

**2/4** of a reactivity-refactor chain (stacked on #1011).

Replace the scattered `kind: () => {}` empty-callback boilerplate used
by six branch/loop-scoped collectors with a single declarative
`stopAt('loop', 'async', 'ifStatement')` combinator exported from
`walker.ts`. New collectors pick the stop recipe by name instead of
re-expressing it inline.

Affected call sites:
- `reactivity.ts`: `traverseForComponents`, `collectLoopChildReactiveTexts`, `collectLoopChildConditionals`
- `collect-elements.ts`: `collectBranchTextEffects`, `collectBranchLoops`, `collectBranchConditionals`

## Test plan

- [x] `bun test` (packages/jsx): 580 pass / 11 fail / 7 errors — unchanged from baseline
- [x] `tsgo --noEmit`: no type errors
- [x] Pure refactor

Chain base: #1011 (`claude/refactor-reactivity-step1-classify`). Once the parent merges, this PR will automatically retarget `main`.

https://claude.ai/code/session_01D3EiEhDTFRRWnGVXoGybAM