### PR TITLE
refactor(compiler): replace regex with AST walk in computePropUsage (C1)

### DIFF
--- a/packages/jsx/src/__tests__/walk-prop-accesses.test.ts
+++ b/packages/jsx/src/__tests__/walk-prop-accesses.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the AST-based prop-access detector
+ * (`ir-to-client-js/walk-prop-accesses.ts`).
+ *
+ * Documents the patterns the detector catches that the pre-C1 regex
+ * pair silently missed — most notably optional-chaining property access
+ * (`props?.foo`) and computed access through arbitrary expressions.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { collectPropAccesses } from '../ir-to-client-js/walk-prop-accesses'
+
+describe('collectPropAccesses', () => {
+  const propNames = new Set(['props', 'user'])
+
+  test('plain `props.foo` records property access', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props.name', propNames, out)
+    expect(out.get('props')?.has('property')).toBe(true)
+  })
+
+  test('optional-chaining `props?.foo` records property access (C1 regression guard)', () => {
+    // Pre-C1 the detector regex `\\b<name>\\.[a-zA-Z_]` failed to match
+    // because the `?` between the identifier and the dot broke the
+    // direct-dot match. The AST walk treats both PropertyAccessExpression
+    // forms identically.
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props?.name', propNames, out)
+    expect(out.get('props')?.has('property')).toBe(true)
+  })
+
+  test('computed `props[i]` records index access', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props[i]', propNames, out)
+    expect(out.get('props')?.has('index')).toBe(true)
+  })
+
+  test('optional-chaining computed `props?.[i]` records index access', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props?.[i]', propNames, out)
+    expect(out.get('props')?.has('index')).toBe(true)
+  })
+
+  test('template literal interpolations are scanned', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('<div>${props.title}: ${user?.name}</div>', propNames, out)
+    expect(out.get('props')?.has('property')).toBe(true)
+    expect(out.get('user')?.has('property')).toBe(true)
+  })
+
+  test('does not record names that only appear bare (no member access)', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props', propNames, out)
+    expect(out.has('props')).toBe(false)
+  })
+
+  test('does not record sibling identifiers that share a substring', () => {
+    // `propsX.foo` is a different identifier — must not match `props`.
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('propsX.foo', propNames, out)
+    expect(out.has('props')).toBe(false)
+  })
+
+  test('mixes property and index access for the same prop', () => {
+    const out = new Map<string, Set<'property' | 'index'>>()
+    collectPropAccesses('props.items[0].name', propNames, out)
+    expect(out.get('props')?.has('property')).toBe(true)
+    expect(out.get('props')?.has('index')).toBe(false) // index is on `.items`, not on `props`
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
@@ -6,57 +6,49 @@
  * the access kinds observed for each prop (bare / property / index)
  * and whether the prop is consumed as a loop's array expression.
  *
- * Replaces `detectPropsWithPropertyAccess` in `prop-handling.ts` and
- * the inline `propsUsedAsLoopArrays` loop in `generate-init.ts`.
- *
- * Stage C.2 of issue #1021 — analysis-on-IR refactor.
+ * Stage C.2 of issue #1021 introduced this file; C1 of the post-#1054
+ * maintainability plan replaced the inline regex pair
+ * (`\\b<name>\\.[a-zA-Z_]` / `\\b<name>\\s*\\[`) with an AST walk via
+ * `collectPropAccesses` so optional-chaining (`<name>?.foo`) and
+ * computed access patterns are no longer silently missed.
  */
 
-import type { ConstantInfo, PropAccessKind, PropUsage } from '../types'
+import type { ConstantInfo, PropUsage } from '../types'
 import type { ClientJsContext } from './types'
+import { collectPropAccesses, type PropAccessKindMap } from './walk-prop-accesses'
 
 export function computePropUsage(
   ctx: ClientJsContext,
-  /** Constants the emitter is going to ship (scope === 'init'). Must
-   *  mirror the sources the pre-Stage C.2 `detectPropsWithPropertyAccess`
-   *  scanned, so that the `{}` default decision stays byte-identical. */
+  /** Constants the emitter is going to ship (scope === 'init'). Mirrors
+   *  the source set the pre-Stage C.2 `detectPropsWithPropertyAccess`
+   *  scanned, so the `{}` default decision stays byte-identical for any
+   *  source the regex did catch. */
   initScopeConstants: readonly ConstantInfo[],
 ): Map<string, PropUsage> {
-  const usage = new Map<string, PropUsage>()
+  const propNames = new Set(ctx.propsParams.map(p => p.name))
+  const accesses: PropAccessKindMap = new Map()
 
-  // Sources mirror the pre-refactor `detectPropsWithPropertyAccess`
-  // scan (prop-handling.ts L150-183): conditional branch HTML +
+  // Same source set as the legacy scan: conditional branch HTML +
   // condition, loop template, dynamic text expression, and init-scope
-  // constant initializers. Extending the scan would widen the `{}`
-  // default coverage — that is a deliberate Stage C.3 / later concern,
-  // not a Stage C.2 change.
-  const sources: string[] = []
+  // constant initializers.
   for (const elem of ctx.conditionalElements) {
-    sources.push(elem.whenTrueHtml, elem.whenFalseHtml, elem.condition)
+    collectPropAccesses(elem.whenTrueHtml, propNames, accesses)
+    collectPropAccesses(elem.whenFalseHtml, propNames, accesses)
+    collectPropAccesses(elem.condition, propNames, accesses)
   }
   for (const elem of ctx.loopElements) {
-    sources.push(elem.template)
+    collectPropAccesses(elem.template, propNames, accesses)
   }
   for (const elem of ctx.dynamicElements) {
-    sources.push(elem.expression)
+    collectPropAccesses(elem.expression, propNames, accesses)
   }
   for (const c of initScopeConstants) {
-    if (c.value) sources.push(c.value)
+    if (c.value) collectPropAccesses(c.value, propNames, accesses)
   }
 
+  const usage = new Map<string, PropUsage>()
   for (const prop of ctx.propsParams) {
-    const accessKinds = new Set<PropAccessKind>()
-    const dotPattern = new RegExp(`\\b${prop.name}\\.[a-zA-Z_]`)
-    const bracketPattern = new RegExp(`\\b${prop.name}\\s*\\[`)
-
-    for (const source of sources) {
-      if (dotPattern.test(source)) accessKinds.add('property')
-      if (bracketPattern.test(source)) accessKinds.add('index')
-      // Early exit once both kinds observed; `bare` is not tracked from
-      // this scan (`detectPropsWithPropertyAccess` never did).
-      if (accessKinds.size === 2) break
-    }
-
+    const accessKinds = accesses.get(prop.name) ?? new Set()
     let usedAsLoopArray = false
     for (const loop of ctx.loopElements) {
       if (loop.array.trim() === prop.name) {
@@ -64,12 +56,7 @@ export function computePropUsage(
         break
       }
     }
-
-    usage.set(prop.name, {
-      propName: prop.name,
-      accessKinds,
-      usedAsLoopArray,
-    })
+    usage.set(prop.name, { propName: prop.name, accessKinds, usedAsLoopArray })
   }
 
   return usage

--- a/packages/jsx/src/ir-to-client-js/walk-prop-accesses.ts
+++ b/packages/jsx/src/ir-to-client-js/walk-prop-accesses.ts
@@ -1,0 +1,110 @@
+/**
+ * AST-based prop-access detector.
+ *
+ * Replaces the regex pair (`\\b<name>\\.[a-zA-Z_]` / `\\b<name>\\s*\\[`)
+ * that `computePropUsage` used pre-C1. The regex form silently missed
+ * optional-chaining property access (`<name>?.foo`) because the `?` between
+ * the identifier and the `.` broke the dot match.
+ *
+ * The detector parses each source via the TypeScript compiler, walks
+ * `PropertyAccessExpression` (covers both `.foo` and `?.foo` — the AST
+ * distinguishes them only via `questionDotToken`, which we ignore) and
+ * `ElementAccessExpression` (`[expr]`) nodes, and records the access
+ * kind for any prop name that is the immediate `expression` of the
+ * access node.
+ *
+ * Template-style sources (HTML strings with `${...}` interpolations) are
+ * normalised by extracting each interpolation expression and parsing
+ * those — the surrounding HTML is irrelevant for prop access.
+ *
+ * C1 of the post-#1054 emit-init maintainability plan.
+ */
+
+import ts from 'typescript'
+import type { PropAccessKind } from '../types'
+
+/** Map from prop name → set of access kinds observed across all sources. */
+export type PropAccessKindMap = Map<string, Set<PropAccessKind>>
+
+/**
+ * Walk every property / element access in `source` and record any whose
+ * receiver is one of `propNames`. Mutates `out` in place so the caller
+ * can fold results from many sources into a single map.
+ *
+ * Sources may be either pure expressions (`condition`, `dynamicElements
+ * .expression`, `constant.value`) or template-style strings carrying
+ * `${...}` interpolations (HTML branches, loop templates). Both are
+ * normalised here.
+ */
+export function collectPropAccesses(
+  source: string,
+  propNames: ReadonlySet<string>,
+  out: PropAccessKindMap,
+): void {
+  if (propNames.size === 0) return
+
+  for (const expr of normaliseExpressionParts(source)) {
+    const sourceFile = ts.createSourceFile(
+      'p.ts',
+      expr,
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ false,
+      ts.ScriptKind.TS,
+    )
+    visit(sourceFile, propNames, out)
+  }
+}
+
+/**
+ * Yield each parseable JS expression embedded in `source`. Pure
+ * expressions yield the whole string; template-style strings yield only
+ * the `${...}` substitution bodies.
+ */
+function normaliseExpressionParts(source: string): string[] {
+  if (!source.includes('${')) return [source]
+  const parts: string[] = []
+  // Mirror `extractTemplateIdentifiers`'s `\$\{([^}]+)\}` heuristic so the
+  // `{}` default decision stays byte-identical with the regex era; using
+  // a character-class instead of full balance-aware extraction keeps the
+  // scanner cheap and matches the legacy reach.
+  const re = /\$\{([^}]+)\}/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(source)) !== null) {
+    parts.push(match[1])
+  }
+  return parts
+}
+
+function visit(
+  node: ts.Node,
+  propNames: ReadonlySet<string>,
+  out: PropAccessKindMap,
+): void {
+  // Both `obj.foo` and `obj?.foo` are PropertyAccessExpression — the
+  // optional-chain bit lives on `questionDotToken`, which we deliberately
+  // ignore: from a "does this prop need a `{}` default" perspective both
+  // forms perform a property read against `obj`.
+  if (ts.isPropertyAccessExpression(node)) {
+    recordIfPropAccess(node.expression, 'property', propNames, out)
+  } else if (ts.isElementAccessExpression(node)) {
+    recordIfPropAccess(node.expression, 'index', propNames, out)
+  }
+  ts.forEachChild(node, child => visit(child, propNames, out))
+}
+
+function recordIfPropAccess(
+  receiver: ts.Expression,
+  kind: PropAccessKind,
+  propNames: ReadonlySet<string>,
+  out: PropAccessKindMap,
+): void {
+  if (!ts.isIdentifier(receiver)) return
+  const name = receiver.text
+  if (!propNames.has(name)) return
+  let kinds = out.get(name)
+  if (!kinds) {
+    kinds = new Set<PropAccessKind>()
+    out.set(name, kinds)
+  }
+  kinds.add(kind)
+}


### PR DESCRIPTION
## Summary

C1 of the post-#1054 emit-init maintainability plan. Drop the regex pair (\`\\b<name>\\.[a-zA-Z_]\` / \`\\b<name>\\s*\\[\`) inside \`computePropUsage\` in favour of a proper TypeScript AST walk.

The pre-C1 regex silently missed optional-chaining property access (\`props?.foo\`): the \`?\` between the identifier and the dot broke the direct-dot match, so the prop never got the \`{}\` default it needed. Components writing \`props?.foo\` would emit \`const props = _p.props\` (no \`?? {}\`), then crash at runtime when the prop was undefined and a downstream consumer dereferenced through the wrapped accessor.

- New \`walk-prop-accesses.ts::collectPropAccesses\` parses each source via TS and walks \`PropertyAccessExpression\` (covers \`.foo\` and \`?.foo\` — the AST distinguishes only via \`questionDotToken\`) and \`ElementAccessExpression\` (\`[expr]\` and \`?.[expr]\`). Template-style sources (HTML branches, loop templates) are normalised by extracting \`\${…}\` substitutions and parsing those.
- \`compute-prop-usage.ts\` calls the helper for the same source set the legacy scan covered.
- New \`__tests__/walk-prop-accesses.test.ts\` (8 tests) documents the patterns the detector catches: \`props?.foo\` regression, computed access (\`props[i]\`, \`props?.[i]\`), template literal interpolations, word-boundary safety (\`propsX.foo\` must NOT match \`props\`).

Output stays byte-identical for the existing test corpus (the regex caught all currently-tested patterns); the AST walk widens coverage for \`?.\` access without affecting today's expected emissions.

Next: C2 (move prop rename to analyzer stage, kill \`renamePropsObjectInInitBody\`).

## Test plan

- [x] \`bun test packages/jsx\` — 791 / 4 unrelated resolver-alias fails unchanged
- [x] \`bun test packages/adapter-tests packages/client\` — 426 / 0 fail
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)