### PR TITLE
refactor(compiler): plan-ify emitDeclaration / emitControlledSignalEffect (A2)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-init-sections.ts
@@ -6,8 +6,7 @@
  * Control flow, reactive updates, and registration are in separate modules.
  */
 
-import type { PropUsage, SignalInfo } from '../types'
-import type { Declaration } from './declaration-sort'
+import type { PropUsage } from '../types'
 import type { ClientJsContext } from './types'
 import { propHasPropertyAccess } from './compute-prop-usage'
 import { inferDefaultValue, toDomEventName, wrapHandlerInBlock, varSlotId, PROPS_PARAM } from './utils'
@@ -86,95 +85,6 @@ export function emitPropsExtraction(
     }
     lines.push('')
   }
-}
-
-/**
- * Emit a single declaration (constant, signal, memo, or function).
- * Dispatches by declaration kind. Used by the unified topological-sort emitter.
- */
-export function emitDeclaration(
-  lines: string[],
-  decl: Declaration,
-  ctx: ClientJsContext,
-  controlledSignals: Array<{ signal: SignalInfo; propName: string }>
-): void {
-  switch (decl.kind) {
-    case 'constant': {
-      const constant = decl.info
-      const keyword = constant.declarationKind ?? 'const'
-      if (constant.value !== undefined) {
-        lines.push(`  ${keyword} ${constant.name} = ${constant.value}`)
-      } else {
-        lines.push(`  ${keyword} ${constant.name}`)
-      }
-      break
-    }
-    case 'signal': {
-      const signal = decl.info
-      const propsName = ctx.propsObjectName ?? 'props'
-      const propsPrefix = `${propsName}.`
-
-      let initialValue: string
-      if (signal.initialValue.startsWith(propsPrefix) && !signal.initialValue.includes('??')) {
-        const propRef = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
-        initialValue = `${propRef} ?? ${inferDefaultValue(signal.type)}`
-      } else {
-        const controlled = controlledSignals.find(c => c.signal === signal)
-        if (controlled) {
-          if (signal.initialValue.includes('??')) {
-            if (ctx.propsObjectName && signal.initialValue.startsWith(propsPrefix)) {
-              initialValue = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
-            } else {
-              initialValue = signal.initialValue
-            }
-          } else {
-            const prop = ctx.propsParams.find(p => p.name === controlled.propName)
-            const defaultVal = prop?.defaultValue ?? inferDefaultValue(signal.type)
-            initialValue = `${PROPS_PARAM}.${controlled.propName} ?? ${defaultVal}`
-          }
-        } else if (ctx.propsObjectName && signal.initialValue.startsWith(propsPrefix)) {
-          initialValue = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
-        } else {
-          initialValue = signal.initialValue
-        }
-      }
-
-      if (signal.setter) {
-        lines.push(`  const [${signal.getter}, ${signal.setter}] = createSignal(${initialValue})`)
-      } else {
-        lines.push(`  const [${signal.getter}] = createSignal(${initialValue})`)
-      }
-      break
-    }
-    case 'memo': {
-      lines.push(`  const ${decl.info.name} = createMemo(${decl.info.computation})`)
-      break
-    }
-    case 'function': {
-      const fn = decl.info
-      const paramStr = fn.params.map((p) => p.name).join(', ')
-      lines.push(`  const ${fn.name} = (${paramStr}) => ${fn.body}`)
-      break
-    }
-  }
-}
-
-/** Emit createEffect for controlled signal synchronization. */
-export function emitControlledSignalEffect(
-  lines: string[],
-  signal: SignalInfo,
-  propName: string,
-  ctx: ClientJsContext
-): void {
-  const prop = ctx.propsParams.find(p => p.name === propName)
-  const accessor = prop?.defaultValue
-    ? `(${PROPS_PARAM}.${propName} ?? ${prop.defaultValue})`
-    : `${PROPS_PARAM}.${propName}`
-  if (!signal.setter) return // read-only signal, no controlled sync needed
-  lines.push(`  createEffect(() => {`)
-  lines.push(`    const __val = ${accessor}`)
-  lines.push(`    if (__val !== undefined) ${signal.setter}(__val)`)
-  lines.push(`  })`)
 }
 
 /** Emit props-based event handler bindings (handlers that come from props, not local definitions). */

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -31,10 +31,8 @@ import { graphUsedIdentifiers } from './build-references'
 import { getControlledPropName } from './prop-handling'
 import { exprReferencesIdent } from './utils'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
-import {
-  emitDeclaration,
-  emitControlledSignalEffect,
-} from './emit-init-sections'
+import { buildDeclarationEmitPlan } from './plan/build-declaration-emit'
+import { stringifyDeclarationEmit } from './stringify/declaration-emit'
 import type { ClientJsContext } from './types'
 
 export interface ControlledSignal {
@@ -170,10 +168,8 @@ export function emitSortedDeclarations(
 
   let emittedAny = false
   for (const decl of sorted) {
-    emitDeclaration(lines, decl, ctx, controlledSignals)
-    if (decl.kind === 'signal' && decl.controlledPropName) {
-      emitControlledSignalEffect(lines, decl.info, decl.controlledPropName, ctx)
-    }
+    const plan = buildDeclarationEmitPlan(decl, ctx, controlledSignals)
+    stringifyDeclarationEmit(lines, plan)
     emittedAny = true
   }
   if (emittedAny) lines.push('')

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -1,0 +1,147 @@
+/**
+ * Build a `DeclarationEmitPlan` from a `Declaration` + the surrounding
+ * client-JS context. Resolves every initial-value / accessor decision
+ * up-front so the stringifier never reads `ctx`.
+ *
+ * The signal builder mirrors the pre-A2 `emitDeclaration::signal` 4-branch
+ * cascade exactly. Comments below cite the legacy lines so future drift
+ * between the cases is easy to review.
+ *
+ * A2 of the post-#1054 emit-init maintainability plan.
+ */
+
+import type { ControlledSignal } from '../init-declarations'
+import type { Declaration } from '../declaration-sort'
+import type { ClientJsContext } from '../types'
+import type { SignalInfo } from '../../types'
+import { inferDefaultValue, PROPS_PARAM } from '../utils'
+import type {
+  ControlledSignalEffectPlan,
+  DeclarationEmitPlan,
+  SignalEmitPlan,
+} from './declaration-emit'
+
+export function buildDeclarationEmitPlan(
+  decl: Declaration,
+  ctx: ClientJsContext,
+  controlledSignals: readonly ControlledSignal[],
+): DeclarationEmitPlan {
+  switch (decl.kind) {
+    case 'constant': {
+      const c = decl.info
+      return {
+        kind: 'constant',
+        keyword: c.declarationKind ?? 'const',
+        name: c.name,
+        valueExpr: c.value !== undefined ? c.value : null,
+      }
+    }
+    case 'signal':
+      return buildSignalPlan(decl.info, ctx, controlledSignals)
+    case 'memo':
+      return {
+        kind: 'memo',
+        name: decl.info.name,
+        computationExpr: decl.info.computation,
+      }
+    case 'function': {
+      const fn = decl.info
+      return {
+        kind: 'function',
+        name: fn.name,
+        paramList: fn.params.map(p => p.name).join(', '),
+        body: fn.body,
+      }
+    }
+  }
+}
+
+function buildSignalPlan(
+  signal: SignalInfo,
+  ctx: ClientJsContext,
+  controlledSignals: readonly ControlledSignal[],
+): SignalEmitPlan {
+  return {
+    kind: 'signal',
+    getter: signal.getter,
+    setter: signal.setter,
+    initialValueExpr: resolveSignalInitialValue(signal, ctx, controlledSignals),
+    controlledEffect: buildControlledSignalEffect(signal, ctx, controlledSignals),
+  }
+}
+
+/**
+ * Mirror of the pre-A2 `emitDeclaration::signal` decision tree. The
+ * `propsName` here is what the user wrote (e.g. `props` or a custom
+ * destructure object name) — `signal.initialValue` may reference it via
+ * `propsName.X`, in which case we rewrite to the generated `_p.X`.
+ *
+ * Order of checks:
+ *   1. Reads a prop directly without `??` → wrap with the prop's inferred
+ *      default (`_p.X ?? <inferredDefault>`).
+ *   2. Controlled signal:
+ *      - has `??` already → respect the user's expression (rewrite props
+ *        prefix only).
+ *      - no `??`           → synthesize `_p.<propName> ?? <defaultVal>`.
+ *   3. Other reads of `propsName.X` → straight prop rewrite.
+ *   4. Otherwise            → verbatim.
+ */
+function resolveSignalInitialValue(
+  signal: SignalInfo,
+  ctx: ClientJsContext,
+  controlledSignals: readonly ControlledSignal[],
+): string {
+  const propsName = ctx.propsObjectName ?? 'props'
+  const propsPrefix = `${propsName}.`
+  const startsWithPropsPrefix = signal.initialValue.startsWith(propsPrefix)
+  const hasNullish = signal.initialValue.includes('??')
+
+  // Case 1: bare `propsName.X` read — append the inferred default so the
+  // signal never starts as `undefined`.
+  if (startsWithPropsPrefix && !hasNullish) {
+    const propRef = `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
+    return `${propRef} ?? ${inferDefaultValue(signal.type)}`
+  }
+
+  const controlled = controlledSignals.find(c => c.signal === signal)
+  if (controlled) {
+    // Case 2a: user already wrote `??` — keep their default but rewrite
+    // a leading `propsName.` prefix.
+    if (hasNullish) {
+      if (ctx.propsObjectName && startsWithPropsPrefix) {
+        return `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
+      }
+      return signal.initialValue
+    }
+    // Case 2b: synthesize the prop accessor + default.
+    const prop = ctx.propsParams.find(p => p.name === controlled.propName)
+    const defaultVal = prop?.defaultValue ?? inferDefaultValue(signal.type)
+    return `${PROPS_PARAM}.${controlled.propName} ?? ${defaultVal}`
+  }
+
+  // Case 3: non-controlled `propsObjectName.X` (only when destructured-
+  // props mode is OFF — the destructured form has no `propsObjectName`).
+  if (ctx.propsObjectName && startsWithPropsPrefix) {
+    return `${PROPS_PARAM}.` + signal.initialValue.slice(propsPrefix.length)
+  }
+
+  // Case 4: fall-through.
+  return signal.initialValue
+}
+
+function buildControlledSignalEffect(
+  signal: SignalInfo,
+  ctx: ClientJsContext,
+  controlledSignals: readonly ControlledSignal[],
+): ControlledSignalEffectPlan | null {
+  const controlled = controlledSignals.find(c => c.signal === signal)
+  if (!controlled) return null
+  if (!signal.setter) return null // read-only — no sync needed
+
+  const prop = ctx.propsParams.find(p => p.name === controlled.propName)
+  const accessorExpr = prop?.defaultValue
+    ? `(${PROPS_PARAM}.${controlled.propName} ?? ${prop.defaultValue})`
+    : `${PROPS_PARAM}.${controlled.propName}`
+
+  return { setter: signal.setter, accessorExpr }
+}

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -1,0 +1,72 @@
+/**
+ * Plan types for emitting one local declaration (constant / signal / memo /
+ * function) and the optional controlled-signal sync effect that follows
+ * a `signal` declaration.
+ *
+ * Replaces the inline 4-branch `if/else` cascade that used to live in
+ * `emit-init-sections.ts::emitDeclaration::signal` (selecting the
+ * `initialValue` expression based on whether the signal is controlled,
+ * whether the user wrote `??`, and whether `propsObjectName` is set).
+ *
+ * Every decision is resolved at build time so the stringifier emits one
+ * line per declaration without inspecting `ctx`.
+ *
+ * A2 of the post-#1054 emit-init maintainability plan.
+ */
+
+export interface ConstantEmitPlan {
+  kind: 'constant'
+  /** Declaration keyword — `const` | `let` | `var`. */
+  keyword: 'const' | 'let' | 'var'
+  name: string
+  /** Initializer expression. `null` when emitting a bare `let X` placeholder. */
+  valueExpr: string | null
+}
+
+export interface SignalEmitPlan {
+  kind: 'signal'
+  /** Getter identifier (the first tuple slot of `createSignal`). */
+  getter: string
+  /** Setter identifier — `null` for read-only signals. */
+  setter: string | null
+  /**
+   * Fully-resolved initial value expression. Prop rewrites
+   * (`<propsName>.X` → `_p.X`) and `?? <default>` insertions for controlled
+   * signals are already applied.
+   */
+  initialValueExpr: string
+  /**
+   * When non-null, the stringifier emits a `createEffect` block after
+   * the signal declaration that syncs the prop value into the setter.
+   */
+  controlledEffect: ControlledSignalEffectPlan | null
+}
+
+export interface ControlledSignalEffectPlan {
+  /** Receiver setter — must equal the parent signal's `setter`. */
+  setter: string
+  /** Fully-resolved accessor expression read inside the effect. */
+  accessorExpr: string
+}
+
+export interface MemoEmitPlan {
+  kind: 'memo'
+  name: string
+  /** Source expression passed to `createMemo(...)`. */
+  computationExpr: string
+}
+
+export interface FunctionEmitPlan {
+  kind: 'function'
+  name: string
+  /** `${param1}, ${param2}, …` — already joined. Empty string when no params. */
+  paramList: string
+  /** Arrow body — verbatim from the IR (block statement or expression). */
+  body: string
+}
+
+export type DeclarationEmitPlan =
+  | ConstantEmitPlan
+  | SignalEmitPlan
+  | MemoEmitPlan
+  | FunctionEmitPlan

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -1,0 +1,87 @@
+/**
+ * Stringify a `DeclarationEmitPlan` to source lines.
+ *
+ * Output shapes (preserved byte-identical from the legacy
+ * `emit-init-sections.ts::emitDeclaration` + `emitControlledSignalEffect`):
+ *
+ *   constant (with value):  <kw> <name> = <valueExpr>
+ *   constant (bare):        <kw> <name>
+ *   memo:                   const <name> = createMemo(<computationExpr>)
+ *   function:               const <name> = (<paramList>) => <body>
+ *
+ *   signal (no setter):     const [<getter>] = createSignal(<initialValueExpr>)
+ *   signal (with setter):   const [<getter>, <setter>] = createSignal(<initialValueExpr>)
+ *
+ *   controlled-signal effect (only when signal.controlledEffect != null):
+ *     createEffect(() => {
+ *       const __val = <accessorExpr>
+ *       if (__val !== undefined) <setter>(__val)
+ *     })
+ *
+ * Indent: every line is `  ` (2 spaces) — same as the legacy emitter.
+ *
+ * A2 of the post-#1054 emit-init maintainability plan.
+ */
+
+import type {
+  ConstantEmitPlan,
+  ControlledSignalEffectPlan,
+  DeclarationEmitPlan,
+  FunctionEmitPlan,
+  MemoEmitPlan,
+  SignalEmitPlan,
+} from '../plan/declaration-emit'
+
+export function stringifyDeclarationEmit(
+  lines: string[],
+  plan: DeclarationEmitPlan,
+): void {
+  switch (plan.kind) {
+    case 'constant':
+      emitConstant(lines, plan)
+      break
+    case 'signal':
+      emitSignal(lines, plan)
+      break
+    case 'memo':
+      emitMemo(lines, plan)
+      break
+    case 'function':
+      emitFunction(lines, plan)
+      break
+  }
+}
+
+function emitConstant(lines: string[], plan: ConstantEmitPlan): void {
+  if (plan.valueExpr !== null) {
+    lines.push(`  ${plan.keyword} ${plan.name} = ${plan.valueExpr}`)
+  } else {
+    lines.push(`  ${plan.keyword} ${plan.name}`)
+  }
+}
+
+function emitSignal(lines: string[], plan: SignalEmitPlan): void {
+  if (plan.setter) {
+    lines.push(`  const [${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr})`)
+  } else {
+    lines.push(`  const [${plan.getter}] = createSignal(${plan.initialValueExpr})`)
+  }
+  if (plan.controlledEffect) {
+    emitControlledEffect(lines, plan.controlledEffect)
+  }
+}
+
+function emitControlledEffect(lines: string[], plan: ControlledSignalEffectPlan): void {
+  lines.push(`  createEffect(() => {`)
+  lines.push(`    const __val = ${plan.accessorExpr}`)
+  lines.push(`    if (__val !== undefined) ${plan.setter}(__val)`)
+  lines.push(`  })`)
+}
+
+function emitMemo(lines: string[], plan: MemoEmitPlan): void {
+  lines.push(`  const ${plan.name} = createMemo(${plan.computationExpr})`)
+}
+
+function emitFunction(lines: string[], plan: FunctionEmitPlan): void {
+  lines.push(`  const ${plan.name} = (${plan.paramList}) => ${plan.body}`)
+}


