### PR TITLE
refactor(compiler): split control-flow/plan/types.ts by Plan kind

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/common.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/common.ts
@@ -1,0 +1,39 @@
+/**
+ * Plan-layer types shared across multiple Plan kinds.
+ *
+ * `ScopeRef` discriminates which scope variable to use in the runtime call;
+ * `ReactiveEffectsPassthrough` is a transitional carrier for IR fields that
+ * still flow through the legacy `emitLoopChildReactiveEffects` helper. PR
+ * 5+ will replace it with a structured `ReactiveEffectsPlan`.
+ */
+
+import type {
+  LoopChildConditional,
+  LoopChildReactiveAttr,
+  LoopChildReactiveText,
+  TopLevelLoop,
+} from '../../types'
+
+/**
+ * The scope variable to pass as the first argument of insert(...) /
+ * mapArray(...). At top-level this is `__scope`; nested inside an arm body
+ * it is `__branchScope`; nested inside a loop renderItem it is the loop
+ * element variable (e.g. `__el`).
+ */
+export type ScopeRef =
+  | { kind: 'top' }                         // emits `__scope`
+  | { kind: 'branchScope' }                 // emits `__branchScope`
+  | { kind: 'var'; name: string }           // emits the literal variable name
+
+/**
+ * Loaned-IR carrier for emitLoopChildReactiveEffects. PR 5+ replaces this
+ * with a structured ReactiveEffectsPlan that addresses O-3 (key dedup) at
+ * the builder level.
+ */
+export interface ReactiveEffectsPassthrough {
+  attrs: LoopChildReactiveAttr[]
+  texts: LoopChildReactiveText[]
+  conditionals: LoopChildConditional[] | undefined
+  loopParam: string
+  loopParamBindings: TopLevelLoop['paramBindings']
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
@@ -1,0 +1,77 @@
+/**
+ * `EventDelegationPlan` and `ItemLookup` Plan types.
+ *
+ * Covers three legacy emitters with one shape — they only differ in the
+ * container variable and the per-event item-lookup strategy.
+ */
+
+import type { LoopChildEvent, TopLevelLoop } from '../../types'
+
+/**
+ * Plan for a loop's event-delegation block. Covers three legacy emitters:
+ *   - `emitDynamicLoopEventDelegation` (top-level dynamic loop)
+ *   - `emitBranchLoopEventDelegation`  (branch-scoped dynamic loop)
+ *   - the inline delegation block at the end of `emitStaticArrayUpdates`
+ *
+ * The differences between the three contexts collapse onto two Plan fields:
+ *   - `containerVar`: `_sN` (top), `__loop_cv` (branch), or `_sN` (static)
+ *   - `itemLookup`: how to recover the loop item for an event target
+ *
+ * The delegation envelope itself (event grouping by name, deepest-first
+ * sorting, capture vs bubble selection) is identical across contexts and
+ * lives in the stringifier.
+ */
+export interface EventDelegationPlan {
+  kind: 'event-delegation'
+  containerVar: string
+  events: LoopChildEvent[]
+  itemLookup: ItemLookup
+}
+
+/**
+ * How to look up the loop item from an event target. Each variant is the
+ * deterministic result of (loop kind, has-key, has-bindings, has-nested-loops)
+ * — flattening the matrix into discriminated cases.
+ */
+export type ItemLookup =
+  | KeyedItemLookup
+  | DynamicIndexItemLookup
+  | StaticIndexItemLookup
+
+export interface KeyedItemLookup {
+  kind: 'keyed'
+  /** Source array expression. */
+  arrayExpr: string
+  /** Loop param identifier (or destructure pattern text — used as receiver name only). */
+  param: string
+  /** Destructured-binding metadata. Determines TDZ-safe `__bfLoopItem` shape (#951). */
+  paramBindings: TopLevelLoop['paramBindings']
+  /**
+   * Key expression with the outer loop param substituted to `item` (so it can
+   * appear inside `arr.find(item => String(KEY_WITH_ITEM) === key)`). Pre-computed
+   * by the builder so the stringifier doesn't repeat the regex / substituteLoopBindings
+   * decision.
+   */
+  keyWithItem: string
+  /** Optional preamble line — emitted before the handler call. */
+  mapPreamble: string | null
+  /** True when `paramBindings` is non-empty — drives TDZ-safe lookup shape. */
+  hasBindings: boolean
+}
+
+export interface DynamicIndexItemLookup {
+  kind: 'dynamic-index'
+  arrayExpr: string
+  param: string
+  mapPreamble: string | null
+  hasBindings: boolean
+}
+
+export interface StaticIndexItemLookup {
+  kind: 'static-index'
+  arrayExpr: string
+  param: string
+  mapPreamble: string | null
+  /** Sibling offset for `__idx` arithmetic; `null` when no offset. */
+  siblingOffset: number | null
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
@@ -1,0 +1,91 @@
+/**
+ * `InsertPlan` and arm-body Plan types.
+ *
+ * The Plan for a single `insert(scope, slotId, () => cond, trueArm, falseArm)`
+ * runtime call. Nested conditionals nest as `InsertPlan` recursively in
+ * `ArmBody.conditionals`, so one stringifier handles arbitrary depth.
+ */
+
+import type { BranchLoop } from '../../types'
+import type { ScopeRef } from './common'
+
+/**
+ * Plan for a single `insert(scope, slotId, () => cond, trueArm, falseArm)`
+ * call. `kind` is included so future dispatcher unions can narrow.
+ */
+export interface InsertPlan {
+  kind: 'insert'
+  /** Variable expression to use as the first argument of `insert(...)`. */
+  scope: ScopeRef
+  slotId: string
+  /** The reactive condition expression. Wrapped at builder time. */
+  condition: string
+  /** Always two arms: [whenTrue, whenFalse]. */
+  arms: [InsertArm, InsertArm]
+  /**
+   * Event-name normalizer applied to events inside arm bodies.
+   * `'dom'` calls `toDomEventName` (drop "on" prefix, lowercase); `'raw'`
+   * keeps the original event name (used by `@client` conditionals).
+   */
+  eventNameMode: 'dom' | 'raw'
+}
+
+/** A single branch arm of an insert(). */
+export interface InsertArm {
+  /** Pre-rendered HTML template string. Already includes the bf-cond-* markers. */
+  templateHtml: string
+  body: ArmBody
+}
+
+/**
+ * Everything that happens inside `bindEvents: (__branchScope) => { ... }`.
+ *
+ * The order of fields matches the emission order (events → refs → child
+ * components → disposable text effects → loop reconciliation → nested
+ * conditionals). Stringifiers MUST follow this order to keep output stable.
+ */
+export interface ArmBody {
+  /** addEventListener calls bound to elements inside the arm. */
+  events: ArmEventBind[]
+  /** Imperative ref callbacks for elements inside the arm. */
+  refs: ArmRefBind[]
+  /** initChild calls for child components materialized by the arm swap. */
+  childComponents: ArmChildComponentInit[]
+  /** Reactive text effects scoped to this branch. Each becomes `createDisposableEffect`. */
+  textEffects: ArmTextEffect[]
+  /**
+   * Branch-scoped loops. Currently kept as raw `BranchLoop` references and
+   * delegated to the legacy `emitBranchLoopBody` helper. A future PR will
+   * turn them into `LoopPlan` and stringify directly.
+   */
+  loopsRaw: BranchLoop[]
+  /**
+   * Nested conditionals within this branch. Built recursively as `InsertPlan`s
+   * so the same stringifier handles them at any depth.
+   */
+  conditionals: InsertPlan[]
+}
+
+export interface ArmEventBind {
+  slotId: string
+  eventName: string
+  /** Handler source expression (already trimmed). The stringifier wraps it. */
+  handler: string
+}
+
+export interface ArmRefBind {
+  slotId: string
+  callback: string
+}
+
+export interface ArmChildComponentInit {
+  name: string
+  slotId: string | null
+  /** Pre-built props object expression (e.g., `{ get name() { return ... } }`). */
+  propsExpr: string
+}
+
+export interface ArmTextEffect {
+  slotId: string
+  expression: string
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -1,0 +1,185 @@
+/**
+ * Plan types for the four loop emission shapes.
+ *
+ * - `PlainLoopPlan`     — body is a plain element (no comp, no inner loop)
+ * - `ComponentLoopPlan` — body is a single child component (with optional nested comps)
+ * - `CompositeLoopPlan` — body is a plain element containing comps and/or inner loops
+ * - `StaticLoopPlan`    — array is a constant literal; only reactive attrs/texts need setup
+ *
+ * The classification is documented in spec/compiler.md "Loop emission shapes".
+ */
+
+import type {
+  LoopChildEvent,
+  LoopChildReactiveAttr,
+  LoopChildReactiveText,
+  TopLevelLoop,
+} from '../../types'
+import type { IRLoopChildComponent } from '../../../types'
+import type { DepthLevel } from '../legacy-helpers'
+import type { ReactiveEffectsPassthrough } from './common'
+
+/**
+ * Plan for a top-level dynamic loop with a plain element body (no child
+ * components, no inner loops). Covers `emitPlainElementLoopReconciliation`.
+ *
+ * The "single-line vs multi-line renderItem" split in the legacy emitter is
+ * a stringifier concern, not a Plan concern — the Plan just records
+ * whether reactive effects exist and the stringifier picks the layout.
+ */
+export interface PlainLoopPlan {
+  kind: 'plain-loop'
+  /** The container element variable, e.g. `_s1`. */
+  containerVar: string
+  /** Array expression to drive `mapArray(() => ARR, ...)`. Already chained (filter/sort). */
+  arrayExpr: string
+  /** Key function source — `null` when the loop has no explicit key. */
+  keyFn: string
+  /** renderItem param identifier (after destructure unwrap rename). */
+  paramHead: string
+  /** Index parameter identifier, e.g. `__idx` or user-supplied. */
+  indexParam: string
+  /** Statement to unwrap a destructured param at body entry. Empty when not needed. */
+  paramUnwrap: string
+  /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
+  mapPreambleWrapped: string
+  /** HTML template string for one item. */
+  template: string
+  /**
+   * Carried IR fields for legacy `emitLoopChildReactiveEffects` passthrough.
+   * `null` means there are no reactive effects; the stringifier emits the
+   * single-line renderItem in that case. PR 5+ will replace this with
+   * structured `ReactiveEffectsPlan`.
+   */
+  reactiveEffects: ReactiveEffectsPassthrough | null
+}
+
+/**
+ * Plan for a top-level dynamic loop whose body is a single child component
+ * (with or without nested child components inside it). Covers
+ * `emitComponentLoopReconciliation`.
+ *
+ * `nestedComps.length === 0`  → emit the simple two-line renderItem
+ *                               (initChild on existing, createComponent on new).
+ * `nestedComps.length > 0`    → emit the SSR/CSR split that initialises both
+ *                               the outer component and each nested child.
+ *
+ * Reactive-effects construction inside `childConditionals` is delegated to
+ * the legacy `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`,
+ * mirroring the PlainLoopPlan strategy.
+ */
+export interface ComponentLoopPlan {
+  kind: 'component-loop'
+  containerVar: string
+  arrayExpr: string
+  keyFn: string
+  paramHead: string
+  paramUnwrap: string
+  indexParam: string
+  /** The outer (loop body) component's name, e.g. `'Card'`. */
+  componentName: string
+  /** Pre-built props object expression for the outer component. */
+  componentPropsExpr: string
+  /** Wrapped key argument passed to `createComponent(name, props, KEY)`. */
+  keyExpr: string
+  /** Nested child component initialisers; empty for the simple case. */
+  nestedComps: NestedComponentInit[]
+  /** Carried IR for legacy reactive-effects passthrough; null when there's nothing to emit. */
+  childConditionalEffects: ReactiveEffectsPassthrough | null
+}
+
+/**
+ * One nested child component to initialise inside a renderItem body.
+ * `childrenTextEffect` is non-null when the component's children are
+ * text-equivalent AND reference the outer loop param — in that case the
+ * stringifier emits a `createEffect` that updates the child's `textContent`.
+ */
+export interface NestedComponentInit {
+  componentName: string
+  /** CSS selector used by `qsa(...)` to find the SSR-rendered placeholder. */
+  selector: string
+  /** Pre-built props object expression for the nested component. */
+  propsExpr: string
+  /** When non-null, emit a reactive textContent effect alongside `initChild`. */
+  childrenTextEffect: { wrappedChildren: string } | null
+}
+
+/**
+ * Plan for a composite loop — body is a plain element that contains either
+ * nested child components (`outerComps`) and/or inner loops
+ * (`depthLevels`). Used for both top-level emission
+ * (`emitCompositeElementReconciliation`) and branch-scoped emission
+ * (`emitCompositeBranchLoop`).
+ *
+ * The two contexts differ only in:
+ *   - container variable name (`_sN` vs `__loop_cv`)
+ *   - `arrayExpr` (top: chained filter/sort/map; branch: raw `loop.array`)
+ *   - leading/body indent
+ *   - `branchClearChildren`: when true, prepends a `getLoopChildren(...)
+ *     .forEach(__el => __el.remove())` line so the branch swap starts from
+ *     a clean slate (legacy parity).
+ *
+ * Inner-loop emission and component-and-event setup remain on the legacy
+ * `emitInnerLoopSetup` / `emitComponentAndEventSetup` helpers, invoked from
+ * the stringifier as a passthrough.
+ */
+export interface CompositeLoopPlan {
+  kind: 'composite-loop'
+  containerVar: string
+  arrayExpr: string
+  keyFn: string
+  paramHead: string
+  paramUnwrap: string
+  indexParam: string
+  /** Wrapped mapPreamble line, hoisted before the SSR/CSR split. Empty when none. */
+  mapPreambleWrapped: string
+  /** Inner template HTML for the loop body (single item). */
+  template: string
+  /** Outer-level child components (depth 0), with `insideConditional` ones already filtered out. */
+  outerComps: readonly IRLoopChildComponent[]
+  /** Outer-level child events (no nested-loop scope). */
+  outerEvents: readonly LoopChildEvent[]
+  /** Per-inner-loop levels for `emitInnerLoopSetup` passthrough. */
+  depthLevels: readonly DepthLevel[]
+  /** Loop param identifier — needed for legacy passthroughs. */
+  loopParam: string
+  /** Destructured-binding metadata for the loop param. */
+  loopParamBindings: TopLevelLoop['paramBindings']
+  /** Reactive effects rendered after the SSR/CSR split. */
+  reactiveEffects: ReactiveEffectsPassthrough | null
+  /**
+   * When true, the stringifier prepends a `getLoopChildren(...).forEach(__el
+   * => __el.remove())` line — branch composite loops need this so mapArray
+   * starts from a clean container after a branch swap. Top-level loops do not.
+   */
+  branchClearChildren: boolean
+  /** Indent of the `mapArray(` line itself. */
+  topIndent: string
+  /** Indent of the lines inside the renderItem body. */
+  bodyIndent: string
+}
+
+/**
+ * Plan for a top-level static array loop. A single `forEach` pass handles
+ * both reactive attrs and reactive texts — mirrors the legacy
+ * `emitStaticArrayUpdates` shape after the O-4 merge.
+ */
+export interface StaticLoopPlan {
+  kind: 'static-loop'
+  containerVar: string
+  /** Source array expression as written in user code (no signal accessor wrap). */
+  arrayExpr: string
+  /** Loop param name. */
+  param: string
+  /** Index parameter identifier. */
+  indexParam: string
+  /** Children-index offset expression — index when no offset, `${idx} + N` otherwise. */
+  childIndexExpr: string
+  /**
+   * Reactive attrs grouped by child slot id (preserves emission order).
+   * Empty list means no attrs to emit.
+   */
+  attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
+  /** Reactive texts in declaration order. */
+  texts: readonly LoopChildReactiveText[]
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -1,397 +1,50 @@
 /**
- * Plan types for the control-flow emitter.
+ * Barrel re-export for Plan types.
  *
- * The control-flow emission pipeline is being migrated from "IR → string[]"
- * directly to "IR → Plan → string[]". This file holds the Plan IR.
+ * The actual type definitions live in dedicated files alongside the
+ * builders / stringifiers that produce / consume them:
  *
- * Plans are pure data — no string templates, no `lines.push`. Every emission
- * decision (which scope to query, which event-name normalizer to use, etc.)
- * is made by the builder; the stringifier is a deterministic function from
- * Plan to source text.
+ *   common.ts            — `ScopeRef`, `ReactiveEffectsPassthrough`
+ *   insert.ts            — `InsertPlan` family (arms, bindings)
+ *   loop.ts              — `PlainLoopPlan`, `ComponentLoopPlan`,
+ *                          `CompositeLoopPlan`, `StaticLoopPlan`,
+ *                          `NestedComponentInit`
+ *   event-delegation.ts  — `EventDelegationPlan`, `ItemLookup` family
  *
- * Migration status (2026-04-25):
- * - PR 1: `InsertPlan` for top-level + nested conditionals.
- * - PR 2: `LoopPlan` (plain → component → composite).
- * - PR 3: `EventDelegationPlan`.
- *
- * Until PR 2 lands, ArmBody.loops is a passthrough escape hatch — see the
- * field comment on `ArmBody.loopsRaw` below.
+ * This file lets callers continue to write
+ * `import type { ... } from '../plan/types'` without caring which file
+ * a particular Plan type lives in.
  */
 
-import type {
-  BranchLoop,
+export type { ScopeRef, ReactiveEffectsPassthrough } from './common'
+export type {
+  InsertPlan,
+  InsertArm,
+  ArmBody,
+  ArmEventBind,
+  ArmRefBind,
+  ArmChildComponentInit,
+  ArmTextEffect,
+} from './insert'
+export type {
+  PlainLoopPlan,
+  ComponentLoopPlan,
+  CompositeLoopPlan,
+  StaticLoopPlan,
+  NestedComponentInit,
+} from './loop'
+export type {
+  EventDelegationPlan,
+  ItemLookup,
+  KeyedItemLookup,
+  DynamicIndexItemLookup,
+  StaticIndexItemLookup,
+} from './event-delegation'
+
+// Re-export legacy types referenced from Plan-level code paths.
+export type {
   ConditionalElement,
   LoopChildConditional,
+  BranchLoop,
   LoopChildEvent,
-  LoopChildReactiveAttr,
-  LoopChildReactiveText,
-  TopLevelLoop,
 } from '../../types'
-import type { IRLoopChildComponent } from '../../../types'
-import type { DepthLevel } from '../legacy-helpers'
-
-// ─────────────────────────────────────────────────────────────────────
-// Top-level
-// ─────────────────────────────────────────────────────────────────────
-
-/**
- * Plan for a single `insert(scope, slotId, () => cond, trueArm, falseArm)`
- * call. `kind` is included so future dispatcher unions can narrow.
- */
-export interface InsertPlan {
-  kind: 'insert'
-  /** Variable expression to use as the first argument of `insert(...)`. */
-  scope: ScopeRef
-  slotId: string
-  /** The reactive condition expression. Wrapped at builder time. */
-  condition: string
-  /** Always two arms: [whenTrue, whenFalse]. */
-  arms: [InsertArm, InsertArm]
-  /**
-   * Event-name normalizer applied to events inside arm bodies.
-   * `'dom'` calls `toDomEventName` (drop "on" prefix, lowercase); `'raw'`
-   * keeps the original event name (used by `@client` conditionals).
-   */
-  eventNameMode: 'dom' | 'raw'
-}
-
-/** A single branch arm of an insert(). */
-export interface InsertArm {
-  /** Pre-rendered HTML template string. Already includes the bf-cond-* markers. */
-  templateHtml: string
-  body: ArmBody
-}
-
-/**
- * Everything that happens inside `bindEvents: (__branchScope) => { ... }`.
- *
- * The order of fields matches the emission order (events → refs → child
- * components → disposable text effects → loop reconciliation → nested
- * conditionals). Stringifiers MUST follow this order to keep output stable.
- */
-export interface ArmBody {
-  /** addEventListener calls bound to elements inside the arm. */
-  events: ArmEventBind[]
-  /** Imperative ref callbacks for elements inside the arm. */
-  refs: ArmRefBind[]
-  /** initChild calls for child components materialized by the arm swap. */
-  childComponents: ArmChildComponentInit[]
-  /** Reactive text effects scoped to this branch. Each becomes `createDisposableEffect`. */
-  textEffects: ArmTextEffect[]
-  /**
-   * Branch-scoped loops. PR 1 keeps these as raw `BranchLoop` references and
-   * delegates back to the legacy `emitBranchLoopBody` helper. PR 2 will turn
-   * them into `LoopPlan` and stringify directly.
-   */
-  loopsRaw: BranchLoop[]
-  /**
-   * Nested conditionals within this branch. Built recursively as `InsertPlan`s
-   * so the same stringifier handles them at any depth.
-   */
-  conditionals: InsertPlan[]
-}
-
-export interface ArmEventBind {
-  slotId: string
-  eventName: string
-  /** Handler source expression (already trimmed). The stringifier wraps it. */
-  handler: string
-}
-
-export interface ArmRefBind {
-  slotId: string
-  callback: string
-}
-
-export interface ArmChildComponentInit {
-  name: string
-  slotId: string | null
-  /** Pre-built props object expression (e.g., `{ get name() { return ... } }`). */
-  propsExpr: string
-}
-
-export interface ArmTextEffect {
-  slotId: string
-  expression: string
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Scope references
-// ─────────────────────────────────────────────────────────────────────
-
-/**
- * The scope variable to pass as the first argument of insert(...) /
- * mapArray(...). At top-level this is `__scope`; nested inside an arm body
- * it is `__branchScope`; nested inside a loop renderItem it is the loop
- * element variable (e.g. `__el`).
- */
-export type ScopeRef =
-  | { kind: 'top' }                         // emits `__scope`
-  | { kind: 'branchScope' }                 // emits `__branchScope`
-  | { kind: 'var'; name: string }           // emits the literal variable name
-
-// ─────────────────────────────────────────────────────────────────────
-// Loops
-// ─────────────────────────────────────────────────────────────────────
-
-/**
- * Plan for a top-level dynamic loop with a plain element body (no child
- * components, no inner loops). Covers `emitPlainElementLoopReconciliation`.
- *
- * The "single-line vs multi-line renderItem" split in the legacy emitter is
- * a stringifier concern, not a Plan concern — the Plan just records
- * whether reactive effects exist and the stringifier picks the layout.
- */
-export interface PlainLoopPlan {
-  kind: 'plain-loop'
-  /** The container element variable, e.g. `_s1`. */
-  containerVar: string
-  /** Array expression to drive `mapArray(() => ARR, ...)`. Already chained (filter/sort). */
-  arrayExpr: string
-  /** Key function source — `null` when the loop has no explicit key. */
-  keyFn: string
-  /** renderItem param identifier (after destructure unwrap rename). */
-  paramHead: string
-  /** Index parameter identifier, e.g. `__idx` or user-supplied. */
-  indexParam: string
-  /** Statement to unwrap a destructured param at body entry. Empty when not needed. */
-  paramUnwrap: string
-  /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
-  mapPreambleWrapped: string
-  /** HTML template string for one item. */
-  template: string
-  /**
-   * Carried IR fields for legacy `emitLoopChildReactiveEffects` passthrough.
-   * `null` means there are no reactive effects; the stringifier emits the
-   * single-line renderItem in that case. PR 5+ will replace this with
-   * structured `ReactiveEffectsPlan`.
-   */
-  reactiveEffects: ReactiveEffectsPassthrough | null
-}
-
-/**
- * Loaned-IR carrier for emitLoopChildReactiveEffects. PR 5+ replaces this
- * with a structured ReactiveEffectsPlan that addresses O-3 (key dedup) at
- * the builder level.
- */
-export interface ReactiveEffectsPassthrough {
-  attrs: LoopChildReactiveAttr[]
-  texts: LoopChildReactiveText[]
-  conditionals: LoopChildConditional[] | undefined
-  loopParam: string
-  loopParamBindings: TopLevelLoop['paramBindings']
-}
-
-/**
- * Plan for a top-level dynamic loop whose body is a single child component
- * (with or without nested child components inside it). Covers
- * `emitComponentLoopReconciliation`.
- *
- * `nestedComps.length === 0`  → emit the simple two-line renderItem
- *                               (initChild on existing, createComponent on new).
- * `nestedComps.length > 0`    → emit the SSR/CSR split that initialises both
- *                               the outer component and each nested child.
- *
- * Reactive-effects construction inside `childConditionals` is delegated to
- * the legacy `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`,
- * mirroring the PlainLoopPlan strategy.
- */
-export interface ComponentLoopPlan {
-  kind: 'component-loop'
-  containerVar: string
-  arrayExpr: string
-  keyFn: string
-  paramHead: string
-  paramUnwrap: string
-  indexParam: string
-  /** The outer (loop body) component's name, e.g. `'Card'`. */
-  componentName: string
-  /** Pre-built props object expression for the outer component. */
-  componentPropsExpr: string
-  /** Wrapped key argument passed to `createComponent(name, props, KEY)`. */
-  keyExpr: string
-  /** Nested child component initialisers; empty for the simple case. */
-  nestedComps: NestedComponentInit[]
-  /** Carried IR for legacy reactive-effects passthrough; null when there's nothing to emit. */
-  childConditionalEffects: ReactiveEffectsPassthrough | null
-}
-
-/**
- * One nested child component to initialise inside a renderItem body.
- * `childrenTextEffect` is non-null when the component's children are
- * text-equivalent AND reference the outer loop param — in that case the
- * stringifier emits a `createEffect` that updates the child's `textContent`.
- */
-export interface NestedComponentInit {
-  componentName: string
-  /** CSS selector used by `qsa(...)` to find the SSR-rendered placeholder. */
-  selector: string
-  /** Pre-built props object expression for the nested component. */
-  propsExpr: string
-  /** When non-null, emit a reactive textContent effect alongside `initChild`. */
-  childrenTextEffect: { wrappedChildren: string } | null
-}
-
-/**
- * Plan for a composite loop — body is a plain element that contains either
- * nested child components (`outerComps`) and/or inner loops
- * (`depthLevels`). Used for both top-level emission
- * (`emitCompositeElementReconciliation`) and branch-scoped emission
- * (`emitCompositeBranchLoop`).
- *
- * The two contexts differ only in:
- *   - container variable name (`_sN` vs `__loop_cv`)
- *   - `arrayExpr` (top: chained filter/sort/map; branch: raw `loop.array`)
- *   - leading/body indent
- *   - `branchClearChildren`: when true, prepends a `getLoopChildren(...)
- *     .forEach(__el => __el.remove())` line so the branch swap starts from
- *     a clean slate (legacy parity).
- *
- * Inner-loop emission and component-and-event setup remain on the legacy
- * `emitInnerLoopSetup` / `emitComponentAndEventSetup` helpers, invoked from
- * the stringifier as a passthrough. PR 2-c does not Plan-ify those — the
- * SSR/CSR duplication noted in observation O-1 and the deep-nested loop
- * degradation in O-8 stay bug-for-bug for this PR; their fixes land in
- * dedicated bug-fix PRs after the migration completes.
- */
-export interface CompositeLoopPlan {
-  kind: 'composite-loop'
-  containerVar: string
-  arrayExpr: string
-  keyFn: string
-  paramHead: string
-  paramUnwrap: string
-  indexParam: string
-  /** Wrapped mapPreamble line, hoisted before the SSR/CSR split. Empty when none. */
-  mapPreambleWrapped: string
-  /** Inner template HTML for the loop body (single item). */
-  template: string
-  /** Outer-level child components (depth 0), with `insideConditional` ones already filtered out. */
-  outerComps: readonly IRLoopChildComponent[]
-  /** Outer-level child events (no nested-loop scope). */
-  outerEvents: readonly LoopChildEvent[]
-  /** Per-inner-loop levels for `emitInnerLoopSetup` passthrough. */
-  depthLevels: readonly DepthLevel[]
-  /** Loop param identifier — needed for legacy passthroughs. */
-  loopParam: string
-  /** Destructured-binding metadata for the loop param. */
-  loopParamBindings: TopLevelLoop['paramBindings']
-  /** Reactive effects rendered after the SSR/CSR split. */
-  reactiveEffects: ReactiveEffectsPassthrough | null
-  /**
-   * When true, the stringifier prepends a `getLoopChildren(...).forEach(__el
-   * => __el.remove())` line — branch composite loops need this so mapArray
-   * starts from a clean container after a branch swap. Top-level loops do not.
-   */
-  branchClearChildren: boolean
-  /** Indent of the `mapArray(` line itself. */
-  topIndent: string
-  /** Indent of the lines inside the renderItem body. */
-  bodyIndent: string
-}
-
-/**
- * Plan for a top-level static array loop. Two parallel `forEach` blocks (one
- * for reactive attrs, one for reactive texts) plus optional event delegation
- * — mirrors the legacy `emitStaticArrayUpdates` shape. The forEach
- * duplication noted in observation O-4 is preserved bug-for-bug here; PR 5+
- * collapses them into a single forEach.
- */
-export interface StaticLoopPlan {
-  kind: 'static-loop'
-  containerVar: string
-  /** Source array expression as written in user code (no signal accessor wrap). */
-  arrayExpr: string
-  /** Loop param name. */
-  param: string
-  /** Index parameter identifier. */
-  indexParam: string
-  /** Children-index offset expression — index when no offset, `${idx} + N` otherwise. */
-  childIndexExpr: string
-  /**
-   * Reactive attrs grouped by child slot id (preserves emission order).
-   * Empty list means the attr forEach block is omitted.
-   */
-  attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
-  /** Reactive texts in declaration order. Empty list means the text forEach block is omitted. */
-  texts: readonly LoopChildReactiveText[]
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Event delegation
-// ─────────────────────────────────────────────────────────────────────
-
-/**
- * Plan for a loop's event-delegation block. Covers three legacy emitters:
- *   - `emitDynamicLoopEventDelegation` (top-level dynamic loop)
- *   - `emitBranchLoopEventDelegation`  (branch-scoped dynamic loop)
- *   - the inline delegation block at the end of `emitStaticArrayUpdates`
- *
- * The differences between the three contexts collapse onto two Plan fields:
- *   - `containerVar`: `_sN` (top), `__loop_cv` (branch), or `_sN` (static)
- *   - `itemLookup`: how to recover the loop item for an event target
- *
- * The delegation envelope itself (event grouping by name, deepest-first
- * sorting, capture vs bubble selection) is identical across contexts and
- * lives in the stringifier.
- */
-export interface EventDelegationPlan {
-  kind: 'event-delegation'
-  containerVar: string
-  events: LoopChildEvent[]
-  itemLookup: ItemLookup
-}
-
-/**
- * How to look up the loop item from an event target. Each variant is the
- * deterministic result of (loop kind, has-key, has-bindings, has-nested-loops)
- * — flattening the matrix into discriminated cases.
- */
-export type ItemLookup =
-  | KeyedItemLookup
-  | DynamicIndexItemLookup
-  | StaticIndexItemLookup
-
-export interface KeyedItemLookup {
-  kind: 'keyed'
-  /** Source array expression. */
-  arrayExpr: string
-  /** Loop param identifier (or destructure pattern text — used as receiver name only). */
-  param: string
-  /** Destructured-binding metadata. Determines TDZ-safe `__bfLoopItem` shape (#951). */
-  paramBindings: TopLevelLoop['paramBindings']
-  /**
-   * Key expression with the outer loop param substituted to `item` (so it can
-   * appear inside `arr.find(item => String(KEY_WITH_ITEM) === key)`). Pre-computed
-   * by the builder so the stringifier doesn't repeat the regex / substituteLoopBindings
-   * decision.
-   */
-  keyWithItem: string
-  /** Optional preamble line — emitted before the handler call. */
-  mapPreamble: string | null
-  /** True when `paramBindings` is non-empty — drives TDZ-safe lookup shape. */
-  hasBindings: boolean
-}
-
-export interface DynamicIndexItemLookup {
-  kind: 'dynamic-index'
-  arrayExpr: string
-  param: string
-  mapPreamble: string | null
-  hasBindings: boolean
-}
-
-export interface StaticIndexItemLookup {
-  kind: 'static-index'
-  arrayExpr: string
-  param: string
-  mapPreamble: string | null
-  /** Sibling offset for `__idx` arithmetic; `null` when no offset. */
-  siblingOffset: number | null
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Re-export legacy types referenced from Plan-level code paths.
-// ─────────────────────────────────────────────────────────────────────
-
-export type { ConditionalElement, LoopChildConditional, BranchLoop, LoopChildEvent }


### PR DESCRIPTION
## Summary

Splits the 397-line \`control-flow/plan/types.ts\` (which aggregated four Plan families) into dedicated files alongside their builders/stringifiers. \`types.ts\` is retained as a barrel re-export for back-compat.

## Stacked on #1047

This PR is **stacked on top of #1047** (entry-points / legacy-helpers split). Review and merge #1047 first; then GitHub will rebase the base of this PR onto main.

## Layout

\`\`\`
control-flow/plan/
├── common.ts             # ScopeRef, ReactiveEffectsPassthrough
├── insert.ts             # InsertPlan + arms + bindings
├── loop.ts               # Plain/Component/Composite/Static + NestedComponentInit
├── event-delegation.ts   # EventDelegationPlan + ItemLookup family
└── types.ts              # barrel re-export (back-compat)
\`\`\`

No call-site changes needed — every existing \`import { ... } from '../plan/types'\` continues to resolve via the barrel. Future callers can target the specific file directly.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 766 / 766 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit