### PR TITLE
refactor(compiler): replace ReactiveEffectsPassthrough with structured ReactiveEffectsPlan

### DIFF
--- a/packages/jsx/src/ir-to-client-js/control-flow/legacy-helpers.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/legacy-helpers.ts
@@ -23,9 +23,10 @@ import type { BranchLoop, LoopChildEvent, LoopChildConditional, TopLevelLoop, Ne
 import type { IRLoopChildComponent, LoopParamBinding } from '../../types'
 import { varSlotId, quotePropName, DATA_BF_PH, keyAttrName, wrapLoopParamAsAccessor, exprReferencesIdent } from '../utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from '../html-template'
-import { emitAttrUpdate } from '../emit-reactive'
 import { buildBranchCompositePlan } from './plan/build-composite-loop'
 import { stringifyCompositeLoop } from './stringify/composite-loop'
+import { buildReactiveEffectsPlan } from './plan/build-reactive-effects'
+import { stringifyReactiveEffects } from './stringify/reactive-effects'
 import {
   buildBranchLoopDelegationPlan,
 } from './plan/build-event-delegation'
@@ -164,16 +165,14 @@ export function emitBranchLoopBody(lines: string[], branchLoops: readonly Branch
           lines.push(`          ${loop.mapPreamble}`)
         }
         lines.push(`          const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${loop.template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
-        emitLoopChildReactiveEffects(
-          lines,
-          '          ',
-          '__el',
-          loop.childReactiveAttrs ?? [],
-          loop.childReactiveTexts ?? [],
-          loop.childConditionals,
-          loop.param,
-          loop.paramBindings,
-        )
+        const branchReactivePlan = buildReactiveEffectsPlan({
+          attrs: loop.childReactiveAttrs ?? [],
+          texts: loop.childReactiveTexts ?? [],
+          conditionals: loop.childConditionals,
+          loopParam: loop.param,
+          loopParamBindings: loop.paramBindings,
+        })
+        stringifyReactiveEffects(lines, branchReactivePlan, { indent: '          ', elVar: '__el' })
         lines.push(`          return __el`)
         lines.push(`        })`)
       }
@@ -191,7 +190,7 @@ export function emitBranchLoopBody(lines: string[], branchLoops: readonly Branch
  * Used by both plain element and composite element dynamic loops.
  */
 /** Emit initChild calls for components inside a conditional branch. */
-function emitBranchChildComponentInits(
+export function emitBranchChildComponentInits(
   lines: string[],
   indent: string,
   components: Array<{ name: string; slotId: string | null; props: import('../../types').IRProp[]; children?: import('../../types').IRNode[] }>,
@@ -232,7 +231,7 @@ function emitBranchChildComponentInits(
  * the inner loop container only exists when the branch is active.
  * This sets up mapArray each time the branch activates.
  */
-function emitBranchInnerLoops(
+export function emitBranchInnerLoops(
   lines: string[],
   indent: string,
   scopeVar: string,
@@ -333,7 +332,7 @@ function emitBranchInnerLoops(
  * Events must be bound after insert() resolves the branch, so the correct DOM element
  * is live (prevents stale-reference bug when insert() replaces SSR elements, #839).
  */
-function emitLoopCondBranchEventBindings(
+export function emitLoopCondBranchEventBindings(
   lines: string[],
   indent: string,
   events: import('../types').ConditionalBranchEvent[] | undefined,
@@ -366,7 +365,7 @@ function emitLoopCondBranchEventBindings(
  * Handles Path A (conditional→conditional) and Path B (loop→conditional) by
  * mutual recursion with emitBranchInnerLoops (#830).
  */
-function emitNestedLoopChildConditionals(
+export function emitNestedLoopChildConditionals(
   lines: string[],
   indent: string,
   scopeVar: string,
@@ -396,101 +395,6 @@ function emitNestedLoopChildConditionals(
     emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam, loopParamBindings)
     lines.push(`${indent}  }`)
     lines.push(`${indent}})`)
-  }
-}
-
-export function emitLoopChildReactiveEffects(
-  lines: string[],
-  indent: string,
-  elVar: string,
-  attrs: TopLevelLoop['childReactiveAttrs'],
-  texts: TopLevelLoop['childReactiveTexts'],
-  conditionals?: TopLevelLoop['childConditionals'],
-  loopParam?: string,
-  loopParamBindings?: readonly LoopParamBinding[],
-): void {
-  const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr
-  // Reactive attribute effects
-  const attrsBySlot = new Map<string, typeof attrs>()
-  for (const attr of attrs) {
-    if (!attrsBySlot.has(attr.childSlotId)) {
-      attrsBySlot.set(attr.childSlotId, [])
-    }
-    attrsBySlot.get(attr.childSlotId)!.push(attr)
-  }
-  for (const [slotId, slotAttrs] of attrsBySlot) {
-    const varName = `__ra_${varSlotId(slotId)}`
-    lines.push(`${indent}{ const ${varName} = qsa(${elVar}, '[bf="${slotId}"]')`)
-    lines.push(`${indent}if (${varName}) {`)
-    for (const attr of slotAttrs) {
-      lines.push(`${indent}  createEffect(() => {`)
-      for (const stmt of emitAttrUpdate(varName, attr.attrName, wrap(attr.expression), attr)) {
-        lines.push(`${indent}    ${stmt}`)
-      }
-      lines.push(`${indent}  })`)
-    }
-    lines.push(`${indent}} }`)
-  }
-
-  // Collect text slot IDs that are inside conditionals — these must be
-  // emitted inside bindEvents, not outside, because insert() branch swaps
-  // replace the DOM nodes that text effects reference.
-  const textSlotsInConditionals = new Set<string>()
-  if (conditionals) {
-    for (const cond of conditionals) {
-      for (const text of texts) {
-        if (cond.whenTrueHtml.includes(`bf:${text.slotId}`) || cond.whenFalseHtml.includes(`bf:${text.slotId}`)) {
-          textSlotsInConditionals.add(text.slotId)
-        }
-      }
-    }
-  }
-
-  // Reactive text content effects (only for slots NOT inside conditionals)
-  for (const text of texts) {
-    if (textSlotsInConditionals.has(text.slotId)) continue
-    const varName = `__rt_${varSlotId(text.slotId)}`
-    lines.push(`${indent}{ const [${varName}] = $t(${elVar}, '${text.slotId}')`)
-    lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${wrap(text.expression)}) }) }`)
-  }
-
-  // Reactive conditional effects
-  if (conditionals) {
-    // Text effects scoped to each branch
-    const textsForBranch = (html: string) =>
-      texts.filter(t => textSlotsInConditionals.has(t.slotId) && html.includes(`bf:${t.slotId}`))
-
-    for (const cond of conditionals) {
-      const whenTrueWithCond = addCondAttrToTemplate(wrap(cond.whenTrueHtml), cond.slotId)
-      const whenFalseWithCond = addCondAttrToTemplate(wrap(cond.whenFalseHtml), cond.slotId)
-      lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${wrap(cond.condition)}, {`)
-      lines.push(`${indent}  template: () => \`${whenTrueWithCond}\`,`)
-      lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenTrue.events, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenTrue.childComponents, loopParam, undefined, loopParamBindings)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenTrue.innerLoops, loopParam, undefined, loopParamBindings)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenTrue.conditionals, wrap, loopParam, loopParamBindings)
-      for (const text of textsForBranch(cond.whenTrueHtml)) {
-        const varName = `__rt_${varSlotId(text.slotId)}`
-        lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
-        lines.push(`${indent}    if (${varName}) createEffect(() => { ${varName}.textContent = String(${wrap(text.expression)}) }) }`)
-      }
-      lines.push(`${indent}  }`)
-      lines.push(`${indent}}, {`)
-      lines.push(`${indent}  template: () => \`${whenFalseWithCond}\`,`)
-      lines.push(`${indent}  bindEvents: (__branchScope) => {`)
-      emitLoopCondBranchEventBindings(lines, `${indent}    `, cond.whenFalse.events, wrap)
-      emitBranchChildComponentInits(lines, `${indent}    `, cond.whenFalse.childComponents, loopParam, undefined, loopParamBindings)
-      emitBranchInnerLoops(lines, `${indent}    `, '__branchScope', cond.whenFalse.innerLoops, loopParam, undefined, loopParamBindings)
-      emitNestedLoopChildConditionals(lines, `${indent}    `, '__branchScope', cond.whenFalse.conditionals, wrap, loopParam, loopParamBindings)
-      for (const text of textsForBranch(cond.whenFalseHtml)) {
-        const varName = `__rt_${varSlotId(text.slotId)}`
-        lines.push(`${indent}    { const [${varName}] = $t(__branchScope, '${text.slotId}')`)
-        lines.push(`${indent}    if (${varName}) createEffect(() => { ${varName}.textContent = String(${wrap(text.expression)}) }) }`)
-      }
-      lines.push(`${indent}  }`)
-      lines.push(`${indent}})`)
-    }
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -8,10 +8,7 @@
  *   - whether each nested component's children should reactive-update via
  *     `createEffect` based on text-only-and-references-loop-param detection
  *   - the wrapped key argument for `createComponent(name, props, KEY)`
- *
- * Reactive effects on `childConditionals` are still routed through
- * `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`, matching
- * PR 2-a's strategy.
+ *   - a fully resolved `ReactiveEffectsPlan` for `childConditionals`
  */
 
 import type { TopLevelLoop } from '../../types'
@@ -29,6 +26,7 @@ import {
   isTextOnlyConditional,
 } from '../legacy-helpers'
 import { irChildrenToJsExpr } from '../../html-template'
+import { buildReactiveEffectsPlan } from './build-reactive-effects'
 import type { ComponentLoopPlan, NestedComponentInit } from './types'
 
 export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
@@ -70,13 +68,13 @@ export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
     keyExpr,
     nestedComps,
     childConditionalEffects: hasChildConds
-      ? {
+      ? buildReactiveEffectsPlan({
           attrs: [],
           texts: [],
           conditionals: elem.childConditionals,
           loopParam: elem.param,
           loopParamBindings: elem.paramBindings,
-        }
+        })
       : null,
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
@@ -20,6 +20,7 @@ import {
   destructureLoopParam,
   buildDepthLevels,
 } from '../legacy-helpers'
+import { buildReactiveEffectsPlan } from './build-reactive-effects'
 import type { CompositeLoopPlan } from './types'
 
 export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPlan {
@@ -46,13 +47,13 @@ export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPla
     loopParam: elem.param,
     loopParamBindings: elem.paramBindings,
     reactiveEffects: hasReactive(elem)
-      ? {
+      ? buildReactiveEffectsPlan({
           attrs: elem.childReactiveAttrs ?? [],
           texts: elem.childReactiveTexts ?? [],
           conditionals: elem.childConditionals,
           loopParam: elem.param,
           loopParamBindings: elem.paramBindings,
-        }
+        })
       : null,
     branchClearChildren: false,
     topIndent: '  ',
@@ -88,13 +89,13 @@ export function buildBranchCompositePlan(loop: BranchLoop, cv: string): Composit
     loopParam: loop.param,
     loopParamBindings: loop.paramBindings,
     reactiveEffects: hasReactiveBranch(loop)
-      ? {
+      ? buildReactiveEffectsPlan({
           attrs: loop.childReactiveAttrs ?? [],
           texts: loop.childReactiveTexts ?? [],
           conditionals: loop.childConditionals,
           loopParam: loop.param,
           loopParamBindings: loop.paramBindings,
-        }
+        })
       : null,
     branchClearChildren: true,
     topIndent: '      ',

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -21,6 +21,7 @@ import {
   loopKeyFn,
   destructureLoopParam,
 } from '../legacy-helpers'
+import { buildLoopReactiveEffectsPlan } from './build-reactive-effects'
 import type { PlainLoopPlan, StaticLoopPlan } from './types'
 
 export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
@@ -40,15 +41,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
     indexParam: elem.index || '__idx',
     mapPreambleWrapped: elem.mapPreamble ? wrap(elem.mapPreamble) : '',
     template: elem.template,
-    reactiveEffects: hasReactive
-      ? {
-          attrs: elem.childReactiveAttrs,
-          texts: elem.childReactiveTexts,
-          conditionals: elem.childConditionals,
-          loopParam: elem.param,
-          loopParamBindings: elem.paramBindings,
-        }
-      : null,
+    reactiveEffects: hasReactive ? buildLoopReactiveEffectsPlan(elem) : null,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
@@ -1,0 +1,154 @@
+/**
+ * Build a `ReactiveEffectsPlan` from the loop's IR fields.
+ *
+ * Decisions resolved at build time (no longer in the stringifier):
+ *   1. Group reactive attrs by `childSlotId` (one qsa() lookup per slot).
+ *   2. Wrap every attr / text / condition expression via
+ *      `wrapLoopParamAsAccessor` so the stringifier never touches the wrap.
+ *   3. Partition reactive texts: those whose slot id appears inside any
+ *      conditional branch HTML must be emitted *inside* that branch's
+ *      `bindEvents` (insert() may replace the DOM nodes), the rest stay in
+ *      the outer renderItem scope.
+ *   4. Apply `addCondAttrToTemplate` to the wrapped branch HTML so the
+ *      stringifier emits a ready-to-interpolate template literal.
+ *
+ * The arm bodies (events / child components / inner loops / nested
+ * conditionals) remain raw — handed back to the legacy helpers via
+ * `legacyWhenTrue` / `legacyWhenFalse`. Item 2 plan-ifies those bodies and
+ * removes the legacy fields.
+ */
+
+import type {
+  TopLevelLoop,
+  LoopChildConditional,
+  LoopChildReactiveAttr,
+  LoopChildReactiveText,
+} from '../../types'
+import type { LoopParamBinding } from '../../../types'
+import { pickAttrMeta } from '../../../types'
+import { wrapLoopParamAsAccessor } from '../../utils'
+import { addCondAttrToTemplate } from '../../html-template'
+import type {
+  NestedConditionalPlan,
+  ReactiveAttrSlot,
+  ReactiveEffectsPlan,
+  ReactiveTextEffect,
+} from './reactive-effects'
+
+export interface BuildReactiveEffectsArgs {
+  attrs: readonly LoopChildReactiveAttr[]
+  texts: readonly LoopChildReactiveText[]
+  conditionals: readonly LoopChildConditional[] | undefined
+  loopParam: string
+  loopParamBindings?: readonly LoopParamBinding[]
+}
+
+/** Build a fully-resolved `ReactiveEffectsPlan` from the IR slice. */
+export function buildReactiveEffectsPlan(
+  args: BuildReactiveEffectsArgs,
+): ReactiveEffectsPlan {
+  const { attrs, texts, conditionals, loopParam, loopParamBindings } = args
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings)
+
+  // 1. Group attrs by slot, preserving declaration order (Map insertion order
+  //    matches the legacy iteration that produced byte-identical output).
+  const attrsBySlot = new Map<string, LoopChildReactiveAttr[]>()
+  for (const attr of attrs) {
+    let bucket = attrsBySlot.get(attr.childSlotId)
+    if (!bucket) {
+      bucket = []
+      attrsBySlot.set(attr.childSlotId, bucket)
+    }
+    bucket.push(attr)
+  }
+  const attrSlots: ReactiveAttrSlot[] = []
+  for (const [slotId, slotAttrs] of attrsBySlot) {
+    attrSlots.push({
+      slotId,
+      attrs: slotAttrs.map(attr => ({
+        attrName: attr.attrName,
+        wrappedExpression: wrap(attr.expression),
+        meta: pickAttrMeta(attr),
+      })),
+    })
+  }
+
+  // 2. Identify text slots that must be deferred into a conditional branch's
+  //    bindEvents. The check mirrors the legacy `cond.whenXxxHtml.includes(
+  //    'bf:' + slotId)` heuristic — the rendered template HTML is the only
+  //    pre-runtime signal available.
+  const textSlotsInConditionals = new Set<string>()
+  if (conditionals) {
+    for (const cond of conditionals) {
+      for (const text of texts) {
+        if (
+          cond.whenTrueHtml.includes(`bf:${text.slotId}`) ||
+          cond.whenFalseHtml.includes(`bf:${text.slotId}`)
+        ) {
+          textSlotsInConditionals.add(text.slotId)
+        }
+      }
+    }
+  }
+
+  const outerTexts: ReactiveTextEffect[] = []
+  for (const text of texts) {
+    if (textSlotsInConditionals.has(text.slotId)) continue
+    outerTexts.push({
+      slotId: text.slotId,
+      wrappedExpression: wrap(text.expression),
+    })
+  }
+
+  // 3. Per-conditional plans. Branch-scoped texts are partitioned by which
+  //    branch HTML mentions the slot (declaration order preserved). The
+  //    legacy emitter scanned `texts` once per branch with the same check.
+  const conditionalPlans: NestedConditionalPlan[] = []
+  if (conditionals) {
+    for (const cond of conditionals) {
+      const trueTexts: ReactiveTextEffect[] = []
+      const falseTexts: ReactiveTextEffect[] = []
+      for (const text of texts) {
+        if (!textSlotsInConditionals.has(text.slotId)) continue
+        const wrapped: ReactiveTextEffect = {
+          slotId: text.slotId,
+          wrappedExpression: wrap(text.expression),
+        }
+        if (cond.whenTrueHtml.includes(`bf:${text.slotId}`)) trueTexts.push(wrapped)
+        if (cond.whenFalseHtml.includes(`bf:${text.slotId}`)) falseTexts.push(wrapped)
+      }
+      conditionalPlans.push({
+        slotId: cond.slotId,
+        wrappedCondition: wrap(cond.condition),
+        whenTrueTemplateHtml: addCondAttrToTemplate(wrap(cond.whenTrueHtml), cond.slotId),
+        whenFalseTemplateHtml: addCondAttrToTemplate(wrap(cond.whenFalseHtml), cond.slotId),
+        whenTrueTexts: trueTexts,
+        whenFalseTexts: falseTexts,
+        legacyWhenTrue: cond.whenTrue,
+        legacyWhenFalse: cond.whenFalse,
+        loopParam,
+        loopParamBindings,
+      })
+    }
+  }
+
+  return {
+    attrSlots,
+    outerTexts,
+    conditionals: conditionalPlans,
+  }
+}
+
+/**
+ * Convenience: build a ReactiveEffectsPlan directly from a `TopLevelLoop`,
+ * pulling the same IR slice the legacy emitter consumed.
+ */
+export function buildLoopReactiveEffectsPlan(elem: TopLevelLoop): ReactiveEffectsPlan {
+  return buildReactiveEffectsPlan({
+    attrs: elem.childReactiveAttrs ?? [],
+    texts: elem.childReactiveTexts ?? [],
+    conditionals: elem.childConditionals,
+    loopParam: elem.param,
+    loopParamBindings: elem.paramBindings,
+  })
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/common.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/common.ts
@@ -1,18 +1,10 @@
 /**
  * Plan-layer types shared across multiple Plan kinds.
  *
- * `ScopeRef` discriminates which scope variable to use in the runtime call;
- * `ReactiveEffectsPassthrough` is a transitional carrier for IR fields that
- * still flow through the legacy `emitLoopChildReactiveEffects` helper. PR
- * 5+ will replace it with a structured `ReactiveEffectsPlan`.
+ * `ScopeRef` discriminates which scope variable to use in the runtime call
+ * (top-level `__scope`, branch-scoped `__branchScope`, or a named loop element
+ * variable like `__el`).
  */
-
-import type {
-  LoopChildConditional,
-  LoopChildReactiveAttr,
-  LoopChildReactiveText,
-  TopLevelLoop,
-} from '../../types'
 
 /**
  * The scope variable to pass as the first argument of insert(...) /
@@ -24,16 +16,3 @@ export type ScopeRef =
   | { kind: 'top' }                         // emits `__scope`
   | { kind: 'branchScope' }                 // emits `__branchScope`
   | { kind: 'var'; name: string }           // emits the literal variable name
-
-/**
- * Loaned-IR carrier for emitLoopChildReactiveEffects. PR 5+ replaces this
- * with a structured ReactiveEffectsPlan that addresses O-3 (key dedup) at
- * the builder level.
- */
-export interface ReactiveEffectsPassthrough {
-  attrs: LoopChildReactiveAttr[]
-  texts: LoopChildReactiveText[]
-  conditionals: LoopChildConditional[] | undefined
-  loopParam: string
-  loopParamBindings: TopLevelLoop['paramBindings']
-}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../types'
 import type { IRLoopChildComponent } from '../../../types'
 import type { DepthLevel } from '../legacy-helpers'
-import type { ReactiveEffectsPassthrough } from './common'
+import type { ReactiveEffectsPlan } from './reactive-effects'
 
 /**
  * Plan for a top-level dynamic loop with a plain element body (no child
@@ -46,12 +46,12 @@ export interface PlainLoopPlan {
   /** HTML template string for one item. */
   template: string
   /**
-   * Carried IR fields for legacy `emitLoopChildReactiveEffects` passthrough.
-   * `null` means there are no reactive effects; the stringifier emits the
-   * single-line renderItem in that case. PR 5+ will replace this with
-   * structured `ReactiveEffectsPlan`.
+   * Fully-resolved reactive-effects plan (attrs / texts / conditionals). When
+   * `null`, the stringifier emits the single-line renderItem. The Plan is
+   * built by `buildReactiveEffectsPlan` — every wrap and partition decision
+   * is already made.
    */
-  reactiveEffects: ReactiveEffectsPassthrough | null
+  reactiveEffects: ReactiveEffectsPlan | null
 }
 
 /**
@@ -64,9 +64,8 @@ export interface PlainLoopPlan {
  * `nestedComps.length > 0`    → emit the SSR/CSR split that initialises both
  *                               the outer component and each nested child.
  *
- * Reactive-effects construction inside `childConditionals` is delegated to
- * the legacy `emitLoopChildReactiveEffects` via `ReactiveEffectsPassthrough`,
- * mirroring the PlainLoopPlan strategy.
+ * Reactive-effects construction inside `childConditionals` is now a fully
+ * resolved `ReactiveEffectsPlan` — same shape as `PlainLoopPlan.reactiveEffects`.
  */
 export interface ComponentLoopPlan {
   kind: 'component-loop'
@@ -84,8 +83,12 @@ export interface ComponentLoopPlan {
   keyExpr: string
   /** Nested child component initialisers; empty for the simple case. */
   nestedComps: NestedComponentInit[]
-  /** Carried IR for legacy reactive-effects passthrough; null when there's nothing to emit. */
-  childConditionalEffects: ReactiveEffectsPassthrough | null
+  /**
+   * Reactive-effects plan for `childConditionals` inside the loop body. Only
+   * populated when conditionals exist (attrs / texts in this shape go through
+   * the per-component nested-init effect, not this plan).
+   */
+  childConditionalEffects: ReactiveEffectsPlan | null
 }
 
 /**
@@ -146,7 +149,7 @@ export interface CompositeLoopPlan {
   /** Destructured-binding metadata for the loop param. */
   loopParamBindings: TopLevelLoop['paramBindings']
   /** Reactive effects rendered after the SSR/CSR split. */
-  reactiveEffects: ReactiveEffectsPassthrough | null
+  reactiveEffects: ReactiveEffectsPlan | null
   /**
    * When true, the stringifier prepends a `getLoopChildren(...).forEach(__el
    * => __el.remove())` line — branch composite loops need this so mapArray

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
@@ -1,0 +1,77 @@
+/**
+ * Plan types for emitting reactive effects (attrs, texts, conditionals)
+ * inside a loop item's renderItem body.
+ *
+ * Every emission decision (attr-by-slot grouping, text-inside-conditional
+ * partition, loop-param wrapping) is resolved at build time so the
+ * stringifier becomes a deterministic walk of pre-computed data.
+ *
+ * Inner branch bodies (events, child component inits, inner loops, nested
+ * conditionals) are still routed through the legacy helpers — Item 2 of the
+ * `tmp/emit-survey/HANDOFF.md` plan replaces those with their own Plans and
+ * removes the `legacyWhenTrue` / `legacyWhenFalse` fields.
+ */
+
+import type { AttrMeta, LoopParamBinding } from '../../../types'
+import type { LoopChildBranchSummary } from '../../types'
+
+/** A single reactive attribute effect (one createEffect block). */
+export interface ReactiveAttrEffect {
+  attrName: string
+  /** Already wrapped via wrapLoopParamAsAccessor at build time. */
+  wrappedExpression: string
+  /** Pre-copied attr metadata used by emitAttrUpdate. */
+  meta: AttrMeta
+}
+
+/** Reactive attrs grouped by child slot (one qsa lookup per slot). */
+export interface ReactiveAttrSlot {
+  slotId: string
+  attrs: readonly ReactiveAttrEffect[]
+}
+
+/** A reactive text effect (one createEffect updating textContent). */
+export interface ReactiveTextEffect {
+  slotId: string
+  /** Already wrapped via wrapLoopParamAsAccessor at build time. */
+  wrappedExpression: string
+}
+
+/**
+ * Plan for one reactive conditional inside a loop scope. The HTML and
+ * condition are wrapped at build time; per-arm reactive text effects are
+ * partitioned out of the outer text list. The arm bodies themselves
+ * (events / child components / inner loops / nested conditionals) are still
+ * delegated to the legacy helpers via `legacyWhenTrue` / `legacyWhenFalse`.
+ */
+export interface NestedConditionalPlan {
+  slotId: string
+  /** Wrapped condition expression (already through wrapLoopParamAsAccessor). */
+  wrappedCondition: string
+  /** Wrapped + addCondAttrToTemplate'd whenTrue HTML — ready for `\`...\``. */
+  whenTrueTemplateHtml: string
+  /** Wrapped + addCondAttrToTemplate'd whenFalse HTML. */
+  whenFalseTemplateHtml: string
+  /** Texts whose slot lives in whenTrue's HTML — emitted inside whenTrue's bindEvents. */
+  whenTrueTexts: readonly ReactiveTextEffect[]
+  /** Texts whose slot lives in whenFalse's HTML. */
+  whenFalseTexts: readonly ReactiveTextEffect[]
+  /**
+   * Branch summaries kept verbatim for the legacy bindEvents emitters
+   * (events / child components / inner loops / nested conditionals). Item 2
+   * Plan-ifies these and removes the field.
+   */
+  legacyWhenTrue: LoopChildBranchSummary
+  legacyWhenFalse: LoopChildBranchSummary
+  /** Loop param identifier — needed by the legacy passthroughs. */
+  loopParam: string
+  /** Destructured-binding metadata for the loop param. */
+  loopParamBindings?: readonly LoopParamBinding[]
+}
+
+export interface ReactiveEffectsPlan {
+  attrSlots: readonly ReactiveAttrSlot[]
+  /** Text effects scoped to the outer renderItem (not inside any conditional). */
+  outerTexts: readonly ReactiveTextEffect[]
+  conditionals: readonly NestedConditionalPlan[]
+}

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -4,7 +4,10 @@
  * The actual type definitions live in dedicated files alongside the
  * builders / stringifiers that produce / consume them:
  *
- *   common.ts            — `ScopeRef`, `ReactiveEffectsPassthrough`
+ *   common.ts            — `ScopeRef`
+ *   reactive-effects.ts  — `ReactiveEffectsPlan`, `ReactiveAttrSlot`,
+ *                          `ReactiveAttrEffect`, `ReactiveTextEffect`,
+ *                          `NestedConditionalPlan`
  *   insert.ts            — `InsertPlan` family (arms, bindings)
  *   loop.ts              — `PlainLoopPlan`, `ComponentLoopPlan`,
  *                          `CompositeLoopPlan`, `StaticLoopPlan`,
@@ -16,7 +19,14 @@
  * a particular Plan type lives in.
  */
 
-export type { ScopeRef, ReactiveEffectsPassthrough } from './common'
+export type { ScopeRef } from './common'
+export type {
+  ReactiveEffectsPlan,
+  ReactiveAttrSlot,
+  ReactiveAttrEffect,
+  ReactiveTextEffect,
+  NestedConditionalPlan,
+} from './reactive-effects'
 export type {
   InsertPlan,
   InsertArm,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
@@ -17,12 +17,12 @@
  *     <i>  if (__existing) {
  *     <i>    initChild('<C>', __existing, <props>)
  *     <i>    {<each nested initChild + optional createEffect>}
- *     <i>    <emitLoopChildReactiveEffects on __existing if childConditionals>
+ *     <i>    <stringifyReactiveEffects on __existing if childConditionals>
  *     <i>    return __existing
  *     <i>  }
  *     <i>  const __csrEl = createComponent('<C>', <props>, <key>)
  *     <i>  {<each nested initChild + optional createEffect>}
- *     <i>  <emitLoopChildReactiveEffects on __csrEl if childConditionals>
+ *     <i>  <stringifyReactiveEffects on __csrEl if childConditionals>
  *     <i>  return __csrEl
  *     <i>})
  *
@@ -30,7 +30,7 @@
  * SSR-side nested-comp lines use 6 spaces (matches legacy).
  */
 
-import { emitLoopChildReactiveEffects } from '../legacy-helpers'
+import { stringifyReactiveEffects } from './reactive-effects'
 import type { ComponentLoopPlan, NestedComponentInit } from '../plan/types'
 
 export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan): void {
@@ -63,14 +63,7 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
   lines.push(`      initChild('${componentName}', __existing, ${componentPropsExpr})`)
   for (const nc of nestedComps) emitNestedInit(lines, '      ', '__existing', nc)
   if (childConditionalEffects) {
-    emitLoopChildReactiveEffects(
-      lines, '      ', '__existing',
-      childConditionalEffects.attrs,
-      childConditionalEffects.texts,
-      childConditionalEffects.conditionals,
-      childConditionalEffects.loopParam,
-      childConditionalEffects.loopParamBindings,
-    )
+    stringifyReactiveEffects(lines, childConditionalEffects, { indent: '      ', elVar: '__existing' })
   }
   lines.push(`      return __existing`)
   lines.push(`    }`)
@@ -79,14 +72,7 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
   lines.push(`    const __csrEl = createComponent('${componentName}', ${componentPropsExpr}, ${keyExpr})`)
   for (const nc of nestedComps) emitNestedInit(lines, '    ', '__csrEl', nc)
   if (childConditionalEffects) {
-    emitLoopChildReactiveEffects(
-      lines, '    ', '__csrEl',
-      childConditionalEffects.attrs,
-      childConditionalEffects.texts,
-      childConditionalEffects.conditionals,
-      childConditionalEffects.loopParam,
-      childConditionalEffects.loopParamBindings,
-    )
+    stringifyReactiveEffects(lines, childConditionalEffects, { indent: '    ', elVar: '__csrEl' })
   }
   lines.push(`    return __csrEl`)
   lines.push(`  })`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -20,7 +20,7 @@
  *   <bodyIndent>  <emitComponentAndEventSetup csr>
  *   <bodyIndent>  <emitInnerLoopSetup csr>
  *   <bodyIndent>}
- *   <bodyIndent><emitLoopChildReactiveEffects?>
+ *   <bodyIndent><stringifyReactiveEffects?>
  *   <bodyIndent>return __el
  *   <topIndent>})
  *
@@ -33,8 +33,8 @@
 import {
   emitComponentAndEventSetup,
   emitInnerLoopSetup,
-  emitLoopChildReactiveEffects,
 } from '../legacy-helpers'
+import { stringifyReactiveEffects } from './reactive-effects'
 import type { CompositeLoopPlan } from '../plan/types'
 
 export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan): void {
@@ -104,14 +104,7 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   }
 
   if (reactiveEffects) {
-    emitLoopChildReactiveEffects(
-      lines, bodyIndent, '__el',
-      reactiveEffects.attrs,
-      reactiveEffects.texts,
-      reactiveEffects.conditionals,
-      reactiveEffects.loopParam,
-      reactiveEffects.loopParamBindings,
-    )
+    stringifyReactiveEffects(lines, reactiveEffects, { indent: bodyIndent, elVar: '__el' })
   }
 
   lines.push(`${bodyIndent}return __el`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -12,7 +12,7 @@
  *     <indent>  <unwrap?>
  *     <indent>  <preamble?>
  *     <indent>  const __el = __existing ?? (() => { ... })()
- *     <indent>  <reactive effects via emitLoopChildReactiveEffects>
+ *     <indent>  <reactive effects via stringifyReactiveEffects>
  *     <indent>  return __el
  *     <indent>})
  *
@@ -25,8 +25,8 @@
  */
 
 import { varSlotId } from '../../utils'
-import { emitLoopChildReactiveEffects } from '../legacy-helpers'
 import { emitAttrUpdate } from '../../emit-reactive'
+import { stringifyReactiveEffects } from './reactive-effects'
 import type { PlainLoopPlan, StaticLoopPlan } from '../plan/types'
 
 export function stringifyPlainLoop(
@@ -62,16 +62,7 @@ export function stringifyPlainLoop(
   if (paramUnwrap) lines.push(`${bodyIndent}${paramUnwrap}`)
   if (mapPreambleWrapped) lines.push(`${bodyIndent}${mapPreambleWrapped}`)
   lines.push(`${bodyIndent}const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
-  emitLoopChildReactiveEffects(
-    lines,
-    bodyIndent,
-    '__el',
-    reactiveEffects.attrs,
-    reactiveEffects.texts,
-    reactiveEffects.conditionals,
-    reactiveEffects.loopParam,
-    reactiveEffects.loopParamBindings,
-  )
+  stringifyReactiveEffects(lines, reactiveEffects, { indent: bodyIndent, elVar: '__el' })
   lines.push(`${bodyIndent}return __el`)
   lines.push(`${topIndent}})`)
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -1,0 +1,128 @@
+/**
+ * Stringify a `ReactiveEffectsPlan` into source lines.
+ *
+ * The stringifier is a deterministic walk: every wrap and every partition
+ * decision was already made by `buildReactiveEffectsPlan`.
+ *
+ * Conditional arm bodies (events / child component inits / inner loops /
+ * nested conditionals) still flow through the legacy helpers — Item 2 of
+ * `tmp/emit-survey/HANDOFF.md` Plan-ifies those next.
+ */
+
+import { varSlotId, wrapLoopParamAsAccessor } from '../../utils'
+import { emitAttrUpdate } from '../../emit-reactive'
+import {
+  emitBranchChildComponentInits,
+  emitBranchInnerLoops,
+  emitLoopCondBranchEventBindings,
+  emitNestedLoopChildConditionals,
+} from '../legacy-helpers'
+import type {
+  NestedConditionalPlan,
+  ReactiveEffectsPlan,
+  ReactiveTextEffect,
+} from '../plan/reactive-effects'
+
+export interface StringifyReactiveEffectsOptions {
+  /** Indent prefix for every emitted line. */
+  indent: string
+  /**
+   * Element variable to attach effects to (e.g., `__el`, `__existing`,
+   * `__csrEl`). The stringifier never inspects it — it is simply substituted
+   * into the qsa() / $t() call shapes.
+   */
+  elVar: string
+}
+
+export function stringifyReactiveEffects(
+  lines: string[],
+  plan: ReactiveEffectsPlan,
+  opts: StringifyReactiveEffectsOptions,
+): void {
+  const { indent, elVar } = opts
+
+  // 1. Reactive attribute effects (one qsa per slot, then per-attr createEffect).
+  for (const slot of plan.attrSlots) {
+    const varName = `__ra_${varSlotId(slot.slotId)}`
+    lines.push(`${indent}{ const ${varName} = qsa(${elVar}, '[bf="${slot.slotId}"]')`)
+    lines.push(`${indent}if (${varName}) {`)
+    for (const attr of slot.attrs) {
+      lines.push(`${indent}  createEffect(() => {`)
+      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
+        lines.push(`${indent}    ${stmt}`)
+      }
+      lines.push(`${indent}  })`)
+    }
+    lines.push(`${indent}} }`)
+  }
+
+  // 2. Outer text effects (slots NOT inside any conditional branch).
+  for (const text of plan.outerTexts) {
+    emitOuterText(lines, indent, elVar, text)
+  }
+
+  // 3. Reactive conditionals — each emits an insert(...) with arm bodies that
+  //    still delegate to the legacy bindEvents emitters (Item 2).
+  for (const cond of plan.conditionals) {
+    emitConditional(lines, indent, elVar, cond)
+  }
+}
+
+function emitOuterText(
+  lines: string[],
+  indent: string,
+  elVar: string,
+  text: ReactiveTextEffect,
+): void {
+  const varName = `__rt_${varSlotId(text.slotId)}`
+  lines.push(`${indent}{ const [${varName}] = $t(${elVar}, '${text.slotId}')`)
+  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }) }`)
+}
+
+function emitBranchText(
+  lines: string[],
+  indent: string,
+  text: ReactiveTextEffect,
+): void {
+  const varName = `__rt_${varSlotId(text.slotId)}`
+  lines.push(`${indent}{ const [${varName}] = $t(__branchScope, '${text.slotId}')`)
+  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }) }`)
+}
+
+function emitConditional(
+  lines: string[],
+  indent: string,
+  elVar: string,
+  cond: NestedConditionalPlan,
+): void {
+  // Re-derive the wrap closure for the legacy passthrough helpers; they each
+  // accept a `wrap` function. wrapLoopParamAsAccessor is idempotent — applying
+  // it to already-wrapped Plan strings would be a re-wrap bug, so the closure
+  // is only handed to helpers that receive *unwrapped* IR data.
+  const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, cond.loopParam, cond.loopParamBindings)
+  const armIndent = `${indent}    `
+
+  lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
+  lines.push(`${indent}  template: () => \`${cond.whenTrueTemplateHtml}\`,`)
+  lines.push(`${indent}  bindEvents: (__branchScope) => {`)
+  emitLoopCondBranchEventBindings(lines, armIndent, cond.legacyWhenTrue.events, wrap)
+  emitBranchChildComponentInits(lines, armIndent, cond.legacyWhenTrue.childComponents, cond.loopParam, undefined, cond.loopParamBindings)
+  emitBranchInnerLoops(lines, armIndent, '__branchScope', cond.legacyWhenTrue.innerLoops, cond.loopParam, undefined, cond.loopParamBindings)
+  emitNestedLoopChildConditionals(lines, armIndent, '__branchScope', cond.legacyWhenTrue.conditionals, wrap, cond.loopParam, cond.loopParamBindings)
+  for (const text of cond.whenTrueTexts) {
+    emitBranchText(lines, armIndent, text)
+  }
+  lines.push(`${indent}  }`)
+  lines.push(`${indent}}, {`)
+  lines.push(`${indent}  template: () => \`${cond.whenFalseTemplateHtml}\`,`)
+  lines.push(`${indent}  bindEvents: (__branchScope) => {`)
+  emitLoopCondBranchEventBindings(lines, armIndent, cond.legacyWhenFalse.events, wrap)
+  emitBranchChildComponentInits(lines, armIndent, cond.legacyWhenFalse.childComponents, cond.loopParam, undefined, cond.loopParamBindings)
+  emitBranchInnerLoops(lines, armIndent, '__branchScope', cond.legacyWhenFalse.innerLoops, cond.loopParam, undefined, cond.loopParamBindings)
+  emitNestedLoopChildConditionals(lines, armIndent, '__branchScope', cond.legacyWhenFalse.conditionals, wrap, cond.loopParam, cond.loopParamBindings)
+  for (const text of cond.whenFalseTexts) {
+    emitBranchText(lines, armIndent, text)
+  }
+  lines.push(`${indent}  }`)
+  lines.push(`${indent}})`)
+}


### PR DESCRIPTION
## Summary

Item 1 of `tmp/emit-survey/HANDOFF.md`. Move every emission decision out of the legacy `emitLoopChildReactiveEffects` helper into a build-time Plan so the stringifier becomes a deterministic walk of pre-computed data.

- New `plan/reactive-effects.ts` types — `ReactiveEffectsPlan`, `ReactiveAttrSlot`, `ReactiveAttrEffect`, `ReactiveTextEffect`, `NestedConditionalPlan` — replacing the old `ReactiveEffectsPassthrough` carrier.
- New `plan/build-reactive-effects.ts` builder. Resolves at build time: attr-by-slot grouping, text-inside-conditional partition, loop-param wrapping (`wrapLoopParamAsAccessor`) of every attr / text / condition expression, and `addCondAttrToTemplate` of branch HTML.
- New `stringify/reactive-effects.ts`. Conditional bindEvents arm bodies (events / child components / inner loops / nested conditionals) still flow through the legacy helpers — Item 2 plan-ifies those.
- Migrated all three loop plan consumers (`PlainLoopPlan`, `ComponentLoopPlan`, `CompositeLoopPlan`) plus `emitBranchLoopBody`'s inline reactive-effect call site.
- Deleted `emitLoopChildReactiveEffects` and `ReactiveEffectsPassthrough`.

Output is byte-identical: existing jsx + adapter + client tests all pass with zero behavioural changes.

Item 2 (PR #TBD) builds on this and finishes the recursive `branch ↔ loop ↔ conditional` helper migration.

## Test plan

- [x] `bun test packages/jsx` (593 → 766 with the resolver-alias env fixed)
- [x] `bun test packages/adapter-tests packages/client`
- [x] `bun run --filter '@barefootjs/jsx' build`
- [x] `bun run --filter '@barefootjs/client' build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)