### PR DESCRIPTION
## Summary

A2 of the post-#1054 emit-init maintainability plan. Replace the 4-branch \`if/else\` cascade in \`emit-init-sections.ts::emitDeclaration::signal\` (plus the standalone \`emitControlledSignalEffect\`) with a typed Plan + stringifier pair, applying the same approach as #1056 (A1).

- New \`plan/declaration-emit.ts\` types — \`DeclarationEmitPlan\` (discriminated union of \`constant\` / \`signal\` / \`memo\` / \`function\`) + \`ControlledSignalEffectPlan\`.
- New \`plan/build-declaration-emit.ts\`. The signal builder mirrors the pre-A2 4-branch tree with one named case per branch — easier to extend with a 5th case (e.g., new "prop-derived signal source") without re-reading the cascade.
- New \`stringify/declaration-emit.ts\`. One switch on \`kind\`; the signal case emits the controlled-effect block inline when present.
- \`init-declarations.ts::emitSortedDeclarations\` per-decl loop body shrinks to 2 lines.
- \`emit-init-sections.ts\` drops from 326 → 236 lines.

Adding a new declaration kind (e.g., a new reactive primitive) now requires: extend the union, add one builder branch, add one stringifier branch — no inline branching in the orchestrator.

Next: B1 (EmitPhase registry) makes the 20-call \`generate-init.ts\` body declarative.

## Test plan

- [x] \`bun test packages/jsx\` (4 pre-existing resolver-alias failures unchanged)
- [x] \`bun test packages/adapter-tests packages/client\` (426 / 0 fail)
- [x] \`bun run --filter '@barefootjs/jsx' build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)