### PR TITLE
Add Toast Queue block

### DIFF
--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -114,10 +114,10 @@ export const blockEntries: BlockEntry[] = [
   { slug: 'state-machine-playground', title: 'State Machine Playground', description: 'Interactive state machine explorer with preset workflows, per-state multi-conditional classes flipping together on transition, a reactive transitions loop source, and a history filter/group memo chain' },
   { slug: 'theme-customizer', title: 'Theme Customizer', description: 'Three signal-driven context providers (palette, spacing, typography) wrapping a 12-level deep consumer tree. Tests Provider value propagation, multi-provider ordering, stale-read safety, and dynamic token add/remove' },
   { slug: 'infinite-scroll', title: 'Async Infinite Scroll', description: 'IntersectionObserver-triggered pagination with <Async> streaming boundary, mapArray append, per-item like/save actions, and effect cleanup on unmount. Tests the IRAsync + mapArray compiler path, reactive list growth, and error/empty-state branches' },
+  { slug: 'toast-queue', title: 'Toast Queue', description: 'Signal-backed notification queue with N simultaneous portals, auto-dismiss timers, manual dismiss, stack ordering, and per-toast cleanup on dynamic unmount' },
 ]
 
 // Helper: get components filtered by category
 export function getComponentsByCategory(category: ComponentCategory): ComponentEntry[] {
   return componentEntries.filter(e => e.category === category)
 }
-

--- a/site/ui/components/toast-queue-demo.test.tsx
+++ b/site/ui/components/toast-queue-demo.test.tsx
@@ -1,0 +1,68 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+import type { TestNode } from '@barefootjs/test'
+
+const source = readFileSync(resolve(__dirname, 'toast-queue-demo.tsx'), 'utf-8')
+const result = renderToTest(source, 'toast-queue-demo.tsx', 'ToastQueueDemo')
+
+function allNodes(node: TestNode): TestNode[] {
+  return [node, ...node.children.flatMap(allNodes)]
+}
+
+describe('ToastQueueDemo structure', () => {
+  test('compiles as a client component with queue state primitives', () => {
+    expect(result.errors).toEqual([])
+    expect(result.isClient).toBe(true)
+    expect(result.signals).toEqual(['toasts', 'paused', 'eventLog'])
+    expect(result.memos).toEqual(['activeCount', 'exitingCount', 'topVariant'])
+    expect(result.effects).toBe(3)
+  })
+
+  test('composes the existing toast UI components', () => {
+    expect(result.find({ componentName: 'ToastProvider' })).not.toBeNull()
+    expect(result.find({ componentName: 'Toast' })).not.toBeNull()
+    expect(result.find({ componentName: 'ToastTitle' })).not.toBeNull()
+    expect(result.find({ componentName: 'ToastDescription' })).not.toBeNull()
+    expect(result.find({ componentName: 'ToastClose' })).not.toBeNull()
+  })
+
+  test('renders queue controls with stable data-slot attributes', () => {
+    const buttons = result.findAll({ componentName: 'Button' })
+
+    expect(buttons).toHaveLength(3)
+    expect(buttons.map(button => button.props['data-slot'])).toEqual([
+      'add-batch',
+      'add-urgent',
+      'clear-queue',
+    ])
+  })
+
+  test('renders stats, source queue, empty state, and event log regions', () => {
+    const nodes = allNodes(result.root)
+    const dataSlots = nodes
+      .map(node => node.props['data-slot'])
+      .filter(Boolean)
+
+    expect(dataSlots).toContain('queue-stats')
+    expect(dataSlots).toContain('queue-source')
+    expect(dataSlots).toContain('empty-queue')
+    expect(dataSlots).toContain('queue-row')
+    expect(dataSlots).toContain('event-log')
+  })
+
+  test('toast content includes variant metadata and title/description components', () => {
+    const nodes = allNodes(result.root)
+    const dataSlots = nodes
+      .map(node => node.props['data-slot'])
+      .filter(Boolean)
+
+    expect(dataSlots).toContain('toast-kind')
+    expect(dataSlots).toContain('toast-id')
+    expect(dataSlots).toContain('toast-order')
+    expect(dataSlots).toContain('toast-time')
+    expect(result.find({ componentName: 'ToastTitle' })).not.toBeNull()
+    expect(result.find({ componentName: 'ToastDescription' })).not.toBeNull()
+  })
+})

