### PR TITLE
refactor(compiler): route emit-registration through the references graph (#1021)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -4,9 +4,10 @@
  * and the final hydrate() call emission.
  */
 
-import type { ComponentIR, IRFragment } from '../types'
+import type { ComponentIR, IRFragment, ReferencesGraph } from '../types'
 import type { ClientJsContext } from './types'
-import { bodyReferencesComponentScope, PROPS_PARAM, inferDefaultValue, exprReferencesIdent } from './utils'
+import { PROPS_PARAM, inferDefaultValue, exprReferencesIdent } from './utils'
+import { graphFunctionReferences } from './build-references'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, createStringProtector } from './html-template'
 
 // JavaScript built-in identifiers that are always available at any scope
@@ -93,11 +94,34 @@ export function resolveChainedRefs(constants: Map<string, string>, freeIdsMap?: 
   }
 }
 
+/** Does any edge from this function point at a name declared inside
+ *  the component? Direct graph replacement for the pre-Stage C.3
+ *  `bodyReferencesComponentScope(fn.body, componentScopeNames)` check.
+ *  Stays regex-semantics-compatible because the graph's function→name
+ *  edges are built via `extractIdentifiers`, i.e. the same
+ *  word-boundary pattern `bodyReferencesComponentScope` used. */
+function functionReferencesDeclaredName(graph: ReferencesGraph, fnName: string): boolean {
+  const refs = graphFunctionReferences(graph, fnName)
+  for (const r of refs) {
+    if (graph.declaredNames.has(r)) return true
+  }
+  return false
+}
+
 /**
  * Build the inlinable constants map and unsafe local names set from a context.
  * Extracted for reuse by both emitRegistrationAndHydration and generateTemplateOnlyMount (#435).
+ *
+ * `graph.declaredNames` is the one source of truth for "what counts as a
+ * component-scope name" — the same set `generate-init.ts` routes scope
+ * decisions off. Pre-Stage C.3 this function rebuilt the set inline and
+ * used a regex helper (`bodyReferencesComponentScope`) to test whether
+ * module-level functions referenced it; both are now graph queries.
  */
