### PR TITLE
fix(compiler): wire mapArray at every nested loop depth (O-8)

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -136,4 +136,56 @@ describe('plain nested loops without conditional wrapper', () => {
     const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
     expect(mapArrayCount).toBeGreaterThanOrEqual(2)
   })
+
+  test('regression: 3-level nested loop wires mapArray at the deepest level (not forEach)', () => {
+    // Before the fix, `emitInnerLoopSetup` decided "is this loop reactive?"
+    // by checking the IR's `inner.refsOuterParam` — a flag set at collect
+    // time against the *outermost* loop's param only. At depth 2+, the array
+    // expression typically references the *immediate* parent (e.g.
+    // `g.items` inside `t.groups.map(g => ...)` body), so the check failed
+    // and the loop fell through to the static `forEach` branch. Result:
+    // additions / removals at the deepest level silently never reached
+    // the DOM.
+    //
+    // Fix: re-check dynamically at each level against the parent param
+    // passed in, and narrow the parent param when recursing into child
+    // levels.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function T() {
+        const [tree, setTree] = createSignal([
+          { id: 1, groups: [{ id: 11, items: [{ id: 111, n: 'a' }] }] },
+        ])
+        return (
+          <ul onClick={() => setTree(prev => [...prev])}>
+            {tree().map(t => (
+              <li key={t.id}>
+                <ul>
+                  {t.groups.map(g => (
+                    <li key={g.id}>
+                      <ul>{g.items.map(it => <li key={it.id}>{it.n}</li>)}</ul>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'T.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The deepest array (`g.items`) must appear inside a mapArray, with
+    // its parent (`g`) wrapped as an accessor. If it ever falls back to
+    // a `forEach`, this guard fires.
+    expect(js).toMatch(/mapArray\(\(\)\s*=>\s*g\(\)\.items/)
+    expect(js).not.toMatch(/\bg\.items\.forEach\b/)
+    // All three levels must be reactive; expect at least 3 mapArray sites
+    // (outer + two inner).
+    const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
+    expect(mapArrayCount).toBeGreaterThanOrEqual(3)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -820,7 +820,17 @@ export function emitInnerLoopSetup(
     const arrayExpr = wrapOuter(inner.array)
     const containerSelector = inner.containerSlotId ? `'[bf="${inner.containerSlotId}"]'` : 'null'
 
-    if (inner.refsOuterParam && inner.template && outerLoopParam) {
+    // `inner.refsOuterParam` is decided at collect-time against the
+    // outermost loop param only — at depth 2+ the array expression typically
+    // references the *immediate* parent loop's param (e.g. `g.items` inside
+    // the `t.groups.map(g => ...)` body), so we re-check dynamically against
+    // whatever `outerLoopParam` was passed in by our caller. Recursion
+    // narrows `outerLoopParam` to `inner.param` for child levels (see end
+    // of this branch), so each level decides correctly. Without this, deep
+    // nested loops fall through to the static-forEach path and inserts /
+    // removals at the deepest level never reach the DOM (observation O-8).
+    const refsParent = !!outerLoopParam && exprReferencesIdent(inner.array, outerLoopParam)
+    if (refsParent && inner.template) {
       // Reactive inner loop: use mapArray for proper add/remove/update.
       // NestedLoop never carries `index`, so loopKeyFn emits `(param) => ...`
       // — matching the plain-item-value contract that mapArray expects.
@@ -883,9 +893,11 @@ export function emitInnerLoopSetup(
         emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'ssr', outerLoopParam, outerLoopParamBindings)
         ls.push(`${indent}  }`)
       }
-      // Recurse for child levels
+      // Recurse for child levels — pass `inner.param` as the outer for the
+      // next level so deeper inner loops see their *immediate* parent and
+      // correctly hit the reactive (mapArray) branch above.
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam, outerLoopParamBindings)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, inner.param, inner.paramBindings)
       }
       // Reactive text effects for inner loop items
       if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
@@ -916,9 +928,11 @@ export function emitInnerLoopSetup(
         ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
       }
       emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam, outerLoopParamBindings)
-      // Recurse for child levels (nested deeper loops)
+      // Recurse for child levels (nested deeper loops) — narrow parent like
+      // the reactive branch above so a static-then-reactive nesting still
+      // hits the reactive path at the next level.
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, outerLoopParam, outerLoopParamBindings)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, inner.param, inner.paramBindings)
       }
       ls.push(`${indent}}) }`)
     }


### PR DESCRIPTION
## Summary

A 3-level nested loop (e.g. \`tree -> groups -> items\`) emitted reactive \`mapArray\` calls at depth 1 (\`t.groups\`) but fell back to a static \`forEach\` at depth 2 (\`g.items\`). **Additions and removals at the deepest level silently never reached the DOM.**

This was identified as observation **O-8** during the survey under \`tmp/emit-survey/\` and confirmed via runtime check.

## Root cause

\`emitInnerLoopSetup\` chose between the reactive (mapArray) and static (forEach) branches by checking \`inner.refsOuterParam\` — a flag set at collect-time that compares the loop's array expression against the **outermost** loop param only. A depth-2 loop typically references its **immediate** parent loop (e.g. \`g.items\` references \`g\`, not \`t\`), so the flag was false and emission silently degraded to forEach.

The recursion call also passed the original \`outerLoopParam\` down unchanged, so \`wrapOuter(inner.array)\` did not turn \`g.items\` into \`g().items\` either — both decisions were stuck on the outermost param.

## Fix

- Re-check the reactive condition dynamically in \`emitInnerLoopSetup\` using \`exprReferencesIdent(inner.array, outerLoopParam)\` instead of the static \`inner.refsOuterParam\` flag.
- Narrow \`outerLoopParam\` to \`inner.param\` (and bindings to \`inner.paramBindings\`) before recursing into child levels, on both the reactive and static branches.

## Verification

Result for the 3-level fixture (tmp/emit-survey runtime check):

| | mapArray calls | forEach calls | deepest in mapArray |
|---|---|---|---|
| before | 3 | 2 | false (was \`g.items.forEach\`) |
| after | 5 | 0 | **true** (\`mapArray(() => g().items, ...)\`) |

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 762 / 762 pass (761 prior + 1 new)
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit
- Adds a regression guard in \`packages/jsx/src/__tests__/nested-loop-plain.test.ts\`