### PR TITLE
fix(site/ui): keep dist intact during incremental builds

### DIFF
--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -30,6 +30,14 @@ import { addScriptCollection } from '../../packages/adapter-hono/src/build'
 
 const ROOT_DIR = dirname(import.meta.path)
 
+// `--clean` wipes dist before building (used by build:worker for CI / deploy).
+// Without it the build overwrites files in place, so a running
+// `bun run --watch server.tsx` never sees a window where
+// `dist/components/*.tsx` is missing. Wiping dist mid-run was the cause of
+// dev-time `Cannot find module '@/components/...'` errors when the dev
+// server reloaded during a rebuild.
+const CLEAN_DIST = process.argv.includes('--clean')
+
 // File type helpers
 function isTsOrTsxFile(filename: string): boolean {
   return filename.endsWith('.tsx') || filename.endsWith('.ts')
@@ -101,8 +109,11 @@ const docsComponentFiles = await discoverComponentFiles(DOCS_COMPONENTS_DIR)
 const sharedComponentFiles = await discoverFiles(SHARED_COMPONENTS_DIR)
 const componentFiles = [...uiComponentFiles, ...docsComponentFiles, ...sharedComponentFiles]
 
-// Clean dist directory to remove stale artifacts from previous builds
-await rm(DIST_DIR, { recursive: true, force: true })
+// Clean dist directory only when explicitly requested (--clean).
+// Default is incremental so dev server imports stay valid mid-rebuild.
+if (CLEAN_DIST) {
+  await rm(DIST_DIR, { recursive: true, force: true })
+}
 await mkdir(DIST_COMPONENTS_DIR, { recursive: true })
 
 // Build and copy barefoot.js from @barefootjs/client.

--- a/site/ui/build:watch.ts
+++ b/site/ui/build:watch.ts
@@ -1,0 +1,108 @@
+/**
+ * Watch component sources and re-run build.ts on change.
+ *
+ * Pair with `bun run dev` (which only watches server.tsx and its imports).
+ * The dev server reads `dist/components/*.tsx` via the `@/*` alias, so dist
+ * has to be kept fresh as sources change. build.ts (without --clean) writes
+ * incrementally so the dev server never sees a missing module mid-rebuild.
+ */
+
+import { watch, stat } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+
+const ROOT_DIR = dirname(import.meta.path)
+
+const SOURCE_DIRS = [
+  resolve(ROOT_DIR, 'components'),
+  resolve(ROOT_DIR, '../../ui/components'),
+  resolve(ROOT_DIR, '../shared/components'),
+  resolve(ROOT_DIR, 'styles'),
+]
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path)
+    return s.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+const DEBOUNCE_MS = 150
+
+let running = false
+let pending = false
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function schedule() {
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(flush, DEBOUNCE_MS)
+}
+
+function flush() {
+  timer = null
+  if (running) {
+    pending = true
+    return
+  }
+  runBuild()
+}
+
+function runBuild() {
+  running = true
+  const t0 = performance.now()
+  const proc = spawn('bun', ['run', 'build.ts'], {
+    cwd: ROOT_DIR,
+    stdio: 'inherit',
+  })
+  proc.on('exit', (code) => {
+    const ms = (performance.now() - t0).toFixed(0)
+    if (code === 0) {
+      console.log(`\n[build:watch] rebuild ok (${ms}ms)\n`)
+    } else {
+      console.error(`\n[build:watch] rebuild failed with code ${code} (${ms}ms)\n`)
+    }
+    running = false
+    if (pending) {
+      pending = false
+      runBuild()
+    }
+  })
+}
+
+const isRelevant = (filename: string | null): boolean => {
+  if (!filename) return false
+  return (
+    filename.endsWith('.tsx') ||
+    filename.endsWith('.ts') ||
+    filename.endsWith('.css') ||
+    filename.endsWith('.json')
+  )
+}
+
+async function watchDir(dir: string) {
+  try {
+    for await (const event of watch(dir, { recursive: true })) {
+      if (!isRelevant(event.filename)) continue
+      schedule()
+    }
+  } catch (err) {
+    console.warn(`[build:watch] watcher for ${dir} stopped: ${(err as Error).message}`)
+  }
+}
+
+console.log('[build:watch] running initial build...')
+runBuild()
+
+const dirsToWatch: string[] = []
+for (const dir of SOURCE_DIRS) {
+  if (await dirExists(dir)) {
+    dirsToWatch.push(dir)
+  } else {
+    console.log(`[build:watch] skipping (not found): ${dir}`)
+  }
+}
+console.log(`[build:watch] watching ${dirsToWatch.length} source dirs (.tsx/.ts/.css/.json)`)
+
+await Promise.all(dirsToWatch.map(watchDir))

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.1",
   "scripts": {
     "build": "bun run build.ts",
+    "build:clean": "bun run build.ts --clean",
+    "build:watch": "bun run build:watch.ts",
     "build:registry": "cd ../../ui && bun run build:registry && mkdir -p ../site/ui/dist/r ../site/ui/dist/meta && cp -r dist/r/* ../site/ui/dist/r/ && cp meta/index.json ../site/ui/dist/r/index.json && cp meta/*.json ../site/ui/dist/meta/",
-    "build:worker": "bun run build && bun run build:registry",
+    "build:worker": "bun run build:clean && bun run build:registry",
     "dev": "bun run --watch server.tsx",
     "deploy": "bun run build:worker && wrangler deploy",
     "test:e2e": "bunx playwright test",


### PR DESCRIPTION
## Summary
- `site/ui/build.ts` no longer wipes `dist/` at the start of every run. Default builds overwrite files in place; the previous behaviour is opt-in via `--clean`.
- `build:worker` (used by CI / `wrangler deploy`) keeps the wipe by calling the new `build:clean` script, so production output stays clean.
- New `build:watch.ts` watches component source dirs (`components/`, `../../ui/components`, `../shared/components`, `styles/`) and re-runs the incremental build on changes.

## Why
While running `bun run dev` (`bun run --watch server.tsx`), modifying a component triggered a rebuild that started by removing `dist/`. The dev server resolves `@/components/*` to `./dist/*` via tsconfig paths and bun's --watch picks up changes there, so during the rebuild window it tried to reload and failed with:

```
error: Cannot find module '@/components/spreadsheet-demo' from \
  site/ui/pages/components/spreadsheet.tsx
```

The barefoot CLI's `build` pipeline (`packages/cli/src/lib/build.ts`) avoids this by writing incrementally with `writeIfChanged`. This change brings `site/ui/build.ts` to the same behaviour for dev, while preserving full clean rebuilds for production.

## Recommended dev workflow
- Terminal 1: `bun run build:watch`
- Terminal 2: `bun run dev`

## Test plan
- [x] `bun run build` (incremental) succeeds and leaves dist populated
- [x] `bun run build:clean` succeeds (wipes + regenerates dist)
- [x] `bun run build:watch` boots, runs the initial build, and watches 4 source dirs
- [ ] Manual: with `bun run dev` + `bun run build:watch` running, edit a demo component and confirm no `Cannot find module` error appears

## Notes
A follow-up could migrate `site/ui` to `barefoot.config.ts` entirely. Out of scope here — see PR description discussion for the required CLI extensions (`cssLayerPrefix`, `localImportPrefixes`, path-qualified manifest keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)