### PR TITLE
refactor(compiler): composite loop emission via CompositeLoopPlan (PR 2-c/N)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
@@ -1,0 +1,136 @@
+/**
+ * Build `CompositeLoopPlan` for top-level (`emitCompositeElementReconciliation`)
+ * and branch-scoped (`emitCompositeBranchLoop`) composite loops.
+ *
+ * The two contexts share the same renderItem body shape — only the container
+ * variable, the array expression chaining, and indentation differ. Both
+ * variants are produced by the same builder so the stringifier sees one
+ * consistent Plan.
+ */
+
+import type { TopLevelLoop, BranchLoop, LoopChildConditional } from '../../types'
+import type { IRLoopChildComponent } from '../../../types'
+import {
+  buildChainedArrayExpr,
+  varSlotId,
+  wrapLoopParamAsAccessor,
+} from '../../utils'
+import {
+  loopKeyFn,
+  destructureLoopParam,
+  buildDepthLevels,
+} from '../../emit-control-flow'
+import type { CompositeLoopPlan } from './types'
+
+export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPlan {
+  const nestedComps = elem.nestedComponents!
+  const depthLevels = buildDepthLevels(elem.innerLoops ?? [], nestedComps, elem.childEvents)
+  const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
+
+  const outerCompsByDepth = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
+
+  return {
+    kind: 'composite-loop',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    arrayExpr: buildChainedArrayExpr(elem),
+    keyFn: loopKeyFn(elem),
+    paramHead,
+    paramUnwrap,
+    indexParam: elem.index || '__idx',
+    mapPreambleWrapped: elem.mapPreamble ? wrap(elem.mapPreamble) : '',
+    template: elem.template,
+    outerComps: filterCondCompsOut(outerCompsByDepth, elem.childConditionals),
+    outerEvents: elem.childEvents.filter(ev => ev.nestedLoops.length === 0),
+    depthLevels,
+    loopParam: elem.param,
+    loopParamBindings: elem.paramBindings,
+    reactiveEffects: hasReactive(elem)
+      ? {
+          attrs: elem.childReactiveAttrs ?? [],
+          texts: elem.childReactiveTexts ?? [],
+          conditionals: elem.childConditionals,
+          loopParam: elem.param,
+          loopParamBindings: elem.paramBindings,
+        }
+      : null,
+    branchClearChildren: false,
+    topIndent: '  ',
+    bodyIndent: '    ',
+  }
+}
+
+export function buildBranchCompositePlan(loop: BranchLoop, cv: string): CompositeLoopPlan {
+  const nestedComps = loop.nestedComponents!
+  const innerLoops = loop.innerLoops ?? []
+  const childEvents = loop.childEvents
+  const depthLevels = buildDepthLevels(innerLoops, nestedComps, childEvents)
+  const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, loop.param, loop.paramBindings)
+
+  const outerCompsByDepth = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
+
+  return {
+    kind: 'composite-loop',
+    containerVar: `__loop_${cv}`,
+    // Branch-scoped loops use the raw array expression (no filter/sort chaining
+    // path — BranchLoop doesn't carry those fields).
+    arrayExpr: loop.array,
+    keyFn: loopKeyFn(loop),
+    paramHead,
+    paramUnwrap,
+    indexParam: loop.index || '__idx',
+    mapPreambleWrapped: loop.mapPreamble ? wrap(loop.mapPreamble) : '',
+    template: loop.template,
+    outerComps: filterCondCompsOut(outerCompsByDepth, loop.childConditionals),
+    outerEvents: childEvents.filter(ev => ev.nestedLoops.length === 0),
+    depthLevels,
+    loopParam: loop.param,
+    loopParamBindings: loop.paramBindings,
+    reactiveEffects: hasReactiveBranch(loop)
+      ? {
+          attrs: loop.childReactiveAttrs ?? [],
+          texts: loop.childReactiveTexts ?? [],
+          conditionals: loop.childConditionals,
+          loopParam: loop.param,
+          loopParamBindings: loop.paramBindings,
+        }
+      : null,
+    branchClearChildren: true,
+    topIndent: '      ',
+    bodyIndent: '        ',
+  }
+}
+
+/**
+ * Drop outer-level child components whose `slotId` lives inside one of the
+ * loop body's reactive conditional branches. Those components are managed by
+ * the conditional's own `insert(...)` bindEvents — initialising them here
+ * too would double-wire event handlers (#929).
+ */
+function filterCondCompsOut(
+  outerComps: readonly IRLoopChildComponent[],
+  conditionals: readonly LoopChildConditional[] | undefined,
+): IRLoopChildComponent[] {
+  if (!conditionals?.length) return [...outerComps]
+  const condCompSlotIds = new Set<string>()
+  for (const cond of conditionals) {
+    for (const comp of [...cond.whenTrue.childComponents, ...cond.whenFalse.childComponents]) {
+      if (comp.slotId) condCompSlotIds.add(comp.slotId)
+    }
+  }
+  if (condCompSlotIds.size === 0) return [...outerComps]
+  return outerComps.filter(c => !c.slotId || !condCompSlotIds.has(c.slotId))
+}
+
+function hasReactive(elem: TopLevelLoop): boolean {
+  return (elem.childReactiveAttrs?.length ?? 0) > 0
+    || (elem.childReactiveTexts?.length ?? 0) > 0
+    || (elem.childConditionals?.length ?? 0) > 0
+}
+
+function hasReactiveBranch(loop: BranchLoop): boolean {
+  return (loop.childReactiveAttrs?.length ?? 0) > 0
+    || (loop.childReactiveTexts?.length ?? 0) > 0
+    || (loop.childConditionals?.length ?? 0) > 0
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -22,10 +22,13 @@ import type {
   BranchLoop,
   ConditionalElement,
   LoopChildConditional,
+  LoopChildEvent,
   LoopChildReactiveAttr,
   LoopChildReactiveText,
   TopLevelLoop,
 } from '../../types'
+import type { IRLoopChildComponent } from '../../../types'
+import type { DepthLevel } from '../../emit-control-flow'
 
 // ─────────────────────────────────────────────────────────────────────
 // Top-level
@@ -227,6 +230,64 @@ export interface NestedComponentInit {
   propsExpr: string
   /** When non-null, emit a reactive textContent effect alongside `initChild`. */
   childrenTextEffect: { wrappedChildren: string } | null
+}
+
+/**
+ * Plan for a composite loop — body is a plain element that contains either
+ * nested child components (`outerComps`) and/or inner loops
+ * (`depthLevels`). Used for both top-level emission
+ * (`emitCompositeElementReconciliation`) and branch-scoped emission
+ * (`emitCompositeBranchLoop`).
+ *
+ * The two contexts differ only in:
+ *   - container variable name (`_sN` vs `__loop_cv`)
+ *   - `arrayExpr` (top: chained filter/sort/map; branch: raw `loop.array`)
+ *   - leading/body indent
+ *   - `branchClearChildren`: when true, prepends a `getLoopChildren(...)
+ *     .forEach(__el => __el.remove())` line so the branch swap starts from
+ *     a clean slate (legacy parity).
+ *
+ * Inner-loop emission and component-and-event setup remain on the legacy
+ * `emitInnerLoopSetup` / `emitComponentAndEventSetup` helpers, invoked from
+ * the stringifier as a passthrough. PR 2-c does not Plan-ify those — the
+ * SSR/CSR duplication noted in observation O-1 and the deep-nested loop
+ * degradation in O-8 stay bug-for-bug for this PR; their fixes land in
+ * dedicated bug-fix PRs after the migration completes.
+ */
+export interface CompositeLoopPlan {
+  kind: 'composite-loop'
+  containerVar: string
+  arrayExpr: string
+  keyFn: string
+  paramHead: string
+  paramUnwrap: string
+  indexParam: string
+  /** Wrapped mapPreamble line, hoisted before the SSR/CSR split. Empty when none. */
+  mapPreambleWrapped: string
+  /** Inner template HTML for the loop body (single item). */
+  template: string
+  /** Outer-level child components (depth 0), with `insideConditional` ones already filtered out. */
+  outerComps: readonly IRLoopChildComponent[]
+  /** Outer-level child events (no nested-loop scope). */
+  outerEvents: readonly LoopChildEvent[]
+  /** Per-inner-loop levels for `emitInnerLoopSetup` passthrough. */
+  depthLevels: readonly DepthLevel[]
+  /** Loop param identifier — needed for legacy passthroughs. */
+  loopParam: string
+  /** Destructured-binding metadata for the loop param. */
+  loopParamBindings: TopLevelLoop['paramBindings']
+  /** Reactive effects rendered after the SSR/CSR split. */
+  reactiveEffects: ReactiveEffectsPassthrough | null
+  /**
+   * When true, the stringifier prepends a `getLoopChildren(...).forEach(__el
+   * => __el.remove())` line — branch composite loops need this so mapArray
+   * starts from a clean container after a branch swap. Top-level loops do not.
+   */
+  branchClearChildren: boolean
+  /** Indent of the `mapArray(` line itself. */
+  topIndent: string
+  /** Indent of the lines inside the renderItem body. */
+  bodyIndent: string
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -1,0 +1,108 @@
+/**
+ * Stringify a `CompositeLoopPlan` to source lines.
+ *
+ * Output shape (preserved byte-identical from the legacy
+ * `emitCompositeRenderItemBody` + dispatch glue):
+ *
+ *   <branchClearPrefix?>
+ *   <topIndent>mapArray(() => <arr>, <container>, <keyFn>, (<head>, <idx>, __existing) => {
+ *   <bodyIndent><unwrap?>
+ *   <bodyIndent><mapPreambleWrapped?>
+ *   <bodyIndent>let __el
+ *   <bodyIndent>if (__existing) {
+ *   <bodyIndent>  __el = __existing
+ *   <bodyIndent>  <emitComponentAndEventSetup ssr>
+ *   <bodyIndent>  <emitInnerLoopSetup ssr>
+ *   <bodyIndent>} else {
+ *   <bodyIndent>  const __tpl = document.createElement('template')
+ *   <bodyIndent>  __tpl.innerHTML = `<template>`
+ *   <bodyIndent>  __el = __tpl.content.firstElementChild.cloneNode(true)
+ *   <bodyIndent>  <emitComponentAndEventSetup csr>
+ *   <bodyIndent>  <emitInnerLoopSetup csr>
+ *   <bodyIndent>}
+ *   <bodyIndent><emitLoopChildReactiveEffects?>
+ *   <bodyIndent>return __el
+ *   <topIndent>})
+ *
+ * Inner-loop setup and component-and-event setup are passthroughs to legacy
+ * helpers so the SSR/CSR duplication (observation O-1) stays bug-for-bug.
+ * Fixing it requires Plan-ifying inner loops too — slated for a bug-fix PR
+ * after the migration completes.
+ */
+
+import {
+  emitComponentAndEventSetup,
+  emitInnerLoopSetup,
+  emitLoopChildReactiveEffects,
+} from '../../emit-control-flow'
+import type { CompositeLoopPlan } from '../plan/types'
+
+export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan): void {
+  const {
+    containerVar,
+    arrayExpr,
+    keyFn,
+    paramHead,
+    paramUnwrap,
+    indexParam,
+    mapPreambleWrapped,
+    template,
+    outerComps,
+    outerEvents,
+    depthLevels,
+    loopParam,
+    loopParamBindings,
+    reactiveEffects,
+    branchClearChildren,
+    topIndent,
+    bodyIndent,
+  } = plan
+
+  if (branchClearChildren) {
+    // Clear template-generated children so mapArray creates fresh elements
+    // with properly initialized components via createComponent in renderItem.
+    lines.push(`${topIndent}if (${containerVar}) getLoopChildren(${containerVar}).forEach(__el => __el.remove())`)
+    lines.push(`${topIndent}if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
+  } else {
+    lines.push(`${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
+  }
+  if (paramUnwrap) lines.push(`${bodyIndent}${paramUnwrap}`)
+
+  // Hoist mapPreamble before the SSR/CSR split so variables it declares are
+  // accessible in both branches and in any reactive attribute getters
+  // emitted after the if/else block.
+  if (mapPreambleWrapped) lines.push(`${bodyIndent}${mapPreambleWrapped}`)
+
+  const innerIndent = bodyIndent + '  '
+  const compsArr = [...outerComps]
+  const eventsArr = [...outerEvents]
+  const levelsArr = [...depthLevels]
+
+  // SSR/CSR split
+  lines.push(`${bodyIndent}let __el`)
+  lines.push(`${bodyIndent}if (__existing) {`)
+  lines.push(`${innerIndent}__el = __existing`)
+  emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'ssr', loopParam, loopParamBindings)
+  emitInnerLoopSetup(lines, innerIndent, '__el', levelsArr, 'ssr', loopParam, loopParamBindings)
+  lines.push(`${bodyIndent}} else {`)
+  lines.push(`${innerIndent}const __tpl = document.createElement('template')`)
+  lines.push(`${innerIndent}__tpl.innerHTML = \`${template}\``)
+  lines.push(`${innerIndent}__el = __tpl.content.firstElementChild.cloneNode(true)`)
+  emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'csr', loopParam, loopParamBindings)
+  emitInnerLoopSetup(lines, innerIndent, '__el', levelsArr, 'csr', loopParam, loopParamBindings)
+  lines.push(`${bodyIndent}}`)
+
+  if (reactiveEffects) {
+    emitLoopChildReactiveEffects(
+      lines, bodyIndent, '__el',
+      reactiveEffects.attrs,
+      reactiveEffects.texts,
+      reactiveEffects.conditionals,
+      reactiveEffects.loopParam,
+      reactiveEffects.loopParamBindings,
+    )
+  }
+
+  lines.push(`${bodyIndent}return __el`)
+  lines.push(`${topIndent}})`)
+}

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -6,7 +6,7 @@
 
 import type { ClientJsContext, BranchLoop, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, buildChainedArrayExpr, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent, substituteLoopBindings } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent, substituteLoopBindings } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 import { buildInsertPlan } from './control-flow/plan/build-insert'
@@ -15,6 +15,8 @@ import { buildPlainLoopPlan, buildStaticLoopPlan } from './control-flow/plan/bui
 import { stringifyPlainLoop, stringifyStaticLoop } from './control-flow/stringify/loop'
 import { buildComponentLoopPlan } from './control-flow/plan/build-component-loop'
 import { stringifyComponentLoop } from './control-flow/stringify/component-loop'
+import { buildTopLevelCompositePlan, buildBranchCompositePlan } from './control-flow/plan/build-composite-loop'
+import { stringifyCompositeLoop } from './control-flow/stringify/composite-loop'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -169,47 +171,7 @@ function emitCompositeBranchLoop(
   loop: BranchLoop,
   cv: string,
 ): void {
-  const nestedComps = loop.nestedComponents!
-  const innerLoops = loop.innerLoops ?? []
-  const childEvents = loop.childEvents
-  const indexParam = loop.index || '__idx'
-
-  const depthLevels = buildDepthLevels(innerLoops, nestedComps, childEvents)
-
-  const outerComps = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
-  const outerEvents = childEvents.filter(ev => ev.nestedLoops.length === 0)
-
-  // Build a partial TopLevelLoop-compatible object for CompositeLoopContext
-  const pseudoElem = {
-    param: loop.param,
-    template: loop.template,
-    mapPreamble: loop.mapPreamble ?? undefined,
-    childReactiveTexts: loop.childReactiveTexts ?? [],
-    childReactiveAttrs: loop.childReactiveAttrs ?? [],
-    childConditionals: loop.childConditionals ?? [],
-  } as unknown as TopLevelLoop
-
-  const ctx: CompositeLoopContext = {
-    elem: pseudoElem,
-    outerComps,
-    outerEvents,
-    depthLevels,
-  }
-
-  const keyFn = loopKeyFn(loop)
-
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
-
-  // Wrap everything in a disposable effect for branch cleanup
-  // Clear template-generated children so mapArray creates fresh elements
-  // with properly initialized components via createComponent in renderItem.
-  lines.push(`      if (__loop_${cv}) getLoopChildren(__loop_${cv}).forEach(__el => __el.remove())`)
-  lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
-  if (pUnwrap) {
-    lines.push(`        ${pUnwrap}`)
-  }
-  emitCompositeRenderItemBody(lines, '        ', ctx)
-  lines.push(`      })`)
+  stringifyCompositeLoop(lines, buildBranchCompositePlan(loop, cv))
 }
 
 /** Emit insert() calls for server-rendered reactive conditionals with branch configs. */
@@ -873,7 +835,7 @@ function emitBranchLoopEventDelegation(lines: string[], loop: BranchLoop, cv: st
 }
 
 /** Per-inner-loop data for composite loop emission. */
-interface DepthLevel {
+export interface DepthLevel {
   comps: (TopLevelLoop['nestedComponents'] & {})[number][]
   events: LoopChildEvent[]
   loopInfo: NestedLoop | null
@@ -884,7 +846,7 @@ interface DepthLevel {
  * One DepthLevel entry per inner loop (not per depth), so sibling loops at the
  * same depth (e.g., reactions.map + replies.map) each get their own forEach block.
  */
-function buildDepthLevels(
+export function buildDepthLevels(
   innerLoops: NestedLoop[],
   nestedComps: IRLoopChildComponent[],
   childEvents: LoopChildEvent[],
@@ -906,16 +868,6 @@ function buildDepthLevels(
     }),
     loopInfo: loop,
   }))
-}
-
-/** Nesting-level-separated data for composite loop emission. */
-interface CompositeLoopContext {
-  elem: TopLevelLoop
-  /** Components and events at the outer level (depth 0) */
-  outerComps: TopLevelLoop['nestedComponents'] & {}
-  outerEvents: LoopChildEvent[]
-  /** Components, events, and loop info grouped by depth (depth 1, 2, ...) */
-  depthLevels: DepthLevel[]
 }
 
 /** Emit a single addEventListener call for a child event on a given element. */
