### PR TITLE
fix(site): tooltip jitter, copy polish, UI Components restructured

### DIFF
--- a/site/core/landing/components/features.tsx
+++ b/site/core/landing/components/features.tsx
@@ -8,7 +8,7 @@ const features = [
   {
     num: '01',
     title: 'Backend Freedom',
-    description: 'Go, Rust, Node... your choice',
+    description: 'Hono, Echo, Mojolicious... your favorite template',
   },
   {
     num: '02',
@@ -51,190 +51,27 @@ export function FeaturesSection() {
   )
 }
 
-export function UIComponentsSection() {
+/**
+ * "One more thing..." teaser pointing to the UI components site.
+ * The actual showcase lives at site/ui's home page; this is a brief
+ * Apple-keynote-style nod from the LP so visitors discover it.
+ */
+export function UIComponentsSection({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: string }) {
   return (
-    <section className="py-24 px-6 sm:px-12 border-t">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-12">
-          <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-4">
-            Ready-to-use UI Components
-          </h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto">
-            Beautiful, accessible components built with Barefoot.js.
-            Copy and paste into your project.
-          </p>
-        </div>
-
-        {/* Practical UI Examples using shadcn/ui style classes */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {/* Login Card */}
-          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
-            <div className="grid gap-1 px-6">
-              <h3 className="text-lg font-semibold leading-tight">Sign In</h3>
-              <p className="text-sm text-muted-foreground">Enter your credentials to continue</p>
-            </div>
-            <div className="px-6 flex flex-col gap-4">
-              <div className="flex flex-col gap-1.5">
-                <label className="text-sm font-medium">Email</label>
-                <input type="email" className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="you@example.com" />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-sm font-medium">Password</label>
-                <input type="password" className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="••••••••" />
-              </div>
-              <label className="flex items-center gap-2 text-sm cursor-pointer">
-                <span className="w-4 h-4 flex items-center justify-center text-xs rounded border bg-foreground text-background border-foreground">✓</span>
-                <span>Remember me</span>
-              </label>
-              <button className="h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Sign In</button>
-            </div>
-          </div>
-
-          {/* Profile Card */}
-          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
-            <div className="px-6 text-center">
-              <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center text-xl font-semibold text-primary-foreground bg-gradient-to-br from-[var(--gradient-start)] to-[var(--gradient-end)] rounded-full">JD</div>
-              <h3 className="text-lg font-semibold">Jane Doe</h3>
-              <p className="text-sm text-muted-foreground mt-1">Software Engineer</p>
-              <div className="flex justify-center gap-8 py-4 my-4 border-t border-b">
-                <div className="text-center">
-                  <span className="block text-lg font-semibold">128</span>
-                  <span className="text-xs text-muted-foreground">Posts</span>
-                </div>
-                <div className="text-center">
-                  <span className="block text-lg font-semibold">2.4k</span>
-                  <span className="text-xs text-muted-foreground">Followers</span>
-                </div>
-                <div className="text-center">
-                  <span className="block text-lg font-semibold">847</span>
-                  <span className="text-xs text-muted-foreground">Following</span>
-                </div>
-              </div>
-              <button className="w-full h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium border bg-background hover:bg-accent">View Profile</button>
-            </div>
-          </div>
-
-          {/* Settings Card */}
-          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
-            <div className="grid gap-1 px-6">
-              <h3 className="text-lg font-semibold leading-tight">Notifications</h3>
-              <p className="text-sm text-muted-foreground">Manage your preferences</p>
-            </div>
-            <div className="px-6 flex flex-col">
-              <div className="flex items-center justify-between py-3 border-b">
-                <div>
-                  <div className="text-sm font-medium">Email alerts</div>
-                  <div className="text-xs text-muted-foreground mt-0.5">Receive email notifications</div>
-                </div>
-                <div className="w-10 h-5 bg-[var(--gradient-start)] rounded-full relative cursor-pointer">
-                  <div className="w-4 h-4 bg-white rounded-full absolute top-0.5 right-0.5 shadow-sm" />
-                </div>
-              </div>
-              <div className="flex items-center justify-between py-3 border-b">
-                <div>
-                  <div className="text-sm font-medium">Push notifications</div>
-                  <div className="text-xs text-muted-foreground mt-0.5">Receive push alerts</div>
-                </div>
-                <div className="w-10 h-5 bg-muted rounded-full relative cursor-pointer">
-                  <div className="w-4 h-4 bg-white rounded-full absolute top-0.5 left-0.5 shadow-sm" />
-                </div>
-              </div>
-              <div className="flex items-center justify-between py-3">
-                <div>
-                  <div className="text-sm font-medium">Weekly digest</div>
-                  <div className="text-xs text-muted-foreground mt-0.5">Summary of activity</div>
-                </div>
-                <div className="w-10 h-5 bg-[var(--gradient-start)] rounded-full relative cursor-pointer">
-                  <div className="w-4 h-4 bg-white rounded-full absolute top-0.5 right-0.5 shadow-sm" />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Pricing Card */}
-          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-[var(--gradient-start)] py-6 shadow-sm ring-1 ring-[var(--gradient-start)]">
-            <div className="grid gap-1 px-6">
-              <span className="inline-flex w-fit items-center px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">Popular</span>
-              <h3 className="text-lg font-semibold leading-tight mt-2">Pro Plan</h3>
-              <div className="mt-1">
-                <span className="text-3xl font-bold">$29</span>
-                <span className="text-sm text-muted-foreground">/month</span>
-              </div>
-            </div>
-            <div className="px-6 flex flex-col gap-4">
-              <ul className="flex flex-col gap-2 text-sm text-muted-foreground">
-                <li>✓ Unlimited projects</li>
-                <li>✓ Priority support</li>
-                <li>✓ Advanced analytics</li>
-                <li>✓ Custom integrations</li>
-              </ul>
-              <button className="h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Get Started</button>
-            </div>
-          </div>
-
-          {/* Chat Card */}
-          <div className="bg-card text-card-foreground flex flex-col rounded-xl border shadow-sm md:col-span-2 lg:col-span-2">
-            <div className="px-6 py-4 border-b">
-              <h3 className="text-lg font-semibold leading-tight">Messages</h3>
-            </div>
-            <div className="px-6 py-4 flex flex-col gap-4 min-h-48">
-              {/* Received message */}
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-primary rounded-full">AS</div>
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-sm font-medium">Alex Smith</span>
-                    <span className="text-xs text-muted-foreground">10:42 AM</span>
-                  </div>
-                  <div className="bg-muted rounded-lg rounded-tl-none px-3 py-2 text-sm max-w-xs">
-                    Hey! How's the project going?
-                  </div>
-                </div>
-              </div>
-              {/* Sent message */}
-              <div className="flex items-start gap-3 flex-row-reverse">
-                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-gradient-to-br from-[var(--gradient-start)] to-[var(--gradient-end)] rounded-full">JD</div>
-                <div className="flex flex-col gap-1 items-end">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-xs text-muted-foreground">10:44 AM</span>
-                    <span className="text-sm font-medium">You</span>
-                  </div>
-                  <div className="bg-primary text-primary-foreground rounded-lg rounded-tr-none px-3 py-2 text-sm max-w-xs">
-                    Going great! Just finished the UI components.
-                  </div>
-                </div>
-              </div>
-              {/* Received message */}
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-primary rounded-full">AS</div>
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-sm font-medium">Alex Smith</span>
-                    <span className="text-xs text-muted-foreground">10:45 AM</span>
-                  </div>
-                  <div className="bg-muted rounded-lg rounded-tl-none px-3 py-2 text-sm max-w-xs">
-                    Awesome! 🎉
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="px-6 py-4 border-t">
-              <div className="flex gap-2">
-                <input type="text" className="flex-1 h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="Type a message..." />
-                <button className="h-9 px-4 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Send</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-12 text-center">
-          <a
-            href="https://ui.barefootjs.dev"
-            className="btn-secondary inline-flex"
-          >
-            Browse All Components →
-          </a>
-        </div>
+    <section className="py-32 px-6 sm:px-12 border-t">
+      <div className="max-w-3xl mx-auto text-center">
+        <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground mb-4">
+          One more thing...
+        </p>
+        <h2 className="text-3xl sm:text-4xl font-bold text-foreground mb-6">
+          <span className="gradient-text">Ready-made</span> UI Components
+        </h2>
+        <p className="text-muted-foreground text-lg max-w-xl mx-auto mb-8">
+          Pick a component. Copy the code. Make it yours.
+        </p>
+        <a href={uiHref} className="btn-primary inline-flex">
+          Explore UI Components →
+        </a>
       </div>
     </section>
   )

--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -279,7 +279,7 @@ export async function Hero() {
                 TSX in. <span className="hero-b-accent">Your template language out.</span>
               </h1>
               <p className="hero-b-body fade-in-1">
-                Barefoot compiles signal-based TSX directly into <strong>Hono</strong>, <strong>Echo</strong>, or the browser.
+                Barefoot compiles signal-based TSX into <strong>Hono</strong>, <strong>Echo</strong>, or your favorite template language.
                 <br />
                 No virtual DOM. No SPA required.
               </p>

--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -248,60 +248,21 @@ const FLOW_DIAGRAM_SCRIPT = `(function () {
     closeOpenTooltipsExcept(null);
   });
 
-  // Mobile tooltip positioning: when a tooltip-content opens, pin it
-  // (position: fixed) just below the .flow-adapters row, full width
-  // minus margin. Avoids per-card centering that overflows the viewport
-  // and avoids relying on offsetParent quirks that produced wrong
-  // absolute coordinates with the wrapper-static layout hack.
-  var adaptersRow = diagram.querySelector('.flow-adapters');
-  function positionMobileTooltips() {
-    if (!isMobile() || !adaptersRow) return;
-    var rowRect = adaptersRow.getBoundingClientRect();
-    var top = rowRect.bottom + 8;
-    var contents = diagram.querySelectorAll('[data-slot="tooltip-content"]');
-    contents.forEach(function (el) {
-      el.style.position = 'fixed';
-      el.style.top = top + 'px';
-      el.style.left = '4vw';
-      el.style.right = '4vw';
-      el.style.bottom = 'auto';
-      el.style.width = 'auto';
-      el.style.maxWidth = 'none';
-    });
-  }
-  function clearMobileTooltipStyles() {
-    var contents = diagram.querySelectorAll('[data-slot="tooltip-content"]');
-    contents.forEach(function (el) {
-      el.style.position = '';
-      el.style.top = '';
-      el.style.left = '';
-      el.style.right = '';
-      el.style.bottom = '';
-      el.style.width = '';
-      el.style.maxWidth = '';
-    });
-  }
-  function syncMobileTooltips() {
-    if (isMobile()) positionMobileTooltips();
-    else clearMobileTooltipStyles();
-  }
-  // Watch state changes so we re-pin when an open transition runs.
-  var mo = new MutationObserver(syncMobileTooltips);
-  diagram.querySelectorAll('[data-slot="tooltip-content"]').forEach(function (el) {
-    mo.observe(el, { attributes: true, attributeFilter: ['data-state'] });
-  });
-  function refresh() { update(); syncMobileTooltips(); }
-  refresh();
-  window.addEventListener('resize', refresh);
-  window.addEventListener('scroll', syncMobileTooltips, { passive: true });
+  // Mobile tooltip positioning is handled entirely by CSS now
+  // (position: absolute relative to .flow-adapters). The previous
+  // version ran on every scroll event to recompute the inline top
+  // against the row's viewport rect, which produced visible jitter.
+
+  update();
+  window.addEventListener('resize', update);
   if (typeof ResizeObserver !== 'undefined') {
-    var ro = new ResizeObserver(refresh);
+    var ro = new ResizeObserver(update);
     ro.observe(diagram);
   }
   if (document.fonts && document.fonts.ready) {
-    document.fonts.ready.then(refresh);
+    document.fonts.ready.then(update);
   }
-  window.addEventListener('load', refresh);
+  window.addEventListener('load', update);
 })();`
 
 export async function Hero() {

--- a/site/core/landing/components/shared/snippets.ts
+++ b/site/core/landing/components/shared/snippets.ts
@@ -40,7 +40,7 @@ export const BROWSER_OUTPUT = `<!-- Rendered & hydrated in the browser -->
   Count: <span bf="slot_0">0</span>
 </button>`
 
-export const CLIENT_CODE = `// Counter.client.js
+export const CLIENT_CODE = `// Hydrate your template
 import { createSignal, createEffect, find, hydrate } from '@barefootjs/client'
 
 export function initCounter(__scope, props = {}) {

--- a/site/core/landing/routes.tsx
+++ b/site/core/landing/routes.tsx
@@ -23,11 +23,13 @@ export async function createLandingApp() {
 
   // Landing page
   app.get('/', (c) => {
+    const hostname = new URL(c.req.url).hostname
+    const uiHref = hostname === 'localhost' ? 'http://localhost:3002/' : 'https://ui.barefootjs.dev'
     return c.render(
       <>
         <Hero />
         <FeaturesSection />
-        <UIComponentsSection />
+        <UIComponentsSection uiHref={uiHref} />
       </>,
       {
         title: 'Barefoot.js - Reactive TSX for any backend',

--- a/site/core/styles/landing.css
+++ b/site/core/styles/landing.css
@@ -489,20 +489,35 @@ img.flow-adapter-logo {
     height: 56px;
   }
 
-  /* On mobile the wide code tooltip is positioned (and sized) at runtime
-     by the inline FLOW_DIAGRAM_SCRIPT — it pins position: fixed below
-     .flow-adapters so the tooltip lives just under the row regardless
-     of which card was tapped, without overflowing the viewport.
-     Reset the Tailwind translate/scale/rotate (CSS individual transform
-     properties — not bundled into `transform`) that `top-1/2 -translate-y-1/2`
-     relies on; otherwise the fixed-positioned tooltip is shifted -50% of
-     its own height upward and lands above the row. */
+  /* On mobile the wide code tooltip lives in normal document flow as
+     position: absolute relative to .flow-adapters (the row), pinned
+     just below it. This means the tooltip scrolls *with* the row —
+     no JS scroll-sync, no jitter.
+
+     - The Tooltip wrapper is forced position: static so the
+       tooltip-content's offsetParent is .flow-adapters (which is
+       position: relative), letting `left: 0; right: 0` span the row's
+       full width.
+     - The Tailwind individual transform properties (translate / scale
+       / rotate — separate from `transform`) must all be reset;
+       otherwise `top-1/2 -translate-y-1/2` from placement="top" leaves
+       the tooltip 50% of its own height above the row. */
+  .flow-adapters > [data-slot="tooltip"] {
+    position: static !important;
+  }
   .flow-adapters [data-slot="tooltip-content"] {
+    position: absolute !important;
+    top: calc(100% + 0.5rem) !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: auto !important;
     transform: none !important;
     translate: none !important;
     scale: 1 !important;
     rotate: none !important;
     margin: 0 !important;
+    max-width: 100% !important;
+    width: auto !important;
     max-height: 50vh;
   }
 

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -130,10 +130,10 @@ export function createApp() {
 
   app.use(renderer)
 
-  // Home - Hero + navigation links
+  // Home - Hero + navigation links + showcase
   app.get('/', (c) => {
     return c.render(
-      <div className="space-y-12">
+      <div>
         {/* Hero */}
         <div className="space-y-6 max-w-2xl">
           <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-foreground">
@@ -146,6 +146,192 @@ export function createApp() {
             <a href="/components" className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground no-underline hover:bg-primary/90 transition-colors">
               Browse All Components
             </a>
+          </div>
+        </div>
+
+        {/* Practical UI examples */}
+        <div className="mt-20 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {/* Login Card */}
+          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
+            <div className="grid gap-1 px-6">
+              <h3 className="text-lg font-semibold leading-tight">Sign In</h3>
+              <p className="text-sm text-muted-foreground">Enter your credentials to continue</p>
+            </div>
+            <div className="px-6 flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Email</label>
+                <input type="email" className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="you@example.com" />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Password</label>
+                <input type="password" className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="••••••••" />
+              </div>
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <span className="w-4 h-4 flex items-center justify-center text-xs rounded border bg-foreground text-background border-foreground">✓</span>
+                <span>Remember me</span>
+              </label>
+              <button className="h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Sign In</button>
+            </div>
+          </div>
+
+          {/* Profile Card */}
+          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
+            <div className="px-6 text-center">
+              <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center text-xl font-semibold text-primary-foreground bg-gradient-to-br from-[var(--gradient-start)] to-[var(--gradient-end)] rounded-full">JD</div>
+              <h3 className="text-lg font-semibold">Jane Doe</h3>
+              <p className="text-sm text-muted-foreground mt-1">Software Engineer</p>
+              <div className="flex justify-center gap-8 py-4 my-4 border-t border-b">
+                <div className="text-center">
+                  <span className="block text-lg font-semibold">128</span>
+                  <span className="text-xs text-muted-foreground">Posts</span>
+                </div>
+                <div className="text-center">
+                  <span className="block text-lg font-semibold">2.4k</span>
+                  <span className="text-xs text-muted-foreground">Followers</span>
+                </div>
+                <div className="text-center">
+                  <span className="block text-lg font-semibold">847</span>
+                  <span className="text-xs text-muted-foreground">Following</span>
+                </div>
+              </div>
+              <button className="w-full h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium border bg-background hover:bg-accent">View Profile</button>
+            </div>
+          </div>
+
+          {/* Settings Card */}
+          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm">
+            <div className="grid gap-1 px-6">
+              <h3 className="text-lg font-semibold leading-tight">Notifications</h3>
+              <p className="text-sm text-muted-foreground">Manage your preferences</p>
+            </div>
+            <div className="px-6 flex flex-col">
+              <div className="flex items-center justify-between py-3 border-b">
+                <div>
+                  <div className="text-sm font-medium">Email alerts</div>
+                  <div className="text-xs text-muted-foreground mt-0.5">Receive email notifications</div>
+                </div>
+                <span
+                  role="switch"
+                  aria-checked="true"
+                  className="relative inline-flex h-5 w-10 flex-shrink-0 rounded-full cursor-pointer"
+                  style="background: var(--gradient-start)"
+                >
+                  <span
+                    className="absolute top-[2px] right-[2px] h-4 w-4 rounded-full"
+                    style="background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,0.2)"
+                  />
+                </span>
+              </div>
+              <div className="flex items-center justify-between py-3 border-b">
+                <div>
+                  <div className="text-sm font-medium">Push notifications</div>
+                  <div className="text-xs text-muted-foreground mt-0.5">Receive push alerts</div>
+                </div>
+                <span
+                  role="switch"
+                  aria-checked="false"
+                  className="relative inline-flex h-5 w-10 flex-shrink-0 rounded-full cursor-pointer"
+                  style="background: var(--muted)"
+                >
+                  <span
+                    className="absolute top-[2px] left-[2px] h-4 w-4 rounded-full"
+                    style="background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,0.2)"
+                  />
+                </span>
+              </div>
+              <div className="flex items-center justify-between py-3">
+                <div>
+                  <div className="text-sm font-medium">Weekly digest</div>
+                  <div className="text-xs text-muted-foreground mt-0.5">Summary of activity</div>
+                </div>
+                <span
+                  role="switch"
+                  aria-checked="true"
+                  className="relative inline-flex h-5 w-10 flex-shrink-0 rounded-full cursor-pointer"
+                  style="background: var(--gradient-start)"
+                >
+                  <span
+                    className="absolute top-[2px] right-[2px] h-4 w-4 rounded-full"
+                    style="background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,0.2)"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Pricing Card */}
+          <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-[var(--gradient-start)] py-6 shadow-sm ring-1 ring-[var(--gradient-start)]">
+            <div className="grid gap-1 px-6">
+              <span className="inline-flex w-fit items-center px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">Popular</span>
+              <h3 className="text-lg font-semibold leading-tight mt-2">Pro Plan</h3>
+              <div className="mt-1">
+                <span className="text-3xl font-bold">$29</span>
+                <span className="text-sm text-muted-foreground">/month</span>
+              </div>
+            </div>
+            <div className="px-6 flex flex-col gap-4">
+              <ul className="flex flex-col gap-2 text-sm text-muted-foreground">
+                <li>✓ Unlimited projects</li>
+                <li>✓ Priority support</li>
+                <li>✓ Advanced analytics</li>
+                <li>✓ Custom integrations</li>
+              </ul>
+              <button className="h-9 px-4 py-2 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Get Started</button>
+            </div>
+          </div>
+
+          {/* Chat Card */}
+          <div className="bg-card text-card-foreground flex flex-col rounded-xl border shadow-sm md:col-span-2 lg:col-span-2">
+            <div className="px-6 py-4 border-b">
+              <h3 className="text-lg font-semibold leading-tight">Messages</h3>
+            </div>
+            <div className="px-6 py-4 flex flex-col gap-4 min-h-48">
+              {/* Received message */}
+              <div className="flex items-start gap-3">
+                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-primary rounded-full">AS</div>
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-medium">Alex Smith</span>
+                    <span className="text-xs text-muted-foreground">10:42 AM</span>
+                  </div>
+                  <div className="bg-muted rounded-lg rounded-tl-none px-3 py-2 text-sm max-w-xs">
+                    Hey! How's the project going?
+                  </div>
+                </div>
+              </div>
+              {/* Sent message */}
+              <div className="flex items-start gap-3 flex-row-reverse">
+                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-gradient-to-br from-[var(--gradient-start)] to-[var(--gradient-end)] rounded-full">JD</div>
+                <div className="flex flex-col gap-1 items-end">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-xs text-muted-foreground">10:44 AM</span>
+                    <span className="text-sm font-medium">You</span>
+                  </div>
+                  <div className="bg-primary text-primary-foreground rounded-lg rounded-tr-none px-3 py-2 text-sm max-w-xs">
+                    Going great! Just finished the UI components.
+                  </div>
+                </div>
+              </div>
+              {/* Received message */}
+              <div className="flex items-start gap-3">
+                <div className="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-semibold text-primary-foreground bg-primary rounded-full">AS</div>
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-medium">Alex Smith</span>
+                    <span className="text-xs text-muted-foreground">10:45 AM</span>
+                  </div>
+                  <div className="bg-muted rounded-lg rounded-tl-none px-3 py-2 text-sm max-w-xs">
+                    Awesome! 🎉
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="px-6 py-4 border-t">
+              <div className="flex gap-2">
+                <input type="text" className="flex-1 h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground" placeholder="Type a message..." />
+                <button className="h-9 px-4 inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90">Send</button>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Stack of post-#1068 fixes and small reshuffles, all on the landing page + UI site home.

## Summary

### Tooltip jitter (the original report)
Scrolling with the Hero adapter Tooltip open caused visible jitter. Root cause was the mobile tooltip running on `position: fixed` with an inline `top` recomputed in a `window.addEventListener('scroll', ...)` listener — those style mutations weren't paint-synced, so the tooltip lagged behind the row.

- Switch the mobile tooltip to `position: absolute` relative to `.flow-adapters` (forcing the per-card Tooltip wrapper to `position: static` so the offsetParent skips up to the row). The tooltip now sits in normal document flow and scrolls with the row at native paint frequency — no JS scroll listener required.
- Reset Tailwind's individual transform properties (`translate`, `scale`, `rotate`) alongside `transform: none`. Without this, `top-1/2 -translate-y-1/2` from `placement="top"` shifts the absolute-positioned tooltip up by 50% of its height.
- Remove `positionMobileTooltips` / `clearMobileTooltipStyles` / `syncMobileTooltips` plus the `MutationObserver` + scroll/resize listeners that drove them.

### Copy polish (site/core)
- Hero body: "Hono, Echo, or the browser" → "Hono, Echo, or your favorite template language" (better captures the template-language-pluggability promise).
- "Backend Freedom" feature description: "Go, Rust, Node... your choice" → "Hono, Echo, Mojolicious... your favorite template" (aligns with the Hero copy and the actual adapter line-up).
- client.js Tooltip header label: "// Counter.client.js" → "// Hydrate your template" (describes the artefact's purpose, not a fictional filename).

### UI Components restructured
The full Ready-to-use UI Components showcase used to live on the LP. It made the LP long and competed with the framework story, while the UI site itself had a sparse home page.

- **site/core**: Replace the showcase with a slim "One more thing..." teaser that links to ui.barefootjs.dev (or http://localhost:3002 in dev). Single primary CTA, "Pick a component. Copy the code. Make it yours."
- **site/ui**: Home page now hosts the practical UI examples grid (login / profile / settings / pricing / chat). `mt-20` between hero and grid prevents the "Browse All Components" button from visually colliding with the first card.
- Settings card toggles rewritten with `style="background: var(--gradient-start)"` + `role="switch"` + `aria-checked`, so the indicator colours render reliably regardless of UnoCSS arbitrary-value scan timing and screen readers announce the switch state.

## Test plan
- [ ] `bun run test:e2e` (site/core) — all 5 Hero tooltip specs pass
- [ ] Open the LP on a narrow viewport (≤ 820px), tap an adapter, scroll the page — tooltip moves perfectly in sync with the adapter row, no jitter
- [ ] Same on desktop (≥ 821px) — tooltip stays anchored above (or below for client.js) the card during scroll
- [ ] LP shows the "One more thing..." section near the bottom; clicking the CTA jumps to the UI site
- [ ] Visit the UI site home — hero, then ~80px gap, then the 5-card showcase grid; toggles in the settings card render in green when on and grey when off
- [ ] Single-open / outside-click / hover-doesn't-open behaviours unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)