### PR TITLE
fix(jsx): re-attach reactive bindings when a conditional branch swaps in a fresh element (#1071)

### DIFF
--- a/packages/client/__tests__/runtime/conditional-reactive-attr-rebind.test.ts
+++ b/packages/client/__tests__/runtime/conditional-reactive-attr-rebind.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Runtime integration test for #1071: when a conditional swaps in a fresh
+ * element, reactive attribute bindings on that element must re-attach so
+ * subsequent signal updates reach the live node.
+ *
+ * Mirrors the shape the compiler now emits: per-branch `bindEvents` resolves
+ * the slot via `qsa(__branchScope, ...)` on every invocation, pushes a
+ * `createDisposableEffect` into a local `__disposers` array, and returns
+ * a cleanup closure that the runtime calls before the next swap.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { insert } from '../../src/runtime/insert'
+import { qsa } from '../../src/runtime/query'
+import { createSignal, createDisposableEffect } from '../../src/reactive'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('conditional swap re-attaches reactive attribute bindings (#1071)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('reactive `d` on a conditional <path> tracks signal across rising edges', () => {
+    // SSR shape: condition is initially false, so only the comment markers
+    // are rendered for slot s0. The path is mounted on the rising edge.
+    document.body.innerHTML = `
+      <svg bf-s="Demo_test1" bf="s2">
+        <!--bf-cond-start:s0--><!--bf-cond-end:s0-->
+      </svg>
+    `
+
+    const scope = document.querySelector('[bf-s]')!
+    expect(scope).not.toBeNull()
+
+    const [shown, setShown] = createSignal(false)
+    const [d, setD] = createSignal('M 0 0 L 10 10')
+
+    insert(scope, 's0', () => shown(), {
+      template: () => `<path bf-c="s0" data-preview d="${d()}" bf="s1"></path>`,
+      bindEvents: (__branchScope) => {
+        const __disposers: Array<() => void> = []
+        const el = qsa(__branchScope, '[bf="s1"]')
+        if (el) {
+          __disposers.push(createDisposableEffect(() => {
+            const v = d()
+            if (v != null) el.setAttribute('d', String(v))
+            else el.removeAttribute('d')
+          }))
+        }
+        return () => __disposers.forEach(f => f())
+      }
+    }, {
+      template: () => `<!--bf-cond-start:s0--><!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    })
+
+    // Falsy branch: path isn't mounted yet.
+    expect(scope.querySelector('[data-preview]')).toBeNull()
+
+    // Rising edge — fresh <path> is inserted. The bindEvents closure
+    // resolves it via `qsa(__branchScope, ...)` and writes the current
+    // signal value.
+    setShown(true)
+    let path = scope.querySelector('[data-preview]') as Element | null
+    expect(path).not.toBeNull()
+    expect(path!.getAttribute('d')).toBe('M 0 0 L 10 10')
+
+    // Drive the signal — the binding writes to the LIVE node.
+    setD('M 50 50 L 60 60')
+    expect(path!.getAttribute('d')).toBe('M 50 50 L 60 60')
+
+    // Falling edge — branch is removed, the disposable effect cleans up.
+    setShown(false)
+    expect(scope.querySelector('[data-preview]')).toBeNull()
+
+    // Rising edge again — a NEW <path> node is inserted. The previous
+    // closure was cleaned up; a fresh `bindEvents` invocation wires a
+    // brand-new effect to the brand-new element.
+    setD('M 99 99 L 100 100')
+    setShown(true)
+    path = scope.querySelector('[data-preview]') as Element | null
+    expect(path).not.toBeNull()
+    expect(path!.getAttribute('d')).toBe('M 99 99 L 100 100')
+
+    // Subsequent updates after the second mount must still flow to the new node.
+    setD('M 1 2 L 3 4')
+    expect(path!.getAttribute('d')).toBe('M 1 2 L 3 4')
+  })
+
+  test('cleanup closure runs before the next bindEvents — no stale effect on detached node', () => {
+    // Guards against a regression where `branchCleanup` is not called and
+    // multiple effects accumulate, each writing to a different (stale or
+    // live) node. Here we count how many times the body ran across two
+    // rising edges; with proper cleanup, exactly one effect is alive at
+    // any given moment.
+    document.body.innerHTML = `
+      <div bf-s="Demo_test2" bf="s2">
+        <!--bf-cond-start:s0--><!--bf-cond-end:s0-->
+      </div>
+    `
+    const scope = document.querySelector('[bf-s]')!
+    const [on, setOn] = createSignal(false)
+    const [tick, setTick] = createSignal(0)
+    let effectRuns = 0
+
+    insert(scope, 's0', () => on(), {
+      template: () => `<span bf-c="s0" data-tick="${tick()}" bf="s1"></span>`,
+      bindEvents: (__branchScope) => {
+        const __disposers: Array<() => void> = []
+        const el = qsa(__branchScope, '[bf="s1"]')
+        if (el) {
+          __disposers.push(createDisposableEffect(() => {
+            effectRuns++
+            el.setAttribute('data-tick', String(tick()))
+          }))
+        }
+        return () => __disposers.forEach(f => f())
+      }
+    }, {
+      template: () => `<!--bf-cond-start:s0--><!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    })
+
+    setOn(true)
+    const initial = effectRuns
+    expect(initial).toBeGreaterThanOrEqual(1)
+
+    // Tick once — exactly one extra run.
+    setTick(1)
+    expect(effectRuns).toBe(initial + 1)
+
+    // Toggle off then on — the old effect is disposed; a fresh one binds.
+    setOn(false)
+    setOn(true)
+    const afterRebind = effectRuns
+
+    // Drive tick — only ONE effect should fire (the freshly-bound one),
+    // not the stale one from the first mount.
+    setTick(2)
+    expect(effectRuns).toBe(afterRebind + 1)
+  })
+})

