### PR TITLE
refactor(compiler): introduce InsertPlan IR for conditional emission (PR 1/N)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
@@ -1,0 +1,88 @@
+/**
+ * Build `InsertPlan` from a `ConditionalElement` IR node.
+ *
+ * The builder is a pure function: given the same IR + eventNameMode it
+ * returns the same Plan. All wrapping decisions (DOM event name vs. raw,
+ * conditional template HTML augmentation, child-component selector vs.
+ * placeholder id) are made here so the stringifier can be a deterministic
+ * data-to-text mapping.
+ */
+
+import type {
+  ConditionalElement,
+  BranchSummary,
+} from '../../types'
+import { addCondAttrToTemplate } from '../../html-template'
+import type {
+  InsertPlan,
+  InsertArm,
+  ArmBody,
+  ScopeRef,
+} from './types'
+
+export interface BuildInsertOptions {
+  scope: ScopeRef
+  eventNameMode: 'dom' | 'raw'
+}
+
+export function buildInsertPlan(
+  elem: ConditionalElement,
+  options: BuildInsertOptions,
+): InsertPlan {
+  return {
+    kind: 'insert',
+    scope: options.scope,
+    slotId: elem.slotId,
+    condition: elem.condition,
+    eventNameMode: options.eventNameMode,
+    arms: [
+      buildArm(elem.whenTrueHtml, elem.slotId, elem.whenTrue, options),
+      buildArm(elem.whenFalseHtml, elem.slotId, elem.whenFalse, options),
+    ],
+  }
+}
+
+function buildArm(
+  html: string,
+  slotId: string,
+  branch: BranchSummary,
+  options: BuildInsertOptions,
+): InsertArm {
+  return {
+    templateHtml: addCondAttrToTemplate(html, slotId),
+    body: buildArmBody(branch, options),
+  }
+}
+
+function buildArmBody(branch: BranchSummary, options: BuildInsertOptions): ArmBody {
+  return {
+    events: branch.events.map(e => ({
+      slotId: e.slotId,
+      eventName: e.eventName,
+      handler: e.handler,
+    })),
+    refs: branch.refs.map(r => ({
+      slotId: r.slotId,
+      callback: r.callback,
+    })),
+    childComponents: branch.childComponents.map(c => ({
+      name: c.name,
+      slotId: c.slotId,
+      propsExpr: c.propsExpr,
+    })),
+    textEffects: branch.textEffects.map(t => ({
+      slotId: t.slotId,
+      expression: t.expression,
+    })),
+    // Branch-scoped loops: PR 1 keeps these as raw IR for legacy passthrough.
+    // PR 2 will replace with `LoopPlan[]`.
+    loopsRaw: branch.loops,
+    // Nested conditionals are themselves InsertPlans — built recursively so
+    // the same stringifier handles arbitrary depth. Their scope is always
+    // `__branchScope` (the parent arm's bindEvents argument), regardless of
+    // the outer scope; only the eventNameMode is inherited.
+    conditionals: branch.conditionals.map(c =>
+      buildInsertPlan(c, { scope: { kind: 'branchScope' }, eventNameMode: options.eventNameMode }),
+    ),
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Plan types for the control-flow emitter.
+ *
+ * The control-flow emission pipeline is being migrated from "IR → string[]"
+ * directly to "IR → Plan → string[]". This file holds the Plan IR.
+ *
+ * Plans are pure data — no string templates, no `lines.push`. Every emission
+ * decision (which scope to query, which event-name normalizer to use, etc.)
+ * is made by the builder; the stringifier is a deterministic function from
+ * Plan to source text.
+ *
+ * Migration status (2026-04-25):
+ * - PR 1: `InsertPlan` for top-level + nested conditionals.
+ * - PR 2: `LoopPlan` (plain → component → composite).
+ * - PR 3: `EventDelegationPlan`.
+ *
+ * Until PR 2 lands, ArmBody.loops is a passthrough escape hatch — see the
+ * field comment on `ArmBody.loopsRaw` below.
+ */
+
+import type {
+  BranchLoop,
+  ConditionalElement,
+  LoopChildConditional,
+} from '../../types'
+
+// ─────────────────────────────────────────────────────────────────────
+// Top-level
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Plan for a single `insert(scope, slotId, () => cond, trueArm, falseArm)`
+ * call. `kind` is included so future dispatcher unions can narrow.
+ */
+export interface InsertPlan {
+  kind: 'insert'
+  /** Variable expression to use as the first argument of `insert(...)`. */
+  scope: ScopeRef
+  slotId: string
+  /** The reactive condition expression. Wrapped at builder time. */
+  condition: string
+  /** Always two arms: [whenTrue, whenFalse]. */
+  arms: [InsertArm, InsertArm]
+  /**
+   * Event-name normalizer applied to events inside arm bodies.
+   * `'dom'` calls `toDomEventName` (drop "on" prefix, lowercase); `'raw'`
+   * keeps the original event name (used by `@client` conditionals).
+   */
+  eventNameMode: 'dom' | 'raw'
+}
+
+/** A single branch arm of an insert(). */
+export interface InsertArm {
+  /** Pre-rendered HTML template string. Already includes the bf-cond-* markers. */
+  templateHtml: string
+  body: ArmBody
+}
+
+/**
+ * Everything that happens inside `bindEvents: (__branchScope) => { ... }`.
+ *
+ * The order of fields matches the emission order (events → refs → child
+ * components → disposable text effects → loop reconciliation → nested
+ * conditionals). Stringifiers MUST follow this order to keep output stable.
+ */
+export interface ArmBody {
+  /** addEventListener calls bound to elements inside the arm. */
+  events: ArmEventBind[]
+  /** Imperative ref callbacks for elements inside the arm. */
+  refs: ArmRefBind[]
+  /** initChild calls for child components materialized by the arm swap. */
+  childComponents: ArmChildComponentInit[]
+  /** Reactive text effects scoped to this branch. Each becomes `createDisposableEffect`. */
+  textEffects: ArmTextEffect[]
+  /**
+   * Branch-scoped loops. PR 1 keeps these as raw `BranchLoop` references and
+   * delegates back to the legacy `emitBranchLoopBody` helper. PR 2 will turn
+   * them into `LoopPlan` and stringify directly.
+   */
+  loopsRaw: BranchLoop[]
+  /**
+   * Nested conditionals within this branch. Built recursively as `InsertPlan`s
+   * so the same stringifier handles them at any depth.
+   */
+  conditionals: InsertPlan[]
+}
+
+export interface ArmEventBind {
+  slotId: string
+  eventName: string
+  /** Handler source expression (already trimmed). The stringifier wraps it. */
+  handler: string
+}
+
+export interface ArmRefBind {
+  slotId: string
+  callback: string
+}
+
+export interface ArmChildComponentInit {
+  name: string
+  slotId: string | null
+  /** Pre-built props object expression (e.g., `{ get name() { return ... } }`). */
+  propsExpr: string
+}
+
+export interface ArmTextEffect {
+  slotId: string
+  expression: string
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Scope references
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * The scope variable to pass as the first argument of insert(...) /
+ * mapArray(...). At top-level this is `__scope`; nested inside an arm body
+ * it is `__branchScope`; nested inside a loop renderItem it is the loop
+ * element variable (e.g. `__el`).
+ */
+export type ScopeRef =
+  | { kind: 'top' }                         // emits `__scope`
+  | { kind: 'branchScope' }                 // emits `__branchScope`
+  | { kind: 'var'; name: string }           // emits the literal variable name
+
+// ─────────────────────────────────────────────────────────────────────
+// Re-export legacy types referenced from Plan-level code paths.
+// PR 2 will drop these once builder coverage is complete.
+// ─────────────────────────────────────────────────────────────────────
+
+export type { ConditionalElement, LoopChildConditional, BranchLoop }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -1,0 +1,170 @@
+/**
+ * Stringify an `InsertPlan` to source lines.
+ *
+ * Output shape (must stay byte-identical to the legacy emitter):
+ *
+ *     <leadingIndent>insert(<scopeVar>, '<slotId>', () => <cond>, {
+ *     <leadingIndent>  template: () => `<true html>`,
+ *     <leadingIndent>  bindEvents: (__branchScope) => {
+ *                <arm body lines, each prefixed with bodyIndent>
+ *     <leadingIndent>  }
+ *     <leadingIndent>}, {
+ *     <leadingIndent>  template: () => `<false html>`,
+ *     <leadingIndent>  bindEvents: (__branchScope) => {
+ *                <arm body lines>
+ *     <leadingIndent>  }
+ *     <leadingIndent>})
+ *
+ * Indent convention (preserved from the legacy emitter, byte-identical):
+ *   - top-level insert call:        `  ` (2 spaces)
+ *   - top-level arm marker line:    `    ` (4 spaces) — `template:`, `bindEvents:`
+ *   - top-level body content:       `      ` (6 spaces) — events, ref, child comp
+ *   - nested insert call:           `      ` (6 spaces) — same as body indent
+ *   - nested arm marker line:       `        ` (8 spaces)
+ *   - nested body content:          `      ` (6 spaces) — bug-for-bug compat (#?)
+ *
+ * The "body content stays at 6 spaces regardless of depth" quirk is a known
+ * legacy oddity (see `emitBranchBindings` hard-coded indents). PR 1 must
+ * preserve it; a follow-up PR can fix it now that the indent is data-driven.
+ */
+
+import { toDomEventName, wrapHandlerInBlock, varSlotId } from '../../utils'
+import { emitBranchLoopBody } from '../../emit-control-flow'
+import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types'
+
+export interface StringifyInsertOptions {
+  /** Indent on the `insert(` line itself. */
+  leadingIndent: string
+  /** Indent for the arm-body content (lines emitted inside bindEvents). */
+  bodyIndent: string
+}
+
+export function stringifyInsert(
+  lines: string[],
+  plan: InsertPlan,
+  opts: StringifyInsertOptions,
+): void {
+  const { leadingIndent, bodyIndent } = opts
+  const scopeVar = scopeRefToVar(plan.scope)
+  const armIndent = leadingIndent + '  '
+
+  lines.push(`${leadingIndent}insert(${scopeVar}, '${plan.slotId}', () => ${plan.condition}, {`)
+  emitArm(lines, plan.arms[0], plan.eventNameMode, armIndent, bodyIndent)
+  lines.push(`${leadingIndent}}, {`)
+  emitArm(lines, plan.arms[1], plan.eventNameMode, armIndent, bodyIndent)
+  lines.push(`${leadingIndent}})`)
+}
+
+function emitArm(
+  lines: string[],
+  arm: InsertArm,
+  mode: 'dom' | 'raw',
+  armIndent: string,
+  bodyIndent: string,
+): void {
+  lines.push(`${armIndent}template: () => \`${arm.templateHtml}\`,`)
+  lines.push(`${armIndent}bindEvents: (__branchScope) => {`)
+  emitArmBody(lines, arm.body, mode, bodyIndent)
+  lines.push(`${armIndent}}`)
+}
+
+function emitArmBody(
+  lines: string[],
+  body: ArmBody,
+  mode: 'dom' | 'raw',
+  indent: string,
+): void {
+  const eventNameFn = mode === 'dom' ? toDomEventName : (n: string) => n
+
+  // 1. Combine event-bearing slots and ref slots into a single `$()` query.
+  //    Order: events-first, then refs (matches legacy emitter).
+  const allSlotIds = new Set<string>()
+  for (const ev of body.events) allSlotIds.add(ev.slotId)
+  for (const ref of body.refs) allSlotIds.add(ref.slotId)
+
+  if (allSlotIds.size > 0) {
+    const slotArr = [...allSlotIds]
+    const vars = slotArr.map(id => `_${varSlotId(id)}`).join(', ')
+    const args = slotArr.map(id => `'${id}'`).join(', ')
+    lines.push(`${indent}const [${vars}] = $(__branchScope, ${args})`)
+  }
+
+  // 2. Group events by slot — preserves legacy emit order (events-by-slot
+  //    in declaration order) without changing the underlying contract.
+  const eventsBySlot = new Map<string, typeof body.events>()
+  for (const ev of body.events) {
+    if (!eventsBySlot.has(ev.slotId)) eventsBySlot.set(ev.slotId, [])
+    eventsBySlot.get(ev.slotId)!.push(ev)
+  }
+  for (const [slotId, slotEvents] of eventsBySlot) {
+    const v = varSlotId(slotId)
+    for (const ev of slotEvents) {
+      const wrapped = wrapHandlerInBlock(ev.handler)
+      lines.push(`${indent}if (_${v}) _${v}.addEventListener('${eventNameFn(ev.eventName)}', ${wrapped})`)
+    }
+  }
+
+  for (const ref of body.refs) {
+    const v = varSlotId(ref.slotId)
+    lines.push(`${indent}if (_${v}) (${ref.callback})(_${v})`)
+  }
+
+  // 3. Child component initializations from the branch swap.
+  for (let i = 0; i < body.childComponents.length; i++) {
+    const comp = body.childComponents[i]
+    const varName = `__c${i}`
+    const selectorArg = comp.slotId || comp.name
+    lines.push(`${indent}const [${varName}] = $c(__branchScope, '${selectorArg}')`)
+    lines.push(`${indent}if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
+  }
+
+  // 4. Disposable section: text effects + branch loops + nested conditionals.
+  //    Emitted inside the same `__disposers = []` / `return () => ...` envelope
+  //    so the legacy single-disposers-array shape is preserved (PR 1).
+  const hasDisposables =
+    body.textEffects.length > 0 ||
+    body.loopsRaw.length > 0 ||
+    body.conditionals.length > 0
+  if (!hasDisposables) return
+
+  lines.push(`${indent}const __disposers = []`)
+
+  for (const te of body.textEffects) {
+    const v = varSlotId(te.slotId)
+    lines.push(`${indent}const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
+    lines.push(`${indent}__disposers.push(createDisposableEffect(() => {`)
+    lines.push(`${indent}  const __val = ${te.expression}`)
+    lines.push(`${indent}  if (__el_${v} && !__val?.__isSlot) __el_${v}.nodeValue = String(__val ?? '')`)
+    lines.push(`${indent}}))`)
+  }
+
+  // Branch loops: delegate to the still-legacy emitter for PR 1. PR 2 will
+  // replace this with a Plan + stringifier pair. The legacy emitter writes
+  // its own `      ` (6 spaces) indent which matches our top-level body
+  // indent contract; nested inserts (PR 1 scope) call back into the same
+  // legacy lines.
+  if (body.loopsRaw.length > 0) {
+    emitBranchLoopBody(lines, body.loopsRaw)
+  }
+
+  // Nested conditionals: leadingIndent = current bodyIndent, but bodyIndent
+  // stays the SAME (6 spaces) — bug-for-bug compat with the legacy emitter
+  // which uses a hard-coded 6-space indent inside emitBranchBindings
+  // regardless of nesting depth. See header comment for details.
+  for (const cond of body.conditionals) {
+    stringifyInsert(lines, cond, {
+      leadingIndent: indent,
+      bodyIndent: indent,
+    })
+  }
+
+  lines.push(`${indent}return () => __disposers.forEach(d => d())`)
+}
+
+function scopeRefToVar(ref: ScopeRef): string {
+  switch (ref.kind) {
+    case 'top': return '__scope'
+    case 'branchScope': return '__branchScope'
+    case 'var': return ref.name
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -4,11 +4,13 @@
  * and event delegation within loop containers.
  */
 
-import type { ClientJsContext, ConditionalBranchEvent, BranchLoop, BranchSummary, ConditionalElement, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
+import type { ClientJsContext, BranchLoop, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../types'
 import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent, substituteLoopBindings } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
+import { buildInsertPlan } from './control-flow/plan/build-insert'
+import { stringifyInsert } from './control-flow/stringify/insert'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -86,165 +88,71 @@ function destructureLoopParam(
 }
 
 /**
- * Emit find() + event binding + ref callbacks + child component inits for a conditional branch.
- * Used by both emitConditionalUpdates and emitClientOnlyConditionals.
+ * Emit branch-scoped loop reconciliation. Extracted so the new Plan-based
+ * stringifier can reuse it verbatim while we incrementally migrate insert()
+ * shapes to Plan IR (PR 1) and only later move loops onto Plan (PR 2).
+ *
+ * The container lookup, mapArray dispatch, and reactive-effect wiring are
+ * the same lines previously inlined in `emitBranchBindings`.
  */
-function emitBranchBindings(
-  lines: string[],
-  branch: BranchSummary,
-  eventNameFn: (eventName: string) => string,
-): void {
-  const { events, refs, childComponents, textEffects, loops: branchLoops, conditionals: branchConditionals } = branch
-  const allSlotIds = new Set<string>()
-  for (const event of events) allSlotIds.add(event.slotId)
-  for (const ref of refs) allSlotIds.add(ref.slotId)
+export function emitBranchLoopBody(lines: string[], branchLoops: readonly BranchLoop[]): void {
+  for (const loop of branchLoops) {
+    const cv = varSlotId(loop.containerSlotId)
+    lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
 
-  const eventsBySlot = new Map<string, ConditionalBranchEvent[]>()
-  for (const event of events) {
-    if (!eventsBySlot.has(event.slotId)) {
-      eventsBySlot.set(event.slotId, [])
-    }
-    eventsBySlot.get(event.slotId)!.push(event)
-  }
+    if (loop.useElementReconciliation && (loop.nestedComponents?.length || loop.innerLoops?.length)) {
+      // Composite loop: items contain child components OR inner loops that
+      // require their own mapArray reconciliation — use the composite
+      // renderItem path (createComponent for nested components, emitInnerLoopSetup
+      // for inner loops).
+      emitCompositeBranchLoop(lines, loop, cv)
+    } else {
+      const keyFn = loopKeyFn(loop)
+      const indexParam = loop.index || '__idx'
+      const hasReactiveEffects = (loop.childReactiveAttrs?.length ?? 0) > 0
+        || (loop.childReactiveTexts?.length ?? 0) > 0
+        || (loop.childConditionals?.length ?? 0) > 0
 
-  if (allSlotIds.size > 0) {
-    const slotArr = [...allSlotIds]
-    const vars = slotArr.map(id => `_${varSlotId(id)}`).join(', ')
-    const args = slotArr.map(id => `'${id}'`).join(', ')
-    lines.push(`      const [${vars}] = $(__branchScope, ${args})`)
-  }
+      const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
+      const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
 
-  for (const [slotId, slotEvents] of eventsBySlot) {
-    const v = varSlotId(slotId)
-    for (const event of slotEvents) {
-      const wrappedHandler = wrapHandlerInBlock(event.handler)
-      lines.push(`      if (_${v}) _${v}.addEventListener('${eventNameFn(event.eventName)}', ${wrappedHandler})`)
-    }
-  }
-
-  for (const ref of refs) {
-    const v = varSlotId(ref.slotId)
-    lines.push(`      if (_${v}) (${ref.callback})(_${v})`)
-  }
-
-  // Initialize child components created by the branch swap
-  for (let i = 0; i < childComponents.length; i++) {
-    const comp = childComponents[i]
-    const varName = `__c${i}`
-    const selectorArg = comp.slotId || comp.name
-    lines.push(`      const [${varName}] = $c(__branchScope, '${selectorArg}')`)
-    lines.push(`      if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
-  }
-
-  // Emit disposable effects scoped to this branch (text effects, loop reconciliation, nested conditionals).
-  // These only run while the branch is active and are disposed on branch switch.
-  const hasDisposables = textEffects.length > 0 || branchLoops.length > 0 || branchConditionals.length > 0
-  if (hasDisposables) {
-    lines.push(`      const __disposers = []`)
-
-    for (const te of textEffects) {
-      const v = varSlotId(te.slotId)
-      lines.push(`      const [__el_${v}] = $t(__branchScope, '${te.slotId}')`)
-      lines.push(`      __disposers.push(createDisposableEffect(() => {`)
-      lines.push(`        const __val = ${te.expression}`)
-      lines.push(`        if (__el_${v} && !__val?.__isSlot) __el_${v}.nodeValue = String(__val ?? '')`)
-      lines.push(`      }))`)
-    }
-
-    // Emit loop reconciliation effects for loops inside this branch.
-    // The loop's container is found via $() and updated reactively via reconcileElements.
-    for (const loop of branchLoops) {
-      const cv = varSlotId(loop.containerSlotId)
-      lines.push(`      const [__loop_${cv}] = $(__branchScope, '${loop.containerSlotId}')`)
-
-      if (loop.useElementReconciliation && (loop.nestedComponents?.length || loop.innerLoops?.length)) {
-        // Composite loop: items contain child components OR inner loops that
-        // require their own mapArray reconciliation — use the composite
-        // renderItem path (createComponent for nested components, emitInnerLoopSetup
-        // for inner loops).
-        emitCompositeBranchLoop(lines, loop, cv)
-      } else {
-        const keyFn = loopKeyFn(loop)
-        const indexParam = loop.index || '__idx'
-        const hasReactiveEffects = (loop.childReactiveAttrs?.length ?? 0) > 0
-          || (loop.childReactiveTexts?.length ?? 0) > 0
-          || (loop.childConditionals?.length ?? 0) > 0
-
-        const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
-        const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
-
-        if (!hasReactiveEffects) {
-          // Simple case: no reactive effects — return existing DOM as-is.
-          // Template expressions use loopParam() to read the current item, so the
-          // signal accessor stays intact without any unwrap.
-          if (loop.mapPreamble) {
-            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
-          } else {
-            lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
-          }
+      if (!hasReactiveEffects) {
+        // Simple case: no reactive effects — return existing DOM as-is.
+        // Template expressions use loopParam() to read the current item, so the
+        // signal accessor stays intact without any unwrap.
+        if (loop.mapPreamble) {
+          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         } else {
-          // Multi-line renderItem with fine-grained effects — applies to both
-          // SSR (existing DOM) and CSR (freshly created) paths so reactive reads
-          // of non-item signals propagate to existing items too.
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
-          if (pUnwrap) {
-            lines.push(`        ${pUnwrap}`)
-          }
-          if (loop.mapPreamble) {
-            lines.push(`        ${loop.mapPreamble}`)
-          }
-          lines.push(`        const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
-          emitLoopChildReactiveEffects(
-            lines,
-            '        ',
-            '__el',
-            loop.childReactiveAttrs ?? [],
-            loop.childReactiveTexts ?? [],
-            loop.childConditionals,
-            loop.param,
-            loop.paramBindings,
-          )
-          lines.push(`        return __el`)
-          lines.push(`      })`)
+          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         }
-        emitBranchLoopEventDelegation(lines, loop, cv)
+      } else {
+        // Multi-line renderItem with fine-grained effects — applies to both
+        // SSR (existing DOM) and CSR (freshly created) paths so reactive reads
+        // of non-item signals propagate to existing items too.
+        lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+        if (pUnwrap) {
+          lines.push(`        ${pUnwrap}`)
+        }
+        if (loop.mapPreamble) {
+          lines.push(`        ${loop.mapPreamble}`)
+        }
+        lines.push(`        const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
+        emitLoopChildReactiveEffects(
+          lines,
+          '        ',
+          '__el',
+          loop.childReactiveAttrs ?? [],
+          loop.childReactiveTexts ?? [],
+          loop.childConditionals,
+          loop.param,
+          loop.paramBindings,
+        )
+        lines.push(`        return __el`)
+        lines.push(`      })`)
       }
+      emitBranchLoopEventDelegation(lines, loop, cv)
     }
-
-    // Emit nested conditionals as insert() calls inside this branch.
-    // These are disposed when the parent branch switches, ensuring inner
-    // conditionals are re-set-up each time the parent branch activates.
-    for (const cond of branchConditionals) {
-      emitNestedBranchConditional(lines, cond, eventNameFn)
-    }
-
-    lines.push(`      return () => __disposers.forEach(d => d())`)
   }
-}
-
-/**
- * Emit a nested conditional as an insert() call inside a parent branch's bindEvents.
- * The insert is wrapped so its effects are disposed when the parent branch deactivates.
- */
-function emitNestedBranchConditional(
-  lines: string[],
-  elem: ConditionalElement,
-  eventNameFn: (eventName: string) => string,
-): void {
-  const whenTrueWithCond = addCondAttrToTemplate(elem.whenTrueHtml, elem.slotId)
-  const whenFalseWithCond = addCondAttrToTemplate(elem.whenFalseHtml, elem.slotId)
-
-  lines.push(`      insert(__branchScope, '${elem.slotId}', () => ${elem.condition}, {`)
-  lines.push(`        template: () => \`${whenTrueWithCond}\`,`)
-  lines.push(`        bindEvents: (__branchScope) => {`)
-  emitBranchBindings(lines, elem.whenTrue, eventNameFn)
-  lines.push(`        }`)
-  lines.push(`      }, {`)
-  lines.push(`        template: () => \`${whenFalseWithCond}\`,`)
-  lines.push(`        bindEvents: (__branchScope) => {`)
-  emitBranchBindings(lines, elem.whenFalse, eventNameFn)
-  lines.push(`        }`)
-  lines.push(`      })`)
 }
 
 /**
@@ -303,20 +211,8 @@ function emitCompositeBranchLoop(
 /** Emit insert() calls for server-rendered reactive conditionals with branch configs. */
 export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): void {
   for (const elem of ctx.conditionalElements) {
-    const whenTrueWithCond = addCondAttrToTemplate(elem.whenTrueHtml, elem.slotId)
-    const whenFalseWithCond = addCondAttrToTemplate(elem.whenFalseHtml, elem.slotId)
-
-    lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
-    lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
-    lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrue, toDomEventName)
-    lines.push(`    }`)
-    lines.push(`  }, {`)
-    lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
-    lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalse, toDomEventName)
-    lines.push(`    }`)
-    lines.push(`  })`)
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'dom' })
+    stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')
   }
 }
@@ -324,22 +220,9 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
 /** Emit insert() calls for client-only conditionals (not server-rendered). */
 export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext): void {
   for (const elem of ctx.clientOnlyConditionals) {
-    const whenTrueWithCond = addCondAttrToTemplate(elem.whenTrueHtml, elem.slotId)
-    const whenFalseWithCond = addCondAttrToTemplate(elem.whenFalseHtml, elem.slotId)
-    const rawEventName = (eventName: string) => eventName
-
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'raw' })
     lines.push(`  // @client conditional: ${elem.slotId}`)
-    lines.push(`  insert(__scope, '${elem.slotId}', () => ${elem.condition}, {`)
-    lines.push(`    template: () => \`${whenTrueWithCond}\`,`)
-    lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenTrue, rawEventName)
-    lines.push(`    }`)
-    lines.push(`  }, {`)
-    lines.push(`    template: () => \`${whenFalseWithCond}\`,`)
-    lines.push(`    bindEvents: (__branchScope) => {`)
-    emitBranchBindings(lines, elem.whenFalse, rawEventName)
-    lines.push(`    }`)
-    lines.push(`  })`)
+    stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')
   }
 }


### PR DESCRIPTION
## Summary

First PR in a series migrating `packages/jsx/src/ir-to-client-js/emit-control-flow.ts` (1566 lines, 30 helpers) off direct string emission and onto a two-phase pipeline:

```
IR -> Plan (pure data) -> source lines (deterministic stringify)
```

This PR covers **conditionals only** (`insert(...)`). Loops and event-delegation move onto the Plan layer in follow-up PRs.

## Why

Investigation in `tmp/emit-survey/` (16-fixture compiler-output catalog + classification + observations) surfaced:

- **30 helpers, ~7 places that all emit `mapArray(...)` with slight variations** — the same shape is rewritten by hand each time, so cross-cutting fixes (e.g. #951's TDZ-safe destructured-param handling) get applied piecewise.
- **3 latent bugs** confirmed via `tmp/emit-survey/runtime-checks.test.ts`:
  - **O-2**: branch-scoped `mapArray` / nested `insert` are never pushed to `__disposers`, leaking effects past the branch swap (verified: renderItem keeps firing after the branch hides).
  - **O-3**: `key` prop ends up emitted both as `data-key=` in the template and via `setAttribute('key', ...)` in a reactive effect.
  - **O-8**: 3-level nested loops collapse the deepest level to a static `forEach` — adds/removes there don't reach the DOM.

Migrating to a Plan IR makes these structural rather than scattered: Plan builders can centralise the "what", and stringifiers can enforce contracts (e.g. dispose collection) uniformly. This PR builds the scaffolding; bug fixes land in PR 5+ once the migration is complete.

## What this PR does

- Adds `control-flow/plan/types.ts` (`InsertPlan`, `InsertArm`, `ArmBody`, `ScopeRef`).
- Adds `control-flow/plan/build-insert.ts` — pure `IR -> InsertPlan`.
- Adds `control-flow/stringify/insert.ts` — deterministic `InsertPlan -> string[]`.
- Rewrites `emitConditionalUpdates`, `emitClientOnlyConditionals`, and the nested-conditional path to delegate to the new pair (~100 lines of legacy emit code removed).
- Extracts `emitBranchLoopBody` so branch-scoped loops can be passthrough'd from Plan stringify until PR 2 moves them onto Plan too.
- Adds `control-flow-snapshot.test.ts` pinning 16 fixtures (every axis combination from the survey) so byte-identical output is verified mechanically through the migration.

## What this PR does NOT do

- No behaviour change. Output is byte-identical to `main`.
- No bug fixes (O-2 / O-3 / O-8). Those land after the Plan layer covers the affected emitters.
- Loops, event delegation, and composite renderItem stay on the legacy emit code.
- The known indentation quirk in the legacy emitter (branch body content stays at 6 spaces regardless of nesting depth) is preserved bug-for-bug and documented in the stringifier header.

## Migration roadmap (for context)

| PR | Scope |
|----|-------|
| **1 (this)** | InsertPlan + insert() emitters |
| 2-a | LoopPlan + plain element loop |
| 2-b | LoopPlan + single-component loop |
| 2-c | LoopPlan + composite loop (nested comps + inner loops) |
| 3 | EventDelegationPlan |
| 4 | Delete legacy `emit-control-flow.ts`, finalise `control-flow/index.ts` |
| 5 | Fix O-3 (drop `key` from reactive attr collection) |
| 6 | Fix O-2 (branch-scoped loop / cond dispose collection) |
| 7 | Fix O-8 (deep-nested loop reactive routing) |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/` — 776 / 776 pass
- [x] `bun test packages/adapter-tests/` — 214 / 214 pass
- [x] `bun test packages/client/` — 212 / 212 pass
- [x] `bun run --filter '@barefootjs/jsx' build` — clean build
- [x] New `control-flow-snapshot.test.ts` pins 16 fixtures byte-identical