### PR TITLE
fix(compiler): merge static-loop attrs and texts into one forEach (O-4)

### DIFF
--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -202,6 +202,39 @@ describe('reactive attributes inside .map() callbacks', () => {
     expect(clientJs!.content).not.toContain('.className =')
   })
 
+  test('static array: reactive attrs and texts share a single forEach pass', () => {
+    // Regression for the "double forEach" bug: the legacy emitter wrote
+    // two separate forEach blocks over the same static array — one for
+    // reactive attrs, one for reactive texts. That meant scanning the
+    // array twice and looking up `__iterEl = container.children[idx]`
+    // twice per item. The merged version emits a single forEach with
+    // both effects inside its body.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      const items = [{ id: 1, name: 'a' }, { id: 2, name: 'b' }]
+      export function L() {
+        const [active, setActive] = createSignal(1)
+        return (
+          <ul>
+            {items.map(item => (
+              <li class={active() === item.id ? 'on' : ''}>{item.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+    // Both effects must still be present.
+    expect(js).toContain("setAttribute('class'")
+    expect(js).toMatch(/textContent\s*=\s*String\(item\.name\)/)
+    // But there must be exactly one `items.forEach` call (not two).
+    const forEachMatches = js.match(/items\.forEach\(/g) ?? []
+    expect(forEachMatches.length).toBe(1)
+  })
+
   test('keyed loop: `key` prop is not emitted as a reactive DOM attribute', () => {
     // Regression guard for the "key duplicate emission" bug:
     // `<li key={item.id}>` used to be both rendered as `data-key=` in the

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -78,50 +78,47 @@ export function stringifyPlainLoop(
 
 export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {
   const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts } = plan
+  const hasAttrs = attrsBySlot.length > 0
+  const hasTexts = texts.length > 0
+  if (!hasAttrs && !hasTexts) return
 
-  // Block 1: reactive attributes.
-  if (attrsBySlot.length > 0) {
-    lines.push(`  // Reactive attributes in static array children`)
-    lines.push(`  if (${containerVar}) {`)
-    lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
-    lines.push(`      if (__iterEl) {`)
-    for (const [slotId, attrs] of attrsBySlot) {
-      const varName = `__t_${varSlotId(slotId)}`
-      lines.push(`        const ${varName} = qsa(__iterEl, '[bf="${slotId}"]')`)
-      lines.push(`        if (${varName}) {`)
-      for (const attr of attrs) {
-        lines.push(`          createEffect(() => {`)
-        for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
-          lines.push(`            ${stmt}`)
-        }
-        lines.push(`          })`)
+  // Single forEach pass that handles both reactive attrs and reactive texts.
+  // Pre-O-4 the legacy emitter wrote two parallel forEach blocks (one per
+  // concern) over the same array — a wasted second iteration plus a second
+  // `__iterEl = container.children[…]` lookup. Merging them keeps the loop
+  // contract identical (`createEffect`s subscribe to the same signals;
+  // attrs run before texts within each iteration) while halving the
+  // setup cost.
+  const heading = hasAttrs && hasTexts
+    ? '// Reactive attributes and texts in static array children'
+    : hasAttrs
+      ? '// Reactive attributes in static array children'
+      : '// Reactive texts in static array children'
+  lines.push(`  ${heading}`)
+  lines.push(`  if (${containerVar}) {`)
+  lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+  lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
+  lines.push(`      if (__iterEl) {`)
+  for (const [slotId, attrs] of attrsBySlot) {
+    const varName = `__t_${varSlotId(slotId)}`
+    lines.push(`        const ${varName} = qsa(__iterEl, '[bf="${slotId}"]')`)
+    lines.push(`        if (${varName}) {`)
+    for (const attr of attrs) {
+      lines.push(`          createEffect(() => {`)
+      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
+        lines.push(`            ${stmt}`)
       }
-      lines.push(`        }`)
+      lines.push(`          })`)
     }
-    lines.push(`      }`)
-    lines.push(`    })`)
-    lines.push(`  }`)
-    lines.push('')
+    lines.push(`        }`)
   }
-
-  // Block 2: reactive texts. NOTE — the second forEach scans the same array
-  // again. This duplication is observation O-4 and will be merged in a
-  // follow-up PR; PR 2-a preserves the legacy shape.
-  if (texts.length > 0) {
-    lines.push(`  // Reactive texts in static array children`)
-    lines.push(`  if (${containerVar}) {`)
-    lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
-    lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
-    lines.push(`      if (__iterEl) {`)
-    for (const text of texts) {
-      const vn = `__rt_${varSlotId(text.slotId)}`
-      lines.push(`        { const [${vn}] = $t(__iterEl, '${text.slotId}')`)
-      lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }) }`)
-    }
-    lines.push(`      }`)
-    lines.push(`    })`)
-    lines.push(`  }`)
-    lines.push('')
+  for (const text of texts) {
+    const vn = `__rt_${varSlotId(text.slotId)}`
+    lines.push(`        { const [${vn}] = $t(__iterEl, '${text.slotId}')`)
+    lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }) }`)
   }
+  lines.push(`      }`)
+  lines.push(`    })`)
+  lines.push(`  }`)
+  lines.push('')
 }


### PR DESCRIPTION
## Summary

\`stringifyStaticLoop\` previously emitted **two parallel \`forEach\` blocks** over the same static array — one for reactive attrs, one for reactive texts. Each block re-scanned the whole array and re-resolved the per-item \`__iterEl = container.children[idx]\` lookup.

This was identified as observation **O-4** during the survey under \`tmp/emit-survey/\`. The legacy emitter (\`emitStaticArrayUpdates\` pre-#1034) had the same shape and #1034 (PR 2-a) preserved it bug-for-bug to keep that PR scoped.

## Fix

Merge both effects into a single \`forEach\`. The \`createEffect\`s still subscribe to the same signals; attrs run before texts within each iteration (matching legacy ordering). The output halves the per-mount setup cost on static arrays and reads as a single intent ("set up effects per item") instead of two duplicate scaffolds.

## Verification

For \`tmp/emit-survey/outputs/loop-top-static.js\`:

| | forEach blocks | iterations per mount | lines (effect setup region) |
|---|---|---|---|
| before | 2 | 2 × items.length | ~26 |
| after | 1 | 1 × items.length | ~14 |

Adds a regression guard in \`packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts\` that asserts a single \`items.forEach(\` call.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 765 / 765 pass (764 prior + 1 new)
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit