### PR TITLE
refactor(compiler): simplify emit-init code (post-#1061 cleanup)

### DIFF
--- a/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-prop-usage.ts
@@ -6,11 +6,10 @@
  * the access kinds observed for each prop (bare / property / index)
  * and whether the prop is consumed as a loop's array expression.
  *
- * Stage C.2 of issue #1021 introduced this file; C1 of the post-#1054
- * maintainability plan replaced the inline regex pair
- * (`\\b<name>\\.[a-zA-Z_]` / `\\b<name>\\s*\\[`) with an AST walk via
- * `collectPropAccesses` so optional-chaining (`<name>?.foo`) and
- * computed access patterns are no longer silently missed.
+ * Detection runs through `collectPropAccesses` (an AST walk) so
+ * optional-chaining (`<name>?.foo`) and computed access patterns are
+ * caught — a regex `\\b<name>\\.[a-zA-Z_]` would silently miss the `?.`
+ * case.
  */
 
 import type { ConstantInfo, PropUsage } from '../types'

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -11,10 +11,7 @@
 import type { ComponentIR } from '../types'
 import type { ClientJsContext } from './types'
 import { PROPS_PARAM } from './utils'
-import {
-  buildReferencesGraph,
-  graphUsedFunctions,
-} from './build-references'
+import { buildReferencesGraph } from './build-references'
 import { computePropUsage } from './compute-prop-usage'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports'
 import { emitRegistrationAndHydration } from './emit-registration'
@@ -44,7 +41,6 @@ export function generateInitFunction(
 
   // --- Analysis: one graph, many queries; scope routing as data ---
   const graph = buildReferencesGraph(ctx, ir.root)
-  const usedFunctions = graphUsedFunctions(graph)
   const classification = classifyLocalDeclarations(ctx, graph)
   const propUsage = computePropUsage(ctx, classification.neededConstants)
 
@@ -58,7 +54,6 @@ export function generateInitFunction(
     graph,
     classification,
     propUsage,
-    usedFunctions,
   })
   runPhases(lines, phaseCtx, PHASES)
 

--- a/packages/jsx/src/ir-to-client-js/identifiers.ts
+++ b/packages/jsx/src/ir-to-client-js/identifiers.ts
@@ -70,14 +70,31 @@ export function extractIdentifiers(expr: string, set: Set<string>): void {
 }
 
 /**
+ * Yield each `${...}` substitution body inside a template-style string.
+ * Returns the inner expressions — the surrounding HTML / static text is
+ * stripped. Empty array when no substitutions are present.
+ *
+ * Uses a `[^}]+` character class rather than a balance-aware scanner —
+ * cheap and matches the legacy reach. Object literals inside `${...}`
+ * are not supported (they would split prematurely on the inner `}`).
+ */
+export function extractTemplateExpressions(template: string): string[] {
+  const re = /\$\{([^}]+)\}/g
+  const out: string[] = []
+  let match
+  while ((match = re.exec(template)) !== null) {
+    out.push(match[1])
+  }
+  return out
+}
+
+/**
  * Extract identifiers from template literal expressions.
  * Finds ${...} patterns and extracts identifiers from inside.
  */
 export function extractTemplateIdentifiers(template: string, set: Set<string>): void {
-  const templatePattern = /\$\{([^}]+)\}/g
-  let match
-  while ((match = templatePattern.exec(template)) !== null) {
-    extractIdentifiers(match[1], set)
+  for (const expr of extractTemplateExpressions(template)) {
+    extractIdentifiers(expr, set)
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -31,7 +31,7 @@ import { graphUsedIdentifiers } from './build-references'
 import { getControlledPropName } from './prop-handling'
 import { exprReferencesIdent } from './utils'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
-import { buildDeclarationEmitPlan } from './plan/build-declaration-emit'
+import { buildDeclarationEmitLookups, buildDeclarationEmitPlan } from './plan/build-declaration-emit'
 import { stringifyDeclarationEmit } from './stringify/declaration-emit'
 import type { ClientJsContext } from './types'
 
@@ -165,10 +165,11 @@ export function emitSortedDeclarations(
   }
 
   const sorted = sortDeclarations(declarations, declNameSet, graph)
+  const lookups = buildDeclarationEmitLookups(ctx, controlledSignals)
 
   let emittedAny = false
   for (const decl of sorted) {
-    const plan = buildDeclarationEmitPlan(decl, ctx, controlledSignals)
+    const plan = buildDeclarationEmitPlan(decl, ctx, lookups)
     stringifyDeclarationEmit(lines, plan)
     emittedAny = true
   }

--- a/packages/jsx/src/ir-to-client-js/phases.ts
+++ b/packages/jsx/src/ir-to-client-js/phases.ts
@@ -11,8 +11,6 @@
  * Adding a new phase: write a new `EmitPhase`, append it to `PHASES`,
  * declare its `dependsOn`. No hunting for the right insertion point in
  * a long manual sequence.
- *
- * B1 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ComponentIR, PropUsage, ReferencesGraph } from '../types'
@@ -38,6 +36,7 @@ import {
 } from './emit-reactive'
 import { emitSortedDeclarations } from './init-declarations'
 import { generateElementRefs } from './element-refs'
+import { graphUsedFunctions } from './build-references'
 
 /**
  * Inputs available to every phase. Built once by `generateInitFunction`
@@ -49,7 +48,6 @@ export interface PhaseCtx {
   graph: ReferencesGraph
   classification: LocalClassification
   propUsage: Map<string, PropUsage>
-  usedFunctions: Set<string>
   /** Slots that live inside a conditional branch (handled via `insert()`).
    *  Cached so `event-handlers` and `ref-callbacks` don't recompute. */
   conditionalSlotIds: Set<string>
@@ -64,14 +62,41 @@ export function buildPhaseCtx(args: Omit<PhaseCtx, 'conditionalSlotIds'>): Phase
 }
 
 /**
+ * String literal union of every phase id in `PHASES`. Typing `id` and
+ * `dependsOn` against this union turns a typo (e.g. `'props-extractio'`
+ * vs `'props-extraction'`) into a TypeScript error rather than a silent
+ * topological-sort reorder.
+ */
+export type PhaseId =
+  | 'props-extraction'
+  | 'sorted-declarations'
+  | 'init-statements'
+  | 'props-event-handlers'
+  | 'element-refs'
+  | 'dynamic-text-updates'
+  | 'client-only-expressions'
+  | 'reactive-attribute-updates'
+  | 'conditional-updates'
+  | 'client-only-conditionals'
+  | 'rest-attr-applications'
+  | 'event-handlers'
+  | 'reactive-prop-bindings'
+  | 'reactive-child-props'
+  | 'ref-callbacks'
+  | 'effects-and-on-mounts'
+  | 'provider-and-child-inits'
+  | 'loop-updates'
+  | 'static-array-child-inits'
+
+/**
  * One emission step. `run` appends to the shared `lines` array; if the
  * step needs to coordinate with another step (output ordering, shared
  * runtime guarantees), declare the upstream `id` in `dependsOn`.
  */
 export interface EmitPhase {
-  id: string
+  id: PhaseId
   /** Phase ids that must execute before this one. Missing ids → throw. */
-  dependsOn: readonly string[]
+  dependsOn: readonly PhaseId[]
   run: (lines: string[], pctx: PhaseCtx) => void
 }
 
