### PR TITLE
feat(blocks): add Async Infinite Scroll block

### DIFF
--- a/packages/hono/src/jsx/jsx-runtime/index.d.ts
+++ b/packages/hono/src/jsx/jsx-runtime/index.d.ts
@@ -25,3 +25,16 @@ export declare namespace JSX {
   type IntrinsicAttributes = BaseJSX.IntrinsicAttributes
   type ElementChildrenAttribute = BaseJSX.ElementChildrenAttribute
 }
+
+/**
+ * BarefootJS compiler built-in: streaming async boundary.
+ *
+ * The compiler intercepts `<Async fallback={...}>` in JSX source and emits it
+ * as a `<Suspense>` node in the Hono adapter output (IRAsync → renderAsync).
+ * This declaration provides TypeScript types for source files; no runtime
+ * implementation is needed because the compiler replaces it before execution.
+ */
+export declare function Async(props: {
+  fallback: JSX.Element
+  children: JSX.Element | JSX.Element[] | null | undefined
+}): JSX.Element

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -5,7 +5,7 @@
 import type { ComponentIR, ConstantInfo, FunctionInfo, IRNode } from '../types'
 import type { ClientJsContext, ConditionalElement } from './types'
 import { varSlotId, bodyReferencesComponentScope, PROPS_PARAM } from './utils'
-import { collectUsedIdentifiers, collectUsedFunctions, collectIdentifiersFromIRTree } from './identifiers'
+import { collectUsedIdentifiers, collectUsedFunctions, collectIdentifiersFromIRTree, extractIdentifiers } from './identifiers'
 import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
@@ -240,6 +240,45 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
       info: fn,
       sourceIndex: fn.loc.start.line,
     })
+  }
+
+  // Second pass: demote module-level function candidates that transitively
+  // reference init-scope functions. A module-level function hoisted for SSR
+  // template accessibility must not call functions that are inside init —
+  // those names are out of scope at the module level.
+  //
+  // Example: fetchPage (module-level candidate) calls articlesForPage which
+  // references ARTICLES (a component-local constant, hence inside init).
+  // Without this pass, fetchPage is emitted at module scope but articlesForPage
+  // is inside init, causing "articlesForPage is not defined" at runtime.
+  {
+    // Names of functions currently in init-scope declarations
+    const initScopeFnNames = new Set<string>()
+    for (const decl of declarations) {
+      if (decl.kind === 'function') initScopeFnNames.add(decl.info.name)
+    }
+
+    // Propagate: if a module-level candidate calls an init-scope function,
+    // move it to declarations too (repeat until stable).
+    let changed = true
+    while (changed) {
+      changed = false
+      const stillModuleLevel: FunctionInfo[] = []
+      for (const fn of moduleLevelFunctions) {
+        const refs = new Set<string>()
+        extractIdentifiers(fn.body, refs)
+        const refsInitFn = [...refs].some(r => initScopeFnNames.has(r))
+        if (refsInitFn) {
+          declarations.push({ kind: 'function', info: fn, sourceIndex: fn.loc.start.line })
+          initScopeFnNames.add(fn.name)
+          changed = true
+        } else {
+          stillModuleLevel.push(fn)
+        }
+      }
+      moduleLevelFunctions.length = 0
+      moduleLevelFunctions.push(...stillModuleLevel)
+    }
   }
 
   // Collect signals

