### PR TITLE
refactor(compiler): move collectLoopChildConditionals to break require() cycle

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,9 +3,9 @@
  */
 
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
-import { attrValueToString, quotePropName, PROPS_PARAM } from './utils'
-import { decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildConditionals } from './reactivity'
+import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
+import { attrValueToString, exprReferencesIdent, quotePropName, PROPS_PARAM } from './utils'
+import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 import { walkIR, stopAt } from './walker'
@@ -822,4 +822,67 @@ function collectBranchConditionals(
     },
   })
   return result
+}
+
+/**
+ * Collect reactive conditionals from loop children.
+ * These are conditional nodes with a slotId that have reactive conditions,
+ * needing insert() calls for fine-grained conditional switching.
+ *
+ * Lives in collect-elements.ts (not reactivity.ts) because it composes
+ * `collectInnerLoops` and `irToHtmlTemplate` to build per-branch metadata
+ * — a branch-summary concern rather than a reactivity-classification one.
+ * Placement here eliminates the former lazy-`require()` cycle between
+ * reactivity.ts and collect-elements.ts.
+ */
+export function collectLoopChildConditionals(
+  node: IRNode,
+  ctx: ClientJsContext,
+  siblingOffsets: Map<IRLoop, number>,
+  loopParam?: string,
+): LoopChildConditional[] {
+  const conditionals: LoopChildConditional[] = []
+
+  walkIR(node, null, {
+    // element / fragment / component / provider auto-descend with same scope.
+    // loop / async / if-statement skipped — nested loops have their own
+    // mapArray, async + if-statement don't appear in loop-body conditionals.
+    ...stopAt<null>('loop', 'async', 'ifStatement'),
+    conditional: ({ node: n }) => {
+      // Don't recurse into conditional branches — nested conditionals
+      // inside branches will be handled by insert()'s own bindEvents.
+      // Non-reactive, non-loop-param conditionals are ignored entirely.
+      if (!n.slotId) return
+      const refsLoopParamInSource = loopParam ? exprReferencesIdent(n.condition, loopParam) : false
+      // Pre-gate using AST `reactive` flag on the source condition before
+      // paying for constant expansion — matches the legacy short-circuit.
+      if (!n.reactive && !refsLoopParamInSource) return
+      const expanded = expandConstantForReactivity(n.condition, ctx)
+      // Loop-param conditionals are reactive via per-item signal accessors;
+      // classifyReactivity sees both paths (signal/memo/prop + loop-param).
+      if (classifyReactivity(expanded, ctx, loopParam).kind === 'none') return
+
+      const loopParamsForCond = loopParam ? [loopParam] : undefined
+      const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
+      const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
+      const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+      const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+      conditionals.push({
+        slotId: n.slotId,
+        condition: expanded,
+        whenTrueHtml,
+        whenFalseHtml,
+        whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
+        whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
+        whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
+        whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
+        whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
+        whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
+        whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
+        whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
+      })
+    },
+  })
+
+  return conditionals
 }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -10,7 +10,6 @@ import type {
   LoopChildEvent,
   LoopChildReactiveAttr,
   LoopChildReactiveText,
-  LoopChildConditional,
   NestedLoop,
 } from './types'
 import { attrValueToString, exprReferencesIdent } from './utils'
@@ -430,67 +429,6 @@ export function collectLoopChildReactiveTexts(
     },
   })
   return texts
-}
-
-/**
- * Collect reactive conditionals from loop children.
- * These are conditional nodes with a slotId that have reactive conditions,
- * needing insert() calls for fine-grained conditional switching.
- */
-export function collectLoopChildConditionals(
-  node: IRNode,
-  ctx: ClientJsContext,
-  siblingOffsets: Map<import('../types').IRLoop, number>,
-  loopParam?: string,
-): LoopChildConditional[] {
-  const conditionals: LoopChildConditional[] = []
-  const { irToHtmlTemplate } = require('./html-template')
-  // Lazy require avoids the collect-elements.ts ↔ reactivity.ts import
-  // cycle; same pattern as irToHtmlTemplate / irToPlaceholderTemplate above.
-  const { collectInnerLoops, branchInnerLoopOptions } = require('./collect-elements')
-
-  walkIR(node, null, {
-    // element / fragment / component / provider auto-descend with same scope.
-    // loop / async / if-statement skipped — nested loops have their own
-    // mapArray, async + if-statement don't appear in loop-body conditionals.
-    ...stopAt<null>('loop', 'async', 'ifStatement'),
-    conditional: ({ node: n }) => {
-      // Don't recurse into conditional branches — nested conditionals
-      // inside branches will be handled by insert()'s own bindEvents.
-      // Non-reactive, non-loop-param conditionals are ignored entirely.
-      if (!n.slotId) return
-      const refsLoopParamInSource = loopParam ? exprReferencesIdent(n.condition, loopParam) : false
-      // Pre-gate using AST `reactive` flag on the source condition before
-      // paying for constant expansion — matches the legacy short-circuit.
-      if (!n.reactive && !refsLoopParamInSource) return
-      const expanded = expandConstantForReactivity(n.condition, ctx)
-      // Loop-param conditionals are reactive via per-item signal accessors;
-      // classifyReactivity sees both paths (signal/memo/prop + loop-param).
-      if (classifyReactivity(expanded, ctx, loopParam).kind === 'none') return
-
-      const loopParamsForCond = loopParam ? [loopParam] : undefined
-      const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
-      const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
-      const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
-      const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
-      conditionals.push({
-        slotId: n.slotId,
-        condition: expanded,
-        whenTrueHtml,
-        whenFalseHtml,
-        whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
-        whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
-        whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
-        whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
-        whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
-        whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
-        whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
-        whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
-      })
-    },
-  })
-
-  return conditionals
 }
 
 /**


### PR DESCRIPTION
## Summary

**3/4** of a reactivity-refactor chain (stacked on #1012).

Move `collectLoopChildConditionals` from `reactivity.ts` to
`collect-elements.ts`. The function's body held a lazy
`require('./html-template')` / `require('./collect-elements')` because
its responsibility is *branch-summary metadata assembly* (building
per-branch HTML, inner-loop metadata, child components, nested
conditionals) rather than *reactivity classification*. Relocating it
to the right module eliminates the cycle-breaking `require()`.

In its new home the function sits next to `collectBranchConditionals`
and `summarizeBranch` — all helpers that bundle per-branch reactive
entities.

## Test plan

- [x] `bun test` (packages/jsx): 580 pass / 11 fail / 7 errors — unchanged from baseline
- [x] `tsgo --noEmit`: no type errors
- [x] Pure move — no logic change (`classifyReactivity` is now imported from `./reactivity` instead)

Chain base: #1012. Next: #1014 (flatten `whenTrueXxx` / `whenFalseXxx` pairs into `LoopChildBranchSummary`).

https://claude.ai/code/session_01D3EiEhDTFRRWnGVXoGybAM