### PR TITLE
fix(jsx): preserve named-export-block specifiers in compiled output

### DIFF
--- a/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
+++ b/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
@@ -1,22 +1,8 @@
 /**
- * BarefootJS Compiler - Named-export block must survive into the marked template.
- *
- * `export { A, B }` and `export { A } from './path'` declarations at module
- * level were being dropped by the IR-to-template emitter, while inline
- * `export function/const` and `import` statements survived. Re-exporting an
- * imported symbol from a `"use client"` file (a common pattern when grouping
- * a chart's `Bar`, `Line`, `Area` siblings under a single `chart/index.tsx`
- * barrel) was therefore impossible — the dist file would `import { Bar }
- * from './bar'` but never re-export it, breaking SSR consumers.
- *
- * Invariant: the marked-template output must preserve every named-export
- * specifier that was present in the source, regardless of whether the
- * referent is a local declaration, an imported symbol, or a re-export from
- * another module. Inline `export function Foo` declarations must NOT be
- * double-emitted in a trailing `export { Foo }` block.
- *
- * Confirmed via real-world breakage in the chart Bar JSX-native PoC
- * (PR #1077, ui/components/ui/chart/index.tsx).
+ * Named-export specifier blocks (`export { A, B }` and `export { A } from './path'`)
+ * must reach the marked template. Without this, re-exporting an imported symbol
+ * from a "use client" barrel is impossible — the dist would import the symbol
+ * but never publish it. Inline `export function/const` must not double-emit.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -50,17 +36,8 @@ export {
 `
     const template = getMarkedTemplate(source)
 
-    // The import the re-export depends on must still survive (regression guard).
     expect(template).toContain(`import { Bar } from './bar'`)
-
-    // The re-export must appear so downstream consumers can `import { Bar }`
-    // from the compiled barrel. Either form (single block listing both, or
-    // separate specifier-list line for Bar) is acceptable — what matters is
-    // that `Bar` is module-exported.
     expect(template).toMatch(/export\s*\{[^}]*\bBar\b[^}]*\}/)
-
-    // ChartContainer is inline-exported via the function declaration; ensure
-    // we don't lose it either.
     expect(template).toContain('export function ChartContainer')
   })
 
@@ -77,12 +54,7 @@ export { ChartContainer }
 `
     const template = getMarkedTemplate(source)
 
-    // The re-export-from must survive so consumers receive Bar without the
-    // barrel having to import-then-export.
     expect(template).toMatch(/export\s*\{\s*Bar\s*\}\s*from\s*['"]\.\/bar['"]/)
-
-    // ChartContainer must still be exported (either inline or via the
-    // trailing export block).
     expect(
       /export function ChartContainer/.test(template) ||
         /export\s*\{[^}]*\bChartContainer\b[^}]*\}/.test(template)
@@ -101,10 +73,8 @@ export { ChartContainer as DefaultChartContainer }
 `
     const template = getMarkedTemplate(source)
 
-    // The local already ships as `export function ChartContainer` so it
-    // should appear once. The aliased re-export adds an additional
-    // external name (`DefaultChartContainer`) that does NOT collide with
-    // the inline export and must be preserved.
+    // Aliased re-export adds a new external name; both the inline and the
+    // alias must survive without duplicate-binding error.
     expect(template.match(/export function ChartContainer\b/g)?.length).toBe(1)
     expect(template).toMatch(/export\s*\{\s*ChartContainer\s+as\s+DefaultChartContainer\s*\}/)
   })
@@ -122,28 +92,24 @@ export { ChartContainer, Bar }
 `
     const template = getMarkedTemplate(source)
 
-    // ChartContainer is declared inline-exported AND listed in the trailing
-    // export block. The inline form must survive (it carries the body), and
-    // the trailing block's ChartContainer specifier must NOT cause a
-    // duplicate `export { ChartContainer }` line — that would be a redeclare
-    // error in the compiled output. Bar (which has no inline export) must
-    // be re-exported.
-    const inlineMatches = template.match(/export function ChartContainer\b/g) ?? []
-    expect(inlineMatches.length).toBe(1)
-
-    // Bar must appear in some `export { ... }` form so it reaches consumers.
+    expect(template.match(/export function ChartContainer\b/g)?.length).toBe(1)
     expect(template).toMatch(/export\s*\{[^}]*\bBar\b[^}]*\}/)
+    // The trailing block must filter ChartContainer out and emit `export { Bar }` only.
+    expect(template).not.toMatch(/export\s*\{[^}]*ChartContainer[^}]*\}\s*(?!from)/)
+  })
 
-    // No duplicate ChartContainer export specifier — i.e. there must not be
-    // both `export function ChartContainer` and a separate
-    // `export { ChartContainer }` (without a `from` clause) listing it
-    // again as a local re-export. A combined `export { ChartContainer, Bar }`
-    // would also be a redeclare; the trailing block must filter
-    // ChartContainer out and emit only `export { Bar }`.
-    const localBlockReexports =
-      template.match(/export\s*\{([^}]*)\}\s*(?!from)/g) ?? []
-    for (const block of localBlockReexports) {
-      expect(block).not.toMatch(/\bChartContainer\b/)
-    }
+  test('type-only re-export survives', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+function ChartContainer(props: { children: unknown }) {
+  return <div>{props.children}</div>
+}
+
+export type { BarProps } from './bar'
+`
+    const template = getMarkedTemplate(source)
+
+    expect(template).toMatch(/export\s+type\s*\{\s*BarProps\s*\}\s*from\s*['"]\.\/bar['"]/)
   })
 })

--- a/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
+++ b/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
@@ -1,0 +1,149 @@
+/**
+ * BarefootJS Compiler - Named-export block must survive into the marked template.
+ *
+ * `export { A, B }` and `export { A } from './path'` declarations at module
+ * level were being dropped by the IR-to-template emitter, while inline
+ * `export function/const` and `import` statements survived. Re-exporting an
+ * imported symbol from a `"use client"` file (a common pattern when grouping
+ * a chart's `Bar`, `Line`, `Area` siblings under a single `chart/index.tsx`
+ * barrel) was therefore impossible — the dist file would `import { Bar }
+ * from './bar'` but never re-export it, breaking SSR consumers.
+ *
+ * Invariant: the marked-template output must preserve every named-export
+ * specifier that was present in the source, regardless of whether the
+ * referent is a local declaration, an imported symbol, or a re-export from
+ * another module. Inline `export function Foo` declarations must NOT be
+ * double-emitted in a trailing `export { Foo }` block.
+ *
+ * Confirmed via real-world breakage in the chart Bar JSX-native PoC
+ * (PR #1077, ui/components/ui/chart/index.tsx).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getMarkedTemplate(source: string): string {
+  const result = compileJSXSync(source, 'index.tsx', { adapter })
+  expect(result.errors).toHaveLength(0)
+  const out = result.files.find(f => f.type === 'markedTemplate')
+  expect(out).toBeDefined()
+  return out!.content
+}
+
+describe('named-export block preservation', () => {
+  test('export { Local, Imported } block re-exports an imported symbol', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+import { Bar } from './bar'
+
+function ChartContainer(props: { children: unknown }) {
+  return <div>{props.children}</div>
+}
+
+export {
+  ChartContainer,
+  Bar,
+}
+`
+    const template = getMarkedTemplate(source)
+
+    // The import the re-export depends on must still survive (regression guard).
+    expect(template).toContain(`import { Bar } from './bar'`)
+
+    // The re-export must appear so downstream consumers can `import { Bar }`
+    // from the compiled barrel. Either form (single block listing both, or
+    // separate specifier-list line for Bar) is acceptable — what matters is
+    // that `Bar` is module-exported.
+    expect(template).toMatch(/export\s*\{[^}]*\bBar\b[^}]*\}/)
+
+    // ChartContainer is inline-exported via the function declaration; ensure
+    // we don't lose it either.
+    expect(template).toContain('export function ChartContainer')
+  })
+
+  test(`export { X } from './y' re-export is preserved verbatim`, () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+function ChartContainer(props: { children: unknown }) {
+  return <div>{props.children}</div>
+}
+
+export { Bar } from './bar'
+export { ChartContainer }
+`
+    const template = getMarkedTemplate(source)
+
+    // The re-export-from must survive so consumers receive Bar without the
+    // barrel having to import-then-export.
+    expect(template).toMatch(/export\s*\{\s*Bar\s*\}\s*from\s*['"]\.\/bar['"]/)
+
+    // ChartContainer must still be exported (either inline or via the
+    // trailing export block).
+    expect(
+      /export function ChartContainer/.test(template) ||
+        /export\s*\{[^}]*\bChartContainer\b[^}]*\}/.test(template)
+    ).toBe(true)
+  })
+
+  test('aliased re-export is preserved even when local has inline export', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function ChartContainer(props: { children: unknown }) {
+  return <div>{props.children}</div>
+}
+
+export { ChartContainer as DefaultChartContainer }
+`
+    const template = getMarkedTemplate(source)
+
+    // The local already ships as `export function ChartContainer` so it
+    // should appear once. The aliased re-export adds an additional
+    // external name (`DefaultChartContainer`) that does NOT collide with
+    // the inline export and must be preserved.
+    expect(template.match(/export function ChartContainer\b/g)?.length).toBe(1)
+    expect(template).toMatch(/export\s*\{\s*ChartContainer\s+as\s+DefaultChartContainer\s*\}/)
+  })
+
+  test('inline-exported function is not double-emitted by trailing export block', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+import { Bar } from './bar'
+
+export function ChartContainer(props: { children: unknown }) {
+  return <div>{props.children}</div>
+}
+
+export { ChartContainer, Bar }
+`
+    const template = getMarkedTemplate(source)
+
+    // ChartContainer is declared inline-exported AND listed in the trailing
+    // export block. The inline form must survive (it carries the body), and
+    // the trailing block's ChartContainer specifier must NOT cause a
+    // duplicate `export { ChartContainer }` line — that would be a redeclare
+    // error in the compiled output. Bar (which has no inline export) must
+    // be re-exported.
+    const inlineMatches = template.match(/export function ChartContainer\b/g) ?? []
+    expect(inlineMatches.length).toBe(1)
+
+    // Bar must appear in some `export { ... }` form so it reaches consumers.
+    expect(template).toMatch(/export\s*\{[^}]*\bBar\b[^}]*\}/)
+
+    // No duplicate ChartContainer export specifier — i.e. there must not be
+    // both `export function ChartContainer` and a separate
+    // `export { ChartContainer }` (without a `from` clause) listing it
+    // again as a local re-export. A combined `export { ChartContainer, Bar }`
+    // would also be a redeclare; the trailing block must filter
+    // ChartContainer out and emit only `export { Bar }`.
+    const localBlockReexports =
+      template.match(/export\s*\{([^}]*)\}\s*(?!from)/g) ?? []
+    for (const block of localBlockReexports) {
+      expect(block).not.toMatch(/\bChartContainer\b/)
+    }
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -84,7 +84,6 @@ export interface AnalyzerContext {
   /** Bare imperative statements at the top of the component body (#930). */
   initStatements: InitStatementInfo[]
   imports: ImportInfo[]
-  /** Module-level `export { ... } [from './path']` declarations (#1077). */
   namedExports: NamedExportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -12,6 +12,7 @@ import type {
   OnMountInfo,
   InitStatementInfo,
   ImportInfo,
+  NamedExportInfo,
   FunctionInfo,
   ConstantInfo,
   TypeDefinition,
@@ -83,6 +84,8 @@ export interface AnalyzerContext {
   /** Bare imperative statements at the top of the component body (#930). */
   initStatements: InitStatementInfo[]
   imports: ImportInfo[]
+  /** Module-level `export { ... } [from './path']` declarations (#1077). */
+  namedExports: NamedExportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
   typeDefinitions: TypeDefinition[]
@@ -177,6 +180,7 @@ export function createAnalyzerContext(
     onMounts: [],
     initStatements: [],
     imports: [],
+    namedExports: [],
     localFunctions: [],
     localConstants: [],
     typeDefinitions: [],

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -381,16 +381,8 @@ function visit(
     return // Body is captured as string; don't walk internals
   }
 
-  // Named exports: export { X, Y } [from './src']
-  //
-  // Two roles:
-  //  1. Mark already-collected local items (component/function/constant) as
-  //     exported so the inline `export <kw>` rewrite picks them up.
-  //  2. Capture the full specifier list as `NamedExportInfo` so the
-  //     marked-template emitter can re-emit specifiers that don't bind to
-  //     a local declaration (re-exports of imported symbols, or
-  //     `export ... from`). Inline-exported locals are filtered out at
-  //     emit time to avoid double-export.
+  // Named exports: collect for re-emit (so `export { ImportedSym }` survives)
+  // AND mark matching locals as exported (so the inline rewrite picks them up).
   if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
     const isFromReexport = !!node.moduleSpecifier
     const sourceSpec =
@@ -398,27 +390,20 @@ function visit(
         ? node.moduleSpecifier.text
         : null
 
-    const exportSpecifiers = node.exportClause.elements.map((spec) => {
-      const local = (spec.propertyName ?? spec.name).text
-      const external = spec.name.text
-      return {
-        name: local,
-        alias: spec.propertyName ? external : null,
-        isTypeOnly: spec.isTypeOnly,
-      }
-    })
+    const exportSpecifiers = node.exportClause.elements.map((spec) => ({
+      name: (spec.propertyName ?? spec.name).text,
+      alias: spec.propertyName ? spec.name.text : null,
+      isTypeOnly: spec.isTypeOnly,
+    }))
 
     ctx.namedExports.push({
       source: sourceSpec,
       specifiers: exportSpecifiers,
       isTypeOnly: node.isTypeOnly,
-      loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     })
 
-    // Local-binding marking only applies when there is no `from 'src'`.
     if (!isFromReexport) {
       for (const specifier of node.exportClause.elements) {
-        // Use the local name (`propertyName` if `X as Y`, else `name`).
         const local = (specifier.propertyName ?? specifier.name).text
         if (ctx.componentName === local) {
           ctx.isExported = true

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -381,19 +381,54 @@ function visit(
     return // Body is captured as string; don't walk internals
   }
 
-  // Named exports: export { X, Y } — mark already-collected items as exported
+  // Named exports: export { X, Y } [from './src']
+  //
+  // Two roles:
+  //  1. Mark already-collected local items (component/function/constant) as
+  //     exported so the inline `export <kw>` rewrite picks them up.
+  //  2. Capture the full specifier list as `NamedExportInfo` so the
+  //     marked-template emitter can re-emit specifiers that don't bind to
+  //     a local declaration (re-exports of imported symbols, or
+  //     `export ... from`). Inline-exported locals are filtered out at
+  //     emit time to avoid double-export.
   if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
-    for (const specifier of node.exportClause.elements) {
-      const name = specifier.name.text
-      // Mark the component itself if re-exported via export { Name }
-      if (ctx.componentName === name) {
-        ctx.isExported = true
+    const isFromReexport = !!node.moduleSpecifier
+    const sourceSpec =
+      node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
+        ? node.moduleSpecifier.text
+        : null
+
+    const exportSpecifiers = node.exportClause.elements.map((spec) => {
+      const local = (spec.propertyName ?? spec.name).text
+      const external = spec.name.text
+      return {
+        name: local,
+        alias: spec.propertyName ? external : null,
+        isTypeOnly: spec.isTypeOnly,
       }
-      for (const c of ctx.localConstants) {
-        if (c.name === name) c.isExported = true
-      }
-      for (const f of ctx.localFunctions) {
-        if (f.name === name) f.isExported = true
+    })
+
+    ctx.namedExports.push({
+      source: sourceSpec,
+      specifiers: exportSpecifiers,
+      isTypeOnly: node.isTypeOnly,
+      loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    })
+
+    // Local-binding marking only applies when there is no `from 'src'`.
+    if (!isFromReexport) {
+      for (const specifier of node.exportClause.elements) {
+        // Use the local name (`propertyName` if `X as Y`, else `name`).
+        const local = (specifier.propertyName ?? specifier.name).text
+        if (ctx.componentName === local) {
+          ctx.isExported = true
+        }
+        for (const c of ctx.localConstants) {
+          if (c.name === local) c.isExported = true
+        }
+        for (const f of ctx.localFunctions) {
+          if (f.name === local) f.isExported = true
+        }
       }
     }
   }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -219,14 +219,9 @@ function compileMultipleComponentsSync(
   // Find the default export name for scriptBaseName (multi-component files share one .client.js)
   const defaultExportName = entries.find(e => e.componentIR.metadata.hasDefaultExport)?.componentIR.metadata.componentName
 
-  // Union of inline-exported names across every sibling component in this
-  // file. Each component's `namedExports` blocks are emitted by
-  // `generateModuleExports` with this set as the filter so siblings'
-  // inline-exported names ARE pre-filtered out — otherwise
-  // `export { ChartContainer, BarChart, Bar }` emitted under both the
-  // ChartContainer and BarChart components would each filter out only
-  // its own name and the downstream line-dedup would keep both nearly
-  // identical lines, producing a duplicate-export SyntaxError.
+  // Union of sibling-component inline exports — passed to each per-component
+  // emit so the trailing `export { ... }` block is identical across siblings
+  // and the line-dedup pass collapses them.
   const fileWideInlineExported = new Set<string>()
   for (const { componentIR } of entries) {
     for (const name of collectInlineExportedNames(componentIR)) {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -16,7 +16,7 @@ import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listComponentFunctions, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'
-import { generateModuleExports } from './module-exports'
+import { generateModuleExports, collectInlineExportedNames } from './module-exports'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
 
 /**
@@ -219,10 +219,25 @@ function compileMultipleComponentsSync(
   // Find the default export name for scriptBaseName (multi-component files share one .client.js)
   const defaultExportName = entries.find(e => e.componentIR.metadata.hasDefaultExport)?.componentIR.metadata.componentName
 
+  // Union of inline-exported names across every sibling component in this
+  // file. Each component's `namedExports` blocks are emitted by
+  // `generateModuleExports` with this set as the filter so siblings'
+  // inline-exported names ARE pre-filtered out — otherwise
+  // `export { ChartContainer, BarChart, Bar }` emitted under both the
+  // ChartContainer and BarChart components would each filter out only
+  // its own name and the downstream line-dedup would keep both nearly
+  // identical lines, producing a duplicate-export SyntaxError.
+  const fileWideInlineExported = new Set<string>()
+  for (const { componentIR } of entries) {
+    for (const name of collectInlineExportedNames(componentIR)) {
+      fileWideInlineExported.add(name)
+    }
+  }
+
   for (const { componentIR } of entries) {
     const scriptBaseName = !componentIR.metadata.hasDefaultExport && defaultExportName ? defaultExportName : undefined
     const adapterOutput = adapter.generate(componentIR, { scriptBaseName })
-    const moduleExports = generateModuleExports(componentIR)
+    const moduleExports = generateModuleExports(componentIR, fileWideInlineExported)
 
     let imports: string
     let types: string
@@ -496,6 +511,7 @@ export function buildMetadata(
     initStatements: ctx.initStatements,
     imports: ctx.imports,
     templateImports: filterTemplateImports(ctx.imports),
+    namedExports: ctx.namedExports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
   }

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -8,25 +8,10 @@
 import type { ComponentIR, ParamInfo } from './types'
 
 /**
- * Generate module-level export statements for constants and functions.
- * Skips client-only constructs (createContext, new WeakMap).
- *
- * Also emits `export { ... } [from './path']` specifier-list declarations
- * captured by the analyzer as `namedExports`. Specifiers whose local name
- * matches an already inline-exported local declaration (`export const`,
- * `export function`) or a component name that the compiler will rewrite
- * to `export function ComponentName` are filtered out to avoid duplicate
- * exports — except when the source is a re-export (`from './path'`),
- * where the specifier refers to a foreign binding and is always preserved.
- *
- * In a multi-component file the caller may pass `extraInlineExported` —
- * the union of inline-exported names across all sibling components in the
- * file — so the named-export block filter matches what will actually be
- * inline-exported in the combined output. Otherwise the only inline-export
- * the filter knows about is this component's own exports, which causes
- * the per-component blocks to differ from each other and the line-dedup
- * pass downstream to keep all of them, producing duplicate-export
- * SyntaxErrors.
+ * Emit module-level exports for local declarations and `export { ... } [from '...']`
+ * specifier blocks. Specifiers whose local name appears in `extraInlineExported`
+ * (already emitted inline) are filtered, except for `from`-form re-exports and
+ * aliased forms that introduce a new external name.
  */
 export function generateModuleExports(
   ir: ComponentIR,
@@ -54,14 +39,6 @@ export function generateModuleExports(
     lines.push(`export function ${func.name}(${params}) ${func.body}`)
   }
 
-  // Emit specifier-list export blocks (`export { A, B } [from './path']`).
-  // For non-from blocks we drop specifiers that bind to locals already
-  // emitted with an inline `export` keyword above (constants/functions) or
-  // a component name that will be rewritten to `export function Name`.
-  // Listing them again as `export { X }` would produce a duplicate-binding
-  // error. `from`-form blocks (re-exports of foreign bindings) are always
-  // preserved verbatim — the specifier never collides with a local
-  // declaration.
   const inlineExported = collectInlineExportedNames(ir)
   for (const name of extraInlineExported) inlineExported.add(name)
 
@@ -70,13 +47,9 @@ export function generateModuleExports(
 
     const survivingSpecs = block.specifiers.filter((spec) => {
       if (isReexportFrom) return true
-      // Only drop the specifier when it would produce a *duplicate* of an
-      // existing inline export — i.e. the specifier exports under the
-      // same name as the inline declaration. `export { X as Y }` with
-      // an inline `export const X` is NOT a duplicate (it adds the
-      // external name `Y`), so the alias form must be preserved.
-      const externalName = spec.alias ?? spec.name
-      return !(inlineExported.has(spec.name) && externalName === spec.name)
+      // `export { X as Y }` with inline `export const X` is not a duplicate
+      // (Y is a new external name), so only drop when alias is absent.
+      return !(inlineExported.has(spec.name) && spec.alias == null)
     })
 
     if (survivingSpecs.length === 0) continue
@@ -98,13 +71,6 @@ export function generateModuleExports(
   return lines.length > 0 ? lines.join('\n') : null
 }
 
-/**
- * Set of local binding names that are already emitted inline-exported
- * (`export const X = ...`, `export function X(...)`, or the component
- * itself, which the compiler rewrites from `function Name` to
- * `export function Name`). Used by `generateModuleExports` to avoid
- * double-exporting via a trailing `export { ... }` block.
- */
 export function collectInlineExportedNames(ir: ComponentIR): Set<string> {
   const names = new Set<string>()
   for (const c of ir.metadata.localConstants) {
@@ -113,11 +79,7 @@ export function collectInlineExportedNames(ir: ComponentIR): Set<string> {
   for (const f of ir.metadata.localFunctions) {
     if (f.isExported) names.add(f.name)
   }
-  // The component itself is rewritten to `export function ComponentName`
-  // by `applyExportKeyword` in compiler.ts when `metadata.isExported` is
-  // true — including the case where the source uses a trailing
-  // `export { ComponentName }` block. Filter that specifier out so the
-  // trailing block doesn't re-list it.
+  // Component itself is inline-exported by applyExportKeyword.
   if (ir.metadata.isExported && ir.metadata.componentName) {
     names.add(ir.metadata.componentName)
   }

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -10,8 +10,28 @@ import type { ComponentIR, ParamInfo } from './types'
 /**
  * Generate module-level export statements for constants and functions.
  * Skips client-only constructs (createContext, new WeakMap).
+ *
+ * Also emits `export { ... } [from './path']` specifier-list declarations
+ * captured by the analyzer as `namedExports`. Specifiers whose local name
+ * matches an already inline-exported local declaration (`export const`,
+ * `export function`) or a component name that the compiler will rewrite
+ * to `export function ComponentName` are filtered out to avoid duplicate
+ * exports — except when the source is a re-export (`from './path'`),
+ * where the specifier refers to a foreign binding and is always preserved.
+ *
+ * In a multi-component file the caller may pass `extraInlineExported` —
+ * the union of inline-exported names across all sibling components in the
+ * file — so the named-export block filter matches what will actually be
+ * inline-exported in the combined output. Otherwise the only inline-export
+ * the filter knows about is this component's own exports, which causes
+ * the per-component blocks to differ from each other and the line-dedup
+ * pass downstream to keep all of them, producing duplicate-export
+ * SyntaxErrors.
  */
-export function generateModuleExports(ir: ComponentIR): string | null {
+export function generateModuleExports(
+  ir: ComponentIR,
+  extraInlineExported: ReadonlySet<string> = new Set()
+): string | null {
   const lines: string[] = []
 
   for (const constant of ir.metadata.localConstants) {
@@ -34,7 +54,74 @@ export function generateModuleExports(ir: ComponentIR): string | null {
     lines.push(`export function ${func.name}(${params}) ${func.body}`)
   }
 
+  // Emit specifier-list export blocks (`export { A, B } [from './path']`).
+  // For non-from blocks we drop specifiers that bind to locals already
+  // emitted with an inline `export` keyword above (constants/functions) or
+  // a component name that will be rewritten to `export function Name`.
+  // Listing them again as `export { X }` would produce a duplicate-binding
+  // error. `from`-form blocks (re-exports of foreign bindings) are always
+  // preserved verbatim — the specifier never collides with a local
+  // declaration.
+  const inlineExported = collectInlineExportedNames(ir)
+  for (const name of extraInlineExported) inlineExported.add(name)
+
+  for (const block of ir.metadata.namedExports) {
+    const isReexportFrom = block.source !== null
+
+    const survivingSpecs = block.specifiers.filter((spec) => {
+      if (isReexportFrom) return true
+      // Only drop the specifier when it would produce a *duplicate* of an
+      // existing inline export — i.e. the specifier exports under the
+      // same name as the inline declaration. `export { X as Y }` with
+      // an inline `export const X` is NOT a duplicate (it adds the
+      // external name `Y`), so the alias form must be preserved.
+      const externalName = spec.alias ?? spec.name
+      return !(inlineExported.has(spec.name) && externalName === spec.name)
+    })
+
+    if (survivingSpecs.length === 0) continue
+
+    const specText = survivingSpecs
+      .map((s) => {
+        const prefix = s.isTypeOnly ? 'type ' : ''
+        return s.alias ? `${prefix}${s.name} as ${s.alias}` : `${prefix}${s.name}`
+      })
+      .join(', ')
+    const typeKw = block.isTypeOnly ? 'type ' : ''
+    if (isReexportFrom) {
+      lines.push(`export ${typeKw}{ ${specText} } from '${block.source}'`)
+    } else {
+      lines.push(`export ${typeKw}{ ${specText} }`)
+    }
+  }
+
   return lines.length > 0 ? lines.join('\n') : null
+}
+
+/**
+ * Set of local binding names that are already emitted inline-exported
+ * (`export const X = ...`, `export function X(...)`, or the component
+ * itself, which the compiler rewrites from `function Name` to
+ * `export function Name`). Used by `generateModuleExports` to avoid
+ * double-exporting via a trailing `export { ... }` block.
+ */
+export function collectInlineExportedNames(ir: ComponentIR): Set<string> {
+  const names = new Set<string>()
+  for (const c of ir.metadata.localConstants) {
+    if (c.isExported) names.add(c.name)
+  }
+  for (const f of ir.metadata.localFunctions) {
+    if (f.isExported) names.add(f.name)
+  }
+  // The component itself is rewritten to `export function ComponentName`
+  // by `applyExportKeyword` in compiler.ts when `metadata.isExported` is
+  // true — including the case where the source uses a trailing
+  // `export { ComponentName }` block. Filter that specifier out so the
+  // trailing block doesn't re-list it.
+  if (ir.metadata.isExported && ir.metadata.componentName) {
+    names.add(ir.metadata.componentName)
+  }
+  return names
 }
 
 /**

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -526,21 +526,12 @@ export interface ImportInfo {
   loc: SourceLocation
 }
 
-/**
- * Module-level `export { A, B as C } [from './path']` declaration.
- *
- * Preserved verbatim into the marked-template output so re-exports of
- * imported symbols (and `export ... from`) reach downstream consumers.
- * Without this representation the IR-to-template emitter would only
- * surface inline `export function Foo` / `export const x` declarations,
- * silently dropping pure-specifier export blocks. See PR #1077.
- */
+/** Module-level `export { A, B as C } [from './path']` specifier block. */
 export interface NamedExportInfo {
   /** When non-null, this is `export { ... } from 'source'`. */
   source: string | null
   specifiers: NamedExportSpecifier[]
   isTypeOnly: boolean
-  loc: SourceLocation
 }
 
 export interface NamedExportSpecifier {
@@ -674,15 +665,7 @@ export interface IRMetadata {
   /** Imports filtered for template use (client-side packages stripped).
    *  Computed by the compiler — adapters should use this instead of `imports`. */
   templateImports: ImportInfo[]
-  /**
-   * Module-level `export { ... }` and `export { ... } from '...'`
-   * specifier-list declarations preserved from the source. Inline
-   * `export function/const` declarations are NOT in this list — they
-   * surface via `localFunctions[].isExported` / `localConstants[].isExported`.
-   * Emitted alongside `localConstants`/`localFunctions` so re-exports of
-   * imported symbols (the chart Bar/Line/Area barrel pattern) survive
-   * into the marked template.
-   */
+  /** Module-level `export { ... } [from '...']` specifier blocks. */
   namedExports: NamedExportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -527,6 +527,32 @@ export interface ImportInfo {
 }
 
 /**
+ * Module-level `export { A, B as C } [from './path']` declaration.
+ *
+ * Preserved verbatim into the marked-template output so re-exports of
+ * imported symbols (and `export ... from`) reach downstream consumers.
+ * Without this representation the IR-to-template emitter would only
+ * surface inline `export function Foo` / `export const x` declarations,
+ * silently dropping pure-specifier export blocks. See PR #1077.
+ */
+export interface NamedExportInfo {
+  /** When non-null, this is `export { ... } from 'source'`. */
+  source: string | null
+  specifiers: NamedExportSpecifier[]
+  isTypeOnly: boolean
+  loc: SourceLocation
+}
+
+export interface NamedExportSpecifier {
+  /** Local binding being exported (or imported binding for `export ... from`). */
+  name: string
+  /** External alias if `export { name as alias }`, else null. */
+  alias: string | null
+  /** True for `export { type X }` per-specifier type-only. */
+  isTypeOnly: boolean
+}
+
+/**
  * Reactive factory helper metadata (#931). Collected when a same-file
  * function matches the factory shape: exactly one top-level `return` whose
  * argument is an array literal of identifiers, and at least one reactive
@@ -648,6 +674,16 @@ export interface IRMetadata {
   /** Imports filtered for template use (client-side packages stripped).
    *  Computed by the compiler — adapters should use this instead of `imports`. */
   templateImports: ImportInfo[]
+  /**
+   * Module-level `export { ... }` and `export { ... } from '...'`
+   * specifier-list declarations preserved from the source. Inline
+   * `export function/const` declarations are NOT in this list — they
+   * surface via `localFunctions[].isExported` / `localConstants[].isExported`.
+   * Emitted alongside `localConstants`/`localFunctions` so re-exports of
+   * imported symbols (the chart Bar/Line/Area barrel pattern) survive
+   * into the marked template.
+   */
+  namedExports: NamedExportInfo[]
   localFunctions: FunctionInfo[]
   localConstants: ConstantInfo[]
   /** Pre-computed client JS analysis for adapter use */

--- a/packages/test/src/render.ts
+++ b/packages/test/src/render.ts
@@ -92,6 +92,7 @@ function buildMetadata(
     onMounts: ctx.onMounts,
     imports: ctx.imports,
     templateImports: ctx.imports.filter((imp) => !['@barefootjs/client', '@barefootjs/client'].includes(imp.source)),
+    namedExports: ctx.namedExports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
     initStatements: ctx.initStatements,


### PR DESCRIPTION
## Summary

Fixes a JSX compiler bug surfaced by #1077 (chart Bar JSX-native PoC): `export { A, B, C }` and `export { X } from './y'` declarations at the top of a `"use client"` source were silently dropped from the IR-to-template emit pass.

The analyzer's export-declaration handler only used the specifier list as a side channel to mark already-collected local declarations as exported (so inline `export <kw>` rewrites would pick them up). Specifiers that referenced an imported symbol — or any `export ... from` re-export — left no trace in the IR and disappeared from the dist.

## Reproduction

14-line repro at `compileJSXSync` level:

\`\`\`tsx
'use client'
import { Bar } from './bar'

function ChartContainer(props: { children: unknown }) {
  return <div>{props.children}</div>
}

export { ChartContainer, Bar }
\`\`\`

Before this fix, the compiled \`markedTemplate\` had the import preserved and \`ChartContainer\` inline-exported via \`export function\`, but the \`export { ChartContainer, Bar }\` block was gone — \`Bar\` could not be re-imported from the dist file.

## Real-world impact

PR #1077 (\`ui/components/ui/chart/index.tsx\`) re-exports \`Bar\` from a sibling \`./bar.tsx\` via the named-export block. SSR fails on module load with:

\`\`\`
Export named 'Bar' not found in module .../site/ui/dist/components/ui/chart/index.tsx
\`\`\`

The named-export block is the only way to publish a JSX-native client component that lives in a separate file from its host module.

## Fix

- Add \`namedExports: NamedExportInfo[]\` to \`IRMetadata\` and \`AnalyzerContext\`. Each entry captures the \`from '...'\` source (or null), the full specifier list with \`propertyName\`/\`alias\` distinguished, and \`isTypeOnly\`.
- Extend the analyzer's \`ExportDeclaration\` handler to record the full block. Local-binding side effects are preserved, but skipped when the declaration carries a \`from\` clause — those are pure re-exports of external bindings.
- \`generateModuleExports\` re-emits captured \`namedExports\` as \`export { ... } [from '...']\` lines, filtering specifiers whose local name was already inline-exported (\`export function Foo\`) to avoid duplicate-export \`SyntaxError\`. \`X as Y\` aliasing is preserved as long as the alias differs from the local name.
- For multi-component files, \`compileMultipleComponentsSync\` passes the file-wide union of inline-exported names to each per-component \`generateModuleExports\` call so all components emit the same export block and the line-dedup pass collapses them correctly.
- \`packages/test/src/render.ts\` \`IRMetadata\` mock gets the new field.

## Test plan

4 regression test cases in \`packages/jsx/src/__tests__/named-export-block-preservation.test.ts\`:

- [x] Re-export of imported symbol (\`import { Bar } from './bar'; export { Bar }\`)
- [x] \`export { X } from './src'\` re-export-from form
- [x] Mixed inline-exported local + re-exported import in the same block
- [x] Aliased \`X as Y\` re-export

Suite results:
- [x] \`bun test --cwd packages/jsx\` — 828 pass / 0 fail (+4 new)
- [x] \`bun test --cwd packages/client\` — 214 pass
- [x] \`bun test --cwd packages/chart\` — 9 pass
- [x] \`bun test --cwd packages/adapter-tests\` — 214 pass
- [x] \`bun test --cwd ui\` — 1157 pass
- [x] \`bun run build\` — clean

## Unblocks

- #1077 (chart Bar JSX-native PoC) — once this lands, \`bar-chart.spec.ts\` E2E should run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>