### PR TITLE
refactor(compiler): extract declaration scope classifier to pure function (#1021)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/compute-scope.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-scope.ts
@@ -1,0 +1,147 @@
+/**
+ * Declaration scope classifier.
+ *
+ * Pure function of `ClientJsContext` + `ReferencesGraph`. Returns the
+ * emission scope (`module` | `init` | `skip`) for every local constant
+ * and every local function, replacing the ad-hoc cascade that used to
+ * live inline in `generate-init.ts`.
+ *
+ * Stage C of issue #1021 — analysis-on-IR refactor. See
+ * `spec/compiler-analysis-ir.md` §"Target IR shape" for the routing
+ * table and §"Invariants after Stages B–C–D" #2 for the guarantee this
+ * function underwrites.
+ */
+
+import type {
+  ConstantInfo,
+  DeclarationScope,
+  FunctionInfo,
+  ReferencesGraph,
+} from '../types'
+import type { ClientJsContext } from './types'
+import {
+  graphAssignedIdentifiers,
+  graphFunctionReferences,
+  graphUsedIdentifiers,
+} from './build-references'
+
+export interface DeclarationScopes {
+  constantScope: Map<string, DeclarationScope>
+  functionScope: Map<string, DeclarationScope>
+}
+
+export function computeDeclarationScopes(
+  ctx: ClientJsContext,
+  graph: ReferencesGraph,
+): DeclarationScopes {
+  const constantScope = new Map<string, DeclarationScope>()
+  const functionScope = new Map<string, DeclarationScope>()
+
+  const usedIdentifiers = graphUsedIdentifiers(graph)
+  const initStmtAssigned = graphAssignedIdentifiers(graph)
+
+  // ============================================================================
+  // Constants
+  //
+  // Cascade order mirrors generate-init.ts L114-151 (pre-Stage C):
+  //
+  //   1. isJsx / isJsxFunction           → skip  (inlined at IR level / call site)
+  //   2. unused (not in graph)           → skip  — except provider context
+  //                                                constants, which must ship
+  //                                                even when nothing else reads
+  //                                                them locally
+  //   3. no value (bare `let x`)         → init  (emitted as `let X` placeholder)
+  //   4. systemConstructKind             → module (unique identity)
+  //   5. isModule + assignment target    → module (#933 ReferenceError avoidance)
+  //   6. otherwise                       → init
+  // ============================================================================
+
+  const providerContextNames = new Set<string>()
+  for (const p of ctx.providerSetups) providerContextNames.add(p.contextName)
+
+  for (const c of ctx.localConstants) {
+    constantScope.set(c.name, classifyConstant(c, usedIdentifiers, initStmtAssigned, providerContextNames))
+  }
+
+  // ============================================================================
+  // Functions — forward-reachability fixpoint
+  //
+  // Seed `initRequired` with anything that must live inside the init
+  // function (reactive roots, props, and every constant classified as
+  // `init` above). Then walk every module-level candidate: if its body
+  // references any name in the set, demote it to init scope and add its
+  // own name so transitive callers demote in the next iteration. Loop
+  // until stable. Functions that survive the fixpoint are `module`.
+  // Mirrors generate-init.ts L218-280 (pre-Stage C).
+  // ============================================================================
+
+  const initRequired = new Set<string>()
+  for (const s of ctx.signals) {
+    initRequired.add(s.getter)
+    if (s.setter) initRequired.add(s.setter)
+  }
+  for (const m of ctx.memos) initRequired.add(m.name)
+  for (const p of ctx.propsParams) initRequired.add(p.name)
+  if (ctx.propsObjectName) initRequired.add(ctx.propsObjectName)
+  for (const c of ctx.localConstants) {
+    if (constantScope.get(c.name) === 'init') initRequired.add(c.name)
+  }
+
+  let pending: FunctionInfo[] = []
+  for (const fn of ctx.localFunctions) {
+    if (fn.isJsxFunction) { functionScope.set(fn.name, 'skip'); continue }
+    if (fn.isMultiReturnJsxHelper) { functionScope.set(fn.name, 'skip'); continue }
+    if (!usedIdentifiers.has(fn.name)) { functionScope.set(fn.name, 'skip'); continue }
+    if (!fn.isModule) { functionScope.set(fn.name, 'init'); continue }
+    pending.push(fn)
+  }
+
+  let changed = true
+  while (changed) {
+    changed = false
+    const stillPending: FunctionInfo[] = []
+    for (const fn of pending) {
+      const refs = graphFunctionReferences(graph, fn.name)
+      // Parameters shadow outer names inside the function body.
+      for (const p of fn.params) refs.delete(p.name)
+      const referencesInit = [...refs].some(r => initRequired.has(r))
+      if (referencesInit) {
+        functionScope.set(fn.name, 'init')
+        initRequired.add(fn.name)
+        changed = true
+      } else {
+        stillPending.push(fn)
+      }
+    }
+    pending = stillPending
+  }
+  for (const fn of pending) functionScope.set(fn.name, 'module')
+
+  return { constantScope, functionScope }
+}
+
+function classifyConstant(
+  c: ConstantInfo,
+  usedIdentifiers: Set<string>,
+  initStmtAssigned: Set<string>,
+  providerContextNames: Set<string>,
+): DeclarationScope {
+  if (c.isJsx) return 'skip'           // Inlined at IR level (#547)
+  if (c.isJsxFunction) return 'skip'   // Inlined at call sites (#569)
+
+  // A provider's context constant must be emitted even if nothing else
+  // in the component references it — the provider setup reads it
+  // through `providerSetups[*].contextName`, which was NOT tracked in
+  // the pre-Stage B reachability walks and so the old classifier
+  // handled this case in a separate post-pass (generate-init.ts
+  // L154-164). With the graph in place, we express it as a first-class
+  // "force include" rule here.
+  const isProviderContext = c.systemConstructKind === 'createContext'
+    && providerContextNames.has(c.name)
+  if (!usedIdentifiers.has(c.name) && !isProviderContext) return 'skip'
+
+  if (!c.value) return 'init'   // `let x` placeholder
+  if (c.systemConstructKind) return 'module'
+  if (c.isModule && initStmtAssigned.has(c.name)) return 'module'
+  return 'init'
+}

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -7,11 +7,10 @@ import type { ClientJsContext, ConditionalElement } from './types'
 import { varSlotId, PROPS_PARAM } from './utils'
 import {
   buildReferencesGraph,
-  graphAssignedIdentifiers,
-  graphFunctionReferences,
   graphUsedFunctions,
   graphUsedIdentifiers,
 } from './build-references'
+import { computeDeclarationScopes } from './compute-scope'
 import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
@@ -90,61 +89,28 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   const graph = buildReferencesGraph(ctx, _ir.root)
   const usedIdentifiers = graphUsedIdentifiers(graph)
   const usedFunctions = graphUsedFunctions(graph)
-  const initStmtAssignedIdentifiers = graphAssignedIdentifiers(graph)
+  const { constantScope, functionScope } = computeDeclarationScopes(ctx, graph)
 
+  // Route each local constant by its precomputed scope. The cascade that
+  // used to branch on `systemConstructKind`, `isModule + initStmtAssigned`,
+  // and provider context hoisting now lives in `compute-scope.ts`; this
+  // file just reads the answer.
   const neededProps = new Set<string>()
   const neededConstants: ConstantInfo[] = []
   const moduleLevelConstants: ConstantInfo[] = []
-  const moduleLevelConstantNames = new Set<string>()
-
   for (const constant of ctx.localConstants) {
-    if (constant.isJsx) continue  // Inlined at IR level (#547)
-    if (constant.isJsxFunction) continue  // Inlined at call sites (#569)
-    if (usedIdentifiers.has(constant.name)) {
-      if (!constant.value) {
-        neededConstants.push(constant)
-        continue
-      }
-
-      // createContext() and new WeakMap() must be at module level to enable
-      // cross-component sharing (unique Symbol / identity-based store)
-      if (constant.systemConstructKind) {
-        moduleLevelConstants.push(constant)
-        moduleLevelConstantNames.add(constant.name)
-        continue
-      }
-
-      // A module-level declaration that an init statement writes to must
-      // be emitted at module scope, otherwise the assignment resolves to
-      // an undeclared identifier in ESM strict mode and hydration throws
-      // `ReferenceError` (#933). Pure-read module constants keep the
-      // existing `neededConstants` (inside-init) path — moving them out
-      // would regress unrelated components whose module consts are
-      // scoped per-instance today.
-      if (constant.isModule && initStmtAssignedIdentifiers.has(constant.name)) {
-        moduleLevelConstants.push(constant)
-        moduleLevelConstantNames.add(constant.name)
-        continue
-      }
-
-      neededConstants.push(constant)
-
+    const scope = constantScope.get(constant.name)
+    if (scope === 'skip') continue
+    if (scope === 'module') {
+      moduleLevelConstants.push(constant)
+      continue
+    }
+    // scope === 'init'
+    neededConstants.push(constant)
+    if (constant.value) {
       const refs = valueReferencesReactiveData(constant.value, ctx)
       for (const propName of refs.usedProps) {
         neededProps.add(propName)
-      }
-    }
-  }
-
-  // Ensure context variables used by providers are at module level
-  for (const provider of ctx.providerSetups) {
-    if (!moduleLevelConstantNames.has(provider.contextName)) {
-      const contextConstant = ctx.localConstants.find(
-        (c) => c.name === provider.contextName && c.systemConstructKind === 'createContext'
-      )
-      if (contextConstant) {
-        moduleLevelConstants.push(contextConstant)
-        moduleLevelConstantNames.add(contextConstant.name)
       }
     }
   }
@@ -189,84 +155,24 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
     })
   }
 
