### PR TITLE
chore: update repo references from barefootjs/barefootjs to piconic-ai/barefootjs

### DIFF
--- a/docs/core/adapters/csr.md
+++ b/docs/core/adapters/csr.md
@@ -76,4 +76,4 @@ The component must be registered first by importing its `.client.js` file — th
 </html>
 ```
 
-See [`integrations/csr/`](https://github.com/barefootjs/barefootjs/tree/main/integrations/csr) for a runnable end-to-end example.
+See [`integrations/csr/`](https://github.com/piconic-ai/barefootjs/tree/main/integrations/csr) for a runnable end-to-end example.

--- a/docs/core/core-concepts/backend-freedom.md
+++ b/docs/core/core-concepts/backend-freedom.md
@@ -16,9 +16,9 @@ JSX → IR (backend-agnostic) → Adapter → Template
 | Language | Adapter | Notes |
 |----------|---------|-------|
 | TypeScript | [HonoAdapter](../adapters/hono-adapter.md) | Hono / JSX-based TS servers |
-| TypeScript | [TestAdapter](https://github.com/barefootjs/barefootjs/tree/main/packages/test) | IR-based component testing |
+| TypeScript | [TestAdapter](https://github.com/piconic-ai/barefootjs/tree/main/packages/test) | IR-based component testing |
 | Go | [GoTemplateAdapter](../adapters/go-template-adapter.md) | `html/template` |
-| Perl | [MojoliciousAdapter](https://github.com/barefootjs/barefootjs/tree/main/packages/adapter-mojolicious) | Mojolicious EP templates |
+| Perl | [MojoliciousAdapter](https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-mojolicious) | Mojolicious EP templates |
 
 ### Planned
 

--- a/docs/core/rendering/client-directive.md
+++ b/docs/core/rendering/client-directive.md
@@ -64,7 +64,7 @@ createEffect(() => {
 
 ### Explicit client-only evaluation
 
-Even for patterns the compiler supports, you can use `/* @client */` to skip server evaluation. The [TodoApp example](https://github.com/barefootjs/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) uses this approach:
+Even for patterns the compiler supports, you can use `/* @client */` to skip server evaluation. The [TodoApp example](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) uses this approach:
 
 ```tsx
 // These expressions CAN compile without @client, but the developer
@@ -74,7 +74,7 @@ checked={/* @client */ todos().every(t => t.done)}
 <strong>{/* @client */ todos().filter(t => !t.done).length}</strong>
 ```
 
-Compare with the [TodoAppSSR version](https://github.com/barefootjs/barefootjs/blob/main/integrations/shared/components/TodoAppSSR.tsx), which omits `/* @client */` and lets the compiler generate marked template equivalents for the same expressions.
+Compare with the [TodoAppSSR version](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoAppSSR.tsx), which omits `/* @client */` and lets the compiler generate marked template equivalents for the same expressions.
 
 
 ## Trade-off

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -143,4 +143,4 @@ Some JavaScript expressions cannot be translated into marked template syntax. Th
 {/* @client */ items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}
 ```
 
-See the [TodoApp example](https://github.com/barefootjs/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) for a real-world component using `/* @client */`.
+See the [TodoApp example](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) for a real-world component using `/* @client */`.

--- a/integrations/echo/go.mod
+++ b/integrations/echo/go.mod
@@ -1,4 +1,4 @@
-module github.com/barefootjs/barefootjs/integrations/echo
+module github.com/piconic-ai/barefootjs/integrations/echo
 
 go 1.25.6
 

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/adapter-go-template"
   },
   "peerDependencies": {

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -91,7 +91,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/adapter-hono"
   },
   "peerDependencies": {

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/adapter-mojolicious"
   },
   "dependencies": {

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/chart"
   },
   "peerDependencies": {

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -4,7 +4,7 @@
 // The current preview package is a monorepo-internal dev tool (hardcoded
 // paths, Hono + Bun-specific `hono/bun`, `bunx unocss` shell-out). A
 // publish-ready rewrite is tracked in
-// https://github.com/barefootjs/barefootjs/issues/885.
+// https://github.com/piconic-ai/barefootjs/issues/885.
 //
 // When the CLI is run from inside the barefootjs monorepo (source tree
 // available), we still delegate to the existing preview package.
@@ -32,7 +32,7 @@ export async function run(args: string[], _ctx: CliContext): Promise<void> {
 
   if (!runPreview) {
     console.error('barefoot preview is not available in the npm distribution yet.')
-    console.error('Tracking issue: https://github.com/barefootjs/barefootjs/issues/885')
+    console.error('Tracking issue: https://github.com/piconic-ai/barefootjs/issues/885')
     console.error('Workaround: run the barefootjs monorepo locally with bun.')
     process.exit(1)
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/client"
   },
   "dependencies": {

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,6 +1,6 @@
 # @barefootjs/form
 
-Signal-based form management for [BarefootJS](https://github.com/barefootjs/barefootjs). Provides reactive per-field state (value, error, touched, dirty), configurable validation timing, and [Standard Schema](https://github.com/standard-schema/standard-schema) integration for library-agnostic validation.
+Signal-based form management for [BarefootJS](https://github.com/piconic-ai/barefootjs). Provides reactive per-field state (value, error, touched, dirty), configurable validation timing, and [Standard Schema](https://github.com/standard-schema/standard-schema) integration for library-agnostic validation.
 
 ## Install
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/form"
   },
   "peerDependencies": {

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/jsx"
   },
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/shared"
   }
 }

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/streaming"
   },
   "dependencies": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/test"
   },
   "dependencies": {

--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/barefootjs/barefootjs",
+    "url": "https://github.com/piconic-ai/barefootjs",
     "directory": "packages/xyflow"
   },
   "peerDependencies": {

--- a/site/core/landing/components/links.tsx
+++ b/site/core/landing/components/links.tsx
@@ -8,7 +8,7 @@ const links = [
   {
     title: 'Documentation',
     description: 'Learn how to use Barefoot.js in your project.',
-    href: 'https://github.com/barefootjs/barefootjs',
+    href: 'https://github.com/piconic-ai/barefootjs',
   },
   {
     title: 'UI Components',
@@ -18,7 +18,7 @@ const links = [
   {
     title: 'GitHub',
     description: 'View the source code and contribute.',
-    href: 'https://github.com/barefootjs/barefootjs',
+    href: 'https://github.com/piconic-ai/barefootjs',
   },
 ]
 

--- a/site/shared/components/header.tsx
+++ b/site/shared/components/header.tsx
@@ -99,7 +99,7 @@ export function Header({
         <div className="flex items-center gap-2 sm:gap-4">
           {searchSlot}
           <a
-            href="https://github.com/barefootjs/barefootjs"
+            href="https://github.com/piconic-ai/barefootjs"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center w-9 h-9 rounded-md text-foreground hover:bg-accent transition-colors"

--- a/site/ui/pages/gallery/admin/analytics.tsx
+++ b/site/ui/pages/gallery/admin/analytics.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminAnalyticsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="analytics">
         <AdminAnalyticsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/index.tsx
+++ b/site/ui/pages/gallery/admin/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminOverviewPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="overview">
         <AdminOverviewDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/notifications.tsx
+++ b/site/ui/pages/gallery/admin/notifications.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminNotificationsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="notifications">
         <AdminNotificationsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/orders.tsx
+++ b/site/ui/pages/gallery/admin/orders.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminOrdersPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="orders">
         <AdminOrdersDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/admin/settings.tsx
+++ b/site/ui/pages/gallery/admin/settings.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from './gallery-meta'
 export function AdminSettingsPage() {
   return (
     <>
-      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/admin" />
+      <GalleryMeta appName="Admin Dashboard" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/admin" />
       <AdminShell currentRoute="settings">
         <AdminSettingsDemo />
       </AdminShell>

--- a/site/ui/pages/gallery/productivity/board.tsx
+++ b/site/ui/pages/gallery/productivity/board.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ProductivityBoardPage() {
   return (
     <>
-      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/productivity" />
       <ProductivityShell currentRoute="board">
         <ProductivityBoardDemo />
       </ProductivityShell>

--- a/site/ui/pages/gallery/productivity/calendar.tsx
+++ b/site/ui/pages/gallery/productivity/calendar.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ProductivityCalendarPage() {
   return (
     <>
-      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/productivity" />
       <ProductivityShell currentRoute="calendar">
         <ProductivityCalendarDemo />
       </ProductivityShell>

--- a/site/ui/pages/gallery/productivity/files.tsx
+++ b/site/ui/pages/gallery/productivity/files.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ProductivityFilesPage() {
   return (
     <>
-      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/productivity" />
       <ProductivityShell currentRoute="files">
         <ProductivityFilesDemo />
       </ProductivityShell>

--- a/site/ui/pages/gallery/productivity/mail.tsx
+++ b/site/ui/pages/gallery/productivity/mail.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ProductivityMailPage() {
   return (
     <>
-      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/productivity" />
+      <GalleryMeta appName="Productivity Suite" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/productivity" />
       <ProductivityShell currentRoute="mail">
         <ProductivityMailDemo />
       </ProductivityShell>

--- a/site/ui/pages/gallery/saas/blog-post.tsx
+++ b/site/ui/pages/gallery/saas/blog-post.tsx
@@ -9,7 +9,7 @@ interface SaasBlogPostPageProps {
 export function SaasBlogPostPage({ slug }: SaasBlogPostPageProps) {
   return (
     <>
-      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/saas" />
       <SaasShell currentRoute="blog">
         <SaasBlogPostDemo slug={slug} />
       </SaasShell>

--- a/site/ui/pages/gallery/saas/blog.tsx
+++ b/site/ui/pages/gallery/saas/blog.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SaasBlogPage() {
   return (
     <>
-      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/saas" />
       <SaasShell currentRoute="blog">
         <SaasBlogIndexDemo />
       </SaasShell>

--- a/site/ui/pages/gallery/saas/index.tsx
+++ b/site/ui/pages/gallery/saas/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SaasLandingPage() {
   return (
     <>
-      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/saas" />
       <SaasShell currentRoute="landing">
         <SaasLandingDemo />
       </SaasShell>

--- a/site/ui/pages/gallery/saas/login.tsx
+++ b/site/ui/pages/gallery/saas/login.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SaasLoginPage() {
   return (
     <>
-      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/saas" />
       <SaasShell currentRoute="login">
         <SaasLoginDemo />
       </SaasShell>

--- a/site/ui/pages/gallery/saas/pricing.tsx
+++ b/site/ui/pages/gallery/saas/pricing.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SaasPricingPage() {
   return (
     <>
-      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/saas" />
+      <GalleryMeta appName="SaaS Marketing" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/saas" />
       <SaasShell currentRoute="pricing">
         <SaasPricingDemo />
       </SaasShell>

--- a/site/ui/pages/gallery/shop/cart.tsx
+++ b/site/ui/pages/gallery/shop/cart.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCartPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="cart">
         <ShopCartDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/shop/checkout.tsx
+++ b/site/ui/pages/gallery/shop/checkout.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCheckoutPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="checkout">
         <ShopCheckoutDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/shop/index.tsx
+++ b/site/ui/pages/gallery/shop/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function ShopCatalogPage() {
   return (
     <>
-      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/shop" />
+      <GalleryMeta appName="E-Commerce Shop" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/shop" />
       <ShopShell currentRoute="catalog">
         <ShopCatalogDemo />
       </ShopShell>

--- a/site/ui/pages/gallery/social/index.tsx
+++ b/site/ui/pages/gallery/social/index.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SocialFeedPage() {
   return (
     <>
-      <GalleryMeta appName="Social App" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/social" />
+      <GalleryMeta appName="Social App" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/social" />
       <SocialShell currentRoute="feed">
         <SocialFeedPageDemo />
       </SocialShell>

--- a/site/ui/pages/gallery/social/messages.tsx
+++ b/site/ui/pages/gallery/social/messages.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SocialMessagesPage() {
   return (
     <>
-      <GalleryMeta appName="Social App" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/social" />
+      <GalleryMeta appName="Social App" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/social" />
       <SocialShell currentRoute="messages">
         <SocialMessagesDemo />
       </SocialShell>

--- a/site/ui/pages/gallery/social/profile.tsx
+++ b/site/ui/pages/gallery/social/profile.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SocialProfilePage() {
   return (
     <>
-      <GalleryMeta appName="Social App" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/social" />
+      <GalleryMeta appName="Social App" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/social" />
       <SocialShell currentRoute="profile">
         <SocialProfileDemo />
       </SocialShell>

--- a/site/ui/pages/gallery/social/thread.tsx
+++ b/site/ui/pages/gallery/social/thread.tsx
@@ -5,7 +5,7 @@ import { GalleryMeta } from '../admin/gallery-meta'
 export function SocialThreadPage() {
   return (
     <>
-      <GalleryMeta appName="Social App" sourceHref="https://github.com/barefootjs/barefootjs/tree/main/site/ui/components/gallery/social" />
+      <GalleryMeta appName="Social App" sourceHref="https://github.com/piconic-ai/barefootjs/tree/main/site/ui/components/gallery/social" />
       <SocialShell currentRoute="thread">
         <SocialThreadDemo />
       </SocialShell>


### PR DESCRIPTION
## Summary

Repository is moving from `barefootjs/barefootjs` to `piconic-ai/barefootjs`. This PR updates every in-repo reference to the old GitHub URL.

Scope of changes (41 files):

- `repository.url` in 12 `packages/*/package.json` files
- Doc links in `docs/core/**` (4 files)
- `packages/cli/src/commands/preview.ts` — issue link in code comment & error message
- `site/core/landing/components/links.tsx`, `site/shared/components/header.tsx` — header / footer GitHub links
- `site/ui/pages/gallery/**/*.tsx` — `GalleryMeta sourceHref` for 19 gallery pages
- `packages/form/README.md` — link in description
- `integrations/echo/go.mod` — Go module path (`module github.com/...`)

Intentionally **not changed**:

- `@barefootjs/*` npm scope — workflows / `bun run --filter` / package names. The npm scope is not moving with the repo.
- CI workflow files — they only reference the npm scope.
- Local-only / gitignored files (`.claude/`, `tmp/`, `hoge.md`).

## Test plan

- [x] `bun install` clean
- [x] `go build ./...` in `integrations/echo`
- [x] `git ls-files | xargs grep -l 'barefootjs/barefootjs'` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)