### PR TITLE
fix(compiler): release branch-scoped loops and nested insert on swap (O-2)

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2407,4 +2407,67 @@ describe('Client JS generation', () => {
       expect(result.errors).toHaveLength(0)
     })
   })
+
+  describe('branch-scoped effect disposal (O-2)', () => {
+    test('mapArray inside a conditional branch is wrapped in createDisposableEffect', () => {
+      // Regression for the dispose-leak in branch-scoped loops:
+      // before the fix, `bindEvents` emitted a bare `if (__loop_) mapArray(...)`
+      // and the inner effect created by mapArray was registered as a child of
+      // the *outer* insert() effect — never disposed on branch swap. Hidden
+      // branches kept re-rendering items whenever their signals changed.
+      // Fix: wrap the mapArray call in `createDisposableEffect` and push it
+      // into the existing `__disposers` array so the cleanup function returned
+      // from `bindEvents` releases it on swap.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Page() {
+          const [show, setShow] = createSignal(true)
+          const [items, setItems] = createSignal([{ id: 1, n: 'a' }])
+          return (
+            <div onClick={() => setShow(v => !v)}>
+              {show()
+                ? <ul>{items().map(item => <li key={item.id}>{item.n}</li>)}</ul>
+                : <span>off</span>}
+            </div>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'Page.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      // The branch arm's mapArray call must live inside a
+      // createDisposableEffect that is pushed into __disposers.
+      expect(js).toMatch(/__disposers\.push\(createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?mapArray\(/)
+    })
+
+    test('nested conditional inside a conditional branch is wrapped in createDisposableEffect', () => {
+      // Same shape for inner insert(): without the wrap the inner
+      // condition signal subscription leaks through every branch swap.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Page() {
+          const [a, setA] = createSignal(true)
+          const [b, setB] = createSignal(true)
+          return (
+            <div onClick={() => setA(v => !v)}>
+              {a()
+                ? (b() ? <span>ab</span> : <span>aB</span>)
+                : <span>noA</span>}
+              <button onClick={() => setB(v => !v)}>tb</button>
+            </div>
+          )
+        }
+      `
+      const result = compileJSXSync(source, 'Page.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      // The inner insert() must live inside a createDisposableEffect that
+      // is pushed into __disposers.
+      expect(js).toMatch(/__disposers\.push\(createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?insert\(__branchScope/)
+    })
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -55,14 +55,25 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
     reactiveEffects,
     branchClearChildren,
     topIndent,
-    bodyIndent,
+    bodyIndent: rawBodyIndent,
   } = plan
+
+  // When wrapping the mapArray in createDisposableEffect (branch case), the
+  // renderItem body is one level deeper. Push everything inside that body
+  // by 2 extra spaces so the output stays well-formed.
+  const bodyIndent = branchClearChildren ? rawBodyIndent + '  ' : rawBodyIndent
+  const mapArrayIndent = branchClearChildren ? topIndent + '  ' : topIndent
 
   if (branchClearChildren) {
     // Clear template-generated children so mapArray creates fresh elements
     // with properly initialized components via createComponent in renderItem.
     lines.push(`${topIndent}if (${containerVar}) getLoopChildren(${containerVar}).forEach(__el => __el.remove())`)
-    lines.push(`${topIndent}if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
+    // Wrap the mapArray call in createDisposableEffect so the inner
+    // createEffects (mapArray's own + per-item child effects) are released
+    // when the surrounding branch swaps away (observation O-2). The branch
+    // arm's bindEvents writer expects a `__disposers` array in scope.
+    lines.push(`${topIndent}__disposers.push(createDisposableEffect(() => {`)
+    lines.push(`${mapArrayIndent}if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   } else {
     lines.push(`${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   }
@@ -104,5 +115,11 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   }
 
   lines.push(`${bodyIndent}return __el`)
-  lines.push(`${topIndent}})`)
+  if (branchClearChildren) {
+    // Close inner mapArray + createDisposableEffect wrapper.
+    lines.push(`${mapArrayIndent}})`)
+    lines.push(`${topIndent}}))`)
+  } else {
+    lines.push(`${topIndent}})`)
+  }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -147,15 +147,24 @@ function emitArmBody(
     emitBranchLoopBody(lines, body.loopsRaw)
   }
 
-  // Nested conditionals: leadingIndent = current bodyIndent, but bodyIndent
-  // stays the SAME (6 spaces) — bug-for-bug compat with the legacy emitter
-  // which uses a hard-coded 6-space indent inside emitBranchBindings
-  // regardless of nesting depth. See header comment for details.
+  // Nested conditionals: wrap in a disposable effect so the inner
+  // `insert()` (and its child createEffects, mapArrays, …) is registered
+  // as a child of this owner — branch swap then dispose()s the entry,
+  // releasing the inner effect tree. Without the wrap the inner effects
+  // leak (observation O-2): hidden nested conditionals keep re-evaluating
+  // their condition signal, and any inner mapArray they own keeps
+  // re-rendering on signal change.
+  //
+  // leadingIndent = current bodyIndent + 2 (inside the disposable arrow);
+  // bodyIndent stays the SAME (6 spaces inside the inner insert) for
+  // compat with the legacy emitter's hard-coded indent.
   for (const cond of body.conditionals) {
+    lines.push(`${indent}__disposers.push(createDisposableEffect(() => {`)
     stringifyInsert(lines, cond, {
-      leadingIndent: indent,
+      leadingIndent: indent + '  ',
       bodyIndent: indent,
     })
+    lines.push(`${indent}}))`)
   }
 
   lines.push(`${indent}return () => __disposers.forEach(d => d())`)

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -128,30 +128,37 @@ export function emitBranchLoopBody(lines: string[], branchLoops: readonly Branch
       const { head: pHead, unwrap: pUnwrap } = destructureLoopParam(loop.param, loop.paramBindings)
       const unwrapInline = pUnwrap ? `${pUnwrap} ` : ''
 
+      // Wrap the mapArray() call in a disposable effect so the inner
+      // createEffect created by mapArray is registered as a child of this
+      // disposable owner — branch swap then dispose()s the entry, releasing
+      // both the effect and its dependency subscriptions. Without the wrap
+      // the inner effect leaks: a hidden branch keeps re-rendering items
+      // whenever its signals change (observation O-2).
+      lines.push(`      __disposers.push(createDisposableEffect(() => {`)
       if (!hasReactiveEffects) {
         // Simple case: no reactive effects — return existing DOM as-is.
         // Template expressions use loopParam() to read the current item, so the
         // signal accessor stays intact without any unwrap.
         if (loop.mapPreamble) {
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+          lines.push(`        if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${loop.mapPreamble}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         } else {
-          lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+          lines.push(`        if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
         }
       } else {
         // Multi-line renderItem with fine-grained effects — applies to both
         // SSR (existing DOM) and CSR (freshly created) paths so reactive reads
         // of non-item signals propagate to existing items too.
-        lines.push(`      if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
+        lines.push(`        if (__loop_${cv}) mapArray(() => ${loop.array}, __loop_${cv}, ${keyFn}, (${pHead}, ${indexParam}, __existing) => {`)
         if (pUnwrap) {
-          lines.push(`        ${pUnwrap}`)
+          lines.push(`          ${pUnwrap}`)
         }
         if (loop.mapPreamble) {
-          lines.push(`        ${loop.mapPreamble}`)
+          lines.push(`          ${loop.mapPreamble}`)
         }
-        lines.push(`        const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
+        lines.push(`          const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
         emitLoopChildReactiveEffects(
           lines,
-          '        ',
+          '          ',
           '__el',
           loop.childReactiveAttrs ?? [],
           loop.childReactiveTexts ?? [],
@@ -159,9 +166,10 @@ export function emitBranchLoopBody(lines: string[], branchLoops: readonly Branch
           loop.param,
           loop.paramBindings,
         )
-        lines.push(`        return __el`)
-        lines.push(`      })`)
+        lines.push(`          return __el`)
+        lines.push(`        })`)
       }
+      lines.push(`      }))`)
       emitBranchLoopEventDelegation(lines, loop, cv)
     }
   }


### PR DESCRIPTION
## Summary

Conditional branches' \`bindEvents\` always built a \`__disposers\` array and pushed text effects into it via \`createDisposableEffect\`, but **loops and nested conditionals were called bare**. \`mapArray\`'s internal \`createEffect\` was registered as a child of the *outer* \`insert()\` effect — never disposed on branch swap. Hidden branches kept re-rendering items whenever their signals changed, leaking work and (per O-2's runtime check) firing \`renderItem\` after the branch had been hidden.

The same shape applied to nested \`insert()\` inside a branch arm: the inner condition signal subscription leaked through every swap.

This was identified as observation **O-2** during the survey under \`tmp/emit-survey/\` and confirmed via runtime check (\`runs before:1 after:2\` after the branch was hidden — the inner renderItem still fired).

## Fix

Wrap every branch-scoped reactive call site in \`createDisposableEffect\` and push it into \`__disposers\`. Three sites covered:

| Site | File | Change |
|------|------|--------|
| simple / reactive-case mapArray | \`emit-control-flow.ts::emitBranchLoopBody\` | wrap in \`createDisposableEffect\` |
| composite branch loop mapArray | \`control-flow/stringify/composite-loop.ts\` (branchClearChildren=true) | wrap in \`createDisposableEffect\` |
| nested \`insert()\` inside branch arm | \`control-flow/stringify/insert.ts\` (body.conditionals) | wrap in \`createDisposableEffect\` |

Query lookups (\`$(__branchScope, ...)\`) and event delegation (\`addEventListener\`) stay outside the disposable effect — listeners are re-attached every \`bindEvents\` call (which runs once per swap), and the query result is captured in a local at swap time so re-query on dispose is unnecessary.

## Verification

- Compiled fixture \`cond-with-branch-loop.js\` now wraps the inner mapArray in \`__disposers.push(createDisposableEffect(() => { ... }))\`.
- Compiled \`cond-nested.js\` does the same for the inner \`insert()\`.
- Adds two regression guards in \`packages/jsx/src/__tests__/client-js-generation.test.ts\` covering both shapes (one for branch-loop wrap, one for nested-insert wrap).

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 764 / 764 pass (762 prior + 2 new)
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit