### PR TITLE
fix(compiler): drop `key` from reactive DOM-attr emission in loops (O-3)

### DIFF
--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -201,4 +201,40 @@ describe('reactive attributes inside .map() callbacks', () => {
     expect(clientJs!.content).not.toContain('__t_')
     expect(clientJs!.content).not.toContain('.className =')
   })
+
+  test('keyed loop: `key` prop is not emitted as a reactive DOM attribute', () => {
+    // Regression guard for the "key duplicate emission" bug:
+    // `<li key={item.id}>` used to be both rendered as `data-key=` in the
+    // template (correct, used by mapArray reconciliation) AND wired as a
+    // reactive `setAttribute('key', ...)` effect on every item (incorrect —
+    // `key` is a virtual prop, not a DOM attribute). This left a non-standard
+    // `key=` attribute on the live DOM and burned a no-op createEffect per
+    // item per signal change.
+    //
+    // Fix: skip `attr.name === 'key'` in collectLoopChildReactiveAttrs.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function L() {
+        const [items, setItems] = createSignal([{ id: 1, name: 'a' }])
+        return (
+          <ul>
+            {items().map(item => (
+              <li key={item.id} onClick={() => setItems(p => p)}>{item.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    // The template still uses `data-key=` for SSR + reconciliation.
+    expect(clientJs!.content).toContain('data-key=')
+    // But there must be NO createEffect that calls setAttribute('key', ...).
+    expect(clientJs!.content).not.toContain("setAttribute('key'")
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -461,6 +461,12 @@ export function collectLoopChildReactiveAttrs(
     if (el.slotId) {
       for (const attr of el.attrs) {
         if (attr.name === '...' || !attr.dynamic || !attr.value) continue
+        // `key` is a reconciliation-only prop: the html-template path renames
+        // it to `data-key` for SSR + mapArray uses it via keyFn. Wiring it
+        // again as a reactive DOM attr would (a) emit a non-standard `key=`
+        // attribute on the live DOM, and (b) burn a no-op createEffect on
+        // every loop item. See observation O-3 in tmp/emit-survey.
+        if (attr.name === 'key') continue
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx)


### PR DESCRIPTION
## Summary

\`<li key={item.id}>\` was emitted **twice** on the client:

- correctly as \`data-key=\` in the rendered template (used by SSR and by mapArray's keyFn for reconciliation), AND
- **incorrectly** as a \`setAttribute('key', ...)\` createEffect on every loop item — leaving a non-standard \`key=\` attribute on the live DOM and burning a no-op createEffect per item per signal change.

## Root cause

\`collectLoopChildReactiveAttrs\` in \`packages/jsx/src/ir-to-client-js/reactivity.ts\` walks every dynamic attribute on a loop child without filtering the reconciliation-only \`key\` prop. Other emit sites (\`html-template.ts\`, child-component init) already strip \`key\`; this collector was the lone gap.

This was identified as observation **O-3** during the survey under \`tmp/emit-survey/\` and confirmed via runtime check.

## Fix

Skip \`attr.name === 'key'\` in \`collectLoopChildReactiveAttrs\`.

## Verification

- \`tmp/emit-survey/runtime-checks.test.ts\` flips \`setAttribute('key',...) in effect: true\` → \`false\`
- Compiled fixture \`loop-top-keyed-event.js\` shrinks 6 lines (the \`qsa(__el, '[bf="..."]')\` block emitted just for the key effect is gone)
- Adds a regression guard in \`packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts\`

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 761 / 761 pass (760 prior + 1 new)
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit