### PR TITLE
refactor(compiler): fold whenTrueXxx/whenFalseXxx into LoopChildBranchSummary

### DIFF
--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,7 +3,7 @@
  */
 
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
+import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
 import { attrValueToString, exprReferencesIdent, quotePropName, PROPS_PARAM } from './utils'
 import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
@@ -167,7 +167,7 @@ export function collectInnerLoops(
         let childConditionals: import('./types').LoopChildConditional[] | undefined
         if (collectBindings) {
           // skipConditionals=true: components inside conditional branches
-          // are collected separately via `childConditionals[i].whenTrueComponents`
+          // are collected separately via `childConditionals[i].whenTrue.childComponents`
           // (below). Including them here would double-init event handlers.
           const rawComps: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: IRNode[] }> = []
           for (const child of n.children) {
@@ -865,24 +865,38 @@ export function collectLoopChildConditionals(
       const loopParamsForCond = loopParam ? [loopParam] : undefined
       const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
       const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
-      const trueInner = collectInnerLoops([n.whenTrue], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
-      const falseInner = collectInnerLoops([n.whenFalse], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
       conditionals.push({
         slotId: n.slotId,
         condition: expanded,
         whenTrueHtml,
         whenFalseHtml,
-        whenTrueComponents: collectConditionalBranchChildComponents(n.whenTrue),
-        whenFalseComponents: collectConditionalBranchChildComponents(n.whenFalse),
-        whenTrueInnerLoops: trueInner.length > 0 ? trueInner : undefined,
-        whenFalseInnerLoops: falseInner.length > 0 ? falseInner : undefined,
-        whenTrueConditionals: collectLoopChildConditionals(n.whenTrue, ctx, siblingOffsets, loopParam),
-        whenFalseConditionals: collectLoopChildConditionals(n.whenFalse, ctx, siblingOffsets, loopParam),
-        whenTrueEvents: collectConditionalBranchEvents(n.whenTrue),
-        whenFalseEvents: collectConditionalBranchEvents(n.whenFalse),
+        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam),
+        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam),
       })
     },
   })
 
   return conditionals
+}
+
+/**
+ * Bundle every reactive entity collected from one branch of a
+ * `LoopChildConditional` into a `LoopChildBranchSummary`. Mirrors the
+ * top-level `summarizeBranch` helper (#1009): one call replaces the four
+ * parallel `whenTrueXxx` / `whenFalseXxx` collection calls that used to
+ * sit inline in `collectLoopChildConditionals`.
+ */
+function summarizeLoopChildBranch(
+  node: IRNode,
+  ctx: ClientJsContext,
+  siblingOffsets: Map<IRLoop, number>,
+  loopParam?: string,
+): LoopChildBranchSummary {
+  const inner = collectInnerLoops([node], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
+  return {
+    childComponents: collectConditionalBranchChildComponents(node),
+    innerLoops: inner.length > 0 ? inner : undefined,
+    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam),
+    events: collectConditionalBranchEvents(node),
+  }
 }

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -524,18 +524,18 @@ function emitNestedLoopChildConditionals(
     lines.push(`${indent}insert(${scopeVar}, '${cond.slotId}', () => ${wrap(cond.condition)}, {`)
     lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-    emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrueEvents, wrap)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents, loopParam, wrap)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrueInnerLoops, loopParam, wrap)
-    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrueConditionals, wrap, loopParam)
+    emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrue.events, wrap)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam, wrap)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam, wrap)
+    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam)
     lines.push(`${indent}  }`)
     lines.push(`${indent}}, {`)
     lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-    emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalseEvents, wrap)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents, loopParam, wrap)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalseInnerLoops, loopParam, wrap)
-    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalseConditionals, wrap, loopParam)
+    emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalse.events, wrap)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam, wrap)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam, wrap)
+    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam)
     lines.push(`${indent}  }`)
     lines.push(`${indent}})`)
   }
@@ -607,10 +607,10 @@ function emitLoopChildReactiveEffects(
       lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${wrap(cond.condition)}, {`)
       lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrueEvents, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrueComponents, loopParam)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrueInnerLoops, loopParam)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrueConditionals, wrap, loopParam)
+      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrue.events, wrap)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam)
+      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam)
       for (const text of textsForBranch(cond.whenTrueHtml)) {
         const varName = `__rt_${varSlotId(text.slotId)}`
         lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
@@ -620,10 +620,10 @@ function emitLoopChildReactiveEffects(
       lines.push(`${indent}}, {`)
       lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalseEvents, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalseComponents, loopParam)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalseInnerLoops, loopParam)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalseConditionals, wrap, loopParam)
+      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalse.events, wrap)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam)
+      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam)
       for (const text of textsForBranch(cond.whenFalseHtml)) {
         const varName = `__rt_${varSlotId(text.slotId)}`
         lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
@@ -1170,7 +1170,7 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
   // Exclude components inside reactive conditionals — managed by insert()
   const condCompSlotIds = new Set<string>()
   for (const cond of ctx.elem.childConditionals ?? []) {
-    for (const comp of [...cond.whenTrueComponents, ...cond.whenFalseComponents]) {
+    for (const comp of [...cond.whenTrue.childComponents, ...cond.whenFalse.childComponents]) {
       if (comp.slotId) condCompSlotIds.add(comp.slotId)
     }
   }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -211,25 +211,43 @@ export interface LoopChildReactiveText {
   insideConditional?: boolean // true if text node is inside a conditional branch (insert() may replace it)
 }
 
+/**
+ * All reactive entities collected from one branch of a `LoopChildConditional`
+ * — child components, inner loops, nested conditionals, and events.
+ *
+ * Mirrors the top-level `BranchSummary` refactor (#1009): replaces the eight
+ * parallel `whenTrueXxx` / `whenFalseXxx` fields that used to live directly
+ * on `LoopChildConditional` with a single bundle per branch.
+ *
+ * Differs from `BranchSummary` by carrying loop-scoped types —
+ * `NestedLoop` instead of `BranchLoop`, recursive `LoopChildConditional`
+ * instead of `ConditionalElement`, raw component data instead of
+ * pre-built `propsExpr` strings — because these structs are consumed
+ * inside a loop item's `mapArray` callback, not at the top-level init.
+ */
+export interface LoopChildBranchSummary {
+  /**
+   * Raw child components inside the branch (for initChild / createComponent).
+   * Unlike `BranchSummary.childComponents` (pre-built `propsExpr`), these
+   * carry raw `props` + `children` — `propsExpr` is built by the emitter
+   * inside the loop's mapArray callback where the loop param is in scope.
+   */
+  childComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }>
+  /** Inner loops inside the branch that need mapArray setup. */
+  innerLoops?: NestedLoop[]
+  /** Nested conditionals inside the branch (recursive — Path A, #830). */
+  conditionals?: LoopChildConditional[]
+  /** Events on elements inside the branch — attached via insert() bindEvents (#839). */
+  events?: ConditionalBranchEvent[]
+}
+
 export interface LoopChildConditional {
   slotId: string       // bf-c slot ID for insert() targeting
   condition: string    // Reactive condition expression
   whenTrueHtml: string // HTML template for true branch
   whenFalseHtml: string // HTML template for false branch (usually comment markers)
-  whenTrueComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }>
-  whenFalseComponents: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children: import('../types').IRNode[] }>
-  /** Inner loops inside whenTrue branch that need mapArray setup */
-  whenTrueInnerLoops?: NestedLoop[]
-  /** Inner loops inside whenFalse branch that need mapArray setup */
-  whenFalseInnerLoops?: NestedLoop[]
-  /** Nested conditionals inside whenTrue branch (recursive — Path A, #830) */
-  whenTrueConditionals?: LoopChildConditional[]
-  /** Nested conditionals inside whenFalse branch (recursive — Path A, #830) */
-  whenFalseConditionals?: LoopChildConditional[]
-  /** Events on elements inside whenTrue branch — attached via insert() bindEvents (#839) */
-  whenTrueEvents?: ConditionalBranchEvent[]
-  /** Events on elements inside whenFalse branch — attached via insert() bindEvents (#839) */
-  whenFalseEvents?: ConditionalBranchEvent[]
+  whenTrue: LoopChildBranchSummary
+  whenFalse: LoopChildBranchSummary
 }
 
 export interface TopLevelLoop extends LoopCore {


### PR DESCRIPTION
## Summary

**4/4** of a reactivity-refactor chain (stacked on #1013).

Collapse the eight parallel `whenTrueXxx` / `whenFalseXxx` fields on
`LoopChildConditional` into **one struct per branch**
(`LoopChildBranchSummary`), mirroring the top-level
`BranchSummary` / `ConditionalElement` pattern introduced in #1009.

### New shape

```ts
export interface LoopChildBranchSummary {
  childComponents: Array<{...}>
  innerLoops?: NestedLoop[]
  conditionals?: LoopChildConditional[]
  events?: ConditionalBranchEvent[]
}

export interface LoopChildConditional {
  slotId: string
  condition: string
  whenTrueHtml: string
  whenFalseHtml: string
  whenTrue: LoopChildBranchSummary
  whenFalse: LoopChildBranchSummary
}
```

### Producer

`collectLoopChildConditionals` delegates per-branch collection to a
new `summarizeLoopChildBranch` helper, collapsing the eight parallel
collection calls into two symmetric ones.

### Consumers

`emit-control-flow.ts` — 17 read sites mechanically rewritten from
`cond.whenTrueXxx` → `cond.whenTrue.xxx`.

## Why not reuse the top-level `BranchSummary` directly

`BranchSummary.childComponents` carries a pre-built `propsExpr: string`,
but in a loop-child branch the per-item `propsExpr` has to be assembled
inside the `mapArray` callback where the loop parameter is in scope —
so this layer needs raw `props` + `children`. Likewise `innerLoops`
(`NestedLoop`) and `conditionals` (recursive `LoopChildConditional`)
have loop-scoped types. Keeping them as a **sibling** type instead of
unifying with `BranchSummary` preserves those distinctions.

## Test plan

- [x] `bun test` (packages/jsx): 580 pass / 11 fail / 7 errors — unchanged from baseline
- [x] `tsgo --noEmit`: no type errors
- [x] Pure refactor — external behaviour unchanged

Chain base: #1013.

https://claude.ai/code/session_01D3EiEhDTFRRWnGVXoGybAM