### PR TITLE
refactor(compiler): collapse generate-init.ts to a ~140-line orchestrator (#1021)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/child-components.ts
+++ b/packages/jsx/src/ir-to-client-js/child-components.ts
@@ -1,0 +1,101 @@
+/**
+ * Child component imports + IR-tree name collection.
+ *
+ * Each component referenced from the current component's IR tree
+ * (directly, via a loop, or inside a conditional branch) needs a
+ * `@bf-child:<Name>` import marker so the bundler can wire up the
+ * cross-file reference. Siblings in the same compilation unit are
+ * skipped — they are declared in the same file and already resolve.
+ */
+
+import type { IRNode } from '../types'
+import type { ClientJsContext, ConditionalElement } from './types'
+
+/** Emit child-component import marker lines for every component name
+ *  reachable from the current component's IR (minus siblings). */
+export function emitChildComponentImports(
+  lines: string[],
+  ctx: ClientJsContext,
+  siblingSet: ReadonlySet<string>,
+): void {
+  const childComponentNames = new Set<string>()
+  for (const loop of ctx.loopElements) {
+    if (loop.childComponent) {
+      childComponentNames.add(loop.childComponent.name)
+      collectComponentNamesFromIR(loop.childComponent.children, childComponentNames)
+    }
+    // Composite element reconciliation: collect component names from nestedComponents
+    if (loop.useElementReconciliation && loop.nestedComponents?.length) {
+      for (const comp of loop.nestedComponents) {
+        childComponentNames.add(comp.name)
+      }
+    }
+  }
+  for (const child of ctx.childInits) {
+    childComponentNames.add(child.name)
+  }
+  for (const cond of [...ctx.conditionalElements, ...ctx.clientOnlyConditionals]) {
+    collectChildNamesFromBranches(cond, childComponentNames)
+  }
+  for (const childName of childComponentNames) {
+    if (!siblingSet.has(childName)) {
+      lines.push(`import '/* @bf-child:${childName} */'`)
+    }
+  }
+}
+
+/**
+ * Recursively collect component names from IR children.
+ * Used to ensure all nested components are imported, and to detect
+ * which components are used as children (for conditional CSR fallback).
+ */
+export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>): void {
+  for (const node of nodes) {
+    if (node.type === 'component') {
+      names.add(node.name)
+      collectComponentNamesFromIR(node.children, names)
+      // Traverse JSX prop children for nested component references
+      for (const prop of node.props) {
+        if (prop.jsxChildren) {
+          collectComponentNamesFromIR(prop.jsxChildren, names)
+        }
+      }
+    } else if (node.type === 'element' || node.type === 'fragment' || node.type === 'provider') {
+      collectComponentNamesFromIR(node.children, names)
+    } else if (node.type === 'conditional') {
+      collectComponentNamesFromIR([node.whenTrue], names)
+      collectComponentNamesFromIR([node.whenFalse], names)
+    } else if (node.type === 'loop') {
+      collectComponentNamesFromIR(node.children, names)
+      if (node.childComponent) {
+        names.add(node.childComponent.name)
+        collectComponentNamesFromIR(node.childComponent.children, names)
+      }
+      if (node.nestedComponents) {
+        for (const nested of node.nestedComponents) {
+          names.add(nested.name)
+          collectComponentNamesFromIR(nested.children, names)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Collect child component names from conditional branch loops and nested conditionals.
+ * Ensures @bf-child import markers are generated for components inside
+ * composite loops within conditional branches (e.g., Badge inside a branch loop).
+ */
+function collectChildNamesFromBranches(
+  cond: Pick<ConditionalElement, 'whenTrue' | 'whenFalse'>,
+  names: Set<string>,
+): void {
+  for (const loop of [...cond.whenTrue.loops, ...cond.whenFalse.loops]) {
+    if (loop.nestedComponents) {
+      for (const comp of loop.nestedComponents) names.add(comp.name)
+    }
+  }
+  for (const nested of [...cond.whenTrue.conditionals, ...cond.whenFalse.conditionals]) {
+    collectChildNamesFromBranches(nested, names)
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/element-refs.ts
+++ b/packages/jsx/src/ir-to-client-js/element-refs.ts
@@ -1,0 +1,89 @@
+/**
+ * Element ref declarations — `const [_s0, _s1] = $(…, 's0', 's1')`.
+ *
+ * Every element the init body needs to find at hydration time (events,
+ * dynamic text, loops, refs, reactive attrs, reactive props, rest-attr
+ * elements, child component slots) is emitted via one of three finders:
+ *
+ *   `$(…)`  — regular DOM elements (bf-*)
+ *   `$t(…)` — text comment markers for dynamic text (`<!--bf:sN-->`)
+ *   `$c(…)` — component slots (bf-s, component-rooted)
+ *
+ * Slots inside conditional branches are excluded here because
+ * `insert()` bindEvents re-queries them when the branch activates.
+ * Component slots take precedence over regular slots (#360): when a
+ * loop inherits its parent component's slot ID, both need the same
+ * DOM element reference and `$c` is the right selector.
+ */
+
+import type { ClientJsContext } from './types'
+import { collectConditionalSlotIds } from './emit-init-sections'
+import { varSlotId } from './utils'
+
+/**
+ * Generate `const _slotId = find(...)` declarations for all elements
+ * that need direct DOM references.
+ */
+export function generateElementRefs(ctx: ClientJsContext): string {
+  const regularSlots = new Set<string>()
+  const textSlots = new Set<string>()
+  const componentSlots = new Set<string>()
+  const conditionalSlotIds = collectConditionalSlotIds(ctx)
+
+  for (const elem of ctx.interactiveElements) {
+    if (elem.slotId !== '__scope' && !conditionalSlotIds.has(elem.slotId)) {
+      regularSlots.add(elem.slotId)
+    }
+  }
+  for (const elem of ctx.dynamicElements) {
+    if (!elem.insideConditional) {
+      textSlots.add(elem.slotId)
+    }
+  }
+  for (const elem of ctx.conditionalElements) {
+    regularSlots.add(elem.slotId)
+  }
+  for (const elem of ctx.loopElements) {
+    regularSlots.add(elem.slotId)
+  }
+  for (const elem of ctx.refElements) {
+    if (!conditionalSlotIds.has(elem.slotId)) {
+      regularSlots.add(elem.slotId)
+    }
+  }
+  for (const attr of ctx.reactiveAttrs) {
+    regularSlots.add(attr.slotId)
+  }
+  for (const prop of ctx.reactiveProps) {
+    componentSlots.add(prop.slotId)
+  }
+  for (const child of ctx.childInits) {
+    if (child.slotId) {
+      componentSlots.add(child.slotId)
+    }
+  }
+  for (const rest of ctx.restAttrElements) {
+    regularSlots.add(rest.slotId)
+  }
+
+  // Component slots take precedence over regular slots (#360) — see
+  // header comment for the why.
+  for (const slotId of componentSlots) {
+    regularSlots.delete(slotId)
+  }
+
+  if (regularSlots.size === 0 && textSlots.size === 0 && componentSlots.size === 0) return ''
+
+  const refLines: string[] = []
+  emitSlotRefs(refLines, [...regularSlots], '$')
+  emitSlotRefs(refLines, [...textSlots], '$t')
+  emitSlotRefs(refLines, [...componentSlots], '$c')
+  return refLines.join('\n')
+}
+
+function emitSlotRefs(lines: string[], slotIds: string[], fn: string): void {
+  if (slotIds.length === 0) return
+  const vars = slotIds.map(id => `_${varSlotId(id)}`).join(', ')
+  const args = slotIds.map(id => `'${id}'`).join(', ')
+  lines.push(`  const [${vars}] = ${fn}(__scope, ${args})`)
+}

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -1,0 +1,83 @@
+/**
+ * Module-level emission + final import resolution.
+ *
+ * Two concerns that run AFTER the init body has been emitted into the
+ * `lines` array and joined into a string:
+ *
+ *   1. `emitModuleLevelDeclarations` produces the code block that
+ *      replaces `MODULE_CONSTANTS_PLACEHOLDER`. Each module-level
+ *      constant / function is emitted as `var X = X ?? <value>` so
+ *      multiple components in the same bundle can share the same
+ *      helper safely (re-declaration is a no-op).
+ *
+ *   2. `resolveFinalImports` scans the joined code for DOM helper
+ *      calls the emitters made (`$`, `$t`, `$c`, `createEffect`,
+ *      `hydrate`, …) and builds the final `import { … } from
+ *      '@barefootjs/client'` line, plus any external/user imports.
+ *
+ * Both are pure functions of their inputs. `generate-init.ts` glues
+ * them onto the placeholder replacements at the end of emission.
+ */
+
+import type { ComponentIR, ConstantInfo, FunctionInfo } from '../types'
+import {
+  RUNTIME_MODULE,
+  collectExternalImports,
+  collectUserDomImports,
+  detectUsedImports,
+} from './imports'
+
+/**
+ * Build the module-level code block that replaces `MODULE_CONSTANTS_PLACEHOLDER`.
+ *
+ * Module-level constants use `var` with nullish coalescing for safe
+ * re-declaration when multiple components in the same file share
+ * context. Module-level functions get the same treatment so components
+ * that import the same helper do not double-declare.
+ *
+ * Returns the empty string when there is nothing to emit (preserves
+ * the legacy behaviour of replacing the placeholder with `""`).
+ */
+export function emitModuleLevelDeclarations(
+  moduleLevelConstants: readonly ConstantInfo[],
+  moduleLevelFunctions: readonly FunctionInfo[],
+): string {
+  const lines: string[] = []
+  for (const constant of moduleLevelConstants) {
+    if (!constant.value) continue
+    lines.push(`var ${constant.name} = ${constant.name} ?? ${constant.value}`)
+  }
+  // `export` is intentionally omitted — client JS files are self-contained
+  // entry points, not imported by other modules. Add export when a concrete
+  // cross-module use case arises.
+  for (const fn of moduleLevelFunctions) {
+    const paramStr = fn.params.map(p => p.name).join(', ')
+    lines.push(`var ${fn.name} = ${fn.name} ?? function(${paramStr}) ${fn.body}`)
+  }
+  return lines.length > 0 ? lines.join('\n') + '\n' : ''
+}
+
+/**
+ * Build the final import line(s) for the emitted client JS.
+ *
+ * - Runtime DOM helpers detected via `detectUsedImports` are merged
+ *   with user-side DOM imports (`useContext` et al) and emitted as a
+ *   single `import { … } from '@barefootjs/client'` line.
+ * - External (non-runtime) imports from the user file are appended on
+ *   following lines.
+ */
+export function resolveFinalImports(
+  generatedCode: string,
+  ir: ComponentIR,
+  localImportPrefixes: string[] | undefined,
+): string {
+  const usedImports = detectUsedImports(generatedCode)
+  for (const userImport of collectUserDomImports(ir)) {
+    usedImports.add(userImport)
+  }
+  const sortedImports = [...usedImports].sort()
+  const importLine = `import { ${sortedImports.join(', ')} } from '${RUNTIME_MODULE}'`
+
+  const externalImportLines = collectExternalImports(ir, generatedCode, localImportPrefixes)
+  return [importLine, ...externalImportLines].join('\n')
+}

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -1,25 +1,25 @@
 /**
- * generateInitFunction orchestrator + generateElementRefs.
+ * `generateInitFunction` — client-JS orchestrator.
+ *
+ * Pipes analysis → emission → finalisation. Every non-trivial stage
+ * lives in its own file; this function's job is to show the order of
+ * the pipeline and the data flowing between stages. See
+ * `spec/compiler-analysis-ir.md` §"Invariants after Stages B–C–D" #7
+ * for the shape target (orchestrator only, no classification logic).
  */
 
-import type { ComponentIR, ConstantInfo, FunctionInfo, IRNode } from '../types'
-import type { ClientJsContext, ConditionalElement } from './types'
-import { varSlotId, PROPS_PARAM } from './utils'
+import type { ComponentIR } from '../types'
+import type { ClientJsContext } from './types'
+import { PROPS_PARAM } from './utils'
 import {
   buildReferencesGraph,
   graphUsedFunctions,
-  graphUsedIdentifiers,
 } from './build-references'
-import { computeDeclarationScopes } from './compute-scope'
-import { valueReferencesReactiveData, getControlledPropName } from './prop-handling'
 import { computePropUsage } from './compute-prop-usage'
-import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectUserDomImports, collectExternalImports } from './imports'
-import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
+import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports'
 import {
   collectConditionalSlotIds,
   emitPropsExtraction,
-  emitDeclaration,
-  emitControlledSignalEffect,
   emitPropsEventHandlers,
   emitEventHandlers,
   emitRestAttrApplications,
@@ -32,195 +32,41 @@ import {
 import { emitConditionalUpdates, emitClientOnlyConditionals, emitLoopUpdates } from './emit-control-flow'
 import { emitDynamicTextUpdates, emitClientOnlyExpressions, emitReactiveAttributeUpdates, emitReactivePropBindings, emitReactiveChildProps } from './emit-reactive'
 import { emitRegistrationAndHydration } from './emit-registration'
+import { generateElementRefs } from './element-refs'
+import { emitChildComponentImports } from './child-components'
+import { classifyLocalDeclarations, emitSortedDeclarations } from './init-declarations'
+import { emitModuleLevelDeclarations, resolveFinalImports } from './emit-module-level'
 
-/**
- * Orchestrate client JS code generation: analyze dependencies, emit code sections,
- * and resolve imports. Returns the complete init function + registration code.
- */
-export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, siblingComponents?: string[], localImportPrefixes?: string[]): string {
+export function generateInitFunction(
+  ir: ComponentIR,
+  ctx: ClientJsContext,
+  siblingComponents?: string[],
+  localImportPrefixes?: string[],
+): string {
   const lines: string[] = []
   const name = ctx.componentName
 
+  // --- Preamble: placeholders for deferred imports + module-level code ---
   lines.push(IMPORT_PLACEHOLDER)
-
-  // Child component imports (skip siblings in the same file)
-  const siblingSet = new Set(siblingComponents || [])
-  const childComponentNames = new Set<string>()
-  for (const loop of ctx.loopElements) {
-    if (loop.childComponent) {
-      childComponentNames.add(loop.childComponent.name)
-      collectComponentNamesFromIR(loop.childComponent.children, childComponentNames)
-    }
-    // Composite element reconciliation: collect component names from nestedComponents
-    if (loop.useElementReconciliation && loop.nestedComponents?.length) {
-      for (const comp of loop.nestedComponents) {
-        childComponentNames.add(comp.name)
-      }
-    }
-  }
-  for (const child of ctx.childInits) {
-    childComponentNames.add(child.name)
-  }
-  // Collect from conditional branch loops and nested conditionals
-  for (const cond of [...ctx.conditionalElements, ...ctx.clientOnlyConditionals]) {
-    collectChildNamesFromBranches(cond, childComponentNames)
-  }
-  for (const childName of childComponentNames) {
-    if (!siblingSet.has(childName)) {
-      lines.push(`import '/* @bf-child:${childName} */'`)
-    }
-  }
-
+  emitChildComponentImports(lines, ctx, new Set(siblingComponents || []))
   lines.push('')
   lines.push(MODULE_CONSTANTS_PLACEHOLDER)
-
   lines.push(`export function init${name}(__scope, ${PROPS_PARAM} = {}) {`)
   lines.push(`  if (!__scope) return`)
   lines.push('')
 
-  // --- Analysis: derive reachability from the component's reference graph ---
-  //
-  // The graph is built once and queried for every reachability question
-  // `generate-init.ts` used to answer via three separate extraction
-  // passes (`collectUsedIdentifiers`, `collectUsedFunctions`,
-  // `collectIdentifiersFromIRTree`) plus a manual init-statement merge.
-  // Each query below is a pure function over the same graph. See
-  // `spec/compiler-analysis-ir.md` for the target invariants.
-
-  const graph = buildReferencesGraph(ctx, _ir.root)
-  const usedIdentifiers = graphUsedIdentifiers(graph)
+  // --- Analysis: one graph, many queries; scope routing as data ---
+  const graph = buildReferencesGraph(ctx, ir.root)
   const usedFunctions = graphUsedFunctions(graph)
-  const { constantScope, functionScope } = computeDeclarationScopes(ctx, graph)
+  const classification = classifyLocalDeclarations(ctx, graph)
+  const propUsage = computePropUsage(ctx, classification.neededConstants)
 
-  // Route each local constant by its precomputed scope. The cascade that
-  // used to branch on `systemConstructKind`, `isModule + initStmtAssigned`,
-  // and provider context hoisting now lives in `compute-scope.ts`; this
-  // file just reads the answer.
-  const neededProps = new Set<string>()
-  const neededConstants: ConstantInfo[] = []
-  const moduleLevelConstants: ConstantInfo[] = []
-  for (const constant of ctx.localConstants) {
-    const scope = constantScope.get(constant.name)
-    if (scope === 'skip') continue
-    if (scope === 'module') {
-      moduleLevelConstants.push(constant)
-      continue
-    }
-    // scope === 'init'
-    neededConstants.push(constant)
-    if (constant.value) {
-      const refs = valueReferencesReactiveData(constant.value, ctx)
-      for (const propName of refs.usedProps) {
-        neededProps.add(propName)
-      }
-    }
-  }
-
-  for (const id of usedIdentifiers) {
-    if (ctx.propsParams.some((p) => p.name === id)) {
-      neededProps.add(id)
-    }
-  }
-
-  const propUsage = computePropUsage(ctx, neededConstants)
-
-  // --- Output: generate code in correct order ---
-
-  emitPropsExtraction(lines, ctx, neededProps, propUsage)
-
-  // Build unified Declaration[] and sort by dependency order (#508)
-  const controlledSignals: Array<{ signal: typeof ctx.signals[0]; propName: string }> = []
-  for (const signal of ctx.signals) {
-    const controlledPropName = getControlledPropName(signal, ctx.propsParams, ctx.propsObjectName)
-    if (controlledPropName) {
-      controlledSignals.push({ signal, propName: controlledPropName })
-    }
-  }
-
-  const declarations: Declaration[] = []
-
-  // Collect constants
-  for (const constant of neededConstants) {
-    declarations.push({
-      kind: 'constant',
-      info: constant,
-      sourceIndex: constant.loc.start.line,
-    })
-  }
-
-  // Route each local function by its precomputed scope. The fixpoint
-  // that used to live here now lives inside `computeDeclarationScopes`
-  // (compute-scope.ts).
-  const moduleLevelFunctions: FunctionInfo[] = []
-  for (const fn of ctx.localFunctions) {
-    const scope = functionScope.get(fn.name)
-    if (scope === 'skip') continue
-    if (scope === 'module') {
-      moduleLevelFunctions.push(fn)
-      continue
-    }
-    // scope === 'init'
-    declarations.push({
-      kind: 'function',
-      info: fn,
-      sourceIndex: fn.loc.start.line,
-    })
-  }
-
-  // Collect signals
-  for (const signal of ctx.signals) {
-    const controlled = controlledSignals.find(c => c.signal === signal)
-    declarations.push({
-      kind: 'signal',
-      info: signal,
-      controlledPropName: controlled?.propName ?? null,
-      sourceIndex: signal.loc.start.line,
-    })
-  }
-
-  // Collect memos
-  for (const memo of ctx.memos) {
-    declarations.push({
-      kind: 'memo',
-      info: memo,
-      sourceIndex: memo.loc.start.line,
-    })
-  }
-
-  // Build the set of all names defined by declarations for dependency filtering
-  const declNameSet = new Set<string>()
-  for (const decl of declarations) {
-    for (const name of providedNames(decl)) {
-      declNameSet.add(name)
-    }
-  }
-
-  const sorted = sortDeclarations(declarations, declNameSet)
-
-  // Emit sorted declarations
-  let emittedAny = false
-  for (const decl of sorted) {
-    emitDeclaration(lines, decl, ctx, controlledSignals)
-    if (decl.kind === 'signal' && decl.controlledPropName) {
-      emitControlledSignalEffect(lines, decl.info, decl.controlledPropName, ctx)
-    }
-    emittedAny = true
-  }
-  if (emittedAny) {
-    lines.push('')
-  }
-
-  // Emit bare imperative statements preserved from the component body (#930).
-  // These run at init time after signals/memos so they can reference them,
-  // but before effects/onMounts/DOM wiring so they can install global
-  // listeners that trigger signal updates without racing the effects.
+  // --- Emission: init body (runs at hydration for each instance) ---
+  emitPropsExtraction(lines, ctx, classification.neededProps, propUsage)
+  emitSortedDeclarations(lines, ctx, classification)
   emitInitStatements(lines, ctx)
-  if (ctx.initStatements.length > 0) {
-    lines.push('')
-  }
-
-  // Emit props-based event handlers (not local definitions)
-  emitPropsEventHandlers(lines, ctx, usedFunctions, neededProps)
+  if (ctx.initStatements.length > 0) lines.push('')
+  emitPropsEventHandlers(lines, ctx, usedFunctions, classification.neededProps)
 
   const elementRefs = generateElementRefs(ctx)
   if (elementRefs) {
@@ -235,7 +81,6 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   emitClientOnlyConditionals(lines, ctx)
 
   const conditionalSlotIds = collectConditionalSlotIds(ctx)
-
   emitRestAttrApplications(lines, ctx)
   emitEventHandlers(lines, ctx, conditionalSlotIds)
   emitReactivePropBindings(lines, ctx)
@@ -243,71 +88,32 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
   emitRefCallbacks(lines, ctx, conditionalSlotIds)
   emitEffectsAndOnMounts(lines, ctx)
   emitProviderAndChildInits(lines, ctx)
-  // Loop updates must run AFTER provider/child inits so that parent
-  // components have already provided their context (e.g., SelectContext)
-  // before loop children (e.g., SelectItem) call useContext().
+  // Loop updates must run AFTER provider/child inits so parent components
+  // have already provided their context before loop children useContext().
   emitLoopUpdates(lines, ctx)
   emitStaticArrayChildInits(lines, ctx)
-  const hydrateLine = emitRegistrationAndHydration(lines, ctx, _ir, graph)
 
-  let generatedCode = lines.join('\n')
+  const hydrateLine = emitRegistrationAndHydration(lines, ctx, ir, graph)
 
-  // Rename source-level props object name to the generated parameter name.
-  // User code may use `props.xxx` or a custom name like `p.xxx`;
-  // the init function parameter is always PROPS_PARAM.
-  // Both property access (props.xxx) and bare references (fn(props)) are renamed.
-  // The hydrate line is structurally excluded — it was not in `lines` during join,
-  // so template expressions (already using PROPS_PARAM) are never double-replaced.
-  const srcPropsName = ctx.propsObjectName ?? 'props'
-  if (srcPropsName !== PROPS_PARAM) {
-    generatedCode = generatedCode.split('\n')
-      .map(line => {
-        // Skip comment lines
-        if (line.trimStart().startsWith('//')) return line
-        return line.replace(new RegExp(`\\b${srcPropsName}\\b`, 'g'), PROPS_PARAM)
-      })
-      .join('\n')
-  }
-
-  // Append hydrate line after props renaming (template expressions are already correct)
+  // --- Finalisation: props rename → hydrate line → import / module-level
+  //     placeholder replacement.
+  //
+  // The props rename is a post-join string hack (replaces a bare
+  // user-level name like `props` or `p` with the generated `_p`
+  // parameter across every non-comment init-body line). Removing it
+  // needs analyzer-time pre-rewriting of every IR string field that
+  // can carry a prop reference — tracked as Stage E / follow-up. ---
+  let generatedCode = renamePropsObjectInInitBody(
+    lines.join('\n'),
+    ctx.propsObjectName,
+  )
   generatedCode += '\n' + hydrateLine
 
-  const usedImports = detectUsedImports(generatedCode)
-
-  for (const userImport of collectUserDomImports(_ir)) {
-    usedImports.add(userImport)
-  }
-
-  const sortedImports = [...usedImports].sort()
-  const importLine = `import { ${sortedImports.join(', ')} } from '${RUNTIME_MODULE}'`
-
-  // Collect external (non-DOM) imports used in the generated code
-  const externalImportLines = collectExternalImports(_ir, generatedCode, localImportPrefixes)
-  const allImportLines = [importLine, ...externalImportLines].join('\n')
-
-  // Module-level constants use `var` with nullish coalescing for safe
-  // re-declaration when multiple components in the same file share context
-  const moduleCodeLines: string[] = []
-  for (const constant of moduleLevelConstants) {
-    if (!constant.value) continue
-    moduleCodeLines.push(`var ${constant.name} = ${constant.name} ?? ${constant.value}`)
-  }
-
-  // Module-level functions: emitted at module scope so they are available
-  // in both the init function and the SSR template.
-  // Uses `var` + nullish coalescing for safe re-declaration when multiple
-  // components in the same bundle share the same helper function.
-  // Note: export is intentionally omitted — client JS files are self-contained
-  // entry points, not imported by other modules. Add export when a concrete
-  // cross-module use case arises.
-  for (const fn of moduleLevelFunctions) {
-    const paramStr = fn.params.map(p => p.name).join(', ')
-    moduleCodeLines.push(`var ${fn.name} = ${fn.name} ?? function(${paramStr}) ${fn.body}`)
-  }
-
-  const moduleConstantsCode = moduleCodeLines.length > 0
-    ? moduleCodeLines.join('\n') + '\n'
-    : ''
+  const allImportLines = resolveFinalImports(generatedCode, ir, localImportPrefixes)
+  const moduleConstantsCode = emitModuleLevelDeclarations(
+    classification.moduleLevelConstants,
+    classification.moduleLevelFunctions,
+  )
 
   return generatedCode
     .replace(IMPORT_PLACEHOLDER, allImportLines)
@@ -315,136 +121,24 @@ export function generateInitFunction(_ir: ComponentIR, ctx: ClientJsContext, sib
 }
 
 /**
- * Generate `const _slotId = find(...)` declarations for all elements
- * that need direct DOM references (events, dynamic text, loops, etc.).
+ * Rename the source-level props object name (`props` / user's custom
+ * name) to the generated parameter name `_p`. Runs on the joined init-
+ * body string, skipping comment lines so JSDoc / explanatory comments
+ * survive verbatim.
+ *
+ * No-op when the user already uses destructured props (`propsObjectName`
+ * is `null`, handled by `?? 'props'` not matching `_p`). The hydrate
+ * line is excluded structurally — callers append it AFTER this runs so
+ * template expressions already using `_p` are never double-replaced.
  */
-export function generateElementRefs(ctx: ClientJsContext): string {
-  const regularSlots = new Set<string>()
-  const textSlots = new Set<string>()
-  const componentSlots = new Set<string>()
-  const conditionalSlotIds = collectConditionalSlotIds(ctx)
-
-  for (const elem of ctx.interactiveElements) {
-    if (elem.slotId !== '__scope' && !conditionalSlotIds.has(elem.slotId)) {
-      regularSlots.add(elem.slotId)
-    }
-  }
-  // Dynamic text expressions use comment markers found via $t()
-  for (const elem of ctx.dynamicElements) {
-    if (!elem.insideConditional) {
-      textSlots.add(elem.slotId)
-    }
-  }
-  for (const elem of ctx.conditionalElements) {
-    regularSlots.add(elem.slotId)
-  }
-  for (const elem of ctx.loopElements) {
-    regularSlots.add(elem.slotId)
-  }
-  for (const elem of ctx.refElements) {
-    if (!conditionalSlotIds.has(elem.slotId)) {
-      regularSlots.add(elem.slotId)
-    }
-  }
-  for (const attr of ctx.reactiveAttrs) {
-    regularSlots.add(attr.slotId)
-  }
-  for (const prop of ctx.reactiveProps) {
-    componentSlots.add(prop.slotId)
-  }
-  for (const child of ctx.childInits) {
-    if (child.slotId) {
-      componentSlots.add(child.slotId)
-    }
-  }
-  for (const rest of ctx.restAttrElements) {
-    regularSlots.add(rest.slotId)
-  }
-
-  // Component slots take precedence over regular slots (#360).
-  // When a component contains a loop that inherits the component's slot ID
-  // (via propagateSlotIdToLoops), both need the same DOM element reference.
-  // Component elements use bf-s attributes, so $c() is the correct selector.
-  for (const slotId of componentSlots) {
-    regularSlots.delete(slotId)
-  }
-
-  if (regularSlots.size === 0 && textSlots.size === 0 && componentSlots.size === 0) return ''
-
-  const refLines: string[] = []
-
-  // Emit element ref declarations, batching 2+ slots into destructured calls
-  emitSlotRefs(refLines, [...regularSlots], '$')
-  emitSlotRefs(refLines, [...textSlots], '$t')
-  emitSlotRefs(refLines, [...componentSlots], '$c')
-
-  return refLines.join('\n')
+function renamePropsObjectInInitBody(code: string, propsObjectName: string | null): string {
+  const srcPropsName = propsObjectName ?? 'props'
+  if (srcPropsName === PROPS_PARAM) return code
+  return code
+    .split('\n')
+    .map(line => {
+      if (line.trimStart().startsWith('//')) return line
+      return line.replace(new RegExp(`\\b${srcPropsName}\\b`, 'g'), PROPS_PARAM)
+    })
+    .join('\n')
 }
-
-/**
- * Emit element ref declarations for a set of slot IDs using the given finder function.
- * Always emits destructured form: `const [_sN, ...] = fn(__scope, 'sN', ...)`
- */
-function emitSlotRefs(lines: string[], slotIds: string[], fn: string): void {
-  if (slotIds.length === 0) return
-  const vars = slotIds.map(id => `_${varSlotId(id)}`).join(', ')
-  const args = slotIds.map(id => `'${id}'`).join(', ')
-  lines.push(`  const [${vars}] = ${fn}(__scope, ${args})`)
-}
-
-/**
- * Recursively collect component names from IR children.
- * Used to ensure all nested components are imported, and to detect
- * which components are used as children (for conditional CSR fallback).
- */
-export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>): void {
-  for (const node of nodes) {
-    if (node.type === 'component') {
-      names.add(node.name)
-      collectComponentNamesFromIR(node.children, names)
-      // Traverse JSX prop children for nested component references
-      for (const prop of node.props) {
-        if (prop.jsxChildren) {
-          collectComponentNamesFromIR(prop.jsxChildren, names)
-        }
-      }
-    } else if (node.type === 'element' || node.type === 'fragment' || node.type === 'provider') {
-      collectComponentNamesFromIR(node.children, names)
-    } else if (node.type === 'conditional') {
-      collectComponentNamesFromIR([node.whenTrue], names)
-      collectComponentNamesFromIR([node.whenFalse], names)
-    } else if (node.type === 'loop') {
-      collectComponentNamesFromIR(node.children, names)
-      if (node.childComponent) {
-        names.add(node.childComponent.name)
-        collectComponentNamesFromIR(node.childComponent.children, names)
-      }
-      if (node.nestedComponents) {
-        for (const nested of node.nestedComponents) {
-          names.add(nested.name)
-          collectComponentNamesFromIR(nested.children, names)
-        }
-      }
-    }
-  }
-}
-
-/**
- * Collect child component names from conditional branch loops and nested conditionals.
- * Ensures @bf-child import markers are generated for components inside
- * composite loops within conditional branches (e.g., Badge inside a branch loop).
- */
-function collectChildNamesFromBranches(
-  cond: Pick<ConditionalElement, 'whenTrue' | 'whenFalse'>,
-  names: Set<string>,
-): void {
-  for (const loop of [...cond.whenTrue.loops, ...cond.whenFalse.loops]) {
-    if (loop.nestedComponents) {
-      for (const comp of loop.nestedComponents) names.add(comp.name)
-    }
-  }
-  for (const nested of [...cond.whenTrue.conditionals, ...cond.whenFalse.conditionals]) {
-    collectChildNamesFromBranches(nested, names)
-  }
-}
-

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -1,0 +1,183 @@
+/**
+ * Local-declaration classification + sorted emission for the init body.
+ *
+ * Splits the orchestrator's analysis-to-emission pipeline into two pure
+ * stages:
+ *
+ *   1. `classifyLocalDeclarations(ctx, graph)` — walks `ctx.localConstants`
+ *      and `ctx.localFunctions`, consults the precomputed scope maps, and
+ *      returns the buckets the orchestrator needs: init-scope constants,
+ *      module-level constants, module-level functions, reactive-data-
+ *      dependent props, and the controlled-signal list.
+ *
+ *   2. `emitSortedDeclarations(lines, ctx, classification)` — builds a
+ *      unified `Declaration[]`, runs the dependency-based topological
+ *      sort (#508), and emits each declaration via the existing
+ *      per-kind emitters.
+ *
+ * Keeping the split lets `generate-init.ts` read like a pipeline of
+ * typed stages rather than an inline cascade of `for`-loops. Byte-
+ * identical to the pre-Stage D.2 inline version.
+ */
+
+import type {
+  ConstantInfo,
+  FunctionInfo,
+  ReferencesGraph,
+  SignalInfo,
+} from '../types'
+import { computeDeclarationScopes } from './compute-scope'
+import { graphUsedIdentifiers } from './build-references'
+import { valueReferencesReactiveData, getControlledPropName } from './prop-handling'
+import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
+import {
+  emitDeclaration,
+  emitControlledSignalEffect,
+} from './emit-init-sections'
+import type { ClientJsContext } from './types'
+
+export interface ControlledSignal {
+  signal: SignalInfo
+  propName: string
+}
+
+export interface LocalClassification {
+  /** Constants routed to init scope — emitted inside the init function. */
+  neededConstants: ConstantInfo[]
+  /** Constants routed to module scope — emitted at module level. */
+  moduleLevelConstants: ConstantInfo[]
+  /** Functions routed to init scope — emitted inside the init function. */
+  initScopeFunctions: FunctionInfo[]
+  /** Functions routed to module scope — emitted at module level. */
+  moduleLevelFunctions: FunctionInfo[]
+  /** Props referenced anywhere reachable from the emitted init body
+   *  (direct identifier match in the reference graph OR transitively
+   *  via an init-scope constant's reactive-data scan). */
+  neededProps: Set<string>
+  /** Signals whose initial value reads a prop — they need a
+   *  createEffect to sync with parent updates. */
+  controlledSignals: ControlledSignal[]
+}
+
+export function classifyLocalDeclarations(
+  ctx: ClientJsContext,
+  graph: ReferencesGraph,
+): LocalClassification {
+  const usedIdentifiers = graphUsedIdentifiers(graph)
+  const { constantScope, functionScope } = computeDeclarationScopes(ctx, graph)
+
+  const neededProps = new Set<string>()
+  const neededConstants: ConstantInfo[] = []
+  const moduleLevelConstants: ConstantInfo[] = []
+  for (const constant of ctx.localConstants) {
+    const scope = constantScope.get(constant.name)
+    if (scope === 'skip') continue
+    if (scope === 'module') {
+      moduleLevelConstants.push(constant)
+      continue
+    }
+    // scope === 'init'
+    neededConstants.push(constant)
+    if (constant.value) {
+      const refs = valueReferencesReactiveData(constant.value, ctx)
+      for (const propName of refs.usedProps) {
+        neededProps.add(propName)
+      }
+    }
+  }
+
+  for (const id of usedIdentifiers) {
+    if (ctx.propsParams.some(p => p.name === id)) {
+      neededProps.add(id)
+    }
+  }
+
+  const moduleLevelFunctions: FunctionInfo[] = []
+  const initScopeFunctions: FunctionInfo[] = []
+  for (const fn of ctx.localFunctions) {
+    const scope = functionScope.get(fn.name)
+    if (scope === 'module') moduleLevelFunctions.push(fn)
+    else if (scope === 'init') initScopeFunctions.push(fn)
+  }
+
+  const controlledSignals: ControlledSignal[] = []
+  for (const signal of ctx.signals) {
+    const controlledPropName = getControlledPropName(signal, ctx.propsParams, ctx.propsObjectName)
+    if (controlledPropName) {
+      controlledSignals.push({ signal, propName: controlledPropName })
+    }
+  }
+
+  return {
+    neededConstants,
+    moduleLevelConstants,
+    initScopeFunctions,
+    moduleLevelFunctions,
+    neededProps,
+    controlledSignals,
+  }
+}
+
+/** Emit the init-scope declarations (constants, init-scope functions,
+ *  signals, memos) in dependency-sorted order (#508). */
+export function emitSortedDeclarations(
+  lines: string[],
+  ctx: ClientJsContext,
+  classification: LocalClassification,
+): void {
+  const { neededConstants, initScopeFunctions, controlledSignals } = classification
+  const declarations: Declaration[] = []
+
+  for (const constant of neededConstants) {
+    declarations.push({
+      kind: 'constant',
+      info: constant,
+      sourceIndex: constant.loc.start.line,
+    })
+  }
+
+  for (const fn of initScopeFunctions) {
+    declarations.push({
+      kind: 'function',
+      info: fn,
+      sourceIndex: fn.loc.start.line,
+    })
+  }
+
+  for (const signal of ctx.signals) {
+    const controlled = controlledSignals.find(c => c.signal === signal)
+    declarations.push({
+      kind: 'signal',
+      info: signal,
+      controlledPropName: controlled?.propName ?? null,
+      sourceIndex: signal.loc.start.line,
+    })
+  }
+
+  for (const memo of ctx.memos) {
+    declarations.push({
+      kind: 'memo',
+      info: memo,
+      sourceIndex: memo.loc.start.line,
+    })
+  }
+
+  const declNameSet = new Set<string>()
+  for (const decl of declarations) {
+    for (const name of providedNames(decl)) {
+      declNameSet.add(name)
+    }
+  }
+
+  const sorted = sortDeclarations(declarations, declNameSet)
+
+  let emittedAny = false
+  for (const decl of sorted) {
+    emitDeclaration(lines, decl, ctx, controlledSignals)
+    if (decl.kind === 'signal' && decl.controlledPropName) {
+      emitControlledSignalEffect(lines, decl.info, decl.controlledPropName, ctx)
+    }
+    emittedAny = true
+  }
+  if (emittedAny) lines.push('')
+}


### PR DESCRIPTION
## Summary

Stage D of #1021 — analysis-on-IR refactor. Final structural pass: \`generateInitFunction\` reads like a pipeline again.

**Before**: 450 lines mixing preamble, analysis, scope routing, declaration collection, DOM-ref generation, reactive emission, string post-processing, module-level emission, and import resolution — all inline.

**After**: **144 lines.** Each non-trivial stage lives in its own file.

This meets the Stage A invariant #7 target: file length under 150 lines, pipeline structure visible, each emitter is a pure function of typed inputs. See \`spec/compiler-analysis-ir.md\` §\"Invariants after Stages B–C–D\".

## What changed

Four new files extracted from \`generate-init.ts\`:

| File | Lines | Purpose |
|------|-------|---------|
| \`element-refs.ts\` | 89 | \`\$\` / \`\$t\` / \`\$c\` slot-ref declarations. |
| \`child-components.ts\` | 101 | \`@bf-child\` import markers + IR-tree name collection (\`collectComponentNamesFromIR\`, \`collectChildNamesFromBranches\`). |
| \`init-declarations.ts\` | 183 | \`classifyLocalDeclarations(ctx, graph) → { neededConstants, moduleLevelConstants, initScopeFunctions, moduleLevelFunctions, neededProps, controlledSignals }\` and \`emitSortedDeclarations\` (Kahn-sort + per-kind emit). |
| \`emit-module-level.ts\` | 83 | \`emitModuleLevelDeclarations\` (\`var X = X ?? …\` for cross-component safe re-declaration) + \`resolveFinalImports\` (runtime DOM helpers + user imports → final \`import { … }\` line). |

\`generate-init.ts\` now orchestrates:

\`\`\`
preamble (import placeholder + child imports + module-consts placeholder + init-function header)
  → analysis (graph + scope + prop usage)
  → init body emission (props extraction → sorted declarations → init statements → handlers → refs → reactive updates → provider/child inits)
  → hydrate line
  → props rename (private helper, one function)
  → placeholder replacement (imports + module-level)
\`\`\`

The props-rename regex hack survives as a private \`renamePropsObjectInInitBody\` helper at the end of \`generate-init.ts\`. Removing it needs analyzer-time pre-rewriting of every IR string field that can carry a prop reference (\`SignalInfo.initialValue\`, \`MemoInfo.computation\`, \`FunctionInfo.body\`, \`InitStatementInfo.body\`, …). That is tracked as **Stage E / follow-up** — it is a substantial analyzer change and was deemed high-risk for the Stage D byte-identical invariant.

## File-size diff

\`\`\`
generate-init.ts:  450 → 144 lines (-306)
new split files:   +456 lines
net:               +150 lines, but each file is focused and testable
\`\`\`

## Invariant — byte-identical output

All 326 \`.client.js\` files under \`site/ui/dist/components/\` are byte-for-byte identical to \`main\`.

## Test matrix

| Suite | Count | Result |
|-------|-------|--------|
| \`packages/jsx\` unit | 763 | ✅ |
| \`packages/adapter-tests\` | 214 | ✅ |
| \`packages/hono\` | 80 | ✅ |
| \`packages/go-template\` | 63 | ✅ |
| \`packages/client\` | 212 | ✅ |
| \`packages/form\` | 40 | ✅ |
| \`ui/components\` IR | 1157 | ✅ |

**Total: 2529 tests, 0 fails.**

## What Stage D accomplished across the issue

| Stage | PR | Line delta in generate-init.ts |
|-------|----|--------------------------------|
| A — design doc | #1022 | — |
| B — references graph | #1023 | 562 → 551 (small) |
| C.1 — scope classifier extracted | #1024 | 551 → 457 |
| C.2 — PropUsage | #1025 | 457 → 450 |
| C.3 — emit-registration through graph | #1026 | 450 → 450 |
| D — orchestrator collapse | this PR | **450 → 144** |

## Not in this PR

- Analyzer-time pre-rewriting of IR string fields so the props-rename regex helper can be deleted — **Stage E / follow-up**.

## Test plan

- [x] All listed test suites pass locally
- [x] Byte-identical \`.client.js\` output vs \`main\`
- [x] \`generate-init.ts\` under 150 lines
- [x] No emitter function in \`generate-init.ts\` contains classification logic (\"if isModule\", \"if systemConstructKind\", fixpoint loops, etc.) — all live in \`compute-scope.ts\` / \`init-declarations.ts\`
- [ ] Reviewer confirms pipeline ordering in \`generateInitFunction\` matches the pre-refactor sequence
- [ ] CI passes

## Related

- Issue: #1021
- Prior stages: #1022 (A), #1023 (B), #1024 (C.1), #1025 (C.2), #1026 (C.3) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)