@@ -101,7 +126,7 @@ export function runPhases(
     }
   }
 
-  const emitted = new Set<string>()
+  const emitted = new Set<PhaseId>()
   const remaining = phases.slice()
   while (remaining.length > 0) {
     const idx = remaining.findIndex(p => p.dependsOn.every(d => emitted.has(d)))
@@ -145,7 +170,7 @@ export const PHASES: readonly EmitPhase[] = [
   {
     id: 'props-event-handlers',
     dependsOn: ['init-statements'],
-    run: (lines, p) => emitPropsEventHandlers(lines, p.ctx, p.usedFunctions, p.classification.neededProps),
+    run: (lines, p) => emitPropsEventHandlers(lines, p.ctx, graphUsedFunctions(p.graph), p.classification.neededProps),
   },
   {
     id: 'element-refs',

--- a/packages/jsx/src/ir-to-client-js/phases/conditional-slot-ids.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/conditional-slot-ids.ts
@@ -6,8 +6,6 @@
  * legacy single-place initialiser doesn't double-bind.
  *
  * Cached once per generate-init invocation (see `buildPhaseCtx`).
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/effects-and-on-mounts.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/effects-and-on-mounts.ts
@@ -5,8 +5,6 @@
  * Effects with a `captureName` keep their `const <name> = createEffect(...)`
  * form so user code calling the captured disposer (or any future return
  * value) still resolves at runtime.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/event-handlers.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/event-handlers.ts
@@ -7,8 +7,6 @@
  *
  * `__scope` is the synthetic root slot id used when the component's
  * root element carries the listener (no `bf=` slot).
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/init-statements.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/init-statements.ts
@@ -9,8 +9,6 @@
  * The trailing blank line (only when statements were emitted) is owned
  * by this phase — it used to live as a conditional `lines.push('')` in
  * the orchestrator. Folding it in keeps the phase self-contained.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/props-event-handlers.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/props-event-handlers.ts
@@ -6,8 +6,6 @@
  * function / constant or destructured prop), emit
  * `const handlerName = _p.handlerName`. Subsequent emission can call
  * `handlerName(...)` without writing the prop accessor inline.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
@@ -15,8 +15,6 @@
  * Skipped entirely when the component uses an opaque props object name
  * (`propsObjectName != null`) — in that case downstream code reads
  * `_p.X` directly via the late-stage rename.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { PropUsage } from '../../types'

--- a/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
@@ -9,8 +9,6 @@
  * Must run before `loop-updates` (encoded as `dependsOn` in `phases.ts`)
  * so context providers are in scope when loop children call
  * `useContext()`.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/ref-callbacks.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/ref-callbacks.ts
@@ -3,8 +3,6 @@
  *
  * Slots inside conditional branches are skipped — `insert(...)` bindEvents
  * runs the ref callback every time the branch swaps in.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/rest-attr-applications.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/rest-attr-applications.ts
@@ -4,8 +4,6 @@
  *
  * The runtime helper applies the spread source's enumerable properties as
  * DOM attributes, skipping the keys statically set on the element.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import type { ClientJsContext } from '../types'

--- a/packages/jsx/src/ir-to-client-js/phases/static-array-child-inits.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/static-array-child-inits.ts
@@ -9,8 +9,6 @@
  *
  * Must run AFTER `provider-and-child-inits` so context providers are
  * available when array children call `useContext()`.
- *
- * B3 of the post-#1054 emit-init maintainability plan.
  */
 
 import { buildStaticArrayChildInitsPlan } from '../plan/build-static-array-child-init'

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -3,17 +3,15 @@
  * client-JS context. Resolves every initial-value / accessor decision
  * up-front so the stringifier never reads `ctx`.
  *
- * The signal builder mirrors the pre-A2 `emitDeclaration::signal` 4-branch
- * cascade exactly. Comments below cite the legacy lines so future drift
- * between the cases is easy to review.
- *
- * A2 of the post-#1054 emit-init maintainability plan.
+ * The signal builder mirrors the legacy `emitDeclaration::signal` 4-branch
+ * cascade exactly. Comments below name each case so future drift between
+ * the branches is easy to review.
  */
 
 import type { ControlledSignal } from '../init-declarations'
 import type { Declaration } from '../declaration-sort'
 import type { ClientJsContext } from '../types'
-import type { SignalInfo } from '../../types'
+import type { ParamInfo, SignalInfo } from '../../types'
 import { inferDefaultValue, PROPS_PARAM } from '../utils'
 import type {
   ControlledSignalEffectPlan,
@@ -21,10 +19,31 @@ import type {
   SignalEmitPlan,
 } from './declaration-emit'
 
+/**
+ * Pre-computed lookup tables used while building declaration plans.
+ * Built once per `emitSortedDeclarations` call so per-signal lookups are
+ * O(1) instead of an O(d × c) `.find()` cascade.
+ */
+export interface DeclarationEmitLookups {
+  controlledBySignal: ReadonlyMap<SignalInfo, ControlledSignal>
+  propByName: ReadonlyMap<string, ParamInfo>
+}
+
+export function buildDeclarationEmitLookups(
+  ctx: ClientJsContext,
+  controlledSignals: readonly ControlledSignal[],
+): DeclarationEmitLookups {
+  const controlledBySignal = new Map<SignalInfo, ControlledSignal>()
+  for (const c of controlledSignals) controlledBySignal.set(c.signal, c)
+  const propByName = new Map<string, ParamInfo>()
+  for (const p of ctx.propsParams) propByName.set(p.name, p)
+  return { controlledBySignal, propByName }
+}
+
 export function buildDeclarationEmitPlan(
   decl: Declaration,
   ctx: ClientJsContext,
-  controlledSignals: readonly ControlledSignal[],
+  lookups: DeclarationEmitLookups,
 ): DeclarationEmitPlan {
   switch (decl.kind) {
     case 'constant': {
@@ -37,7 +56,7 @@ export function buildDeclarationEmitPlan(
       }
     }
     case 'signal':
-      return buildSignalPlan(decl.info, ctx, controlledSignals)
+      return buildSignalPlan(decl.info, ctx, lookups)
     case 'memo':
       return {
         kind: 'memo',
@@ -59,23 +78,18 @@ export function buildDeclarationEmitPlan(
 function buildSignalPlan(
   signal: SignalInfo,
   ctx: ClientJsContext,
-  controlledSignals: readonly ControlledSignal[],
+  lookups: DeclarationEmitLookups,
 ): SignalEmitPlan {
   return {
     kind: 'signal',
     getter: signal.getter,
     setter: signal.setter,
-    initialValueExpr: resolveSignalInitialValue(signal, ctx, controlledSignals),
-    controlledEffect: buildControlledSignalEffect(signal, ctx, controlledSignals),
+    initialValueExpr: resolveSignalInitialValue(signal, ctx, lookups),
+    controlledEffect: buildControlledSignalEffect(signal, lookups),
   }
 }
 
 /**
- * Mirror of the pre-A2 `emitDeclaration::signal` decision tree. The
- * `propsName` here is what the user wrote (e.g. `props` or a custom
- * destructure object name) — `signal.initialValue` may reference it via
- * `propsName.X`, in which case we rewrite to the generated `_p.X`.
- *
  * Order of checks:
  *   1. Reads a prop directly without `??` → wrap with the prop's inferred
  *      default (`_p.X ?? <inferredDefault>`).
@@ -89,7 +103,7 @@ function buildSignalPlan(
 function resolveSignalInitialValue(
   signal: SignalInfo,
   ctx: ClientJsContext,
-  controlledSignals: readonly ControlledSignal[],
+  lookups: DeclarationEmitLookups,
 ): string {
   const propsName = ctx.propsObjectName ?? 'props'
   const propsPrefix = `${propsName}.`
@@ -103,7 +117,7 @@ function resolveSignalInitialValue(
     return `${propRef} ?? ${inferDefaultValue(signal.type)}`
   }
 
-  const controlled = controlledSignals.find(c => c.signal === signal)
+  const controlled = lookups.controlledBySignal.get(signal)
   if (controlled) {
     // Case 2a: user already wrote `??` — keep their default but rewrite
     // a leading `propsName.` prefix.
@@ -114,7 +128,7 @@ function resolveSignalInitialValue(
       return signal.initialValue
     }
     // Case 2b: synthesize the prop accessor + default.
-    const prop = ctx.propsParams.find(p => p.name === controlled.propName)
+    const prop = lookups.propByName.get(controlled.propName)
     const defaultVal = prop?.defaultValue ?? inferDefaultValue(signal.type)
     return `${PROPS_PARAM}.${controlled.propName} ?? ${defaultVal}`
   }
@@ -131,14 +145,13 @@ function resolveSignalInitialValue(
 
 function buildControlledSignalEffect(
   signal: SignalInfo,
-  ctx: ClientJsContext,
-  controlledSignals: readonly ControlledSignal[],
+  lookups: DeclarationEmitLookups,
 ): ControlledSignalEffectPlan | null {
-  const controlled = controlledSignals.find(c => c.signal === signal)
+  const controlled = lookups.controlledBySignal.get(signal)
   if (!controlled) return null
   if (!signal.setter) return null // read-only — no sync needed
 
-  const prop = ctx.propsParams.find(p => p.name === controlled.propName)
+  const prop = lookups.propByName.get(controlled.propName)
   const accessorExpr = prop?.defaultValue
     ? `(${PROPS_PARAM}.${controlled.propName} ?? ${prop.defaultValue})`
     : `${PROPS_PARAM}.${controlled.propName}`

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -17,6 +17,7 @@ import type { IRLoopChildComponent } from '../../types'
 import type { NestedLoop, TopLevelLoop } from '../types'
 import type { ClientJsContext } from '../types'
 import { quotePropName, varSlotId } from '../utils'
+import { buildCompSelector } from '../control-flow/shared'
 
 /** The inline prop shape carried on `IRLoopChildComponent.props`. */
 type LoopChildCompProp = IRLoopChildComponent['props'][number]
@@ -97,7 +98,7 @@ function buildOuterNestedPlan(
     kind: 'outer-nested',
     containerVar: `_${varSlotId(elem.slotId)}`,
     componentName: comp.name,
-    selector: buildNestedSelector(comp),
+    selector: buildCompSelector(comp),
     arrayExpr: elem.array,
     param: elem.param,
     indexParam,
@@ -114,7 +115,7 @@ function buildInnerLoopNestedPlan(
   const outerIndexParam = elem.index || '__idx'
   const comps: InnerLoopComp[] = innerComps.map(comp => ({
     componentName: comp.name,
-    selector: buildNestedSelector(comp),
+    selector: buildCompSelector(comp),
     propsExpr: buildStaticPropsExpr(comp.props),
   }))
 
@@ -160,9 +161,3 @@ function buildStaticPropsExpr(props: readonly LoopChildCompProp[]): PropsExpr {
   return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
 }
 
-/** Selector used by nested-comp init: slotId suffix match or name prefix. */
-function buildNestedSelector(comp: IRLoopChildComponent): string {
-  return comp.slotId
-    ? `[bf-s$="_${comp.slotId}"]`
-    : `[bf-s^="~${comp.name}_"], [bf-s^="${comp.name}_"]`
-}

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -10,8 +10,6 @@
  *
  * Every decision is resolved at build time so the stringifier emits one
  * line per declaration without inspecting `ctx`.
- *
- * A2 of the post-#1054 emit-init maintainability plan.
  */
 
 export interface ConstantEmitPlan {

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -13,8 +13,7 @@
  * build time so the stringifier becomes a deterministic walk.
  *
  * Replaces the legacy 120-line `emitStaticArrayChildInits` whose emission
- * shapes were determined by inline branching on the IR. See repository
- * follow-up plan "A1" of the post-#1054 maintainability evaluation.
+ * shapes were determined by inline branching on the IR.
  */
 
 /** Pre-built `{ name: value, ... }` props object expression. */

--- a/packages/jsx/src/ir-to-client-js/rewrite-props-object.ts
+++ b/packages/jsx/src/ir-to-client-js/rewrite-props-object.ts
@@ -20,8 +20,6 @@
  * may move it into analyzer-time IR rewriting (mirroring `templateXxx`
  * fields) and introduce a `PropRewritten<T>` brand type so missing the
  * rewrite becomes a compile-time error.
- *
- * C2 of the post-#1054 emit-init maintainability plan.
  */
 
 import ts from 'typescript'

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -19,8 +19,6 @@
  *     })
  *
  * Indent: every line is `  ` (2 spaces) — same as the legacy emitter.
- *
- * A2 of the post-#1054 emit-init maintainability plan.
  */
 
 import type {

--- a/packages/jsx/src/ir-to-client-js/walk-prop-accesses.ts
+++ b/packages/jsx/src/ir-to-client-js/walk-prop-accesses.ts
@@ -16,12 +16,11 @@
  * Template-style sources (HTML strings with `${...}` interpolations) are
  * normalised by extracting each interpolation expression and parsing
  * those — the surrounding HTML is irrelevant for prop access.
- *
- * C1 of the post-#1054 emit-init maintainability plan.
  */
 
 import ts from 'typescript'
 import type { PropAccessKind } from '../types'
+import { extractTemplateExpressions } from './identifiers'
 
 /** Map from prop name → set of access kinds observed across all sources. */
 export type PropAccessKindMap = Map<string, Set<PropAccessKind>>
@@ -43,6 +42,15 @@ export function collectPropAccesses(
 ): void {
   if (propNames.size === 0) return
 
+  // Quick exit: if the source mentions none of the candidate names by
+  // substring, no AST walk is needed. Saves a TS parse per source for
+  // the common case where most strings touch only a handful of props.
+  let anyMentioned = false
+  for (const name of propNames) {
+    if (source.includes(name)) { anyMentioned = true; break }
+  }
+  if (!anyMentioned) return
+
   for (const expr of normaliseExpressionParts(source)) {
     const sourceFile = ts.createSourceFile(
       'p.ts',
@@ -58,21 +66,12 @@ export function collectPropAccesses(
 /**
  * Yield each parseable JS expression embedded in `source`. Pure
  * expressions yield the whole string; template-style strings yield only
- * the `${...}` substitution bodies.
+ * the `${...}` substitution bodies via the shared
+ * `extractTemplateExpressions` helper.
  */
 function normaliseExpressionParts(source: string): string[] {
   if (!source.includes('${')) return [source]
-  const parts: string[] = []
-  // Mirror `extractTemplateIdentifiers`'s `\$\{([^}]+)\}` heuristic so the
-  // `{}` default decision stays byte-identical with the regex era; using
-  // a character-class instead of full balance-aware extraction keeps the
-  // scanner cheap and matches the legacy reach.
-  const re = /\$\{([^}]+)\}/g
-  let match: RegExpExecArray | null
-  while ((match = re.exec(source)) !== null) {
-    parts.push(match[1])
-  }
-  return parts
+  return extractTemplateExpressions(source)
 }
 
 function visit(


### PR DESCRIPTION
## Summary

Cleanup pass over the emit-init refactor (#1056-#1061), driven by three parallel review agents (reuse / quality / efficiency).

### Reuse
- **\`buildNestedSelector\` → \`buildCompSelector\`** — the local copy in \`plan/build-static-array-child-init.ts\` was byte-identical to the shared \`control-flow/shared.ts::buildCompSelector\`. Replaced with import.
- **Template \`\${…}\` extraction unified** — \`walk-prop-accesses.ts::normaliseExpressionParts\` and \`identifiers.ts::extractTemplateIdentifiers\` shared the same \`\\\$\\{([^}]+)\\}\` regex. Extracted \`extractTemplateExpressions\` in \`identifiers.ts\` and consolidated.

### Quality
- **Stage labels removed** — stripped \`A1/A2/B1/B3/C1/C2 of the post-#1054 maintainability plan\` from 18 file headers. Stage labels belong in commit messages, not source.
- **\`PhaseId\` string literal union** — \`EmitPhase.id\` and \`dependsOn\` are now typed as \`PhaseId\` (a union of all 19 ids). A typo in \`dependsOn\` becomes a compile error instead of a silent topological-sort reorder.
- **\`usedFunctions\` cache removed from \`PhaseCtx\`** — only one phase consumed it. The phase now calls \`graphUsedFunctions(p.graph)\` on-demand, freeing \`PhaseCtx\` of an unnecessary precomputed-Set field.

### Efficiency
- **N+1 lookups → Map (\`build-declaration-emit\`)** — \`controlledSignals.find(...)\` and \`propsParams.find(...)\` ran 2-3× per signal. New \`buildDeclarationEmitLookups\` (called once per \`emitSortedDeclarations\`) provides O(1) lookups.
- **Quick string check in \`collectPropAccesses\`** — skip the TS parse when the source mentions none of the candidate prop names by substring. Saves a parse per source for the common case where most strings touch only a handful of props.

### Skipped findings
- \`buildStaticPropsExpr\` vs \`buildComponentPropsExpr\` consolidation — they emit subtly different shapes (literal as plain prop vs getter); merging risks silent breakage. Kept separate.
- \`prop-rewrite.ts::rewriteBarePropRefs\` + \`walk-prop-accesses.ts::visit\` AST walk consolidation — the use cases differ enough that a shared helper would have a complex signature. Worth doing if a third caller appears.
- \`init-declarations.ts::addConstantPropRefsToSet\` regex scan AST-ification — outside the emit-init refactor scope.

## Test plan

- [x] \`bun test packages/jsx\` — 803 / 4 unrelated resolver-alias fails unchanged
- [x] \`bun test packages/adapter-tests packages/client\` — 426 / 0 fail
- [x] \`bun run --filter '@barefootjs/jsx' build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)