@@ -950,11 +902,11 @@ export function isTextOnlyConditional(node: { type: string; [k: string]: any }):
   return checkNode(node.whenTrue) && checkNode(node.whenFalse)
 }
 
-function emitComponentAndEventSetup(
+export function emitComponentAndEventSetup(
   ls: string[],
   indent: string,
   elVar: string,
-  comps: CompositeLoopContext['outerComps'],
+  comps: TopLevelLoop['nestedComponents'] & {},
   events: LoopChildEvent[],
   mode: 'csr' | 'ssr',
   loopParam?: string,
@@ -1006,57 +958,10 @@ function emitComponentAndEventSetup(
  * Handles both CSR (create from template) and SSR (initialize existing element).
  * Inner loops, events, and reactive effects are shared between both paths.
  */
-function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: CompositeLoopContext): void {
-  const param = ctx.elem.param
-  const paramBindings = ctx.elem.paramBindings
-  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, param, paramBindings)
-
-  // Exclude components inside reactive conditionals — managed by insert()
-  const condCompSlotIds = new Set<string>()
-  for (const cond of ctx.elem.childConditionals ?? []) {
-    for (const comp of [...cond.whenTrue.childComponents, ...cond.whenFalse.childComponents]) {
-      if (comp.slotId) condCompSlotIds.add(comp.slotId)
-    }
-  }
-  const filteredComps = condCompSlotIds.size > 0
-    ? ctx.outerComps.filter(c => !c.slotId || !condCompSlotIds.has(c.slotId))
-    : ctx.outerComps
-
-  // Hoist mapPreamble before the SSR/CSR split so variables it declares
-  // (e.g. `const f = arr.find(...)`) are accessible in both branches and in
-  // any reactive attribute getters emitted after the if/else block.
-  if (ctx.elem.mapPreamble) {
-    ls.push(`${indent}${wrap(ctx.elem.mapPreamble)}`)
-  }
-
-  // Branch: SSR (existing element) vs CSR (create from template)
-  ls.push(`${indent}let __el`)
-  ls.push(`${indent}if (__existing) {`)
-  ls.push(`${indent}  __el = __existing`)
-  // SSR: initialize nested components via initChild
-  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'ssr', param, paramBindings)
-  // SSR: inner loop initialization
-  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'ssr', param, paramBindings)
-  ls.push(`${indent}} else {`)
-  // CSR: create element from template, replace placeholders with createComponent
-  ls.push(`${indent}  const __tpl = document.createElement('template')`)
-  // Template is already wrapped at generation time (irToPlaceholderTemplate with loopParams)
-  ls.push(`${indent}  __tpl.innerHTML = \`${ctx.elem.template}\``)
-  ls.push(`${indent}  __el = __tpl.content.firstElementChild.cloneNode(true)`)
-  emitComponentAndEventSetup(ls, `${indent}  `, '__el', filteredComps, ctx.outerEvents, 'csr', param, paramBindings)
-  // CSR: inner loop initialization
-  emitInnerLoopSetup(ls, `${indent}  `, '__el', ctx.depthLevels, 'csr', param, paramBindings)
-  ls.push(`${indent}}`)
-
-  const reactiveAttrs = ctx.elem.childReactiveAttrs ?? []
-  const reactiveTexts = ctx.elem.childReactiveTexts ?? []
-  const reactiveConditionals = ctx.elem.childConditionals ?? []
-  if (reactiveAttrs.length > 0 || reactiveTexts.length > 0 || reactiveConditionals.length > 0) {
-    emitLoopChildReactiveEffects(ls, indent, '__el', reactiveAttrs, reactiveTexts, reactiveConditionals, param, paramBindings)
-  }
-
-  ls.push(`${indent}return __el`)
-}
+// emitCompositeRenderItemBody — replaced by stringifyCompositeLoop.
+// The conditional-slot filter (excluding components inside reactive
+// conditional branches) is now applied in the Plan builder
+// (`build-composite-loop.ts::filterCondCompsOut`).
 
 /**
  * Emit inner loop forEach + component/event setup for CSR and SSR.
@@ -1064,7 +969,7 @@ function emitCompositeRenderItemBody(ls: string[], indent: string, ctx: Composit
  * nested loops at increasing depth (emitted inside their parent's forEach).
  * Levels are ordered by DFS walk, so child levels immediately follow their parent.
  */
-function emitInnerLoopSetup(
+export function emitInnerLoopSetup(
   ls: string[],
   indent: string,
   parentElVar: string,
@@ -1211,31 +1116,10 @@ function emitInnerLoopSetup(
 function emitCompositeElementReconciliation(
   lines: string[],
   elem: TopLevelLoop,
-  keyFn: string,
+  _keyFn: string,
 ): void {
-  const vLoop = varSlotId(elem.slotId)
-  const chainedExpr = buildChainedArrayExpr(elem)
-  const indexParam = elem.index || '__idx'
-
-  const nestedComps = elem.nestedComponents!
-  const innerLoops = elem.innerLoops ?? []
-
-  const depthLevels = buildDepthLevels(innerLoops, nestedComps, elem.childEvents)
-
-  const ctx: CompositeLoopContext = {
-    elem,
-    outerComps: nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0),
-    outerEvents: elem.childEvents.filter(ev => ev.nestedLoops.length === 0),
-    depthLevels,
-  }
-
-  const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
-  lines.push(`  mapArray(() => ${chainedExpr}, _${vLoop}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
-  if (pUnwrap) {
-    lines.push(`    ${pUnwrap}`)
-  }
-  emitCompositeRenderItemBody(lines, '    ', ctx)
-  lines.push(`  })`)
+  // _keyFn ignored — buildTopLevelCompositePlan recomputes via loopKeyFn(elem).
+  stringifyCompositeLoop(lines, buildTopLevelCompositePlan(elem))
 }
 
 /**


### PR DESCRIPTION
## Summary

Continues the \`IR -> Plan -> string\` migration started in #1033 / #1034 / #1035. This PR moves the three composite-loop entry points onto the Plan layer and finishes the loop family.

| Legacy emitter | Plan |
|----------------|------|
| \`emitCompositeElementReconciliation\` | \`buildTopLevelCompositePlan\` |
| \`emitCompositeBranchLoop\`            | \`buildBranchCompositePlan\`   |
| \`emitCompositeRenderItemBody\`        | \`stringifyCompositeLoop\`     |

Both top-level and branch-scoped composites now share **one** \`CompositeLoopPlan\` shape and **one** stringifier — the only differences (container variable, array expression, leading/body indent, the one-line \`getLoopChildren(...).forEach(remove)\` prefix on branch swaps) are modelled as Plan fields.

## Why

Same goal as the prior PRs: separate **what to emit** (Plan, pure data) from **how to write it** (stringifier, deterministic). With this PR, every loop variant is on the Plan; what remains for full migration is event delegation (PR 3) and the legacy passthroughs (\`emitInnerLoopSetup\`, \`emitComponentAndEventSetup\`, \`emitLoopChildReactiveEffects\`), which are best removed as part of the bug-fix PRs that target their actual defects (O-1 / O-3 / O-8).

## Scope

**In:**
- \`control-flow/plan/types.ts\` — \`CompositeLoopPlan\`
- \`control-flow/plan/build-composite-loop.ts\` — both top-level and branch builders, plus a shared \`filterCondCompsOut\` helper that captures the conditional-branch-component exclusion (#929) as a Plan-side decision
- \`control-flow/stringify/composite-loop.ts\` — single stringifier covering both contexts
- Replace \`emitCompositeElementReconciliation\` / \`emitCompositeBranchLoop\` / \`emitCompositeRenderItemBody\` with builder + stringifier calls; delete the latter
- Export \`buildDepthLevels\`, \`DepthLevel\`, \`emitInnerLoopSetup\`, \`emitComponentAndEventSetup\` so the Plan layer can reuse them
- Remove the dead \`CompositeLoopContext\` interface

**Out (follow-ups):**
- Event delegation (\`emitDynamicLoopEventDelegation\`, \`emitBranchLoopEventDelegation\`, \`emitLoopEventDelegation\`) — PR 3
- Latent bugs O-1 (SSR/CSR duplication), O-3 (\`key\` attr dup), O-4 (static-loop double forEach), O-8 (deep-nested degradation) — PR 5+

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 760 / 760 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit
- Output is byte-identical to \`main\` (verified by the existing test suite, which compares emitted strings throughout)