### PR TITLE
fix(compiler): make data-key on loop items unconditional (O-7)

### DIFF
--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -152,10 +152,13 @@ describe('Compiler-Runtime Contract', () => {
       // data-key for outer items and data-key-1 for inner items, matching
       // what the event dispatcher searches for.
       expect(js).not.toContain('data-key-2')
-      // Outer loop items must have data-key in the SSR branch template
-      expect(js).toMatch(/data-key="['"] \+ \(group\.id\)/)
-      // Inner loop items must have data-key-1 in the SSR branch template
-      expect(js).toMatch(/data-key-1="['"] \+ \(item\.id\)/)
+      // Outer loop items must have data-key in the SSR branch template.
+      // Post-O-7 the emission is an unguarded template-literal interpolation
+      // (`data-key="${group.id}"`) instead of a `... != null ? ... : ''`
+      // ternary string concat.
+      expect(js).toMatch(/data-key="\$\{group\.id\}"/)
+      // Inner loop items must have data-key-1 in the SSR branch template.
+      expect(js).toMatch(/data-key-1="\$\{item\.id\}"/)
     })
 
     test('loop inside conditional wires reactive conditionals in mapArray callback', () => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -53,6 +53,13 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
   if (attrName === 'style') {
     return `\${((v) => v != null ? 'style="' + v + '"' : '')(styleToCss(${valExpr}))}`
   }
+  // `data-key` / `data-key-N` is a reconciliation contract — every loop item
+  // must carry one. Emit unconditionally; if the user passes `key={undefined}`
+  // we want it to surface as `data-key="undefined"` (and ultimately a runtime
+  // assertion in mapArray) rather than silently fall back to "no key".
+  if (attrName === 'data-key' || attrName.startsWith('data-key-')) {
+    return `${attrName}="\${${valExpr}}"`
+  }
   return `\${(${valExpr}) != null ? '${attrName}="' + (${valExpr}) + '"' : ''}`
 }
 


### PR DESCRIPTION
## Summary

The hydrate / insert template emitted \`data-key\` through the generic dynamic-attribute path, which guards every value with \`!= null\`:

\`\`\`
<li \${(item().id) != null ? 'data-key="' + (item().id) + '"' : ''}>
\`\`\`

\`data-key\` is the reconciliation contract for \`mapArray\` — if it's absent on any item, hydration silently mis-aligns SSR DOM with the client signal. The "skip when null" branch was a defensive holdover from a time when \`key\` was optional. With keyed loops now requiring a key (the only non-keyed mapArray path uses \`keyFn=null\` and explicitly does not emit \`data-key\` at all), the null guard hides bugs: a stray \`key={undefined}\` would silently drop the attribute and desync the loop, instead of surfacing as \`data-key="undefined"\` that mapArray's reconciler can fail loudly on.

## Fix

\`templateAttrExpr\` now special-cases \`data-key\` and \`data-key-N\`, emitting an unconditional template-literal interpolation:

| | output |
|---|---|
| before | \`\${(item().id) != null ? 'data-key="' + (item().id) + '"' : ''}\` |
| after  | \`data-key="\${item().id}"\` |

Smaller, no branching, and \`key={undefined}\` now propagates verbatim to the DOM.

## Falling tests

One test pinned to the legacy string-concat shape:

- \`compiler-runtime-contract.test.ts\` → "loop inside conditional: outer=data-key, inner=data-key-1 in SSR template"

Updated to match the new template-literal form. Comment notes the post-O-7 shape so the reason is recorded.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 766 / 766 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit