### PR TITLE
refactor(compiler): introduce declarative EmitPhase registry (B1)

### DIFF
--- a/packages/jsx/src/__tests__/phases.test.ts
+++ b/packages/jsx/src/__tests__/phases.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Registry-validation tests for `PHASES` in `phases.ts`.
+ *
+ * Catches drift in the dependsOn graph at compile / test time so a broken
+ * cross-phase contract surfaces here before it becomes a silent emission
+ * order bug. Pairs with the runtime `runPhases` cycle / unknown-id check.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { PHASES } from '../ir-to-client-js/phases'
+
+describe('PHASES registry', () => {
+  test('every dependsOn id refers to an existing phase', () => {
+    const knownIds = new Set(PHASES.map(p => p.id))
+    for (const phase of PHASES) {
+      for (const dep of phase.dependsOn) {
+        expect(knownIds.has(dep)).toBe(true)
+      }
+    }
+  })
+
+  test('phase ids are unique', () => {
+    const seen = new Set<string>()
+    for (const phase of PHASES) {
+      expect(seen.has(phase.id)).toBe(false)
+      seen.add(phase.id)
+    }
+  })
+
+  test('dependency graph is acyclic (topological order exists)', () => {
+    // Run a virtual sort: pick phases whose deps are satisfied; loop until
+    // empty or stuck. Stuck → cycle.
+    const emitted = new Set<string>()
+    const remaining = PHASES.slice()
+    while (remaining.length > 0) {
+      const idx = remaining.findIndex(p => p.dependsOn.every(d => emitted.has(d)))
+      expect(idx).toBeGreaterThanOrEqual(0)
+      const phase = remaining.splice(idx, 1)[0]
+      emitted.add(phase.id)
+    }
+  })
+
+  test('the load-bearing constraint loop-updates → provider-and-child-inits is recorded', () => {
+    // Encoded directly in the registry rather than as a code comment, so
+    // re-ordering can't silently break the runtime contract that parent
+    // components must call provideContext() before loop children call
+    // useContext().
+    const loop = PHASES.find(p => p.id === 'loop-updates')
+    expect(loop).toBeDefined()
+    expect(loop!.dependsOn).toContain('provider-and-child-inits')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -17,25 +17,11 @@ import {
 } from './build-references'
 import { computePropUsage } from './compute-prop-usage'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports'
-import {
-  collectConditionalSlotIds,
-  emitPropsExtraction,
-  emitPropsEventHandlers,
-  emitEventHandlers,
-  emitRestAttrApplications,
-  emitRefCallbacks,
-  emitEffectsAndOnMounts,
-  emitInitStatements,
-  emitProviderAndChildInits,
-  emitStaticArrayChildInits,
-} from './emit-init-sections'
-import { emitConditionalUpdates, emitClientOnlyConditionals, emitLoopUpdates } from './control-flow'
-import { emitDynamicTextUpdates, emitClientOnlyExpressions, emitReactiveAttributeUpdates, emitReactivePropBindings, emitReactiveChildProps } from './emit-reactive'
 import { emitRegistrationAndHydration } from './emit-registration'
-import { generateElementRefs } from './element-refs'
 import { emitChildComponentImports } from './child-components'
-import { classifyLocalDeclarations, emitSortedDeclarations } from './init-declarations'
+import { classifyLocalDeclarations } from './init-declarations'
 import { emitModuleLevelDeclarations, resolveFinalImports } from './emit-module-level'
+import { buildPhaseCtx, PHASES, runPhases } from './phases'
 
 export function generateInitFunction(
   ir: ComponentIR,
@@ -61,37 +47,19 @@ export function generateInitFunction(
   const classification = classifyLocalDeclarations(ctx, graph)
   const propUsage = computePropUsage(ctx, classification.neededConstants)
 
-  // --- Emission: init body (runs at hydration for each instance) ---
-  emitPropsExtraction(lines, ctx, classification.neededProps, propUsage)
-  emitSortedDeclarations(lines, ctx, classification, graph)
-  emitInitStatements(lines, ctx)
-  if (ctx.initStatements.length > 0) lines.push('')
-  emitPropsEventHandlers(lines, ctx, usedFunctions, classification.neededProps)
-
-  const elementRefs = generateElementRefs(ctx)
-  if (elementRefs) {
-    lines.push(elementRefs)
-    lines.push('')
-  }
-
-  emitDynamicTextUpdates(lines, ctx)
-  emitClientOnlyExpressions(lines, ctx)
-  emitReactiveAttributeUpdates(lines, ctx)
-  emitConditionalUpdates(lines, ctx)
-  emitClientOnlyConditionals(lines, ctx)
-
-  const conditionalSlotIds = collectConditionalSlotIds(ctx)
-  emitRestAttrApplications(lines, ctx)
-  emitEventHandlers(lines, ctx, conditionalSlotIds)
-  emitReactivePropBindings(lines, ctx)
-  emitReactiveChildProps(lines, ctx)
-  emitRefCallbacks(lines, ctx, conditionalSlotIds)
-  emitEffectsAndOnMounts(lines, ctx)
-  emitProviderAndChildInits(lines, ctx)
-  // Loop updates must run AFTER provider/child inits so parent components
-  // have already provided their context before loop children useContext().
-  emitLoopUpdates(lines, ctx)
-  emitStaticArrayChildInits(lines, ctx)
+  // --- Emission: declarative phase pipeline. Each entry in `PHASES`
+  //     declares its inputs (dependsOn) and emission action (run); the
+  //     stable topological execution preserves the legacy by-position
+  //     order whenever no constraint forces a different one. ---
+  const phaseCtx = buildPhaseCtx({
+    ctx,
+    ir,
+    graph,
+    classification,
+    propUsage,
+    usedFunctions,
+  })
+  runPhases(lines, phaseCtx, PHASES)
 
   const hydrateLine = emitRegistrationAndHydration(lines, ctx, ir, graph)
 

--- a/packages/jsx/src/ir-to-client-js/phases.ts
+++ b/packages/jsx/src/ir-to-client-js/phases.ts
@@ -1,0 +1,240 @@
+/**
+ * Declarative emit-phase pipeline for `generateInitFunction`.
+ *
+ * Replaces the 20+ direct `emit*(lines, ctx, …)` calls in `generate-init.ts`
+ * with a single `PHASES` registry whose entries declare their inputs
+ * (`dependsOn`) and emission action (`run`). `runPhases` walks the
+ * registry in stable topological order so cross-phase contracts like
+ * "loop updates must come after provider/child inits" become first-class
+ * data instead of comments.
+ *
+ * Adding a new phase: write a new `EmitPhase`, append it to `PHASES`,
+ * declare its `dependsOn`. No hunting for the right insertion point in
+ * a long manual sequence.
+ *
+ * B1 of the post-#1054 emit-init maintainability plan.
+ */
+
+import type { ComponentIR, PropUsage, ReferencesGraph } from '../types'
+import type { ClientJsContext } from './types'
+import type { LocalClassification } from './init-declarations'
+import {
+  collectConditionalSlotIds,
+  emitEffectsAndOnMounts,
+  emitEventHandlers,
+  emitInitStatements,
+  emitProviderAndChildInits,
+  emitPropsEventHandlers,
+  emitPropsExtraction,
+  emitRefCallbacks,
+  emitRestAttrApplications,
+  emitStaticArrayChildInits,
+} from './emit-init-sections'
+import { emitClientOnlyConditionals, emitConditionalUpdates, emitLoopUpdates } from './control-flow'
+import {
+  emitClientOnlyExpressions,
+  emitDynamicTextUpdates,
+  emitReactiveAttributeUpdates,
+  emitReactiveChildProps,
+  emitReactivePropBindings,
+} from './emit-reactive'
+import { emitSortedDeclarations } from './init-declarations'
+import { generateElementRefs } from './element-refs'
+
+/**
+ * Inputs available to every phase. Built once by `generateInitFunction`
+ * before phase execution starts; phases read but never mutate.
+ */
+export interface PhaseCtx {
+  ctx: ClientJsContext
+  ir: ComponentIR
+  graph: ReferencesGraph
+  classification: LocalClassification
+  propUsage: Map<string, PropUsage>
+  usedFunctions: Set<string>
+  /** Slots that live inside a conditional branch (handled via `insert()`).
+   *  Cached so `event-handlers` and `ref-callbacks` don't recompute. */
+  conditionalSlotIds: Set<string>
+}
+
+/** Build the read-only carrier that every phase consumes. */
+export function buildPhaseCtx(args: Omit<PhaseCtx, 'conditionalSlotIds'>): PhaseCtx {
+  return {
+    ...args,
+    conditionalSlotIds: collectConditionalSlotIds(args.ctx),
+  }
+}
+
+/**
+ * One emission step. `run` appends to the shared `lines` array; if the
+ * step needs to coordinate with another step (output ordering, shared
+ * runtime guarantees), declare the upstream `id` in `dependsOn`.
+ */
+export interface EmitPhase {
+  id: string
+  /** Phase ids that must execute before this one. Missing ids → throw. */
+  dependsOn: readonly string[]
+  run: (lines: string[], pctx: PhaseCtx) => void
+}
+
+/**
+ * Stable topological execution.
+ *
+ * Pick the first phase (in array order) whose `dependsOn` are all
+ * already emitted. The "first in array order" tiebreaker preserves the
+ * legacy by-position emission order whenever no constraint forces a
+ * different one — so a freshly-introduced `dependsOn` doesn't perturb
+ * unrelated downstream output.
+ *
+ * Throws on cycle or unknown `dependsOn` id (caught early during
+ * development, not silently miss-ordered).
+ */
+export function runPhases(
+  lines: string[],
+  pctx: PhaseCtx,
+  phases: readonly EmitPhase[],
+): void {
+  const knownIds = new Set(phases.map(p => p.id))
+  for (const phase of phases) {
+    for (const dep of phase.dependsOn) {
+      if (!knownIds.has(dep)) {
+        throw new Error(`EmitPhase '${phase.id}' depends on unknown phase '${dep}'`)
+      }
+    }
+  }
+
+  const emitted = new Set<string>()
+  const remaining = phases.slice()
+  while (remaining.length > 0) {
+    const idx = remaining.findIndex(p => p.dependsOn.every(d => emitted.has(d)))
+    if (idx < 0) {
+      const stuck = remaining.map(p => p.id).join(', ')
+      throw new Error(`EmitPhase cycle or unsatisfied dependency among: ${stuck}`)
+    }
+    const phase = remaining.splice(idx, 1)[0]
+    phase.run(lines, pctx)
+    emitted.add(phase.id)
+  }
+}
+
+// ============================================================================
+// PHASES — array order matches the legacy `generate-init.ts` L65-94 sequence
+// so output stays byte-identical when `dependsOn` is empty / non-conflicting.
+//
+// The single non-trivial constraint is `loop-updates` after
+// `provider-and-child-inits` — previously a code comment, now a typed
+// `dependsOn`.
+// ============================================================================
+
+export const PHASES: readonly EmitPhase[] = [
+  {
+    id: 'props-extraction',
+    dependsOn: [],
+    run: (lines, p) => emitPropsExtraction(lines, p.ctx, p.classification.neededProps, p.propUsage),
+  },
+  {
+    id: 'sorted-declarations',
+    dependsOn: ['props-extraction'],
+    run: (lines, p) => emitSortedDeclarations(lines, p.ctx, p.classification, p.graph),
+  },
+  {
+    id: 'init-statements',
+    dependsOn: ['sorted-declarations'],
+    run: (lines, p) => {
+      emitInitStatements(lines, p.ctx)
+      // Trailing blank line (only when statements were emitted) — folded in
+      // here so the orchestrator stays a flat phase list.
+      if (p.ctx.initStatements.length > 0) lines.push('')
+    },
+  },
+  {
+    id: 'props-event-handlers',
+    dependsOn: ['init-statements'],
+    run: (lines, p) => emitPropsEventHandlers(lines, p.ctx, p.usedFunctions, p.classification.neededProps),
+  },
+  {
+    id: 'element-refs',
+    dependsOn: ['props-event-handlers'],
+    run: (lines, p) => {
+      const refs = generateElementRefs(p.ctx)
+      if (refs) {
+        lines.push(refs)
+        lines.push('')
+      }
+    },
+  },
+  {
+    id: 'dynamic-text-updates',
+    dependsOn: ['element-refs'],
+    run: (lines, p) => emitDynamicTextUpdates(lines, p.ctx),
+  },
+  {
+    id: 'client-only-expressions',
+    dependsOn: ['dynamic-text-updates'],
+    run: (lines, p) => emitClientOnlyExpressions(lines, p.ctx),
+  },
+  {
+    id: 'reactive-attribute-updates',
+    dependsOn: ['client-only-expressions'],
+    run: (lines, p) => emitReactiveAttributeUpdates(lines, p.ctx),
+  },
+  {
+    id: 'conditional-updates',
+    dependsOn: ['reactive-attribute-updates'],
+    run: (lines, p) => emitConditionalUpdates(lines, p.ctx),
+  },
+  {
+    id: 'client-only-conditionals',
+    dependsOn: ['conditional-updates'],
+    run: (lines, p) => emitClientOnlyConditionals(lines, p.ctx),
+  },
+  {
+    id: 'rest-attr-applications',
+    dependsOn: ['client-only-conditionals'],
+    run: (lines, p) => emitRestAttrApplications(lines, p.ctx),
+  },
+  {
+    id: 'event-handlers',
+    dependsOn: ['rest-attr-applications'],
+    run: (lines, p) => emitEventHandlers(lines, p.ctx, p.conditionalSlotIds),
+  },
+  {
+    id: 'reactive-prop-bindings',
+    dependsOn: ['event-handlers'],
+    run: (lines, p) => emitReactivePropBindings(lines, p.ctx),
+  },
+  {
+    id: 'reactive-child-props',
+    dependsOn: ['reactive-prop-bindings'],
+    run: (lines, p) => emitReactiveChildProps(lines, p.ctx),
+  },
+  {
+    id: 'ref-callbacks',
+    dependsOn: ['reactive-child-props'],
+    run: (lines, p) => emitRefCallbacks(lines, p.ctx, p.conditionalSlotIds),
+  },
+  {
+    id: 'effects-and-on-mounts',
+    dependsOn: ['ref-callbacks'],
+    run: (lines, p) => emitEffectsAndOnMounts(lines, p.ctx),
+  },
+  {
+    id: 'provider-and-child-inits',
+    dependsOn: ['effects-and-on-mounts'],
+    run: (lines, p) => emitProviderAndChildInits(lines, p.ctx),
+  },
+  {
+    // Loop updates must run AFTER provider/child inits so parent components
+    // have already provided their context before loop children call
+    // useContext(). Encoded as data instead of a code comment so the
+    // contract is enforceable at registry-validation time.
+    id: 'loop-updates',
+    dependsOn: ['provider-and-child-inits'],
+    run: (lines, p) => emitLoopUpdates(lines, p.ctx),
+  },
+  {
+    id: 'static-array-child-inits',
+    dependsOn: ['loop-updates'],
+    run: (lines, p) => emitStaticArrayChildInits(lines, p.ctx),
+  },
+]


### PR DESCRIPTION
## Summary

B1 of the post-#1054 emit-init maintainability plan. Replace the 20+ direct \`emit*(lines, ctx, …)\` calls in \`generateInitFunction\` with a single \`PHASES\` registry whose entries declare their inputs (\`dependsOn\`) and emission action (\`run\`).

- New \`phases.ts\` defines \`EmitPhase\` / \`PhaseCtx\` and a stable topological executor \`runPhases\`. Tiebreaker is array order so the registry preserves the legacy by-position emission order whenever no constraint forces a different one. Throws on cycle / unknown \`dependsOn\` id.
- \`PHASES\` lists 19 entries — one per existing emit function — in canonical order. The single load-bearing cross-phase contract (\`loop-updates\` after \`provider-and-child-inits\`, so context providers run before \`useContext()\` consumers) is now encoded as \`dependsOn\` instead of a code comment.
- \`generate-init.ts\` shrinks from 165 → 132 lines: the L65-94 sequence collapses to \`runPhases(lines, phaseCtx, PHASES)\`. \`buildPhaseCtx\` caches \`conditionalSlotIds\` once for the two phases that need it.
- New \`__tests__/phases.test.ts\` validates registry integrity at test time — every \`dependsOn\` resolves, ids are unique, the graph is acyclic, and the load-bearing \`loop-updates\` constraint is present.

Adding a new emit phase now requires: write a new \`EmitPhase\`, append to \`PHASES\`, declare its \`dependsOn\`. No hunting for the right insertion point; ordering contracts are machine-checked.

Sequential dependsOn chains in this initial migration are intentionally tight — they preserve the legacy emission order until each link's actual constraint is understood. Subsequent PRs may relax non-load-bearing links.

Next: B3 (split emit-init-sections.ts by phase), then C1/C2 (analyzer-side propUsage / prop rename).

## Test plan

- [x] \`bun test packages/jsx\` — 779 → 783 tests (new phases test); 4 unrelated resolver-alias failures unchanged
- [x] \`bun test packages/adapter-tests packages/client\` — 426 / 0 fail
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)