### PR TITLE
refactor(compiler): plain & static loop emission via LoopPlan IR (PR 2-a/N)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -1,0 +1,83 @@
+/**
+ * Build LoopPlan variants from a `TopLevelLoop` IR node.
+ *
+ * Coverage (PR 2-a):
+ *   - PlainLoopPlan  ← plain element body, no child components, no inner loops
+ *   - StaticLoopPlan ← static array (literal) with reactive attrs / texts
+ *
+ * PR 2-b will add `SingleComponentLoopPlan`; PR 2-c adds `CompositeLoopPlan`.
+ */
+
+import type {
+  TopLevelLoop,
+  LoopChildReactiveAttr,
+} from '../../types'
+import {
+  buildChainedArrayExpr,
+  varSlotId,
+  wrapLoopParamAsAccessor,
+} from '../../utils'
+import {
+  loopKeyFn,
+  destructureLoopParam,
+} from '../../emit-control-flow'
+import type { PlainLoopPlan, StaticLoopPlan } from './types'
+
+export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
+  const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
+  const hasReactive = elem.childReactiveAttrs.length > 0
+    || elem.childReactiveTexts.length > 0
+    || (elem.childConditionals?.length ?? 0) > 0
+
+  return {
+    kind: 'plain-loop',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    arrayExpr: buildChainedArrayExpr(elem),
+    keyFn: loopKeyFn(elem),
+    paramHead,
+    paramUnwrap,
+    indexParam: elem.index || '__idx',
+    mapPreambleWrapped: elem.mapPreamble ? wrap(elem.mapPreamble) : '',
+    template: elem.template,
+    reactiveEffects: hasReactive
+      ? {
+          attrs: elem.childReactiveAttrs,
+          texts: elem.childReactiveTexts,
+          conditionals: elem.childConditionals,
+          loopParam: elem.param,
+          loopParamBindings: elem.paramBindings,
+        }
+      : null,
+  }
+}
+
+export function buildStaticLoopPlan(elem: TopLevelLoop): StaticLoopPlan {
+  // Group reactive attrs by their child slot id, preserving the legacy
+  // declaration-order Map-iteration semantics.
+  const attrsBySlotMap = new Map<string, LoopChildReactiveAttr[]>()
+  if (!elem.childComponent) {
+    for (const attr of elem.childReactiveAttrs) {
+      let bucket = attrsBySlotMap.get(attr.childSlotId)
+      if (!bucket) {
+        bucket = []
+        attrsBySlotMap.set(attr.childSlotId, bucket)
+      }
+      bucket.push(attr)
+    }
+  }
+
+  const indexParam = elem.index || '__idx'
+  const childIndexExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
+
+  return {
+    kind: 'static-loop',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    arrayExpr: elem.array,
+    param: elem.param,
+    indexParam,
+    childIndexExpr,
+    attrsBySlot: [...attrsBySlotMap].map(([slotId, attrs]) => [slotId, attrs] as const),
+    texts: elem.childReactiveTexts,
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -22,6 +22,9 @@ import type {
   BranchLoop,
   ConditionalElement,
   LoopChildConditional,
+  LoopChildReactiveAttr,
+  LoopChildReactiveText,
+  TopLevelLoop,
 } from '../../types'
 
 // ─────────────────────────────────────────────────────────────────────
@@ -125,8 +128,87 @@ export type ScopeRef =
   | { kind: 'var'; name: string }           // emits the literal variable name
 
 // ─────────────────────────────────────────────────────────────────────
+// Loops
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Plan for a top-level dynamic loop with a plain element body (no child
+ * components, no inner loops). Covers `emitPlainElementLoopReconciliation`.
+ *
+ * The "single-line vs multi-line renderItem" split in the legacy emitter is
+ * a stringifier concern, not a Plan concern — the Plan just records
+ * whether reactive effects exist and the stringifier picks the layout.
+ */
+export interface PlainLoopPlan {
+  kind: 'plain-loop'
+  /** The container element variable, e.g. `_s1`. */
+  containerVar: string
+  /** Array expression to drive `mapArray(() => ARR, ...)`. Already chained (filter/sort). */
+  arrayExpr: string
+  /** Key function source — `null` when the loop has no explicit key. */
+  keyFn: string
+  /** renderItem param identifier (after destructure unwrap rename). */
+  paramHead: string
+  /** Index parameter identifier, e.g. `__idx` or user-supplied. */
+  indexParam: string
+  /** Statement to unwrap a destructured param at body entry. Empty when not needed. */
+  paramUnwrap: string
+  /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
+  mapPreambleWrapped: string
+  /** HTML template string for one item. */
+  template: string
+  /**
+   * Carried IR fields for legacy `emitLoopChildReactiveEffects` passthrough.
+   * `null` means there are no reactive effects; the stringifier emits the
+   * single-line renderItem in that case. PR 5+ will replace this with
+   * structured `ReactiveEffectsPlan`.
+   */
+  reactiveEffects: ReactiveEffectsPassthrough | null
+}
+
+/**
+ * Loaned-IR carrier for emitLoopChildReactiveEffects. PR 5+ replaces this
+ * with a structured ReactiveEffectsPlan that addresses O-3 (key dedup) at
+ * the builder level.
+ */
+export interface ReactiveEffectsPassthrough {
+  attrs: LoopChildReactiveAttr[]
+  texts: LoopChildReactiveText[]
+  conditionals: LoopChildConditional[] | undefined
+  loopParam: string
+  loopParamBindings: TopLevelLoop['paramBindings']
+}
+
+/**
+ * Plan for a top-level static array loop. Two parallel `forEach` blocks (one
+ * for reactive attrs, one for reactive texts) plus optional event delegation
+ * — mirrors the legacy `emitStaticArrayUpdates` shape. The forEach
+ * duplication noted in observation O-4 is preserved bug-for-bug here; PR 5+
+ * collapses them into a single forEach.
+ */
+export interface StaticLoopPlan {
+  kind: 'static-loop'
+  containerVar: string
+  /** Source array expression as written in user code (no signal accessor wrap). */
+  arrayExpr: string
+  /** Loop param name. */
+  param: string
+  /** Index parameter identifier. */
+  indexParam: string
+  /** Children-index offset expression — index when no offset, `${idx} + N` otherwise. */
+  childIndexExpr: string
+  /**
+   * Reactive attrs grouped by child slot id (preserves emission order).
+   * Empty list means the attr forEach block is omitted.
+   */
+  attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
+  /** Reactive texts in declaration order. Empty list means the text forEach block is omitted. */
+  texts: readonly LoopChildReactiveText[]
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Re-export legacy types referenced from Plan-level code paths.
-// PR 2 will drop these once builder coverage is complete.
+// PR 2-b/c will extend this with single-component / composite plans.
 // ─────────────────────────────────────────────────────────────────────
 
 export type { ConditionalElement, LoopChildConditional, BranchLoop }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -1,0 +1,127 @@
+/**
+ * Stringify LoopPlan variants to source lines.
+ *
+ * Output shapes (preserved byte-identical from the legacy emitter):
+ *
+ *   PlainLoopPlan, no reactive effects (single-line renderItem):
+ *     <indent>mapArray(() => <arr>, <container>, <keyFn>, (<head>, <idx>, __existing) =>
+ *       { <unwrap?> <preamble?>; if (__existing) return __existing; const __tpl = ...; return ... })
+ *
+ *   PlainLoopPlan, with reactive effects (multi-line renderItem):
+ *     <indent>mapArray(() => <arr>, <container>, <keyFn>, (<head>, <idx>, __existing) => {
+ *     <indent>  <unwrap?>
+ *     <indent>  <preamble?>
+ *     <indent>  const __el = __existing ?? (() => { ... })()
+ *     <indent>  <reactive effects via emitLoopChildReactiveEffects>
+ *     <indent>  return __el
+ *     <indent>})
+ *
+ *   StaticLoopPlan: two parallel forEach blocks (attrs / texts) — see
+ *     emitStaticLoop. The forEach-duplication noted in observation O-4 is
+ *     preserved bug-for-bug; PR 5+ collapses them.
+ *
+ * Indent convention for plain loops: top-level emission uses `'  '` (2 sp);
+ * passed in via `topIndent`.
+ */
+
+import { varSlotId } from '../../utils'
+import { emitLoopChildReactiveEffects } from '../../emit-control-flow'
+import { emitAttrUpdate } from '../../emit-reactive'
+import type { PlainLoopPlan, StaticLoopPlan } from '../plan/types'
+
+export function stringifyPlainLoop(
+  lines: string[],
+  plan: PlainLoopPlan,
+  topIndent: string = '  ',
+): void {
+  const {
+    containerVar,
+    arrayExpr,
+    keyFn,
+    paramHead,
+    paramUnwrap,
+    indexParam,
+    mapPreambleWrapped,
+    template,
+    reactiveEffects,
+  } = plan
+
+  if (reactiveEffects === null) {
+    // Single-line renderItem (no reactive effects).
+    const unwrapInline = paramUnwrap ? `${paramUnwrap} ` : ''
+    const preamble = mapPreambleWrapped ? `${mapPreambleWrapped}; ` : ''
+    lines.push(
+      `${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`,
+    )
+    return
+  }
+
+  // Multi-line renderItem (reactive effects present).
+  lines.push(`${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
+  const bodyIndent = topIndent + '  '
+  if (paramUnwrap) lines.push(`${bodyIndent}${paramUnwrap}`)
+  if (mapPreambleWrapped) lines.push(`${bodyIndent}${mapPreambleWrapped}`)
+  lines.push(`${bodyIndent}const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
+  emitLoopChildReactiveEffects(
+    lines,
+    bodyIndent,
+    '__el',
+    reactiveEffects.attrs,
+    reactiveEffects.texts,
+    reactiveEffects.conditionals,
+    reactiveEffects.loopParam,
+    reactiveEffects.loopParamBindings,
+  )
+  lines.push(`${bodyIndent}return __el`)
+  lines.push(`${topIndent}})`)
+}
+
+export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {
+  const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts } = plan
+
+  // Block 1: reactive attributes.
+  if (attrsBySlot.length > 0) {
+    lines.push(`  // Reactive attributes in static array children`)
+    lines.push(`  if (${containerVar}) {`)
+    lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+    lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
+    lines.push(`      if (__iterEl) {`)
+    for (const [slotId, attrs] of attrsBySlot) {
+      const varName = `__t_${varSlotId(slotId)}`
+      lines.push(`        const ${varName} = qsa(__iterEl, '[bf="${slotId}"]')`)
+      lines.push(`        if (${varName}) {`)
+      for (const attr of attrs) {
+        lines.push(`          createEffect(() => {`)
+        for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
+          lines.push(`            ${stmt}`)
+        }
+        lines.push(`          })`)
+      }
+      lines.push(`        }`)
+    }
+    lines.push(`      }`)
+    lines.push(`    })`)
+    lines.push(`  }`)
+    lines.push('')
+  }
+
+  // Block 2: reactive texts. NOTE — the second forEach scans the same array
+  // again. This duplication is observation O-4 and will be merged in a
+  // follow-up PR; PR 2-a preserves the legacy shape.
+  if (texts.length > 0) {
+    lines.push(`  // Reactive texts in static array children`)
+    lines.push(`  if (${containerVar}) {`)
+    lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+    lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
+    lines.push(`      if (__iterEl) {`)
+    for (const text of texts) {
+      const vn = `__rt_${varSlotId(text.slotId)}`
+      lines.push(`        { const [${vn}] = $t(__iterEl, '${text.slotId}')`)
+      lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }) }`)
+    }
+    lines.push(`      }`)
+    lines.push(`    })`)
+    lines.push(`  }`)
+    lines.push('')
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -11,6 +11,8 @@ import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 import { buildInsertPlan } from './control-flow/plan/build-insert'
 import { stringifyInsert } from './control-flow/stringify/insert'
+import { buildPlainLoopPlan, buildStaticLoopPlan } from './control-flow/plan/build-loop'
+import { stringifyPlainLoop, stringifyStaticLoop } from './control-flow/stringify/loop'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -18,7 +20,7 @@ import { stringifyInsert } from './control-flow/stringify/insert'
  * off `NestedLoop` (nested loops never thread an explicit index parameter)
  * and lets the compiler verify we handled every flavour exhaustively.
  */
-function loopKeyFn(loop: CollectedLoop): string {
+export function loopKeyFn(loop: CollectedLoop): string {
   if (loop.key === null) return 'null'
   const params = loop.kind === 'nested'
     ? loop.param
@@ -71,7 +73,7 @@ function exprRefsLoopBinding(expr: string, loop: { param: string; paramBindings?
  * (rest element, computed property key — see `BF025`), we fall back to
  * the original unwrap so the captured-semantics path still compiles.
  */
-function destructureLoopParam(
+export function destructureLoopParam(
   param: string,
   paramBindings?: readonly LoopParamBinding[],
 ): { head: string; unwrap: string } {
@@ -451,7 +453,7 @@ function emitNestedLoopChildConditionals(
   }
 }
 
-function emitLoopChildReactiveEffects(
+export function emitLoopChildReactiveEffects(
   lines: string[],
   indent: string,
   elVar: string,
@@ -554,70 +556,12 @@ function emitLoopChildReactiveEffects(
 function emitStaticArrayUpdates(lines: string[], elem: TopLevelLoop): void {
   // Static array initChild calls are deferred to emitStaticArrayChildInits()
   // so that parent context providers (provideContext) run first.
-
-  // Reactive attribute effects for plain elements in static arrays.
-  if (!elem.childComponent && elem.childReactiveAttrs.length > 0) {
-    const v = varSlotId(elem.slotId)
-    lines.push(`  // Reactive attributes in static array children`)
-    lines.push(`  if (_${v}) {`)
-    const indexParam = elem.index || '__idx'
-    const offsetExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
-    lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = _${v}.children[${offsetExpr}]`)
-    lines.push(`      if (__iterEl) {`)
-    // Group attrs by childSlotId to avoid duplicate const declarations
-    const attrsBySlot = new Map<string, typeof elem.childReactiveAttrs>()
-    for (const attr of elem.childReactiveAttrs) {
-      if (!attrsBySlot.has(attr.childSlotId)) {
-        attrsBySlot.set(attr.childSlotId, [])
-      }
-      attrsBySlot.get(attr.childSlotId)!.push(attr)
-    }
-    for (const [slotId, attrs] of attrsBySlot) {
-      const varName = `__t_${varSlotId(slotId)}`
-      lines.push(`        const ${varName} = qsa(__iterEl, '[bf="${slotId}"]')`)
-      lines.push(`        if (${varName}) {`)
-      for (const attr of attrs) {
-        lines.push(`          createEffect(() => {`)
-        for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
-          lines.push(`            ${stmt}`)
-        }
-        lines.push(`          })`)
-      }
-      lines.push(`        }`)
-    }
-    lines.push(`      }`)
-    lines.push(`    })`)
-    lines.push(`  }`)
-    lines.push('')
-  }
-
-  // Reactive text effects for static array children (both plain and component loops).
-  // Text expressions that read signals (e.g., {isAnnual() ? x : y}) need
-  // createEffect to update when the signal changes.
-  if (elem.childReactiveTexts.length > 0) {
-    const v = varSlotId(elem.slotId)
-    lines.push(`  // Reactive texts in static array children`)
-    lines.push(`  if (_${v}) {`)
-    const indexParam = elem.index || '__idx'
-    const offsetExpr2 = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
-    lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = _${v}.children[${offsetExpr2}]`)
-    lines.push(`      if (__iterEl) {`)
-    for (const text of elem.childReactiveTexts) {
-      const vn = `__rt_${varSlotId(text.slotId)}`
-      lines.push(`        { const [${vn}] = $t(__iterEl, '${text.slotId}')`)
-      lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }) }`)
-    }
-    lines.push(`      }`)
-    lines.push(`    })`)
-    lines.push(`  }`)
-    lines.push('')
-  }
+  stringifyStaticLoop(lines, buildStaticLoopPlan(elem))
 
   // Event delegation for plain elements in static arrays (#537).
   // Static arrays have no data-key/bf-i markers, so walk up from target to
   // the container's direct child and use indexOf for index lookup.
+  // Event delegation stays on the legacy emitter — moves to Plan in PR 3.
   if (!elem.childComponent && elem.childEvents.length > 0) {
     const v = varSlotId(elem.slotId)
     emitLoopEventDelegation(lines, `_${v}`, elem.childEvents, (ls, ev, handlerCall, cVar) => {
@@ -794,38 +738,11 @@ function emitHydrationTagging(
 }
 
 /** Emit mapArray for a plain element loop with unified CSR/SSR. */
-function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop, keyFn: string): void {
-  const vLoop = varSlotId(elem.slotId)
-  const chainedExpr = buildChainedArrayExpr(elem)
-  const indexParam = elem.index || '__idx'
-  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
-
-  const hasReactiveEffects = elem.childReactiveAttrs.length > 0
-    || elem.childReactiveTexts.length > 0
-    || (elem.childConditionals?.length ?? 0) > 0
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
-  const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
-
-  if (!hasReactiveEffects) {
-    // Simple case: no reactive effects
-    // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
-    const preamble = elem.mapPreamble ? `${wrap(elem.mapPreamble)}; ` : ''
-    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}${preamble}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
-  } else {
-    // Multi-line renderItem with fine-grained effects (shared for CSR and SSR)
-    lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
-    if (pUnwrap) {
-      lines.push(`    ${pUnwrap}`)
-    }
-    if (elem.mapPreamble) {
-      lines.push(`    ${wrap(elem.mapPreamble)}`)
-    }
-    // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
-    lines.push(`    const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${elem.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
-    emitLoopChildReactiveEffects(lines, '    ', '__el', elem.childReactiveAttrs, elem.childReactiveTexts, elem.childConditionals, elem.param, elem.paramBindings)
-    lines.push(`    return __el`)
-    lines.push(`  })`)
-  }
+function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop, _keyFn: string): void {
+  // _keyFn ignored — buildPlainLoopPlan recomputes via loopKeyFn(elem) so
+  // the plan is self-contained. Kept in the signature so the dispatcher
+  // (emitDynamicLoopUpdates) doesn't need to learn the new shape yet.
+  stringifyPlainLoop(lines, buildPlainLoopPlan(elem))
 }
 
 /** Emit event delegation for dynamic (non-static) loop child events. */


### PR DESCRIPTION
## Summary

Continues the `IR -> Plan -> string` migration started in #1033. This PR moves two more emitters off direct `lines.push(...)` and onto a Plan layer:

| Legacy emitter | Plan |
|----------------|------|
| `emitPlainElementLoopReconciliation` | `PlainLoopPlan` |
| `emitStaticArrayUpdates` | `StaticLoopPlan` |

## Why

Same goal as #1033: separate **what to emit** (Plan, pure data) from **how to write it** (stringifier, deterministic). This is the second of ~5 PRs that finish the migration. Once all loop variants live on the Plan, the latent bugs surfaced in the survey (O-2 dispose leak, O-3 `key` attr duplication, O-8 deep-nested loop degradation) become local to a builder/stringifier pair instead of scattered across the legacy emitter.

## Scope

**In:**
- `control-flow/plan/types.ts` — `PlainLoopPlan`, `StaticLoopPlan`, `ReactiveEffectsPassthrough`
- `control-flow/plan/build-loop.ts` — pure `IR -> *LoopPlan` builders
- `control-flow/stringify/loop.ts` — `*LoopPlan -> string[]`
- Replace the bodies of `emitPlainElementLoopReconciliation` / `emitStaticArrayUpdates` with builder + stringifier calls
- Export `loopKeyFn`, `destructureLoopParam`, `emitLoopChildReactiveEffects` so the Plan layer can reuse them

**Out (follow-ups):**
- Single-component loops (`emitComponentLoopReconciliation`) — PR 2-b
- Composite loops (`emitCompositeElementReconciliation`) — PR 2-c
- Event delegation — PR 3
- Latent bugs O-2 / O-3 / O-4 / O-8 — PR 5+

## Preserved bug-for-bug

- The reactive-attrs and reactive-texts blocks in `StaticLoopPlan` still emit two separate `forEach` passes over the same array (observation O-4). Documented in the stringifier header and slated for collapse in a follow-up.
- Reactive-effects construction inside a Plain loop's renderItem still goes through the legacy `emitLoopChildReactiveEffects`. The structured `ReactiveEffectsPlan` lands with the O-3 bug-fix PR.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/` — 760 / 760 pass
- [x] `bun test packages/adapter-tests/` — 214 / 214 pass
- [x] `bun test packages/client/` — 212 / 212 pass
- [x] `bun run --filter '@barefootjs/jsx' build` — clean exit
- Output is byte-identical to `main` (verified by the existing test suite, which compares emitted strings throughout)