### PR TITLE
refactor(compiler): single-component loop emission via ComponentLoopPlan (PR 2-b/N)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -1,0 +1,82 @@
+/**
+ * Build `ComponentLoopPlan` from a `TopLevelLoop` IR node whose body is a
+ * single child component (with optional nested child components).
+ *
+ * The plan resolves all stringification decisions up-front:
+ *   - props expression for the outer component and each nested component
+ *   - selector to find the SSR-rendered nested component
+ *   - whether each nested component's children should reactive-update via
+ *     `createEffect` based on text-only-and-references-loop-param detection
+ *   - the wrapped key argument for `createComponent(name, props, KEY)`
+ *
+ * Reactive effects on `childConditionals` are still routed through
+ * `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`, matching
+ * PR 2-a's strategy.
+ */
+
+import type { TopLevelLoop } from '../../types'
+import {
+  buildChainedArrayExpr,
+  varSlotId,
+  wrapLoopParamAsAccessor,
+  exprReferencesIdent,
+} from '../../utils'
+import {
+  loopKeyFn,
+  destructureLoopParam,
+  buildComponentPropsExpr,
+  buildCompSelector,
+  isTextOnlyConditional,
+} from '../../emit-control-flow'
+import { irChildrenToJsExpr } from '../../html-template'
+import type { ComponentLoopPlan, NestedComponentInit } from './types'
+
+export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
+  const { name } = elem.childComponent!
+  const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
+  const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param, elem.paramBindings)
+  const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
+
+  // Only init components at loopDepth 0 — inner-loop components are handled by their own loop
+  const outerNestedComps = (elem.nestedComponents ?? []).filter(c => !c.loopDepth)
+  const nestedComps: NestedComponentInit[] = outerNestedComps.map(comp => {
+    const isTextOnly = comp.children?.length
+      ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
+      : false
+    const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
+    const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
+    return {
+      componentName: comp.name,
+      selector: buildCompSelector(comp),
+      propsExpr: buildComponentPropsExpr(comp, elem.param),
+      childrenTextEffect: childrenRefsLoop
+        ? { wrappedChildren: wrapLoopParamAsAccessor(rawChildrenExpr!, elem.param, elem.paramBindings) }
+        : null,
+    }
+  })
+
+  const hasChildConds = (elem.childConditionals?.length ?? 0) > 0
+
+  return {
+    kind: 'component-loop',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    arrayExpr: buildChainedArrayExpr(elem),
+    keyFn: loopKeyFn(elem),
+    paramHead,
+    paramUnwrap,
+    indexParam: elem.index || '__idx',
+    componentName: name,
+    componentPropsExpr: propsExpr,
+    keyExpr,
+    nestedComps,
+    childConditionalEffects: hasChildConds
+      ? {
+          attrs: [],
+          texts: [],
+          conditionals: elem.childConditionals,
+          loopParam: elem.param,
+          loopParamBindings: elem.paramBindings,
+        }
+      : null,
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -180,6 +180,56 @@ export interface ReactiveEffectsPassthrough {
 }
 
 /**
+ * Plan for a top-level dynamic loop whose body is a single child component
+ * (with or without nested child components inside it). Covers
+ * `emitComponentLoopReconciliation`.
+ *
+ * `nestedComps.length === 0`  → emit the simple two-line renderItem
+ *                               (initChild on existing, createComponent on new).
+ * `nestedComps.length > 0`    → emit the SSR/CSR split that initialises both
+ *                               the outer component and each nested child.
+ *
+ * Reactive-effects construction inside `childConditionals` is delegated to
+ * the legacy `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`,
+ * mirroring the PlainLoopPlan strategy.
+ */
+export interface ComponentLoopPlan {
+  kind: 'component-loop'
+  containerVar: string
+  arrayExpr: string
+  keyFn: string
+  paramHead: string
+  paramUnwrap: string
+  indexParam: string
+  /** The outer (loop body) component's name, e.g. `'Card'`. */
+  componentName: string
+  /** Pre-built props object expression for the outer component. */
+  componentPropsExpr: string
+  /** Wrapped key argument passed to `createComponent(name, props, KEY)`. */
+  keyExpr: string
+  /** Nested child component initialisers; empty for the simple case. */
+  nestedComps: NestedComponentInit[]
+  /** Carried IR for legacy reactive-effects passthrough; null when there's nothing to emit. */
+  childConditionalEffects: ReactiveEffectsPassthrough | null
+}
+
+/**
+ * One nested child component to initialise inside a renderItem body.
+ * `childrenTextEffect` is non-null when the component's children are
+ * text-equivalent AND reference the outer loop param — in that case the
+ * stringifier emits a `createEffect` that updates the child's `textContent`.
+ */
+export interface NestedComponentInit {
+  componentName: string
+  /** CSS selector used by `qsa(...)` to find the SSR-rendered placeholder. */
+  selector: string
+  /** Pre-built props object expression for the nested component. */
+  propsExpr: string
+  /** When non-null, emit a reactive textContent effect alongside `initChild`. */
+  childrenTextEffect: { wrappedChildren: string } | null
+}
+
+/**
  * Plan for a top-level static array loop. Two parallel `forEach` blocks (one
  * for reactive attrs, one for reactive texts) plus optional event delegation
  * — mirrors the legacy `emitStaticArrayUpdates` shape. The forEach

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
@@ -1,0 +1,101 @@
+/**
+ * Stringify a `ComponentLoopPlan` to source lines.
+ *
+ * Two output shapes (preserved byte-identical from the legacy
+ * `emitComponentLoopReconciliation`):
+ *
+ *   nestedComps.length === 0 (simple) — two-line renderItem body:
+ *     <i>mapArray(() => <arr>, <container>, <keyFn>, (<head>, <idx>, __existing) => {
+ *     <i>  <unwrap?>
+ *     <i>  if (__existing) { initChild('<C>', __existing, <props>); return __existing }
+ *     <i>  return createComponent('<C>', <props>, <key>)
+ *     <i>})
+ *
+ *   nestedComps.length >  0 (nested) — SSR/CSR split:
+ *     <i>mapArray(...) => {
+ *     <i>  <unwrap?>
+ *     <i>  if (__existing) {
+ *     <i>    initChild('<C>', __existing, <props>)
+ *     <i>    {<each nested initChild + optional createEffect>}
+ *     <i>    <emitLoopChildReactiveEffects on __existing if childConditionals>
+ *     <i>    return __existing
+ *     <i>  }
+ *     <i>  const __csrEl = createComponent('<C>', <props>, <key>)
+ *     <i>  {<each nested initChild + optional createEffect>}
+ *     <i>  <emitLoopChildReactiveEffects on __csrEl if childConditionals>
+ *     <i>  return __csrEl
+ *     <i>})
+ *
+ * Indent: top emission uses 2 spaces; renderItem body uses 4 spaces;
+ * SSR-side nested-comp lines use 6 spaces (matches legacy).
+ */
+
+import { emitLoopChildReactiveEffects } from '../../emit-control-flow'
+import type { ComponentLoopPlan, NestedComponentInit } from '../plan/types'
+
+export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan): void {
+  const {
+    containerVar,
+    arrayExpr,
+    keyFn,
+    paramHead,
+    paramUnwrap,
+    indexParam,
+    componentName,
+    componentPropsExpr,
+    keyExpr,
+    nestedComps,
+    childConditionalEffects,
+  } = plan
+
+  lines.push(`  mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
+  if (paramUnwrap) lines.push(`    ${paramUnwrap}`)
+
+  if (nestedComps.length === 0) {
+    lines.push(`    if (__existing) { initChild('${componentName}', __existing, ${componentPropsExpr}); return __existing }`)
+    lines.push(`    return createComponent('${componentName}', ${componentPropsExpr}, ${keyExpr})`)
+    lines.push(`  })`)
+    return
+  }
+
+  // SSR side
+  lines.push(`    if (__existing) {`)
+  lines.push(`      initChild('${componentName}', __existing, ${componentPropsExpr})`)
+  for (const nc of nestedComps) emitNestedInit(lines, '      ', '__existing', nc)
+  if (childConditionalEffects) {
+    emitLoopChildReactiveEffects(
+      lines, '      ', '__existing',
+      childConditionalEffects.attrs,
+      childConditionalEffects.texts,
+      childConditionalEffects.conditionals,
+      childConditionalEffects.loopParam,
+      childConditionalEffects.loopParamBindings,
+    )
+  }
+  lines.push(`      return __existing`)
+  lines.push(`    }`)
+
+  // CSR side
+  lines.push(`    const __csrEl = createComponent('${componentName}', ${componentPropsExpr}, ${keyExpr})`)
+  for (const nc of nestedComps) emitNestedInit(lines, '    ', '__csrEl', nc)
+  if (childConditionalEffects) {
+    emitLoopChildReactiveEffects(
+      lines, '    ', '__csrEl',
+      childConditionalEffects.attrs,
+      childConditionalEffects.texts,
+      childConditionalEffects.conditionals,
+      childConditionalEffects.loopParam,
+      childConditionalEffects.loopParamBindings,
+    )
+  }
+  lines.push(`    return __csrEl`)
+  lines.push(`  })`)
+}
+
+function emitNestedInit(lines: string[], indent: string, parentVar: string, nc: NestedComponentInit): void {
+  if (nc.childrenTextEffect) {
+    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) { initChild('${nc.componentName}', __c, ${nc.propsExpr}); createEffect(() => { const __v = ${nc.childrenTextEffect.wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+  } else {
+    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) initChild('${nc.componentName}', __c, ${nc.propsExpr}) }`)
+  }
+}

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -13,6 +13,8 @@ import { buildInsertPlan } from './control-flow/plan/build-insert'
 import { stringifyInsert } from './control-flow/stringify/insert'
 import { buildPlainLoopPlan, buildStaticLoopPlan } from './control-flow/plan/build-loop'
 import { stringifyPlainLoop, stringifyStaticLoop } from './control-flow/stringify/loop'
+import { buildComponentLoopPlan } from './control-flow/plan/build-component-loop'
+import { stringifyComponentLoop } from './control-flow/stringify/component-loop'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -608,7 +610,7 @@ function emitDynamicLoopUpdates(lines: string[], elem: TopLevelLoop): void {
  * Build a props object expression string from component prop definitions.
  * Shared by emitComponentLoopReconciliation and emitCompositeElementReconciliation.
  */
-function buildComponentPropsExpr(
+export function buildComponentPropsExpr(
   comp: { props: Array<{ name: string; value: string; isEventHandler: boolean; isLiteral: boolean }>, children?: import('../types').IRNode[] },
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
@@ -634,75 +636,11 @@ function buildComponentPropsExpr(
 }
 
 /** Emit mapArray for a loop whose body is a single child component. */
-function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, keyFn: string): void {
-  const { name } = elem.childComponent!
-  const vLoop = varSlotId(elem.slotId)
-  const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
-  const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param, elem.paramBindings)
-  const indexParam = elem.index || '__idx'
-  const chainedExpr = buildChainedArrayExpr(elem)
-  // Only init components at loopDepth 0 — inner-loop components are handled by their own loop
-  const nestedComps = (elem.nestedComponents ?? []).filter(c => !c.loopDepth)
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
-
-  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
-  if (pUnwrap) {
-    lines.push(`    ${pUnwrap}`)
-  }
-  if (nestedComps.length > 0) {
-    // Unified renderItem: SSR hydrates nested components, CSR creates from scratch
-    lines.push(`    if (__existing) {`)
-    lines.push(`      initChild('${name}', __existing, ${propsExpr})`)
-    // Initialize nested child components within the SSR-rendered element
-    for (const comp of nestedComps) {
-      const selector = buildCompSelector(comp)
-      const nestedPropsExpr = buildComponentPropsExpr(comp, elem.param)
-      // Check if children are text-only and reference the loop param.
-      // Only text-only children can safely use textContent update;
-      // children containing elements/components would be destroyed.
-      const isTextOnly = comp.children?.length
-        ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
-        : false
-      const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
-      const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
-      if (childrenRefsLoop) {
-        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param, elem.paramBindings)
-        lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
-      } else {
-        lines.push(`      { const __c = qsa(__existing, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
-      }
-    }
-    // Emit reactive effects for conditionals/texts inside component children
-    if (elem.childConditionals && elem.childConditionals.length > 0) {
-      emitLoopChildReactiveEffects(lines, '      ', '__existing', [], [], elem.childConditionals, elem.param, elem.paramBindings)
-    }
-    lines.push(`      return __existing`)
-    lines.push(`    }`)
-    lines.push(`    const __csrEl = createComponent('${name}', ${propsExpr}, ${keyExpr})`)
-    for (const comp of nestedComps) {
-      const selector = buildCompSelector(comp)
-      const nestedPropsExpr = buildComponentPropsExpr(comp, elem.param)
-      const isTextOnly = comp.children?.length
-        ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
-        : false
-      const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
-      const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
-      if (childrenRefsLoop) {
-        const wrappedChildren = wrapLoopParamAsAccessor(rawChildrenExpr, elem.param, elem.paramBindings)
-        lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${nestedPropsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
-      } else {
-        lines.push(`    { const __c = qsa(__csrEl, '${selector}'); if (__c) initChild('${comp.name}', __c, ${nestedPropsExpr}) }`)
-      }
-    }
-    if (elem.childConditionals && elem.childConditionals.length > 0) {
-      emitLoopChildReactiveEffects(lines, '    ', '__csrEl', [], [], elem.childConditionals, elem.param, elem.paramBindings)
-    }
-    lines.push(`    return __csrEl`)
-  } else {
-    lines.push(`    if (__existing) { initChild('${name}', __existing, ${propsExpr}); return __existing }`)
-    lines.push(`    return createComponent('${name}', ${propsExpr}, ${keyExpr})`)
-  }
-  lines.push(`  })`)
+function emitComponentLoopReconciliation(lines: string[], elem: TopLevelLoop, _keyFn: string): void {
+  // _keyFn ignored — buildComponentLoopPlan recomputes via loopKeyFn(elem)
+  // so the plan is self-contained. Kept in the signature so the dispatcher
+  // doesn't need to learn the new shape yet.
+  stringifyComponentLoop(lines, buildComponentLoopPlan(elem))
 }
 
 /**
@@ -988,7 +926,7 @@ function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChi
 }
 
 /** Build the component-finder CSS selector for SSR hydration initChild. */
-function buildCompSelector(comp: { slotId?: string | null; name: string }): string {
+export function buildCompSelector(comp: { slotId?: string | null; name: string }): string {
   // When slotId is available, use suffix-only selector. It is unique within
   // the parent scope and avoids matching siblings of the same component type
   // (e.g. two Buttons with different slotIds).
@@ -1005,7 +943,7 @@ function buildCompSelector(comp: { slotId?: string | null; name: string }): stri
  * For SSR elements (hydration): finds scope elements and calls initChild.
  */
 /** Check if an IR node is a conditional whose branches are text/expression only. */
-function isTextOnlyConditional(node: { type: string; [k: string]: any }): boolean {
+export function isTextOnlyConditional(node: { type: string; [k: string]: any }): boolean {
   if (node.type !== 'conditional') return false
   const checkNode = (n: { type: string; [k: string]: any }): boolean =>
     n.type === 'text' || n.type === 'expression' || (n.type === 'conditional' && isTextOnlyConditional(n))


### PR DESCRIPTION
## Summary

Continues the `IR -> Plan -> string` migration started in #1033 and continued in #1034. This PR moves `emitComponentLoopReconciliation` onto the Plan layer.

| Legacy emitter | Plan |
|----------------|------|
| `emitComponentLoopReconciliation` | `ComponentLoopPlan` |

## Why

Same goal: separate **what to emit** (Plan, pure data) from **how to write it** (stringifier, deterministic). Once all loop variants live on the Plan, the latent bugs surfaced in the survey (O-2 dispose leak, O-3 \`key\` attr duplication, O-8 deep-nested loop degradation) become local to a builder/stringifier pair instead of scattered through a 70-line if/else.

## Scope

**In:**
- `control-flow/plan/types.ts` — `ComponentLoopPlan`, `NestedComponentInit`
- `control-flow/plan/build-component-loop.ts` — pure `IR -> ComponentLoopPlan`
- `control-flow/stringify/component-loop.ts` — `ComponentLoopPlan -> string[]`
- Replace `emitComponentLoopReconciliation` body (~70 lines) with builder + stringifier calls
- Export `buildComponentPropsExpr`, `buildCompSelector`, `isTextOnlyConditional` so the Plan layer can reuse them

**Out (follow-ups):**
- Composite loops (`emitCompositeElementReconciliation`) — PR 2-c
- Event delegation — PR 3
- Latent bugs O-2 / O-3 / O-4 / O-8 — PR 5+

## Plan shape decision

A single `ComponentLoopPlan` covers both legacy paths (simple vs SSR/CSR-split-with-nested-comps) via \`nestedComps.length === 0\`. Resolving the per-nested-component decisions (selector, propsExpr, text-only-children detection) up-front in the builder lets the stringifier be a flat switch, not a nested if/else.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 760 / 760 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit
- Output is byte-identical to \`main\` (verified by the existing test suite, which compares emitted strings throughout)