### PR TITLE
fix(compiler): keep destructured .map() bindings reactive on same-key setItem (#951)

### DIFF
--- a/packages/client/__tests__/runtime/map-array.test.ts
+++ b/packages/client/__tests__/runtime/map-array.test.ts
@@ -384,16 +384,20 @@ describe('mapArray', () => {
     expect(container.children[1].textContent).toBe('C')
   })
 
-  // Pinning test for the #949 known limitation. The fix (see
-  // destructureLoopParam in emit-control-flow.ts) unwraps the accessor
-  // once at renderItem body entry, so destructured locals are captured
-  // at first render. mapArray skips renderItem for same-key setItem
-  // updates, which means the locals freeze — fine-grained reactivity
-  // through destructured bindings needs Option 3 (template-time
-  // rewriting to `__bfItem().path`), tracked in #951. This test locks
-  // the current behaviour in so the Option 3 PR must consciously flip
-  // it from green to red rather than silently changing semantics.
-  test('destructured locals captured once — frozen on same-key update (known limitation)', () => {
+  // #951 regression guard. Compiled output for a destructured `.map()`
+  // callback no longer emits `const [, b] = __bfItem()` at body entry —
+  // references to `b` are rewritten to `__bfItem()[1]` at IR emission
+  // time, so fine-grained effects read the live per-item accessor.
+  // mapArray still reuses the DOM node on same-key setItem updates, but
+  // effects registered inside renderItem re-run when the signal changes,
+  // so the DOM refreshes.
+  //
+  // This test mirrors the compiled output shape: no local destructure,
+  // effects read `__bfItem()[1]` directly. The predecessor pinning test
+  // locked in the pre-#951 captured-once semantics; flipping it here is
+  // intentional. See `jsx-to-ir.ts::extractLoopParamBindings` and
+  // `emit-control-flow.ts::destructureLoopParam`.
+  test('destructured locals refresh via signal accessor on same-key setItem (#951)', () => {
     const [items, setItems] = createSignal<[string, string][]>([['1', 'A']])
 
     mapArray(
@@ -401,33 +405,37 @@ describe('mapArray', () => {
       container,
       (item) => item[0],
       (__bfItem) => {
-        const [, b] = __bfItem()
         const li = document.createElement('li')
-        // Read `b` once — mirrors captured-semantics in compiled output.
-        li.setAttribute('data-b', b)
-        li.textContent = b
+        // Compiler-generated shape: each destructured reference becomes
+        // an `__bfItem().path` accessor read inside a createEffect.
+        // `bf-test-val` makes the assertion target clearly a barefoot-test
+        // marker, not a generic user attribute.
+        createEffect(() => {
+          li.setAttribute('bf-test-val', __bfItem()[1])
+          li.textContent = __bfItem()[1]
+        })
         return li
       },
     )
 
     const firstEl = container.children[0]
     expect(firstEl.textContent).toBe('A')
-    expect(firstEl.getAttribute('data-b')).toBe('A')
+    expect(firstEl.getAttribute('bf-test-val')).toBe('A')
 
-    // Same key '1', new inner value — mapArray fires setItem and
-    // reuses the DOM node, but `b` was captured on first render so
-    // the DOM attribute / text stay at the original value.
+    // Same key '1', new inner value — mapArray reuses the DOM node and
+    // fires setItem. The effects re-run because they read the per-item
+    // accessor, so the DOM text/attribute refresh to the new value.
     setItems([['1', 'B']])
 
     expect(container.children[0]).toBe(firstEl)
-    expect(firstEl.textContent).toBe('A')
-    expect(firstEl.getAttribute('data-b')).toBe('A')
+    expect(firstEl.textContent).toBe('B')
+    expect(firstEl.getAttribute('bf-test-val')).toBe('B')
 
-    // Array-level update (different key) produces a fresh renderItem
-    // call, so `b` is re-captured from the new value — this path works.
+    // Array-level update (different key) still produces a fresh
+    // renderItem call, so a new DOM node is created.
     setItems([['2', 'C']])
 
-    expect(container.children[0].getAttribute('data-b')).toBe('C')
+    expect(container.children[0].getAttribute('bf-test-val')).toBe('C')
     expect(container.children[0].textContent).toBe('C')
   })
 })

--- a/packages/jsx/src/__tests__/destructured-map-params.test.ts
+++ b/packages/jsx/src/__tests__/destructured-map-params.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for #951: destructured `.map()` callbacks rewrite binding
+ * references to `__bfItem().path` at IR emission time.
+ *
+ * Replaces the #950 body-entry unwrap (`const [, cfg] = __bfItem()`)
+ * which froze destructured locals at first render. With the rewrite,
+ * fine-grained effects read the per-item signal accessor, so same-key
+ * setItem updates refresh the DOM.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { ErrorCodes } from '../errors'
+
+const adapter = new TestAdapter()
+
+function compile(source: string, filename: string) {
+  return compileJSXSync(source, filename, { adapter })
+}
+
+function getClientJs(source: string, filename: string): string {
+  const result = compile(source, filename)
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('destructured .map() param rewriting (#951)', () => {
+  test('object destructure: references become __bfItem().property', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [todos, setTodos] = createSignal([{ id: '1', label: 'First', done: false }])
+        return (
+          <ul onClick={() => setTodos(prev => prev)}>
+            {todos().map(({ id, label, done }) => (
+              <li key={id} class={done ? 'done' : 'pending'}>{label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'TodoList.tsx')
+
+    // No entry-point unwrap
+    expect(js).not.toContain('const { id, label, done } = __bfItem();')
+    // Binding references rewritten to accessor paths
+    expect(js).toContain('__bfItem().label')
+    expect(js).toContain('__bfItem().done')
+    expect(js).toContain('__bfItem().id')
+  })
+
+  test('tuple destructure with hole: references become __bfItem()[index]', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const chartConfig = { a: { color: 'red' } }
+
+      export function Legend() {
+        const [, setFoo] = createSignal(0)
+        return (
+          <div onClick={() => setFoo(1)}>
+            {Object.entries(chartConfig).map(([, cfg]) => (
+              <span key={cfg.color}>{cfg.color}</span>
+            ))}
+          </div>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Legend.tsx')
+
+    expect(js).not.toContain('const [, cfg] = __bfItem();')
+    expect(js).toContain('__bfItem()[1].color')
+  })
+
+  test('tuple destructure with both elements: references use positional paths', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Pairs() {
+        const [pairs, setPairs] = createSignal<[string, number][]>([['a', 1]])
+        return (
+          <ul onClick={() => setPairs(p => p)}>
+            {pairs().map(([label, count]) => (
+              <li key={label}>{label}:{count}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Pairs.tsx')
+
+    expect(js).toContain('__bfItem()[0]')
+    expect(js).toContain('__bfItem()[1]')
+    expect(js).not.toContain('const [label, count] = __bfItem();')
+  })
+
+  test('renamed object destructure: path uses the property key, not the local name', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Aliased() {
+        const [items, setItems] = createSignal([{ foo: 'A' }])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ foo: bar }) => (
+              <li key={bar}>{bar}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Aliased.tsx')
+
+    // The local name `bar` is rewritten to the item accessor's `.foo` path.
+    expect(js).toContain('__bfItem().foo')
+    expect(js).not.toContain('const { foo: bar } = __bfItem();')
+  })
+
+  test('nested destructure: path walks through intermediate keys', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Profiles() {
+        const [items, setItems] = createSignal([{ user: { name: 'Ada' } }])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ user: { name } }) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Profiles.tsx')
+
+    expect(js).toContain('__bfItem().user.name')
+    expect(js).not.toContain('const { user: { name } } = __bfItem();')
+  })
+
+  test('binding name appearing in a string literal is not rewritten', () => {
+    // The string-context-aware replacement in wrapLoopParamAsAccessor
+    // must leave bare occurrences inside single/double/backtick string
+    // literals alone.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Badges() {
+        const [items, setItems] = createSignal([{ label: 'A' }])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ label }) => (
+              <li key={label} title="label">{label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Badges.tsx')
+
+    // The title attribute value is a string literal "label" — must not be
+    // rewritten to "__bfItem().label".
+    expect(js).toContain('title="label"')
+    expect(js).toContain('__bfItem().label')
+  })
+
+  test('rest element in destructure raises BF025', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function RestUser() {
+        const [items, setItems] = createSignal<{ a: number; b: number }[]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ a, ...rest }) => (
+              <li key={a}>{a}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'RestUser.tsx')
+    const errs = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST)
+    expect(errs.length).toBe(1)
+    expect(errs[0].severity).toBe('error')
+  })
+
+  test('array rest element in destructure also raises BF025', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function RestTuple() {
+        const [items, setItems] = createSignal<[string, ...string[]][]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(([first, ...tail]) => (
+              <li key={first}>{first}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'RestTuple.tsx')
+    const errs = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST)
+    expect(errs.length).toBe(1)
+  })
+
+  test('event delegation lands on a plain local before destructuring (TDZ-safe)', () => {
+    // Pre-#951 shape was `const { id } = arr.find(item => String(id) === key)`,
+    // which throws a TDZ ReferenceError on the find callback's reference to
+    // the outer `id` (still being declared). With binding info available, the
+    // delegation emitter rewrites the key to use `item.<path>` and lands on a
+    // plain `__bfLoopItem` sentinel before destructuring.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ClickToggle() {
+        const [todos, setTodos] = createSignal([{ id: '1', label: 'a' }])
+        const toggle = (id: string) => setTodos(p => p)
+        return (
+          <ul>
+            {todos().map(({ id, label }) => (
+              <li key={id} onClick={() => toggle(id)}>{label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'ClickToggle.tsx')
+
+    // Key lookup runs under `item.id`, not under the binding name.
+    expect(js).toContain('String(item.id)')
+    // Sentinel local precedes the destructure — no TDZ.
+    expect(js).toContain('const __bfLoopItem =')
+    expect(js).toContain('const { id, label } = __bfLoopItem')
+    // The raw handler is preserved so `toggle(id)` closes over the local `id`.
+    expect(js).toContain('toggle(id)')
+  })
+
+  test('reactive attr inside destructured loop (issue #951 repro)', () => {
+    // Class attribute reads the destructured `done` binding. Before
+    // #951, the compiled createEffect read a frozen local captured at
+    // first render, so same-key `setItem` updates left the class stale.
+    // After #951, the effect reads `__bfItem().done` and refreshes.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggler() {
+        const [todos, setTodos] = createSignal([{ id: '1', done: false }])
+        return (
+          <ul>
+            {todos().map(({ id, done }) => (
+              <li key={id} class={done ? 'done' : ''}>{id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Toggler.tsx')
+
+    // Reactive class attribute reads the accessor for `done`.
+    expect(js).toContain('__bfItem().done')
+    // No body-entry unwrap.
+    expect(js).not.toContain('const { id, done } = __bfItem();')
+  })
+
+  test('mapPreamble in block-body callback rewrites binding refs', () => {
+    // Block-body `.map` callbacks put statements before the return in a
+    // `mapPreamble`. Those statements must also participate in the
+    // binding-path rewrite so locals they derive from the destructured
+    // bindings stay reactive.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Combined() {
+        const [items, setItems] = createSignal([{ label: 'A', value: '1' }])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ label, value }) => {
+              const combined = \`\${label}:\${value}\`
+              return <li key={value}>{combined}</li>
+            })}
+          </ul>
+        )
+      }
+    `
+    const js = getClientJs(source, 'Combined.tsx')
+
+    // In the CSR mapPreamble, `label` and `value` should be rewritten.
+    expect(js).toContain('__bfItem().label')
+    expect(js).toContain('__bfItem().value')
+  })
+})

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -187,15 +187,17 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).toContain('o.children')
   })
 
-  test('destructured map param now reconciles (#949 emitter fix)', () => {
+  test('destructured map param now reconciles (#949 emitter fix, #951 inline rewrite)', () => {
     // `mapArray` passes the item as a signal accessor (a function) to the
     // renderItem callback; destructuring a function would throw
     // "function is not iterable" at runtime. Before #949 the emitter
     // interpolated `elem.param` verbatim into the renderItem arrow head,
     // so this path was excluded from the #943 widening to avoid the
-    // crash. With #949 the emitter renames the param to a synthetic
-    // accessor and unwraps once at body entry, so destructured-param
-    // callbacks are safe to reconcile like any other dynamic array.
+    // crash. #950 introduced a synthetic-accessor renderItem head plus an
+    // entry-point unwrap (`const [, cfg] = __bfItem();`). #951 replaces
+    // that unwrap by rewriting each destructured binding reference to
+    // `__bfItem().path` at IR emission time, so fine-grained effects read
+    // the live per-item accessor on same-key setItem updates.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -216,10 +218,12 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
 
     const clientJs = getClientJs(source, 'Legend.tsx')
     // mapArray is emitted (widening now applies). renderItem uses the
-    // synthetic `__bfItem` param and unwraps at entry.
+    // synthetic `__bfItem` param; references to `cfg` are rewritten
+    // inline and no unwrap statement is emitted.
     expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('(__bfItem, ')
-    expect(clientJs).toContain('const [, cfg] = __bfItem();')
+    expect(clientJs).not.toContain('const [, cfg] = __bfItem();')
+    expect(clientJs).toContain('__bfItem()[1].color')
   })
 
   test('loop with child component on unrecognised-call array reconciles', () => {
@@ -248,12 +252,13 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).toContain('listOf()')
   })
 
-  test('typed destructured map param also reconciles (#949)', () => {
+  test('typed destructured map param also reconciles (#949, #951)', () => {
     // TypeScript type annotations on the binding pattern live in
     // `firstParam.type`, not `firstParam.name`. The emitter extracts
     // `param` from `firstParam.name.getText()`, so a typed destructure
-    // still yields `param = "[, cfg]"`. Once #949 landed, the
-    // destructureLoopParam helper picks up both plain and typed forms.
+    // still yields `param = "[, cfg]"`. The #951 IR rewriter walks the
+    // same AST binding name, so type annotations don't disrupt
+    // binding-path extraction.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -276,16 +281,18 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     const clientJs = getClientJs(source, 'TypedLegend.tsx')
     expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('(__bfItem, ')
-    expect(clientJs).toContain('const [, cfg] = __bfItem();')
+    expect(clientJs).not.toContain('const [, cfg] = __bfItem();')
+    expect(clientJs).toContain('__bfItem()[1].color')
   })
 
-  test('object-destructured map param on signal array reconciles (#949)', () => {
+  test('object-destructured map param on signal array reconciles (#949, #951)', () => {
     // Object-pattern destructure on a signal array. Before #949 this
     // produced `({ label, value }, __idx, __existing) =>` as the
     // renderItem head, and mapArray's accessor contract meant the
-    // destructure tried to unpack a function at hydration. With the
-    // emitter fix, the synthetic accessor + entry unwrap keeps the
-    // destructured bindings in scope for the template body.
+    // destructure tried to unpack a function at hydration. #951 drops
+    // the body-entry unwrap and rewrites every `label` / `value`
+    // reference to `__bfItem().label` / `__bfItem().value` so same-key
+    // setItem updates refresh the DOM.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -305,6 +312,8 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     const clientJs = getClientJs(source, 'Fields.tsx')
     expect(clientJs).toContain('mapArray(')
     expect(clientJs).toContain('(__bfItem, ')
-    expect(clientJs).toContain('const { label, value } = __bfItem();')
+    expect(clientJs).not.toContain('const { label, value } = __bfItem();')
+    expect(clientJs).toContain('__bfItem().label')
+    expect(clientJs).toContain('__bfItem().value')
   })
 })

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -30,6 +30,7 @@ export const ErrorCodes = {
   INVALID_JSX_ATTRIBUTE: 'BF022',
   MISSING_KEY_IN_LIST: 'BF023',
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
+  UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
   // Type errors (BF030-BF039)
   TYPE_INFERENCE_FAILED: 'BF030',
@@ -81,6 +82,8 @@ const errorMessages: Record<ErrorCode, string> = {
     'Missing key attribute in list rendering. Add a key prop for efficient updates',
   [ErrorCodes.MISSING_KEY_IN_NESTED_LIST]:
     'Nested .map() loop requires key attribute for event delegation. Add a key prop to elements in the inner loop',
+  [ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST]:
+    'Rest element or computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
   [ErrorCodes.TYPE_INFERENCE_FAILED]: 'Failed to infer type',
   [ErrorCodes.PROPS_TYPE_MISMATCH]: 'Props type mismatch',

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -145,7 +145,11 @@ export function collectInnerLoops(
         const emitDepth = fixedDepth ?? scope.depth + 1
         // Generate item template for CSR rendering in mapArray.
         // Pass loopParams so expressions are wrapped at generation time (not post-hoc regex).
-        const loopParamsForTemplate = outerLoopParam ? [outerLoopParam, n.param] : undefined
+        // Forward destructured bindings (#951) so inner-loop template
+        // references to the destructured locals are rewritten.
+        const loopParamsForTemplate = outerLoopParam
+          ? [outerLoopParam, { param: n.param, bindings: n.paramBindings }]
+          : undefined
         const template = n.children.map(c => irToPlaceholderTemplate(c, undefined, emitDepth, loopParamsForTemplate)).join('')
         // Check if array expression references the outer loop param
         const refsOuter = outerLoopParam
@@ -155,7 +159,7 @@ export function collectInnerLoops(
         const innerReactiveTexts: Array<{ slotId: string; expression: string }> = []
         if (refsOuter && ctx) {
           for (const child of n.children) {
-            innerReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
+            innerReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings))
           }
         }
 
@@ -201,6 +205,7 @@ export function collectInnerLoops(
               ctx,
               siblingOffsets,
               n.param,
+              n.paramBindings,
             )
             if (conds.length > 0) childConditionals = conds
           }
@@ -211,6 +216,7 @@ export function collectInnerLoops(
           depth: emitDepth,
           array: n.array,
           param: n.param,
+          paramBindings: n.paramBindings,
           key: n.key,
           containerSlotId: scope.parentSlotId,
           template,
@@ -452,9 +458,9 @@ export function collectElements(
       for (const child of l.children) {
         childHandlers.push(...collectEventHandlersFromIR(child))
         childEvents.push(...collectLoopChildEventsWithNesting(child))
-        childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, l.param))
-        childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, l.param))
-        childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, l.param))
+        childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, l.param, l.paramBindings))
+        childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, l.param, l.paramBindings))
+        childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, l.param, l.paramBindings))
       }
 
       if (l.childComponent) {
@@ -474,9 +480,12 @@ export function collectElements(
       } else if (l.children[0]) {
         // Pass loopParams so expressions are wrapped at generation time,
         // avoiding post-hoc regex wrapping that corrupts literal attribute values.
+        // Forward destructured bindings (#951) so references like `cfg.color`
+        // in the emitted template literal are rewritten to `__bfItem()[1].color`.
+        const loopParamSpec = [{ param: l.param, bindings: l.paramBindings }]
         template = useElementReconciliation
-          ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0, [l.param])
-          : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0, [l.param])
+          ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0, loopParamSpec)
+          : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0, loopParamSpec)
       }
 
       ctx.loopElements.push({
@@ -484,6 +493,7 @@ export function collectElements(
         slotId: l.slotId,
         array: l.array,
         param: l.param,
+        paramBindings: l.paramBindings,
         index: l.index,
         key: l.key,
         template,
@@ -707,10 +717,11 @@ function collectBranchLoops(
       // keeping the template consistent with reactive effect expressions that
       // use `param()` to read the current item value.
       let childTemplate: string
+      const branchLoopParamSpec = [{ param: n.param, bindings: n.paramBindings }]
       if (useElementReconciliation && n.children[0]) {
-        childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0, [n.param])
+        childTemplate = irToPlaceholderTemplate(n.children[0], restNames, 0, branchLoopParamSpec)
       } else {
-        childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0, [n.param])).join('')
+        childTemplate = n.children.map(c => irToHtmlTemplate(c, undefined, 0, branchLoopParamSpec)).join('')
       }
 
       // Collect child events, reactive texts/attrs, and conditionals for ALL
@@ -725,9 +736,9 @@ function collectBranchLoops(
       if (ctx) {
         for (const child of n.children) {
           childEvents.push(...collectLoopChildEventsWithNesting(child))
-          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param))
-          childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param))
-          childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, n.param))
+          childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, n.param, n.paramBindings))
+          childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings))
+          childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, n.param, n.paramBindings))
         }
       }
 
@@ -735,6 +746,7 @@ function collectBranchLoops(
         kind: 'branch',
         array: n.array,
         param: n.param,
+        paramBindings: n.paramBindings,
         index: n.index,
         key: n.key,
         template: childTemplate,
@@ -840,8 +852,22 @@ export function collectLoopChildConditionals(
   ctx: ClientJsContext,
   siblingOffsets: Map<IRLoop, number>,
   loopParam?: string,
+  loopParamBindings?: readonly import('../types').LoopParamBinding[],
 ): LoopChildConditional[] {
   const conditionals: LoopChildConditional[] = []
+
+  // Widen the source-level "references loop param" check so destructured
+  // callbacks fire too — the pattern text `[, cfg]` never word-matches on
+  // bare `cfg` but individual binding names do (#951).
+  const refsAnyBinding = (expr: string): boolean => {
+    if (loopParamBindings && loopParamBindings.length > 0) {
+      for (const b of loopParamBindings) {
+        if (exprReferencesIdent(expr, b.name)) return true
+      }
+      return false
+    }
+    return loopParam ? exprReferencesIdent(expr, loopParam) : false
+  }
 
   walkIR(node, null, {
     // element / fragment / component / provider auto-descend with same scope.
@@ -853,16 +879,18 @@ export function collectLoopChildConditionals(
       // inside branches will be handled by insert()'s own bindEvents.
       // Non-reactive, non-loop-param conditionals are ignored entirely.
       if (!n.slotId) return
-      const refsLoopParamInSource = loopParam ? exprReferencesIdent(n.condition, loopParam) : false
+      const refsLoopParamInSource = refsAnyBinding(n.condition)
       // Pre-gate using AST `reactive` flag on the source condition before
       // paying for constant expansion — matches the legacy short-circuit.
       if (!n.reactive && !refsLoopParamInSource) return
       const expanded = expandConstantForReactivity(n.condition, ctx)
       // Loop-param conditionals are reactive via per-item signal accessors;
       // classifyReactivity sees both paths (signal/memo/prop + loop-param).
-      if (classifyReactivity(expanded, ctx, loopParam).kind === 'none') return
+      if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') return
 
-      const loopParamsForCond = loopParam ? [loopParam] : undefined
+      const loopParamsForCond = loopParam
+        ? [{ param: loopParam, bindings: loopParamBindings }]
+        : undefined
       const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
       const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
       conditionals.push({
@@ -870,8 +898,8 @@ export function collectLoopChildConditionals(
         condition: expanded,
         whenTrueHtml,
         whenFalseHtml,
-        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam),
-        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam),
+        whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings),
+        whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings),
       })
     },
   })
@@ -891,12 +919,13 @@ function summarizeLoopChildBranch(
   ctx: ClientJsContext,
   siblingOffsets: Map<IRLoop, number>,
   loopParam?: string,
+  loopParamBindings?: readonly import('../types').LoopParamBinding[],
 ): LoopChildBranchSummary {
   const inner = collectInnerLoops([node], siblingOffsets, loopParam, ctx, branchInnerLoopOptions)
   return {
     childComponents: collectConditionalBranchChildComponents(node),
     innerLoops: inner.length > 0 ? inner : undefined,
-    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam),
+    conditionals: collectLoopChildConditionals(node, ctx, siblingOffsets, loopParam, loopParamBindings),
     events: collectConditionalBranchEvents(node),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -5,8 +5,8 @@
  */
 
 import type { ClientJsContext, ConditionalBranchEvent, BranchLoop, BranchSummary, ConditionalElement, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
-import type { IRLoopChildComponent } from '../types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
+import type { IRLoopChildComponent, LoopParamBinding } from '../types'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent, substituteLoopBindings } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 
@@ -25,14 +25,31 @@ function loopKeyFn(loop: CollectedLoop): string {
 }
 
 /**
+ * Return true when `expr` references the loop's param — either the simple
+ * identifier itself, or any of its destructured binding names (#951). The
+ * pattern text (e.g. `[, cfg]`) never word-matches on a bare name, so the
+ * simple `exprReferencesIdent(expr, elem.param)` check misses destructured
+ * callbacks without this widening.
+ */
+function exprRefsLoopBinding(expr: string, loop: { param: string; paramBindings?: readonly LoopParamBinding[] }): boolean {
+  if (loop.paramBindings && loop.paramBindings.length > 0) {
+    for (const b of loop.paramBindings) {
+      if (exprReferencesIdent(expr, b.name)) return true
+    }
+    return false
+  }
+  return exprReferencesIdent(expr, loop.param)
+}
+
+/**
  * Compute the mapArray renderItem parameter head and any unwrap statement
- * needed when the map callback destructures its item parameter (#949).
+ * needed when the map callback destructures its item parameter.
  *
  * mapArray passes the item to renderItem as a signal accessor (function).
  * Interpolating `[a, b]` or `{ x, y }` verbatim into the arrow head crashes
- * at hydration with "function is not iterable". We rename the param to a
- * synthetic accessor name and unwrap once at body entry, so destructured
- * bindings become plain locals that the rest of the emitted body can read.
+ * at hydration with "function is not iterable" (#949). We rename the param
+ * to a synthetic accessor name and — for patterns the IR rewriter can't
+ * fully express as per-binding accessor paths — unwrap once at body entry.
  *
  * The `__bf_` prefix is a barefoot-reserved namespace — avoids any chance
  * of collision if the user writes `.map(item => ...)` with a matching name.
@@ -43,17 +60,23 @@ function loopKeyFn(loop: CollectedLoop): string {
  * upstream contract changes, the prefix check must be widened in lockstep
  * or the #949 crash resurfaces silently.
  *
- * Known limitation: destructured locals are captured at first render and
- * will not refresh on same-key setItem updates. Array-level updates (add /
- * remove / reorder / key change) work correctly because a new renderItem
- * call produces fresh locals. Same-key fine-grained reactivity through
- * destructured bindings requires template-time rewriting of binding
- * references to `__bfItem().path` — tracked in #951 (Option 3 follow-up).
- * See the pinning test in `map-array.test.ts::destructured locals
- * captured once — frozen on same-key update (known limitation)`.
+ * Option 3 path (#951): when `paramBindings` is supplied, every
+ * destructured reference has already been rewritten to `__bfItem().path`
+ * in template strings, event handlers, reactive attrs, and preambles. No
+ * body-entry unwrap is emitted — the destructured locals simply don't
+ * exist in the generated code, so same-key `setItem` updates read the
+ * live accessor and refresh the DOM. When `paramBindings` is missing
+ * (rest element, computed property key — see `BF025`), we fall back to
+ * the original unwrap so the captured-semantics path still compiles.
  */
-function destructureLoopParam(param: string): { head: string; unwrap: string } {
+function destructureLoopParam(
+  param: string,
+  paramBindings?: readonly LoopParamBinding[],
+): { head: string; unwrap: string } {
   if (param.startsWith('[') || param.startsWith('{')) {
+    if (paramBindings && paramBindings.length > 0) {
+      return { head: '__bfItem', unwrap: '' }
+    }
     return {
       head: '__bfItem',
       unwrap: `const ${param} = __bfItem();`,
@@ -147,7 +170,7 @@ function emitBranchBindings(
           || (loop.childReactiveTexts?.length ?? 0) > 0
           || (loop.childConditionals?.length ?? 0) > 0
 
-        const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param)
+        const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
         const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
 
         if (!hasReactiveEffects) {
@@ -179,6 +202,7 @@ function emitBranchBindings(
             loop.childReactiveTexts ?? [],
             loop.childConditionals,
             loop.param,
+            loop.paramBindings,
           )
           lines.push(`        return __el`)
           lines.push(`      })`)
@@ -262,7 +286,7 @@ function emitCompositeBranchLoop(
 
   const keyFn = loopKeyFn(loop)
 
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
 
   // Wrap everything in a disposable effect for branch cleanup
   // Clear template-generated children so mapArray creates fresh elements
@@ -344,8 +368,9 @@ function emitBranchChildComponentInits(
   components: Array<{ name: string; slotId: string | null; props: import('../types').IRProp[]; children?: import('../types').IRNode[] }>,
   loopParam?: string,
   wrapFn?: (expr: string) => string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): void {
-  const wrap = wrapFn ?? (loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr)
+  const wrap = wrapFn ?? (loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr)
   for (const comp of components) {
     // Use slotId suffix match only when available to avoid matching
     // siblings of the same component type (e.g. two Buttons with different slotIds).
@@ -385,9 +410,10 @@ function emitBranchInnerLoops(
   innerLoops: import('./types').NestedLoop[] | undefined,
   outerLoopParam?: string,
   outerWrapFn?: (expr: string) => string,
+  outerLoopParamBindings?: readonly LoopParamBinding[],
 ): void {
   if (!innerLoops || !outerLoopParam) return
-  const wrapOuter = outerWrapFn ?? ((expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam))
+  const wrapOuter = outerWrapFn ?? ((expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam, outerLoopParamBindings))
 
   for (let i = 0; i < innerLoops.length; i++) {
     const inner = innerLoops[i]
@@ -396,7 +422,7 @@ function emitBranchInnerLoops(
     const uid = `br_${i}`
     const arrayExpr = wrapOuter(inner.array)
     const keyFn = loopKeyFn(inner)
-    const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param)
+    const wrapBoth = (expr: string) => wrapLoopParamAsAccessor(wrapOuter(expr), inner.param, inner.paramBindings)
     // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
     const wrappedTemplate = inner.template
     // Find the container for the inner loop. Try bf= attribute (plain elements) first,
@@ -406,7 +432,7 @@ function emitBranchInnerLoops(
       ? `(${scopeVar}.querySelector('[bf="${csl}"]') ?? ${scopeVar}.querySelector('[bf-s$="_${csl}"]') ?? ${scopeVar})`
       : scopeVar
 
-    const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param)
+    const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param, inner.paramBindings)
 
     lines.push(`${indent}{ const __bic${uid} = ${containerExpr}`)
     lines.push(`${indent}if (__bic${uid}) mapArray(() => ${arrayExpr} || [], __bic${uid}, ${keyFn}, (${innerHead}, __bidx${uid}, __existing) => {`)
@@ -415,11 +441,11 @@ function emitBranchInnerLoops(
     }
     lines.push(`${indent}  let __bel${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
     if (inner.key) {
-      const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
+      const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param, inner.paramBindings)
       lines.push(`${indent}  __bel${uid}.setAttribute('${keyAttrName(1)}', String(${wrappedKey}))`)
     }
     // Components and events inside inner loop items
-    const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
+    const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param, inner.paramBindings)
     // Recursively wrap IR nodes for inner loop param accessor conversion
     const wrapIRNodeBranch = (node: any): any => {
       if (node.type === 'component') {
@@ -440,9 +466,9 @@ function emitBranchInnerLoops(
     }))
     if (comps.length > 0 || events.length > 0) {
       lines.push(`${indent}  if (!__existing) {`)
-      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'csr', outerLoopParam)
+      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'csr', outerLoopParam, outerLoopParamBindings)
       lines.push(`${indent}  } else {`)
-      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'ssr', outerLoopParam)
+      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'ssr', outerLoopParam, outerLoopParamBindings)
       lines.push(`${indent}  }`)
     }
     // Reactive text effects for inner loop items
@@ -516,6 +542,7 @@ function emitNestedLoopChildConditionals(
   conditionals: LoopChildConditional[] | undefined,
   wrap: (expr: string) => string,
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): void {
   if (!conditionals || conditionals.length === 0) return
   for (const cond of conditionals) {
@@ -525,17 +552,17 @@ function emitNestedLoopChildConditionals(
     lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
     emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrue.events, wrap)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam, wrap)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam, wrap)
-    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam, wrap, loopParamBindings)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam, wrap, loopParamBindings)
+    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam, loopParamBindings)
     lines.push(`${indent}  }`)
     lines.push(`${indent}}, {`)
     lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
     lines.push(`${indent}  bindEvents: (__branchScope) => {`)
     emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalse.events, wrap)
-    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam, wrap)
-    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam, wrap)
-    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam)
+    emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam, wrap, loopParamBindings)
+    emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam, wrap, loopParamBindings)
+    emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam, loopParamBindings)
     lines.push(`${indent}  }`)
     lines.push(`${indent}})`)
   }
@@ -549,8 +576,9 @@ function emitLoopChildReactiveEffects(
   texts: TopLevelLoop['childReactiveTexts'],
   conditionals?: TopLevelLoop['childConditionals'],
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): void {
-  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr
+  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr
   // Reactive attribute effects
   const attrsBySlot = new Map<string, typeof attrs>()
   for (const attr of attrs) {
@@ -608,9 +636,9 @@ function emitLoopChildReactiveEffects(
       lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
       emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrue.events, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam, undefined, loopParamBindings)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam, undefined, loopParamBindings)
+      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam, loopParamBindings)
       for (const text of textsForBranch(cond.whenTrueHtml)) {
         const varName = `__rt_${varSlotId(text.slotId)}`
         lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
@@ -621,9 +649,9 @@ function emitLoopChildReactiveEffects(
       lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
       lines.push(`${indent}  bindEvents: (__branchScope) => {`)
       emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalse.events, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam)
+      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam, undefined, loopParamBindings)
+      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam, undefined, loopParamBindings)
+      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam, loopParamBindings)
       for (const text of textsForBranch(cond.whenFalseHtml)) {
         const varName = `__rt_${varSlotId(text.slotId)}`
         lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
@@ -756,8 +784,9 @@ function emitDynamicLoopUpdates(lines: string[], elem: TopLevelLoop): void {
 function buildComponentPropsExpr(
   comp: { props: Array<{ name: string; value: string; isEventHandler: boolean; isLiteral: boolean }>, children?: import('../types').IRNode[] },
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): string {
-  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr
+  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr
   const entries = comp.props.map((p) => {
     if (p.isEventHandler) {
       return `${quotePropName(p.name)}: ${wrap(p.value)}`
@@ -782,12 +811,12 @@ function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, ke
   const { name } = elem.childComponent!
   const vLoop = varSlotId(elem.slotId)
   const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
-  const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param)
+  const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param, elem.paramBindings)
   const indexParam = elem.index || '__idx'
   const chainedExpr = buildChainedArrayExpr(elem)
   // Only init components at loopDepth 0 — inner-loop components are handled by their own loop
   const nestedComps = (elem.nestedComponents ?? []).filter(c => !c.loopDepth)
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
 
   lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
   if (pUnwrap) {
@@ -810,7 +839,7 @@ function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, ke
       const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
       const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
       if (childrenRefsLoop) {
-        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param)
+        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param, elem.paramBindings)
         lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
         lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
@@ -818,7 +847,7 @@ function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, ke
     }
     // Emit reactive effects for conditionals/texts inside component children
     if (elem.childConditionals && elem.childConditionals.length > 0) {
-      emitLoopChildReactiveEffects(lines, '      ', '__existing', [], [], elem.childConditionals, elem.param)
+      emitLoopChildReactiveEffects(lines, '      ', '__existing', [], [], elem.childConditionals, elem.param, elem.paramBindings)
     }
     lines.push(`      return __existing`)
     lines.push(`    }`)
@@ -832,14 +861,14 @@ function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, ke
       const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
       const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
       if (childrenRefsLoop) {
-        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param)
+        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param, elem.paramBindings)
         lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
       } else {
         lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
       }
     }
     if (elem.childConditionals && elem.childConditionals.length > 0) {
-      emitLoopChildReactiveEffects(lines, '    ', '__csrEl', [], [], elem.childConditionals, elem.param)
+      emitLoopChildReactiveEffects(lines, '    ', '__csrEl', [], [], elem.childConditionals, elem.param, elem.paramBindings)
     }
     lines.push(`    return __csrEl`)
   } else {
@@ -886,12 +915,12 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop,
   const vLoop = varSlotId(elem.slotId)
   const chainedExpr = buildChainedArrayExpr(elem)
   const indexParam = elem.index || '__idx'
-  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param)
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
 
   const hasReactiveEffects = elem.childReactiveAttrs.length > 0
     || elem.childReactiveTexts.length > 0
     || (elem.childConditionals?.length ?? 0) > 0
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
   const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
 
   if (!hasReactiveEffects) {
@@ -910,7 +939,7 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop,
     }
     // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
     lines.push(`    const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
-    emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts, elem.childConditionals, elem.param)
+    emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts, elem.childConditionals, elem.param, elem.paramBindings)
     lines.push(`    return __el`)
     lines.push(`  })`)
   }
@@ -919,19 +948,39 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop,
 /** Emit event delegation for dynamic (non-static) loop child events. */
 function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): void {
   const vLoop = varSlotId(elem.slotId)
+  const hasBindings = (elem.paramBindings?.length ?? 0) > 0
 
   if (elem.key) {
-    // Dynamic keyed: find item by data-key attribute
-    const keyWithItem = elem.key.replace(new RegExp(`\\b${elem.param}\\b`, 'g'), 'item')
+    // Dynamic keyed: find item by data-key attribute.
+    // For destructured `.map(({ id }) => ...)`, the raw regex replace below
+    // can't reach binding names (the pattern text `{ id }` never word-matches
+    // on `id`), so we substitute bindings with `item.<path>` directly (#951).
+    const keyWithItem = hasBindings
+      ? substituteLoopBindings(elem.key, elem.paramBindings!, 'item')
+      : elem.key.replace(new RegExp(`\\b${elem.param}\\b`, 'g'), 'item')
     emitLoopEventDelegation(lines, `_${vLoop}`, elem.childEvents, (ls, ev, handlerCall) => {
       if (ev.nestedLoops.length === 0) {
-        // Direct child of outer loop — single-level lookup
+        // Direct child of outer loop — single-level lookup.
+        // For destructured outer param, `const { id } = arr.find(item => ...)`
+        // would throw a TDZ ReferenceError if the find callback references the
+        // outer `id` while the `const` is still being declared. Land on a
+        // plain `__bfLoopItem` local first, then destructure once the lookup
+        // is done (#951).
         ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
         ls.push(`      if (li) {`)
         ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
-        ls.push(`        const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
-        if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
-        ls.push(`        if (${elem.param}) ${handlerCall}`)
+        if (hasBindings) {
+          ls.push(`        const __bfLoopItem = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
+          ls.push(`        if (__bfLoopItem) {`)
+          ls.push(`          const ${elem.param} = __bfLoopItem`)
+          if (elem.mapPreamble) ls.push(`          ${elem.mapPreamble}`)
+          ls.push(`          ${handlerCall}`)
+          ls.push(`        }`)
+        } else {
+          ls.push(`        const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
+          if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
+          ls.push(`        if (${elem.param}) ${handlerCall}`)
+        }
         ls.push(`      }`)
       } else {
         // Nested loop event — multi-level data-key-N resolution
@@ -945,19 +994,32 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): vo
         // Resolve outer loop key
         ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
         ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
-        // Resolve outer loop variable
-        ls.push(`      const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
-        // Resolve inner loop variables via the outer param's nested array
+        // Resolve outer loop variable — TDZ-safe for destructured params.
+        if (hasBindings) {
+          ls.push(`      const __bfLoopItem = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
+          ls.push(`      const ${elem.param} = __bfLoopItem ?? ({})`)
+        } else {
+          ls.push(`      const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
+        }
+        // Resolve inner loop variables via the outer param's nested array.
+        // Destructured inner params get the same `substituteLoopBindings`
+        // treatment; otherwise fall through to the legacy regex replace.
         for (const nested of ev.nestedLoops) {
           // `nested.key` can be null for unkeyed loops; coerce to '' so the
           // resolution silently no-ops (String('') never matches a real
           // key), matching prior behavior when NestedLoop.key was
           // always a string defaulting to ''.
-          const innerKeyExpr = (nested.key ?? '').replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
-          ls.push(`      const ${nested.param} = ${elem.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
+          const rawKey = nested.key ?? ''
+          const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
+            ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
+            : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+          const outerRef = hasBindings ? '__bfLoopItem' : elem.param
+          ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
         }
-        // Guard all resolved variables
-        const allParams = [elem.param, ...ev.nestedLoops.map(n => n.param)]
+        // Guard all resolved variables — for destructured outer we use the
+        // __bfLoopItem sentinel because the pattern text itself isn't truthy-testable.
+        const outerGuard = hasBindings ? '__bfLoopItem' : elem.param
+        const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
         if (elem.mapPreamble) ls.push(`      ${elem.mapPreamble}`)
         ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
       }
@@ -968,9 +1030,18 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): vo
       ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
       ls.push(`      if (li && li.parentElement) {`)
       ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
-      ls.push(`        const ${elem.param} = ${elem.array}[idx]`)
-      if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
-      ls.push(`        if (${elem.param}) ${handlerCall}`)
+      if (hasBindings) {
+        ls.push(`        const __bfLoopItem = ${elem.array}[idx]`)
+        ls.push(`        if (__bfLoopItem) {`)
+        ls.push(`          const ${elem.param} = __bfLoopItem`)
+        if (elem.mapPreamble) ls.push(`          ${elem.mapPreamble}`)
+        ls.push(`          ${handlerCall}`)
+        ls.push(`        }`)
+      } else {
+        ls.push(`        const ${elem.param} = ${elem.array}[idx]`)
+        if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
+        ls.push(`        if (${elem.param}) ${handlerCall}`)
+      }
       ls.push(`      }`)
     })
   }
@@ -983,18 +1054,31 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): vo
 function emitBranchLoopEventDelegation(lines: string[], loop: BranchLoop, cv: string): void {
   const containerVar = `__loop_${cv}`
   const childEvents = loop.childEvents
+  const hasBindings = (loop.paramBindings?.length ?? 0) > 0
 
   if (loop.key) {
-    // Keyed: find item by data-key attribute
-    const keyWithItem = loop.key.replace(new RegExp(`\\b${loop.param}\\b`, 'g'), 'item')
+    // Keyed: find item by data-key attribute. See emitDynamicLoopEventDelegation
+    // for the destructured-param TDZ-safe shape (#951).
+    const keyWithItem = hasBindings
+      ? substituteLoopBindings(loop.key, loop.paramBindings!, 'item')
+      : loop.key.replace(new RegExp(`\\b${loop.param}\\b`, 'g'), 'item')
     emitLoopEventDelegation(lines, containerVar, childEvents, (ls, ev, handlerCall) => {
       if (ev.nestedLoops.length === 0) {
         ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
         ls.push(`      if (li) {`)
         ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
-        ls.push(`        const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
-        if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
-        ls.push(`        if (${loop.param}) ${handlerCall}`)
+        if (hasBindings) {
+          ls.push(`        const __bfLoopItem = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
+          ls.push(`        if (__bfLoopItem) {`)
+          ls.push(`          const ${loop.param} = __bfLoopItem`)
+          if (loop.mapPreamble) ls.push(`          ${loop.mapPreamble}`)
+          ls.push(`          ${handlerCall}`)
+          ls.push(`        }`)
+        } else {
+          ls.push(`        const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
+          if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
+          ls.push(`        if (${loop.param}) ${handlerCall}`)
+        }
         ls.push(`      }`)
       } else {
         // Nested loop event — multi-level data-key-N resolution
@@ -1006,13 +1090,23 @@ function emitBranchLoopEventDelegation(lines: string[], loop: BranchLoop, cv: st
         }
         ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
         ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
-        ls.push(`      const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
+        if (hasBindings) {
+          ls.push(`      const __bfLoopItem = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
+          ls.push(`      const ${loop.param} = __bfLoopItem ?? ({})`)
+        } else {
+          ls.push(`      const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
+        }
         for (const nested of ev.nestedLoops) {
           // See sibling comment above — `nested.key` may be null.
-          const innerKeyExpr = (nested.key ?? '').replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
-          ls.push(`      const ${nested.param} = ${loop.param} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
+          const rawKey = nested.key ?? ''
+          const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
+            ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
+            : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+          const outerRef = hasBindings ? '__bfLoopItem' : loop.param
+          ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
         }
-        const allParams = [loop.param, ...ev.nestedLoops.map(n => n.param)]
+        const outerGuard = hasBindings ? '__bfLoopItem' : loop.param
+        const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
         if (loop.mapPreamble) ls.push(`      ${loop.mapPreamble}`)
         ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
       }
@@ -1023,9 +1117,18 @@ function emitBranchLoopEventDelegation(lines: string[], loop: BranchLoop, cv: st
       ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
       ls.push(`      if (li && li.parentElement) {`)
       ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
-      ls.push(`        const ${loop.param} = ${loop.array}[idx]`)
-      if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
-      ls.push(`        if (${loop.param}) ${handlerCall}`)
+      if (hasBindings) {
+        ls.push(`        const __bfLoopItem = ${loop.array}[idx]`)
+        ls.push(`        if (__bfLoopItem) {`)
+        ls.push(`          const ${loop.param} = __bfLoopItem`)
+        if (loop.mapPreamble) ls.push(`          ${loop.mapPreamble}`)
+        ls.push(`          ${handlerCall}`)
+        ls.push(`        }`)
+      } else {
+        ls.push(`        const ${loop.param} = ${loop.array}[idx]`)
+        if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
+        ls.push(`        if (${loop.param}) ${handlerCall}`)
+      }
       ls.push(`      }`)
     })
   }
@@ -1078,8 +1181,8 @@ interface CompositeLoopContext {
 }
 
 /** Emit a single addEventListener call for a child event on a given element. */
-function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChildEvent, loopParam?: string): void {
-  let handler = loopParam ? wrapLoopParamAsAccessor(ev.handler, loopParam) : ev.handler
+function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChildEvent, loopParam?: string, loopParamBindings?: readonly LoopParamBinding[]): void {
+  let handler = loopParam ? wrapLoopParamAsAccessor(ev.handler, loopParam, loopParamBindings) : ev.handler
   handler = wrapHandlerInBlock(handler)
   ls.push(`${indent}{ const __e = qsa(${elVar}, '[bf="${ev.childSlotId}"]'); if (__e) __e.addEventListener('${toDomEventName(ev.eventName)}', ${handler}) }`)
 }
@@ -1117,10 +1220,11 @@ function emitComponentAndEventSetup(
   events: LoopChildEvent[],
   mode: 'csr' | 'ssr',
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): void {
-  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam) : (expr: string) => expr
+  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr
   for (const comp of comps) {
-    const propsExpr = buildComponentPropsExpr(comp, loopParam)
+    const propsExpr = buildComponentPropsExpr(comp, loopParam, loopParamBindings)
     // Check if children are text-equivalent and reference the loop param — if so,
     // emit a createEffect to reactively update textContent when the signal changes.
     // Text-equivalent: expression, text, or conditional with text-only branches.
@@ -1128,7 +1232,8 @@ function emitComponentAndEventSetup(
       ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
       : false
     const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
-    const childrenRefsLoop = loopParam != null && rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, loopParam)
+    const childrenRefsLoop = loopParam != null && rawChildrenExpr != null
+      && exprRefsLoopBinding(rawChildrenExpr, { param: loopParam, paramBindings: loopParamBindings })
     if (mode === 'csr') {
       const phId = comp.slotId || comp.name
       const keyProp = comp.props.find(p => p.name === 'key')
@@ -1154,7 +1259,7 @@ function emitComponentAndEventSetup(
     }
   }
   for (const ev of events) {
-    emitEventSetup(ls, indent, elVar, ev, loopParam)
+    emitEventSetup(ls, indent, elVar, ev, loopParam, loopParamBindings)
   }
 }
 
@@ -1165,7 +1270,8 @@ function emitComponentAndEventSetup(
  */
 function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: CompositeLoopContext): void {
   const param = ctx.elem.param
-  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, param)
+  const paramBindings = ctx.elem.paramBindings
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, param, paramBindings)
 
   // Exclude components inside reactive conditionals — managed by insert()
   const condCompSlotIds = new Set<string>()
@@ -1190,25 +1296,25 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
   ls.push(`${indent}if (__existing) {`)
   ls.push(`${indent}  __el = __existing`)
   // SSR: initialize nested components via initChild
-  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'ssr', param)
+  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'ssr', param, paramBindings)
   // SSR: inner loop initialization
-  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'ssr', param)
+  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'ssr', param, paramBindings)
   ls.push(`${indent}} else {`)
   // CSR: create element from template, replace placeholders with createComponent
   ls.push(`${indent}  const __tpl = document.createElement('template')`)
   // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
   ls.push(`${indent}  __tpl.innerHTML = \`${ctx.elem.template}\``)
   ls.push(`${indent}  __el = __tpl.content.firstElementChild.cloneNode(true)`)
-  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'csr', param)
+  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'csr', param, paramBindings)
   // CSR: inner loop initialization
-  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'csr', param)
+  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'csr', param, paramBindings)
   ls.push(`${indent}}`)
 
   const reactiveAttrs = ctx.elem.childReactiveAttrs ?? []
   const reactiveTexts = ctx.elem.childReactiveTexts ?? []
   const reactiveConditionals = ctx.elem.childConditionals ?? []
   if (reactiveAttrs.length > 0 || reactiveTexts.length > 0 || reactiveConditionals.length > 0) {
-    emitLoopChildReactiveEffects(ls, indent, '__el', reactiveAttrs, reactiveTexts, reactiveConditionals, param)
+    emitLoopChildReactiveEffects(ls, indent, '__el', reactiveAttrs, reactiveTexts, reactiveConditionals, param, paramBindings)
   }
 
   ls.push(`${indent}return __el`)
@@ -1227,9 +1333,10 @@ function emitInnerLoopSetup(
   levels: DepthLevel[],
   mode: 'csr' | 'ssr',
   outerLoopParam?: string,
+  outerLoopParamBindings?: readonly LoopParamBinding[],
 ): void {
   const wrapOuter = outerLoopParam
-    ? (expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam) : (expr: string) => expr
+    ? (expr: string) => wrapLoopParamAsAccessor(expr, outerLoopParam, outerLoopParamBindings) : (expr: string) => expr
   let i = 0
   while (i < levels.length) {
     const level = levels[i]
@@ -1259,7 +1366,7 @@ function emitInnerLoopSetup(
       const keyFn = loopKeyFn(inner)
       // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
       const wrappedTemplate = inner.template!
-      const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param)
+      const { head: innerHead, unwrap: innerUnwrap } = destructureLoopParam(inner.param, inner.paramBindings)
       ls.push(`${indent}// Reactive inner loop: ${inner.array}`)
       ls.push(`${indent}{ const __ic${uid} = ${containerSelector !== 'null' ? `qsa(${parentElVar}, ${containerSelector})` : parentElVar}`)
       ls.push(`${indent}if (__ic${uid}) mapArray(() => ${arrayExpr} || [], __ic${uid}, ${keyFn}, (${innerHead}, __innerIdx${uid}, __existing) => {`)
@@ -1270,7 +1377,7 @@ function emitInnerLoopSetup(
       ls.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
       if (inner.key) {
         // Inside renderItem, inner.param is an accessor
-        const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param)
+        const wrappedKey = wrapLoopParamAsAccessor(inner.key, inner.param, inner.paramBindings)
         ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${wrappedKey}))`)
       }
       // Set up components and events — wrap inner loop param as accessor
@@ -1279,7 +1386,7 @@ function emitInnerLoopSetup(
         // Children IR nodes must be wrapped recursively so nested component props
         // (e.g., SelectItem value inside SelectContent inside Select) also get
         // the inner loop param converted to signal accessor form.
-        const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param)
+        const wrapInner = (expr: string) => wrapLoopParamAsAccessor(expr, inner.param, inner.paramBindings)
         const wrapIRNode = (node: any): any => {
           if (node.type === 'component') {
             return {
@@ -1310,19 +1417,19 @@ function emitInnerLoopSetup(
           handler: wrapInner(ev.handler),
         }))
         ls.push(`${indent}  if (!__existing) {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'csr', outerLoopParam)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'csr', outerLoopParam, outerLoopParamBindings)
         ls.push(`${indent}  } else {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'ssr', outerLoopParam)
+        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'ssr', outerLoopParam, outerLoopParamBindings)
         ls.push(`${indent}  }`)
       }
       // Recurse for child levels
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam, outerLoopParamBindings)
       }
       // Reactive text effects for inner loop items
       if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
         for (const text of inner.childReactiveTexts) {
-          const wrappedExpr = wrapLoopParamAsAccessor(wrapOuter(text.expression), inner.param)
+          const wrappedExpr = wrapLoopParamAsAccessor(wrapOuter(text.expression), inner.param, inner.paramBindings)
           if (text.insideConditional) {
             // Text is inside a conditional branch: insert() may replace the DOM element,
             // making a captured text node stale. Re-query $t inside the effect so each
@@ -1347,10 +1454,10 @@ function emitInnerLoopSetup(
       if (inner.key) {
         ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
       }
-      emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam)
+      emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam, outerLoopParamBindings)
       // Recurse for child levels (nested deeper loops)
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam, outerLoopParamBindings)
       }
       ls.push(`${indent}}) }`)
     }
@@ -1384,7 +1491,7 @@ function emitCompositeElementReconciliation(
     depthLevels,
   }
 
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param)
+  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
   lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
   if (pUnwrap) {
     lines.push(`    ${pUnwrap}`)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -5,6 +5,7 @@
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, BF_LOOP_START, BF_LOOP_END, exprReferencesIdent, wrapExprWithLoopParams } from './utils'
+import type { LoopParamSpec } from './utils'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -59,7 +60,7 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
  *  @param loopDepth - Current nesting depth inside inner loops. 0 = outer loop level.
  *    When > 0, `key` attributes are converted to `data-key-{depth}` instead of `data-key`.
  */
-export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: string[]): string {
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>): string {
   const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
 
@@ -195,7 +196,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
  * elements (`<div data-bf-ph="sN"></div>`) instead of renderChild() calls.
  * The placeholders are replaced with real createComponent() elements at runtime.
  */
-export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: string[]): string {
+export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>): string {
   const recurse = (n: IRNode): string => irToPlaceholderTemplate(n, restSpreadNames, loopDepth, loopParams)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -2,7 +2,7 @@
  * Reactivity detection: reactive expression checking, event/ref collection.
  */
 
-import { type IRNode, type IRElement, type IRProp, pickAttrMeta } from '../types'
+import { type IRNode, type IRElement, type IRProp, type LoopParamBinding, pickAttrMeta } from '../types'
 import type {
   ClientJsContext,
   ConditionalBranchEvent,
@@ -163,13 +163,26 @@ export type ReactivitySource =
  * matching takes precedence so `loop-param` is reported even when the
  * expression also reads a signal — the `kind` is purely informational and
  * collectors only care about `kind !== 'none'`.
+ *
+ * For destructured `.map()` callbacks (#951), `loopParamBindings` lists each
+ * destructured binding name; any reference to one of those names is treated
+ * as a `loop-param` hit. The pattern text itself (e.g. `{ id, label }`)
+ * never word-matches on a bare binding like `id`, so the straight
+ * `loopParam` check misses destructured references without this widening.
  */
 export function classifyReactivity(
   expr: string,
   ctx: ClientJsContext,
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): ReactivitySource {
-  if (loopParam && exprReferencesIdent(expr, loopParam)) {
+  if (loopParamBindings && loopParamBindings.length > 0) {
+    for (const b of loopParamBindings) {
+      if (exprReferencesIdent(expr, b.name)) {
+        return { kind: 'loop-param', param: loopParam ?? b.name }
+      }
+    }
+  } else if (loopParam && exprReferencesIdent(expr, loopParam)) {
     return { kind: 'loop-param', param: loopParam }
   }
   if (needsEffectWrapper(expr, ctx)) {
@@ -409,6 +422,7 @@ export function collectLoopChildReactiveTexts(
   node: IRNode,
   ctx: ClientJsContext,
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): LoopChildReactiveText[] {
   const texts: LoopChildReactiveText[] = []
   walkIR(node, false, {
@@ -421,7 +435,7 @@ export function collectLoopChildReactiveTexts(
       const expanded = expandConstantForReactivity(n.expr, ctx)
       // Include if expression reads signals OR references the loop parameter
       // (loop param becomes a signal accessor via per-item signals).
-      if (classifyReactivity(expanded, ctx, loopParam).kind === 'none') return
+      if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') return
       texts.push({ slotId: n.slotId, expression: expanded, insideConditional: insideConditional || undefined })
     },
     conditional: ({ descend }) => {
@@ -440,6 +454,7 @@ export function collectLoopChildReactiveAttrs(
   node: IRNode,
   ctx: ClientJsContext,
   loopParam?: string,
+  loopParamBindings?: readonly LoopParamBinding[],
 ): LoopChildReactiveAttr[] {
   const attrs: LoopChildReactiveAttr[] = []
   traverseElements(node, (el) => {
@@ -449,7 +464,7 @@ export function collectLoopChildReactiveAttrs(
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx)
-        if (classifyReactivity(expanded, ctx, loopParam).kind === 'none') continue
+        if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') continue
         attrs.push({
           childSlotId: el.slotId,
           attrName: attr.name,

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -115,6 +115,14 @@ export interface LoopCore {
   param: string
   /** Key expression — e.g. `item.id`. `null` when the loop has no explicit key. */
   key: string | null
+  /**
+   * Destructured-binding accessor paths when `param` is an array/object
+   * binding pattern (#951). The client-JS emitter rewrites each binding
+   * name to `__bfItem().path` so fine-grained effects read the per-item
+   * signal accessor instead of a once-captured local. Absent for
+   * simple-name callbacks.
+   */
+  paramBindings?: readonly import('../types').LoopParamBinding[]
 }
 
 /** Loop info extracted from a conditional branch for reactive reconciliation. */

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -3,7 +3,7 @@
  * No dependencies on ClientJsContext or other internal modules.
  */
 
-import type { IRTemplateLiteral } from '../types'
+import type { IRTemplateLiteral, LoopParamBinding } from '../types'
 import type { TopLevelLoop } from './types'
 import {
   BF_KEY as DATA_KEY,
@@ -191,14 +191,57 @@ function escapeRegExp(s: string): string {
  * String-context aware: skips replacements inside string literals and template
  * literal string parts (e.g., CSS class name "preview-field" stays unchanged
  * when paramName is "field"). Handles arbitrarily nested template literals.
+ *
+ * When `bindings` is supplied (destructured `.map()` callback, #951), each
+ * binding name is rewritten to `__bfItem()${path}` instead of wrapping the
+ * raw pattern text. `paramName` is ignored in that case — destructured
+ * callbacks never expose the pattern itself as a local.
  */
-export function wrapLoopParamAsAccessor(expr: string, paramName: string): string {
+export function wrapLoopParamAsAccessor(expr: string, paramName: string, bindings?: readonly LoopParamBinding[]): string {
+  if (bindings && bindings.length > 0) {
+    // Build a single alternation regex so rewriting is a one-pass operation.
+    // Iterating per-binding risks re-matching the replacement text (e.g. a
+    // binding named `a` with path `.a` would cascade into `__bfItem().a`
+    // then back into `__bfItem().__bfItem().a`).
+    const byName = new Map<string, string>()
+    for (const b of bindings) byName.set(b.name, b.path)
+    const alt = bindings.map(b => escapeRegExp(b.name)).join('|')
+    const re = new RegExp(`\\b(${alt})\\b`, 'g')
+    return _replaceInExprContexts(expr, re, (_m: string, name: string) => `__bfItem()${byName.get(name)!}`)
+  }
   const re = new RegExp(`\\b${escapeRegExp(paramName)}\\b(?!\\s*\\()(?!-)`, 'g')
   return _replaceInExprContexts(expr, re, `${paramName}()`)
 }
 
+/**
+ * Rewrite each destructured binding reference to `${accessor}${path}` in
+ * `expr`, reusing the string-context-aware replacement that keeps literal
+ * text untouched (#951).
+ *
+ * Used by the event-delegation emitter, which resolves the current item
+ * via `arr.find(item => ...)` at click time and therefore wants `item`
+ * as the accessor prefix instead of `__bfItem()`.
+ */
+export function substituteLoopBindings(
+  expr: string,
+  bindings: readonly LoopParamBinding[],
+  accessor: string,
+): string {
+  if (!bindings || bindings.length === 0) return expr
+  const byName = new Map<string, string>()
+  for (const b of bindings) byName.set(b.name, b.path)
+  const alt = bindings.map(b => escapeRegExp(b.name)).join('|')
+  const re = new RegExp(`\\b(${alt})\\b`, 'g')
+  return _replaceInExprContexts(expr, re, (_m: string, name: string) => `${accessor}${byName.get(name)!}`)
+}
+
+// Matches the JS `String.prototype.replace` replacer signature. The lib's
+// own type uses `any[]` for the rest args because regex capture groups and
+// offsets have heterogeneous types; narrow them at the callback instead.
+type Replacement = string | ((substring: string, ...args: any[]) => string)
+
 /** Replace `re` with `replacement` only in expression contexts (not in string literals). */
-function _replaceInExprContexts(code: string, re: RegExp, replacement: string): string {
+function _replaceInExprContexts(code: string, re: RegExp, replacement: Replacement): string {
   let result = ''
   let i = 0
   let exprStart = 0
@@ -206,7 +249,10 @@ function _replaceInExprContexts(code: string, re: RegExp, replacement: string): 
   const flushExpr = (end: number) => {
     if (end > exprStart) {
       re.lastIndex = 0
-      result += code.slice(exprStart, end).replace(re, replacement)
+      const slice = code.slice(exprStart, end)
+      result += typeof replacement === 'string'
+        ? slice.replace(re, replacement)
+        : slice.replace(re, replacement as (substring: string, ...args: any[]) => string)
     }
     exprStart = end
   }
@@ -244,7 +290,7 @@ function _skipQuotedString(code: string, start: number): number {
 }
 
 /** Process a template literal from the opening backtick. Returns [result, nextIndex]. */
-function _processTemplateLiteral(code: string, start: number, re: RegExp, replacement: string): [string, number] {
+function _processTemplateLiteral(code: string, start: number, re: RegExp, replacement: Replacement): [string, number] {
   let result = '`'
   let i = start + 1
   while (i < code.length) {
@@ -271,7 +317,7 @@ function _processTemplateLiteral(code: string, start: number, re: RegExp, replac
 }
 
 /** Process inside ${...}. Returns [content without closing }, nextIndex after }]. */
-function _processInterpolation(code: string, start: number, re: RegExp, replacement: string): [string, number] {
+function _processInterpolation(code: string, start: number, re: RegExp, replacement: Replacement): [string, number] {
   let i = start
   let depth = 1
   let exprStart = i
@@ -280,7 +326,10 @@ function _processInterpolation(code: string, start: number, re: RegExp, replacem
   const flushExpr = (end: number) => {
     if (end > exprStart) {
       re.lastIndex = 0
-      result += code.slice(exprStart, end).replace(re, replacement)
+      const slice = code.slice(exprStart, end)
+      result += typeof replacement === 'string'
+        ? slice.replace(re, replacement)
+        : slice.replace(re, replacement as (substring: string, ...args: any[]) => string)
     }
     exprStart = end
   }
@@ -318,14 +367,30 @@ function _processInterpolation(code: string, start: number, re: RegExp, replacem
 }
 
 /**
+ * A loop parameter binding spec for template-time rewriting. Either a plain
+ * parameter name (simple-identifier callback) or the pattern text plus the
+ * destructured bindings whose references should be rewritten to
+ * `__bfItem().path` (#951).
+ */
+export interface LoopParamSpec {
+  param: string
+  bindings?: readonly LoopParamBinding[]
+}
+
+/**
  * Apply wrapLoopParamAsAccessor for multiple loop params.
  * Used during template generation to wrap expression values at IR level,
  * avoiding post-hoc regex replacement on full template strings.
+ *
+ * Accepts either a bare param name or a spec carrying destructure bindings.
  */
-export function wrapExprWithLoopParams(expr: string, loopParams?: string[]): string {
+export function wrapExprWithLoopParams(expr: string, loopParams?: ReadonlyArray<string | LoopParamSpec>): string {
   if (!loopParams) return expr
   let result = expr
-  for (const p of loopParams) result = wrapLoopParamAsAccessor(result, p)
+  for (const p of loopParams) {
+    const spec = typeof p === 'string' ? { param: p } : p
+    result = wrapLoopParamAsAccessor(result, spec.param, spec.bindings)
+  }
   return result
 }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -22,6 +22,7 @@ import {
   type IRProp,
   type IRTemplateLiteral,
   type IRTemplatePart,
+  type LoopParamBinding,
   type SourceLocation,
   type TypeInfo,
   pickAttrMeta,
@@ -1537,6 +1538,86 @@ function extractFilterPredicate(
   return { result: { param, predicate, raw } }
 }
 
+/**
+ * Build the list of destructured bindings for a `.map()` callback parameter.
+ *
+ * Returns:
+ * - `null` when the parameter is a plain identifier (no destructuring).
+ * - `{ unsupported: true }` when the pattern contains a rest element or a
+ *   non-literal computed property key — shapes that can't be expressed as a
+ *   single fixed accessor path. Callers surface these as `BF025`.
+ * - An array of `{ name, path }` otherwise. Each `path` is a JS accessor
+ *   suffix starting with `.` or `[` and is appended to the synthetic
+ *   `__bfItem()` call in the emitted client JS.
+ */
+function extractLoopParamBindings(
+  pattern: ts.BindingName,
+  ctx: TransformContext,
+): LoopParamBinding[] | { unsupported: true } | null {
+  if (ts.isIdentifier(pattern)) return null
+
+  const bindings: LoopParamBinding[] = []
+  let unsupported = false
+
+  // `.foo` is only valid when `foo` parses as an IdentifierName. Numeric or
+  // reserved-keyed properties fall back to `["foo"]` bracket access so the
+  // emitted JS accessor suffix is always syntactically valid.
+  const appendDotAccess = (prefix: string, key: string): string => {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+      ? `${prefix}.${key}`
+      : `${prefix}[${JSON.stringify(key)}]`
+  }
+
+  const walk = (p: ts.ArrayBindingPattern | ts.ObjectBindingPattern, prefix: string): void => {
+    if (unsupported) return
+    if (ts.isArrayBindingPattern(p)) {
+      p.elements.forEach((el, index) => {
+        if (unsupported) return
+        if (ts.isOmittedExpression(el)) return
+        if (el.dotDotDotToken) { unsupported = true; return }
+        const path = `${prefix}[${index}]`
+        if (ts.isIdentifier(el.name)) {
+          bindings.push({ name: el.name.text, path })
+        } else {
+          walk(el.name, path)
+        }
+      })
+      return
+    }
+    // ObjectBindingPattern
+    for (const el of p.elements) {
+      if (unsupported) return
+      if (el.dotDotDotToken) { unsupported = true; return }
+      let keyText: string | null = null
+      if (el.propertyName) {
+        const pn = el.propertyName
+        if (ts.isIdentifier(pn)) keyText = pn.text
+        else if (ts.isStringLiteral(pn)) keyText = pn.text
+        else if (ts.isNumericLiteral(pn)) keyText = pn.text
+        else { unsupported = true; return }
+      } else if (ts.isIdentifier(el.name)) {
+        keyText = el.name.text
+      } else {
+        unsupported = true
+        return
+      }
+      const path = appendDotAccess(prefix, keyText)
+      if (ts.isIdentifier(el.name)) {
+        bindings.push({ name: el.name.text, path })
+      } else {
+        walk(el.name, path)
+      }
+    }
+  }
+
+  if (ts.isArrayBindingPattern(pattern) || ts.isObjectBindingPattern(pattern)) {
+    walk(pattern, '')
+    if (unsupported) return { unsupported: true }
+    return bindings
+  }
+  return null
+}
+
 function transformMapCall(
   node: ts.CallExpression,
   ctx: TransformContext,
@@ -1699,6 +1780,7 @@ function transformMapCall(
   let index: string | null = null
   let indexType: string | undefined
   let children: IRNode[] = []
+  let paramBindings: LoopParamBinding[] | undefined
 
   if (ts.isArrowFunction(callback)) {
     // Extract parameter names and type annotations
@@ -1707,6 +1789,22 @@ function transformMapCall(
       param = firstParam.name.getText(ctx.sourceFile)
       if (firstParam.type) {
         paramType = firstParam.type.getText(ctx.sourceFile)
+      }
+      // Destructured param (`([, cfg]) => ...`, `({ x, y }) => ...`): walk
+      // the binding pattern into per-binding accessor paths so the client
+      // JS emitter can rewrite references to `__bfItem().path` (#951). Rest
+      // elements and computed keys can't be expressed as a fixed path — we
+      // raise `BF025` and leave `paramBindings` undefined so the emitter
+      // falls back to the #950 unwrap behaviour.
+      const bindingResult = extractLoopParamBindings(firstParam.name, ctx)
+      if (bindingResult && !Array.isArray(bindingResult)) {
+        ctx.analyzer.errors.push(
+          createError(ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST,
+            getSourceLocation(firstParam, ctx.sourceFile, ctx.filePath),
+          )
+        )
+      } else if (Array.isArray(bindingResult)) {
+        paramBindings = bindingResult
       }
     }
     if (callback.parameters.length > 1) {
@@ -1717,8 +1815,16 @@ function transformMapCall(
       }
     }
 
-    // Register loop params so expressions referencing them get slotId
-    ctx.loopParams.add(param)
+    // Register loop params so expressions referencing them get slotId.
+    // For destructured patterns, register the individual binding names —
+    // `\b${param}\b` never matches a bare name like `cfg` when `param` is
+    // `[, cfg]`, which would otherwise leave reactive-expression detection
+    // silently broken for destructured callbacks.
+    if (paramBindings) {
+      for (const b of paramBindings) ctx.loopParams.add(b.name)
+    } else {
+      ctx.loopParams.add(param)
+    }
     if (index) ctx.loopParams.add(index)
 
     // Transform callback body
@@ -1790,7 +1896,11 @@ function transformMapCall(
     }
 
     // Unregister loop params
-    ctx.loopParams.delete(param)
+    if (paramBindings) {
+      for (const b of paramBindings) ctx.loopParams.delete(b.name)
+    } else {
+      ctx.loopParams.delete(param)
+    }
     if (index) ctx.loopParams.delete(index)
   }
 
@@ -1895,6 +2005,7 @@ function transformMapCall(
     paramType,
     indexType,
     typedMapPreamble,
+    paramBindings,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -272,6 +272,32 @@ export interface IRLoop {
   indexType?: string
   /** mapPreamble with TypeScript type annotations preserved, for .tsx output */
   typedMapPreamble?: string
+
+  /**
+   * When `.map(callback)` destructures its item parameter (array or object
+   * pattern), this captures each destructured binding's name and the
+   * accessor path into the item. The client-JS emitter rewrites binding
+   * references to `__bfItem().path` so fine-grained effects read the
+   * per-item signal accessor instead of a once-captured local (#951).
+   *
+   * Example: `.map(([, cfg]) => ...)` produces `[{ name: 'cfg', path: '[1]' }]`.
+   * Example: `.map(({ user: { name } }) => ...)` produces `[{ name: 'name', path: '.user.name' }]`.
+   *
+   * Absent when the param is a simple identifier or when the pattern
+   * contains unsupported shapes (rest element, computed property key) —
+   * those cases raise `BF025` at Phase 1.
+   */
+  paramBindings?: LoopParamBinding[]
+}
+
+/**
+ * Destructured binding extracted from a `.map()` callback's item parameter.
+ * The `path` is a JS accessor suffix (starts with `.` or `[`) appended to
+ * the synthetic `__bfItem()` call in the emitted client JS.
+ */
+export interface LoopParamBinding {
+  name: string
+  path: string
 }
 
 export interface IRComponent {

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -414,6 +414,7 @@ For non-JS backends, ensure proper UTF-8 handling:
 | BF011 | Signal used outside component |
 | BF020 | Invalid JSX expression |
 | BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation) |
+| BF025 | Unsupported destructure shape in `.map()` callback (rest element or computed property key) |
 | BF030 | Type inference failed |
 | BF031 | Props type mismatch |
 | BF043 | Props destructuring breaks reactivity |


### PR DESCRIPTION
Closes #951.

## What this fixes

A destructured `.map()` callback (`.map(({ id, label, done }) => ...)`) loses reactivity on same-key `setItem` updates — the destructured locals are captured once at first render, so a `createEffect` reading `done` never re-runs when the item object is replaced with the same key.

Concretely, the issue's repro:

```tsx
{todos().map(({ id, label, done }) => (
  <li>
    <button class={done ? 'done' : ''} onClick={() => toggle(id)}>{label}</button>
  </li>
))}
```

With `setTodos(prev => prev.map(t => t.id === id ? { ...t, done: !t.done } : t))` keeping the key `id` stable, `mapArray` reuses the same DOM node. Before this PR the emitted `createEffect` closed over a stale `done`, so the `class` attribute never updated. After this PR it reads `__bfItem().done`, so clicking the toggle refreshes the class.

## How

**Phase 1 — IR extraction** (`jsx-to-ir.ts::extractLoopParamBindings`)

Walks the binding pattern into `{ name, path }` entries and attaches them to `IRLoop.paramBindings`:

| Pattern | Bindings |
|---|---|
| `([, cfg]) => ...`            | `[{ name: 'cfg', path: '[1]' }]` |
| `({ label, value }) => ...`   | `[{ name: 'label', path: '.label' }, { name: 'value', path: '.value' }]` |
| `({ user: { name } }) => ...` | `[{ name: 'name', path: '.user.name' }]` |
| `({ foo: bar }) => ...`       | `[{ name: 'bar', path: '.foo' }]` |

Rest elements and computed property keys raise `BF025 UNSUPPORTED_DESTRUCTURE_REST`. The #950 body-entry unwrap stays as a fallback for that case so the crash fix still holds even when the diagnostic is later relaxed.

Binding names (not the raw pattern text) are now registered in `ctx.loopParams` so reactivity detection via `referencesLoopParam` actually fires for destructured callbacks — previously `\b{ id, label, done }\b` matched nothing.

**Phase 2 — emission**

- `wrapLoopParamAsAccessor(expr, param, bindings?)` builds a single alternation regex over binding names and rewrites each to `__bfItem()${path}`. Reuses the existing string-literal-aware replacement so text inside quotes is untouched.
- `destructureLoopParam(param, bindings)` returns `{ head: '__bfItem', unwrap: '' }` when bindings are present; falls back to `const ${param} = __bfItem();` for unsupported patterns.
- The seven renderItem emission sites (plain / component / composite, branch-loop variants, inner-loop setup) thread `paramBindings` through to template strings, reactive attrs, reactive texts, conditionals, and event handlers.
- `classifyReactivity` takes a `loopParamBindings` parameter so the single reactivity-classification helper handles destructured callbacks uniformly.
- `LoopParamSpec` type added in `utils.ts` so `wrapExprWithLoopParams` / `irToHtmlTemplate` / `irToPlaceholderTemplate` accept either a bare param name or a spec with bindings.

**Bonus — event delegation TDZ**

The pre-existing `const { id } = arr.find(item => String(id) === key)` shape threw a `ReferenceError` on the find callback's reference to the outer `id` (still in TDZ during the destructure). The emitter now substitutes bindings with `item.<path>` in the key expression (`String(item.id)`) and lands on a plain `__bfLoopItem` sentinel before destructuring, so the handler closure sees a real `id` binding.

## Acceptance criteria

- [x] `destructured locals captured once — frozen on same-key update (known limitation)` pinning test in `map-array.test.ts` flipped from green to red and rewritten as `destructured locals refresh via signal accessor on same-key setItem (#951)`.
- [x] Issue repro compiles to a `createEffect` that reads `__bfItem().done`. Verified via `destructured-map-params.test.ts::reactive attr inside destructured loop (issue #951 repro)`.
- [x] Nested destructure (`({ user: { name } }) => ...`) supported via path composition.
- [x] Rest elements produce `BF025` with a suggestion to rewrite the callback.
- [x] `destructureLoopParam` kept as a fallback for patterns the IR rewriter can't handle; comment documents the split.

## Files

- `packages/jsx/src/jsx-to-ir.ts` — binding extraction + loopParams registration fix
- `packages/jsx/src/types.ts` — `LoopParamBinding` type + `IRLoop.paramBindings` field
- `packages/jsx/src/errors.ts` — `BF025 UNSUPPORTED_DESTRUCTURE_REST`
- `packages/jsx/src/ir-to-client-js/{types,utils,html-template,collect-elements,reactivity,emit-control-flow}.ts` — plumbing + rewriting
- `packages/jsx/src/__tests__/destructured-map-params.test.ts` — 11 new compiler unit tests (object / tuple / renamed / nested destructures, string-literal safety, `BF025`, event-delegation TDZ shape, mapPreamble rewriting, issue #951 repro)
- `packages/jsx/src/__tests__/loop-fallback-wrap.test.ts` — three #950 tests rewritten to assert the new output
- `packages/client/__tests__/runtime/map-array.test.ts` — pinning test flipped
- `spec/compiler.md` — documents `BF025`

## Test plan

- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests` → 1200 pass, 0 fail (matches CI's `ci.yml::test`)
- [x] `bun test ui/components` → 1157 pass, 0 fail (matches CI's `ci.yml::test-ui`)
- [x] `bun run --cwd packages/jsx build` (incl. `tsgo --emitDeclarationOnly`) passes
- [x] Manual compile of issue #951 repro — emits `createEffect(() => { ... __bfItem().done ... })` for the class attr; event delegation uses `const __bfLoopItem = ... ; const { id, label, done } = __bfLoopItem`.

## Out of scope

Playwright E2E for the exact `TodoList` repro wasn't added — the compiler-unit + CSR-runtime coverage locks in the same code path. Happy to add one if you want the visual regression guard.

https://claude.ai/code/session_01Rntfio98nq2aouDXGXQTKh