### PR TITLE
fix(compiler): re-emit inner .map() callback locals in mapArray renderItem (#1052)

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -223,4 +223,65 @@ describe('plain nested loops without conditional wrapper', () => {
     const innerMapArrayCount = (js.match(/mapArray\(\(\)\s*=>\s*g\(\)\.items/g) || []).length
     expect(innerMapArrayCount).toBe(1)
   })
+
+  test('regression #1052: inner .map() block-body locals are re-declared inside the mapArray renderItem', () => {
+    // Before the fix, an inner `.map()` callback that declares local
+    // variables (block body with `const x = ...`) and uses them in the
+    // returned JSX produced a broken renderItem callback: the locals
+    // appeared in the cloned-template IIFE but were never declared in
+    // the renderItem closure, raising `ReferenceError: x is not defined`
+    // when the inner mapArray needed to create new elements.
+    //
+    // Fix: thread the inner loop's `mapPreamble` through `NestedLoop`
+    // and re-emit it (with inner+outer loop param references rewritten
+    // to signal-accessor form) at the top of the renderItem callback so
+    // the IIFE and any subsequent reads see the locals.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; value: string; flag: boolean }
+
+      export function GridDemo() {
+        const [grid, setGrid] = createSignal<Cell[][]>([
+          [{ id: 1, value: 'a', flag: true }],
+        ])
+        return (
+          <div onClick={() => setGrid(prev => [...prev])}>
+            {grid().map((row, i) => (
+              <div key={i}>
+                {row.map((cell) => {
+                  const derivedClass = cell.flag ? 'on' : 'off'
+                  return (
+                    <span key={cell.id} className={derivedClass}>{cell.value}</span>
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'GridDemo.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The inner mapArray's renderItem must declare `derivedClass` so the
+    // new-element-creation IIFE doesn't throw `ReferenceError`. The
+    // declaration must use `cell()` — the signal-accessor form of the
+    // inner loop param — not the bare `cell` from the outer template.
+    expect(js).toMatch(
+      /\(cell, __innerIdx[^,]+, __existing\) => \{[\s\S]*?const\s+derivedClass\s*=\s*cell\(\)\.flag/
+    )
+    // Within the inner renderItem body (delimited by the outer
+    // `mapArray(() => row()` block), every reference to the inner loop
+    // param must be the accessor form — bare `cell.flag` would mean the
+    // preamble wrapping pass missed a reference.
+    const innerSection = js.slice(
+      js.indexOf('mapArray(() => row()'),
+      js.indexOf('return __innerEl1_0'),
+    )
+    expect(innerSection.length).toBeGreaterThan(0)
+    expect(innerSection).not.toMatch(/\bcell\.flag\b/)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -220,6 +220,7 @@ export function collectInnerLoops(
           key: n.key,
           containerSlotId: scope.parentSlotId,
           template,
+          mapPreamble: n.mapPreamble,
           refsOuterParam: refsOuter,
           childReactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
           childComponents,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -166,11 +166,23 @@ function buildReactiveEmit(
     insideConditional: !!text.insideConditional,
   }))
 
+  // The inner `.map()` callback's block-body locals (e.g.
+  // `const derivedClass = cell.flag ? 'on' : 'off'`) are baked into
+  // `inner.template` at the outer-loop SSR level, but the `mapArray`
+  // renderItem closure does not declare them — references inside the
+  // cloned-template IIFE would throw `ReferenceError`. Re-emit the
+  // preamble at the top of the renderItem with both inner and outer
+  // loop param references rewritten to signal-accessor form (#1052).
+  const preambleWrapped = inner.mapPreamble
+    ? wrapInner(wrapOuter(inner.mapPreamble))
+    : ''
+
   return {
     mode: 'reactive',
     keyFn: loopKeyFn(inner),
     paramHead,
     paramUnwrap,
+    preambleWrapped,
     wrappedTemplate: inner.template!,
     wrappedKey,
     components,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -173,16 +173,18 @@ function buildReactiveEmit(
   // cloned-template IIFE would throw `ReferenceError`. Re-emit the
   // preamble at the top of the renderItem with both inner and outer
   // loop param references rewritten to signal-accessor form (#1052).
-  const preambleWrapped = inner.mapPreamble
-    ? wrapInner(wrapOuter(inner.mapPreamble))
-    : ''
+  // The destructure unwrap (when `inner.param` is a binding pattern)
+  // has to land before the preamble so the preamble's bare-binding
+  // references resolve.
+  const preludeStatements: string[] = []
+  if (paramUnwrap) preludeStatements.push(paramUnwrap)
+  if (inner.mapPreamble) preludeStatements.push(wrapInner(wrapOuter(inner.mapPreamble)))
 
   return {
     mode: 'reactive',
     keyFn: loopKeyFn(inner),
     paramHead,
-    paramUnwrap,
-    preambleWrapped,
+    preludeStatements,
     wrappedTemplate: inner.template!,
     wrappedKey,
     components,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -83,6 +83,14 @@ export interface InnerLoopReactiveEmit {
   paramHead: string
   /** Body-entry unwrap statement (empty when no destructured param). */
   paramUnwrap: string
+  /**
+   * Inner `.map()` callback's `mapPreamble` (block-body local declarations),
+   * with both inner and outer loop param references rewritten to signal
+   * accessor form. Empty when the source had no preamble. Emitted at the
+   * top of the renderItem callback so the cloned-template IIFE and any
+   * subsequent reads can resolve the locals (#1052).
+   */
+  preambleWrapped: string
   /** Already-wrapped HTML template for one inner-loop item. */
   wrappedTemplate: string
   /** Pre-wrapped key expression for setAttribute, or null when no key. */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -81,16 +81,15 @@ export interface InnerLoopReactiveEmit {
   keyFn: string
   /** mapArray renderItem param head — `inner.param` or `__bfItem`. */
   paramHead: string
-  /** Body-entry unwrap statement (empty when no destructured param). */
-  paramUnwrap: string
   /**
-   * Inner `.map()` callback's `mapPreamble` (block-body local declarations),
-   * with both inner and outer loop param references rewritten to signal
-   * accessor form. Empty when the source had no preamble. Emitted at the
-   * top of the renderItem callback so the cloned-template IIFE and any
-   * subsequent reads can resolve the locals (#1052).
+   * Body-entry statements emitted in order at the top of the renderItem
+   * callback, before the `let __innerEl = ...` clone. Holds the optional
+   * destructured-param unwrap and the (signal-accessor wrapped) inner
+   * `.map()` callback preamble locals (#1052). Empty when neither applies.
+   * Modeled as a list so the stringifier walks it deterministically
+   * instead of branching on multiple independent emptiness checks.
    */
-  preambleWrapped: string
+  preludeStatements: readonly string[]
   /** Already-wrapped HTML template for one inner-loop item. */
   wrappedTemplate: string
   /** Pre-wrapped key expression for setAttribute, or null when no key. */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -61,6 +61,13 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
   if (emit.paramUnwrap) {
     lines.push(`${indent}  ${emit.paramUnwrap}`)
   }
+  // Hoist the inner `.map()` callback's preamble locals so the
+  // cloned-template IIFE below (and any later reads in this body) can
+  // resolve them. References to the inner/outer loop params are
+  // already in signal-accessor form (#1052).
+  if (emit.preambleWrapped) {
+    lines.push(`${indent}  ${emit.preambleWrapped}`)
+  }
   lines.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${emit.wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
   if (emit.wrappedKey) {
     lines.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.keyDepth)}', String(${emit.wrappedKey}))`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -8,7 +8,7 @@
  *     <indent>// Reactive inner loop: <arraySrc>
  *     <indent>{ const __ic<uid> = <containerExpr>
  *     <indent>if (__ic<uid>) mapArray(() => <arrayExpr> || [], __ic<uid>, <keyFn>, (<head>, __innerIdx<uid>, __existing) => {
- *     <indent>  <unwrap?>
+ *     <indent>  <preludeStatements*>   // unwrap, then preamble (#1052)
  *     <indent>  let __innerEl<uid> = __existing ?? clone(template)
  *     <indent>  __innerEl<uid>.setAttribute('<keyAttr>', String(<wrappedKey>))?
  *     <indent>  emitComponentAndEventSetup(...)
@@ -58,15 +58,11 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
   lines.push(`${indent}// Reactive inner loop: ${inner.arraySrc}`)
   lines.push(`${indent}{ const __ic${uid} = ${inner.containerExpr}`)
   lines.push(`${indent}if (__ic${uid}) mapArray(() => ${inner.arrayExpr} || [], __ic${uid}, ${emit.keyFn}, (${emit.paramHead}, __innerIdx${uid}, __existing) => {`)
-  if (emit.paramUnwrap) {
-    lines.push(`${indent}  ${emit.paramUnwrap}`)
-  }
-  // Hoist the inner `.map()` callback's preamble locals so the
-  // cloned-template IIFE below (and any later reads in this body) can
-  // resolve them. References to the inner/outer loop params are
-  // already in signal-accessor form (#1052).
-  if (emit.preambleWrapped) {
-    lines.push(`${indent}  ${emit.preambleWrapped}`)
+  // Body-entry statements: optional destructure unwrap, then optional
+  // inner-`.map()` preamble locals (signal-accessor wrapped, #1052).
+  // The clone IIFE below depends on both being in scope.
+  for (const stmt of emit.preludeStatements) {
+    lines.push(`${indent}  ${stmt}`)
   }
   lines.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${emit.wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
   if (emit.wrappedKey) {

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -181,6 +181,14 @@ export interface NestedLoop extends LoopCore {
   containerSlotId: string | null // Slot ID of the parent element containing the loop (for hydration)
   /** HTML template for a single inner loop item (for mapArray CSR rendering) */
   template?: string
+  /**
+   * Raw JS of pre-return statements in the inner `.map()` callback's block
+   * body. The reactive emitter re-emits this (with loop-param references
+   * rewritten to signal-accessor form) at the top of the `mapArray`
+   * `renderItem` callback so locals referenced by the cloned-template IIFE
+   * (and any subsequent reads) are in scope (#1052).
+   */
+  mapPreamble?: string
   /** Whether the inner array references the outer loop param (needs reactive mapArray) */
   refsOuterParam?: boolean
   /** Reactive text expressions inside inner loop items (slotId → expression) */


### PR DESCRIPTION
## Summary

Closes #1052.

When an inner `.map()` callback uses a block body to declare locals referenced by the returned JSX, the compiler baked those references into the cloned-template IIFE inside the inner `mapArray` `renderItem` without declaring the locals in the `renderItem` closure. Creating new inner items (e.g., when keys change) then threw `ReferenceError: <local> is not defined`, silently killing the surrounding reactive effect chain.

## Fix

Thread the inner `.map()`'s `mapPreamble` through and re-emit it at the top of the `renderItem` callback with inner+outer loop-param references rewritten to signal-accessor form:

1. `IRLoop.mapPreamble` → `NestedLoop.mapPreamble` (`collect-elements.ts`)
2. `NestedLoop.mapPreamble` → `InnerLoopReactiveEmit.preambleWrapped` (`build-inner-loop.ts`, wrapping with `wrapInner(wrapOuter(...))`)
3. Emit `preambleWrapped` at the top of the reactive `mapArray` `renderItem` body (`stringify/inner-loop.ts`)

### Before

```js
(cell, __innerIdx1_0, __existing) => {
  let __innerEl1_0 = __existing ?? (() => {
    const __t = document.createElement('template')
    __t.innerHTML = `... ${(derivedClass) != null ? 'class="' + (derivedClass) + '"' : ''} ...`
    // ❌ ReferenceError: derivedClass is not defined
    ...
  })()
```

### After

```js
(cell, __innerIdx1_0, __existing) => {
  const derivedClass = cell().flag ? 'on' : 'off';   // ← re-emitted, accessor form
  let __innerEl1_0 = __existing ?? (() => {
    const __t = document.createElement('template')
    __t.innerHTML = `... ${(derivedClass) != null ? 'class="' + (derivedClass) + '"' : ''} ...`
    ...
  })()
```

## Test plan

- [x] Added `regression #1052` test in `packages/jsx/src/__tests__/nested-loop-plain.test.ts`
- [x] `bun test packages/jsx` — 804 pass, 0 fail
- [x] `bun test packages/adapter-tests` — 214 pass, 0 fail
- [x] `bun test ui/components` — 1162 pass, 0 fail
- [x] `bun test packages/client` — 212 pass, 0 fail
- [x] `bun run --cwd site/ui build` — Build complete!

🤖 Generated with [Claude Code](https://claude.com/claude-code)