### PR TITLE
ci: add pkg.pr.new preview workflow (cr-tracked opt-in)

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,69 @@
+name: Preview Release (pkg.pr.new)
+
+# Publishes preview packages via https://pkg.pr.new whenever a PR carries the
+# `cr-tracked` label. The label is the opt-in: add it to a PR you want to
+# preview-publish, remove it to stop. While none of these packages are on npm
+# yet, install previews via the long-form URL:
+#
+#   bun add https://pkg.pr.new/piconic-ai/barefootjs/@barefootjs/<pkg>@<sha>
+#
+# After the first npm release, the compact form
+# (`https://pkg.pr.new/<pkg>@<sha>`) starts working as well.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  publish:
+    if: contains(github.event.pull_request.labels.*.name, 'cr-tracked')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      # Build all publishable packages. Order matters: client and jsx are
+      # consumed by the others, so build them first.
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/form' build
+          bun run --filter '@barefootjs/chart' build
+          bun run --filter '@barefootjs/xyflow' build
+          bun run --filter '@barefootjs/test' build
+          bun run --filter '@barefootjs/hono' build
+          bun run --filter '@barefootjs/go-template' build
+          bun run --filter '@barefootjs/mojolicious' build
+          bun run --filter '@barefootjs/cli' build
+
+      # Single invocation across all preview-publishable packages.
+      # `@barefootjs/preview` is private and `@barefootjs/adapter-tests` is an
+      # internal test util — both are skipped by listing targets explicitly.
+      - name: Publish preview to pkg.pr.new
+        run: |
+          bunx pkg-pr-new publish --bun \
+            './packages/client' \
+            './packages/jsx' \
+            './packages/form' \
+            './packages/chart' \
+            './packages/xyflow' \
+            './packages/test' \
+            './packages/adapter-hono' \
+            './packages/adapter-go-template' \
+            './packages/adapter-mojolicious' \
+            './packages/cli' \
+            './packages/shared' \
+            './packages/streaming'

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "@types/node": "^22.10.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@typescript/native-preview": "beta",
     "concurrently": "^9.1.0",
     "happy-dom": "^20.0.11",
+    "pkg-pr-new": "^0.0.67",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "solid-js": "^1.9.12",
-    "@typescript/native-preview": "beta",
     "typescript": "^5.9.3"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pkg-pr-new.yml` to publish preview packages via [pkg.pr.new](https://pkg.pr.new) on PRs that carry the `cr-tracked` label.
- Adds `pkg-pr-new` as a root `devDependency` so CI invokes the binary from the installed lockfile (not `dlx`-style).
- Builds and publishes the 12 public packages in a single command. `@barefootjs/preview` is `private: true` and `@barefootjs/adapter-tests` is an internal test util, both intentionally skipped.

## Why this design
- pkg.pr.new has **no built-in PR-scoping** mechanism — the gate is implemented here as `if: contains(github.event.pull_request.labels.*.name, 'cr-tracked')` so previews never publish unless explicitly opted in.
- A single `pkg-pr-new publish` invocation handles the whole monorepo, which is the recommended pattern (avoids duplicated comments).
- While nothing is on npm yet, install previews via the **long-form URL**:
  ```
  bun add https://pkg.pr.new/piconic-ai/barefootjs/@barefootjs/<pkg>@<sha>
  ```
  After the first npm release the compact form (`pkg.pr.new/<pkg>@<sha>`) starts working as well.

## How to use
1. Create the `cr-tracked` label in this repo (one-time):
   ```
   gh label create cr-tracked --color 0E8A16 --description "Publish preview packages via pkg.pr.new"
   ```
2. Install the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) on `piconic-ai/barefootjs` (one-time).
3. Add the `cr-tracked` label to any PR (including this one) to trigger a preview build. pkg.pr.new will post a comment with install URLs.

## Test plan
- [ ] Create the `cr-tracked` label.
- [ ] Install the pkg.pr.new GitHub App.
- [ ] Apply `cr-tracked` to this PR and confirm the workflow runs and pkg.pr.new comments install commands for all 12 packages.
- [ ] Try `bun add https://pkg.pr.new/piconic-ai/barefootjs/@barefootjs/client@<sha>` in a sandbox and verify it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)