### PR TITLE
refactor(compiler): loop event delegation via EventDelegationPlan (PR 3/N)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -1,0 +1,106 @@
+/**
+ * Build `EventDelegationPlan` for the three legacy emitters:
+ *   - `emitDynamicLoopEventDelegation` (top-level dynamic loop)
+ *   - `emitBranchLoopEventDelegation`  (branch-scoped dynamic loop)
+ *   - the inline delegation block in `emitStaticArrayUpdates`
+ *
+ * Builders take the smallest IR slice they need (loop core + childEvents +
+ * containerVar) so the same shape works for `TopLevelLoop`, `BranchLoop`,
+ * and the static-array context.
+ */
+
+import type { TopLevelLoop, BranchLoop, LoopChildEvent } from '../../types'
+import { varSlotId, substituteLoopBindings } from '../../utils'
+import type {
+  EventDelegationPlan,
+  ItemLookup,
+} from './types'
+
+export function buildDynamicLoopDelegationPlan(elem: TopLevelLoop): EventDelegationPlan {
+  return {
+    kind: 'event-delegation',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    events: elem.childEvents,
+    itemLookup: buildKeyedOrIndexLookup({
+      array: elem.array,
+      param: elem.param,
+      paramBindings: elem.paramBindings,
+      key: elem.key,
+      mapPreamble: elem.mapPreamble ?? null,
+    }),
+  }
+}
+
+export function buildBranchLoopDelegationPlan(loop: BranchLoop, cv: string): EventDelegationPlan {
+  return {
+    kind: 'event-delegation',
+    containerVar: `__loop_${cv}`,
+    events: loop.childEvents,
+    itemLookup: buildKeyedOrIndexLookup({
+      array: loop.array,
+      param: loop.param,
+      paramBindings: loop.paramBindings,
+      key: loop.key,
+      mapPreamble: loop.mapPreamble ?? null,
+    }),
+  }
+}
+
+/**
+ * Build a Plan for the static-array event-delegation block. Static arrays have
+ * no `data-key` markers, so the lookup walks up to the container's direct
+ * child and uses `indexOf` (with optional sibling offset).
+ */
+export function buildStaticArrayDelegationPlan(elem: TopLevelLoop): EventDelegationPlan {
+  return {
+    kind: 'event-delegation',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    events: elem.childEvents,
+    itemLookup: {
+      kind: 'static-index',
+      arrayExpr: elem.array,
+      param: elem.param,
+      mapPreamble: elem.mapPreamble ?? null,
+      siblingOffset: elem.siblingOffset ?? null,
+    },
+  }
+}
+
+/**
+ * Helper used by both the top-level and branch-scoped builders. Picks
+ * `keyed` vs `dynamic-index` based on whether the loop has an explicit key.
+ */
+function buildKeyedOrIndexLookup(args: {
+  array: string
+  param: string
+  paramBindings: TopLevelLoop['paramBindings']
+  key: string | null
+  mapPreamble: string | null
+}): ItemLookup {
+  const hasBindings = (args.paramBindings?.length ?? 0) > 0
+  if (args.key !== null) {
+    // For destructured params the regex replace can't reach binding names, so
+    // we substitute bindings with `item.<path>` directly (#951).
+    const keyWithItem = hasBindings
+      ? substituteLoopBindings(args.key, args.paramBindings!, 'item')
+      : args.key.replace(new RegExp(`\\b${args.param}\\b`, 'g'), 'item')
+    return {
+      kind: 'keyed',
+      arrayExpr: args.array,
+      param: args.param,
+      paramBindings: args.paramBindings,
+      keyWithItem,
+      mapPreamble: args.mapPreamble,
+      hasBindings,
+    }
+  }
+  return {
+    kind: 'dynamic-index',
+    arrayExpr: args.array,
+    param: args.param,
+    mapPreamble: args.mapPreamble,
+    hasBindings,
+  }
+}
+
+export type { LoopChildEvent }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -318,8 +318,80 @@ export interface StaticLoopPlan {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Re-export legacy types referenced from Plan-level code paths.
-// PR 2-b/c will extend this with single-component / composite plans.
+// Event delegation
 // ─────────────────────────────────────────────────────────────────────
 
-export type { ConditionalElement, LoopChildConditional, BranchLoop }
+/**
+ * Plan for a loop's event-delegation block. Covers three legacy emitters:
+ *   - `emitDynamicLoopEventDelegation` (top-level dynamic loop)
+ *   - `emitBranchLoopEventDelegation`  (branch-scoped dynamic loop)
+ *   - the inline delegation block at the end of `emitStaticArrayUpdates`
+ *
+ * The differences between the three contexts collapse onto two Plan fields:
+ *   - `containerVar`: `_sN` (top), `__loop_cv` (branch), or `_sN` (static)
+ *   - `itemLookup`: how to recover the loop item for an event target
+ *
+ * The delegation envelope itself (event grouping by name, deepest-first
+ * sorting, capture vs bubble selection) is identical across contexts and
+ * lives in the stringifier.
+ */
+export interface EventDelegationPlan {
+  kind: 'event-delegation'
+  containerVar: string
+  events: LoopChildEvent[]
+  itemLookup: ItemLookup
+}
+
+/**
+ * How to look up the loop item from an event target. Each variant is the
+ * deterministic result of (loop kind, has-key, has-bindings, has-nested-loops)
+ * — flattening the matrix into discriminated cases.
+ */
+export type ItemLookup =
+  | KeyedItemLookup
+  | DynamicIndexItemLookup
+  | StaticIndexItemLookup
+
+export interface KeyedItemLookup {
+  kind: 'keyed'
+  /** Source array expression. */
+  arrayExpr: string
+  /** Loop param identifier (or destructure pattern text — used as receiver name only). */
+  param: string
+  /** Destructured-binding metadata. Determines TDZ-safe `__bfLoopItem` shape (#951). */
+  paramBindings: TopLevelLoop['paramBindings']
+  /**
+   * Key expression with the outer loop param substituted to `item` (so it can
+   * appear inside `arr.find(item => String(KEY_WITH_ITEM) === key)`). Pre-computed
+   * by the builder so the stringifier doesn't repeat the regex / substituteLoopBindings
+   * decision.
+   */
+  keyWithItem: string
+  /** Optional preamble line — emitted before the handler call. */
+  mapPreamble: string | null
+  /** True when `paramBindings` is non-empty — drives TDZ-safe lookup shape. */
+  hasBindings: boolean
+}
+
+export interface DynamicIndexItemLookup {
+  kind: 'dynamic-index'
+  arrayExpr: string
+  param: string
+  mapPreamble: string | null
+  hasBindings: boolean
+}
+
+export interface StaticIndexItemLookup {
+  kind: 'static-index'
+  arrayExpr: string
+  param: string
+  mapPreamble: string | null
+  /** Sibling offset for `__idx` arithmetic; `null` when no offset. */
+  siblingOffset: number | null
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Re-export legacy types referenced from Plan-level code paths.
+// ─────────────────────────────────────────────────────────────────────
+
+export type { ConditionalElement, LoopChildConditional, BranchLoop, LoopChildEvent }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
@@ -1,0 +1,193 @@
+/**
+ * Stringify an `EventDelegationPlan` to source lines.
+ *
+ * Output shape (preserved byte-identical from the legacy
+ * `emitLoopEventDelegation`):
+ *
+ *     if (<container>) <container>.addEventListener('<eventName>', (e) => {
+ *       const target = e.target
+ *       const <slot>El = target.closest('[bf="<slotId>"]')
+ *       if (<slot>El) {
+ *         <item-lookup specific>
+ *         <handlerCall>
+ *         return
+ *       }
+ *       ... more events sharing the same name (deepest-first)
+ *     })   // or `}, true)` for non-bubbling events
+ *
+ * Item lookup shapes:
+ *   - keyed (no nested loops):   `closest('[data-key]')` + `arr.find`
+ *   - keyed (nested loops):       multi-level data-key-N + outer find + inner find
+ *   - dynamic-index:              `closest('li, [bf-i]') + indexOf`
+ *   - static-index:               walk-up + indexOf - offset
+ *
+ * Each shape has a `hasBindings` variant that lands on a `__bfLoopItem`
+ * sentinel before destructuring (#951 TDZ-safe).
+ */
+
+import { toDomEventName, varSlotId, substituteLoopBindings, DATA_KEY, keyAttrName } from '../../utils'
+import type {
+  EventDelegationPlan,
+  KeyedItemLookup,
+  DynamicIndexItemLookup,
+  StaticIndexItemLookup,
+  LoopChildEvent,
+} from '../plan/types'
+
+/** Non-bubbling events that require addEventListener with capture for delegation. */
+const NON_BUBBLING_EVENTS = new Set([
+  'blur', 'focus', 'load', 'unload',
+  'mouseenter', 'mouseleave',
+  'pointerenter', 'pointerleave',
+])
+
+export function stringifyEventDelegation(lines: string[], plan: EventDelegationPlan): void {
+  const { containerVar, events, itemLookup } = plan
+  const eventsByName = new Map<string, LoopChildEvent[]>()
+  for (const ev of events) {
+    if (!eventsByName.has(ev.eventName)) eventsByName.set(ev.eventName, [])
+    eventsByName.get(ev.eventName)!.push(ev)
+  }
+
+  for (const [eventName, evs] of eventsByName) {
+    // Sort deepest-first so child elements are checked before parents (#774)
+    evs.sort((a, b) => b.domDepth - a.domDepth)
+    const useCapture = NON_BUBBLING_EVENTS.has(eventName)
+    if (useCapture) {
+      lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${eventName}', (e) => {`)
+    } else {
+      lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${toDomEventName(eventName)}', (e) => {`)
+    }
+    lines.push(`    const target = e.target`)
+    for (const ev of evs) {
+      const childVar = varSlotId(ev.childSlotId)
+      lines.push(`    const ${childVar}El = target.closest('[bf="${ev.childSlotId}"]')`)
+      lines.push(`    if (${childVar}El) {`)
+      const handlerCall = `(${ev.handler.trim()})(e)`
+      switch (itemLookup.kind) {
+        case 'keyed':
+          emitKeyedLookup(lines, ev, handlerCall, itemLookup)
+          break
+        case 'dynamic-index':
+          emitDynamicIndexLookup(lines, ev, handlerCall, itemLookup)
+          break
+        case 'static-index':
+          emitStaticIndexLookup(lines, ev, handlerCall, itemLookup, containerVar)
+          break
+      }
+      lines.push(`      return`)
+      lines.push(`    }`)
+    }
+    if (useCapture) {
+      lines.push(`  }, true)`)
+    } else {
+      lines.push(`  })`)
+    }
+    lines.push('')
+  }
+}
+
+function emitKeyedLookup(
+  ls: string[],
+  ev: LoopChildEvent,
+  handlerCall: string,
+  lookup: KeyedItemLookup,
+): void {
+  const { arrayExpr, param, keyWithItem, mapPreamble, hasBindings } = lookup
+
+  if (ev.nestedLoops.length === 0) {
+    // Single-level keyed lookup.
+    ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
+    ls.push(`      if (li) {`)
+    ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
+    if (hasBindings) {
+      // TDZ-safe shape — see #951.
+      ls.push(`        const __bfLoopItem = ${arrayExpr}.find(item => String(${keyWithItem}) === key)`)
+      ls.push(`        if (__bfLoopItem) {`)
+      ls.push(`          const ${param} = __bfLoopItem`)
+      if (mapPreamble) ls.push(`          ${mapPreamble}`)
+      ls.push(`          ${handlerCall}`)
+      ls.push(`        }`)
+    } else {
+      ls.push(`        const ${param} = ${arrayExpr}.find(item => String(${keyWithItem}) === key)`)
+      if (mapPreamble) ls.push(`        ${mapPreamble}`)
+      ls.push(`        if (${param}) ${handlerCall}`)
+    }
+    ls.push(`      }`)
+    return
+  }
+
+  // Nested-loop event — multi-level data-key-N resolution.
+  const evVar = varSlotId(ev.childSlotId)
+  for (const nested of ev.nestedLoops) {
+    const dataAttr = keyAttrName(nested.depth)
+    ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
+    ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
+  }
+  ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
+  ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
+  if (hasBindings) {
+    ls.push(`      const __bfLoopItem = ${arrayExpr}.find(item => String(${keyWithItem}) === outerKey)`)
+    ls.push(`      const ${param} = __bfLoopItem ?? ({})`)
+  } else {
+    ls.push(`      const ${param} = ${arrayExpr}.find(item => String(${keyWithItem}) === outerKey)`)
+  }
+  for (const nested of ev.nestedLoops) {
+    // `nested.key` may be null for unkeyed loops; coerce to '' so the lookup
+    // silently no-ops (String('') never matches a real key).
+    const rawKey = nested.key ?? ''
+    const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
+      ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
+      : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
+    const outerRef = hasBindings ? '__bfLoopItem' : param
+    ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
+  }
+  const outerGuard = hasBindings ? '__bfLoopItem' : param
+  const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
+  if (mapPreamble) ls.push(`      ${mapPreamble}`)
+  ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
+}
+
+function emitDynamicIndexLookup(
+  ls: string[],
+  ev: LoopChildEvent,
+  handlerCall: string,
+  lookup: DynamicIndexItemLookup,
+): void {
+  const { arrayExpr, param, mapPreamble, hasBindings } = lookup
+  ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
+  ls.push(`      if (li && li.parentElement) {`)
+  ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
+  if (hasBindings) {
+    ls.push(`        const __bfLoopItem = ${arrayExpr}[idx]`)
+    ls.push(`        if (__bfLoopItem) {`)
+    ls.push(`          const ${param} = __bfLoopItem`)
+    if (mapPreamble) ls.push(`          ${mapPreamble}`)
+    ls.push(`          ${handlerCall}`)
+    ls.push(`        }`)
+  } else {
+    ls.push(`        const ${param} = ${arrayExpr}[idx]`)
+    if (mapPreamble) ls.push(`        ${mapPreamble}`)
+    ls.push(`        if (${param}) ${handlerCall}`)
+  }
+  ls.push(`      }`)
+}
+
+function emitStaticIndexLookup(
+  ls: string[],
+  ev: LoopChildEvent,
+  handlerCall: string,
+  lookup: StaticIndexItemLookup,
+  containerVar: string,
+): void {
+  const { arrayExpr, param, mapPreamble, siblingOffset } = lookup
+  ls.push(`      let __el = ${varSlotId(ev.childSlotId)}El`)
+  ls.push(`      while (__el.parentElement && __el.parentElement !== ${containerVar}) __el = __el.parentElement`)
+  ls.push(`      if (__el.parentElement === ${containerVar}) {`)
+  const idxOffset = siblingOffset ? ` - ${siblingOffset}` : ''
+  ls.push(`        const __idx = Array.from(${containerVar}.children).indexOf(__el)${idxOffset}`)
+  ls.push(`        const ${param} = ${arrayExpr}[__idx]`)
+  if (mapPreamble) ls.push(`        ${mapPreamble}`)
+  ls.push(`        if (${param}) ${handlerCall}`)
+  ls.push(`      }`)
+}

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -6,7 +6,7 @@
 
 import type { ClientJsContext, BranchLoop, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent, substituteLoopBindings } from './utils'
+import { toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, DATA_KEY, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 import { buildInsertPlan } from './control-flow/plan/build-insert'
@@ -17,6 +17,12 @@ import { buildComponentLoopPlan } from './control-flow/plan/build-component-loop
 import { stringifyComponentLoop } from './control-flow/stringify/component-loop'
 import { buildTopLevelCompositePlan, buildBranchCompositePlan } from './control-flow/plan/build-composite-loop'
 import { stringifyCompositeLoop } from './control-flow/stringify/composite-loop'
+import {
+  buildDynamicLoopDelegationPlan,
+  buildBranchLoopDelegationPlan,
+  buildStaticArrayDelegationPlan,
+} from './control-flow/plan/build-event-delegation'
+import { stringifyEventDelegation } from './control-flow/stringify/event-delegation'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -525,20 +531,8 @@ function emitStaticArrayUpdates(lines: string[], elem: TopLevelLoop): void {
   // Event delegation for plain elements in static arrays (#537).
   // Static arrays have no data-key/bf-i markers, so walk up from target to
   // the container's direct child and use indexOf for index lookup.
-  // Event delegation stays on the legacy emitter — moves to Plan in PR 3.
   if (!elem.childComponent && elem.childEvents.length > 0) {
-    const v = varSlotId(elem.slotId)
-    emitLoopEventDelegation(lines, `_${v}`, elem.childEvents, (ls, ev, handlerCall, cVar) => {
-      ls.push(`      let __el = ${varSlotId(ev.childSlotId)}El`)
-      ls.push(`      while (__el.parentElement && __el.parentElement !== ${cVar}) __el = __el.parentElement`)
-      ls.push(`      if (__el.parentElement === ${cVar}) {`)
-      const idxOffset = elem.siblingOffset ? ` - ${elem.siblingOffset}` : ''
-      ls.push(`        const __idx = Array.from(${cVar}.children).indexOf(__el)${idxOffset}`)
-      ls.push(`        const ${elem.param} = ${elem.array}[__idx]`)
-      if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
-      ls.push(`        if (${elem.param}) ${handlerCall}`)
-      ls.push(`      }`)
-    })
+    stringifyEventDelegation(lines, buildStaticArrayDelegationPlan(elem))
   }
 }
 
@@ -647,104 +641,7 @@ function emitPlainElementLoopReconciliation(lines: string[], elem: TopLevelLoop,
 
 /** Emit event delegation for dynamic (non-static) loop child events. */
 function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): void {
-  const vLoop = varSlotId(elem.slotId)
-  const hasBindings = (elem.paramBindings?.length ?? 0) > 0
-
-  if (elem.key) {
-    // Dynamic keyed: find item by data-key attribute.
-    // For destructured `.map(({ id }) => ...)`, the raw regex replace below
-    // can't reach binding names (the pattern text `{ id }` never word-matches
-    // on `id`), so we substitute bindings with `item.<path>` directly (#951).
-    const keyWithItem = hasBindings
-      ? substituteLoopBindings(elem.key, elem.paramBindings!, 'item')
-      : elem.key.replace(new RegExp(`\\b${elem.param}\\b`, 'g'), 'item')
-    emitLoopEventDelegation(lines, `_${vLoop}`, elem.childEvents, (ls, ev, handlerCall) => {
-      if (ev.nestedLoops.length === 0) {
-        // Direct child of outer loop — single-level lookup.
-        // For destructured outer param, `const { id } = arr.find(item => ...)`
-        // would throw a TDZ ReferenceError if the find callback references the
-        // outer `id` while the `const` is still being declared. Land on a
-        // plain `__bfLoopItem` local first, then destructure once the lookup
-        // is done (#951).
-        ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
-        ls.push(`      if (li) {`)
-        ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
-        if (hasBindings) {
-          ls.push(`        const __bfLoopItem = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
-          ls.push(`        if (__bfLoopItem) {`)
-          ls.push(`          const ${elem.param} = __bfLoopItem`)
-          if (elem.mapPreamble) ls.push(`          ${elem.mapPreamble}`)
-          ls.push(`          ${handlerCall}`)
-          ls.push(`        }`)
-        } else {
-          ls.push(`        const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === key)`)
-          if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
-          ls.push(`        if (${elem.param}) ${handlerCall}`)
-        }
-        ls.push(`      }`)
-      } else {
-        // Nested loop event — multi-level data-key-N resolution
-        const evVar = varSlotId(ev.childSlotId)
-        // Resolve inner loop keys (innermost first)
-        for (const nested of ev.nestedLoops) {
-          const dataAttr = keyAttrName(nested.depth)
-          ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
-          ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
-        }
-        // Resolve outer loop key
-        ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
-        ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
-        // Resolve outer loop variable — TDZ-safe for destructured params.
-        if (hasBindings) {
-          ls.push(`      const __bfLoopItem = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
-          ls.push(`      const ${elem.param} = __bfLoopItem ?? ({})`)
-        } else {
-          ls.push(`      const ${elem.param} = ${elem.array}.find(item => String(${keyWithItem}) === outerKey)`)
-        }
-        // Resolve inner loop variables via the outer param's nested array.
-        // Destructured inner params get the same `substituteLoopBindings`
-        // treatment; otherwise fall through to the legacy regex replace.
-        for (const nested of ev.nestedLoops) {
-          // `nested.key` can be null for unkeyed loops; coerce to '' so the
-          // resolution silently no-ops (String('') never matches a real
-          // key), matching prior behavior when NestedLoop.key was
-          // always a string defaulting to ''.
-          const rawKey = nested.key ?? ''
-          const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
-            ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
-            : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
-          const outerRef = hasBindings ? '__bfLoopItem' : elem.param
-          ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
-        }
-        // Guard all resolved variables — for destructured outer we use the
-        // __bfLoopItem sentinel because the pattern text itself isn't truthy-testable.
-        const outerGuard = hasBindings ? '__bfLoopItem' : elem.param
-        const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
-        if (elem.mapPreamble) ls.push(`      ${elem.mapPreamble}`)
-        ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
-      }
-    })
-  } else {
-    // Dynamic non-keyed: find item by index in parent children
-    emitLoopEventDelegation(lines, `_${vLoop}`, elem.childEvents, (ls, ev, handlerCall) => {
-      ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
-      ls.push(`      if (li && li.parentElement) {`)
-      ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
-      if (hasBindings) {
-        ls.push(`        const __bfLoopItem = ${elem.array}[idx]`)
-        ls.push(`        if (__bfLoopItem) {`)
-        ls.push(`          const ${elem.param} = __bfLoopItem`)
-        if (elem.mapPreamble) ls.push(`          ${elem.mapPreamble}`)
-        ls.push(`          ${handlerCall}`)
-        ls.push(`        }`)
-      } else {
-        ls.push(`        const ${elem.param} = ${elem.array}[idx]`)
-        if (elem.mapPreamble) ls.push(`        ${elem.mapPreamble}`)
-        ls.push(`        if (${elem.param}) ${handlerCall}`)
-      }
-      ls.push(`      }`)
-    })
-  }
+  stringifyEventDelegation(lines, buildDynamicLoopDelegationPlan(elem))
 }
 
 /**
@@ -752,86 +649,7 @@ function emitDynamicLoopEventDelegation(lines: string[], elem: TopLevelLoop): vo
  * Mirrors emitDynamicLoopEventDelegation but uses branch-scoped container variable.
  */
 function emitBranchLoopEventDelegation(lines: string[], loop: BranchLoop, cv: string): void {
-  const containerVar = `__loop_${cv}`
-  const childEvents = loop.childEvents
-  const hasBindings = (loop.paramBindings?.length ?? 0) > 0
-
-  if (loop.key) {
-    // Keyed: find item by data-key attribute. See emitDynamicLoopEventDelegation
-    // for the destructured-param TDZ-safe shape (#951).
-    const keyWithItem = hasBindings
-      ? substituteLoopBindings(loop.key, loop.paramBindings!, 'item')
-      : loop.key.replace(new RegExp(`\\b${loop.param}\\b`, 'g'), 'item')
-    emitLoopEventDelegation(lines, containerVar, childEvents, (ls, ev, handlerCall) => {
-      if (ev.nestedLoops.length === 0) {
-        ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
-        ls.push(`      if (li) {`)
-        ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
-        if (hasBindings) {
-          ls.push(`        const __bfLoopItem = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
-          ls.push(`        if (__bfLoopItem) {`)
-          ls.push(`          const ${loop.param} = __bfLoopItem`)
-          if (loop.mapPreamble) ls.push(`          ${loop.mapPreamble}`)
-          ls.push(`          ${handlerCall}`)
-          ls.push(`        }`)
-        } else {
-          ls.push(`        const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === key)`)
-          if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
-          ls.push(`        if (${loop.param}) ${handlerCall}`)
-        }
-        ls.push(`      }`)
-      } else {
-        // Nested loop event — multi-level data-key-N resolution
-        const evVar = varSlotId(ev.childSlotId)
-        for (const nested of ev.nestedLoops) {
-          const dataAttr = keyAttrName(nested.depth)
-          ls.push(`      const innerLi${nested.depth} = ${evVar}El.closest('[${dataAttr}]')`)
-          ls.push(`      const innerKey${nested.depth} = innerLi${nested.depth}?.getAttribute('${dataAttr}')`)
-        }
-        ls.push(`      const outerLi = ${evVar}El.closest('[${DATA_KEY}]')`)
-        ls.push(`      const outerKey = outerLi?.getAttribute('${DATA_KEY}')`)
-        if (hasBindings) {
-          ls.push(`      const __bfLoopItem = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
-          ls.push(`      const ${loop.param} = __bfLoopItem ?? ({})`)
-        } else {
-          ls.push(`      const ${loop.param} = ${loop.array}.find(item => String(${keyWithItem}) === outerKey)`)
-        }
-        for (const nested of ev.nestedLoops) {
-          // See sibling comment above — `nested.key` may be null.
-          const rawKey = nested.key ?? ''
-          const innerKeyExpr = nested.paramBindings && nested.paramBindings.length > 0
-            ? substituteLoopBindings(rawKey, nested.paramBindings, 'item')
-            : rawKey.replace(new RegExp(`\\b${nested.param}\\b`, 'g'), 'item')
-          const outerRef = hasBindings ? '__bfLoopItem' : loop.param
-          ls.push(`      const ${nested.param} = ${outerRef} && ${nested.array}.find(item => String(${innerKeyExpr}) === innerKey${nested.depth})`)
-        }
-        const outerGuard = hasBindings ? '__bfLoopItem' : loop.param
-        const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
-        if (loop.mapPreamble) ls.push(`      ${loop.mapPreamble}`)
-        ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
-      }
-    })
-  } else {
-    // Non-keyed: find item by index in parent children
-    emitLoopEventDelegation(lines, containerVar, childEvents, (ls, ev, handlerCall) => {
-      ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
-      ls.push(`      if (li && li.parentElement) {`)
-      ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
-      if (hasBindings) {
-        ls.push(`        const __bfLoopItem = ${loop.array}[idx]`)
-        ls.push(`        if (__bfLoopItem) {`)
-        ls.push(`          const ${loop.param} = __bfLoopItem`)
-        if (loop.mapPreamble) ls.push(`          ${loop.mapPreamble}`)
-        ls.push(`          ${handlerCall}`)
-        ls.push(`        }`)
-      } else {
-        ls.push(`        const ${loop.param} = ${loop.array}[idx]`)
-        if (loop.mapPreamble) ls.push(`        ${loop.mapPreamble}`)
-        ls.push(`        if (${loop.param}) ${handlerCall}`)
-      }
-      ls.push(`      }`)
-    })
-  }
+  stringifyEventDelegation(lines, buildBranchLoopDelegationPlan(loop, cv))
 }
 
 /** Per-inner-loop data for composite loop emission. */
@@ -1122,67 +940,3 @@ function emitCompositeElementReconciliation(
   stringifyCompositeLoop(lines, buildTopLevelCompositePlan(elem))
 }
 
-/**
- * Callback that emits the item-lookup lines inside a loop event delegation handler.
- * Called once per event after target.closest() matched.
- */
-type ItemLookupEmitter = (
-  lines: string[],
-  ev: LoopChildEvent,
-  handlerCall: string,
-  containerVar: string,
-) => void
-
-/** Non-bubbling events that require addEventListener with capture for delegation. */
-const NON_BUBBLING_EVENTS = new Set([
-  'blur', 'focus', 'load', 'unload',
-  'mouseenter', 'mouseleave',
-  'pointerenter', 'pointerleave',
-])
-
-/**
- * Emit event delegation for child events inside a loop (static or dynamic).
- * The shared shell (event grouping, closest matching, handler call construction)
- * is handled here; the strategy-specific item-lookup is injected via callback.
- */
-function emitLoopEventDelegation(
-  lines: string[],
-  containerVar: string,
-  childEvents: LoopChildEvent[],
-  emitItemLookup: ItemLookupEmitter,
-): void {
-  const eventsByName = new Map<string, LoopChildEvent[]>()
-  for (const ev of childEvents) {
-    if (!eventsByName.has(ev.eventName)) {
-      eventsByName.set(ev.eventName, [])
-    }
-    eventsByName.get(ev.eventName)!.push(ev)
-  }
-
-  for (const [eventName, events] of eventsByName) {
-    // Sort deepest-first so child elements are checked before parents (#774)
-    events.sort((a, b) => b.domDepth - a.domDepth)
-    const useCapture = NON_BUBBLING_EVENTS.has(eventName)
-    if (useCapture) {
-      lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${eventName}', (e) => {`)
-    } else {
-      lines.push(`  if (${containerVar}) ${containerVar}.addEventListener('${toDomEventName(eventName)}', (e) => {`)
-    }
-    lines.push(`    const target = e.target`)
-    for (const ev of events) {
-      const childVar = varSlotId(ev.childSlotId)
-      lines.push(`    const ${childVar}El = target.closest('[bf="${ev.childSlotId}"]')`)
-      lines.push(`    if (${childVar}El) {`)
-      const handlerCall = `(${ev.handler.trim()})(e)`
-      emitItemLookup(lines, ev, handlerCall, containerVar)
-      lines.push(`      return`)
-      lines.push(`    }`)
-    }
-    if (useCapture) {
-      lines.push(`  }, true)`)
-    } else {
-      lines.push(`  })`)
-    }
-    lines.push('')
-  }
-}


### PR DESCRIPTION
## Summary

Continues the \`IR -> Plan -> string\` migration started in #1033 and continued in #1034 / #1035 / #1036. This PR moves all three loop event-delegation emitters onto a single \`EventDelegationPlan\` + stringifier:

| Legacy emitter | Plan |
|----------------|------|
| \`emitDynamicLoopEventDelegation\` | \`buildDynamicLoopDelegationPlan\` |
| \`emitBranchLoopEventDelegation\` | \`buildBranchLoopDelegationPlan\` |
| inline static-array delegation block | \`buildStaticArrayDelegationPlan\` |

The shared \`emitLoopEventDelegation\` callback-injection helper, the \`ItemLookupEmitter\` type, and the \`NON_BUBBLING_EVENTS\` constant move to the new \`stringify/event-delegation.ts\` (or are deleted).

## Plan shape

The four item-lookup variants are flattened into a discriminated \`ItemLookup\` union, resolved up-front by the builder:

| variant | when | shape |
|---------|------|-------|
| \`keyed\` (no nested) | dynamic loop with explicit key, event on direct child | \`closest('[data-key]') + arr.find\` |
| \`keyed\` (nested loops) | dynamic loop with explicit key, event on nested-loop descendant | multi-level data-key-N + outer find + inner find per level |
| \`dynamic-index\` | dynamic loop without key | \`closest('li, [bf-i]') + indexOf\` |
| \`static-index\` | static array loop | walk-up to container's direct child + \`indexOf - offset\` |

The TDZ-safe \`__bfLoopItem\` shape (#951) and the destructured-binding regex / \`substituteLoopBindings\` choice are computed once in the builder, not re-derived per call site.

## Why

Same goal as the prior PRs: separate **what to emit** (Plan, pure data) from **how to write it** (stringifier, deterministic). With this PR, the loop family — plain, single-component, composite, static, and event delegation — is fully on the Plan. The legacy \`emit-control-flow.ts\` retains only thin wrappers around Plan calls plus the still-shared passthrough helpers (\`emitInnerLoopSetup\`, \`emitComponentAndEventSetup\`, \`emitLoopChildReactiveEffects\`, \`emitBranchLoopBody\`, branch-inner helpers). Those move onto the Plan in dedicated bug-fix PRs (PR 5+ for O-1 / O-2 / O-3 / O-8) where their respective issues get solved.

## Scope

**In:**
- \`control-flow/plan/types.ts\` — \`EventDelegationPlan\`, \`ItemLookup\`, \`KeyedItemLookup\`, \`DynamicIndexItemLookup\`, \`StaticIndexItemLookup\`
- \`control-flow/plan/build-event-delegation.ts\` — three builders + a shared \`buildKeyedOrIndexLookup\` helper
- \`control-flow/stringify/event-delegation.ts\` — single stringifier, \`NON_BUBBLING_EVENTS\` lives here now
- Replace the three legacy emitter bodies with builder + stringifier calls
- Delete the \`emitLoopEventDelegation\` helper (~60 lines), \`ItemLookupEmitter\` type, \`NON_BUBBLING_EVENTS\` constant

**Out (follow-ups):**
- Latent bugs O-1 / O-2 / O-3 / O-8 — PR 5+
- Removing the remaining passthrough helpers — paired with the bug fixes that target them

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 760 / 760 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit
- Output is byte-identical to \`main\` (verified by the existing test suite, which compares emitted strings throughout)