### PR TITLE
feat(runtime): upsertChild — collapse SSR/CSR mode in composite emit

### DIFF
--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -77,7 +77,7 @@ export { styleToCss } from './style'
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa } from './query'
 export { hydrate, rehydrateAll } from './hydrate'
-export { registerComponent, getComponentInit, initChild } from './registry'
+export { registerComponent, getComponentInit, initChild, upsertChild } from './registry'
 export { insert, type BranchConfig } from './insert'
 export { updateClientMarker } from './client-marker'
 

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -8,6 +8,7 @@
 import { BF_SCOPE, BF_CHILD_PREFIX } from '@barefootjs/shared'
 import { hydratedScopes } from './hydration-state'
 import { setCurrentScope } from './context'
+import { createComponent } from './component'
 import type { InitFn } from './types'
 
 /**
@@ -97,4 +98,46 @@ export function initChild(
   const prevScope = setCurrentScope(childScope)
   init(childScope, props)
   setCurrentScope(prevScope)
+}
+
+/**
+ * Upsert a child component at a slot inside `parent`. Resolves the SSR vs
+ * CSR shape at runtime in one place — so the compiler doesn't need a
+ * `mode: 'csr' | 'ssr'` argument for child component emission.
+ *
+ *   1. SSR: a `[bf-s$="_<slotId>"]` (or `[bf-s^="<name>_"]` when slotId is
+ *      null) element exists. Initialise it via initChild and return it.
+ *   2. CSR: a `[data-bf-ph="<slotId|name>"]` placeholder exists. Replace it
+ *      with `createComponent(name, props, key)` and return the new element.
+ *   3. Neither matches (already initialised on a previous reconcile pass) —
+ *      no-op, return null.
+ *
+ * The returned element is the live component scope element — callers can
+ * use it for follow-up effects (e.g. a children-textContent createEffect).
+ */
+export function upsertChild(
+  parent: Element,
+  name: string,
+  slotId: string | null,
+  props: Record<string, unknown>,
+  key?: string | number,
+): HTMLElement | null {
+  // SSR: scope element is already in the tree.
+  const ssrSelector = slotId
+    ? `[bf-s$="_${slotId}"]`
+    : `[bf-s^="~${name}_"], [bf-s^="${name}_"]`
+  const ssr = parent.querySelector(ssrSelector) as HTMLElement | null
+  if (ssr) {
+    initChild(name, ssr, props)
+    return ssr
+  }
+  // CSR: replace placeholder with a freshly-created component.
+  const phId = slotId ?? name
+  const ph = parent.querySelector(`[data-bf-ph="${phId}"]`) as HTMLElement | null
+  if (ph) {
+    const comp = createComponent(name, props, key)
+    ph.replaceWith(comp)
+    return comp
+  }
+  return null
 }

--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -55,8 +55,12 @@ describe('composite loops inside conditional branches (#724)', () => {
     // Should use reconcileElements inside the branch's bindEvents
     expect(js).toContain('mapArray(')
 
-    // Should use createComponent for Button inside renderItem (CSR path)
-    expect(js).toContain("createComponent('Button'")
+    // After O-1's mode-collapse PR, child component init goes through the
+    // runtime `upsertChild` helper instead of an emit-side
+    // createComponent/initChild dispatch. The helper resolves the SSR vs
+    // CSR shape at runtime — see `packages/client/src/runtime/registry.ts`.
+    expect(js).toContain("upsertChild(")
+    expect(js).toContain("'Button'")
 
     // Should use placeholder template (data-bf-ph) instead of inline renderChild
     expect(js).toContain('data-bf-ph')
@@ -181,8 +185,11 @@ describe('composite loops inside conditional branches (#724)', () => {
     expect(clientJs).toBeDefined()
     const js = clientJs!.content
 
-    // CSR path should call createComponent for elements (branch loops use CSR rendering)
-    expect(js).toContain("createComponent('Badge'")
+    // After O-1's mode-collapse PR, the SSR initChild and CSR createComponent
+    // emissions are unified into a single `upsertChild` runtime call that
+    // resolves the shape at runtime — see registry.ts.
+    expect(js).toContain("upsertChild(")
+    expect(js).toContain("'Badge'")
   })
 })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/legacy-helpers.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/legacy-helpers.ts
@@ -294,11 +294,10 @@ function emitBranchInnerLoops(
       handler: wrapInner(ev.handler),
     }))
     if (comps.length > 0 || events.length > 0) {
-      lines.push(`${indent}  if (!__existing) {`)
-      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'csr', outerLoopParam, outerLoopParamBindings)
-      lines.push(`${indent}  } else {`)
-      emitComponentAndEventSetup(lines, `${indent}    `, `__bel${uid}`, comps, events, 'ssr', outerLoopParam, outerLoopParamBindings)
-      lines.push(`${indent}  }`)
+      // upsertChild resolves SSR vs CSR at runtime, so a single call site
+      // works regardless of whether `__bel${uid}` was hydrated or freshly
+      // created — no `if (!__existing)` split needed.
+      emitComponentAndEventSetup(lines, `${indent}  `, `__bel${uid}`, comps, events, outerLoopParam, outerLoopParamBindings)
     }
     // Reactive text effects for inner loop items
     if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
@@ -599,13 +598,22 @@ export function isTextOnlyConditional(node: { type: string; [k: string]: any }):
   return checkNode(node.whenTrue) && checkNode(node.whenFalse)
 }
 
+/**
+ * Emit child component initialisation + event listener setup for a list of
+ * components and events on `elVar`. Mode-independent: each comp emits a
+ * single `upsertChild(...)` runtime call that resolves SSR (initialise
+ * existing scope) vs CSR (replace placeholder + createComponent) at runtime.
+ *
+ * Pre-O-1-mode-removal this function took a `mode: 'csr' | 'ssr'` argument
+ * and the caller emitted both branches inside an `if (!__existing) ... else
+ * ...` block. The branches are now collapsed into one call site.
+ */
 export function emitComponentAndEventSetup(
   ls: string[],
   indent: string,
   elVar: string,
   comps: TopLevelLoop['nestedComponents'] & {},
   events: LoopChildEvent[],
-  mode: 'csr' | 'ssr',
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
 ): void {
@@ -621,28 +629,17 @@ export function emitComponentAndEventSetup(
     const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
     const childrenRefsLoop = loopParam != null && rawChildrenExpr != null
       && exprRefsLoopBinding(rawChildrenExpr, { param: loopParam, paramBindings: loopParamBindings })
-    if (mode === 'csr') {
-      const phId = comp.slotId || comp.name
-      const keyProp = comp.props.find(p => p.name === 'key')
-      const keyArg = keyProp ? `, ${wrap(keyProp.value)}` : ''
-      if (childrenRefsLoop) {
-        const wrappedChildren = wrap(rawChildrenExpr!)
-        // Use qsa so the placeholder element is found even when it IS elVar itself
-        // (e.g., loop body = bare component: <div data-bf-ph="sN"> is both the item and the placeholder).
-        // When __ph === elVar, the element is detached so replaceWith is a no-op; reassign instead.
-        ls.push(`${indent}{ const __ph = qsa(${elVar}, '[${DATA_BF_PH}="${phId}"]'); if (__ph) { const __comp = createComponent('${comp.name}', ${propsExpr}${keyArg}); if (__ph === ${elVar}) ${elVar} = __comp; else __ph.replaceWith(__comp); createEffect(() => { const __v = ${wrappedChildren}; __comp.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
-      } else {
-        // Same qsa + reassignment fix for the non-children-reactive case.
-        ls.push(`${indent}{ const __ph = qsa(${elVar}, '[${DATA_BF_PH}="${phId}"]'); if (__ph) { const __comp = createComponent('${comp.name}', ${propsExpr}${keyArg}); if (__ph === ${elVar}) ${elVar} = __comp; else __ph.replaceWith(__comp) } }`)
-      }
+
+    const slotIdLit = comp.slotId ? `'${comp.slotId}'` : 'null'
+    const keyProp = comp.props.find(p => p.name === 'key')
+    const keyArg = keyProp ? `, ${wrap(keyProp.value)}` : ''
+    const upsertCall = `upsertChild(${elVar}, '${comp.name}', ${slotIdLit}, ${propsExpr}${keyArg})`
+
+    if (childrenRefsLoop) {
+      const wrappedChildren = wrap(rawChildrenExpr!)
+      ls.push(`${indent}{ const __c = ${upsertCall}; if (__c) { createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
     } else {
-      const selector = buildCompSelector(comp)
-      if (childrenRefsLoop) {
-        const wrappedChildren = wrap(rawChildrenExpr!)
-        ls.push(`${indent}{ const __c = qsa(${elVar}, '${selector}'); if (__c) { initChild('${comp.name}', __c, ${propsExpr}); createEffect(() => { const __v = ${wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
-      } else {
-        ls.push(`${indent}{ const __c = qsa(${elVar}, '${selector}'); if (__c) initChild('${comp.name}', __c, ${propsExpr}) }`)
-      }
+      ls.push(`${indent}${upsertCall}`)
     }
   }
   for (const ev of events) {
@@ -671,7 +668,6 @@ export function emitInnerLoopSetup(
   indent: string,
   parentElVar: string,
   levels: DepthLevel[],
-  mode: 'csr' | 'ssr',
   outerLoopParam?: string,
   outerLoopParamBindings?: readonly LoopParamBinding[],
 ): void {
@@ -762,17 +758,14 @@ export function emitInnerLoopSetup(
           ...ev,
           handler: wrapInner(ev.handler),
         }))
-        ls.push(`${indent}  if (!__existing) {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'csr', outerLoopParam, outerLoopParamBindings)
-        ls.push(`${indent}  } else {`)
-        emitComponentAndEventSetup(ls, `${indent}    `, `__innerEl${uid}`, wrappedComps, wrappedEvents, 'ssr', outerLoopParam, outerLoopParamBindings)
-        ls.push(`${indent}  }`)
+        // upsertChild resolves SSR vs CSR at runtime; one call regardless of __existing.
+        emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, wrappedComps, wrappedEvents, outerLoopParam, outerLoopParamBindings)
       }
       // Recurse for child levels — pass `inner.param` as the outer for the
       // next level so deeper inner loops see their *immediate* parent and
       // correctly hit the reactive (mapArray) branch above.
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, inner.param, inner.paramBindings)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, inner.param, inner.paramBindings)
       }
       // Reactive text effects for inner loop items
       if (inner.childReactiveTexts && inner.childReactiveTexts.length > 0) {
@@ -802,12 +795,12 @@ export function emitInnerLoopSetup(
       if (inner.key) {
         ls.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.depth)}', String(${inner.key}))`)
       }
-      emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, mode, outerLoopParam, outerLoopParamBindings)
+      emitComponentAndEventSetup(ls, `${indent}  `, `__innerEl${uid}`, level.comps, level.events, outerLoopParam, outerLoopParamBindings)
       // Recurse for child levels (nested deeper loops) — narrow parent like
       // the reactive branch above so a static-then-reactive nesting still
       // hits the reactive path at the next level.
       if (childLevels.length > 0) {
-        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, mode, inner.param, inner.paramBindings)
+        emitInnerLoopSetup(ls, `${indent}  `, `__innerEl${uid}`, childLevels, inner.param, inner.paramBindings)
       }
       ls.push(`${indent}}) }`)
     }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -89,31 +89,18 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   const eventsArr = [...outerEvents]
   const levelsArr = [...depthLevels]
 
-  // SSR/CSR split — only the bits that genuinely differ live inside the
-  // if/else: __el initialisation and `emitComponentAndEventSetup`
-  // (createComponent vs initChild). Inner-loop setup is hoisted out below
-  // because the mapArray it emits is mode-independent — the outer if/else
-  // used to duplicate every inner loop's body verbatim (observation O-1).
-  lines.push(`${bodyIndent}let __el`)
-  lines.push(`${bodyIndent}if (__existing) {`)
-  lines.push(`${innerIndent}__el = __existing`)
-  emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'ssr', loopParam, loopParamBindings)
-  lines.push(`${bodyIndent}} else {`)
+  // __el is either the existing SSR-rendered element or a fresh clone of
+  // the template — both shapes accept the same mode-independent setup
+  // (upsertChild resolves SSR vs CSR per-component at runtime, inner-loop
+  // mapArrays are mode-independent by definition).
+  lines.push(`${bodyIndent}const __el = __existing ?? (() => {`)
   lines.push(`${innerIndent}const __tpl = document.createElement('template')`)
   lines.push(`${innerIndent}__tpl.innerHTML = \`${template}\``)
-  lines.push(`${innerIndent}__el = __tpl.content.firstElementChild.cloneNode(true)`)
-  emitComponentAndEventSetup(lines, innerIndent, '__el', compsArr, eventsArr, 'csr', loopParam, loopParamBindings)
-  lines.push(`${bodyIndent}}`)
-
-  // Inner-loop setup runs once for both SSR and CSR. The mode argument is
-  // forwarded to `emitInnerLoopSetup`'s static-forEach branch where it
-  // matters for inner `emitComponentAndEventSetup` calls; reactive inner
-  // loops dispatch SSR vs CSR per-item via mapArray's `__existing` check
-  // and don't read it. We pass `'ssr'` so a static inner loop nested
-  // inside a composite renderItem still gets the SSR initChild shape
-  // (matching the historical behaviour for hydration).
+  lines.push(`${innerIndent}return __tpl.content.firstElementChild.cloneNode(true)`)
+  lines.push(`${bodyIndent}})()`)
+  emitComponentAndEventSetup(lines, bodyIndent, '__el', compsArr, eventsArr, loopParam, loopParamBindings)
   if (levelsArr.length > 0) {
-    emitInnerLoopSetup(lines, bodyIndent, '__el', levelsArr, 'ssr', loopParam, loopParamBindings)
+    emitInnerLoopSetup(lines, bodyIndent, '__el', levelsArr, loopParam, loopParamBindings)
   }
 
   if (reactiveEffects) {

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -8,7 +8,7 @@ import type { ComponentIR, IRNode } from '../types'
 export const RUNTIME_IMPORT_CANDIDATES = [
   'createSignal', 'createMemo', 'createEffect', 'onCleanup', 'onMount',
   'hydrate', 'insert', 'reconcileElements', 'getLoopChildren', 'mapArray', 'createDisposableEffect',
-  'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'updateClientMarker',
+  'createComponent', 'renderChild', 'registerComponent', 'registerTemplate', 'initChild', 'upsertChild', 'updateClientMarker',
   'createPortal',
   'provideContext', 'createContext', 'useContext',
   'forwardProps', 'applyRestAttrs', 'splitProps', 'spreadAttrs', 'styleToCss',


### PR DESCRIPTION
## Summary

Adds \`upsertChild(parent, name, slotId, props, key?)\` to the client runtime — a single helper that resolves SSR (find existing scope + \`initChild\`) vs CSR (find placeholder + \`createComponent\` + \`replaceWith\`) at runtime. Returns the resolved element (or null when neither shape matches — already initialised on a previous reconcile pass).

This lets the compiler drop the \`mode: 'csr' | 'ssr'\` argument that \`emitComponentAndEventSetup\` (and transitively \`emitInnerLoopSetup\`) had to thread through every composite-loop call site. The hand-rolled \`if (__existing) { initChild(...) } else { createComponent + replaceWith }\` block at every call site collapses to a single \`upsertChild(...)\` call.

## Stacked on #1048 (which is stacked on #1047)

Review and merge #1047 → #1048 first; then GitHub will rebase this PR's base onto main.

## Cascade in the emit layer

| Site | Before | After |
|---|---|---|
| \`emitComponentAndEventSetup\` | takes \`mode\` arg, emits 2 different blocks per comp | no \`mode\`, emits 1 \`upsertChild(...)\` per comp |
| \`emitInnerLoopSetup\` | takes \`mode\` arg, threads it through recursion | no \`mode\` |
| \`emitBranchInnerLoops\` | wraps comp setup in \`if (!__existing) { csr } else { ssr }\` | one call, no split |
| \`stringify/composite-loop.ts\` | \`let __el; if (__existing) { __el = … } else { __el = … clone …}\` | \`const __el = __existing ?? (() => { … clone … })()\` (matches \`stringifyPlainLoop\`'s shape) |

## Concrete diff in generated code

For \`loop-nested-plain\` (composite, no nested comps): the composite renderItem now matches the plain-loop renderItem shape — one-liner \`__el\` initialisation, then inner-loop setup, then return.

For composites with nested comps (e.g. the \`composite-branch-loop\` test fixtures), each nested component goes from a 4-line SSR block + a 4-line CSR block paired inside an \`if (!__existing)\` to a single \`upsertChild(...)\` line — roughly halves the per-component emission.

## Tests touched

Two regression tests (\`composite-branch-loop.test.ts\`) asserted on the literal \`createComponent('Badge'\` / \`createComponent('Button'\` strings the old emitter produced. Updated to assert on \`upsertChild(...)\` + the component name in the new emission, with a comment explaining why.

## Test plan

- [x] \`bun test packages/jsx/src/__tests__/\` — 766 / 766 pass
- [x] \`bun test packages/adapter-tests/\` — 214 / 214 pass
- [x] \`bun test packages/client/\` — 212 / 212 pass
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean exit
- [x] \`bun run --filter '@barefootjs/client' build\` — clean exit