### PR TITLE
refactor(compiler): plan-ify emitStaticArrayChildInits (A1)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -10,7 +10,9 @@ import type { PropUsage, SignalInfo } from '../types'
 import type { Declaration } from './declaration-sort'
 import type { ClientJsContext } from './types'
 import { propHasPropertyAccess } from './compute-prop-usage'
-import { inferDefaultValue, toDomEventName, wrapHandlerInBlock, varSlotId, quotePropName, PROPS_PARAM } from './utils'
+import { inferDefaultValue, toDomEventName, wrapHandlerInBlock, varSlotId, PROPS_PARAM } from './utils'
+import { buildStaticArrayChildInitsPlan } from './plan/build-static-array-child-init'
+import { stringifyStaticArrayChildInits } from './stringify/static-array-child-init'
 
 
 /**
@@ -312,131 +314,13 @@ export function emitProviderAndChildInits(lines: string[], ctx: ClientJsContext)
  * Must run AFTER emitProviderAndChildInits so that parent components
  * have already provided their context (e.g., SelectContext) before
  * array children (e.g., SelectItem) call useContext().
+ *
+ * Drives the per-loop emission via a `StaticArrayChildInitsPlan` built up-
+ * front. Three Plan kinds (`single-comp`, `outer-nested`,
+ * `inner-loop-nested`) cover every shape this helper used to emit inline.
  */
 export function emitStaticArrayChildInits(lines: string[], ctx: ClientJsContext): void {
-  for (const elem of ctx.loopElements) {
-    if (!elem.isStaticArray) continue
-
-    if (elem.childComponent) {
-      const { name, props } = elem.childComponent
-      const v = varSlotId(elem.slotId)
-
-      const propsEntries = props.map((p) => {
-        if (p.isEventHandler) {
-          return `${quotePropName(p.name)}: ${p.value}`
-        } else if (p.isLiteral) {
-          return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-        } else {
-          return `get ${quotePropName(p.name)}() { return ${p.value} }`
-        }
-      })
-      const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
-
-      lines.push(`  // Initialize static array children (hydrate skips nested instances)`)
-      lines.push(`  if (_${v}) {`)
-      // Use both suffix match (for inlined stateless components whose bf-s uses
-      // parent scope + slotId, e.g. ~ParentName_hash_s3) and prefix match (for
-      // stateful components whose bf-s uses their own name, e.g. ToggleItem_hash)
-      const namePrefixSelector = `[bf-s^="~${name}_"], [bf-s^="${name}_"]`
-      const childSelector = elem.childComponent.slotId
-        ? `[bf-s$="_${elem.childComponent.slotId}"], ${namePrefixSelector}`
-        : namePrefixSelector
-      lines.push(`    const __childScopes = _${v}.querySelectorAll('${childSelector}')`)
-      const indexParam = elem.index || '__idx'
-      lines.push(`    __childScopes.forEach((childScope, ${indexParam}) => {`)
-      lines.push(`      const ${elem.param} = ${elem.array}[${indexParam}]`)
-      lines.push(`      initChild('${name}', childScope, ${propsExpr})`)
-      lines.push(`    })`)
-      lines.push(`  }`)
-      lines.push('')
-    }
-
-    if (elem.nestedComponents && elem.nestedComponents.length > 0) {
-      const v = varSlotId(elem.slotId)
-
-      // Outer-level components (loopDepth === 0 or undefined)
-      const outerComps = elem.nestedComponents.filter(c => !c.loopDepth)
-      for (const comp of outerComps) {
-        const propsEntries = comp.props.map((p) => {
-          if (p.isEventHandler) {
-            return `${quotePropName(p.name)}: ${p.value}`
-          } else if (p.isLiteral) {
-            return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-          } else {
-            return `get ${quotePropName(p.name)}() { return ${p.value} }`
-          }
-        })
-        const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
-
-        const selector = comp.slotId
-          ? `[bf-s$="_${comp.slotId}"]`
-          : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
-
-        lines.push(`  // Initialize nested ${comp.name} in static array`)
-        lines.push(`  if (_${v}) {`)
-        const indexParam = elem.index || '__idx'
-        const offsetExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
-        lines.push(`    ${elem.array}.forEach((${elem.param}, ${indexParam}) => {`)
-        lines.push(`      const __iterEl = _${v}.children[${offsetExpr}]`)
-        lines.push(`      if (__iterEl) {`)
-        lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
-        lines.push(`        if (__compEl) initChild('${comp.name}', __compEl, ${propsExpr})`)
-        lines.push(`      }`)
-        lines.push(`    })`)
-        lines.push(`  }`)
-        lines.push('')
-      }
-
-      // Inner-loop components (loopDepth > 0): iterate outer then inner loop
-      if (elem.innerLoops) {
-        for (const innerLoop of elem.innerLoops) {
-          const innerComps = elem.nestedComponents.filter(c =>
-            (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array
-          )
-          if (innerComps.length === 0) continue
-
-          lines.push(`  // Initialize inner-loop components in static array (depth ${innerLoop.depth})`)
-          lines.push(`  if (_${v}) {`)
-          const outerIdx = elem.index || '__idx'
-          const outerOffset = elem.siblingOffset ? `${outerIdx} + ${elem.siblingOffset}` : outerIdx
-          lines.push(`    ${elem.array}.forEach((${elem.param}, ${outerIdx}) => {`)
-          lines.push(`      const __outerEl = _${v}.children[${outerOffset}]`)
-          lines.push(`      if (!__outerEl) return`)
-          if (innerLoop.containerSlotId) {
-            lines.push(`      const __ic = __outerEl.querySelector('[bf="${innerLoop.containerSlotId}"]') || __outerEl`)
-          } else {
-            lines.push(`      const __ic = __outerEl`)
-          }
-          const innerOffset = innerLoop.siblingOffset ? `__innerIdx + ${innerLoop.siblingOffset}` : '__innerIdx'
-          lines.push(`      ${innerLoop.array}.forEach((${innerLoop.param}, __innerIdx) => {`)
-          lines.push(`        const __innerEl = __ic.children[${innerOffset}]`)
-          lines.push(`        if (!__innerEl) return`)
-
-          for (const comp of innerComps) {
-            const propsEntries = comp.props.map((p) => {
-              if (p.isEventHandler) {
-                return `${quotePropName(p.name)}: ${p.value}`
-              } else if (p.isLiteral) {
-                return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-              } else {
-                return `get ${quotePropName(p.name)}() { return ${p.value} }`
-              }
-            })
-            const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
-            const selector = comp.slotId
-              ? `[bf-s$="_${comp.slotId}"]`
-              : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
-            lines.push(`        const __compEl = __innerEl.querySelector('${selector}')`)
-            lines.push(`        if (__compEl) initChild('${comp.name}', __compEl, ${propsExpr})`)
-          }
-
-          lines.push(`      })`)
-          lines.push(`    })`)
-          lines.push(`  }`)
-          lines.push('')
-        }
-      }
-    }
-  }
+  const plans = buildStaticArrayChildInitsPlan(ctx)
+  stringifyStaticArrayChildInits(lines, plans)
 }
 

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -1,0 +1,168 @@
+/**
+ * Build `StaticArrayChildInitsPlan` from a `ClientJsContext`.
+ *
+ * Walks `ctx.loopElements`, filters static-array entries, and emits
+ * one or more Plan entries per loop:
+ *
+ *   1. `single-comp` when `elem.childComponent` is set.
+ *   2. `outer-nested` for each depth-0 entry in `elem.nestedComponents`.
+ *   3. `inner-loop-nested` for each `elem.innerLoops` entry that has
+ *      matching depth-N components.
+ *
+ * Selector / propsExpr / offset decisions all resolve here. The
+ * stringifier never inspects raw IR.
+ */
+
+import type { IRLoopChildComponent } from '../../types'
+import type { NestedLoop, TopLevelLoop } from '../types'
+import type { ClientJsContext } from '../types'
+import { quotePropName, varSlotId } from '../utils'
+
+/** The inline prop shape carried on `IRLoopChildComponent.props`. */
+type LoopChildCompProp = IRLoopChildComponent['props'][number]
+import type {
+  InnerLoopComp,
+  InnerLoopNestedInitPlan,
+  OuterNestedInitPlan,
+  PropsExpr,
+  SingleCompInitPlan,
+  StaticArrayChildInitPlan,
+  StaticArrayChildInitsPlan,
+} from './static-array-child-init'
+
+export function buildStaticArrayChildInitsPlan(
+  ctx: ClientJsContext,
+): StaticArrayChildInitsPlan {
+  const plans: StaticArrayChildInitPlan[] = []
+
+  for (const elem of ctx.loopElements) {
+    if (!elem.isStaticArray) continue
+
+    if (elem.childComponent) {
+      plans.push(buildSingleCompPlan(elem, elem.childComponent))
+    }
+
+    if (elem.nestedComponents && elem.nestedComponents.length > 0) {
+      for (const comp of elem.nestedComponents) {
+        if (comp.loopDepth) continue // handled in inner-loop pass
+        plans.push(buildOuterNestedPlan(elem, comp))
+      }
+
+      if (elem.innerLoops) {
+        for (const innerLoop of elem.innerLoops) {
+          const innerComps = elem.nestedComponents.filter(c =>
+            (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array,
+          )
+          if (innerComps.length === 0) continue
+          plans.push(buildInnerLoopNestedPlan(elem, innerLoop, innerComps))
+        }
+      }
+    }
+  }
+
+  return plans
+}
+
+function buildSingleCompPlan(
+  elem: TopLevelLoop,
+  childComponent: IRLoopChildComponent,
+): SingleCompInitPlan {
+  const { name, props, slotId } = childComponent
+  // Use both suffix match (for inlined stateless components whose bf-s uses
+  // parent scope + slotId, e.g. ~ParentName_hash_s3) and prefix match (for
+  // stateful components whose bf-s uses their own name, e.g. ToggleItem_hash).
+  const namePrefixSelector = `[bf-s^="~${name}_"], [bf-s^="${name}_"]`
+  const childSelector = slotId
+    ? `[bf-s$="_${slotId}"], ${namePrefixSelector}`
+    : namePrefixSelector
+
+  return {
+    kind: 'single-comp',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    componentName: name,
+    childSelector,
+    arrayExpr: elem.array,
+    param: elem.param,
+    indexParam: elem.index || '__idx',
+    propsExpr: buildStaticPropsExpr(props),
+  }
+}
+
+function buildOuterNestedPlan(
+  elem: TopLevelLoop,
+  comp: IRLoopChildComponent,
+): OuterNestedInitPlan {
+  const indexParam = elem.index || '__idx'
+  return {
+    kind: 'outer-nested',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    componentName: comp.name,
+    selector: buildNestedSelector(comp),
+    arrayExpr: elem.array,
+    param: elem.param,
+    indexParam,
+    offsetExpr: elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam,
+    propsExpr: buildStaticPropsExpr(comp.props),
+  }
+}
+
+function buildInnerLoopNestedPlan(
+  elem: TopLevelLoop,
+  innerLoop: NestedLoop,
+  innerComps: readonly IRLoopChildComponent[],
+): InnerLoopNestedInitPlan {
+  const outerIndexParam = elem.index || '__idx'
+  const comps: InnerLoopComp[] = innerComps.map(comp => ({
+    componentName: comp.name,
+    selector: buildNestedSelector(comp),
+    propsExpr: buildStaticPropsExpr(comp.props),
+  }))
+
+  return {
+    kind: 'inner-loop-nested',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    outerArrayExpr: elem.array,
+    outerParam: elem.param,
+    outerIndexParam,
+    outerOffsetExpr: elem.siblingOffset
+      ? `${outerIndexParam} + ${elem.siblingOffset}`
+      : outerIndexParam,
+    innerContainerSlotId: innerLoop.containerSlotId ?? null,
+    innerArrayExpr: innerLoop.array,
+    innerParam: innerLoop.param,
+    innerOffsetExpr: innerLoop.siblingOffset
+      ? `__innerIdx + ${innerLoop.siblingOffset}`
+      : '__innerIdx',
+    depth: innerLoop.depth,
+    comps,
+  }
+}
+
+/**
+ * Build the props object expression used by static-array child inits.
+ *
+ * Differs from `buildComponentPropsExpr` in `control-flow/shared.ts`:
+ *   - Static-array context has no loop-param `wrap` (forEach binds the
+ *     param as a plain value, not a signal accessor).
+ *   - Literal props are emitted as `name: JSON.stringify(value)` (a plain
+ *     property, NOT a getter), matching the legacy emitter byte-for-byte.
+ */
+function buildStaticPropsExpr(props: readonly LoopChildCompProp[]): PropsExpr {
+  const entries = props.map(p => {
+    if (p.isEventHandler) {
+      return `${quotePropName(p.name)}: ${p.value}`
+    }
+    if (p.isLiteral) {
+      return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
+    }
+    return `get ${quotePropName(p.name)}() { return ${p.value} }`
+  })
+  return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
+}
+
+/** Selector used by nested-comp init: slotId suffix match or name prefix. */
+function buildNestedSelector(comp: IRLoopChildComponent): string {
+  return comp.slotId
+    ? `[bf-s$="_${comp.slotId}"]`
+    : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
+}

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -1,0 +1,100 @@
+/**
+ * Plan types for `emitStaticArrayChildInits` — the three shapes that
+ * `static array` loops emit for child component initialisation:
+ *
+ *   - `single-comp`        — `loop.childComponent` ケース。一つの child component
+ *                            を `querySelectorAll` で全インスタンスに initChild。
+ *   - `outer-nested`       — depth 0 の `nestedComponents`。outer forEach で
+ *                            `__iterEl.querySelector(...)` 経由で initChild。
+ *   - `inner-loop-nested`  — depth > 0 の `nestedComponents`。outer + inner
+ *                            forEach の二重ループで initChild。
+ *
+ * All decisions (selector, propsExpr, offset expressions) are resolved at
+ * build time so the stringifier becomes a deterministic walk.
+ *
+ * Replaces the legacy 120-line `emitStaticArrayChildInits` whose emission
+ * shapes were determined by inline branching on the IR. See repository
+ * follow-up plan "A1" of the post-#1054 maintainability evaluation.
+ */
+
+/** Pre-built `{ name: value, ... }` props object expression. */
+export type PropsExpr = string
+
+/** A single child-component initialiser inside an inner-loop body. */
+export interface InnerLoopComp {
+  componentName: string
+  /** CSS selector for `__innerEl.querySelector(...)`. */
+  selector: string
+  /** Pre-built props object expression. */
+  propsExpr: PropsExpr
+}
+
+/** Plan for `loop.childComponent` (single child component per iteration). */
+export interface SingleCompInitPlan {
+  kind: 'single-comp'
+  /** Container variable name — e.g. `_s4` (already prefixed). */
+  containerVar: string
+  componentName: string
+  /** Combined selector: slotId-suffix match OR name-prefix match. */
+  childSelector: string
+  /** Array expression as written in user code. */
+  arrayExpr: string
+  /** Loop parameter identifier. */
+  param: string
+  /** Index parameter identifier (e.g. `__idx` or user-supplied). */
+  indexParam: string
+  /** Pre-built props object expression for the child component. */
+  propsExpr: PropsExpr
+}
+
+/** Plan for one depth-0 component inside `loop.nestedComponents`. */
+export interface OuterNestedInitPlan {
+  kind: 'outer-nested'
+  containerVar: string
+  componentName: string
+  /** CSS selector for `__iterEl.querySelector(...)`. */
+  selector: string
+  arrayExpr: string
+  param: string
+  indexParam: string
+  /** `indexParam` or `${indexParam} + ${siblingOffset}` — already substituted. */
+  offsetExpr: string
+  propsExpr: PropsExpr
+}
+
+/**
+ * Plan for one inner-loop level's nested components (depth > 0). Mirrors
+ * the `outer.forEach((p, idx) => inner.forEach((q, jdx) => initChild...))`
+ * shape verbatim; multiple `comps` share the same outer/inner skeleton.
+ */
+export interface InnerLoopNestedInitPlan {
+  kind: 'inner-loop-nested'
+  containerVar: string
+  /** Outer loop's array expression. */
+  outerArrayExpr: string
+  outerParam: string
+  outerIndexParam: string
+  /** Outer offset — `outerIndexParam` or `${outerIndexParam} + ${siblingOffset}`. */
+  outerOffsetExpr: string
+  /**
+   * Inner loop's container slot id. When non-null, the stringifier emits
+   * `__outerEl.querySelector('[bf="..."]') || __outerEl`; otherwise
+   * `__outerEl` is used directly.
+   */
+  innerContainerSlotId: string | null
+  innerArrayExpr: string
+  innerParam: string
+  /** Inner offset — `__innerIdx` or `__innerIdx + ${siblingOffset}`. */
+  innerOffsetExpr: string
+  /** Depth used in the leading comment line (e.g. `depth 2`). */
+  depth: number
+  /** Per-component initialisers emitted inside the inner forEach body. */
+  comps: readonly InnerLoopComp[]
+}
+
+export type StaticArrayChildInitPlan =
+  | SingleCompInitPlan
+  | OuterNestedInitPlan
+  | InnerLoopNestedInitPlan
+
+export type StaticArrayChildInitsPlan = readonly StaticArrayChildInitPlan[]

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -1,0 +1,142 @@
+/**
+ * Stringify `StaticArrayChildInitsPlan` to source lines.
+ *
+ * Three output shapes (preserved byte-identical from the legacy
+ * `emitStaticArrayChildInits`):
+ *
+ *   single-comp:
+ *     <i>// Initialize static array children (hydrate skips nested instances)
+ *     <i>if (<container>) {
+ *     <i>  const __childScopes = <container>.querySelectorAll('<selector>')
+ *     <i>  __childScopes.forEach((childScope, <idx>) => {
+ *     <i>    const <param> = <array>[<idx>]
+ *     <i>    initChild('<name>', childScope, <props>)
+ *     <i>  })
+ *     <i>}
+ *
+ *   outer-nested:
+ *     <i>// Initialize nested <name> in static array
+ *     <i>if (<container>) {
+ *     <i>  <array>.forEach((<param>, <idx>) => {
+ *     <i>    const __iterEl = <container>.children[<offset>]
+ *     <i>    if (__iterEl) {
+ *     <i>      const __compEl = __iterEl.querySelector('<selector>')
+ *     <i>      if (__compEl) initChild('<name>', __compEl, <props>)
+ *     <i>    }
+ *     <i>  })
+ *     <i>}
+ *
+ *   inner-loop-nested:
+ *     <i>// Initialize inner-loop components in static array (depth N)
+ *     <i>if (<container>) {
+ *     <i>  <outerArr>.forEach((<outerParam>, <outerIdx>) => {
+ *     <i>    const __outerEl = <container>.children[<outerOffset>]
+ *     <i>    if (!__outerEl) return
+ *     <i>    const __ic = <innerContainer-or-outerEl>
+ *     <i>    <innerArr>.forEach((<innerParam>, __innerIdx) => {
+ *     <i>      const __innerEl = __ic.children[<innerOffset>]
+ *     <i>      if (!__innerEl) return
+ *     <i>      <per-comp lookup + initChild>
+ *     <i>    })
+ *     <i>  })
+ *     <i>}
+ *
+ * Each block is followed by a single blank line for readability — same
+ * as the legacy emitter.
+ */
+
+import type {
+  InnerLoopNestedInitPlan,
+  OuterNestedInitPlan,
+  SingleCompInitPlan,
+  StaticArrayChildInitPlan,
+  StaticArrayChildInitsPlan,
+} from '../plan/static-array-child-init'
+
+export function stringifyStaticArrayChildInits(
+  lines: string[],
+  plans: StaticArrayChildInitsPlan,
+): void {
+  for (const plan of plans) {
+    stringifyOne(lines, plan)
+  }
+}
+
+function stringifyOne(lines: string[], plan: StaticArrayChildInitPlan): void {
+  switch (plan.kind) {
+    case 'single-comp':
+      emitSingleComp(lines, plan)
+      break
+    case 'outer-nested':
+      emitOuterNested(lines, plan)
+      break
+    case 'inner-loop-nested':
+      emitInnerLoopNested(lines, plan)
+      break
+  }
+}
+
+function emitSingleComp(lines: string[], plan: SingleCompInitPlan): void {
+  const { containerVar, componentName, childSelector, arrayExpr, param, indexParam, propsExpr } = plan
+  lines.push(`  // Initialize static array children (hydrate skips nested instances)`)
+  lines.push(`  if (${containerVar}) {`)
+  lines.push(`    const __childScopes = ${containerVar}.querySelectorAll('${childSelector}')`)
+  lines.push(`    __childScopes.forEach((childScope, ${indexParam}) => {`)
+  lines.push(`      const ${param} = ${arrayExpr}[${indexParam}]`)
+  lines.push(`      initChild('${componentName}', childScope, ${propsExpr})`)
+  lines.push(`    })`)
+  lines.push(`  }`)
+  lines.push('')
+}
+
+function emitOuterNested(lines: string[], plan: OuterNestedInitPlan): void {
+  const { containerVar, componentName, selector, arrayExpr, param, indexParam, offsetExpr, propsExpr } = plan
+  lines.push(`  // Initialize nested ${componentName} in static array`)
+  lines.push(`  if (${containerVar}) {`)
+  lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+  lines.push(`      const __iterEl = ${containerVar}.children[${offsetExpr}]`)
+  lines.push(`      if (__iterEl) {`)
+  lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
+  lines.push(`        if (__compEl) initChild('${componentName}', __compEl, ${propsExpr})`)
+  lines.push(`      }`)
+  lines.push(`    })`)
+  lines.push(`  }`)
+  lines.push('')
+}
+
+function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): void {
+  const {
+    containerVar,
+    outerArrayExpr,
+    outerParam,
+    outerIndexParam,
+    outerOffsetExpr,
+    innerContainerSlotId,
+    innerArrayExpr,
+    innerParam,
+    innerOffsetExpr,
+    depth,
+    comps,
+  } = plan
+  lines.push(`  // Initialize inner-loop components in static array (depth ${depth})`)
+  lines.push(`  if (${containerVar}) {`)
+  lines.push(`    ${outerArrayExpr}.forEach((${outerParam}, ${outerIndexParam}) => {`)
+  lines.push(`      const __outerEl = ${containerVar}.children[${outerOffsetExpr}]`)
+  lines.push(`      if (!__outerEl) return`)
+  if (innerContainerSlotId) {
+    lines.push(`      const __ic = __outerEl.querySelector('[bf="${innerContainerSlotId}"]') || __outerEl`)
+  } else {
+    lines.push(`      const __ic = __outerEl`)
+  }
+  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}, __innerIdx) => {`)
+  lines.push(`        const __innerEl = __ic.children[${innerOffsetExpr}]`)
+  lines.push(`        if (!__innerEl) return`)
+  for (const comp of comps) {
+    lines.push(`        const __compEl = __innerEl.querySelector('${comp.selector}')`)
+    lines.push(`        if (__compEl) initChild('${comp.componentName}', __compEl, ${comp.propsExpr})`)
+  }
+  lines.push(`      })`)
+  lines.push(`    })`)
+  lines.push(`  }`)
+  lines.push('')
+}


### PR DESCRIPTION
## Summary

A1 of the post-#1054 emit-init maintainability plan. Replace the legacy 120-line `emitStaticArrayChildInits` with a Plan + stringifier pair, applying the same Plan-driven approach used in #1053 / #1054 for control-flow.

- New \`plan/static-array-child-init.ts\` types — \`StaticArrayChildInitPlan\` (discriminated union of \`single-comp\` / \`outer-nested\` / \`inner-loop-nested\`).
- New \`plan/build-static-array-child-init.ts\`. Resolves selector / propsExpr / offset expressions at build time. Three copies of the legacy props-builder collapse into one \`buildStaticPropsExpr\`.
- New \`stringify/static-array-child-init.ts\`. Per-kind stringifier emits the byte-identical block shape.
- \`emit-init-sections.ts::emitStaticArrayChildInits\` shrinks to 4 lines (build plan, stringify).
- \`emit-init-sections.ts\` drops from 442 → 326 lines.

Adding a 4th emission shape now requires: add a \`kind\` to the union, a builder branch, and a stringifier — no inline branching in the orchestrator. Static-array context (no loop-param wrap) stays distinct from control-flow's \`buildComponentPropsExpr\` (literal-as-getter) so the byte-identical contract is preserved.

Subsequent steps in the plan: A2 (\`SignalEmitPlan\` for \`emitDeclaration::signal\`), B1 (EmitPhase registry), C1/C2 (analyzer-side propUsage / prop rename).

## Test plan

- [x] \`bun test packages/jsx\` (only 4 pre-existing resolver-alias failures, unchanged from baseline)
- [x] \`bun test packages/adapter-tests packages/client\` (426 / 0 fail)
- [x] \`bun run --filter '@barefootjs/jsx' build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)