### PR TITLE
fix(compiler): hoist composite inner-loop setup out of SSR/CSR if/else (O-1)

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -337,11 +337,14 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
     expect(clientJs).toBeDefined()
     const content = clientJs!.content
 
-    // Locate the nested mapArray callback body — the second mapArray in the file
-    // is the inner `node.children.map(child => ...)`.
+    // Locate the nested mapArray callback body — the inner one is the
+    // `node.children.map(child => ...)` that uses `child.id` as its key.
+    // Note: pre-O-1 the inner mapArray was emitted twice (once per
+    // SSR/CSR side of the outer renderItem) so this regex used to find
+    // 2+ matches. After the O-1 dedup we only need at least 1.
     const mapCalls = content.match(/mapArray\([\s\S]*?\}\)\s*\}/g)
     expect(mapCalls).not.toBeNull()
-    expect(mapCalls!.length).toBeGreaterThanOrEqual(2)
+    expect(mapCalls!.length).toBeGreaterThanOrEqual(1)
 
     // Pick the inner mapArray. It references `child.id` as the key function.
     const innerMapArray = mapCalls!.find(m => /\(child\)\s*=>\s*String\(child\.id\)/.test(m))

--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -188,4 +188,39 @@ describe('plain nested loops without conditional wrapper', () => {
     const mapArrayCount = (js.match(/\bmapArray\(/g) || []).length
     expect(mapArrayCount).toBeGreaterThanOrEqual(3)
   })
+
+  test('regression: composite renderItem hoists inner mapArray out of the SSR/CSR if/else (O-1)', () => {
+    // Before the fix, the composite renderItem's SSR/CSR split duplicated
+    // the entire inner-loop emission verbatim — both branches re-emitted
+    // the same `qsa(__el, '[bf="..."]')` + `mapArray(() => g().items, ...)`
+    // block. Doubled code size, doubled effect setup work, and any
+    // future bug fix would have needed to be applied in two places.
+    //
+    // Fix: hoist `emitInnerLoopSetup` after the if/else (the mapArray
+    // call it emits is mode-independent). For this 2-level fixture we
+    // expect exactly 2 mapArray call sites in the file (outer + the
+    // single deduped inner), not 3.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function L() {
+        const [groups, setGroups] = createSignal([{ id: 1, items: [{ id: 11, n: 'a' }] }])
+        return (
+          <ul onClick={() => setGroups(prev => [...prev])}>
+            {groups().map(g => (
+              <li key={g.id}>
+                <ul>{g.items.map(it => <li key={it.id}>{it.n}</li>)}</ul>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    const innerMapArrayCount = (js.match(/mapArray\(\(\)\s*=>\s*g\(\)\.items/g) || []).length
+    expect(innerMapArrayCount).toBe(1)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -89,19 +89,32 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   const eventsArr = [...outerEvents]
   const levelsArr = [...depthLevels]
 
-  // SSR/CSR split
+  // SSR/CSR split — only the bits that genuinely differ live inside the
+  // if/else: __el initialisation and `emitComponentAndEventSetup`
+  // (createComponent vs initChild). Inner-loop setup is hoisted out below
+  // because the mapArray it emits is mode-independent — the outer if/else
+  // used to duplicate every inner loop's body verbatim (observation O-1).
   lines.push(`${bodyIndent}let __el`)
   lines.push(`${bodyIndent}if (__existing) {`)
   lines.push(`${innerIndent}__el = __existing`)
   emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'ssr', loopParam, loopParamBindings)
-  emitInnerLoopSetup(lines, innerIndent, '__el', levelsArr, 'ssr', loopParam, loopParamBindings)
   lines.push(`${bodyIndent}} else {`)
   lines.push(`${innerIndent}const __tpl = document.createElement('template')`)
   lines.push(`${innerIndent}__tpl.innerHTML = \`${template}\``)
   lines.push(`${innerIndent}__el = __tpl.content.firstElementChild.cloneNode(true)`)
   emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'csr', loopParam, loopParamBindings)
-  emitInnerLoopSetup(lines, innerIndent, '__el', levelsArr, 'csr', loopParam, loopParamBindings)
   lines.push(`${bodyIndent}}`)
+
+  // Inner-loop setup runs once for both SSR and CSR. The mode argument is
+  // forwarded to `emitInnerLoopSetup`'s static-forEach branch where it
+  // matters for inner `emitComponentAndEventSetup` calls; reactive inner
+  // loops dispatch SSR vs CSR per-item via mapArray's `__existing` check
+  // and don't read it. We pass `'ssr'` so a static inner loop nested
+  // inside a composite renderItem still gets the SSR initChild shape
+  // (matching the historical behaviour for hydration).
+  if (levelsArr.length > 0) {
+    emitInnerLoopSetup(lines, bodyIndent, '__el', levelsArr, 'ssr', loopParam, loopParamBindings)
+  }
 
   if (reactiveEffects) {
     emitLoopChildReactiveEffects(


### PR DESCRIPTION
## Summary

The composite renderItem's SSR/CSR split duplicated the **entire** inner-loop emission verbatim — both branches re-emitted the same \`qsa(__el, '[bf="..."]')\` + \`mapArray(() => g().items, ...)\` block. For a 2-level nested loop this doubled the inner mapArray's setup code; for 3-level nesting it cascaded.

This was identified as observation **O-1** during the survey under \`tmp/emit-survey/\`.

## Root cause

\`stringifyCompositeLoop\` called \`emitInnerLoopSetup\` separately on the SSR and CSR sides. But the mapArray that emitter writes is **mode-independent** — its renderItem itself dispatches SSR vs CSR per-item via \`__existing\`. Only \`emitComponentAndEventSetup\` (createComponent vs initChild on the outer element) actually needs both modes.

## Fix

In \`stringifyCompositeLoop\`:

- Keep \`emitComponentAndEventSetup\` inside the if/else (mode-dependent).
- Hoist \`emitInnerLoopSetup\` after the if/else, called once with \`mode='ssr'\`. The mode argument matters only for any static inner \`forEach\` inside, which expects the SSR \`initChild\` shape (the same default as hydration); reactive inner mapArrays ignore the argument.

## Verification

For \`tmp/emit-survey/outputs/loop-nested-plain.js\`:

| | inner-mapArray sites | total mapArray sites |
|---|---|---|
| before | 2 (one per outer arm) | 3 |
| after  | 1 (shared) | 2 |

For \`loop-nested-3lv.js\` the saving compounds (the 3rd-level mapArray was triplicated through the outer arms × the inner reactive renderItem).

The existing test \`child component inside nested conditional is only initialized once (#929)\` was updated: it asserted "≥ 2 mapArray sites" purely to scope its inner-mapArray search; now it correctly asserts ≥ 1.

Adds a regression guard in \`packages/jsx/src/__tests__/nested-loop-plain.test.ts\` that asserts exactly one inner mapArray site for the 2-level fixture.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 766 / 766 pass (765 prior + 1 new)
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit