### PR TITLE
refactor(compiler): event-listener emit helpers + spec doc (O-6, O-9)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-listener.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-listener.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared helpers for emitting `addEventListener` lines.
+ *
+ * Three legacy emission sites all built the same shape by hand:
+ *   1. branch arm bindings    (`stringify/insert.ts::emitArmBody`)
+ *   2. inline event setup     (`emit-control-flow.ts::emitEventSetup`)
+ *   3. loop-cond branch bindings (`emit-control-flow.ts::emitLoopCondBranchEventBindings`)
+ *
+ * Each repeated `wrapHandlerInBlock(handler)` + DOM-event-name normalisation +
+ * `if (elem) elem.addEventListener(...)` line. Centralising the shape here
+ * keeps the wrap and the event-name decision in one place — useful when
+ * we eventually drop the legacy "raw event name" mode (currently only used
+ * by `@client` conditionals).
+ */
+
+import { toDomEventName, wrapHandlerInBlock } from '../../utils'
+
+export type EventNameMode = 'dom' | 'raw'
+
+/**
+ * Emit `if (<elementVar>) <elementVar>.addEventListener('<eventName>',
+ * <wrappedHandler>)` on a single line. The handler is already
+ * source-level — pass it verbatim; the helper applies
+ * `wrapHandlerInBlock` so block-form arrow functions are safe to drop
+ * into an expression position.
+ */
+export function emitListenerLine(
+  lines: string[],
+  indent: string,
+  elementVar: string,
+  eventName: string,
+  handler: string,
+  mode: EventNameMode = 'dom',
+): void {
+  const wrapped = wrapHandlerInBlock(handler)
+  const name = mode === 'dom' ? toDomEventName(eventName) : eventName
+  lines.push(`${indent}if (${elementVar}) ${elementVar}.addEventListener('${name}', ${wrapped})`)
+}
+
+/**
+ * Emit a `{ qsa lookup; if (elem) addEventListener; }` block on
+ * (potentially) multiple lines. Used inside loop renderItem bodies
+ * where the element variable doesn't already exist in scope.
+ */
+export function emitListenerBlock(
+  lines: string[],
+  indent: string,
+  scopeVar: string,
+  slotId: string,
+  elementLocal: string,
+  eventName: string,
+  handler: string,
+  mode: EventNameMode = 'dom',
+): void {
+  const wrapped = wrapHandlerInBlock(handler)
+  const name = mode === 'dom' ? toDomEventName(eventName) : eventName
+  lines.push(`${indent}{ const ${elementLocal} = qsa(${scopeVar}, '[bf="${slotId}"]'); if (${elementLocal}) ${elementLocal}.addEventListener('${name}', ${wrapped}) }`)
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -28,9 +28,10 @@
  * preserve it; a follow-up PR can fix it now that the indent is data-driven.
  */
 
-import { toDomEventName, wrapHandlerInBlock, varSlotId } from '../../utils'
+import { varSlotId } from '../../utils'
 import { emitBranchLoopBody } from '../../emit-control-flow'
 import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types'
+import { emitListenerLine } from './event-listener'
 
 export interface StringifyInsertOptions {
   /** Indent on the `insert(` line itself. */
@@ -74,8 +75,6 @@ function emitArmBody(
   mode: 'dom' | 'raw',
   indent: string,
 ): void {
-  const eventNameFn = mode === 'dom' ? toDomEventName : (n: string) => n
-
   // 1. Combine event-bearing slots and ref slots into a single `$()` query.
   //    Order: events-first, then refs (matches legacy emitter).
   const allSlotIds = new Set<string>()
@@ -99,8 +98,7 @@ function emitArmBody(
   for (const [slotId, slotEvents] of eventsBySlot) {
     const v = varSlotId(slotId)
     for (const ev of slotEvents) {
-      const wrapped = wrapHandlerInBlock(ev.handler)
-      lines.push(`${indent}if (_${v}) _${v}.addEventListener('${eventNameFn(ev.eventName)}', ${wrapped})`)
+      emitListenerLine(lines, indent, `_${v}`, ev.eventName, ev.handler, mode)
     }
   }
 

--- a/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-control-flow.ts
@@ -6,11 +6,12 @@
 
 import type { ClientJsContext, BranchLoop, LoopChildEvent, LoopChildConditional, TopLevelLoop, NestedLoop, CollectedLoop } from './types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../types'
-import { toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
+import { varSlotId, quotePropName, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from './utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from './html-template'
 import { emitAttrUpdate } from './emit-reactive'
 import { buildInsertPlan } from './control-flow/plan/build-insert'
 import { stringifyInsert } from './control-flow/stringify/insert'
+import { emitListenerLine, emitListenerBlock } from './control-flow/stringify/event-listener'
 import { buildPlainLoopPlan, buildStaticLoopPlan } from './control-flow/plan/build-loop'
 import { stringifyPlainLoop, stringifyStaticLoop } from './control-flow/stringify/loop'
 import { buildComponentLoopPlan } from './control-flow/plan/build-component-loop'
@@ -387,9 +388,12 @@ function emitLoopCondBranchEventBindings(
     // to find descendants when the nearest bf-s is the component root.
     lines.push(`${indent}{ const _${v} = qsa(__branchScope, '[bf="${slotId}"]')`)
     for (const ev of slotEvents) {
-      const handler = wrapHandlerInBlock(wrap(ev.handler))
-      lines.push(`${indent}  if (_${v}) _${v}.addEventListener('${toDomEventName(ev.eventName)}', ${handler}) }`)
+      emitListenerLine(lines, `${indent}  `, `_${v}`, ev.eventName, wrap(ev.handler))
     }
+    // Close the block opened above. (Multi-listener-per-slot share one query;
+    // legacy emitter put the close brace inline with the LAST listener line —
+    // moving it to its own line keeps each emitListenerLine call uniform.)
+    lines.push(`${indent}}`)
   }
 }
 
@@ -666,9 +670,8 @@ export function buildDepthLevels(
 
 /** Emit a single addEventListener call for a child event on a given element. */
 function emitEventSetup(ls: string[], indent: string, elVar: string, ev: LoopChildEvent, loopParam?: string, loopParamBindings?: readonly LoopParamBinding[]): void {
-  let handler = loopParam ? wrapLoopParamAsAccessor(ev.handler, loopParam, loopParamBindings) : ev.handler
-  handler = wrapHandlerInBlock(handler)
-  ls.push(`${indent}{ const __e = qsa(${elVar}, '[bf="${ev.childSlotId}"]'); if (__e) __e.addEventListener('${toDomEventName(ev.eventName)}', ${handler}) }`)
+  const handler = loopParam ? wrapLoopParamAsAccessor(ev.handler, loopParam, loopParamBindings) : ev.handler
+  emitListenerBlock(ls, indent, elVar, ev.childSlotId, '__e', ev.eventName, handler)
 }
 
 /** Build the component-finder CSS selector for SSR hydration initChild. */

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -280,6 +280,32 @@ interface FilterPredicate {
 
 Adapters should render the filter as a conditional wrapper inside the loop (e.g., `if (condition) { children }`), not by pre-filtering the array. The filter param may differ from the loop param (e.g., filter uses `t`, loop uses `todo`) — adapters must map between them.
 
+### Loop emission shapes (client JS)
+
+The client JS emitter classifies each `IRLoop` into one of four shapes for code generation. The category is captured by the corresponding `*LoopPlan` type in `packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts`:
+
+| Shape | Body | Plan type | Client emission |
+|---|---|---|---|
+| **Static** | array is a constant literal (no signal) | `StaticLoopPlan` | `arr.forEach(...)` for reactive attrs / texts only |
+| **Plain** | dynamic array, body is a plain element with no child components and no inner loops | `PlainLoopPlan` | `mapArray(() => arr, container, keyFn, renderItem)` returning a clone of the template |
+| **Component** | dynamic array, body is a single child component (with optional nested child components) | `ComponentLoopPlan` | `mapArray(...)` whose `renderItem` calls `initChild` (SSR) or `createComponent` (CSR) |
+| **Composite** | dynamic array, body is a plain element that **contains** at least one child component or inner loop | `CompositeLoopPlan` | `mapArray(...)` whose `renderItem` rebuilds the body element and dispatches both component init and inner-loop setup |
+
+"Composite" specifically denotes the *plain-element-with-children* case. A loop whose body is a bare component is **Component**, not Composite — keeping the two separate avoids the historical "composite means two different things" confusion.
+
+### Loop param evaluation contexts
+
+A user-written `item.x` reference inside a loop body is rewritten differently depending on which of four contexts the expression lands in:
+
+| Context | `item` is... | Why |
+|---|---|---|
+| Hydrate / insert template (SSR-side string) | plain value | Template renders once from initial state; no per-tick re-eval |
+| Dynamic loop renderItem (`mapArray` callback) | signal accessor `item()` | mapArray passes a signal so per-item updates re-fire fine-grained effects |
+| Nested dynamic loop renderItem | both parent and self are accessors | Same reason; outer accessor wraps the array expression of the inner mapArray |
+| Static array forEach | plain value | Array is constant; no reactivity needed |
+
+`wrapLoopParamAsAccessor(expr, param, paramBindings)` is the single function that performs the rewrite for the renderItem contexts. Destructured params (`map(({ id, name }) => ...)`) are rewritten to `__bfItem().id` etc. via `paramBindings` (#951).
+
 ### Metadata
 
 Each compiled component includes metadata:


### PR DESCRIPTION
## Summary

Two paired observations from \`tmp/emit-survey/\` that pair naturally:

### O-6 — addEventListener emission helpers

Three legacy emission sites built the same shape by hand:

- \`stringify/insert.ts::emitArmBody\` (branch arm bindings)
- \`emit-control-flow.ts::emitEventSetup\` (inline event setup in composite renderItem bodies)
- \`emit-control-flow.ts::emitLoopCondBranchEventBindings\` (loop-cond branch bindings)

Each repeated \`wrapHandlerInBlock(handler)\` + DOM-event-name normalisation + the \`if (elem) elem.addEventListener(...)\` line.

Centralised into \`control-flow/stringify/event-listener.ts\`:

| Helper | Use case |
|---|---|
| \`emitListenerLine\` | single-line shape with a pre-fetched element |
| \`emitListenerBlock\` | inline \`{ qsa + listener }\` block used in renderItem bodies |

Also drops the legacy \`emitLoopCondBranchEventBindings\` quirk where the closing \`}\` rode on the LAST listener line; the brace now lands on its own line, keeping every \`emitListenerLine\` call uniform.

### O-9 — spec / terminology

Adds two new sections to \`spec/compiler.md\`:

- **Loop emission shapes** — pins the four-way classification (Static / Plain / Component / Composite) used by the Plan layer, and explicitly notes that "Composite" means *plain element with children inside*, **not** "single component". Closes the historical "composite means two different things" confusion by name.

- **Loop param evaluation contexts** — documents when \`item.x\` is rewritten to \`item().x\` (renderItem contexts) vs left plain (templates, static forEach), so future contributors don't need to trace \`wrapLoopParamAsAccessor\` call sites to find the contract.

## No behaviour change

The byte output is identical except for the one cosmetic fix to the \`emitLoopCondBranchEventBindings\` close-brace position.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 766 / 766 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit