### PR TITLE
docs: align README tagline with site copy and add alpha warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 </p>
 
 <p align="center">
-  <strong>Reactive JSX for any backend</strong><br>
-  Generates Marked Templates + Client JS from Signal-based JSX
+  <strong>TSX in. Your template language out.</strong><br>
+  Barefoot compiles signal-based TSX into Hono, Echo, or your favorite template language.<br>
+  No virtual DOM. No SPA required.
 </p>
+
+> [!WARNING]
+> **Alpha Software** — BarefootJS is in early alpha. APIs may change without notice. Not recommended for production use.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update the tagline below the logo to match the site copy: **TSX in. Your template language out.**
- Add a standard GitHub `[!WARNING]` callout noting that BarefootJS is in early alpha, APIs may change without notice, and production use is not recommended.

## Test plan

- [ ] README renders correctly on GitHub (callout box displays as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)