--- a/packages/jsx/src/__tests__/conditional-reactive-binding-rebind.test.ts
+++ b/packages/jsx/src/__tests__/conditional-reactive-binding-rebind.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for #1071: reactive attribute bindings inside a
+ * conditional branch must re-attach when `insert()` swaps in a fresh
+ * element on the rising edge of the condition.
+ *
+ * Surfaced by the Phase 9 graph editor (#135). The block has a
+ * connect-preview path mounted via `{cond ? <path d={signal()}/> : null}`.
+ * Before this fix, the compiler emitted the reactive `d` updater at the
+ * init-level top-level: a single `_sN` variable was resolved once via
+ * `__scope.querySelector('[bf="sN"]')`, and the surrounding
+ * `createEffect(...)` always wrote to that initial reference. When
+ * `insert()` later swapped in a fresh element for the truthy branch, the
+ * effect kept writing to the now-detached placeholder and the live
+ * element's `d` attribute never updated.
+ *
+ * The fix moves branch-interior reactive attribute bindings into the
+ * branch's `bindEvents(__branchScope)` callback so they re-resolve their
+ * slot from the freshly-inserted DOM on every swap. The init-level emit
+ * for those slots disappears; the only `setAttribute('d', …)` for the
+ * conditional path lives inside the truthy arm's `bindEvents` body.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSXSync(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('conditional reactive bindings re-attach on branch swap (#1071)', () => {
+  test('reactive attr inside a conditional element lives in bindEvents, not at init level', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Demo() {
+        const [shown, setShown] = createSignal(false)
+        const [d, setD] = createSignal('M 0 0 L 10 10')
+        return (
+          <svg onClick={() => setShown(true)}>
+            {shown() ? (
+              <path data-preview d={d()} />
+            ) : null}
+          </svg>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Demo.tsx')
+
+    // The reactive `d` setter must live inside the truthy branch's
+    // bindEvents body, scoped on `__branchScope`. Without this, the
+    // setter writes to a stale, detached node.
+    const insertIdx = clientJs.indexOf('insert(')
+    expect(insertIdx).toBeGreaterThanOrEqual(0)
+    const insertBlock = clientJs.slice(insertIdx)
+    expect(insertBlock).toMatch(/bindEvents:\s*\(__branchScope\)\s*=>\s*\{[\s\S]*?setAttribute\(['"]d['"]/)
+
+    // The slot must be resolved relative to __branchScope so each fresh
+    // DOM swap finds the live element, not a once-captured reference.
+    expect(insertBlock).toMatch(/qsa\(__branchScope,\s*'\[bf="[^"]+"\]'\)/)
+  })
+
+  test('reactive attr inside a conditional is not also emitted at the init top-level', () => {
+    // The bug was that the reactive updater appeared BOTH at init level
+    // (binding to a stale `_sN`) and (after the fix) inside bindEvents.
+    // The branch path is the only one that should remain — otherwise
+    // both effects fire, and the init-level effect writes to the
+    // detached node every signal change.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Demo() {
+        const [shown, setShown] = createSignal(false)
+        const [d, setD] = createSignal('M 0 0 L 10 10')
+        return (
+          <svg onClick={() => setShown(true)}>
+            {shown() ? (
+              <path data-preview d={d()} />
+            ) : null}
+          </svg>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Demo.tsx')
+    const insertIdx = clientJs.indexOf('insert(')
+    expect(insertIdx).toBeGreaterThanOrEqual(0)
+
+    // Everything before insert() is the init-level emit. There must be
+    // NO setAttribute('d', …) call there — the only one is inside the
+    // bindEvents body of the truthy arm.
+    const initSection = clientJs.slice(0, insertIdx)
+    expect(initSection).not.toMatch(/setAttribute\(['"]d['"]/)
+  })
+
+  test('branch-interior reactive effect uses createDisposableEffect for cleanup on branch swap', () => {
+    // Branch-scoped effects must dispose when the branch deactivates,
+    // otherwise stale subscriptions accumulate every time the condition
+    // flips. `createDisposableEffect` returns a dispose callback; the
+    // arm body collects them into `__disposers` and returns a cleanup
+    // closure that the runtime's `branchCleanup` calls before swap.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Demo() {
+        const [shown, setShown] = createSignal(false)
+        const [d, setD] = createSignal('M 0 0 L 10 10')
+        return (
+          <svg onClick={() => setShown(true)}>
+            {shown() ? (
+              <path data-preview d={d()} />
+            ) : null}
+          </svg>
+        )
+      }
+    `
+
+    const clientJs = getClientJs(source, 'Demo.tsx')
+    const insertIdx = clientJs.indexOf('insert(')
+    expect(insertIdx).toBeGreaterThanOrEqual(0)
+    const insertBlock = clientJs.slice(insertIdx)
+
+    // The branch body wraps the reactive attr update in createDisposableEffect.
+    expect(insertBlock).toMatch(/createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?setAttribute\(['"]d['"]/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -3,7 +3,7 @@
  */
 
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
-import type { ClientJsContext, ConditionalBranchChildComponent, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
+import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
 import { attrValueToString, exprReferencesIdent, quotePropName, PROPS_PARAM } from './utils'
 import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
@@ -571,8 +571,16 @@ export function collectElements(
   })
 }
 
-/** Extract events, refs, and reactive attributes from a single IR element into ctx. */
-function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideConditional = false): void {
+/**
+ * Extract events, refs, and reactive attributes from a single IR element into ctx.
+ *
+ * `insideConditional` gates the push to `ctx.reactiveAttrs`: when the element
+ * lives inside a conditional branch, the binding is collected separately by
+ * `collectBranchReactiveAttrs` and emitted inside the branch's `bindEvents`
+ * so it re-attaches on every DOM swap (#1071). Events, refs and rest-attr
+ * elements are unaffected — they have their own per-branch collection paths.
+ */
+function collectFromElement(element: IRElement, ctx: ClientJsContext, insideConditional = false): void {
   if (element.events.length > 0 && element.slotId) {
     ctx.interactiveElements.push({
       slotId: element.slotId,
@@ -637,6 +645,11 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
         // literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and
         // don't depend on the expansion order of local constants.
         if (decideWrapForAttr(expandedValueStr, ctx, attr).wrap) {
+          // Slots inside a conditional branch are collected per-branch by
+          // `collectBranchReactiveAttrs` and emitted inside `insert()`
+          // bindEvents — keeping them out of init-level `ctx.reactiveAttrs`
+          // avoids binding to a stale node reference after a branch swap (#1071).
+          if (insideConditional) continue
           ctx.reactiveAttrs.push({
             slotId: element.slotId,
             attrName: attr.name,
@@ -647,6 +660,44 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, _insideCon
       }
     }
   }
+}
+
+/**
+ * Collect reactive attribute bindings from a conditional branch IR subtree (#1071).
+ * Walks the branch tree to find dynamic attributes that need a `createEffect`
+ * update on the live element — emitted inside `insert()` bindEvents so the
+ * binding re-resolves its target on every DOM swap.
+ *
+ * Does NOT recurse into nested conditionals (they get their own insert() call)
+ * or loops (whose body uses loop-scoped variables and is handled by the
+ * loop's own reconciliation path).
+ */
+function collectBranchReactiveAttrs(node: IRNode, ctx: ClientJsContext): ConditionalBranchReactiveAttr[] {
+  const attrs: ConditionalBranchReactiveAttr[] = []
+  walkIR(node, null, {
+    ...stopAt<null>('conditional', 'ifStatement', 'loop'),
+    element: ({ node: el, descend }) => {
+      if (!el.slotId) {
+        descend()
+        return
+      }
+      for (const attr of el.attrs) {
+        if (attr.name === '...' || !attr.dynamic || !attr.value) continue
+        const valueStr = attrValueToString(attr.value)
+        if (!valueStr) continue
+        const expanded = expandConstantForReactivity(valueStr, ctx)
+        if (!decideWrapForAttr(expanded, ctx, attr).wrap) continue
+        attrs.push({
+          slotId: el.slotId,
+          attrName: attr.name,
+          expression: expanded,
+          ...pickAttrMeta(attr),
+        })
+      }
+      descend()
+    },
+  })
+  return attrs
 }
 
 /**
@@ -807,6 +858,7 @@ function summarizeBranch(
     refs: collectConditionalBranchRefs(node),
     childComponents: buildBranchChildComponents(collectConditionalBranchChildComponents(node), ctx),
     textEffects: collectBranchTextEffects(node),
+    reactiveAttrs: collectBranchReactiveAttrs(node, ctx),
     loops: collectBranchLoops(node, ctx, siblingOffsets),
     conditionals: collectBranchConditionals(node, ctx, siblingOffsets),
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
@@ -71,6 +71,11 @@ function buildArmBody(branch: BranchSummary, options: BuildInsertOptions): ArmBo
       slotId: c.slotId,
       propsExpr: c.propsExpr,
     })),
+    // Branch-scoped reactive attribute bindings (#1071). Spread the
+    // collected entry as-is — `ConditionalBranchReactiveAttr` already
+    // extends `AttrMeta` so the meta flags carry through to the
+    // emitter (`emitAttrUpdate` consumes them).
+    reactiveAttrs: branch.reactiveAttrs.map(a => ({ ...a })),
     textEffects: branch.textEffects.map(t => ({
       slotId: t.slotId,
       expression: t.expression,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
@@ -6,6 +6,7 @@
  * `ArmBody.conditionals`, so one stringifier handles arbitrary depth.
  */
 
+import type { AttrMeta } from '../../../types'
 import type { ScopeRef } from './common'
 import type { BranchLoopPlan } from './branch-loop'
 
@@ -41,8 +42,9 @@ export interface InsertArm {
  * Everything that happens inside `bindEvents: (__branchScope) => { ... }`.
  *
  * The order of fields matches the emission order (events → refs → child
- * components → disposable text effects → loop reconciliation → nested
- * conditionals). Stringifiers MUST follow this order to keep output stable.
+ * components → disposable reactive attrs → disposable text effects → loop
+ * reconciliation → nested conditionals). Stringifiers MUST follow this
+ * order to keep output stable.
  */
 export interface ArmBody {
   /** addEventListener calls bound to elements inside the arm. */
@@ -51,6 +53,13 @@ export interface ArmBody {
   refs: ArmRefBind[]
   /** initChild calls for child components materialized by the arm swap. */
   childComponents: ArmChildComponentInit[]
+  /**
+   * Reactive attribute bindings scoped to this branch (#1071). Each
+   * becomes a `createDisposableEffect` whose body resolves the target
+   * element from `__branchScope` on every run, so the binding follows
+   * the freshly-inserted DOM after a branch swap.
+   */
+  reactiveAttrs: ArmReactiveAttr[]
   /** Reactive text effects scoped to this branch. Each becomes `createDisposableEffect`. */
   textEffects: ArmTextEffect[]
   /**
@@ -86,5 +95,18 @@ export interface ArmChildComponentInit {
 
 export interface ArmTextEffect {
   slotId: string
+  expression: string
+}
+
+/**
+ * Reactive attribute binding inside a conditional branch (#1071). The
+ * stringifier emits `qsa(__branchScope, '[bf="<slotId>"]')` to resolve
+ * the target on every effect run, then dispatches through `emitAttrUpdate`
+ * for the per-attribute write shape (style / class / value / boolean /
+ * presence / generic).
+ */
+export interface ArmReactiveAttr extends AttrMeta {
+  slotId: string
+  attrName: string
   expression: string
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -29,6 +29,7 @@
  */
 
 import { varSlotId } from '../../utils'
+import { emitAttrUpdate } from '../../emit-reactive'
 import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types'
 import { stringifyBranchLoops } from './branch-loop'
 import { emitListenerLine } from './event-listener'
@@ -116,16 +117,43 @@ function emitArmBody(
     lines.push(`${indent}if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
   }
 
-  // 4. Disposable section: text effects + branch loops + nested conditionals.
+  // 4. Disposable section: reactive attrs + text effects + branch loops + nested conditionals.
   //    Emitted inside the same `__disposers = []` / `return () => ...` envelope
   //    so the legacy single-disposers-array shape is preserved (PR 1).
   const hasDisposables =
+    body.reactiveAttrs.length > 0 ||
     body.textEffects.length > 0 ||
     body.loops.length > 0 ||
     body.conditionals.length > 0
   if (!hasDisposables) return
 
   lines.push(`${indent}const __disposers = []`)
+
+  // Reactive attribute bindings inside the branch (#1071). Each effect
+  // resolves its target via `qsa(__branchScope, ...)` so a fresh DOM swap
+  // produces a fresh element reference; without this, the effect would
+  // keep writing to a stale, detached node placed there at first hydration.
+  // Group by slot so each `qsa` call covers all attrs on the same element,
+  // mirroring the init-level `attrsBySlot` shape in `emit-reactive.ts`.
+  const attrsBySlot = new Map<string, typeof body.reactiveAttrs>()
+  for (const attr of body.reactiveAttrs) {
+    if (!attrsBySlot.has(attr.slotId)) attrsBySlot.set(attr.slotId, [])
+    attrsBySlot.get(attr.slotId)!.push(attr)
+  }
+  for (const [slotId, attrs] of attrsBySlot) {
+    const v = varSlotId(slotId)
+    const elVar = `__ra_${v}`
+    lines.push(`${indent}{ const ${elVar} = qsa(__branchScope, '[bf="${slotId}"]')`)
+    lines.push(`${indent}if (${elVar}) {`)
+    for (const attr of attrs) {
+      lines.push(`${indent}  __disposers.push(createDisposableEffect(() => {`)
+      for (const stmt of emitAttrUpdate(elVar, attr.attrName, attr.expression, attr)) {
+        lines.push(`${indent}    ${stmt}`)
+      }
+      lines.push(`${indent}  }))`)
+    }
+    lines.push(`${indent}} }`)
+  }
 
   for (const te of body.textEffects) {
     const v = varSlotId(te.slotId)

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -104,6 +104,20 @@ export interface ConditionalBranchTextEffect {
 }
 
 /**
+ * Reactive attribute binding scoped to a single conditional branch (#1071).
+ * Each becomes a `createDisposableEffect` inside the branch's
+ * `bindEvents(__branchScope)` so the binding re-resolves its target on
+ * every DOM swap done by `insert()`. Attributes on the branch's root
+ * element or any descendant of it are routed here; init-level
+ * `ctx.reactiveAttrs` only carries non-branch attrs.
+ */
+export interface ConditionalBranchReactiveAttr extends AttrMeta {
+  slotId: string
+  attrName: string
+  expression: string
+}
+
+/**
  * Fields shared by every flavour of collected loop (top-level, branch-scoped, nested).
  * The three loop-info variants (`TopLevelLoop`, `BranchLoop`, `NestedLoop`) each extend
  * this base and add a `kind` discriminator so callers can narrow exhaustively.
@@ -155,6 +169,12 @@ export interface BranchSummary {
   refs: ConditionalBranchRef[]
   childComponents: ConditionalBranchChildComponent[]
   textEffects: ConditionalBranchTextEffect[]
+  /**
+   * Reactive attribute bindings on the branch's root element or descendants.
+   * Emitted inside `insert()` bindEvents so they re-attach when `insert()`
+   * swaps in a fresh element on the rising edge of the condition (#1071).
+   */
+  reactiveAttrs: ConditionalBranchReactiveAttr[]
   loops: BranchLoop[]
   conditionals: ConditionalElement[]
 }

--- a/site/ui/components/graph-editor-demo.tsx
+++ b/site/ui/components/graph-editor-demo.tsx
@@ -414,23 +414,20 @@ export function GraphEditorDemo() {
             ))}
           </g>
 
-          {/* Connect-in-progress preview path. Always mounted (toggled via
-              `display`) so the reactive `d` binding stays wired across drag
-              start/stop — the BF compiler does not currently re-attach
-              reactive bindings to a path that lives inside a conditional
-              branch (#135 follow-up). Pointer-transparent so the drop
-              hit-test sees through to the target node underneath. */}
-          <path
-            className="graph-connect-preview"
-            data-connect-preview
-            d={connectPreview() ?? ''}
-            stroke="#2563eb"
-            strokeWidth="1.5"
-            strokeDasharray="4 4"
-            fill="none"
-            pointerEvents="none"
-            display={connectPreview() !== null ? 'inline' : 'none'}
-          />
+          {/* Connect-in-progress preview path. Pointer-transparent so the
+              drop hit-test sees through to the target node underneath. */}
+          {connectPreview() !== null ? (
+            <path
+              className="graph-connect-preview"
+              data-connect-preview
+              d={connectPreview() ?? ''}
+              stroke="#2563eb"
+              strokeWidth="1.5"
+              strokeDasharray="4 4"
+              fill="none"
+              pointerEvents="none"
+            />
+          ) : null}
 
           {/* Nodes loop — every node has reactive cx/cy on its circle and
               x/y on its label, plus a connect handle whose cx/cy track the

--- a/site/ui/e2e/graph-editor.spec.ts
+++ b/site/ui/e2e/graph-editor.spec.ts
@@ -250,15 +250,15 @@ test.describe('Graph Editor Block', () => {
       await page.mouse.down()
       // Step through so the connect-preview path renders along the way.
       await page.mouse.move((sx + ex) / 2, (sy + ey) / 2, { steps: 5 })
-      // Preview is always mounted; while dragging it must be visible.
-      await expect(preview).toHaveAttribute('display', 'inline')
+      // While dragging, the preview path is mounted via the conditional.
+      await expect(preview).toHaveCount(1)
       await page.mouse.move(ex, ey, { steps: 5 })
       await page.mouse.up()
 
       await expect(s.locator('[data-edge-id]')).toHaveCount(6)
       await expect(s.locator('.edge-count')).toHaveText('6 edges')
-      // The connect preview is hidden once drag ends.
-      await expect(preview).toHaveAttribute('display', 'none')
+      // The connect preview is unmounted once drag ends.
+      await expect(preview).toHaveCount(0)
     })
 
     test('drag-to-connect onto the source node itself does not create a self-edge', async ({ page }) => {


### PR DESCRIPTION
Closes #1071

## Summary

- Compiler now emits per-branch reactive **attribute** bindings inside `bindEvents(__branchScope)` so they re-attach on every DOM swap performed by `insert()`. The slot is re-queried via `qsa(__branchScope, '[bf="..."]')` on each branch activation, and each binding is wrapped in `createDisposableEffect` with cleanup collected into the existing `__disposers` array.
- Removes the always-mounted `display:inline|none` preview workaround in `graph-editor-demo`, restoring the natural `{cond ? <path/> : null}` shape.
- Updates the connect-preview E2E assertions back to `toHaveCount(1)` while dragging and `toHaveCount(0)` after release.

## Root cause

Reactive attribute updates were collected via the IR walker into `ctx.reactiveAttrs` regardless of whether the element lived inside a conditional branch. `emit-reactive.ts` then emitted a single top-level `createEffect` whose body wrote to `_sN` — a slot variable resolved exactly once at init via `scope.querySelector('[bf="sN"]')`. On the rising edge of the conditional, `insert()` replaced that DOM node; the effect kept writing to the detached placeholder.

## Fix

1. `BranchSummary.reactiveAttrs` (new) — per-branch list of reactive attribute bindings, populated by a new `collectBranchReactiveAttrs` walker that mirrors `collectBranchTextEffects` (stops at nested conditionals / loops / if-statements).
2. `collectFromElement` skips pushing to `ctx.reactiveAttrs` when `insideConditional` is set; the binding is collected per-branch instead.
3. `ArmBody.reactiveAttrs` (new) and `build-insert.ts` plumbs `BranchSummary.reactiveAttrs` → `ArmBody.reactiveAttrs`.
4. `stringify/insert.ts` emits inside `bindEvents`:

   ```js
   { const __ra_sN = qsa(__branchScope, '[bf="sN"]')
   if (__ra_sN) {
     __disposers.push(createDisposableEffect(() => {
       /* emitAttrUpdate output */
     }))
   } }
   ```

   Existing `__disposers.forEach(d => d())` cleanup envelope handles disposal on branch swap; no runtime change needed.

## Test plan

- [x] New compiler unit tests in `packages/jsx/src/__tests__/conditional-reactive-binding-rebind.test.ts` — assert the reactive `setAttribute` lives inside `bindEvents(__branchScope)` and is no longer emitted at init level, and that it is wrapped in `createDisposableEffect`.
- [x] New runtime integration tests in `packages/client/__tests__/runtime/conditional-reactive-attr-rebind.test.ts` — drive signals across condition rising/falling edges and assert the live element's attribute follows; counts effect runs to confirm cleanup runs before each rebind (no stale-effect accumulation).
- [x] `bun test` in `packages/jsx` — 824 / 824 passing.
- [x] `bun test` in `packages/adapter-tests` — 214 / 214 passing.
- [x] `bun test` in `packages/client` — 214 / 214 passing.
- [x] `bun run build` — clean build green across all workspaces.
- [x] `bunx playwright test --project=chromium` in `site/ui` — 1083 / 1083 passing, including the connect-preview E2E (drag mounts the path, release unmounts it).