--- a/site/ui/components/infinite-scroll-demo.tsx
+++ b/site/ui/components/infinite-scroll-demo.tsx
@@ -1,0 +1,312 @@
+"use client"
+/**
+ * InfiniteScrollDemo
+ *
+ * Async infinite scroll feed with IntersectionObserver-triggered pagination,
+ * per-item like/save actions, and streaming SSR via <Async> boundary.
+ *
+ * Compiler stress targets:
+ * - <Async> boundary wrapping items().map() — streaming IR paths (#135)
+ * - mapArray append: setItems(prev => [...prev, ...newItems]) grows the list
+ * - Effect cleanup: IntersectionObserver.disconnect via onCleanup
+ * - Error and empty-state branches: conditional rendering on status signal
+ * - createMemo chain: totalCount → likedCount → savedCount from items signal
+ * - Per-item immutable updates inside a reactive loop
+ */
+
+import { createSignal, createMemo, onMount, onCleanup } from '@barefootjs/client'
+import { Avatar, AvatarFallback } from '@ui/components/ui/avatar'
+import { Button } from '@ui/components/ui/button'
+import { Separator } from '@ui/components/ui/separator'
+
+// Compiler built-in: the BarefootJS compiler intercepts <Async> and emits it
+// as <Suspense> in the Hono adapter output. declare keeps TypeScript happy;
+// no runtime function is needed because it is compiled away.
+declare function Async(props: { fallback: unknown; children: unknown }): unknown
+
+// --- Types ---
+
+type Article = {
+  id: number
+  title: string
+  excerpt: string
+  author: string
+  initials: string
+  category: string
+  readTime: number
+  publishedAt: string
+  liked: boolean
+  saved: boolean
+}
+
+type FetchStatus = 'idle' | 'loading' | 'error' | 'end'
+
+// --- Data ---
+
+const ARTICLES: Omit<Article, 'liked' | 'saved'>[] = [
+  // Page 1 — initial (8 items)
+  { id: 1, title: 'Type-Safe API Clients with Zod and TypeScript', excerpt: 'Build end-to-end type safety from your OpenAPI spec to your React components using Zod schema inference.', author: 'Maya Hoffman', initials: 'MH', category: 'TypeScript', readTime: 7, publishedAt: '2h ago' },
+  { id: 2, title: 'React Server Components: A Practical Guide', excerpt: 'Move data fetching to the server without sacrificing interactivity. How RSC changes the mental model for building apps.', author: 'Leon Park', initials: 'LP', category: 'React', readTime: 12, publishedAt: '4h ago' },
+  { id: 3, title: 'Core Web Vitals in 2025: What Changed', excerpt: 'INP replaced FID. Interaction to Next Paint measures responsiveness more accurately. Here is how to optimize for it.', author: 'Sara Chen', initials: 'SC', category: 'Performance', readTime: 9, publishedAt: '6h ago' },
+  { id: 4, title: 'Testing the UI Layer Without a Browser', excerpt: 'Snapshot testing is dead. Here is how to write IR-level component tests that run in milliseconds with zero flakiness.', author: 'James Okafor', initials: 'JO', category: 'Testing', readTime: 6, publishedAt: '1d ago' },
+  { id: 5, title: 'CSS Container Queries: Beyond Responsive Breakpoints', excerpt: 'Container queries let components adapt to their own size, not the viewport. The end of media query hacks.', author: 'Priya Nair', initials: 'PN', category: 'CSS', readTime: 8, publishedAt: '1d ago' },
+  { id: 6, title: 'Zero-Downtime Deployments with Feature Flags', excerpt: 'Ship to production continuously without breaking users. A pragmatic guide to trunk-based development.', author: 'Tom Eriksen', initials: 'TE', category: 'DevOps', readTime: 11, publishedAt: '2d ago' },
+  { id: 7, title: 'OWASP Top 10 for Frontend Developers', excerpt: 'XSS, CSRF, and clickjacking are still rampant. Concrete mitigations every frontend engineer should know.', author: 'Aisha Okonkwo', initials: 'AO', category: 'Security', readTime: 14, publishedAt: '2d ago' },
+  { id: 8, title: 'Micro-Frontends: Lessons from the Trenches', excerpt: 'Three years running a micro-frontend architecture at scale. What worked, what did not, and what we would do differently.', author: 'Wei Zhang', initials: 'WZ', category: 'Architecture', readTime: 16, publishedAt: '3d ago' },
+  // Page 2
+  { id: 9, title: 'Discriminated Unions for Exhaustive State Machines', excerpt: 'Use TypeScript discriminated unions to make impossible states unrepresentable. A pattern that eliminates entire bug classes.', author: 'Maya Hoffman', initials: 'MH', category: 'TypeScript', readTime: 8, publishedAt: '3d ago' },
+  { id: 10, title: 'useReducer vs. Signals: When to Choose What', excerpt: 'Both primitives manage state, but they excel in different scenarios. A practical decision framework.', author: 'Leon Park', initials: 'LP', category: 'React', readTime: 10, publishedAt: '4d ago' },
+  { id: 11, title: 'JavaScript Bundle Analysis with Source Maps', excerpt: 'Your bundle is bigger than you think. How to identify and eliminate hidden dependencies dragging down performance.', author: 'Sara Chen', initials: 'SC', category: 'Performance', readTime: 7, publishedAt: '4d ago' },
+  { id: 12, title: 'Property-Based Testing with fast-check', excerpt: 'Generate hundreds of edge-case inputs automatically. A hands-on introduction to property-based testing in TypeScript.', author: 'James Okafor', initials: 'JO', category: 'Testing', readTime: 9, publishedAt: '5d ago' },
+  { id: 13, title: 'Cascade Layers and the Future of CSS Specificity', excerpt: '@layer gives you explicit control over cascade order. Bye-bye specificity wars, hello predictable styles.', author: 'Priya Nair', initials: 'PN', category: 'CSS', readTime: 6, publishedAt: '5d ago' },
+  { id: 14, title: 'GitHub Actions for Frontend CI/CD', excerpt: 'Parallel jobs, caching, and matrix builds. Build a fast, reliable CI pipeline for your JavaScript monorepo.', author: 'Tom Eriksen', initials: 'TE', category: 'DevOps', readTime: 13, publishedAt: '6d ago' },
+  { id: 15, title: 'Content Security Policy Without the Headache', excerpt: 'CSP is hard to configure correctly. A step-by-step approach that balances security and developer ergonomics.', author: 'Aisha Okonkwo', initials: 'AO', category: 'Security', readTime: 11, publishedAt: '6d ago' },
+  { id: 16, title: 'Module Federation at Runtime', excerpt: 'Load remote modules dynamically without a build-time handshake. How Webpack 5 Module Federation works under the hood.', author: 'Wei Zhang', initials: 'WZ', category: 'Architecture', readTime: 15, publishedAt: '1w ago' },
+  // Page 3
+  { id: 17, title: 'Conditional Types and Mapped Types: A Deep Dive', excerpt: 'From infer to distributive conditionals, mapped type modifiers to template literal types — master the TypeScript type system.', author: 'Maya Hoffman', initials: 'MH', category: 'TypeScript', readTime: 13, publishedAt: '1w ago' },
+  { id: 18, title: 'Concurrent Mode Explained: Transitions and Deferred Values', excerpt: 'React 18 concurrency primitives let you keep the UI responsive under load. Here is how to use them effectively.', author: 'Leon Park', initials: 'LP', category: 'React', readTime: 11, publishedAt: '1w ago' },
+  { id: 19, title: 'Edge Functions: The New Frontend Backend', excerpt: 'Run server logic 50ms from every user. The tradeoffs of moving compute to the edge and when it makes sense.', author: 'Sara Chen', initials: 'SC', category: 'Performance', readTime: 9, publishedAt: '1w ago' },
+  { id: 20, title: 'Playwright vs. Cypress in 2025', excerpt: 'Both tools have matured. A head-to-head comparison of DX, reliability, debugging experience, and CI integration.', author: 'James Okafor', initials: 'JO', category: 'Testing', readTime: 8, publishedAt: '2w ago' },
+  { id: 21, title: 'Fluid Typography with clamp()', excerpt: 'One line of CSS scales type from mobile to desktop. No media queries, no JavaScript — just math.', author: 'Priya Nair', initials: 'PN', category: 'CSS', readTime: 5, publishedAt: '2w ago' },
+  { id: 22, title: 'Secrets Management for the Frontend Dev', excerpt: 'Environment variables are not secrets. How to handle sensitive config safely from local dev to production.', author: 'Tom Eriksen', initials: 'TE', category: 'DevOps', readTime: 12, publishedAt: '2w ago' },
+  { id: 23, title: 'Subresource Integrity for Third-Party Scripts', excerpt: 'SRI hashes guarantee the CDN cannot silently tamper with your scripts. Setting it up and keeping it current.', author: 'Aisha Okonkwo', initials: 'AO', category: 'Security', readTime: 7, publishedAt: '2w ago' },
+  { id: 24, title: 'Vertical Slice Architecture in a Monorepo', excerpt: 'Organize by feature, not by layer. How vertical slices reduce coupling and make large repos navigable.', author: 'Wei Zhang', initials: 'WZ', category: 'Architecture', readTime: 14, publishedAt: '2w ago' },
+  // Page 4
+  { id: 25, title: 'Branded Types: Preventing Primitive Obsession', excerpt: 'Wrap your strings and numbers in branded types to make ID mix-ups a compile error, not a runtime surprise.', author: 'Maya Hoffman', initials: 'MH', category: 'TypeScript', readTime: 6, publishedAt: '3w ago' },
+  { id: 26, title: 'Server Actions and the End of the API Route', excerpt: 'Call server functions directly from forms. How Next.js Server Actions simplify the full-stack data flow.', author: 'Leon Park', initials: 'LP', category: 'React', readTime: 10, publishedAt: '3w ago' },
+  { id: 27, title: 'Virtual Scrolling for Large Lists', excerpt: 'Render 100,000 rows without DOM overhead. A from-scratch walkthrough of windowing algorithms in JavaScript.', author: 'Sara Chen', initials: 'SC', category: 'Performance', readTime: 12, publishedAt: '3w ago' },
+  { id: 28, title: 'Visual Regression Testing with Storybook and Chromatic', excerpt: 'Catch UI regressions before they reach users. Integrating Storybook stories into a visual regression pipeline.', author: 'James Okafor', initials: 'JO', category: 'Testing', readTime: 9, publishedAt: '3w ago' },
+  { id: 29, title: 'CSS Scroll-Driven Animations', excerpt: 'Animate elements as the user scrolls — without JavaScript. The new animation-timeline property and its power.', author: 'Priya Nair', initials: 'PN', category: 'CSS', readTime: 7, publishedAt: '3w ago' },
+  { id: 30, title: 'OpenTelemetry for Node.js Services', excerpt: 'Traces, metrics, and logs in one standard. Adding observability to your backend without vendor lock-in.', author: 'Tom Eriksen', initials: 'TE', category: 'DevOps', readTime: 13, publishedAt: '4w ago' },
+  { id: 31, title: 'Preventing Supply Chain Attacks in npm Projects', excerpt: 'Lockfiles, audit CIs, and provenance attestation. A layered defence for your JavaScript dependency tree.', author: 'Aisha Okonkwo', initials: 'AO', category: 'Security', readTime: 10, publishedAt: '4w ago' },
+  { id: 32, title: 'Domain-Driven Design for Frontend Applications', excerpt: 'Ubiquitous language, bounded contexts, and anti-corruption layers applied to the frontend layer.', author: 'Wei Zhang', initials: 'WZ', category: 'Architecture', readTime: 17, publishedAt: '4w ago' },
+  // Page 5 (last)
+  { id: 33, title: 'TypeScript 5.4: What Is New and What Matters', excerpt: 'Preserved narrowing, NoInfer, and groupBy — the most impactful additions in the latest TypeScript release.', author: 'Maya Hoffman', initials: 'MH', category: 'TypeScript', readTime: 7, publishedAt: '1mo ago' },
+  { id: 34, title: 'Fine-Grained Reactivity Without a Framework', excerpt: 'Implement a minimal signal-based reactive system from scratch. Understand what SolidJS and Preact Signals do under the hood.', author: 'Leon Park', initials: 'LP', category: 'React', readTime: 14, publishedAt: '1mo ago' },
+  { id: 35, title: 'HTTP/3 and QUIC for Frontend Engineers', excerpt: 'Connection migration, 0-RTT, and stream multiplexing. How HTTP/3 reduces perceived latency for web apps.', author: 'Sara Chen', initials: 'SC', category: 'Performance', readTime: 8, publishedAt: '1mo ago' },
+  { id: 36, title: 'Contract Testing with Pact', excerpt: 'Test the consumer-provider contract without running both services simultaneously. How Pact fits into a CI pipeline.', author: 'James Okafor', initials: 'JO', category: 'Testing', readTime: 10, publishedAt: '1mo ago' },
+  { id: 37, title: 'The Anchor Positioning API', excerpt: 'Position tooltips, popovers, and dropdowns relative to their triggers — in CSS alone. No JavaScript calculations.', author: 'Priya Nair', initials: 'PN', category: 'CSS', readTime: 6, publishedAt: '1mo ago' },
+  { id: 38, title: 'Immutable Infrastructure with Docker and Terraform', excerpt: 'Treat servers as cattle, not pets. Build a reproducible deployment pipeline where every deploy is identical.', author: 'Tom Eriksen', initials: 'TE', category: 'DevOps', readTime: 15, publishedAt: '1mo ago' },
+  { id: 39, title: 'OAuth 2.0 PKCE Flow for Single-Page Apps', excerpt: 'Why implicit flow is dead and how PKCE protects your SPA from auth code interception attacks.', author: 'Aisha Okonkwo', initials: 'AO', category: 'Security', readTime: 11, publishedAt: '1mo ago' },
+  { id: 40, title: 'Event Sourcing for the Frontend', excerpt: 'Store user intent as events, derive state on demand. How event sourcing solves undo/redo and audit trails at the UI layer.', author: 'Wei Zhang', initials: 'WZ', category: 'Architecture', readTime: 13, publishedAt: '1mo ago' },
+]
+
+const PAGE_SIZE = 8
+
+function articlesForPage(page: number): Article[] {
+  const start = page * PAGE_SIZE
+  const items = ARTICLES.slice(start, start + PAGE_SIZE)
+  return items.map(a => ({ ...a, liked: false, saved: false }))
+}
+
+async function fetchPage(page: number): Promise<Article[]> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (Math.random() < 0.12) {
+        reject(new Error('Network error — please retry'))
+        return
+      }
+      resolve(articlesForPage(page))
+    }, 700)
+  })
+}
+
+const INITIAL_ITEMS: Article[] = articlesForPage(0)
+const TOTAL_PAGES = Math.ceil(ARTICLES.length / PAGE_SIZE)
+
+// --- Category badge color ---
+
+const CATEGORY_COLOR: Record<string, string> = {
+  TypeScript: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  React: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/40 dark:text-cyan-300',
+  Performance: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  Testing: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  CSS: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+  DevOps: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+  Security: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+  Architecture: 'bg-slate-100 text-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+}
+
+// --- Demo component ---
+
+export function InfiniteScrollDemo() {
+  const [items, setItems] = createSignal<Article[]>(INITIAL_ITEMS)
+  const [cursor, setCursor] = createSignal(1)
+  const [status, setStatus] = createSignal<FetchStatus>('idle')
+
+  const totalCount = createMemo(() => items().length)
+  const likedCount = createMemo(() => items().filter(a => a.liked).length)
+  const savedCount = createMemo(() => items().filter(a => a.saved).length)
+
+  const toggleLike = (id: number) => {
+    setItems(prev => prev.map(a => a.id === id ? { ...a, liked: !a.liked } : a))
+  }
+
+  const toggleSave = (id: number) => {
+    setItems(prev => prev.map(a => a.id === id ? { ...a, saved: !a.saved } : a))
+  }
+
+  const loadMore = async () => {
+    if (status() === 'loading' || status() === 'end') return
+    const page = cursor()
+    if (page >= TOTAL_PAGES) {
+      setStatus('end')
+      return
+    }
+    setStatus('loading')
+    try {
+      const newItems = await fetchPage(page)
+      setItems(prev => [...prev, ...newItems])
+      setCursor(page + 1)
+      setStatus(page + 1 >= TOTAL_PAGES ? 'end' : 'idle')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  onMount(() => {
+    const sentinel = document.querySelector('.is-sentinel')
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) loadMore()
+      },
+      { threshold: 0.1 }
+    )
+    observer.observe(sentinel)
+    onCleanup(() => observer.disconnect())
+  })
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4">
+      {/* Stats bar */}
+      <div
+        data-slot="stats-bar"
+        className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3"
+      >
+        <div className="text-sm text-muted-foreground">
+          <span className="scroll-total-count font-semibold text-foreground">{totalCount()}</span> articles
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="scroll-liked-count font-semibold text-foreground">{likedCount()}</span> liked
+        </div>
+        <Separator orientation="vertical" decorative className="h-4" />
+        <div className="text-sm text-muted-foreground">
+          <span className="scroll-saved-count font-semibold text-foreground">{savedCount()}</span> saved
+        </div>
+        <div className="ml-auto text-xs text-muted-foreground">
+          Page {cursor()} / {TOTAL_PAGES}
+        </div>
+      </div>
+
+      {/* Article list — <Async> wraps the signal-driven map (streaming IR path) */}
+      <Async
+        fallback={
+          <div data-slot="initial-skeleton" className="space-y-3">
+            {[1, 2, 3, 4, 5].map(i => (
+              <div
+                key={i}
+                className="h-28 animate-pulse rounded-lg border bg-muted"
+              />
+            ))}
+          </div>
+        }
+      >
+        <div data-slot="article-list" className="space-y-3">
+          {items().map(article => (
+            <article
+              key={article.id}
+              data-article-id={article.id}
+              className="scroll-article rounded-lg border bg-card p-4 transition-shadow hover:shadow-sm"
+            >
+              <div className="flex items-start gap-3">
+                <Avatar className="mt-0.5 size-8 shrink-0">
+                  <AvatarFallback className="text-xs">{article.initials}</AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0 space-y-1.5">
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="text-sm font-semibold leading-snug">{article.title}</h3>
+                    <span
+                      className={`scroll-category-badge shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${CATEGORY_COLOR[article.category]}`}
+                    >
+                      {article.category}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground line-clamp-2">{article.excerpt}</p>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">{article.author}</span>
+                    <Separator orientation="vertical" decorative className="h-3" />
+                    <span className="text-xs text-muted-foreground">{article.readTime} min read</span>
+                    <Separator orientation="vertical" decorative className="h-3" />
+                    <span className="text-xs text-muted-foreground">{article.publishedAt}</span>
+                    <div className="ml-auto flex items-center gap-1">
+                      <button
+                        data-slot="like-btn"
+                        data-article-id={article.id}
+                        data-liked={article.liked ? 'true' : 'false'}
+                        aria-label={article.liked ? 'Unlike' : 'Like'}
+                        aria-pressed={article.liked ? 'true' : 'false'}
+                        className={`scroll-like-btn inline-flex size-7 items-center justify-center rounded text-xs transition-colors hover:bg-accent ${article.liked ? 'text-red-500' : 'text-muted-foreground'}`}
+                        onClick={() => toggleLike(article.id)}
+                      >
+                        {article.liked ? '♥' : '♡'}
+                      </button>
+                      <button
+                        data-slot="save-btn"
+                        data-article-id={article.id}
+                        data-saved={article.saved ? 'true' : 'false'}
+                        aria-label={article.saved ? 'Unsave' : 'Save'}
+                        aria-pressed={article.saved ? 'true' : 'false'}
+                        className={`scroll-save-btn inline-flex size-7 items-center justify-center rounded text-xs transition-colors hover:bg-accent ${article.saved ? 'text-amber-500' : 'text-muted-foreground'}`}
+                        onClick={() => toggleSave(article.id)}
+                      >
+                        {article.saved ? '★' : '☆'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </Async>
+
+      {/* Sentinel + status — IntersectionObserver anchor */}
+      <div className="is-sentinel flex flex-col items-center gap-3 py-4">
+        {status() === 'loading' ? (
+          <div data-slot="loading-indicator" className="flex items-center gap-2 text-sm text-muted-foreground">
+            <svg className="size-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Loading more articles…
+          </div>
+        ) : null}
+        {status() === 'error' ? (
+          <div data-slot="error-state" className="flex flex-col items-center gap-2 text-center">
+            <p className="text-sm text-destructive">Failed to load articles.</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="scroll-retry-btn"
+              onClick={() => {
+                setStatus('idle')
+                loadMore()
+              }}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+        {status() === 'end' ? (
+          <div data-slot="end-state" className="text-center">
+            <p className="text-sm text-muted-foreground">
+              You have reached the end · {totalCount()} articles
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -113,6 +113,7 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'dashboard-builder', title: 'Dashboard Builder', description: 'Dynamic widget composition with per-widget signal isolation, dynamic component switching per item, and layout memo driven by widget count' },
   { slug: 'state-machine-playground', title: 'State Machine Playground', description: 'Interactive state machine explorer with preset workflows, per-state multi-conditional classes flipping together on transition, a reactive transitions loop source, and a history filter/group memo chain' },
   { slug: 'theme-customizer', title: 'Theme Customizer', description: 'Three signal-driven context providers (palette, spacing, typography) wrapping a 12-level deep consumer tree. Tests Provider value propagation, multi-provider ordering, stale-read safety, and dynamic token add/remove' },
+  { slug: 'infinite-scroll', title: 'Async Infinite Scroll', description: 'IntersectionObserver-triggered pagination with <Async> streaming boundary, mapArray append, per-item like/save actions, and effect cleanup on unmount. Tests the IRAsync + mapArray compiler path, reactive list growth, and error/empty-state branches' },
 ]
 
 // Helper: get components filtered by category

--- a/site/ui/e2e/infinite-scroll.spec.ts
+++ b/site/ui/e2e/infinite-scroll.spec.ts
@@ -1,0 +1,254 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Async Infinite Scroll Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/infinite-scroll')
+  })
+
+  const section = (page: any) =>
+    page.locator('[bf-s^="InfiniteScrollDemo_"]:not([data-slot])').first()
+
+  // --- Initial Render ---
+
+  test.describe('Initial Render', () => {
+    test('renders stats bar with initial counts', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('[data-slot="stats-bar"]')).toBeVisible()
+      await expect(s.locator('.scroll-total-count')).toContainText('8')
+      await expect(s.locator('.scroll-liked-count')).toContainText('0')
+      await expect(s.locator('.scroll-saved-count')).toContainText('0')
+    })
+
+    test('renders initial 8 articles', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('[data-slot="article-list"]')).toBeVisible()
+      await expect(s.locator('.scroll-article')).toHaveCount(8)
+    })
+
+    test('renders like and save buttons for each article', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('[data-slot="like-btn"]')).toHaveCount(8)
+      await expect(s.locator('[data-slot="save-btn"]')).toHaveCount(8)
+    })
+
+    test('all like buttons start in unpressed state', async ({ page }) => {
+      const s = section(page)
+      const likeBtns = s.locator('[data-slot="like-btn"]')
+      for (let i = 0; i < 8; i++) {
+        await expect(likeBtns.nth(i)).toHaveAttribute('aria-pressed', 'false')
+        await expect(likeBtns.nth(i)).toHaveAttribute('data-liked', 'false')
+      }
+    })
+
+    test('all save buttons start in unpressed state', async ({ page }) => {
+      const s = section(page)
+      const saveBtns = s.locator('[data-slot="save-btn"]')
+      for (let i = 0; i < 8; i++) {
+        await expect(saveBtns.nth(i)).toHaveAttribute('aria-pressed', 'false')
+        await expect(saveBtns.nth(i)).toHaveAttribute('data-saved', 'false')
+      }
+    })
+
+    test('renders sentinel div for IntersectionObserver', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.is-sentinel')).toBeVisible()
+    })
+  })
+
+  // --- Per-Item Actions ---
+
+  test.describe('Like action', () => {
+    test('clicking like button toggles liked state', async ({ page }) => {
+      const s = section(page)
+      const likeBtn = s.locator('[data-slot="like-btn"]').first()
+
+      await expect(likeBtn).toHaveAttribute('aria-pressed', 'false')
+      await likeBtn.click()
+      await expect(likeBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(likeBtn).toHaveAttribute('data-liked', 'true')
+    })
+
+    test('liking an article increments the liked count', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.scroll-liked-count')).toContainText('0')
+
+      await s.locator('[data-slot="like-btn"]').first().click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('1')
+    })
+
+    test('unliking an article decrements the liked count', async ({ page }) => {
+      const s = section(page)
+      const likeBtn = s.locator('[data-slot="like-btn"]').first()
+
+      await likeBtn.click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('1')
+
+      await likeBtn.click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('0')
+    })
+
+    test('liking multiple articles updates count correctly', async ({ page }) => {
+      const s = section(page)
+      const likeBtns = s.locator('[data-slot="like-btn"]')
+
+      await likeBtns.nth(0).click()
+      await likeBtns.nth(2).click()
+      await likeBtns.nth(4).click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('3')
+    })
+  })
+
+  test.describe('Save action', () => {
+    test('clicking save button toggles saved state', async ({ page }) => {
+      const s = section(page)
+      const saveBtn = s.locator('[data-slot="save-btn"]').first()
+
+      await expect(saveBtn).toHaveAttribute('aria-pressed', 'false')
+      await saveBtn.click()
+      await expect(saveBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(saveBtn).toHaveAttribute('data-saved', 'true')
+    })
+
+    test('saving an article increments the saved count', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.scroll-saved-count')).toContainText('0')
+
+      await s.locator('[data-slot="save-btn"]').first().click()
+      await expect(s.locator('.scroll-saved-count')).toContainText('1')
+    })
+
+    test('unsaving an article decrements the saved count', async ({ page }) => {
+      const s = section(page)
+      const saveBtn = s.locator('[data-slot="save-btn"]').first()
+
+      await saveBtn.click()
+      await expect(s.locator('.scroll-saved-count')).toContainText('1')
+
+      await saveBtn.click()
+      await expect(s.locator('.scroll-saved-count')).toContainText('0')
+    })
+  })
+
+  test.describe('Like and Save independence', () => {
+    test('liking an article does not affect the save count', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-slot="like-btn"]').first().click()
+      await expect(s.locator('.scroll-saved-count')).toContainText('0')
+    })
+
+    test('saving an article does not affect the like count', async ({ page }) => {
+      const s = section(page)
+      await s.locator('[data-slot="save-btn"]').first().click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('0')
+    })
+  })
+
+  // --- Infinite Scroll (load more) ---
+
+  test.describe('Load more via scroll', () => {
+    test('scrolling to bottom loads additional articles', async ({ page }) => {
+      const s = section(page)
+      await expect(s.locator('.scroll-article')).toHaveCount(8)
+
+      // Scroll the sentinel into view to trigger IntersectionObserver
+      await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+
+      // Wait for next page to load (simulated 700ms delay + some buffer)
+      await expect(s.locator('.scroll-article')).toHaveCount(16, { timeout: 5000 })
+      await expect(s.locator('.scroll-total-count')).toContainText('16')
+    })
+
+    test('loaded articles are appended after existing articles', async ({ page }) => {
+      const s = section(page)
+
+      // Record first article id before load
+      const firstBefore = await s.locator('.scroll-article').first().getAttribute('data-article-id')
+
+      await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+      await expect(s.locator('.scroll-article')).toHaveCount(16, { timeout: 5000 })
+
+      // First article should be the same (items were appended, not prepended)
+      const firstAfter = await s.locator('.scroll-article').first().getAttribute('data-article-id')
+      expect(firstAfter).toBe(firstBefore)
+    })
+
+    test('likes persist on existing articles after loading more', async ({ page }) => {
+      const s = section(page)
+
+      // Like the first article
+      await s.locator('[data-slot="like-btn"]').first().click()
+      await expect(s.locator('.scroll-liked-count')).toContainText('1')
+
+      // Trigger load more
+      await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+      await expect(s.locator('.scroll-article')).toHaveCount(16, { timeout: 5000 })
+
+      // Liked count should still be 1 (immutable update, not reset)
+      await expect(s.locator('.scroll-liked-count')).toContainText('1')
+
+      // First article should still be liked
+      await expect(s.locator('[data-slot="like-btn"]').first()).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    test('page indicator advances after loading more', async ({ page }) => {
+      const s = section(page)
+
+      await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+      await expect(s.locator('.scroll-article')).toHaveCount(16, { timeout: 5000 })
+
+      // Page should have advanced from 1 to 2
+      await expect(s.locator('[data-slot="stats-bar"]')).toContainText('Page 2')
+    })
+  })
+
+  // --- End of List ---
+
+  test.describe('End state', () => {
+    test('end-of-list message appears after all 40 articles are loaded', async ({ page }) => {
+      const s = section(page)
+
+      // Load all 5 pages (8 articles each = 40 total)
+      for (let i = 0; i < 4; i++) {
+        await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+        const expectedCount = (i + 2) * 8
+        await expect(s.locator('.scroll-article')).toHaveCount(expectedCount, { timeout: 5000 })
+      }
+
+      // Now all 40 articles are loaded — end state should appear
+      await expect(s.locator('[data-slot="end-state"]')).toBeVisible({ timeout: 3000 })
+      await expect(s.locator('[data-slot="end-state"]')).toContainText('40 articles')
+    })
+  })
+
+  // --- Retry after error ---
+
+  test.describe('Error state', () => {
+    test('retry button reloads after error', async ({ page }) => {
+      const s = section(page)
+
+      // Force an error by overriding Math.random to always return below the threshold
+      await page.evaluate(() => {
+        (window as any).__originalMathRandom = Math.random
+        Math.random = () => 0.01 // always triggers the 12% error condition
+      })
+
+      await s.locator('.is-sentinel').scrollIntoViewIfNeeded()
+
+      // Wait for error state (random still set to 0.01)
+      await expect(s.locator('[data-slot="error-state"]')).toBeVisible({ timeout: 3000 })
+
+      // Restore Math.random so the retry succeeds
+      await page.evaluate(() => {
+        Math.random = (window as any).__originalMathRandom
+      })
+
+      // Click retry — should load page 2
+      await s.locator('.scroll-retry-btn').click()
+      await expect(s.locator('.scroll-article')).toHaveCount(16, { timeout: 5000 })
+      await expect(s.locator('[data-slot="error-state"]')).not.toBeVisible()
+    })
+  })
+})

