### PR TITLE
fix(compiler): wrap mapPreamble with signal-accessor in plain branch loop (#1065)

### DIFF
--- a/packages/jsx/src/__tests__/branch-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/branch-loop-plain.test.ts
@@ -1,0 +1,111 @@
+/**
+ * BarefootJS Compiler — Plain `.map()` inside a conditional branch (#1065)
+ *
+ * Sibling file of `composite-branch-loop.test.ts`. Covers the **plain**
+ * branch-loop emission path: a `.map()` whose body is a single native
+ * element with no child components and no nested inner loops (so
+ * `useElementReconciliation` is false and `BranchPlainLoopPlan` is built
+ * instead of `BranchCompositeLoopPlan`).
+ *
+ * Issue #1065: the plain path's `mapPreambleRaw` field carried the inner
+ * `.map()` callback's block-body locals **without** rewriting loop-param
+ * references to signal-accessor form. The renderItem callback then read
+ * `cell.flag` instead of `cell().flag` — bare `cell` inside the renderItem
+ * is the signal accessor function, so `cell.flag === undefined` and the
+ * preamble produced wrong values silently. The composite path used
+ * `mapPreambleWrapped` correctly.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('plain `.map()` inside a conditional branch (#1065)', () => {
+  test('regression #1065: branch-plain mapPreamble references the loop param via signal accessor', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; value: string; flag: boolean }
+
+      export function CondList() {
+        const [show] = createSignal(true)
+        const [items, setItems] = createSignal<Cell[]>([
+          { id: 1, value: 'a', flag: true },
+        ])
+        return (
+          <div onClick={() => setItems(prev => [...prev])}>
+            {show() ? (
+              <ul>
+                {items().map((cell) => {
+                  const cls = cell.flag ? 'on' : 'off'
+                  return <li key={cell.id} className={cls}>{cell.value}</li>
+                })}
+              </ul>
+            ) : null}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CondList.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    // The branch-plain renderItem must rewrite preamble references to
+    // `cell()` — `cell` inside the renderItem is the signal accessor, so
+    // bare `cell.flag` would resolve to `undefined`. Composite-loop's
+    // `${cell().id}` template references are already wrapped; the
+    // preamble must match.
+    const renderItemSection = js.slice(
+      js.indexOf('__disposers.push(createDisposableEffect'),
+      js.indexOf('return () => __disposers'),
+    )
+    expect(renderItemSection.length).toBeGreaterThan(0)
+    expect(renderItemSection).toMatch(/const\s+cls\s*=\s*cell\(\)\.flag/)
+    expect(renderItemSection).not.toMatch(/const\s+cls\s*=\s*cell\.flag/)
+  })
+
+  test('regression #1065: destructured branch-plain mapPreamble rewrites bindings to __bfItem()', () => {
+    // Destructured callback param (#951): the wrap pass must rewrite each
+    // binding name (here `flag`) to `__bfItem().flag`, matching the
+    // template-literal references that already use the destructured form.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; value: string; flag: boolean }
+
+      export function CondListD() {
+        const [show] = createSignal(true)
+        const [items, setItems] = createSignal<Cell[]>([
+          { id: 1, value: 'a', flag: true },
+        ])
+        return (
+          <div onClick={() => setItems(prev => [...prev])}>
+            {show() ? (
+              <ul>
+                {items().map(({ id, value, flag }) => {
+                  const cls = flag ? 'on' : 'off'
+                  return <li key={id} className={cls}>{value}</li>
+                })}
+              </ul>
+            ) : null}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CondListD.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    const renderItemSection = js.slice(
+      js.indexOf('__disposers.push(createDisposableEffect'),
+      js.indexOf('return () => __disposers'),
+    )
+    // Destructured bindings inside the preamble must read via __bfItem().
+    expect(renderItemSection).toMatch(/const\s+cls\s*=\s*__bfItem\(\)\.flag/)
+    expect(renderItemSection).not.toMatch(/const\s+cls\s*=\s*flag\b/)
+  })
+})

--- a/packages/jsx/src/__tests__/branch-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/branch-loop-plain.test.ts
@@ -108,4 +108,115 @@ describe('plain `.map()` inside a conditional branch (#1065)', () => {
     expect(renderItemSection).toMatch(/const\s+cls\s*=\s*__bfItem\(\)\.flag/)
     expect(renderItemSection).not.toMatch(/const\s+cls\s*=\s*flag\b/)
   })
+
+  test('regression #1065: single-line renderItem shape (no reactive effects) wraps preamble', () => {
+    // The plain branch-loop emitter has two emission shapes — a multi-line
+    // body when `loop.childReactive*` is non-empty, and a single-line body
+    // (everything packed into one `mapArray(...)` line) when there are no
+    // reactive effects on item children. The previous two tests had a
+    // `{cell.value}` reactive text inside the `<li>` body, which forced
+    // the multi-line branch; the single-line branch's preamble wrap was
+    // therefore untested and could have silently regressed.
+    //
+    // This source has no reactive expressions inside the loop item, so the
+    // emitter takes the single-line path:
+    //
+    //   mapArray(...,(cell, idx, __existing) => {
+    //     if (__existing) return __existing;
+    //     const cls = cell().flag ? 'on' : 'off';   ← must be wrapped
+    //     ...
+    //   })
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; flag: boolean }
+
+      export function CondListSL() {
+        const [show] = createSignal(true)
+        const [items, setItems] = createSignal<Cell[]>([
+          { id: 1, flag: true },
+        ])
+        return (
+          <div onClick={() => setItems(prev => [...prev])}>
+            {show() ? (
+              <ul>
+                {items().map((cell) => {
+                  const cls = cell.flag ? 'on' : 'off'
+                  return <li key={cell.id} className={cls}>x</li>
+                })}
+              </ul>
+            ) : null}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CondListSL.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    const renderItemSection = js.slice(
+      js.indexOf('__disposers.push(createDisposableEffect'),
+      js.indexOf('return () => __disposers'),
+    )
+    expect(renderItemSection.length).toBeGreaterThan(0)
+    // Confirm we're in the single-line branch by asserting all of
+    // `mapArray(...)` lives on one source line — multi-line would split
+    // across newlines.
+    const mapArrayLine = renderItemSection
+      .split('\n')
+      .find(l => l.includes('mapArray('))
+    expect(mapArrayLine).toBeDefined()
+    expect(mapArrayLine!).toContain(' return __existing;')
+    expect(mapArrayLine!).toContain('cell().flag')
+    expect(mapArrayLine!).not.toContain(' cell.flag')
+  })
+
+  test('regression #1065: destructured + single-line shape rewrites bindings to __bfItem()', () => {
+    // Cross-product of the two sub-features: destructured callback param
+    // (#951) AND single-line emission shape (no reactive effects). Both
+    // wrap pathways must compose so the preamble stays consistent with
+    // the template literal's already-wrapped reads.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; flag: boolean }
+
+      export function CondListSLD() {
+        const [show] = createSignal(true)
+        const [items, setItems] = createSignal<Cell[]>([
+          { id: 1, flag: true },
+        ])
+        return (
+          <div onClick={() => setItems(prev => [...prev])}>
+            {show() ? (
+              <ul>
+                {items().map(({ id, flag }) => {
+                  const cls = flag ? 'on' : 'off'
+                  return <li key={id} className={cls}>x</li>
+                })}
+              </ul>
+            ) : null}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CondListSLD.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')!.content
+
+    const renderItemSection = js.slice(
+      js.indexOf('__disposers.push(createDisposableEffect'),
+      js.indexOf('return () => __disposers'),
+    )
+    const mapArrayLine = renderItemSection
+      .split('\n')
+      .find(l => l.includes('mapArray('))
+    expect(mapArrayLine).toBeDefined()
+    expect(mapArrayLine!).toContain('__bfItem().flag')
+    // Bare `flag` reference (without `__bfItem().` prefix) would mean the
+    // wrap pass missed the destructured binding.
+    expect(mapArrayLine!).not.toMatch(/\bcls\s*=\s*flag\b/)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
@@ -38,8 +38,16 @@ export interface BranchPlainLoopPlan {
   paramUnwrap: string
   /** Index parameter identifier (e.g. `__idx`). */
   indexParam: string
-  /** Pre-render preamble line — empty when not present. Already raw, no wrap. */
-  mapPreambleRaw: string
+  /**
+   * Inner `.map()` callback's `mapPreamble` (block-body local
+   * declarations), with loop-param references rewritten to
+   * signal-accessor form. The renderItem's first arg is the per-item
+   * signal accessor (`item: () => T`), so bare `item.x` would resolve to
+   * `(function).x === undefined` — wrapping is required to keep the
+   * preamble consistent with the template-literal references that already
+   * use `${item().x}` (#1065). Empty when the source had no preamble.
+   */
+  mapPreambleWrapped: string
   /** HTML template string for one item. */
   template: string
   /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
@@ -11,7 +11,7 @@
  */
 
 import type { BranchLoop } from '../../types'
-import { varSlotId } from '../../utils'
+import { varSlotId, wrapLoopParamAsAccessor } from '../../utils'
 import { buildBranchCompositePlan } from './build-composite-loop'
 import { buildBranchLoopDelegationPlan } from './build-event-delegation'
 import { buildReactiveEffectsPlan } from './build-reactive-effects'
@@ -51,7 +51,11 @@ export function buildBranchLoopPlan(loop: BranchLoop): BranchLoopPlan {
     paramHead,
     paramUnwrap,
     indexParam: loop.index || '__idx',
-    mapPreambleRaw: loop.mapPreamble || '',
+    // Wrap loop-param references to signal-accessor form so the preamble
+    // matches the template literal's already-wrapped reads (#1065).
+    mapPreambleWrapped: loop.mapPreamble
+      ? wrapLoopParamAsAccessor(loop.mapPreamble, loop.param, loop.paramBindings)
+      : '',
     template: loop.template,
     reactiveEffects: hasReactiveEffects
       ? buildReactiveEffectsPlan({

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
@@ -48,7 +48,7 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     paramHead,
     paramUnwrap,
     indexParam,
-    mapPreambleRaw,
+    mapPreambleWrapped,
     template,
     reactiveEffects,
     eventDelegation,
@@ -64,8 +64,8 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
 
   if (reactiveEffects === null) {
     // Simple case: single-line renderItem.
-    if (mapPreambleRaw) {
-      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${mapPreambleRaw}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
+    if (mapPreambleWrapped) {
+      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${mapPreambleWrapped}; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
     } else {
       lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })`)
     }
@@ -75,8 +75,8 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     if (paramUnwrap) {
       lines.push(`          ${paramUnwrap}`)
     }
-    if (mapPreambleRaw) {
-      lines.push(`          ${mapPreambleRaw}`)
+    if (mapPreambleWrapped) {
+      lines.push(`          ${mapPreambleWrapped}`)
     }
     lines.push(`          const __el = __existing ?? (() => { const __tpl = document.createElement('template'); __tpl.innerHTML = \`${template}\`; return __tpl.content.firstElementChild.cloneNode(true) })()`)
     stringifyReactiveEffects(lines, reactiveEffects, { indent: '          ', elVar: '__el' })


### PR DESCRIPTION
## Summary

Closes #1065. Last sibling of #1052 / #1063 / #1064 in the **plain branch-loop** emission path (a `.map()` directly inside a conditional branch with no nested inner loops, no child components — `useElementReconciliation` is false and `BranchPlainLoopPlan` is built instead of `BranchCompositeLoopPlan`).

The plain path's `mapPreambleRaw` field was emitted **verbatim** into the renderItem body. The composite branch path correctly applied `wrapLoopParamAsAccessor` (`build-composite-loop.ts:90`); only the plain path was the outlier.

## Root cause

Inside the renderItem closure, the loop param is a signal accessor (`item: () => T`):

```js
mapArray(() => items(), __loop_s2, (cell) => String(cell.id), (cell, __idx, __existing) => {
  const cls = cell.flag ? 'on' : 'off';   // ← cell is a function ⇒ cell.flag === undefined
  const __el = ... `\${cell().id}` ...    // ← template reads use cell() (correct)
})
```

`cell.flag` resolves to `undefined`, so `cls` was always `'off'`. The bug was silent — no `ReferenceError`, just incorrect derived values.

## Fix

| Layer | Change |
|---|---|
| `branch-loop.ts` (plan) | Renamed `mapPreambleRaw: string` → `mapPreambleWrapped: string`; updated JSDoc to describe the signal-accessor rewrite |
| `build-branch-loop.ts` (builder) | Pass `loop.mapPreamble` through `wrapLoopParamAsAccessor(..., loop.param, loop.paramBindings)` — same as `buildBranchCompositePlan` |
| `branch-loop.ts` (stringify) | Reference `mapPreambleWrapped` (no behavior change beyond the name) |

`wrapLoopParamAsAccessor` already handles destructured callbacks via `__bfItem()` substitution (#951), so destructured `({ flag }) => { const cls = flag ? ... }` becomes `const cls = __bfItem().flag ? ...` — confirmed by the second test below.

### Before

```js
mapArray(() => items(), __loop_s2, (cell) => String(cell.id), (cell, __idx, __existing) => {
  const cls = cell.flag ? 'on' : 'off';
  ...
})
```

### After

```js
mapArray(() => items(), __loop_s2, (cell) => String(cell.id), (cell, __idx, __existing) => {
  const cls = cell().flag ? 'on' : 'off';
  ...
})
```

## Test plan

- [x] Added `branch-loop-plain.test.ts` with two regression tests:
  - simple-name param: `cell.flag` → `cell().flag`
  - destructured param: `flag` → `__bfItem().flag`
- [x] `bun test packages/jsx` — 810 pass, 0 fail
- [x] `bun test packages/adapter-tests` — 214 pass, 0 fail
- [x] `bun test ui/components` — 1162 pass, 0 fail
- [x] `bun test packages/client` — 212 pass, 0 fail
- [x] `bun run --cwd site/ui build` — Build complete!

## Related

Closes the four-issue arc started by #1052:
- #1063 — fix inner mapArray renderItem (reactive)
- #1066 — fix static-array child init (#1064)
- #1067 ← this PR — fix plain branch-loop wrap (#1065)

🤖 Generated with [Claude Code](https://claude.com/claude-code)