### PR TITLE
fix(compiler): re-emit static inner forEach preamble for nested .map() locals (#1064)

### DIFF
--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -284,4 +284,65 @@ describe('plain nested loops without conditional wrapper', () => {
     expect(innerSection.length).toBeGreaterThan(0)
     expect(innerSection).not.toMatch(/\bcell\.flag\b/)
   })
+
+  test('regression #1064: static inner forEach also re-declares inner .map() block-body locals', () => {
+    // Sibling of #1052 in the **static** inner-loop emission path. When the
+    // outer array is a plain literal (not a signal) and the inner `.map()`
+    // callback's block-body declares locals referenced by a child component
+    // prop or event handler, the static `forEach` body did not declare those
+    // locals — `initChild`'s prop getter would throw `ReferenceError` when
+    // the child component first mounted.
+    //
+    // Fix: thread `inner.mapPreamble` through `InnerLoopStaticEmit` and emit
+    // it (raw — `forEach`'s param is the literal item, not a signal accessor)
+    // at the top of the forEach body so the component setup can resolve the
+    // locals.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { id: number; n: number }
+
+      function MyChild(props: { label: string }) {
+        return <span>{props.label}</span>
+      }
+
+      export function StaticGrid() {
+        const items: Item[][] = [[{ id: 1, n: 5 }]]
+        const [, setX] = createSignal(0)
+        return (
+          <div onClick={() => setX(1)}>
+            {items.map((row, i) => (
+              <div key={i}>
+                {row.map((it) => {
+                  const lbl = \`item-\${it.n}\`
+                  return <MyChild key={it.id} label={lbl} />
+                })}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'StaticGrid.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The static `forEach((it, ...) => { ... })` body must declare `lbl`
+    // before `initChild('MyChild', ...)` runs. `it` is the raw item here
+    // (forEach, not mapArray) so the preamble is emitted unwrapped.
+    expect(js).toMatch(
+      /\.forEach\(\(it, __innerIdx\) => \{[\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild'/
+    )
+    // No `ReferenceError` shape: the `initChild('MyChild', ...)` getter must
+    // reach a declared `lbl` — the static body cannot rely on the outer
+    // `.map()` callback's scope (that scope only existed at SSR time).
+    const staticSection = js.slice(
+      js.indexOf('items.forEach('),
+      js.indexOf('hydrate(\'StaticGrid\''),
+    )
+    expect(staticSection).toMatch(/const\s+lbl\s*=/)
+    expect(staticSection).toMatch(/initChild\('MyChild'/)
+    expect(staticSection.indexOf('const lbl')).toBeLessThan(staticSection.indexOf('initChild'))
+  })
 })

--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -345,4 +345,143 @@ describe('plain nested loops without conditional wrapper', () => {
     expect(staticSection).toMatch(/initChild\('MyChild'/)
     expect(staticSection.indexOf('const lbl')).toBeLessThan(staticSection.indexOf('initChild'))
   })
+
+  test('regression #1064: single-comp static array with preamble (loop body is one component)', () => {
+    // The `single-comp` static-init shape fires when the `.map()` body
+    // returns a single component instance. Its `__childScopes.forEach`
+    // body resolves the loop param via index lookup — but did not
+    // declare outer `.map()` locals, so the propsExpr getter saw
+    // `ReferenceError` at first render.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { id: number; n: number }
+
+      function MyChild(props: { label: string }) {
+        return <span>{props.label}</span>
+      }
+
+      export function FlatList() {
+        const items: Item[] = [{ id: 1, n: 5 }]
+        const [, setX] = createSignal(0)
+        return (
+          <ul onClick={() => setX(1)}>
+            {items.map((it) => {
+              const lbl = \`item-\${it.n}\`
+              return <MyChild key={it.id} label={lbl} />
+            })}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'FlatList.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The single-comp emit declares the loop param via `[<idx>]` lookup;
+    // the preamble must appear after that lookup and before initChild
+    // so propsExpr getters can read it.
+    const section = js.slice(
+      js.indexOf('__childScopes.forEach'),
+      js.indexOf('hydrate(\'FlatList\''),
+    )
+    expect(section).toMatch(/const\s+it\s*=\s*items\[__idx\][\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild'/)
+    expect(section.indexOf('const lbl')).toBeLessThan(section.indexOf('initChild'))
+  })
+
+  test('regression #1064: inner-loop-nested static array with OUTER preamble', () => {
+    // The `inner-loop-nested` shape carries two preamble slots
+    // (`outerPreludeStatements` + `innerPreludeStatements`). The previous
+    // test exercised the inner one; this one exercises the outer slot —
+    // the outer preamble must land after `if (!__outerEl) return` and
+    // before the inner forEach so the inner forEach's component setup
+    // can read it.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; n: number }
+      type Row = { id: number; cells: Cell[]; label: string }
+
+      function MyChild(props: { tag: string }) {
+        return <span>{props.tag}</span>
+      }
+
+      export function OuterPreambleGrid() {
+        const rows: Row[] = [{ id: 1, label: 'top', cells: [{ id: 11, n: 5 }] }]
+        const [, setX] = createSignal(0)
+        return (
+          <div onClick={() => setX(1)}>
+            {rows.map((row) => {
+              const rowTag = \`row-\${row.label}\`
+              return (
+                <div key={row.id}>
+                  {row.cells.map((cell) => (
+                    <MyChild key={cell.id} tag={rowTag + '-' + cell.n} />
+                  ))}
+                </div>
+              )
+            })}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'OuterPreambleGrid.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The outer preamble (`const rowTag = ...`) must appear in the
+    // outer forEach body, after `if (!__outerEl) return` and before the
+    // inner forEach — and the inner forEach's `initChild` getter reads it.
+    const section = js.slice(
+      js.indexOf('rows.forEach('),
+      js.indexOf('hydrate(\'OuterPreambleGrid\''),
+    )
+    expect(section).toMatch(/if \(!__outerEl\) return[\s\S]*?const\s+rowTag\s*=\s*`row-\$\{row\.label\}`[\s\S]*?\.cells\.forEach/)
+    expect(section.indexOf('const rowTag')).toBeLessThan(section.indexOf('initChild'))
+  })
+
+  test('regression #1064: control-flow static inner forEach (signal outer + literal-array inner) emits inner preamble', () => {
+    // The `control-flow/inner-loop.ts::emitStatic` path fires when a
+    // reactive composite renderItem hosts a static inner loop — the
+    // outer array is a signal, but the inner array is referenced via
+    // a non-reactive lookup so its rendering stays setup-only.
+    // Use a `__innerIdx<uid>` suffix in the regex to specifically
+    // target this path (vs. the unsuffixed `static-array-child-init`).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; n: number }
+      const SHARED: Cell[] = [{ id: 1, n: 7 }]
+
+      function MyChild(props: { tag: string }) {
+        return <span>{props.tag}</span>
+      }
+
+      export function MixedGrid() {
+        const [rows, setRows] = createSignal([{ id: 1, key: 'a' }])
+        return (
+          <div onClick={() => setRows(prev => [...prev])}>
+            {rows().map((row) => (
+              <div key={row.id}>
+                {SHARED.map((cell) => {
+                  const tag = \`\${row.key}-\${cell.n}\`
+                  return <MyChild key={cell.id} tag={tag} />
+                })}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'MixedGrid.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The static forEach uses a `__innerIdx<uid>` suffix in this path —
+    // assert preamble appears in that body and precedes any prop read.
+    expect(js).toMatch(/SHARED\.forEach\(\(cell, __innerIdx\d+_\d+\) => \{[\s\S]*?const\s+tag\s*=/)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -194,9 +194,15 @@ function buildReactiveEmit(
 }
 
 function buildStaticEmit(inner: NestedLoop, level: DepthLevel): InnerLoopStaticEmit {
+  // Static `forEach` iterates with the literal item as its first param, so
+  // no signal-accessor rewrite is needed — emit the preamble verbatim
+  // before the component/event setup so prop getters and event handlers
+  // can resolve the locals (#1064).
+  const preludeStatements: string[] = inner.mapPreamble ? [inner.mapPreamble] : []
   return {
     mode: 'static',
     rawKey: inner.key ?? null,
+    preludeStatements,
     components: level.comps,
     events: level.events,
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -106,6 +106,15 @@ export interface InnerLoopStaticEmit {
   mode: 'static'
   /** Raw key expression (used as-is in setAttribute) — null when no key. */
   rawKey: string | null
+  /**
+   * Body-entry statements emitted in order at the top of the static
+   * `forEach(...)` body, after the existence guard. Holds the inner
+   * `.map()` callback preamble locals (#1064). Emitted unwrapped because
+   * the forEach param is the literal item, not a signal accessor — no
+   * accessor rewrite is needed. Empty when the source had no preamble.
+   * Mirrors the reactive emit's `preludeStatements` shape (#1052/#1063).
+   */
+  preludeStatements: readonly string[]
   /** Raw components (no inner-wrap; the static body has no signal accessor). */
   components: readonly IRLoopChildComponent[]
   /** Raw events (no inner-wrap). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -16,6 +16,18 @@ import type {
   LoopParamBinding,
 } from '../../../types'
 
+/**
+ * Body-entry statements emitted in order at the top of a `mapArray`
+ * renderItem or static `forEach` body. Used by every nested-loop emission
+ * point that needs to inject the inner `.map()` callback's preamble locals
+ * (and, for reactive renderItems, the destructured-param unwrap).
+ *
+ * Empty array = no statements. The list shape lets the stringifier walk
+ * deterministically instead of branching on multiple independent
+ * emptiness checks (#1063 / #1064).
+ */
+export type PreludeStatements = readonly string[]
+
 /** A reactive text effect inside a reactive inner loop's renderItem body. */
 export interface InnerLoopText {
   slotId: string
@@ -82,14 +94,12 @@ export interface InnerLoopReactiveEmit {
   /** mapArray renderItem param head — `inner.param` or `__bfItem`. */
   paramHead: string
   /**
-   * Body-entry statements emitted in order at the top of the renderItem
-   * callback, before the `let __innerEl = ...` clone. Holds the optional
-   * destructured-param unwrap and the (signal-accessor wrapped) inner
-   * `.map()` callback preamble locals (#1052). Empty when neither applies.
-   * Modeled as a list so the stringifier walks it deterministically
-   * instead of branching on multiple independent emptiness checks.
+   * Body-entry statements (see `PreludeStatements`) emitted at the top of
+   * the renderItem callback, before the `let __innerEl = ...` clone.
+   * Holds the optional destructured-param unwrap and the (signal-accessor
+   * wrapped) inner `.map()` callback preamble locals (#1052).
    */
-  preludeStatements: readonly string[]
+  preludeStatements: PreludeStatements
   /** Already-wrapped HTML template for one inner-loop item. */
   wrappedTemplate: string
   /** Pre-wrapped key expression for setAttribute, or null when no key. */
@@ -107,14 +117,13 @@ export interface InnerLoopStaticEmit {
   /** Raw key expression (used as-is in setAttribute) — null when no key. */
   rawKey: string | null
   /**
-   * Body-entry statements emitted in order at the top of the static
-   * `forEach(...)` body, after the existence guard. Holds the inner
-   * `.map()` callback preamble locals (#1064). Emitted unwrapped because
-   * the forEach param is the literal item, not a signal accessor — no
-   * accessor rewrite is needed. Empty when the source had no preamble.
-   * Mirrors the reactive emit's `preludeStatements` shape (#1052/#1063).
+   * Body-entry statements (see `PreludeStatements`) emitted at the top of
+   * the static `forEach(...)` body, after the existence guard. Holds the
+   * inner `.map()` callback preamble locals (#1064). Emitted unwrapped
+   * because the forEach param is the literal item, not a signal accessor —
+   * no accessor rewrite is needed.
    */
-  preludeStatements: readonly string[]
+  preludeStatements: PreludeStatements
   /** Raw components (no inner-wrap; the static body has no signal accessor). */
   components: readonly IRLoopChildComponent[]
   /** Raw events (no inner-wrap). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -23,6 +23,7 @@
  *     <indent>if (__ic<uid> && <arrayExpr>) <arrayExpr>.forEach((<param>, __innerIdx<uid>) => {
  *     <indent>  const __innerEl<uid> = __ic<uid>.children[__innerIdx<uid>]
  *     <indent>  if (!__innerEl<uid>) return
+ *     <indent>  <preludeStatements*>   // raw preamble (#1064)
  *     <indent>  __innerEl<uid>.setAttribute('<keyAttr>', String(<rawKey>))?
  *     <indent>  emitComponentAndEventSetup(...)
  *     <indent>  recurse on childLevels
@@ -107,6 +108,12 @@ function emitStatic(lines: string[], inner: InnerLoopPlan, indent: string): void
   lines.push(`${indent}if (__ic${uid} && ${inner.arrayExpr}) ${inner.arrayExpr}.forEach((${inner.param}, __innerIdx${uid}) => {`)
   lines.push(`${indent}  const __innerEl${uid} = __ic${uid}.children[__innerIdx${uid}]`)
   lines.push(`${indent}  if (!__innerEl${uid}) return`)
+  // Body-entry statements: inner-`.map()` preamble locals (raw, since the
+  // forEach param is the literal item — #1064). Emitted before component
+  // and event setup so their prop getters / handlers resolve the locals.
+  for (const stmt of emit.preludeStatements) {
+    lines.push(`${indent}  ${stmt}`)
+  }
   if (emit.rawKey) {
     lines.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.keyDepth)}', String(${emit.rawKey}))`)
   }

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -103,6 +103,7 @@ function buildOuterNestedPlan(
     param: elem.param,
     indexParam,
     offsetExpr: elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam,
+    preludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
     propsExpr: buildStaticPropsExpr(comp.props),
   }
 }
@@ -128,12 +129,14 @@ function buildInnerLoopNestedPlan(
     outerOffsetExpr: elem.siblingOffset
       ? `${outerIndexParam} + ${elem.siblingOffset}`
       : outerIndexParam,
+    outerPreludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
     innerContainerSlotId: innerLoop.containerSlotId ?? null,
     innerArrayExpr: innerLoop.array,
     innerParam: innerLoop.param,
     innerOffsetExpr: innerLoop.siblingOffset
       ? `__innerIdx + ${innerLoop.siblingOffset}`
       : '__innerIdx',
+    innerPreludeStatements: innerLoop.mapPreamble ? [innerLoop.mapPreamble] : [],
     depth: innerLoop.depth,
     comps,
   }

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -85,6 +85,7 @@ function buildSingleCompPlan(
     arrayExpr: elem.array,
     param: elem.param,
     indexParam: elem.index || '__idx',
+    outerPreludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
     propsExpr: buildStaticPropsExpr(props),
   }
 }
@@ -103,7 +104,7 @@ function buildOuterNestedPlan(
     param: elem.param,
     indexParam,
     offsetExpr: elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam,
-    preludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
+    outerPreludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
     propsExpr: buildStaticPropsExpr(comp.props),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -58,6 +58,14 @@ export interface OuterNestedInitPlan {
   indexParam: string
   /** `indexParam` or `${indexParam} + ${siblingOffset}` — already substituted. */
   offsetExpr: string
+  /**
+   * Body-entry statements emitted at the top of the outer `forEach(...)`
+   * body, before the per-component lookup. Holds the outer `.map()`
+   * callback preamble locals (#1064). Emitted unwrapped — the forEach
+   * param is the literal item, not a signal accessor. Empty when the
+   * source had no preamble.
+   */
+  preludeStatements: readonly string[]
   propsExpr: PropsExpr
 }
 
@@ -76,6 +84,12 @@ export interface InnerLoopNestedInitPlan {
   /** Outer offset — `outerIndexParam` or `${outerIndexParam} + ${siblingOffset}`. */
   outerOffsetExpr: string
   /**
+   * Outer `.map()` callback preamble locals, emitted at the top of the
+   * outer `forEach(...)` body so the inner forEach (and its component
+   * setup) can resolve them (#1064). Empty when no preamble.
+   */
+  outerPreludeStatements: readonly string[]
+  /**
    * Inner loop's container slot id. When non-null, the stringifier emits
    * `__outerEl.querySelector('[bf="..."]') || __outerEl`; otherwise
    * `__outerEl` is used directly.
@@ -85,6 +99,12 @@ export interface InnerLoopNestedInitPlan {
   innerParam: string
   /** Inner offset — `__innerIdx` or `__innerIdx + ${siblingOffset}`. */
   innerOffsetExpr: string
+  /**
+   * Inner `.map()` callback preamble locals, emitted at the top of the
+   * inner `forEach(...)` body so the per-component prop getters can
+   * resolve them (#1064). Empty when no preamble.
+   */
+  innerPreludeStatements: readonly string[]
   /** Depth used in the leading comment line (e.g. `depth 2`). */
   depth: number
   /** Per-component initialisers emitted inside the inner forEach body. */

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -16,6 +16,8 @@
  * shapes were determined by inline branching on the IR.
  */
 
+import type { PreludeStatements } from '../control-flow/plan/inner-loop'
+
 /** Pre-built `{ name: value, ... }` props object expression. */
 export type PropsExpr = string
 
@@ -42,6 +44,13 @@ export interface SingleCompInitPlan {
   param: string
   /** Index parameter identifier (e.g. `__idx` or user-supplied). */
   indexParam: string
+  /**
+   * Outer `.map()` callback preamble locals (#1064), emitted inside the
+   * `__childScopes.forEach` body after the `const <param> = ...[__idx]`
+   * lookup so the propsExpr getter can resolve them. Empty when no
+   * preamble.
+   */
+  outerPreludeStatements: PreludeStatements
   /** Pre-built props object expression for the child component. */
   propsExpr: PropsExpr
 }
@@ -59,13 +68,12 @@ export interface OuterNestedInitPlan {
   /** `indexParam` or `${indexParam} + ${siblingOffset}` — already substituted. */
   offsetExpr: string
   /**
-   * Body-entry statements emitted at the top of the outer `forEach(...)`
-   * body, before the per-component lookup. Holds the outer `.map()`
-   * callback preamble locals (#1064). Emitted unwrapped — the forEach
-   * param is the literal item, not a signal accessor. Empty when the
-   * source had no preamble.
+   * Outer `.map()` callback preamble locals (#1064), emitted inside the
+   * outer `forEach`'s `if (__iterEl)` block — i.e. only when the SSR
+   * element exists, matching `inner-loop-nested`'s post-guard placement.
+   * Empty when the source had no preamble.
    */
-  preludeStatements: readonly string[]
+  outerPreludeStatements: PreludeStatements
   propsExpr: PropsExpr
 }
 
@@ -84,11 +92,11 @@ export interface InnerLoopNestedInitPlan {
   /** Outer offset — `outerIndexParam` or `${outerIndexParam} + ${siblingOffset}`. */
   outerOffsetExpr: string
   /**
-   * Outer `.map()` callback preamble locals, emitted at the top of the
-   * outer `forEach(...)` body so the inner forEach (and its component
-   * setup) can resolve them (#1064). Empty when no preamble.
+   * Outer `.map()` callback preamble locals, emitted after the
+   * `if (!__outerEl) return` guard so the inner forEach (and its
+   * component setup) can resolve them (#1064). Empty when no preamble.
    */
-  outerPreludeStatements: readonly string[]
+  outerPreludeStatements: PreludeStatements
   /**
    * Inner loop's container slot id. When non-null, the stringifier emits
    * `__outerEl.querySelector('[bf="..."]') || __outerEl`; otherwise
@@ -100,11 +108,11 @@ export interface InnerLoopNestedInitPlan {
   /** Inner offset — `__innerIdx` or `__innerIdx + ${siblingOffset}`. */
   innerOffsetExpr: string
   /**
-   * Inner `.map()` callback preamble locals, emitted at the top of the
-   * inner `forEach(...)` body so the per-component prop getters can
-   * resolve them (#1064). Empty when no preamble.
+   * Inner `.map()` callback preamble locals, emitted after the
+   * `if (!__innerEl) return` guard so the per-component prop getters
+   * can resolve them (#1064). Empty when no preamble.
    */
-  innerPreludeStatements: readonly string[]
+  innerPreludeStatements: PreludeStatements
   /** Depth used in the leading comment line (e.g. `depth 2`). */
   depth: number
   /** Per-component initialisers emitted inside the inner forEach body. */

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -18,6 +18,7 @@
  *     <i>// Initialize nested <name> in static array
  *     <i>if (<container>) {
  *     <i>  <array>.forEach((<param>, <idx>) => {
+ *     <i>    <preludeStatements*>   // raw outer preamble (#1064)
  *     <i>    const __iterEl = <container>.children[<offset>]
  *     <i>    if (__iterEl) {
  *     <i>      const __compEl = __iterEl.querySelector('<selector>')
@@ -32,10 +33,12 @@
  *     <i>  <outerArr>.forEach((<outerParam>, <outerIdx>) => {
  *     <i>    const __outerEl = <container>.children[<outerOffset>]
  *     <i>    if (!__outerEl) return
+ *     <i>    <outerPreludeStatements*>   // raw outer preamble (#1064)
  *     <i>    const __ic = <innerContainer-or-outerEl>
  *     <i>    <innerArr>.forEach((<innerParam>, __innerIdx) => {
  *     <i>      const __innerEl = __ic.children[<innerOffset>]
  *     <i>      if (!__innerEl) return
+ *     <i>      <innerPreludeStatements*>   // raw inner preamble (#1064)
  *     <i>      <per-comp lookup + initChild>
  *     <i>    })
  *     <i>  })
@@ -90,10 +93,16 @@ function emitSingleComp(lines: string[], plan: SingleCompInitPlan): void {
 }
 
 function emitOuterNested(lines: string[], plan: OuterNestedInitPlan): void {
-  const { containerVar, componentName, selector, arrayExpr, param, indexParam, offsetExpr, propsExpr } = plan
+  const { containerVar, componentName, selector, arrayExpr, param, indexParam, offsetExpr, preludeStatements, propsExpr } = plan
   lines.push(`  // Initialize nested ${componentName} in static array`)
   lines.push(`  if (${containerVar}) {`)
   lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+  // Outer `.map()` callback preamble locals — emitted unwrapped because
+  // the forEach param is the literal item (#1064). Must precede the prop
+  // lookup so the propsExpr getter can resolve them.
+  for (const stmt of preludeStatements) {
+    lines.push(`      ${stmt}`)
+  }
   lines.push(`      const __iterEl = ${containerVar}.children[${offsetExpr}]`)
   lines.push(`      if (__iterEl) {`)
   lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
@@ -111,10 +120,12 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
     outerParam,
     outerIndexParam,
     outerOffsetExpr,
+    outerPreludeStatements,
     innerContainerSlotId,
     innerArrayExpr,
     innerParam,
     innerOffsetExpr,
+    innerPreludeStatements,
     depth,
     comps,
   } = plan
@@ -123,6 +134,11 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
   lines.push(`    ${outerArrayExpr}.forEach((${outerParam}, ${outerIndexParam}) => {`)
   lines.push(`      const __outerEl = ${containerVar}.children[${outerOffsetExpr}]`)
   lines.push(`      if (!__outerEl) return`)
+  // Outer `.map()` callback preamble — locals declared here may be read
+  // by inner forEach's component setup (#1064).
+  for (const stmt of outerPreludeStatements) {
+    lines.push(`      ${stmt}`)
+  }
   if (innerContainerSlotId) {
     lines.push(`      const __ic = __outerEl.querySelector('[bf="${innerContainerSlotId}"]') || __outerEl`)
   } else {
@@ -131,6 +147,11 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
   lines.push(`      ${innerArrayExpr}.forEach((${innerParam}, __innerIdx) => {`)
   lines.push(`        const __innerEl = __ic.children[${innerOffsetExpr}]`)
   lines.push(`        if (!__innerEl) return`)
+  // Inner `.map()` callback preamble — must precede the per-component
+  // prop getters so they can resolve the locals (#1064).
+  for (const stmt of innerPreludeStatements) {
+    lines.push(`        ${stmt}`)
+  }
   for (const comp of comps) {
     lines.push(`        const __compEl = __innerEl.querySelector('${comp.selector}')`)
     lines.push(`        if (__compEl) initChild('${comp.componentName}', __compEl, ${comp.propsExpr})`)

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -10,6 +10,7 @@
  *     <i>  const __childScopes = <container>.querySelectorAll('<selector>')
  *     <i>  __childScopes.forEach((childScope, <idx>) => {
  *     <i>    const <param> = <array>[<idx>]
+ *     <i>    <outerPreludeStatements*>   // raw outer preamble (#1064)
  *     <i>    initChild('<name>', childScope, <props>)
  *     <i>  })
  *     <i>}
@@ -18,9 +19,9 @@
  *     <i>// Initialize nested <name> in static array
  *     <i>if (<container>) {
  *     <i>  <array>.forEach((<param>, <idx>) => {
- *     <i>    <preludeStatements*>   // raw outer preamble (#1064)
  *     <i>    const __iterEl = <container>.children[<offset>]
  *     <i>    if (__iterEl) {
+ *     <i>      <outerPreludeStatements*>   // raw outer preamble (#1064)
  *     <i>      const __compEl = __iterEl.querySelector('<selector>')
  *     <i>      if (__compEl) initChild('<name>', __compEl, <props>)
  *     <i>    }
@@ -80,12 +81,18 @@ function stringifyOne(lines: string[], plan: StaticArrayChildInitPlan): void {
 }
 
 function emitSingleComp(lines: string[], plan: SingleCompInitPlan): void {
-  const { containerVar, componentName, childSelector, arrayExpr, param, indexParam, propsExpr } = plan
+  const { containerVar, componentName, childSelector, arrayExpr, param, indexParam, outerPreludeStatements, propsExpr } = plan
   lines.push(`  // Initialize static array children (hydrate skips nested instances)`)
   lines.push(`  if (${containerVar}) {`)
   lines.push(`    const __childScopes = ${containerVar}.querySelectorAll('${childSelector}')`)
   lines.push(`    __childScopes.forEach((childScope, ${indexParam}) => {`)
   lines.push(`      const ${param} = ${arrayExpr}[${indexParam}]`)
+  // Outer `.map()` callback preamble locals — emitted unwrapped after
+  // the `param` lookup so they can read it (#1064). Must precede the
+  // `initChild` call because the propsExpr getter resolves them lazily.
+  for (const stmt of outerPreludeStatements) {
+    lines.push(`      ${stmt}`)
+  }
   lines.push(`      initChild('${componentName}', childScope, ${propsExpr})`)
   lines.push(`    })`)
   lines.push(`  }`)
@@ -93,18 +100,19 @@ function emitSingleComp(lines: string[], plan: SingleCompInitPlan): void {
 }
 
 function emitOuterNested(lines: string[], plan: OuterNestedInitPlan): void {
-  const { containerVar, componentName, selector, arrayExpr, param, indexParam, offsetExpr, preludeStatements, propsExpr } = plan
+  const { containerVar, componentName, selector, arrayExpr, param, indexParam, offsetExpr, outerPreludeStatements, propsExpr } = plan
   lines.push(`  // Initialize nested ${componentName} in static array`)
   lines.push(`  if (${containerVar}) {`)
   lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
-  // Outer `.map()` callback preamble locals — emitted unwrapped because
-  // the forEach param is the literal item (#1064). Must precede the prop
-  // lookup so the propsExpr getter can resolve them.
-  for (const stmt of preludeStatements) {
-    lines.push(`      ${stmt}`)
-  }
   lines.push(`      const __iterEl = ${containerVar}.children[${offsetExpr}]`)
   lines.push(`      if (__iterEl) {`)
+  // Outer `.map()` callback preamble locals — emitted unwrapped (forEach
+  // param is the literal item, #1064). Placed inside the `if (__iterEl)`
+  // block so the "no SSR element ⇒ skip work" semantics match
+  // `inner-loop-nested`'s post-guard placement.
+  for (const stmt of outerPreludeStatements) {
+    lines.push(`        ${stmt}`)
+  }
   lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
   lines.push(`        if (__compEl) initChild('${componentName}', __compEl, ${propsExpr})`)
   lines.push(`      }`)


### PR DESCRIPTION
## Summary

Closes #1064. Sibling of #1052 / #1063 in the **static-array** emission paths.

When the outer array is a literal (not a signal) and the inner `.map()` callback declares block-body locals referenced by a child component prop or event handler, the static `forEach` body did not declare those locals — `initChild`'s prop getter would throw `ReferenceError` when the child first mounted.

## Fix

Threads `inner.mapPreamble` (and outer `loop.mapPreamble`) through **both** static emission paths:

| Path | File | What it emits |
|------|------|---------------|
| Control-flow static inner-loop | `stringify/control-flow/inner-loop.ts::emitStatic` | `forEach((p, idx) => { ... })` inside reactive composite renderItems |
| Top-level static-array child init — outer-nested | `stringify/static-array-child-init.ts::emitOuterNested` | `outer.forEach((p, idx) => initChild...)` |
| Top-level static-array child init — inner-loop-nested | `stringify/static-array-child-init.ts::emitInnerLoopNested` | `outer.forEach((op, oi) => inner.forEach((ip, ii) => initChild...))` |

In all three the preamble is emitted **unwrapped** — `forEach`'s param is the literal item, not a signal accessor, so no accessor rewrite is needed.

Mirrors the `preludeStatements: readonly string[]` shape introduced in #1063 so each emission point is **one ordered list** rather than a parallel of optional fields.

### Before

```js
row.forEach((it, __innerIdx) => {
  const __innerEl = __ic.children[__innerIdx]
  if (!__innerEl) return
  const __compEl = __innerEl.querySelector('[bf-s\$=\"_s0\"]')
  if (__compEl) initChild('MyChild', __compEl, { get label() { return lbl } })
  //                                                            ^^^ ReferenceError
})
```

### After

```js
row.forEach((it, __innerIdx) => {
  const __innerEl = __ic.children[__innerIdx]
  if (!__innerEl) return
  const lbl = \`item-\${it.n}\`;        // ← inner preamble re-emitted
  const __compEl = __innerEl.querySelector('[bf-s\$=\"_s0\"]')
  if (__compEl) initChild('MyChild', __compEl, { get label() { return lbl } })
})
```

## Test plan

- [x] Added `regression #1064` test in `packages/jsx/src/__tests__/nested-loop-plain.test.ts`
- [x] `bun test packages/jsx` — 805 pass, 0 fail
- [x] `bun test packages/adapter-tests` — 214 pass, 0 fail
- [x] `bun test ui/components` — 1162 pass, 0 fail
- [x] `bun test packages/client` — 212 pass, 0 fail
- [x] `bun run --cwd site/ui build` — Build complete!

## Follow-up

Issue #1065 (plain branch loop preamble wrap) remains; that one needs `wrap` (signal-accessor rewrite), not raw emission, and lives in a different emission path (`stringify/control-flow/branch-loop.ts::emitPlain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)