### PR TITLE
docs(compiler): document renamePropsObjectInInitBody as intentional (#1021)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -126,6 +126,26 @@ export function generateInitFunction(
  * body string, skipping comment lines so JSDoc / explanatory comments
  * survive verbatim.
  *
+ * This is the canonical single place where init-body prop-name
+ * normalization happens. Companion of the `templateXxx` IR fields on
+ * the template side:
+ *   - Template path: analyzer pre-rewrites destructured bare prop
+ *     names → `_p.X` into `*.templateXxx` fields (case
+ *     `propsObjectName == null`).
+ *   - Init path (this helper): post-processes the emitted init body
+ *     rewriting `propsObjectName` → `_p` (case
+ *     `propsObjectName != null`).
+ *
+ * Kept as a late-stage normalization deliberately. Issue #1021 Stage
+ * E.5 considered moving the rewrite earlier (parallel `initXxx` IR
+ * fields, per-emit-site rewrite, or an auto-rewriting lines sink)
+ * and concluded that every alternative either (a) required
+ * enumerating ~20 emission sites across five files with a missing-
+ * one-breaks-it risk, (b) widened IR surface by 8+ fields for
+ * a single consumer, or (c) broke multi-line `lines.push` call
+ * patterns. The 12-line regex below runs once per component and is
+ * the right granularity for what it does.
+ *
  * No-op when the user already uses destructured props (`propsObjectName`
  * is `null`, handled by `?? 'props'` not matching `_p`). The hydrate
  * line is excluded structurally — callers append it AFTER this runs so


### PR DESCRIPTION
## Summary

Closes #1021. Expands the inline comment on \`renamePropsObjectInInitBody\` in \`generate-init.ts\` to record the Stage E.5 investigation outcome: the late-stage post-pass is the deliberate companion of the template path's \`templateXxx\` pre-rewrites, not a smell that a future refactor should chase.

## Why E.5 was dropped

Three alternatives were prototyped during Stage E.5 and rejected:

| Option | Issue |
|--------|-------|
| Per-emit-site rewrite | ~20 emission sites across five files; missing one reintroduces a byte divergence. No simplification over the post-pass. |
| Analyzer-side \`initXxx\` parallel IR fields | 8+ new fields for a single consumer. Complementary-but-asymmetric to the existing \`templateXxx\` pattern (destructured vs non-destructured cases) — reasoning about which field to read where adds complexity without a visible payoff. |
| Auto-rewriting \`lines\` sink | Breaks multi-line \`lines.push\` patterns (e.g. \`generateElementRefs\` returns \`\\n\`-joined chunks). |

The 12-line helper runs once per component, has a clear scope (non-comment lines of the joined init body, excluding the hydrate line which is appended after), and is the right granularity.

## Test plan

- [x] jsx unit tests pass
- [ ] CI passes

## Related

- Issue: #1021 — closes with this PR
- Stage PRs: #1022 (A), #1023 (B), #1024 (C.1), #1025 (C.2), #1026 (C.3), #1028 (D), #1029 (E) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)