### PR TITLE
refactor(compiler): consolidate prop access + loop-array facts as PropUsage (#1021)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-prop usage classifier.
+ *
+ * Pure function of `ClientJsContext` + the init-scope constants
+ * classifier output. Returns a `Map<propName, PropUsage>` describing
+ * the access kinds observed for each prop (bare / property / index)
+ * and whether the prop is consumed as a loop's array expression.
+ *
+ * Replaces `detectPropsWithPropertyAccess` in `prop-handling.ts` and
+ * the inline `propsUsedAsLoopArrays` loop in `generate-init.ts`.
+ *
+ * Stage C.2 of issue #1021. See `spec/compiler-analysis-ir.md`
+ * §"Target IR shape" #3 for the target field and §"Invariants" #4 for
+ * the guarantee this function underwrites.
+ */
+
+import type { ConstantInfo, PropAccessKind, PropUsage } from '../types'
+import type { ClientJsContext } from './types'
+
+export function computePropUsage(
+  ctx: ClientJsContext,
+  /** Constants the emitter is going to ship (scope === 'init'). Must
+   *  mirror the sources the pre-Stage C.2 `detectPropsWithPropertyAccess`
+   *  scanned, so that the `{}` default decision stays byte-identical. */
+  initScopeConstants: readonly ConstantInfo[],
+): Map<string, PropUsage> {
+  const usage = new Map<string, PropUsage>()
+
+  // Sources mirror the pre-refactor `detectPropsWithPropertyAccess`
+  // scan (prop-handling.ts L150-183): conditional branch HTML +
+  // condition, loop template, dynamic text expression, and init-scope
+  // constant initializers. Extending the scan would widen the `{}`
+  // default coverage — that is a deliberate Stage C.3 / later concern,
+  // not a Stage C.2 change.
+  const sources: string[] = []
+  for (const elem of ctx.conditionalElements) {
+    sources.push(elem.whenTrueHtml, elem.whenFalseHtml, elem.condition)
+  }
+  for (const elem of ctx.loopElements) {
+    sources.push(elem.template)
+  }
+  for (const elem of ctx.dynamicElements) {
+    sources.push(elem.expression)
+  }
+  for (const c of initScopeConstants) {
+    if (c.value) sources.push(c.value)
+  }
+
+  for (const prop of ctx.propsParams) {
+    const accessKinds = new Set<PropAccessKind>()
+    const dotPattern = new RegExp(`\\b${prop.name}\\.[a-zA-Z_]`)
+    const bracketPattern = new RegExp(`\\b${prop.name}\\s*\\[`)
+
+    for (const source of sources) {
+      if (dotPattern.test(source)) accessKinds.add('property')
+      if (bracketPattern.test(source)) accessKinds.add('index')
+      // Early exit once both kinds observed; `bare` is not tracked from
+      // this scan (`detectPropsWithPropertyAccess` never did).
+      if (accessKinds.size === 2) break
+    }
+
+    let usedAsLoopArray = false
+    for (const loop of ctx.loopElements) {
+      if (loop.array.trim() === prop.name) {
+        usedAsLoopArray = true
+        break
+      }
+    }
+
+    usage.set(prop.name, {
+      propName: prop.name,
+      accessKinds,
+      usedAsLoopArray,
+    })
+  }
+
+  return usage
+}
+
+/** Convenience predicate: does this prop need a `{}` default in the
+ *  destructure to guard against `undefined.xxx` at runtime? */
+export function propHasPropertyAccess(u: PropUsage | undefined): boolean {
+  if (!u) return false
+  return u.accessKinds.has('property') || u.accessKinds.has('index')
+}

--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -6,9 +6,10 @@
  * Control flow, reactive updates, and registration are in separate modules.
  */
 
-import type { SignalInfo } from '../types'
+import type { PropUsage, SignalInfo } from '../types'
 import type { Declaration } from './declaration-sort'
 import type { ClientJsContext } from './types'
+import { propHasPropertyAccess } from './compute-prop-usage'
 import { inferDefaultValue, toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, PROPS_PARAM } from './utils'
 
 
@@ -40,8 +41,7 @@ export function emitPropsExtraction(
   lines: string[],
   ctx: ClientJsContext,
   neededProps: Set<string>,
-  propsWithPropertyAccess: Set<string>,
-  propsUsedAsLoopArrays: Set<string>
+  propUsage: Map<string, PropUsage>,
 ): void {
   // Props used as conditional guards must remain falsy when undefined,
   // so we must NOT default them to {} (which is truthy).
@@ -60,15 +60,16 @@ export function emitPropsExtraction(
   if (neededProps.size > 0 && !ctx.propsObjectName) {
     for (const propName of neededProps) {
       const prop = ctx.propsParams.find((p) => p.name === propName)
+      const usage = propUsage.get(propName)
       const defaultVal = prop?.defaultValue
       if (defaultVal) {
         // Wrap arrow function defaults in parentheses to avoid operator precedence issues
         // e.g., `props.onInput ?? () => {}` is a syntax error; must be `props.onInput ?? (() => {})`
         const wrappedDefault = prop?.defaultContainsArrow ? `(${defaultVal})` : defaultVal
         lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? ${wrappedDefault}`)
-      } else if (propsUsedAsLoopArrays.has(propName)) {
+      } else if (usage?.usedAsLoopArray) {
         lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? []`)
-      } else if (propsWithPropertyAccess.has(propName) && !propsUsedAsConditions.has(propName)) {
+      } else if (propHasPropertyAccess(usage) && !propsUsedAsConditions.has(propName)) {
         lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? {}`)
       } else if (prop?.optional && prop?.type) {
         const inferredDefault = inferDefaultValue(prop.type)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -11,7 +11,8 @@ import {
   graphUsedIdentifiers,
 } from './build-references'
 import { computeDeclarationScopes } from './compute-scope'
-import { valueReferencesReactiveData, getControlledPropName, detectPropsWithPropertyAccess } from './prop-handling'
+import { valueReferencesReactiveData, getControlledPropName } from './prop-handling'
+import { computePropUsage } from './compute-prop-usage'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
 import {
@@ -121,19 +122,11 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
     }
   }
 
-  const propsWithPropertyAccess = detectPropsWithPropertyAccess(ctx, neededConstants)
-
-  const propsUsedAsLoopArrays = new Set<string>()
-  for (const loop of ctx.loopElements) {
-    const arrayName = loop.array.trim()
-    if (ctx.propsParams.some((p) => p.name === arrayName)) {
-      propsUsedAsLoopArrays.add(arrayName)
-    }
-  }
+  const propUsage = computePropUsage(ctx, neededConstants)
 
   // --- Output: generate code in correct order ---
 
-  emitPropsExtraction(lines, ctx, neededProps, propsWithPropertyAccess, propsUsedAsLoopArrays)
+  emitPropsExtraction(lines, ctx, neededProps, propUsage)
 
   // Build unified Declaration[] and sort by dependency order (#508)
   const controlledSignals: Array<{ signal: typeof ctx.signals[0]; propName: string }> = []

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -2,9 +2,9 @@
  * Props expansion, dependency analysis, and controlled component detection.
  */
 
-import type { ConstantInfo, ParamInfo, SignalInfo } from '../types'
+import type { ParamInfo, SignalInfo } from '../types'
 import type { ClientJsContext } from './types'
-import { PROPS_PARAM, exprReferencesIdent } from './utils'
+import { exprReferencesIdent } from './utils'
 
 /**
  * Expand dynamic prop value by resolving local constants.
@@ -143,41 +143,3 @@ export function getControlledPropName(
   return null
 }
 
-/**
- * Detect props that are used with property access (e.g., highlightedCommands.pnpm).
- * These props need a default value of {} to avoid "cannot read properties of undefined".
- */
-export function detectPropsWithPropertyAccess(
-  ctx: ClientJsContext,
-  neededConstants: ConstantInfo[]
-): Set<string> {
-  const result = new Set<string>()
-  const sources: string[] = []
-
-  for (const elem of ctx.conditionalElements) {
-    sources.push(elem.whenTrueHtml, elem.whenFalseHtml, elem.condition)
-  }
-  for (const elem of ctx.loopElements) {
-    sources.push(elem.template)
-  }
-  for (const elem of ctx.dynamicElements) {
-    sources.push(elem.expression)
-  }
-  for (const constant of neededConstants) {
-    if (constant.value) sources.push(constant.value)
-  }
-
-  for (const prop of ctx.propsParams) {
-    const dotPattern = new RegExp(`\\b${prop.name}\\.[a-zA-Z_]`)
-    const bracketPattern = new RegExp(`\\b${prop.name}\\s*\\[`)
-
-    for (const source of sources) {
-      if (dotPattern.test(source) || bracketPattern.test(source)) {
-        result.add(prop.name)
-        break
-      }
-    }
-  }
-
-  return result
-}

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -776,6 +776,27 @@ export interface ReferencesGraph {
  */
 export type DeclarationScope = 'module' | 'init' | 'skip'
 
+/**
+ * How a prop identifier is accessed somewhere the emitter scans. Used
+ * by `emitPropsExtraction` to pick the right default for the prop's
+ * destructure: `.xxx` access needs `{}` (to avoid "cannot read
+ *  properties of undefined"), `[…]` access likewise.
+ *
+ * `bare` is tracked for completeness but has no consumer today — future
+ * rules (e.g., "prop is read only as a value, so static template can
+ * inline it") would gate on it.
+ */
+export type PropAccessKind = 'bare' | 'property' | 'index'
+
+export interface PropUsage {
+  propName: string
+  /** Every access kind observed across the sources the emitter scans. */
+  accessKinds: ReadonlySet<PropAccessKind>
+  /** True when the prop is consumed as a loop's array expression
+   *  (`<loop>.array`). Triggers the `[]` default in the destructure. */
+  usedAsLoopArray: boolean
+}
+
 export interface ClientAnalysis {
   needsInit: boolean
   usedProps: string[]


### PR DESCRIPTION
## Summary

Stage C.2 of #1021 — analysis-on-IR refactor.

Introduces \`PropUsage\` on the IR type surface and replaces two independent computations in \`generate-init.ts\` — \`detectPropsWithPropertyAccess\` (prop-handling.ts) and the inline \`propsUsedAsLoopArrays\` loop — with a single pure function \`computePropUsage(ctx, initScopeConstants)\`. The destructure-default decision inside \`emitPropsExtraction\` now reads from a per-prop \`PropUsage\` lookup.

See \`spec/compiler-analysis-ir.md\` §\"Target IR shape\" #3 and §\"Invariants\" #4 for the target shape.

## What changed

| File | Purpose |
|------|---------|
| \`packages/jsx/src/types.ts\` | Adds \`PropAccessKind = 'bare' \| 'property' \| 'index'\` and \`PropUsage\` interface. |
| \`packages/jsx/src/ir-to-client-js/compute-prop-usage.ts\` | **New.** \`computePropUsage\` + \`propHasPropertyAccess\` predicate. Scan scope mirrors \`detectPropsWithPropertyAccess\` verbatim to keep the destructure default set byte-identical. |
| \`packages/jsx/src/ir-to-client-js/generate-init.ts\` | Removed the inline \`propsUsedAsLoopArrays\` loop. Routes \`emitPropsExtraction\` through the new \`propUsage\` map. |
| \`packages/jsx/src/ir-to-client-js/emit-init-sections.ts\` | \`emitPropsExtraction\` signature: \`(… , propUsage: Map)\` instead of the two-Set pair. |
| \`packages/jsx/src/ir-to-client-js/prop-handling.ts\` | Deleted \`detectPropsWithPropertyAccess\` (-42 lines). |

Net diff: +118 / -56.

## Destructure default decision (unchanged logic, consolidated source)

| Condition | Default |
|-----------|---------|
| \`prop.defaultValue\` set | explicit default from JSX |
| \`usage.usedAsLoopArray\` | \`?? []\` |
| \`usage.accessKinds\` has \`property\` or \`index\` AND prop is not a conditional guard | \`?? {}\` |
| \`prop.optional && prop.type\` primitive/array/object | \`?? inferDefaultValue(prop.type)\` |
| otherwise | no default |

## Invariant — byte-identical output

All 326 \`.client.js\` files under \`site/ui/dist/components/\` are byte-for-byte identical to \`main\`.

## Test matrix

| Suite | Count | Result |
|-------|-------|--------|
| \`packages/jsx\` unit | 763 | ✅ |
| \`packages/adapter-tests\` | 214 | ✅ |
| \`packages/hono\` | 80 | ✅ |
| \`packages/go-template\` | 63 | ✅ |
| \`packages/client\` | 212 | ✅ |
| \`packages/form\` | 40 | ✅ |
| \`ui/components\` IR | 1157 | ✅ |

**Total: 2529 tests, 0 fails.**

## Notes

- \`bare\` access kind is declared on the type but not populated by the current scanner — the pre-refactor behaviour did not distinguish it, so adding it now would widen the \`{}\` default coverage and break the byte-identical invariant. Populating \`bare\` is a later-stage concern (e.g., when the static-template safety checker needs it).
- Populating \`IRMetadata.propUsage\` at analyzer time (for adapter consumption) is **not** done here — adapters do not currently need this signal, so \`computePropUsage\` remains a Phase-2 pure function like \`computeDeclarationScopes\`.

## Not in this PR

- **Stage C.3** — \`emit-registration.ts\`'s \`componentScopeNames\` + \`buildInlinableConstants\` rewritten against the graph. This is where the one intentional Stage C emission deviation lands (CSR template visibility widens).
- **Stage D** — \`generate-init.ts\` collapses to a pure emitter.

## Test plan

- [x] All listed test suites pass locally
- [x] Byte-identical \`.client.js\` output vs \`main\`
- [x] \`computePropUsage\` is a pure function
- [ ] Reviewer verifies scan scope in \`compute-prop-usage.ts\` matches the pre-refactor \`detectPropsWithPropertyAccess\` at prop-handling.ts:150-183 (pre-deletion)
- [ ] CI passes

## Related

- Issue: #1021
- Prior stages: #1022 (A), #1023 (B), #1024 (C.1) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)