### PR TITLE
feat(xyflow): refactor edge-renderer to per-edge reactive scopes (Phase 9 PoC)

### DIFF
--- a/packages/xyflow/e2e/serve.ts
+++ b/packages/xyflow/e2e/serve.ts
@@ -9,27 +9,39 @@ import { resolve } from 'path'
 const ROOT = resolve(import.meta.dir, '..')
 const CLIENT_ROOT = resolve(ROOT, '../client')
 
-// Bundle @barefootjs/client for the browser
+// Bundle @barefootjs/client/reactive — the leaf module that owns
+// reactive primitives. Both client/index and client/runtime re-export
+// from this subpath, so for the browser we serve it as its own file
+// (matching the package's three-output build).
+const reactiveBuild = await Bun.build({
+  entrypoints: [resolve(CLIENT_ROOT, 'src/reactive.ts')],
+  format: 'esm',
+})
+
+// Bundle @barefootjs/client (main entry). Externalizes reactive so the
+// reactive module exists once in the browser.
 const clientBuild = await Bun.build({
   entrypoints: [resolve(CLIENT_ROOT, 'src/index.ts')],
   format: 'esm',
+  external: ['@barefootjs/client/reactive'],
 })
 
 // Bundle the compiler-emit runtime entry (`@barefootjs/client/runtime`).
-// It consumes the main client entry for reactive primitives.
+// Externalizes both main + reactive so the reactive module is shared.
 const runtimeBuild = await Bun.build({
   entrypoints: [resolve(CLIENT_ROOT, 'src/runtime/index.ts')],
   format: 'esm',
-  external: ['@barefootjs/client'],
+  external: ['@barefootjs/client', '@barefootjs/client/reactive'],
 })
 
-// Bundle @barefootjs/xyflow for the browser (external client + runtime)
+// Bundle @barefootjs/xyflow for the browser (external client + runtime + reactive)
 const xyflowBuild = await Bun.build({
   entrypoints: [resolve(ROOT, 'src/index.ts')],
   format: 'esm',
-  external: ['@barefootjs/client', '@barefootjs/client/runtime'],
+  external: ['@barefootjs/client', '@barefootjs/client/runtime', '@barefootjs/client/reactive'],
 })
 
+const reactiveJs = await reactiveBuild.outputs[0].text()
 const clientJs = await clientBuild.outputs[0].text()
 const runtimeJs = await runtimeBuild.outputs[0].text()
 const xyflowJs = await xyflowBuild.outputs[0].text()
@@ -46,6 +58,9 @@ Bun.serve({
 
     if (url.pathname === '/barefoot-client.js') {
       return new Response(clientJs, { headers: { 'Content-Type': 'application/javascript' } })
+    }
+    if (url.pathname === '/barefoot-client-reactive.js') {
+      return new Response(reactiveJs, { headers: { 'Content-Type': 'application/javascript' } })
     }
     if (url.pathname === '/barefoot-client-runtime.js') {
       return new Response(runtimeJs, { headers: { 'Content-Type': 'application/javascript' } })

--- a/packages/xyflow/e2e/test-page.html
+++ b/packages/xyflow/e2e/test-page.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@barefootjs/xyflow E2E Tests</title>
   <script type="importmap">
-    { "imports": { "@barefootjs/client": "/barefoot-client.js", "@barefootjs/client/runtime": "/barefoot-client-runtime.js", "@barefootjs/xyflow": "/barefoot-xyflow.js" } }
+    { "imports": { "@barefootjs/client": "/barefoot-client.js", "@barefootjs/client/reactive": "/barefoot-client-reactive.js", "@barefootjs/client/runtime": "/barefoot-client-runtime.js", "@barefootjs/xyflow": "/barefoot-xyflow.js" } }
   </script>
   <style>
     body { margin: 0; font-family: sans-serif; }

--- a/packages/xyflow/src/__tests__/edge-renderer.test.ts
+++ b/packages/xyflow/src/__tests__/edge-renderer.test.ts
@@ -1,6 +1,19 @@
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+// Register happy-dom globals BEFORE importing modules that use the DOM.
+// Without this, document.createElementNS is undefined when edge-renderer
+// loads and the per-edge mount path fails on import.
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
 import { createRoot } from '@barefootjs/client'
 import { createFlowStore } from '../store'
+import { createEdgeRenderer } from '../edge-renderer'
+import { SVG_NS } from '../constants'
 
 describe('Edge processing in store', () => {
   test('edgeLookup is populated from edges', () => {
@@ -64,6 +77,177 @@ describe('Edge processing in store', () => {
       const lookup = store.edgeLookup()
       expect(lookup.size).toBe(2)
       expect(lookup.get('e1')?.hidden).toBe(true)
+    })
+  })
+})
+
+/**
+ * Per-edge scope tests — exercise the post-PoC architecture where
+ * each edge is mounted in its own createRoot with an inner createEffect.
+ *
+ * These tests assert the public DOM contract that the legacy
+ * implementation also held (`.bf-flow__edge[data-id]` visible path,
+ * `path[data-hit-id]` invisible hit area, classes for selected/animated).
+ * The reconnection handler in `connection.ts` queries that contract by
+ * selector, so keeping it stable is what enables the refactor without
+ * changing call sites.
+ */
+function makeFlowDom() {
+  // initFlow normally creates this wrapper structure. For the renderer
+  // unit test, we mimic the relevant parts: a viewport <div> with an
+  // <svg> child for edges.
+  const viewport = document.createElement('div')
+  document.body.appendChild(viewport)
+  const svg = document.createElementNS(SVG_NS, 'svg') as SVGSVGElement
+  viewport.appendChild(svg)
+  return { viewport, svg }
+}
+
+describe('createEdgeRenderer (per-edge scope)', () => {
+  test('mounts a visible path and a hit-area path per edge', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      })
+      // Force lookups to populate (initFlow normally does this via measure)
+      store.nodesInitialized()
+
+      createEdgeRenderer(store, svg)
+
+      const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement | null
+      const hit = svg.querySelector('path[data-hit-id="e1"]') as SVGPathElement | null
+
+      expect(visible).not.toBeNull()
+      expect(hit).not.toBeNull()
+      // Visible path has a `d` attribute populated by the inner effect
+      expect(visible!.getAttribute('d')).toBeTruthy()
+      // Hit area mirrors visible path's `d` so click detection follows
+      // the same shape
+      expect(hit!.getAttribute('d')).toBe(visible!.getAttribute('d'))
+    })
+  })
+
+  test('applies bf-flow__edge--selected class when edge is selected', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement
+      expect(visible.classList.contains('bf-flow__edge--selected')).toBe(false)
+
+      // Toggle selection — only this edge's per-edge effect should re-run
+      store.setEdges([{ id: 'e1', source: 'a', target: 'b', selected: true }])
+
+      expect(visible.classList.contains('bf-flow__edge--selected')).toBe(true)
+    })
+  })
+
+  test('removes per-edge DOM when edge is removed from the array', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [
+          { id: 'e1', source: 'a', target: 'b' },
+          { id: 'e2', source: 'b', target: 'a' },
+        ],
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      expect(svg.querySelectorAll('.bf-flow__edge').length).toBe(2)
+
+      store.setEdges([{ id: 'e1', source: 'a', target: 'b' }])
+
+      // Disposing the per-edge root should also remove its DOM nodes
+      expect(svg.querySelectorAll('.bf-flow__edge').length).toBe(1)
+      expect(svg.querySelector('.bf-flow__edge[data-id="e1"]')).not.toBeNull()
+      expect(svg.querySelector('.bf-flow__edge[data-id="e2"]')).toBeNull()
+      // Hit areas should also be cleaned up
+      expect(svg.querySelector('path[data-hit-id="e2"]')).toBeNull()
+    })
+  })
+
+  test('hidden edges are not mounted', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [
+          { id: 'e1', source: 'a', target: 'b', hidden: true },
+          { id: 'e2', source: 'b', target: 'a' },
+        ],
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      expect(svg.querySelector('.bf-flow__edge[data-id="e1"]')).toBeNull()
+      expect(svg.querySelector('.bf-flow__edge[data-id="e2"]')).not.toBeNull()
+    })
+  })
+
+  test('animated edges get bf-flow__edge--animated class', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [{ id: 'e1', source: 'a', target: 'b', animated: true }],
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement
+      expect(visible.classList.contains('bf-flow__edge--animated')).toBe(true)
+    })
+  })
+
+  test('positionEpoch bump re-runs the per-edge effect', () => {
+    createRoot(() => {
+      const { svg } = makeFlowDom()
+      const store = createFlowStore({
+        nodes: [
+          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+        ],
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement
+      const dBefore = visible.getAttribute('d')!
+
+      // Mutate the source node's positionAbsolute in place (mirrors what
+      // updateNodePositions does during a drag) and bump positionEpoch.
+      const lookup = store.nodeLookup()
+      const a = lookup.get('a')!
+      a.internals.positionAbsolute = { x: 0, y: 100 }
+      store.triggerPositionUpdate()
+
+      const dAfter = visible.getAttribute('d')!
+      expect(dAfter).not.toBe(dBefore)
     })
   })
 })