-export function buildInlinableConstants(ctx: ClientJsContext): {
+export function buildInlinableConstants(
+  ctx: ClientJsContext,
+  graph: ReferencesGraph,
+): {
   inlinableConstants: Map<string, string>
   unsafeLocalNames: Set<string>
 } {
@@ -108,18 +132,10 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
   const signalSetters = new Set(ctx.signals.filter(s => s.setter).map(s => s.setter!))
   const memoNames = new Set(ctx.memos.map(m => m.name))
 
-  const componentScopeNames = new Set<string>()
-  for (const c of ctx.localConstants) componentScopeNames.add(c.name)
-  for (const s of ctx.signals) { componentScopeNames.add(s.getter); if (s.setter) componentScopeNames.add(s.setter) }
-  for (const m of ctx.memos) componentScopeNames.add(m.name)
-  for (const f of ctx.localFunctions) componentScopeNames.add(f.name)
-  for (const p of ctx.propsParams) componentScopeNames.add(p.name)
-  if (ctx.propsObjectName) componentScopeNames.add(ctx.propsObjectName)
-
   for (const fn of ctx.localFunctions) {
     // Module-level functions that don't reference component internals
     // are emitted at module scope, so they are available in the template.
-    if (fn.isModule && !bodyReferencesComponentScope(fn.body, componentScopeNames)) continue
+    if (fn.isModule && !functionReferencesDeclaredName(graph, fn.name)) continue
     unsafeLocalNames.add(fn.name)
   }
 
@@ -167,7 +183,7 @@ export function buildInlinableConstants(ctx: ClientJsContext): {
       continue
     }
 
-    if (!valueOnlyUsesKnownNames(constant.freeIdentifiers!, componentScopeNames)) {
+    if (!valueOnlyUsesKnownNames(constant.freeIdentifiers!, graph.declaredNames)) {
       unsafeLocalNames.add(constant.name)
       continue
     }
@@ -351,6 +367,7 @@ export function emitRegistrationAndHydration(
   lines: string[],
   ctx: ClientJsContext,
   _ir: ComponentIR,
+  graph: ReferencesGraph,
 ): string {
   const name = ctx.componentName
 
@@ -358,7 +375,7 @@ export function emitRegistrationAndHydration(
   lines.push('')
 
   const propNamesForStaticCheck = new Set(ctx.propsParams.map((p) => p.name))
-  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
+  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx, graph)
 
   // Build rest spread names: these are rest/props spreads handled by applyRestAttrs, not spreadAttrs
   const restSpreadNames = new Set<string>()

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -248,7 +248,7 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   // before loop children (e.g., SelectItem) call useContext().
   emitLoopUpdates(lines, ctx)
   emitStaticArrayChildInits(lines, ctx)
-  const hydrateLine = emitRegistrationAndHydration(lines, ctx, _ir)
+  const hydrateLine = emitRegistrationAndHydration(lines, ctx, _ir, graph)
 
   let generatedCode = lines.join('\n')
 

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -164,7 +164,8 @@ function needsClientJs(ctx: ClientJsContext): boolean {
  */
 function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): string {
   const propNamesForStaticCheck = new Set(ctx.propsParams.map((p) => p.name))
-  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx)
+  const graph = buildReferencesGraph(ctx, ir.root)
+  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx, graph)
 
   // Build rest spread names: these are rest/props spreads handled by applyRestAttrs, not spreadAttrs
   const restSpreadNames = new Set<string>()

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -160,18 +160,6 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
 }
 
 /**
- * Check if a function body references any identifiers from the given scope.
- * Used to determine if a module-level function can be emitted outside the
- * component init function, or if it must stay inside due to scope dependencies.
- */
-export function bodyReferencesComponentScope(body: string, scopeNames: Set<string>): boolean {
-  for (const name of scopeNames) {
-    if (exprReferencesIdent(body, name)) return true
-  }
-  return false
-}
-
-/**
  * Check if a JS expression string references a given identifier.
  * Uses word-boundary matching with proper regex escaping.
  */


### PR DESCRIPTION
## Summary

Stage C.3 of #1021 — analysis-on-IR refactor.

Pulls the duplicated \`componentScopeNames\` rebuild out of \`buildInlinableConstants\` (emit-registration.ts) and deletes the regex-based \`bodyReferencesComponentScope\` helper (utils.ts). Both are replaced by queries against the shared \`ReferencesGraph\` that \`generate-init.ts\` already consumes for scope routing.

This closes the duplication table row #D1 in \`spec/compiler-analysis-ir.md\`: \"what counts as a component-scope name\" was rebuilt in *two* places with the exact same contents. Now \`graph.declaredNames\` is the one source.

## What changed

| File | Purpose |
|------|---------|
| \`packages/jsx/src/ir-to-client-js/emit-registration.ts\` | \`buildInlinableConstants(ctx, graph)\`. Deleted the inline \`componentScopeNames\` build (L111-117). Replaced the \`fn.isModule && !bodyReferencesComponentScope(…)\` gate with \`functionReferencesDeclaredName(graph, fn.name)\`. The constant \`valueOnlyUsesKnownNames\` check now reads \`graph.declaredNames\` instead of the rebuilt set. \`emitRegistrationAndHydration\` signature extended with \`graph\`. |
| \`packages/jsx/src/ir-to-client-js/generate-init.ts\` | Pass \`graph\` into \`emitRegistrationAndHydration\`. |
| \`packages/jsx/src/ir-to-client-js/index.ts\` | \`generateTemplateOnlyMount\` builds its own graph and passes to \`buildInlinableConstants\`. |
| \`packages/jsx/src/ir-to-client-js/utils.ts\` | Deleted \`bodyReferencesComponentScope\`. It had one caller and its semantics matched \`graphFunctionReferences\` ∩ \`graph.declaredNames\`. |

Net diff: +34 / -28 across 4 files.

## Semantic equivalence

| Pre-Stage C.3 | Post |
|---------------|------|
| \`componentScopeNames\` rebuilt from \`ctx.{localConstants,localFunctions,signals,memos,propsParams,propsObjectName}\` | \`graph.declaredNames\` — same 6 sources, built once, shared |
| \`bodyReferencesComponentScope(fn.body, scope)\` — outer loop over \`scope\`, regex per name | \`graphFunctionReferences(graph, fn.name)\` ∩ \`graph.declaredNames\` — one pass over precomputed edges |

The graph's function→name edges are built using \`extractIdentifiers\`, which is the same word-boundary regex as \`exprReferencesIdent\` (the primitive \`bodyReferencesComponentScope\` called), modulo \`KEYWORDS_AND_GLOBALS\` filtering. Users cannot shadow those keywords, so the filter is semantically inert for this query.

## Invariant — byte-identical output

All 326 \`.client.js\` files under \`site/ui/dist/components/\` are byte-for-byte identical to \`main\`.

## Test matrix

| Suite | Count | Result |
|-------|-------|--------|
| \`packages/jsx\` unit | 763 | ✅ |
| \`packages/adapter-tests\` | 214 | ✅ |
| \`packages/hono\` | 80 | ✅ |
| \`packages/go-template\` | 63 | ✅ |
| \`packages/client\` | 212 | ✅ |
| \`packages/form\` | 40 | ✅ |
| \`ui/components\` IR | 1157 | ✅ |

**Total: 2529 tests, 0 fails.**

## CSR template visibility note

The Stage A plan reserved room for one intentional emission deviation in Stage C — unlocking the \`static-array-children\` CSR fixture skip (and siblings). This refactor keeps behaviour byte-identical because:

- \`graph.declaredNames\` is the *exact same set* as the old \`componentScopeNames\` (same 6 sources).
- The CSR fixture's skip is about what CSR templates can SEE at their module closure (a distinct question from the \"unsafe local names\" classification decided by \`buildInlinableConstants\`).

Recording as \"known limit of per-instance reactive data\" per \`spec/compiler-analysis-ir.md\` §5. Unlocking those fixtures is a separate concern, not a Stage C.3 deliverable.

## Not in this PR

- **Stage D** — \`generate-init.ts\` collapses to a pure emitter (~150 line target).

## Test plan

- [x] All listed test suites pass locally
- [x] Byte-identical \`.client.js\` output vs \`main\`
- [x] No remaining callers of \`bodyReferencesComponentScope\` (grep confirms)
- [ ] Reviewer confirms \`functionReferencesDeclaredName\` matches the pre-refactor check's semantics (param shadowing NOT filtered — intentional, matches the old code)
- [ ] CI passes

## Related

- Issue: #1021
- Prior stages: #1022 (A), #1023 (B), #1024 (C.1), #1025 (C.2) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)