### PR TITLE
test(e2e): stub Math.random in infinite-scroll beforeEach to eliminate flake

### DIFF
--- a/site/ui/e2e/infinite-scroll.spec.ts
+++ b/site/ui/e2e/infinite-scroll.spec.ts
@@ -5,6 +5,13 @@ test.describe('Async Infinite Scroll Block', () => {
     page.on('pageerror', error => {
       console.log('Page error:', error.message)
     })
+    // Stub Math.random before any page script runs so the demo's 12%
+    // random error injection in fetchPage never fires for pagination
+    // flows. Individual tests that need to exercise the error path
+    // override Math.random locally (see the "Error state" suite).
+    await page.addInitScript(() => {
+      Math.random = () => 0.5
+    })
     await page.goto('/components/infinite-scroll')
   })
 


### PR DESCRIPTION
## Summary

Fixes the `e2e-site-ui (2)` flake that's been blocking #1019 and made the `#1017` merge CI fail.

`site/ui/components/infinite-scroll-demo.tsx` rejects `fetchPage` with a 12% probability to simulate network errors for realism. The E2E tests don't account for this, causing:

| test | failure rate |
|------|-------------|
| `scrolling to bottom loads additional articles` (L152) | ~12% |
| `page indicator advances after loading more` (L196) | ~12% |
| `end-of-list message appears after all 40 articles are loaded` (L210, 4 scrolls) | ~40% |
| `retry button reloads after error` (L229, retries with real `Math.random`) | ~12% |

Combined probability of at least one failing per run: **~55%**.

## Change

Stub `Math.random` via `page.addInitScript` in `beforeEach` to return `0.5` before any page script runs. `0.5 >= 0.12`, so `fetchPage` never takes the error path by default.

The existing "Error state" test at L229 is unaffected:
1. It captures `Math.random` (now our stub `() => 0.5`) into `window.__originalMathRandom`
2. Overrides to `() => 0.01` to force error
3. Restores `Math.random = window.__originalMathRandom` — which is our stub, so the subsequent retry is deterministic, not subject to the real 12% rate

## Verification

5 consecutive local runs against this change, all 21/21 pass:

```
=== flake-fix run 1 ===  21 passed (9.8s)
=== flake-fix run 2 ===  21 passed (9.0s)
=== flake-fix run 3 ===  21 passed (8.8s)
=== flake-fix run 4 ===  21 passed (8.9s)
=== flake-fix run 5 ===  21 passed (8.8s)
```

Baseline (current `main`): 4 of 5 runs failed with different tests on each.

## Test plan

- [ ] CI: all `e2e-site-ui` shards green on this PR
- [ ] After merge, CI on #1019 passes