--- a/site/ui/components/toast-queue-demo.tsx
+++ b/site/ui/components/toast-queue-demo.tsx
@@ -1,0 +1,267 @@
+"use client"
+/**
+ * ToastQueueDemo
+ *
+ * Notification queue block built from the existing Toast UI components.
+ * It stresses queued toast state, provider portal ownership, manual/automatic
+ * dismiss, and per-toast timer cleanup on dynamic unmount.
+ */
+
+import { createSignal, createMemo, createEffect, onCleanup } from '@barefootjs/client'
+import { Button } from '@ui/components/ui/button'
+import { Badge } from '@ui/components/ui/badge'
+import { Separator } from '@ui/components/ui/separator'
+import { ToastProvider, Toast, ToastTitle, ToastDescription, ToastClose } from '@ui/components/ui/toast'
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info'
+type ToastStatus = 'visible' | 'exiting'
+
+type QueueToast = {
+  id: number
+  variant: ToastVariant
+  title: string
+  description: string
+  duration: number
+  status: ToastStatus
+  createdAt: string
+}
+
+type ToastTemplate = Omit<QueueToast, 'id' | 'status' | 'createdAt'>
+
+const templates: ToastTemplate[] = [
+  {
+    variant: 'success',
+    title: 'Invoice paid',
+    description: 'Acme Studio completed payment for INV-4281.',
+    duration: 4200,
+  },
+  {
+    variant: 'info',
+    title: 'Build finished',
+    description: 'Preview deployment is ready for QA review.',
+    duration: 5200,
+  },
+  {
+    variant: 'warning',
+    title: 'Storage threshold',
+    description: 'Media storage is at 82 percent capacity.',
+    duration: 6500,
+  },
+  {
+    variant: 'error',
+    title: 'Webhook failed',
+    description: 'Retry scheduled after a 429 response from Stripe.',
+    duration: 7200,
+  },
+]
+
+let nextToastId = 1
+
+function variantTone(variant: ToastVariant) {
+  if (variant === 'success') return 'border-emerald-500/40 bg-emerald-50 text-emerald-950 dark:bg-emerald-950/50 dark:text-emerald-50'
+  if (variant === 'error') return 'border-red-500/40 bg-red-50 text-red-950 dark:bg-red-950/50 dark:text-red-50'
+  if (variant === 'warning') return 'border-amber-500/40 bg-amber-50 text-amber-950 dark:bg-amber-950/50 dark:text-amber-50'
+  return 'border-sky-500/40 bg-sky-50 text-sky-950 dark:bg-sky-950/50 dark:text-sky-50'
+}
+
+function variantBadge(variant: ToastVariant) {
+  if (variant === 'success') return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200'
+  if (variant === 'error') return 'bg-red-100 text-red-800 dark:bg-red-900/60 dark:text-red-200'
+  if (variant === 'warning') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/60 dark:text-amber-200'
+  return 'bg-sky-100 text-sky-800 dark:bg-sky-900/60 dark:text-sky-200'
+}
+
+export function ToastQueueDemo() {
+  const [toasts, setToasts] = createSignal<QueueToast[]>([])
+  const [paused, setPaused] = createSignal(false)
+  const [eventLog, setEventLog] = createSignal<string[]>(['Queue ready'])
+  const removeTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+  const activeCount = createMemo(() => toasts().filter(t => t.status !== 'exiting').length)
+  const exitingCount = createMemo(() => toasts().filter(t => t.status === 'exiting').length)
+  const topVariant = createMemo(() => {
+    const current = toasts().filter(t => t.status !== 'exiting')[0]
+    return current ? current.variant : 'none'
+  })
+
+  const pushLog = (message: string) => {
+    setEventLog(prev => [message, ...prev].slice(0, 5))
+  }
+
+  const dismissToast = (id: number) => {
+    setToasts(prev => prev.map(t => t.id === id && t.status !== 'exiting' ? { ...t, status: 'exiting' as ToastStatus } : t))
+    pushLog(`Dismissed toast #${id}`)
+  }
+
+  const removeToast = (id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }
+
+  const addToast = (template: ToastTemplate) => {
+    const id = nextToastId++
+    const toast: QueueToast = {
+      ...template,
+      id,
+      status: 'visible',
+      createdAt: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    }
+    setToasts(prev => [toast, ...prev].slice(0, 6))
+    pushLog(`Added ${template.variant} toast #${id}`)
+  }
+
+  const addBatch = () => {
+    templates.forEach(template => addToast(template))
+  }
+
+  const addUrgent = () => {
+    addToast({
+      variant: 'error',
+      title: 'Incident escalated',
+      description: 'On-call acknowledged a production alert.',
+      duration: 9000,
+    })
+  }
+
+  createEffect(() => {
+    const currentToasts = toasts()
+    const currentIds = currentToasts.map(t => t.id)
+
+    currentToasts.forEach(toast => {
+      if (toast.status !== 'exiting' || removeTimers.has(toast.id)) return
+      removeTimers.set(toast.id, setTimeout(() => {
+        removeTimers.delete(toast.id)
+        removeToast(toast.id)
+      }, 340))
+    })
+
+    Array.from(removeTimers.keys()).forEach(id => {
+      if (currentIds.includes(id)) return
+      const timer = removeTimers.get(id)
+      if (timer) clearTimeout(timer)
+      removeTimers.delete(id)
+    })
+  })
+
+  createEffect(() => {
+    onCleanup(() => {
+      Array.from(removeTimers.values()).forEach(timer => clearTimeout(timer))
+      removeTimers.clear()
+    })
+  })
+
+  createEffect(() => {
+    if (!paused()) return
+    const timer = setTimeout(() => setPaused(false), 1500)
+    onCleanup(() => clearTimeout(timer))
+  })
+
+  return (
+    <div className="space-y-6">
+      <ToastProvider position="bottom-right" className="gap-3">
+        {toasts().map((toast, index) => (
+          <Toast
+            key={toast.id}
+            id={`queue-toast-${toast.id}`}
+            variant={toast.variant}
+            open={toast.status !== 'exiting'}
+            duration={toast.duration}
+            onOpenChange={open => {
+              if (!open) dismissToast(toast.id)
+            }}
+            className={`toast-queue-item w-[min(24rem,calc(100vw-2rem))] ${variantTone(toast.variant)}`}
+          >
+            <div className="flex-1 space-y-1">
+              <div className="flex items-center gap-2">
+                <span data-slot="toast-kind" className={`rounded px-1.5 py-0.5 text-xs font-medium uppercase ${variantBadge(toast.variant)}`}>{toast.variant}</span>
+                <span data-slot="toast-id" className="text-xs opacity-70">#{toast.id}</span>
+                <span data-slot="toast-order" className="sr-only">{index + 1}</span>
+                <span data-slot="toast-time" className="ml-auto text-xs opacity-70">{toast.createdAt}</span>
+              </div>
+              <ToastTitle>{toast.title}</ToastTitle>
+              <ToastDescription>{toast.description}</ToastDescription>
+            </div>
+            <ToastClose />
+          </Toast>
+        ))}
+      </ToastProvider>
+
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold">Notification Queue</h3>
+            <p className="text-sm text-muted-foreground">Notifications are rendered through the shared ToastProvider portal.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button data-slot="add-batch" size="sm" onClick={addBatch}>Add batch</Button>
+            <Button data-slot="add-urgent" size="sm" variant="destructive" onClick={addUrgent}>Add urgent</Button>
+            <Button data-slot="clear-queue" size="sm" variant="outline" onClick={() => {
+              setToasts(prev => prev.map(t => ({ ...t, status: 'exiting' as ToastStatus })))
+              pushLog('Cleared queue')
+            }}>
+              Clear
+            </Button>
+          </div>
+        </div>
+
+        <Separator className="my-4" />
+
+        <div data-slot="queue-stats" className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-md bg-muted/50 p-3">
+            <div className="text-xs text-muted-foreground">Active toasts</div>
+            <div className="queue-active-count text-2xl font-semibold">{activeCount()}</div>
+          </div>
+          <div className="rounded-md bg-muted/50 p-3">
+            <div className="text-xs text-muted-foreground">Exiting</div>
+            <div className="queue-exiting-count text-2xl font-semibold">{exitingCount()}</div>
+          </div>
+          <div className="rounded-md bg-muted/50 p-3">
+            <div className="text-xs text-muted-foreground">Top variant</div>
+            <div className="queue-top-variant text-2xl font-semibold">{topVariant()}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
+        <div data-slot="queue-source" className="rounded-lg border bg-card p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Source queue</h3>
+            <Badge variant="outline">{toasts().length} tracked</Badge>
+          </div>
+          <div className="space-y-2">
+            {toasts().length === 0 ? (
+              <div data-slot="empty-queue" className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No notifications in the queue
+              </div>
+            ) : null}
+            {toasts().map((toast, index) => (
+              <div
+                key={toast.id}
+                data-slot="queue-row"
+                data-toast-id={toast.id}
+                data-state={toast.status}
+                className="flex items-center gap-3 rounded-md border bg-background p-3"
+              >
+                <span className="text-xs tabular-nums text-muted-foreground">{index + 1}</span>
+                <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${variantBadge(toast.variant)}`}>{toast.variant}</span>
+                <span className="min-w-0 flex-1 truncate text-sm">{toast.title}</span>
+                <span className="text-xs text-muted-foreground">{toast.status}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div data-slot="event-log" className="rounded-lg border bg-card p-4">
+          <h3 className="mb-3 text-sm font-semibold">Event log</h3>
+          <div className="space-y-2">
+            {eventLog().map(entry => (
+              <div key={entry} className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+                {entry}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/site/ui/e2e/toast-queue.spec.ts
+++ b/site/ui/e2e/toast-queue.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Toast Queue Block', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', error => {
+      console.log('Page error:', error.message)
+    })
+    await page.goto('/components/toast-queue')
+  })
+
+  const demo = (page: any) =>
+    page.locator('[bf-s^="ToastQueueDemo_"]:not([data-slot])').first()
+
+  const toastProvider = (page: any) =>
+    page.locator('body > [data-slot="toast-provider"]')
+
+  const portalToasts = (page: any) =>
+    toastProvider(page).locator('[data-slot="toast"]')
+
+  test('adds a batch through ToastProvider without overlapping variable-height toasts', async ({ page }) => {
+    const d = demo(page)
+
+    await d.locator('[data-slot="add-batch"]').click()
+
+    await expect(portalToasts(page)).toHaveCount(4)
+    await expect(toastProvider(page)).toHaveAttribute('bf-po', /.+/)
+    await expect(portalToasts(page).filter({ hasText: 'Invoice paid' })).toBeVisible()
+    await expect(portalToasts(page).filter({ hasText: 'Build finished' })).toBeVisible()
+    await expect(portalToasts(page).filter({ hasText: 'Storage threshold' })).toBeVisible()
+    await expect(portalToasts(page).filter({ hasText: 'Webhook failed' })).toBeVisible()
+    await expect(d.locator('.queue-active-count')).toContainText('4')
+    await expect(d.locator('.queue-top-variant')).toContainText('error')
+
+    const boxes = await portalToasts(page).evaluateAll(elements =>
+      elements.map(el => {
+        const rect = el.getBoundingClientRect()
+        return { top: rect.top, bottom: rect.bottom }
+      }),
+    )
+
+    for (let i = 1; i < boxes.length; i++) {
+      expect(boxes[i - 1].bottom).toBeLessThanOrEqual(boxes[i].top - 8)
+    }
+  })
+
+  test('manual dismiss transitions one toast out and removes it from the provider', async ({ page }) => {
+    const d = demo(page)
+
+    await d.locator('[data-slot="add-batch"]').click()
+    await expect(portalToasts(page)).toHaveCount(4)
+
+    await portalToasts(page).first().locator('[data-slot="toast-close"]').click()
+
+    await expect(d.locator('.queue-exiting-count')).toContainText('1')
+    await expect(portalToasts(page)).toHaveCount(3, { timeout: 2000 })
+    await expect(d.locator('.queue-active-count')).toContainText('3')
+  })
+
+  test('clear queue dynamically unmounts every toast', async ({ page }) => {
+    const d = demo(page)
+
+    await d.locator('[data-slot="add-batch"]').click()
+    await expect(portalToasts(page)).toHaveCount(4)
+
+    await d.locator('[data-slot="clear-queue"]').click()
+
+    await expect(d.locator('.queue-exiting-count')).toContainText('4')
+    await expect(portalToasts(page)).toHaveCount(0, { timeout: 2500 })
+    await expect(d.locator('[data-slot="empty-queue"]')).toBeVisible()
+  })
+
+  test('auto-dismiss removes toast after its per-toast timer', async ({ page }) => {
+    const d = demo(page)
+
+    await d.locator('[data-slot="add-batch"]').click()
+    await expect(portalToasts(page)).toHaveCount(4)
+
+    await expect(portalToasts(page)).toHaveCount(3, { timeout: 5500 })
+    await expect(d.locator('.queue-active-count')).toContainText('3')
+  })
+
+  test('urgent toast prepends and event log records dismissal', async ({ page }) => {
+    const d = demo(page)
+
+    await d.locator('[data-slot="add-urgent"]').click()
+    await expect(portalToasts(page)).toHaveCount(1)
+    await expect(portalToasts(page).first()).toContainText('Incident escalated')
+    await expect(d.locator('.queue-top-variant')).toContainText('error')
+    await expect(d.locator('[data-slot="event-log"]')).toContainText('Added error toast')
+
+    await portalToasts(page).first().locator('[data-slot="toast-close"]').click()
+    await expect(d.locator('[data-slot="event-log"]')).toContainText('Dismissed toast')
+  })
+})

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/test": "workspace:*",
     "@unocss/cli": "^66.0.0",
     "@unocss/preset-wind": "^66.0.0",
     "bun-types": "^1.1.0",

--- a/site/ui/pages/components/toast-queue.tsx
+++ b/site/ui/pages/components/toast-queue.tsx
@@ -1,0 +1,163 @@
+/**
+ * Toast Queue Reference Page (/components/toast-queue)
+ *
+ * Block-level composition pattern: a signal-backed notification queue built
+ * from the existing Toast UI components and ToastProvider portal.
+ */
+
+import { ToastQueueDemo } from '@/components/toast-queue-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'features', title: 'Features' },
+]
+
+const previewCode = `"use client"
+
+import { createSignal, createMemo, createEffect, onCleanup } from '@barefootjs/client'
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+} from '@ui/components/ui/toast'
+
+type QueueToast = {
+  id: number
+  variant: 'success' | 'error' | 'warning' | 'info'
+  title: string
+  description: string
+  duration: number
+  status: 'visible' | 'exiting'
+}
+
+const removeTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+export function ToastQueueDemo() {
+  const [toasts, setToasts] = createSignal<QueueToast[]>([])
+  const activeCount = createMemo(() => toasts().filter(t => t.status !== 'exiting').length)
+
+  const dismissToast = (id: number) => {
+    setToasts(prev => prev.map(t => t.id === id ? { ...t, status: 'exiting' } : t))
+  }
+
+  createEffect(() => {
+    const current = toasts()
+    current.forEach(toast => {
+      if (toast.status !== 'exiting' || removeTimers.has(toast.id)) return
+      removeTimers.set(toast.id, setTimeout(() => {
+        removeTimers.delete(toast.id)
+        setToasts(prev => prev.filter(t => t.id !== toast.id))
+      }, 340))
+    })
+  })
+
+  createEffect(() => {
+    onCleanup(() => removeTimers.forEach(timer => clearTimeout(timer)))
+  })
+
+  return (
+    <div>
+      <button onClick={() => setToasts(prev => [makeToast(), ...prev])}>
+        Add batch
+      </button>
+      <span>{activeCount()} active toasts</span>
+
+      <ToastProvider position="bottom-right">
+        {toasts().map(toast => (
+          <Toast
+            key={toast.id}
+            variant={toast.variant}
+            open={toast.status !== 'exiting'}
+            duration={toast.duration}
+            onOpenChange={open => {
+              if (!open) dismissToast(toast.id)
+            }}
+          >
+            <div className="flex-1">
+              <ToastTitle>{toast.title}</ToastTitle>
+              <ToastDescription>{toast.description}</ToastDescription>
+            </div>
+            <ToastClose />
+          </Toast>
+        ))}
+      </ToastProvider>
+    </div>
+  )
+}`
+
+export function ToastQueueRefPage() {
+  return (
+    <DocPage slug="toast-queue" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="Toast Queue"
+          description="Signal-backed notification queue composed with the existing ToastProvider, Toast, ToastTitle, ToastDescription, and ToastClose components."
+          {...getNavLinks('toast-queue')}
+        />
+
+        <Section id="preview" title="Preview">
+          <Example title="" code={previewCode}>
+            <ToastQueueDemo />
+          </Example>
+        </Section>
+
+        <Section id="features" title="Features">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Toast Component Composition
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                The queue renders each notification with the existing{' '}
+                <code className="text-xs">Toast</code> subcomponents instead of hand-written
+                toast markup, so variants, roles, close behavior, and animation classes stay
+                aligned with the UI registry.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Owner-Scope Tracking
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                <code className="text-xs">ToastProvider</code> owns the portal into{' '}
+                <code className="text-xs">document.body</code>, preserving the signal
+                ownership chain after the provider node is moved outside the component tree.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Per-Toast Cleanup
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                <code className="text-xs">Toast</code> handles auto-dismiss through its
+                duration prop, while the queue tracks exit-removal timers and clears them
+                through <code className="text-xs">onCleanup</code>.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-medium text-foreground mb-2">
+                Stack Ordering + Exit Animation
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                The signal-backed queue keeps newest notifications first, and the provider's
+                flex stack handles variable-height toast spacing. Manual dismiss changes
+                the item status to <code className="text-xs">exiting</code>, then removes it
+                after the animation delay.
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -68,6 +68,7 @@ import { DashboardBuilderRefPage } from './pages/components/dashboard-builder'
 import { StateMachinePlaygroundRefPage } from './pages/components/state-machine-playground'
 import { ThemeCustomizerRefPage } from './pages/components/theme-customizer'
 import { InfiniteScrollRefPage } from './pages/components/infinite-scroll'
+import { ToastQueueRefPage } from './pages/components/toast-queue'
 import { HoverCardRefPage } from './pages/components/hover-card'
 import { MenubarRefPage } from './pages/components/menubar'
 import { NavigationMenuRefPage } from './pages/components/navigation-menu'
@@ -497,6 +498,11 @@ export function createApp() {
   // Async Infinite Scroll block page
   app.get('/components/infinite-scroll', (c) => {
     return c.render(<InfiniteScrollRefPage />)
+  })
+
+  // Toast Queue block page
+  app.get('/components/toast-queue', (c) => {
+    return c.render(<ToastQueueRefPage />)
   })
 
   // Gallery — Admin app (Phase 9 pilot)


### PR DESCRIPTION
## Summary

- Add a Toast Queue block at `/components/toast-queue`
- Register it in the Blocks navigation and routes
- Cover simultaneous portals, owner-scope markers, stack ordering, manual dismiss, auto-dismiss, and cleanup with Playwright E2E tests

## Validation

- `bun run --filter barefootjs-components build`
- `PORT=3102 bun run dev`
- `PORT=3102 bunx playwright test e2e/toast-queue.spec.ts`