-  // Classify local functions into module-level vs init-scope via a single
-  // fixpoint over a dependency graph rooted at "must-be-in-init" names.
-  //
-  // Seed `initRequiredNames` with reactive roots (signals, memos, props) and
-  // the constants routed to init scope (`neededConstants`). Constants destined
-  // for module scope (`systemConstructKind`, `initStmtAssigned`) are NOT in
-  // `neededConstants`, so functions that reference only those can still live
-  // at module level.
-  //
-  // Then walk every module-level candidate: if its body references any name
-  // in the set, demote it to init scope and add its own name to the set so
-  // transitive callers are demoted in the next iteration. Loop until stable.
-  const initRequiredNames = new Set<string>()
-  for (const s of ctx.signals) {
-    initRequiredNames.add(s.getter)
-    if (s.setter) initRequiredNames.add(s.setter)
-  }
-  for (const m of ctx.memos) initRequiredNames.add(m.name)
-  for (const p of ctx.propsParams) initRequiredNames.add(p.name)
-  if (ctx.propsObjectName) initRequiredNames.add(ctx.propsObjectName)
-  for (const c of neededConstants) initRequiredNames.add(c.name)
-
-  // Seed candidates: filter out inlined/unused functions and JSX helpers.
-  // Functions flagged !isModule by the JSX→IR analyzer are always init-scope
-  // and bypass the fixpoint entirely.
-  // Multi-return JSX helpers (#932) are preserved verbatim for the SSR marked
-  // template, but their body contains raw JSX syntax that is not valid
-  // JavaScript. Skip them here so client JS stays parseable; hydration of the
-  // referencing component does not need the helper at runtime (the SVG / JSX
-  // was already rendered by SSR). Do NOT rely on `containsJsx` — that regex
-  // flag also matches helpers whose body has JSX-like strings inside string
-  // literals (e.g. a code-snippet builder), and skipping those would regress
-  // real client-side logic.
-  let pendingModuleLevel: FunctionInfo[] = []
+  // Route each local function by its precomputed scope. The fixpoint
+  // that used to live here now lives inside `computeDeclarationScopes`
+  // (compute-scope.ts).
+  const moduleLevelFunctions: FunctionInfo[] = []
   for (const fn of ctx.localFunctions) {
-    if (fn.isJsxFunction) continue  // Inlined at call sites (#569)
-    if (fn.isMultiReturnJsxHelper) continue
-    if (!usedIdentifiers.has(fn.name)) continue
-    if (fn.isModule) {
-      pendingModuleLevel.push(fn)
-    } else {
-      declarations.push({
-        kind: 'function',
-        info: fn,
-        sourceIndex: fn.loc.start.line,
-      })
+    const scope = functionScope.get(fn.name)
+    if (scope === 'skip') continue
+    if (scope === 'module') {
+      moduleLevelFunctions.push(fn)
+      continue
     }
+    // scope === 'init'
+    declarations.push({
+      kind: 'function',
+      info: fn,
+      sourceIndex: fn.loc.start.line,
+    })
   }
-
-  // Forward reachability over the pre-built function→name edges from the
-  // references graph. The loop still sweeps until no further demotions
-  // happen; each sweep is a graph lookup (`graphFunctionReferences`)
-  // rather than a regex re-tokenisation of the function body.
-  let changed = true
-  while (changed) {
-    changed = false
-    const stillModuleLevel: FunctionInfo[] = []
-    for (const fn of pendingModuleLevel) {
-      const refs = graphFunctionReferences(graph, fn.name)
-      // Parameters shadow outer names inside the function body.
-      for (const p of fn.params) refs.delete(p.name)
-      const referencesInit = [...refs].some(r => initRequiredNames.has(r))
-      if (referencesInit) {
-        declarations.push({
-          kind: 'function',
-          info: fn,
-          sourceIndex: fn.loc.start.line,
-        })
-        initRequiredNames.add(fn.name)
-        changed = true
-      } else {
-        stillModuleLevel.push(fn)
-      }
-    }
-    pendingModuleLevel = stillModuleLevel
-  }
-
-  const moduleLevelFunctions: FunctionInfo[] = pendingModuleLevel
 
   // Collect signals
   for (const signal of ctx.signals) {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -754,6 +754,28 @@ export interface ReferencesGraph {
   propNames: Set<string>
 }
 
+/**
+ * Emission scope for a local declaration (constant / function). Stage C
+ * of issue #1021 replaces the cascade of `if (c.systemConstructKind) ...`
+ * / `if (c.isModule && assigned) ...` branches in `generate-init.ts`
+ * with a single lookup keyed by this enum.
+ *
+ * - `module` — emitted at module level, OUTSIDE the init function.
+ *   Required for `createContext()` / `new WeakMap()` (unique identity
+ *   for cross-component sharing), for declarations that init-statements
+ *   assign to (#933, ESM strict-mode ReferenceError avoidance), and for
+ *   module-level functions whose bodies do NOT reference init-scope
+ *   names.
+ * - `init` — emitted INSIDE the init function body. This is the default
+ *   for signals, memos, and any declaration that transitively reads
+ *   reactive values or per-instance props.
+ * - `skip` — not emitted at all. Covers JSX inlined at IR level (#547),
+ *   JSX-returning helpers inlined at call sites (#569), multi-return
+ *   JSX helpers preserved only for the SSR marked template (#932), and
+ *   declarations that are simply unused by the emitted client JS.
+ */
+export type DeclarationScope = 'module' | 'init' | 'skip'
+
 export interface ClientAnalysis {
   needsInit: boolean
   usedProps: string[]


### PR DESCRIPTION
## Summary

Stage C.1 of #1021 — analysis-on-IR refactor.

Pulls the scope cascade out of \`generate-init.ts\` into a pure function \`computeDeclarationScopes(ctx, graph)\` in a new \`compute-scope.ts\`. The emitter now routes every local constant and every local function by a single map lookup instead of re-deriving the decision from a cascade of \`if (c.systemConstructKind) …\` / \`if (c.isModule && initStmtAssigned.has(…)) …\` branches inline.

See \`spec/compiler-analysis-ir.md\` §\"Target IR shape\" for the classifier spec and §\"Invariants after Stages B–C–D\" #2 for the guarantee.

## What changed

| File | Purpose |
|------|---------|
| \`packages/jsx/src/types.ts\` | Adds \`DeclarationScope = 'module' \| 'init' \| 'skip'\`. |
| \`packages/jsx/src/ir-to-client-js/compute-scope.ts\` | **New.** \`computeDeclarationScopes(ctx, graph)\` → \`{ constantScope, functionScope }\` maps. Cascade logic — including provider-context hoisting, which was a separate post-pass before — is expressed as ordered rules inside one function. |
| \`packages/jsx/src/ir-to-client-js/generate-init.ts\` | Deleted the per-constant cascade (L101-137), the provider-context hoisting post-pass (L140-150), and the function partition + fixpoint (L204-267). Now reads \`constantScope.get(name)\` / \`functionScope.get(name)\` and routes. |

Net diff: +199 / -124 across 3 files. \`generate-init.ts\` is 551 → 457 lines (-94).

## Classifier spec

### Constants

| Rule | Scope |
|------|-------|
| \`isJsx\` / \`isJsxFunction\` | \`skip\` |
| unused (not in graph reachability) | \`skip\` — **except provider context constants**, which must ship even when nothing else reads them locally |
| no value (bare \`let x\`) | \`init\` (emitted as \`let X\` placeholder) |
| \`systemConstructKind\` | \`module\` (unique identity — \`createContext\` / \`WeakMap\`) |
| \`isModule\` + init-statement assigns to it | \`module\` (#933 — ESM strict-mode ReferenceError avoidance) |
| otherwise | \`init\` |

### Functions (forward-reachability fixpoint)

| Rule | Scope |
|------|-------|
| \`isJsxFunction\` / \`isMultiReturnJsxHelper\` | \`skip\` |
| unused | \`skip\` |
| \`!isModule\` | \`init\` |
| \`isModule\` + body references any init-scope name | \`init\` (transitively demotes callers on the next iteration) |
| otherwise | \`module\` |

## Invariant — byte-identical output

All 326 \`.client.js\` files under \`site/ui/dist/components/\` are byte-for-byte identical to \`main\`:

\`\`\`
bun run --filter '@barefootjs/jsx' build
cd site/ui && bun run build
diff -rq /tmp/bf-stagec-main-dist/components site/ui/dist/components
# (empty output)
\`\`\`

## Test matrix

| Suite | Count | Result |
|-------|-------|--------|
| \`packages/jsx\` unit | 763 | ✅ |
| \`packages/adapter-tests\` | 214 | ✅ |
| \`packages/hono\` | 80 | ✅ |
| \`packages/go-template\` | 63 | ✅ |
| \`packages/client\` | 212 | ✅ |
| \`packages/form\` | 40 | ✅ |
| \`ui/components\` IR | 1157 | ✅ |

**Total: 2529 tests, 0 fails.**

## Not in this PR (per Stage A plan)

- **Stage C.2** — \`PropUsage\` replacing \`detectPropsWithPropertyAccess\`.
- **Stage C.3** — \`emit-registration.ts\`'s \`componentScopeNames\` + \`buildInlinableConstants\` rewritten against the graph. This is where the one intentional Stage C emission deviation lands (CSR template visibility widens; separate PR with a pinning fixture).
- **Stage D** — \`generate-init.ts\` collapses to a pure emitter (~150 lines target).
- \`ConstantInfo.scope\` / \`FunctionInfo.scope\` populated on IR from the analyzer — a later stage can move \`computeDeclarationScopes\` earlier so emitters read the precomputed field instead of calling the function.

## Test plan

- [x] All listed test suites pass locally
- [x] Byte-identical \`.client.js\` output vs \`main\` for every \`site/ui\` fixture
- [x] \`computeDeclarationScopes\` is a pure function — no IR or \`ctx\` mutation
- [ ] Reviewer verifies the cascade order in \`compute-scope.ts\` \`classifyConstant\` matches the pre-refactor \`generate-init.ts\` L101-150 branch order
- [ ] CI passes

## Related

- Issue: #1021
- Prior stages: #1022 (Stage A, merged), #1023 (Stage B, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)