--- a/site/ui/pages/components/infinite-scroll.tsx
+++ b/site/ui/pages/components/infinite-scroll.tsx
@@ -1,0 +1,197 @@
+/**
+ * Async Infinite Scroll Reference Page (/components/infinite-scroll)
+ *
+ * Block-level composition pattern: <Async> streaming boundary wraps a
+ * signal-driven items().map(), exercising the IRAsync + IRMap compiler path.
+ * IntersectionObserver triggers next-page fetch; per-item like/save actions
+ * test reactive immutable updates inside a growing mapArray. Effect cleanup
+ * (observer.disconnect) and error / empty-state branches round out the coverage.
+ */
+
+import { InfiniteScrollDemo } from '@/components/infinite-scroll-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo, onMount, onCleanup } from '@barefootjs/client'
+
+type Article = { id: number; title: string; liked: boolean; saved: boolean; /* ... */ }
+type FetchStatus = 'idle' | 'loading' | 'error' | 'end'
+
+export function InfiniteScrollDemo() {
+  const [items, setItems] = createSignal<Article[]>(INITIAL_ITEMS)
+  const [cursor, setCursor] = createSignal(1)
+  const [status, setStatus] = createSignal<FetchStatus>('idle')
+
+  const totalCount = createMemo(() => items().length)
+  const likedCount = createMemo(() => items().filter(a => a.liked).length)
+
+  const toggleLike = (id: number) => {
+    setItems(prev => prev.map(a => a.id === id ? { ...a, liked: !a.liked } : a))
+  }
+
+  const loadMore = async () => {
+    if (status() === 'loading' || status() === 'end') return
+    setStatus('loading')
+    try {
+      const newItems = await fetchPage(cursor())
+      setItems(prev => [...prev, ...newItems]) // mapArray append
+      setCursor(c => c + 1)
+      setStatus('idle')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  onMount(() => {
+    const sentinel = document.querySelector('.is-sentinel')
+    const observer = new IntersectionObserver(
+      entries => { if (entries[0].isIntersecting) loadMore() },
+      { threshold: 0.1 }
+    )
+    observer.observe(sentinel!)
+    onCleanup(() => observer.disconnect()) // effect cleanup on unmount
+  })
+
+  return (
+    <div>
+      <div>{totalCount()} articles · {likedCount()} liked</div>
+
+      {/* <Async> boundary — IRAsync wrapping a signal-driven map */}
+      <Async fallback={<ArticleSkeleton />}>
+        <div data-slot="article-list">
+          {items().map(article => (
+            <article key={article.id}>
+              <h3>{article.title}</h3>
+              <button
+                aria-pressed={article.liked ? 'true' : 'false'}
+                onClick={() => toggleLike(article.id)}
+              >
+                {article.liked ? '♥' : '♡'}
+              </button>
+            </article>
+          ))}
+        </div>
+      </Async>
+
+      {/* Sentinel + status branches */}
+      <div className="is-sentinel">
+        {status() === 'loading' ? <p>Loading…</p> : null}
+        {status() === 'error'   ? <button onClick={loadMore}>Retry</button> : null}
+        {status() === 'end'     ? <p>You have reached the end · {totalCount()} articles</p> : null}
+      </div>
+    </div>
+  )
+}`
+
+export function InfiniteScrollRefPage() {
+  return (
+    <DocPage slug="infinite-scroll" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Async Infinite Scroll"
+          description="IntersectionObserver-triggered pagination with <Async> streaming boundary, mapArray append, per-item like/save actions, and effect cleanup on unmount. Tests the IRAsync + mapArray compiler path, reactive list growth, and error/empty-state branches."
+          {...getNavLinks('infinite-scroll')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <InfiniteScrollDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                {'<Async>'} Boundary + mapArray
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                The initial article list is wrapped in an{' '}
+                <code className="text-xs">{'<Async fallback={skeleton}>'}</code> boundary.
+                In SSR the compiler emits a{' '}
+                <code className="text-xs">{'<Suspense>'}</code> node (IRAsync → Hono
+                adapter) containing the{' '}
+                <code className="text-xs">items().map()</code> loop.
+                This exercises the IRAsync + IRMap compiler path that was previously
+                untested by any block demo.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                IntersectionObserver + Effect Cleanup
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                <code className="text-xs">onMount</code> registers an{' '}
+                <code className="text-xs">IntersectionObserver</code> on the sentinel
+                div at the bottom of the list.{' '}
+                <code className="text-xs">onCleanup(() =&gt; observer.disconnect())</code>{' '}
+                ensures the observer is torn down if the component unmounts mid-fetch,
+                preventing stale callbacks and memory leaks.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                mapArray Append
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Each page load calls{' '}
+                <code className="text-xs">
+                  setItems(prev =&gt; [...prev, ...newItems])
+                </code>
+                , appending to the existing signal array.
+                BarefootJS's client-side <code className="text-xs">mapArray</code>{' '}
+                reconciles the new items by keyed diffing — only the new DOM nodes
+                are created; existing article cards are not re-rendered.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Error and Empty States
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                A{' '}
+                <code className="text-xs">
+                  createSignal{'<FetchStatus>'}
+                </code>{' '}
+                drives three conditional branches:{' '}
+                <code className="text-xs">loading</code> (spinner),{' '}
+                <code className="text-xs">error</code> (retry button), and{' '}
+                <code className="text-xs">end</code> (end-of-list message).
+                The 12% simulated error rate makes the retry branch reachable
+                during testing.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Per-Item Reactive Actions
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Each article card has like and save toggles that call{' '}
+                <code className="text-xs">
+                  setItems(prev =&gt; prev.map(a =&gt; a.id === id ? ...))
+                </code>
+                , an immutable update inside a reactive loop.{' '}
+                <code className="text-xs">createMemo</code> chains derive
+                aggregate counts (liked, saved) from the items signal,
+                updating the stats bar reactively.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -67,6 +67,7 @@ import { PivotTableRefPage } from './pages/components/pivot-table'
 import { DashboardBuilderRefPage } from './pages/components/dashboard-builder'
 import { StateMachinePlaygroundRefPage } from './pages/components/state-machine-playground'
 import { ThemeCustomizerRefPage } from './pages/components/theme-customizer'
+import { InfiniteScrollRefPage } from './pages/components/infinite-scroll'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -491,6 +492,11 @@ export function createApp() {
   // Theme Customizer block page
   app.get('/components/theme-customizer', (c) => {
     return c.render(<ThemeCustomizerRefPage />)
+  })
+
+  // Async Infinite Scroll block page
+  app.get('/components/infinite-scroll', (c) => {
+    return c.render(<InfiniteScrollRefPage />)
   })
 
   // Gallery — Admin app (Phase 9 pilot)


### PR DESCRIPTION
## Summary

- Adds the Async Infinite Scroll block (`/components/infinite-scroll`), the last block from the Phase 9 TODO list
- `<Async>` boundary wraps the `items().map()` list with IntersectionObserver-triggered pagination
- Per-item like/save actions with immutable array updates; error/empty/end-state branches; effect cleanup via `onCleanup(() => observer.disconnect())`
- 21 E2E tests covering initial render, like/save toggles, load-more append, end-state, and retry-after-error

## Compiler fix

Fixes a transitive dependency bug in `generate-init.ts`: module-level function candidates were not checked against init-scope function names. If `fetchPage` calls `articlesForPage` (which stayed in init scope because it closed over `ARTICLES`), `fetchPage` must also stay in init scope. A fixpoint loop now demotes such candidates iteratively.

## Test plan

- [x] `bun run test --filter=packages/jsx` — 1809 pass, 0 fail
- [x] `bunx playwright test infinite-scroll` (from `site/ui/`) — 21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)