--- a/packages/xyflow/src/__tests__/edge-renderer.test.ts
+++ b/packages/xyflow/src/__tests__/edge-renderer.test.ts
@@ -14,6 +14,7 @@ import { createRoot } from '@barefootjs/client'
 import { createFlowStore } from '../store'
 import { createEdgeRenderer } from '../edge-renderer'
 import { SVG_NS } from '../constants'
+import type { EdgeBase } from '../types'
 
 describe('Edge processing in store', () => {
   test('edgeLookup is populated from edges', () => {
@@ -135,12 +136,17 @@ describe('createEdgeRenderer (per-edge scope)', () => {
   test('applies bf-flow__edge--selected class when edge is selected', () => {
     createRoot(() => {
       const { svg } = makeFlowDom()
+      // Annotate edges as EdgeBase[] so subsequent setEdges() calls accept
+      // the full EdgeBase shape (e.g. `selected`). Without this, TypeScript
+      // narrows EdgeType to the literal `{ id, source, target }` shape of
+      // the initial array, rejecting any extra optional fields below.
+      const initialEdges: EdgeBase[] = [{ id: 'e1', source: 'a', target: 'b' }]
       const store = createFlowStore({
         nodes: [
           { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
           { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
         ],
-        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+        edges: initialEdges,
       })
       store.nodesInitialized()
       createEdgeRenderer(store, svg)

--- a/packages/xyflow/src/__tests__/edge-renderer.test.ts
+++ b/packages/xyflow/src/__tests__/edge-renderer.test.ts
@@ -1,9 +1,8 @@
-import { describe, test, expect, beforeAll } from 'bun:test'
+import { describe, test, expect, beforeAll, afterEach } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
-// Register happy-dom globals BEFORE importing modules that use the DOM.
-// Without this, document.createElementNS is undefined when edge-renderer
-// loads and the per-edge mount path fails on import.
+// The renderer tests below call `document.createElement*` directly, so a
+// DOM must be registered before they run.
 beforeAll(() => {
   if (typeof window === 'undefined') {
     GlobalRegistrator.register()
@@ -83,41 +82,49 @@ describe('Edge processing in store', () => {
 })
 
 /**
- * Per-edge scope tests — exercise the post-PoC architecture where
- * each edge is mounted in its own createRoot with an inner createEffect.
- *
- * These tests assert the public DOM contract that the legacy
- * implementation also held (`.bf-flow__edge[data-id]` visible path,
- * `path[data-hit-id]` invisible hit area, classes for selected/animated).
- * The reconnection handler in `connection.ts` queries that contract by
- * selector, so keeping it stable is what enables the refactor without
- * changing call sites.
+ * Per-edge scope tests — assert the public DOM contract preserved by the
+ * Phase-9 refactor (`.bf-flow__edge[data-id]` visible path,
+ * `path[data-hit-id]` invisible hit area, classes for selected/animated)
+ * and the per-edge isolation of the class effect.
  */
-function makeFlowDom() {
-  // initFlow normally creates this wrapper structure. For the renderer
-  // unit test, we mimic the relevant parts: a viewport <div> with an
-  // <svg> child for edges.
-  const viewport = document.createElement('div')
-  document.body.appendChild(viewport)
-  const svg = document.createElementNS(SVG_NS, 'svg') as SVGSVGElement
-  viewport.appendChild(svg)
-  return { viewport, svg }
-}
+const TWO_NODES = [
+  { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+  { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
+]
 
 describe('createEdgeRenderer (per-edge scope)', () => {
+  let dispose: (() => void) | null = null
+  let viewport: HTMLElement | null = null
+
+  function setup(): { svg: SVGSVGElement; run: <T>(fn: () => T) => T } {
+    viewport = document.createElement('div')
+    document.body.appendChild(viewport)
+    const svg = document.createElementNS(SVG_NS, 'svg') as SVGSVGElement
+    viewport.appendChild(svg)
+    let captured!: <T>(fn: () => T) => T
+    createRoot((d) => {
+      dispose = d
+      captured = (fn) => fn()
+    })
+    return { svg, run: captured }
+  }
+
+  afterEach(() => {
+    dispose?.()
+    dispose = null
+    viewport?.remove()
+    viewport = null
+  })
+
   test('mounts a visible path and a hit-area path per edge', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
+    const { svg, run } = setup()
+    run(() => {
       const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
+        nodes: TWO_NODES,
         edges: [{ id: 'e1', source: 'a', target: 'b' }],
       })
-      // Force lookups to populate (initFlow normally does this via measure)
+      // initFlow normally populates lookups via measure; mimic that here.
       store.nodesInitialized()
-
       createEdgeRenderer(store, svg)
 
       const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement | null
@@ -125,50 +132,35 @@ describe('createEdgeRenderer (per-edge scope)', () => {
 
       expect(visible).not.toBeNull()
       expect(hit).not.toBeNull()
-      // Visible path has a `d` attribute populated by the inner effect
       expect(visible!.getAttribute('d')).toBeTruthy()
-      // Hit area mirrors visible path's `d` so click detection follows
-      // the same shape
       expect(hit!.getAttribute('d')).toBe(visible!.getAttribute('d'))
     })
   })
 
   test('applies bf-flow__edge--selected class when edge is selected', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
-      // Annotate edges as EdgeBase[] so subsequent setEdges() calls accept
-      // the full EdgeBase shape (e.g. `selected`). Without this, TypeScript
-      // narrows EdgeType to the literal `{ id, source, target }` shape of
-      // the initial array, rejecting any extra optional fields below.
+    const { svg, run } = setup()
+    run(() => {
+      // Annotate as EdgeBase[] so subsequent setEdges() accepts the full
+      // shape; without this, EdgeType is narrowed to the literal initial
+      // shape and rejects optional fields like `selected`.
       const initialEdges: EdgeBase[] = [{ id: 'e1', source: 'a', target: 'b' }]
-      const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
-        edges: initialEdges,
-      })
+      const store = createFlowStore({ nodes: TWO_NODES, edges: initialEdges })
       store.nodesInitialized()
       createEdgeRenderer(store, svg)
 
       const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement
       expect(visible.classList.contains('bf-flow__edge--selected')).toBe(false)
 
-      // Toggle selection — only this edge's per-edge effect should re-run
       store.setEdges([{ id: 'e1', source: 'a', target: 'b', selected: true }])
-
       expect(visible.classList.contains('bf-flow__edge--selected')).toBe(true)
     })
   })
 
   test('removes per-edge DOM when edge is removed from the array', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
+    const { svg, run } = setup()
+    run(() => {
       const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
+        nodes: TWO_NODES,
         edges: [
           { id: 'e1', source: 'a', target: 'b' },
           { id: 'e2', source: 'b', target: 'a' },
@@ -178,47 +170,43 @@ describe('createEdgeRenderer (per-edge scope)', () => {
       createEdgeRenderer(store, svg)
 
       expect(svg.querySelectorAll('.bf-flow__edge').length).toBe(2)
-
       store.setEdges([{ id: 'e1', source: 'a', target: 'b' }])
 
-      // Disposing the per-edge root should also remove its DOM nodes
       expect(svg.querySelectorAll('.bf-flow__edge').length).toBe(1)
       expect(svg.querySelector('.bf-flow__edge[data-id="e1"]')).not.toBeNull()
       expect(svg.querySelector('.bf-flow__edge[data-id="e2"]')).toBeNull()
-      // Hit areas should also be cleaned up
       expect(svg.querySelector('path[data-hit-id="e2"]')).toBeNull()
     })
   })
 
-  test('hidden edges are not mounted', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
-      const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
-        edges: [
-          { id: 'e1', source: 'a', target: 'b', hidden: true },
-          { id: 'e2', source: 'b', target: 'a' },
-        ],
-      })
+  test('hidden edges are not mounted, and become mounted when toggled visible', () => {
+    const { svg, run } = setup()
+    run(() => {
+      const initialEdges: EdgeBase[] = [
+        { id: 'e1', source: 'a', target: 'b', hidden: true },
+        { id: 'e2', source: 'b', target: 'a' },
+      ]
+      const store = createFlowStore({ nodes: TWO_NODES, edges: initialEdges })
       store.nodesInitialized()
       createEdgeRenderer(store, svg)
 
       expect(svg.querySelector('.bf-flow__edge[data-id="e1"]')).toBeNull()
       expect(svg.querySelector('.bf-flow__edge[data-id="e2"]')).not.toBeNull()
+
+      // Flip hidden → visible. Outer effect should pick this up and mount e1.
+      store.setEdges([
+        { id: 'e1', source: 'a', target: 'b' },
+        { id: 'e2', source: 'b', target: 'a' },
+      ])
+      expect(svg.querySelector('.bf-flow__edge[data-id="e1"]')).not.toBeNull()
     })
   })
 
   test('animated edges get bf-flow__edge--animated class', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
+    const { svg, run } = setup()
+    run(() => {
       const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
+        nodes: TWO_NODES,
         edges: [{ id: 'e1', source: 'a', target: 'b', animated: true }],
       })
       store.nodesInitialized()
@@ -230,13 +218,10 @@ describe('createEdgeRenderer (per-edge scope)', () => {
   })
 
   test('positionEpoch bump re-runs the per-edge effect', () => {
-    createRoot(() => {
-      const { svg } = makeFlowDom()
+    const { svg, run } = setup()
+    run(() => {
       const store = createFlowStore({
-        nodes: [
-          { id: 'a', position: { x: 0, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-          { id: 'b', position: { x: 200, y: 0 }, data: {}, measured: { width: 150, height: 40 } },
-        ],
+        nodes: TWO_NODES,
         edges: [{ id: 'e1', source: 'a', target: 'b' }],
       })
       store.nodesInitialized()
@@ -245,15 +230,76 @@ describe('createEdgeRenderer (per-edge scope)', () => {
       const visible = svg.querySelector('.bf-flow__edge[data-id="e1"]') as SVGPathElement
       const dBefore = visible.getAttribute('d')!
 
-      // Mutate the source node's positionAbsolute in place (mirrors what
-      // updateNodePositions does during a drag) and bump positionEpoch.
+      // Mutate position in place (matches updateNodePositions during drag)
+      // and bump positionEpoch.
       const lookup = store.nodeLookup()
       const a = lookup.get('a')!
       a.internals.positionAbsolute = { x: 0, y: 100 }
       store.triggerPositionUpdate()
 
-      const dAfter = visible.getAttribute('d')!
-      expect(dAfter).not.toBe(dBefore)
+      expect(visible.getAttribute('d')!).not.toBe(dBefore)
+    })
+  })
+
+  test('toggling selection on edge A does not invalidate edge B class effect', () => {
+    // Per-edge isolation contract: per-field memos (selected/animated)
+    // dedupe on Object.is, so the class effect for an unrelated edge does
+    // not re-run when only another edge's selected flips. Instrument by
+    // replacing classList.toggle on each path with a counter.
+    const { svg, run } = setup()
+    run(() => {
+      const initialEdges: EdgeBase[] = [
+        { id: 'e1', source: 'a', target: 'b' },
+        { id: 'e2', source: 'b', target: 'a' },
+      ]
+      const store = createFlowStore({ nodes: TWO_NODES, edges: initialEdges })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      const e2Path = svg.querySelector('.bf-flow__edge[data-id="e2"]') as SVGPathElement
+      let e2ClassToggleCount = 0
+      const originalToggle = e2Path.classList.toggle.bind(e2Path.classList)
+      e2Path.classList.toggle = ((token: string, force?: boolean) => {
+        e2ClassToggleCount += 1
+        return originalToggle(token, force as boolean)
+      }) as DOMTokenList['toggle']
+
+      // Toggle selection on e1 only — e2's class effect must not fire.
+      store.setEdges([
+        { id: 'e1', source: 'a', target: 'b', selected: true },
+        { id: 'e2', source: 'b', target: 'a' },
+      ])
+
+      expect(e2ClassToggleCount).toBe(0)
+    })
+  })
+
+  test('reconnect handles unmount when edge becomes non-reconnectable', () => {
+    // Asserts the lifecycle fix: flipping `reconnectable: false` removes
+    // the previously-mounted handle circles instead of leaking them.
+    const { svg, run } = setup()
+    run(() => {
+      const initialEdges: EdgeBase[] = [{ id: 'e1', source: 'a', target: 'b' }]
+      const store = createFlowStore({
+        nodes: TWO_NODES,
+        edges: initialEdges,
+        edgesReconnectable: true,
+      })
+      store.nodesInitialized()
+      createEdgeRenderer(store, svg)
+
+      // Handles are mounted in the reconnect overlay, which is a sibling
+      // of the edge SVG inside the viewport wrapper.
+      const reconnectOverlay = viewport!.querySelector('.bf-flow__reconnect-overlay')!
+      expect(reconnectOverlay.querySelectorAll('.bf-flow__edge-reconnect').length).toBe(2)
+
+      // Flip per-edge reconnectable to false.
+      store.setEdges([{ id: 'e1', source: 'a', target: 'b', reconnectable: false } as EdgeBase])
+      expect(reconnectOverlay.querySelectorAll('.bf-flow__edge-reconnect').length).toBe(0)
+
+      // Flip back — handles should re-mount.
+      store.setEdges([{ id: 'e1', source: 'a', target: 'b' }])
+      expect(reconnectOverlay.querySelectorAll('.bf-flow__edge-reconnect').length).toBe(2)
     })
   })
 })

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -1,5 +1,6 @@
 import {
   createEffect,
+  createRoot,
   onCleanup,
 } from '@barefootjs/client'
 import {
@@ -21,7 +22,32 @@ import { attachReconnectionHandler } from './connection'
 
 /**
  * Reactively renders all edges as SVG paths.
- * A single effect re-draws all edges when edges or node positions change.
+ *
+ * Architecture (post-Phase-9 refactor):
+ *
+ * - The outer effect tracks `edges()` and maintains the **set** of edge IDs:
+ *   when an edge appears, a per-edge `createRoot` is mounted; when it
+ *   disappears, the root is disposed. This replaces the old hand-rolled
+ *   `Map<id, SVGPathElement>` diff bookkeeping.
+ *
+ * - Each per-edge root owns one inner `createEffect` that re-runs only when
+ *   `positionEpoch` / `nodeLookup` / the per-edge data changes. Moving a
+ *   single node only re-runs the effects of edges whose endpoints touch
+ *   that node, instead of looping over every edge in one big effect.
+ *
+ * This is the Solid-style pattern that compiler-emitted JSX produces for
+ * `edges().map(e => <path d={...} />)`. Implemented with `createElementNS`
+ * here because the xyflow package is not currently part of the JSX
+ * compilation pipeline (see rollout plan in PR description).
+ *
+ * Escape hatches kept imperative for now:
+ * - Custom edge types (`edgeTypes[type]` is a function): user functions
+ *   write into a managed `<g>` via `innerHTML = ''` + DOM API. JSX-ifying
+ *   this is out of scope because the user supplies the rendering function.
+ * - Reconnection handles: `attachReconnectionHandler` queries the SVG by
+ *   `[data-id]` / `[data-hit-id]` selectors at drag-start time. The
+ *   per-edge root keeps the same selectors, so the handler is wire-
+ *   compatible.
  */
 export function createEdgeRenderer<
   NodeType extends NodeBase = NodeBase,
@@ -54,268 +80,404 @@ export function createEdgeRenderer<
   const reconnectGroup = document.createElementNS(SVG_NS, 'g')
   reconnectOverlay.appendChild(reconnectGroup)
 
-  // Track edge path elements, hit areas, custom groups, and reconnection handles by edge id
-  const edgeElements = new Map<string, SVGPathElement>()
-  const hitElements = new Map<string, SVGPathElement>()
-  const customEdgeGroups = new Map<string, SVGGElement>()
-  const reconnectSourceHandles = new Map<string, SVGCircleElement>()
-  const reconnectTargetHandles = new Map<string, SVGCircleElement>()
+  // Sync reconnect overlay transform with viewport
+  createEffect(() => {
+    const vp = store.viewport()
+    reconnectGroup.setAttribute('transform', `translate(${vp.x}, ${vp.y}) scale(${vp.zoom})`)
+  })
 
-  // Expose label positions so the edge label renderer can read them
+  // Expose label positions so the edge label renderer can read them.
+  // The label renderer reads this map inside its own createEffect, so
+  // updates here are observed via the per-edge effect's positionEpoch read.
   const labelPositions = new Map<string, { x: number; y: number }>()
   ;(store as any)._edgeLabelPositions = labelPositions
 
+  // Per-edge scope: owns this edge's DOM elements + cleanup
+  type EdgeScope = {
+    dispose: () => void
+  }
+  const edgeScopes = new Map<string, EdgeScope>()
+
+  // Outer effect: structural diff (add/remove edges) only.
+  // Per-edge rendering lives in mountEdgeScope's inner effect, which
+  // re-runs independently when its node positions change.
   createEffect(() => {
     const edges = store.edges()
-    // Re-run when node positions change during drag (lightweight epoch bump)
-    // or when nodes are structurally changed (add/remove triggers nodes()).
-    store.positionEpoch()
-    store.nodes()
-    const nodeLookup = store.nodeLookup()
-
-    // Sync reconnect overlay transform with viewport
-    const vp = store.viewport()
-    reconnectGroup.setAttribute('transform', `translate(${vp.x}, ${vp.y}) scale(${vp.zoom})`)
-    const existingIds = new Set(edgeElements.keys())
+    const seen = new Set<string>()
 
     for (const edge of edges) {
       if (edge.hidden) continue
+      seen.add(edge.id)
 
-      existingIds.delete(edge.id)
-
-      const sourceNode = nodeLookup.get(edge.source)
-      const targetNode = nodeLookup.get(edge.target)
-
-      if (!sourceNode || !targetNode) continue
-
-      // Get source/target positions from @xyflow/system.
-      // Use Strict mode when handle IDs are present so the exact handle is
-      // resolved by ID rather than by closest-position heuristic (Loose).
-      const hasHandleIds = !!(edge.sourceHandle || edge.targetHandle)
-      let edgePos = getEdgePosition({
-        id: edge.id,
-        sourceNode,
-        sourceHandle: edge.sourceHandle ?? null,
-        targetNode,
-        targetHandle: edge.targetHandle ?? null,
-        connectionMode: hasHandleIds ? ConnectionMode.Strict : ConnectionMode.Loose,
-      })
-
-      // Fallback: if no handle bounds, use node center positions
-      if (!edgePos) {
-        const sw = sourceNode.measured.width ?? 150
-        const sh = sourceNode.measured.height ?? 40
-        const tw = targetNode.measured.width ?? 150
-
-        const sourcePos = sourceNode.internals.positionAbsolute
-        const targetPos = targetNode.internals.positionAbsolute
-
-        edgePos = {
-          sourceX: sourcePos.x + sw / 2,
-          sourceY: sourcePos.y + sh,
-          targetX: targetPos.x + tw / 2,
-          targetY: targetPos.y,
-          sourcePosition: Position.Bottom,
-          targetPosition: Position.Top,
-        }
-      }
-
-      // Check for custom edge type
-      const edgeType = edge.type
-      const customEdgeType = edgeType && store.edgeTypes?.[edgeType]
-
-      if (customEdgeType && typeof customEdgeType === 'function') {
-        // Custom edge rendering via plain function
-        const midX = (edgePos.sourceX + edgePos.targetX) / 2
-        const midY = (edgePos.sourceY + edgePos.targetY) / 2
-        labelPositions.set(edge.id, { x: midX, y: midY })
-
-        let group = customEdgeGroups.get(edge.id)
-        if (!group) {
-          group = document.createElementNS(SVG_NS, 'g')
-          group.setAttribute('class', 'bf-flow__edge-custom')
-          group.dataset.id = edge.id
-          group.style.cursor = 'pointer'
-          group.style.pointerEvents = 'all'
-          group.addEventListener('mousedown', (e) => {
-            e.stopPropagation()
-            const container = store.domNode()
-            if (container) container.focus()
-            const edgeId = edge.id
-            store.unselectNodesAndEdges()
-            store.setEdges((prev) =>
-              prev.map((ed) =>
-                ed.id === edgeId ? { ...ed, selected: true } : ed,
-              ),
-            )
-          })
-          edgeGroup.appendChild(group)
-          customEdgeGroups.set(edge.id, group)
-
-          // Also track in edgeElements for cleanup
-          edgeElements.set(edge.id, group as unknown as SVGPathElement)
-        }
-
-        // Clear and re-render custom content
-        group.innerHTML = ''
-
-        const edgeProps: EdgeComponentProps<EdgeType> = {
-          id: edge.id,
-          source: edge.source,
-          target: edge.target,
-          sourceX: edgePos.sourceX,
-          sourceY: edgePos.sourceY,
-          targetX: edgePos.targetX,
-          targetY: edgePos.targetY,
-          sourcePosition: edgePos.sourcePosition,
-          targetPosition: edgePos.targetPosition,
-          data: edge.data,
-          selected: !!edge.selected,
-          animated: !!edge.animated,
-          label: (edge as EdgeType & { label?: string }).label,
-          svgGroup: group,
-        }
-
-        customEdgeType(edgeProps)
-        continue
-      }
-
-      const pathData = getEdgePath(edge, edgePos)
-      if (!pathData) continue
-
-      const [path, labelX, labelY] = pathData
-
-      // Store label position for the edge label renderer
-      labelPositions.set(edge.id, { x: labelX, y: labelY })
-
-      let pathEl = edgeElements.get(edge.id)
-      if (!pathEl) {
-        // Invisible hit area for click selection (wider than visible path)
-        const hitPath = document.createElementNS(SVG_NS, 'path')
-        hitPath.setAttribute('fill', 'none')
-        hitPath.setAttribute('stroke', 'transparent')
-        hitPath.setAttribute('stroke-width', '20')
-        hitPath.dataset.hitId = edge.id
-        hitPath.style.cursor = 'pointer'
-        hitPath.style.pointerEvents = 'stroke'
-        hitPath.addEventListener('mousedown', (e) => {
-          e.stopPropagation()
-          // Focus container for keyboard events (Delete)
-          const container = store.domNode()
-          if (container) container.focus()
-          const edgeId = edge.id
-          store.unselectNodesAndEdges()
-          store.setEdges((prev) =>
-            prev.map((ed) =>
-              ed.id === edgeId ? { ...ed, selected: true } : ed,
-            ),
-          )
-        })
-        edgeGroup.appendChild(hitPath)
-        hitElements.set(edge.id, hitPath)
-
-        // Visible path
-        pathEl = document.createElementNS(SVG_NS, 'path')
-        pathEl.setAttribute('class', 'bf-flow__edge')
-        pathEl.dataset.id = edge.id
-        edgeGroup.appendChild(pathEl)
-        edgeElements.set(edge.id, pathEl)
-      }
-
-      pathEl.setAttribute('d', path)
-
-      // Update hit area path
-      const hitEl = hitElements.get(edge.id)
-      if (hitEl) hitEl.setAttribute('d', path)
-
-      pathEl.classList.toggle('bf-flow__edge--selected', !!edge.selected)
-      pathEl.classList.toggle('bf-flow__edge--animated', !!edge.animated)
-
-      // Edge reconnection handles
-      const isReconnectable = store.edgesReconnectable && (edge as any).reconnectable !== false
-      if (isReconnectable) {
-        // Source reconnection handle
-        let srcHandle = reconnectSourceHandles.get(edge.id)
-        if (!srcHandle) {
-          srcHandle = document.createElementNS(SVG_NS, 'circle') as SVGCircleElement
-          srcHandle.setAttribute('class', 'bf-flow__edge-reconnect bf-flow__edge-reconnect--source')
-          srcHandle.setAttribute('r', '10')
-          srcHandle.style.pointerEvents = 'all'
-          reconnectGroup.appendChild(srcHandle)
-          reconnectSourceHandles.set(edge.id, srcHandle)
-          // Darken edge on reconnect handle hover
-          const srcEdgeId = edge.id
-          srcHandle.addEventListener('mouseenter', () => {
-            edgeElements.get(srcEdgeId)?.classList.add('bf-flow__edge--reconnect-hover')
-          })
-          srcHandle.addEventListener('mouseleave', () => {
-            edgeElements.get(srcEdgeId)?.classList.remove('bf-flow__edge--reconnect-hover')
-          })
-          // Attach reconnection handler
-          const container = store.domNode()
-          if (container) {
-            attachReconnectionHandler(srcHandle, edge, 'source', container, svgContainer, store)
-          }
-        }
-        // Shift outward from node by radius (matching React Flow's shiftX/shiftY)
-        const srcR = 10
-        srcHandle.setAttribute('cx', String(edgePos.sourceX))
-        srcHandle.setAttribute('cy', String(edgePos.sourceY + srcR))
-
-        // Target reconnection handle
-        let tgtHandle = reconnectTargetHandles.get(edge.id)
-        if (!tgtHandle) {
-          tgtHandle = document.createElementNS(SVG_NS, 'circle') as SVGCircleElement
-          tgtHandle.setAttribute('class', 'bf-flow__edge-reconnect bf-flow__edge-reconnect--target')
-          tgtHandle.setAttribute('r', '10')
-          tgtHandle.style.pointerEvents = 'all'
-          reconnectGroup.appendChild(tgtHandle)
-          reconnectTargetHandles.set(edge.id, tgtHandle)
-          const tgtEdgeId = edge.id
-          tgtHandle.addEventListener('mouseenter', () => {
-            edgeElements.get(tgtEdgeId)?.classList.add('bf-flow__edge--reconnect-hover')
-          })
-          tgtHandle.addEventListener('mouseleave', () => {
-            edgeElements.get(tgtEdgeId)?.classList.remove('bf-flow__edge--reconnect-hover')
-          })
-          const container = store.domNode()
-          if (container) {
-            attachReconnectionHandler(tgtHandle, edge, 'target', container, svgContainer, store)
-          }
-        }
-        // Shift outward from node by radius (matching React Flow's shiftX/shiftY)
-        const tgtR = 10
-        tgtHandle.setAttribute('cx', String(edgePos.targetX))
-        tgtHandle.setAttribute('cy', String(edgePos.targetY - tgtR))
+      if (!edgeScopes.has(edge.id)) {
+        edgeScopes.set(edge.id, mountEdgeScope(edge, store, edgeGroup, reconnectGroup, svgContainer, labelPositions))
+      } else {
+        // Edge object identity may have changed (selection toggled, etc).
+        // The inner effect re-reads `edges()` lazily — but since `edge`
+        // here is the new reference, hand it through by re-mounting only
+        // when structural identity is gone. For per-edge updates (label,
+        // selected, animated), we rely on the inner effect already
+        // tracking edges() and doing a lookup-by-id.
+        // For simplicity in this PoC, the inner effect tracks edges() so
+        // any change to the edge array re-runs all per-edge effects;
+        // they each pull their own edge from edgeLookup by id.
       }
     }
 
-    // Remove edges that no longer exist
-    for (const removedId of existingIds) {
-      const el = edgeElements.get(removedId)
-      if (el) { el.remove(); edgeElements.delete(removedId) }
-      const hit = hitElements.get(removedId)
-      if (hit) { hit.remove(); hitElements.delete(removedId) }
-      const customGroup = customEdgeGroups.get(removedId)
-      if (customGroup) { customGroup.remove(); customEdgeGroups.delete(removedId) }
-      labelPositions.delete(removedId)
-      const srcH = reconnectSourceHandles.get(removedId)
-      if (srcH) { srcH.remove(); reconnectSourceHandles.delete(removedId) }
-      const tgtH = reconnectTargetHandles.get(removedId)
-      if (tgtH) { tgtH.remove(); reconnectTargetHandles.delete(removedId) }
+    // Tear down edges that disappeared
+    for (const [id, scope] of edgeScopes) {
+      if (!seen.has(id)) {
+        scope.dispose()
+        edgeScopes.delete(id)
+        labelPositions.delete(id)
+      }
     }
   })
 
   onCleanup(() => {
+    for (const scope of edgeScopes.values()) scope.dispose()
+    edgeScopes.clear()
+    labelPositions.clear()
     edgeGroup.remove()
     reconnectOverlay.remove()
-    edgeElements.clear()
-    hitElements.clear()
-    customEdgeGroups.clear()
-    labelPositions.clear()
-    reconnectSourceHandles.clear()
-    reconnectTargetHandles.clear()
   })
+}
+
+/**
+ * Mount one edge in its own reactive root.
+ *
+ * The root contains a single `createEffect` that:
+ * - Looks up the current edge object by id from `edgeLookup` (this gives
+ *   us reactivity over `edges()` array updates without per-edge identity
+ *   coupling).
+ * - Computes endpoint positions from `nodeLookup` + `positionEpoch`.
+ * - Updates the visible path `d`, hit-area path `d`, and class list.
+ * - Updates reconnect handle positions if applicable.
+ *
+ * For custom edge types (function-form edgeTypes), falls back to the
+ * imperative `<g>` + `innerHTML = ''` pattern — these are user-supplied
+ * render functions and JSX-ifying them is out of scope.
+ */
+function mountEdgeScope<
+  NodeType extends NodeBase,
+  EdgeType extends EdgeBase,
+>(
+  initialEdge: EdgeType,
+  store: FlowStore<NodeType, EdgeType>,
+  edgeGroup: SVGGElement,
+  reconnectGroup: SVGGElement,
+  svgContainer: SVGSVGElement,
+  labelPositions: Map<string, { x: number; y: number }>,
+): { dispose: () => void } {
+  let dispose!: () => void
+  const edgeId = initialEdge.id
+
+  createRoot((d) => {
+    dispose = d
+
+    const edgeType = initialEdge.type
+    const customEdgeType = edgeType && store.edgeTypes?.[edgeType]
+    const isCustom = customEdgeType && typeof customEdgeType === 'function'
+
+    if (isCustom) {
+      mountCustomEdge(edgeId, store, edgeGroup, labelPositions)
+    } else {
+      mountSimpleEdge(edgeId, store, edgeGroup, reconnectGroup, svgContainer, labelPositions)
+    }
+  })
+
+  return { dispose }
+}
+
+/**
+ * Simple-edge mount path. JSX-equivalent of:
+ *   <g>
+ *     <path data-hit-id={id} stroke="transparent" stroke-width="20" d={path} onMouseDown={selectEdge} />
+ *     <path class="bf-flow__edge" data-id={id} d={path} class:selected={selected} class:animated={animated} />
+ *   </g>
+ *
+ * The two `<path>` elements live directly in `edgeGroup` (no per-edge
+ * wrapper `<g>`) to match the legacy DOM shape that `attachReconnection
+ * Handler` queries via selectors. The hit-area is the wider invisible
+ * stroke that captures click selection.
+ */
+function mountSimpleEdge<
+  NodeType extends NodeBase,
+  EdgeType extends EdgeBase,
+>(
+  edgeId: string,
+  store: FlowStore<NodeType, EdgeType>,
+  edgeGroup: SVGGElement,
+  reconnectGroup: SVGGElement,
+  svgContainer: SVGSVGElement,
+  labelPositions: Map<string, { x: number; y: number }>,
+): void {
+  // Invisible hit area (wider stroke for click detection)
+  const hitPath = document.createElementNS(SVG_NS, 'path')
+  hitPath.setAttribute('fill', 'none')
+  hitPath.setAttribute('stroke', 'transparent')
+  hitPath.setAttribute('stroke-width', '20')
+  hitPath.dataset.hitId = edgeId
+  hitPath.style.cursor = 'pointer'
+  hitPath.style.pointerEvents = 'stroke'
+  hitPath.addEventListener('mousedown', (e) => {
+    e.stopPropagation()
+    const container = store.domNode()
+    if (container) container.focus()
+    store.unselectNodesAndEdges()
+    store.setEdges((prev) =>
+      prev.map((ed) =>
+        ed.id === edgeId ? { ...ed, selected: true } : ed,
+      ),
+    )
+  })
+  edgeGroup.appendChild(hitPath)
+
+  // Visible path
+  const pathEl = document.createElementNS(SVG_NS, 'path')
+  pathEl.setAttribute('class', 'bf-flow__edge')
+  pathEl.dataset.id = edgeId
+  edgeGroup.appendChild(pathEl)
+
+  // Reconnect handles (lazily mounted on first reactive run when the
+  // edge is reconnectable). Kept imperative — see file header.
+  let srcHandle: SVGCircleElement | null = null
+  let tgtHandle: SVGCircleElement | null = null
+
+  // Per-edge reactive effect: re-runs when this edge's endpoints move
+  // or its data (selected/animated) changes.
+  createEffect(() => {
+    // Look up current edge by id so changes to the edges() array
+    // (e.g. select toggle) re-run this effect.
+    const edge = store.edgeLookup().get(edgeId)
+    if (!edge) return
+
+    // Tracks position changes during drag (positionEpoch bumped by rAF
+    // in node-wrapper) AND structural commits via store.nodes() (mouseup
+    // commits the dragged position via setNodes — adoptUserNodes then
+    // rebuilds internals.positionAbsolute, but signals don't fire because
+    // the in-place mutated nodeLookup map keeps identity. We must read
+    // store.nodes() so the commit flows through to the path d attribute
+    // even if the rAF was cancelled by mouseup before firing.)
+    store.positionEpoch()
+    store.nodes()
+    const nodeLookup = store.nodeLookup()
+
+    const sourceNode = nodeLookup.get(edge.source)
+    const targetNode = nodeLookup.get(edge.target)
+    if (!sourceNode || !targetNode) return
+
+    const edgePos = computeEdgePosition(edge, sourceNode, targetNode)
+    if (!edgePos) return
+
+    const pathData = getEdgePath(edge, edgePos)
+    if (!pathData) return
+
+    const [path, labelX, labelY] = pathData
+    labelPositions.set(edgeId, { x: labelX, y: labelY })
+
+    pathEl.setAttribute('d', path)
+    hitPath.setAttribute('d', path)
+
+    pathEl.classList.toggle('bf-flow__edge--selected', !!edge.selected)
+    pathEl.classList.toggle('bf-flow__edge--animated', !!edge.animated)
+
+    // Reconnect handles — created lazily on first eligible run.
+    const isReconnectable = store.edgesReconnectable && (edge as any).reconnectable !== false
+    if (isReconnectable) {
+      if (!srcHandle) {
+        srcHandle = createReconnectHandle('source', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
+      }
+      if (!tgtHandle) {
+        tgtHandle = createReconnectHandle('target', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
+      }
+      const r = 10
+      srcHandle.setAttribute('cx', String(edgePos.sourceX))
+      srcHandle.setAttribute('cy', String(edgePos.sourceY + r))
+      tgtHandle.setAttribute('cx', String(edgePos.targetX))
+      tgtHandle.setAttribute('cy', String(edgePos.targetY - r))
+    }
+  })
+
+  // Cleanup: remove DOM nodes when this edge is disposed.
+  onCleanup(() => {
+    hitPath.remove()
+    pathEl.remove()
+    if (srcHandle) srcHandle.remove()
+    if (tgtHandle) tgtHandle.remove()
+  })
+}
+
+/**
+ * Custom-edge mount path (escape hatch).
+ *
+ * The user-supplied function writes into a managed `<g>` via DOM API.
+ * We can't JSX-ify this without forcing every consumer to migrate.
+ * Kept imperative; rebuilds the group's contents on every reactive run.
+ */
+function mountCustomEdge<
+  NodeType extends NodeBase,
+  EdgeType extends EdgeBase,
+>(
+  edgeId: string,
+  store: FlowStore<NodeType, EdgeType>,
+  edgeGroup: SVGGElement,
+  labelPositions: Map<string, { x: number; y: number }>,
+): void {
+  const group = document.createElementNS(SVG_NS, 'g')
+  group.setAttribute('class', 'bf-flow__edge-custom')
+  group.dataset.id = edgeId
+  group.style.cursor = 'pointer'
+  group.style.pointerEvents = 'all'
+  group.addEventListener('mousedown', (e) => {
+    e.stopPropagation()
+    const container = store.domNode()
+    if (container) container.focus()
+    store.unselectNodesAndEdges()
+    store.setEdges((prev) =>
+      prev.map((ed) =>
+        ed.id === edgeId ? { ...ed, selected: true } : ed,
+      ),
+    )
+  })
+  edgeGroup.appendChild(group)
+
+  createEffect(() => {
+    const edge = store.edgeLookup().get(edgeId)
+    if (!edge) return
+
+    // See mountSimpleEdge for why both positionEpoch and nodes() are read.
+    store.positionEpoch()
+    store.nodes()
+    const nodeLookup = store.nodeLookup()
+
+    const sourceNode = nodeLookup.get(edge.source)
+    const targetNode = nodeLookup.get(edge.target)
+    if (!sourceNode || !targetNode) return
+
+    const edgePos = computeEdgePosition(edge, sourceNode, targetNode)
+    if (!edgePos) return
+
+    const midX = (edgePos.sourceX + edgePos.targetX) / 2
+    const midY = (edgePos.sourceY + edgePos.targetY) / 2
+    labelPositions.set(edgeId, { x: midX, y: midY })
+
+    // Clear and re-render custom content
+    group.innerHTML = ''
+
+    const edgeType = edge.type
+    const customEdgeType = edgeType && store.edgeTypes?.[edgeType]
+    if (typeof customEdgeType !== 'function') return
+
+    const edgeProps: EdgeComponentProps<EdgeType> = {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceX: edgePos.sourceX,
+      sourceY: edgePos.sourceY,
+      targetX: edgePos.targetX,
+      targetY: edgePos.targetY,
+      sourcePosition: edgePos.sourcePosition,
+      targetPosition: edgePos.targetPosition,
+      data: edge.data,
+      selected: !!edge.selected,
+      animated: !!edge.animated,
+      label: (edge as EdgeType & { label?: string }).label,
+      svgGroup: group,
+    }
+    customEdgeType(edgeProps)
+  })
+
+  onCleanup(() => {
+    group.remove()
+  })
+}
+
+/**
+ * Compute endpoint positions for an edge using @xyflow/system's
+ * getEdgePosition, falling back to node-center positioning if no
+ * handle bounds are available.
+ */
+function computeEdgePosition<NodeType extends NodeBase>(
+  edge: EdgeBase,
+  sourceNode: NodeType extends NodeBase ? Parameters<typeof getEdgePosition>[0]['sourceNode'] : never,
+  targetNode: NodeType extends NodeBase ? Parameters<typeof getEdgePosition>[0]['targetNode'] : never,
+): EdgePosition | null {
+  const hasHandleIds = !!(edge.sourceHandle || edge.targetHandle)
+  const edgePos = getEdgePosition({
+    id: edge.id,
+    sourceNode,
+    sourceHandle: edge.sourceHandle ?? null,
+    targetNode,
+    targetHandle: edge.targetHandle ?? null,
+    connectionMode: hasHandleIds ? ConnectionMode.Strict : ConnectionMode.Loose,
+  })
+
+  if (edgePos) return edgePos
+
+  // Fallback: use node center positions when no handle bounds resolved
+  const sw = (sourceNode as any).measured.width ?? 150
+  const sh = (sourceNode as any).measured.height ?? 40
+  const tw = (targetNode as any).measured.width ?? 150
+  const sourcePos = (sourceNode as any).internals.positionAbsolute
+  const targetPos = (targetNode as any).internals.positionAbsolute
+
+  return {
+    sourceX: sourcePos.x + sw / 2,
+    sourceY: sourcePos.y + sh,
+    targetX: targetPos.x + tw / 2,
+    targetY: targetPos.y,
+    sourcePosition: Position.Bottom,
+    targetPosition: Position.Top,
+  }
+}
+
+/**
+ * Create a reconnection handle circle and wire it up.
+ * The element is appended to `reconnectGroup` (the overlay above nodes),
+ * but the hover effect targets the visible path inside `edgeGroup`.
+ */
+function createReconnectHandle<
+  NodeType extends NodeBase,
+  EdgeType extends EdgeBase,
+>(
+  endpointType: 'source' | 'target',
+  edgeId: string,
+  edgeGroup: SVGGElement,
+  reconnectGroup: SVGGElement,
+  edge: EdgeType,
+  store: FlowStore<NodeType, EdgeType>,
+  svgContainer: SVGSVGElement,
+): SVGCircleElement {
+  const handle = document.createElementNS(SVG_NS, 'circle') as SVGCircleElement
+  handle.setAttribute(
+    'class',
+    `bf-flow__edge-reconnect bf-flow__edge-reconnect--${endpointType}`,
+  )
+  handle.setAttribute('r', '10')
+  handle.style.pointerEvents = 'all'
+  reconnectGroup.appendChild(handle)
+
+  // Hover: darken the visible edge path while pointing at the handle.
+  // Resolve the edge element via querySelector each time so we don't
+  // hold a stale reference if the path was re-mounted.
+  handle.addEventListener('mouseenter', () => {
+    edgeGroup
+      .querySelector(`.bf-flow__edge[data-id="${edgeId}"]`)
+      ?.classList.add('bf-flow__edge--reconnect-hover')
+  })
+  handle.addEventListener('mouseleave', () => {
+    edgeGroup
+      .querySelector(`.bf-flow__edge[data-id="${edgeId}"]`)
+      ?.classList.remove('bf-flow__edge--reconnect-hover')
+  })
+
+  const container = store.domNode()
+  if (container) {
+    attachReconnectionHandler(handle, edge, endpointType, container, svgContainer, store)
+  }
+
+  return handle
 }
 
 /**

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -1,7 +1,9 @@
 import {
   createEffect,
+  createMemo,
   createRoot,
   onCleanup,
+  untrack,
 } from '@barefootjs/client'
 import {
   getBezierPath,
@@ -15,6 +17,7 @@ import type {
   NodeBase,
   EdgeBase,
   EdgePosition,
+  InternalNodeBase,
 } from '@xyflow/system'
 import type { FlowStore, EdgeComponentProps } from './types'
 import { SVG_NS } from './constants'
@@ -27,11 +30,10 @@ import { attachReconnectionHandler } from './connection'
  * mounted set; each per-edge root owns the rendering effect for that
  * edge alone.
  *
- * Custom edge types (`edgeTypes[type]` user function) and reconnection
- * handles stay imperative — the former because the user supplies the
- * render function, the latter because `attachReconnectionHandler`
- * queries by `[data-id]` / `[data-hit-id]` selectors that the per-edge
- * mount preserves.
+ * Custom edge types stay imperative because the user supplies the
+ * render function. Reconnect handle hover/grab logic in
+ * `attachReconnectionHandler` is pointer-paced and gets no leverage
+ * from signal binding — kept imperative for the same reason.
  */
 export function createEdgeRenderer<
   NodeType extends NodeBase = NodeBase,
@@ -192,10 +194,33 @@ function mountSimpleEdge<
   pathEl.dataset.id = edgeId
   edgeGroup.appendChild(pathEl)
 
-  // Reconnect handles, lazily mounted in the effect below.
   let srcHandle: SVGCircleElement | null = null
   let tgtHandle: SVGCircleElement | null = null
 
+  // Per-edge field memos. createSignal/createMemo dedupe on Object.is, so
+  // a memo over a primitive (boolean) only fires when its value actually
+  // changes. This isolates per-edge property updates: toggling another
+  // edge's `selected` no longer re-runs this edge's class effect.
+  const selected = createMemo(() => !!store.edgeLookup().get(edgeId)?.selected)
+  const animated = createMemo(() => !!store.edgeLookup().get(edgeId)?.animated)
+  const reconnectable = createMemo(
+    () =>
+      store.edgesReconnectable &&
+      (store.edgeLookup().get(edgeId) as { reconnectable?: boolean } | undefined)
+        ?.reconnectable !== false &&
+      !!store.edgeLookup().get(edgeId),
+  )
+
+  // Class effect: tracks only selected/animated (per-edge isolated).
+  createEffect(() => {
+    pathEl.classList.toggle('bf-flow__edge--selected', selected())
+    pathEl.classList.toggle('bf-flow__edge--animated', animated())
+  })
+
+  // Position effect: tracks position signals + edgeLookup (for source/
+  // target/handle ids). Re-runs on any edges array change, but the
+  // setAttribute calls are DOM-level no-ops when the resulting `d` string
+  // is identical, so unrelated edge updates don't dirty the path.
   createEffect(() => {
     const edge = store.edgeLookup().get(edgeId)
     if (!edge) return
@@ -225,23 +250,33 @@ function mountSimpleEdge<
     pathEl.setAttribute('d', path)
     hitPath.setAttribute('d', path)
 
-    pathEl.classList.toggle('bf-flow__edge--selected', !!edge.selected)
-    pathEl.classList.toggle('bf-flow__edge--animated', !!edge.animated)
-
-    // Reconnect handles — created lazily on first eligible run.
-    const isReconnectable = store.edgesReconnectable && (edge as any).reconnectable !== false
-    if (isReconnectable) {
-      if (!srcHandle) {
-        srcHandle = createReconnectHandle('source', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
-      }
-      if (!tgtHandle) {
-        tgtHandle = createReconnectHandle('target', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
-      }
+    if (srcHandle && tgtHandle) {
       const r = 10
       srcHandle.setAttribute('cx', String(edgePos.sourceX))
       srcHandle.setAttribute('cy', String(edgePos.sourceY + r))
       tgtHandle.setAttribute('cx', String(edgePos.targetX))
       tgtHandle.setAttribute('cy', String(edgePos.targetY - r))
+    }
+  })
+
+  // Reconnect lifecycle: tracks the reconnectable memo only. `untrack`
+  // the edge fetch so this effect doesn't re-run for unrelated edges-array
+  // changes.
+  createEffect(() => {
+    if (!reconnectable()) {
+      srcHandle?.remove()
+      srcHandle = null
+      tgtHandle?.remove()
+      tgtHandle = null
+      return
+    }
+    const edge = untrack(() => store.edgeLookup().get(edgeId))
+    if (!edge) return
+    if (!srcHandle) {
+      srcHandle = createReconnectHandle('source', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
+    }
+    if (!tgtHandle) {
+      tgtHandle = createReconnectHandle('target', edgeId, edgeGroup, reconnectGroup, edge, store, svgContainer)
     }
   })
 
@@ -333,14 +368,13 @@ function mountCustomEdge<
 }
 
 /**
- * Compute endpoint positions for an edge using @xyflow/system's
- * getEdgePosition, falling back to node-center positioning if no
- * handle bounds are available.
+ * Compute endpoint positions for an edge, falling back to node-center
+ * positioning when no handle bounds are available.
  */
-function computeEdgePosition<NodeType extends NodeBase>(
+function computeEdgePosition(
   edge: EdgeBase,
-  sourceNode: NodeType extends NodeBase ? Parameters<typeof getEdgePosition>[0]['sourceNode'] : never,
-  targetNode: NodeType extends NodeBase ? Parameters<typeof getEdgePosition>[0]['targetNode'] : never,
+  sourceNode: InternalNodeBase,
+  targetNode: InternalNodeBase,
 ): EdgePosition | null {
   const hasHandleIds = !!(edge.sourceHandle || edge.targetHandle)
   const edgePos = getEdgePosition({
@@ -354,12 +388,11 @@ function computeEdgePosition<NodeType extends NodeBase>(
 
   if (edgePos) return edgePos
 
-  // Fallback: use node center positions when no handle bounds resolved
-  const sw = (sourceNode as any).measured.width ?? 150
-  const sh = (sourceNode as any).measured.height ?? 40
-  const tw = (targetNode as any).measured.width ?? 150
-  const sourcePos = (sourceNode as any).internals.positionAbsolute
-  const targetPos = (targetNode as any).internals.positionAbsolute
+  const sw = sourceNode.measured.width ?? 150
+  const sh = sourceNode.measured.height ?? 40
+  const tw = targetNode.measured.width ?? 150
+  const sourcePos = sourceNode.internals.positionAbsolute
+  const targetPos = targetNode.internals.positionAbsolute
 
   return {
     sourceX: sourcePos.x + sw / 2,

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -21,33 +21,17 @@ import { SVG_NS } from './constants'
 import { attachReconnectionHandler } from './connection'
 
 /**
- * Reactively renders all edges as SVG paths.
+ * Renders all edges as SVG paths via per-edge `createRoot` scopes — the
+ * Solid-style pattern that compiler-emitted JSX produces for
+ * `edges().map(e => <path d={...} />)`. The outer effect maintains the
+ * mounted set; each per-edge root owns the rendering effect for that
+ * edge alone.
  *
- * Architecture (post-Phase-9 refactor):
- *
- * - The outer effect tracks `edges()` and maintains the **set** of edge IDs:
- *   when an edge appears, a per-edge `createRoot` is mounted; when it
- *   disappears, the root is disposed. This replaces the old hand-rolled
- *   `Map<id, SVGPathElement>` diff bookkeeping.
- *
- * - Each per-edge root owns one inner `createEffect` that re-runs only when
- *   `positionEpoch` / `nodeLookup` / the per-edge data changes. Moving a
- *   single node only re-runs the effects of edges whose endpoints touch
- *   that node, instead of looping over every edge in one big effect.
- *
- * This is the Solid-style pattern that compiler-emitted JSX produces for
- * `edges().map(e => <path d={...} />)`. Implemented with `createElementNS`
- * here because the xyflow package is not currently part of the JSX
- * compilation pipeline (see rollout plan in PR description).
- *
- * Escape hatches kept imperative for now:
- * - Custom edge types (`edgeTypes[type]` is a function): user functions
- *   write into a managed `<g>` via `innerHTML = ''` + DOM API. JSX-ifying
- *   this is out of scope because the user supplies the rendering function.
- * - Reconnection handles: `attachReconnectionHandler` queries the SVG by
- *   `[data-id]` / `[data-hit-id]` selectors at drag-start time. The
- *   per-edge root keeps the same selectors, so the handler is wire-
- *   compatible.
+ * Custom edge types (`edgeTypes[type]` user function) and reconnection
+ * handles stay imperative — the former because the user supplies the
+ * render function, the latter because `attachReconnectionHandler`
+ * queries by `[data-id]` / `[data-hit-id]` selectors that the per-edge
+ * mount preserves.
  */
 export function createEdgeRenderer<
   NodeType extends NodeBase = NodeBase,
@@ -86,9 +70,8 @@ export function createEdgeRenderer<
     reconnectGroup.setAttribute('transform', `translate(${vp.x}, ${vp.y}) scale(${vp.zoom})`)
   })
 
-  // Expose label positions so the edge label renderer can read them.
-  // The label renderer reads this map inside its own createEffect, so
-  // updates here are observed via the per-edge effect's positionEpoch read.
+  // The label renderer reads this map from its own effect, observed via
+  // each per-edge effect's positionEpoch read.
   const labelPositions = new Map<string, { x: number; y: number }>()
   ;(store as any)._edgeLabelPositions = labelPositions
 
@@ -98,9 +81,9 @@ export function createEdgeRenderer<
   }
   const edgeScopes = new Map<string, EdgeScope>()
 
-  // Outer effect: structural diff (add/remove edges) only.
-  // Per-edge rendering lives in mountEdgeScope's inner effect, which
-  // re-runs independently when its node positions change.
+  // Outer effect: structural diff. Per-edge updates (selected/animated/
+  // endpoint position) flow through each scope's own effect, which looks
+  // the edge up by id from `edgeLookup`.
   createEffect(() => {
     const edges = store.edges()
     const seen = new Set<string>()
@@ -108,23 +91,11 @@ export function createEdgeRenderer<
     for (const edge of edges) {
       if (edge.hidden) continue
       seen.add(edge.id)
-
       if (!edgeScopes.has(edge.id)) {
         edgeScopes.set(edge.id, mountEdgeScope(edge, store, edgeGroup, reconnectGroup, svgContainer, labelPositions))
-      } else {
-        // Edge object identity may have changed (selection toggled, etc).
-        // The inner effect re-reads `edges()` lazily — but since `edge`
-        // here is the new reference, hand it through by re-mounting only
-        // when structural identity is gone. For per-edge updates (label,
-        // selected, animated), we rely on the inner effect already
-        // tracking edges() and doing a lookup-by-id.
-        // For simplicity in this PoC, the inner effect tracks edges() so
-        // any change to the edge array re-runs all per-edge effects;
-        // they each pull their own edge from edgeLookup by id.
       }
     }
 
-    // Tear down edges that disappeared
     for (const [id, scope] of edgeScopes) {
       if (!seen.has(id)) {
         scope.dispose()
@@ -143,21 +114,7 @@ export function createEdgeRenderer<
   })
 }
 
-/**
- * Mount one edge in its own reactive root.
- *
- * The root contains a single `createEffect` that:
- * - Looks up the current edge object by id from `edgeLookup` (this gives
- *   us reactivity over `edges()` array updates without per-edge identity
- *   coupling).
- * - Computes endpoint positions from `nodeLookup` + `positionEpoch`.
- * - Updates the visible path `d`, hit-area path `d`, and class list.
- * - Updates reconnect handle positions if applicable.
- *
- * For custom edge types (function-form edgeTypes), falls back to the
- * imperative `<g>` + `innerHTML = ''` pattern — these are user-supplied
- * render functions and JSX-ifying them is out of scope.
- */
+/** Mount one edge in its own reactive root, dispatching to simple- or custom-edge mount. */
 function mountEdgeScope<
   NodeType extends NodeBase,
   EdgeType extends EdgeBase,
@@ -190,16 +147,12 @@ function mountEdgeScope<
 }
 
 /**
- * Simple-edge mount path. JSX-equivalent of:
- *   <g>
- *     <path data-hit-id={id} stroke="transparent" stroke-width="20" d={path} onMouseDown={selectEdge} />
- *     <path class="bf-flow__edge" data-id={id} d={path} class:selected={selected} class:animated={animated} />
- *   </g>
+ * Simple-edge mount. JSX-equivalent of:
+ *   <path data-hit-id={id} stroke="transparent" stroke-width="20" d={path} onMouseDown={selectEdge} />
+ *   <path class="bf-flow__edge" data-id={id} d={path} class:selected={selected} class:animated={animated} />
  *
- * The two `<path>` elements live directly in `edgeGroup` (no per-edge
- * wrapper `<g>`) to match the legacy DOM shape that `attachReconnection
- * Handler` queries via selectors. The hit-area is the wider invisible
- * stroke that captures click selection.
+ * Both paths sit directly in `edgeGroup` (no per-edge wrapper `<g>`) to
+ * keep the selectors `attachReconnectionHandler` queries against intact.
  */
 function mountSimpleEdge<
   NodeType extends NodeBase,
@@ -239,26 +192,19 @@ function mountSimpleEdge<
   pathEl.dataset.id = edgeId
   edgeGroup.appendChild(pathEl)
 
-  // Reconnect handles (lazily mounted on first reactive run when the
-  // edge is reconnectable). Kept imperative — see file header.
+  // Reconnect handles, lazily mounted in the effect below.
   let srcHandle: SVGCircleElement | null = null
   let tgtHandle: SVGCircleElement | null = null
 
-  // Per-edge reactive effect: re-runs when this edge's endpoints move
-  // or its data (selected/animated) changes.
   createEffect(() => {
-    // Look up current edge by id so changes to the edges() array
-    // (e.g. select toggle) re-run this effect.
     const edge = store.edgeLookup().get(edgeId)
     if (!edge) return
 
-    // Tracks position changes during drag (positionEpoch bumped by rAF
-    // in node-wrapper) AND structural commits via store.nodes() (mouseup
-    // commits the dragged position via setNodes — adoptUserNodes then
-    // rebuilds internals.positionAbsolute, but signals don't fire because
-    // the in-place mutated nodeLookup map keeps identity. We must read
-    // store.nodes() so the commit flows through to the path d attribute
-    // even if the rAF was cancelled by mouseup before firing.)
+    // BOTH reads are required. positionEpoch fires for in-flight drag
+    // updates (rAF-batched in node-wrapper); nodes() fires for the
+    // post-drag commit, where setNodes mutates nodeLookup in place
+    // (identity preserved → no positionEpoch bump). Reading nodes()
+    // catches that commit even when rAF was cancelled by mouseup.
     store.positionEpoch()
     store.nodes()
     const nodeLookup = store.nodeLookup()
@@ -299,22 +245,15 @@ function mountSimpleEdge<
     }
   })
 
-  // Cleanup: remove DOM nodes when this edge is disposed.
   onCleanup(() => {
     hitPath.remove()
     pathEl.remove()
-    if (srcHandle) srcHandle.remove()
-    if (tgtHandle) tgtHandle.remove()
+    srcHandle?.remove()
+    tgtHandle?.remove()
   })
 }
 
-/**
- * Custom-edge mount path (escape hatch).
- *
- * The user-supplied function writes into a managed `<g>` via DOM API.
- * We can't JSX-ify this without forcing every consumer to migrate.
- * Kept imperative; rebuilds the group's contents on every reactive run.
- */
+/** Custom-edge mount: rebuilds a managed `<g>`'s contents via the user-supplied render fn. */
 function mountCustomEdge<
   NodeType extends NodeBase,
   EdgeType extends EdgeBase,


### PR DESCRIPTION
## Summary

First PoC migration in the Phase-9 xyflow re-architecture effort (#125 → #135 follow-up). Replaces the hand-rolled `Map<id, SVGPathElement>` diff bookkeeping inside `createEdgeRenderer` with per-edge `createRoot` + `createEffect` scopes — Solid-style fine-grained reactivity.

Net effect: ~150 SLOC of bookkeeping removed; auto-cleanup on edge removal; one effect per edge tracks only the signals that edge actually depends on; ready as a 1:1 translation target for when xyflow itself gets JSX-compiled (each edge effect maps directly to a `mapArray` body with `<path d={pathFor(edge)} class={...}>`).

## Changes

- `packages/xyflow/src/edge-renderer.ts` — rewrite simple-edge path: per-edge `createRoot` + per-attribute `createEffect`. Custom-edge path (`edgeTypes[type]` user functions, `innerHTML` rebuild) and reconnection handles kept as imperative escape hatches — both have wire-compatible DOM contracts (`.bf-flow__edge[data-id]`, `path[data-hit-id]`) so existing handlers in `connection.ts` continue to work without changes.
- `packages/xyflow/src/__tests__/edge-renderer.test.ts` — 6 new happy-dom unit tests asserting per-edge scope contract: mount/unmount lifecycle, class application, `positionEpoch` re-render, `EdgeBase` type widening for the `selected` field
- `packages/xyflow/e2e/serve.ts` + `test-page.html` — bundle `@barefootjs/client/reactive` as a separate file with importmap entry (matches the package's three-output build); without this the browser couldn't resolve the bare specifier and 1 e2e was failing on infra alone

## Subtle reactive issue caught (worth flagging)

The per-edge effect must read **both** `positionEpoch` AND `store.nodes()`, not just `positionEpoch`. During a drag, `triggerPositionUpdate` is rAF-deferred in `node-wrapper.ts`, and `mouseup` cancels the pending rAF — the committed-position update flows in via `setNodes()` from the mouseup handler. The original single big effect was reading `nodes()` as part of its multi-signal track; per-edge effects need to be explicit. First e2e run revealed this (the \"edges update during node drag\" test failed); adding `store.nodes()` to the tracked reads fixed it.

## Why a runtime-level rewrite (not full JSX) for this PoC

xyflow is **not** part of the JSX compilation pipeline yet (no JSX in tsconfig, no compiler hookup, no SSR template emission). Wiring it up is significant infrastructure (JSX TS config, build pipeline integration with `@barefootjs/jsx`, registry registration) — a separate, larger workstream. The PoC at the runtime layer proves the same fine-grained reactivity model works, and is a 1:1 translation target for the eventual JSX rewrite.

## Test plan

- [x] `bun test --cwd packages/xyflow` — 36/36 (was 30, +6 per-edge tests)
- [x] `bun test --cwd packages/jsx` — 824/824 (no regressions)
- [x] `bun run build` (xyflow) — clean (135.30 KB minified)
- [x] `bunx playwright test` (xyflow e2e) — 119/119 (was 118+1-fail before the importmap fix)
- [x] `tsgo --noEmit -p packages/xyflow/tsconfig.json` — clean

## Rollout plan for the rest of @barefootjs/xyflow

| File | LoC | JSX-ification value | Action |
|---|---|---|---|
| `node-wrapper.ts` | 523 | **High**. Same shape as edge-renderer: `Map<id, NodeInstance>` + reactive class/transform updates. HTML rendering, so the compiler's HTML path (more mature than SVG) makes this an easier port. | **Next PoC** — apply per-node `createRoot` + per-attribute `createEffect` |
| `background.ts` | small | **Medium**. `<svg>` with `<pattern>` + `<rect>`. Ideal for `<svg viewBox>` reactive binding (graph-editor-demo-style). | Quick win, batch with node-wrapper |
| `controls.ts` | small | **Medium**. HTML buttons + reactive class. JSX-friendly. | Quick win, batch with node-wrapper |
| `minimap.ts` | medium | **High**. `<svg>` + per-node `<rect>` from store + `<path>` mask for viewport. Exact graph-editor-demo pattern. | After node-wrapper |
| `handle.ts` | small | **Medium**. Per-handle DOM with reactive class. | Batch with node-wrapper |
| `selection.ts` | medium | **Keep imperative**. Global pointer capture, drag-rect math, viewport hit-testing. JSX provides little leverage. | No migration |
| `connection.ts` | medium | **Keep imperative**. Pointer capture + temporary preview path + `elementFromPoint` hit-testing. Lifecycle-bound to a pointer cycle, not a reactive signal. | No migration |
| `node-resizer.ts` | medium | **Keep imperative**. Pointer capture + dimension math + per-handle pointer events. Heavy DOM measurement. | No migration |
| `compat.ts` | small | **Keep**. React-Flow API shim, no DOM. | No migration |

**Suggested PR sequence**: (1) this PR (edge-renderer simple path) → (2) `node-wrapper` + `handle` + `background` + `controls` (HTML rendering layer) → (3) `minimap` (the other SVG renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>