### PR TITLE
compiler: rewrite @barefootjs/client SSR imports to adapter shim (#1084)

### DIFF
--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -30,6 +30,10 @@
       "types": "./src/dialog-context.tsx",
       "import": "./src/dialog-context.tsx"
     },
+    "./client-shim": {
+      "types": "./src/client-shim.ts",
+      "import": "./src/client-shim.ts"
+    },
     "./preload": {
       "types": "./src/preload.tsx",
       "import": "./src/preload.tsx"
@@ -95,6 +99,7 @@
     "directory": "packages/adapter-hono"
   },
   "peerDependencies": {
+    "@barefootjs/client": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
     "hono": "^4.0.0"
   },

--- a/packages/adapter-hono/src/__tests__/ssr-context-bridge.test.ts
+++ b/packages/adapter-hono/src/__tests__/ssr-context-bridge.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SSR context-bridge end-to-end (#1084).
+ *
+ * Verifies that BarefootJS components using `<Context.Provider>` plus
+ * `useContext` actually flow values through Hono's per-render context stack
+ * at SSR time. This is the bonus path of Option B: not only does the SSR
+ * template no longer crash with `ReferenceError: useContext is not defined`,
+ * the rendered HTML reflects the provided value rather than the context
+ * default.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { renderHonoComponent } from '../test-render'
+import { HonoAdapter } from '../adapter/hono-adapter'
+
+describe('SSR context bridge (#1084 / Option B)', () => {
+  test('useContext returns the value provided by an enclosing Context.Provider at SSR', async () => {
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        'use client'
+        import { createContext, useContext } from '@barefootjs/client'
+
+        const ThemeContext = createContext('light')
+
+        function ThemeLabel() {
+          const theme = useContext(ThemeContext)
+          return <span class="theme">{theme}</span>
+        }
+
+        export function ThemeRoot() {
+          return (
+            <div class="root">
+              <ThemeContext.Provider value="dark">
+                <ThemeLabel />
+              </ThemeContext.Provider>
+            </div>
+          )
+        }
+      `,
+    })
+
+    expect(html).toContain('class="theme"')
+    // The provided value flows through to the consumer at SSR.
+    expect(html).toContain('>dark<')
+    expect(html).not.toContain('>light<')
+  })
+
+  test('useContext falls back to defaultValue when no provider is in scope', async () => {
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        'use client'
+        import { createContext, useContext } from '@barefootjs/client'
+
+        const LocaleContext = createContext('en')
+
+        export function LocaleLabel() {
+          const locale = useContext(LocaleContext)
+          return <span>{locale}</span>
+        }
+      `,
+    })
+    expect(html).toContain('>en<')
+  })
+
+  test('reads a memo body that depends on a context value at SSR', async () => {
+    // Mirrors the pattern blocking step 2 of #1080: a primitive consumes the
+    // chart container's scales via useContext and computes geometry inside a
+    // createMemo. The memo body runs at SSR and used to throw because
+    // useContext was undefined; now it produces real markup.
+    const html = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: `
+        'use client'
+        import { createContext, createMemo, useContext } from '@barefootjs/client'
+
+        const GridContext = createContext({ ticks: [] })
+
+        function GridLines() {
+          const ctx = useContext(GridContext)
+          const lines = createMemo(() => ctx.ticks.map((y) => ({ y })))
+          return (
+            <g class="grid">
+              {lines().map((l) => <line key={l.y} y1={l.y} y2={l.y} />)}
+            </g>
+          )
+        }
+
+        export function Chart() {
+          return (
+            <svg>
+              <GridContext.Provider value={{ ticks: [10, 20, 30] }}>
+                <GridLines />
+              </GridContext.Provider>
+            </svg>
+          )
+        }
+      `,
+    })
+
+    // Three <line> elements emitted at SSR — proving the memo body executed
+    // with a populated context (vs. the empty default).
+    const lineMatches = html.match(/<line\b/g) ?? []
+    expect(lineMatches.length).toBe(3)
+    expect(html).toMatch(/y1="10"/)
+    expect(html).toMatch(/y1="20"/)
+    expect(html).toMatch(/y1="30"/)
+  })
+})

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -77,15 +77,14 @@ export class HonoAdapter extends JsxAdapter {
     const component = this.generateComponent(ir)
     const types = this.generateTypes(ir, component)
     const componentCode = [types, component].filter(Boolean).join('\n')
-    const baseImports = this.generateImports(ir, componentCode)
+    const imports = this.generateImports(ir, componentCode)
     // Module-level Context bindings (`const Ctx = createContext()`) are
     // skipped from the SSR signal-initializer block by JsxAdapter — they
     // need to live at module scope so providers and consumers in the same
-    // render share the same Context object identity.
+    // render share the same Context object identity. Emitted in a dedicated
+    // section so multi-component dedup works on the full block (not per
+    // line, which would split multi-line `({...})` arguments).
     const moduleConstants = this.generateModuleLevelContextBindings(ir)
-    const imports = moduleConstants
-      ? `${baseImports}\n\n${moduleConstants}`
-      : baseImports
 
     const defaultExport = ir.metadata.hasDefaultExport
       ? `\nexport default ${this.componentName}`
@@ -96,10 +95,11 @@ export class HonoAdapter extends JsxAdapter {
       types: types || '',
       component,
       defaultExport,
+      moduleConstants,
     }
 
     // Assemble template for backward compat (external consumers using output.template)
-    const template = [imports, types, component].filter(Boolean).join('\n\n') + defaultExport
+    const template = [imports, moduleConstants, types, component].filter(Boolean).join('\n\n') + defaultExport
 
     return {
       template,

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -49,6 +49,7 @@ export interface HonoAdapterOptions {
 export class HonoAdapter extends JsxAdapter {
   name = 'hono'
   extension = '.tsx'
+  clientShimSource = '@barefootjs/hono/client-shim'
 
   protected jsxConfig: JsxAdapterConfig = { preserveTypes: true }
 
@@ -76,7 +77,15 @@ export class HonoAdapter extends JsxAdapter {
     const component = this.generateComponent(ir)
     const types = this.generateTypes(ir, component)
     const componentCode = [types, component].filter(Boolean).join('\n')
-    const imports = this.generateImports(ir, componentCode)
+    const baseImports = this.generateImports(ir, componentCode)
+    // Module-level Context bindings (`const Ctx = createContext()`) are
+    // skipped from the SSR signal-initializer block by JsxAdapter — they
+    // need to live at module scope so providers and consumers in the same
+    // render share the same Context object identity.
+    const moduleConstants = this.generateModuleLevelContextBindings(ir)
+    const imports = moduleConstants
+      ? `${baseImports}\n\n${moduleConstants}`
+      : baseImports
 
     const defaultExport = ir.metadata.hasDefaultExport
       ? `\nexport default ${this.componentName}`
@@ -98,6 +107,20 @@ export class HonoAdapter extends JsxAdapter {
       types: types || undefined,
       extension: this.extension,
     }
+  }
+
+  private generateModuleLevelContextBindings(ir: ComponentIR): string {
+    const lines: string[] = []
+    for (const c of ir.metadata.localConstants) {
+      if (!c.isModule) continue
+      if (c.isExported) continue
+      if (c.systemConstructKind !== 'createContext') continue
+      if (!c.value) continue
+      const keyword = c.declarationKind ?? 'const'
+      const value = this.jsxConfig.preserveTypes ? (c.typedValue ?? c.value) : c.value
+      lines.push(`${keyword} ${c.name} = ${value}`)
+    }
+    return lines.join('\n')
   }
 
   // ===========================================================================
@@ -123,7 +146,8 @@ export class HonoAdapter extends JsxAdapter {
       lines.push(`import { Suspense } from 'hono/jsx/streaming'`)
     }
 
-    // Re-export template imports (client-side packages already filtered by compiler)
+    // Re-emit template imports (compiler already rewrote @barefootjs/client to
+    // the shim source).
     for (const imp of ir.metadata.templateImports) {
       if (imp.specifiers.length === 0) {
         if (!imp.isTypeOnly) {
@@ -136,6 +160,13 @@ export class HonoAdapter extends JsxAdapter {
       } else {
         lines.push(`import ${this.formatImportSpecifiers(imp.specifiers)} from '${imp.source}'`)
       }
+    }
+
+    // Provider IR rendering emits `provideContextSSR(...)` calls. Emit the
+    // import on its own line so multi-component files dedupe it cleanly via
+    // the compiler's per-line import merging.
+    if (/\bprovideContextSSR\(/.test(componentCode)) {
+      lines.push(`import { provideContextSSR } from '@barefootjs/hono/client-shim'`)
     }
 
     return lines.join('\n')
@@ -431,8 +462,21 @@ export class HonoAdapter extends JsxAdapter {
         // If-statements are rendered at the component level, not inline
         // This case shouldn't normally be hit, but return empty for safety
         return ''
-      case 'provider':
-        return this.renderChildren((node as IRProvider).children)
+      case 'provider': {
+        const provider = node as IRProvider
+        const children = this.renderChildren(provider.children)
+        // Quote string-literal values; dynamic expressions emit raw.
+        const rawValue = provider.valueProp.value ?? ''
+        const valueExpr = provider.valueProp.dynamic ? rawValue : JSON.stringify(rawValue)
+        // Bridge BarefootJS Context to Hono's per-render context stack so
+        // descendants that call useContext() at SSR see the provided value.
+        // `provideContextSSR` is a helper exported from the client shim
+        // (`@barefootjs/hono/client-shim`); generateImports auto-injects the
+        // import when this expression is present in the rendered output.
+        // The outer fragment makes the form valid JSX whether the provider
+        // appears as the component root or nested inside JSX siblings.
+        return `<>{provideContextSSR(${provider.contextName}, ${valueExpr}, <>${children}</>)}</>`
+      }
       case 'async':
         return this.renderAsync(node as IRAsync)
       default:

--- a/packages/adapter-hono/src/client-shim.ts
+++ b/packages/adapter-hono/src/client-shim.ts
@@ -1,0 +1,165 @@
+/**
+ * SSR shim for `@barefootjs/client` when targeting the Hono adapter.
+ *
+ * The compiler rewrites `@barefootjs/client` imports inside SSR templates to
+ * this module. The shim provides:
+ *
+ *   - `useContext` / `provideContext` bridged to Hono's per-render context
+ *     stack, so context values flow through `<Context.Provider value=...>`
+ *     during SSR. The compiler emits provider IR via `provideContextSSR`.
+ *   - Pure helpers (`createContext`, `splitProps`, `forwardProps`, `unwrap`,
+ *     `__slot`) re-exported from `@barefootjs/client`.
+ *   - Reactive primitives (`createSignal`, `createMemo`, etc.) replaced with
+ *     stubs that throw if called — the compiler is expected to rewrite all
+ *     reachable call sites to plain values during SSR codegen.
+ *   - Portal helpers as no-ops; portals are realized at hydration time.
+ */
+
+/** @jsxImportSource hono/jsx */
+
+import { createContext as honoCreateContext, useContext as honoUseContext, jsx } from 'hono/jsx'
+import type { Context as HonoContext } from 'hono/jsx'
+import type { Context } from '@barefootjs/client'
+
+export {
+  createContext,
+  splitProps,
+  forwardProps,
+  unwrap,
+  __slot,
+} from '@barefootjs/client'
+
+export type {
+  Context,
+  Reactive,
+  Signal,
+  Memo,
+  CleanupFn,
+  EffectFn,
+  SlotMarker,
+  Portal,
+  PortalChildren,
+  PortalOptions,
+  Renderable,
+} from '@barefootjs/client'
+
+// ---------------------------------------------------------------------------
+// Context bridge: BarefootJS Context → Hono Context
+// ---------------------------------------------------------------------------
+
+const honoCtxBridge = new WeakMap<Context<unknown>, HonoContext<unknown>>()
+
+/**
+ * Lazily map a BarefootJS Context object to a Hono context. The mapping is
+ * stable (WeakMap keyed by the Context object itself), so providers and
+ * consumers in the same render see the same Hono context.
+ */
+export function getHonoContext<T>(bfCtx: Context<T>): HonoContext<T | undefined> {
+  let hc = honoCtxBridge.get(bfCtx as Context<unknown>) as HonoContext<T | undefined> | undefined
+  if (!hc) {
+    hc = honoCreateContext<T | undefined>(bfCtx.defaultValue)
+    honoCtxBridge.set(bfCtx as Context<unknown>, hc as HonoContext<unknown>)
+  }
+  return hc
+}
+
+/**
+ * SSR `useContext`: read from Hono's per-render stack, falling back to the
+ * BarefootJS Context's default value. Throws when no provider is in scope and
+ * the context was created without a default — matching client semantics.
+ */
+export function useContext<T>(bfCtx: Context<T>): T {
+  const hc = getHonoContext(bfCtx)
+  const v = honoUseContext(hc) as T | undefined
+  if (v !== undefined) return v
+  if (bfCtx._hasDefault) return bfCtx.defaultValue as T
+  throw new Error('useContext: no provider found and no default value (SSR)')
+}
+
+/**
+ * SSR `provideContext`: imperative provider calls inside init code are
+ * unreachable from SSR templates (they live in client JS). At SSR, the
+ * `<Context.Provider value=...>` JSX is compiled to `provideContextSSR`
+ * instead, which uses Hono's stack-scoped Provider.
+ */
+export function provideContext<T>(_bfCtx: Context<T>, _value: T): void {
+  // intentional no-op
+}
+
+/**
+ * Compiler-emitted helper for `<Context.Provider value=...>{children}</...>`
+ * at SSR. Wraps children with the bridged Hono Provider so that descendants
+ * resolving the same BarefootJS Context via `useContext` see this value.
+ */
+export function provideContextSSR<T>(
+  bfCtx: Context<T>,
+  value: T,
+  children: unknown,
+): unknown {
+  const HonoCtx = getHonoContext(bfCtx)
+  return jsx(HonoCtx.Provider as unknown as Function, { value, children })
+}
+
+// ---------------------------------------------------------------------------
+// Reactive primitives — never reached at SSR (compiler rewrites call sites)
+// ---------------------------------------------------------------------------
+
+function calledAtSSR(name: string): never {
+  throw new Error(
+    `[barefootjs] ${name}() reached SSR. The compiler should have rewritten this call site — please report a bug.`,
+  )
+}
+
+export function createSignal<T>(_initial?: T): never {
+  return calledAtSSR('createSignal')
+}
+export function createMemo<T>(_fn: () => T): never {
+  return calledAtSSR('createMemo')
+}
+export function createEffect(_fn: () => void): never {
+  return calledAtSSR('createEffect')
+}
+export function createDisposableEffect(_fn: () => void): never {
+  return calledAtSSR('createDisposableEffect')
+}
+export function createRoot<T>(_fn: (dispose: () => void) => T): never {
+  return calledAtSSR('createRoot')
+}
+
+export function onMount(_fn: () => void): void {
+  // no-op at SSR
+}
+export function onCleanup(_fn: () => void): void {
+  // no-op at SSR
+}
+
+export function untrack<T>(fn: () => T): T {
+  return fn()
+}
+export function batch<T>(fn: () => T): T {
+  return fn()
+}
+
+// ---------------------------------------------------------------------------
+// Portal stubs — portals are realized at hydration time, not at SSR
+// ---------------------------------------------------------------------------
+
+export function createPortal(
+  _children: unknown,
+  _container?: unknown,
+  _options?: unknown,
+): never {
+  return calledAtSSR('createPortal')
+}
+
+export function isSSRPortal(_element: unknown): boolean {
+  return false
+}
+
+export function findSiblingSlot(_el: unknown, _slotSelector: string): null {
+  return null
+}
+
+export function cleanupPortalPlaceholder(_portalId: string): void {
+  // no-op
+}

--- a/packages/jsx/src/__tests__/ssr-client-shim-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/ssr-client-shim-rewrite.test.ts
@@ -1,0 +1,129 @@
+/**
+ * SSR client-shim import rewrite (#1084).
+ *
+ * The compiler used to strip every `@barefootjs/client` import from the SSR
+ * template, which left bindings like `useContext` undefined when the call
+ * site survived reachability analysis. We now rewrite those imports to the
+ * adapter-provided shim source so SSR can resolve the symbols.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+const onlyErrors = (errors: { severity?: string }[]) =>
+  errors.filter(e => e.severity === 'error')
+
+describe('SSR client-shim rewrite (#1084)', () => {
+  test('Hono adapter rewrites @barefootjs/client to the client-shim source', () => {
+    const source = `
+      'use client'
+      import { createMemo, useContext } from '@barefootjs/client'
+      import { BarChartContext } from './bar-chart-context'
+
+      export function CartesianGrid() {
+        const ctx = useContext(BarChartContext)
+        const lines = createMemo(() => {
+          const ys = ctx.yScale()
+          if (!ys) return []
+          return ys.ticks().map((tick) => ({ y: ys(tick) }))
+        })
+        return <g class="chart-grid">{lines().map((l) => <line key={l.y} y1={l.y} y2={l.y} />)}</g>
+      }
+    `
+    const result = compileJSXSync(source, 'CartesianGrid.tsx', { adapter: new HonoAdapter() })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const tpl = result.files.find(f => f.type === 'markedTemplate')!
+    // Old behaviour: no import survived. New behaviour: shim import emitted.
+    expect(tpl.content).toContain("from '@barefootjs/hono/client-shim'")
+    expect(tpl.content).not.toMatch(/from '@barefootjs\/client'/)
+    // The user's named imports flow into the shim import.
+    expect(tpl.content).toMatch(/import \{[^}]*\buseContext\b[^}]*\} from '@barefootjs\/hono\/client-shim'/)
+    // The useContext call site is preserved verbatim (no longer dropped).
+    expect(tpl.content).toContain('const ctx = useContext(BarChartContext)')
+  })
+
+  test('TestAdapter (no clientShimSource) keeps the legacy strip behaviour', () => {
+    const source = `
+      'use client'
+      import { createSignal, useContext } from '@barefootjs/client'
+
+      export function Box() {
+        const [n] = createSignal(0)
+        return <div>{n()}</div>
+      }
+    `
+    const adapter = new TestAdapter()
+    expect((adapter as { clientShimSource?: string }).clientShimSource).toBeUndefined()
+
+    const result = compileJSXSync(source, 'Box.tsx', { adapter })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const tpl = result.files.find(f => f.type === 'markedTemplate')!
+    // No shim source set: imports remain stripped (legacy behaviour).
+    expect(tpl.content).not.toContain('@barefootjs/client')
+  })
+
+  test('Hono adapter renders <Context.Provider> as provideContextSSR()', () => {
+    const source = `
+      'use client'
+      import { createContext, createSignal } from '@barefootjs/client'
+      const Ctx = createContext()
+      export function Tabs({ children }) {
+        const [active, setActive] = createSignal(0)
+        return (
+          <Ctx.Provider value={{ active, setActive }}>
+            <div>{children}</div>
+          </Ctx.Provider>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Tabs.tsx', { adapter: new HonoAdapter() })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const tpl = result.files.find(f => f.type === 'markedTemplate')!
+    expect(tpl.content).toContain('provideContextSSR(Ctx, { active, setActive }')
+    // The helper is auto-imported from the shim even though the user did not
+    // reference it in source.
+    expect(tpl.content).toMatch(/import \{[^}]*\bprovideContextSSR\b[^}]*\} from '@barefootjs\/hono\/client-shim'/)
+  })
+
+  test('Hono adapter merges provideContextSSR into the user-rewritten shim import', () => {
+    const source = `
+      'use client'
+      import { createContext, useContext } from '@barefootjs/client'
+      const Ctx = createContext('default')
+      function Inner() {
+        const v = useContext(Ctx)
+        return <span>{v}</span>
+      }
+      export function Outer() {
+        return (
+          <Ctx.Provider value="hi">
+            <Inner />
+          </Ctx.Provider>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Outer.tsx', { adapter: new HonoAdapter() })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const tpl = result.files.find(f => f.type === 'markedTemplate')!
+    // The shim provideContextSSR import is emitted on its own line so the
+    // compiler's per-line dedupe collapses it across components.
+    const providerImportLines = tpl.content
+      .split('\n')
+      .filter(l => /provideContextSSR/.test(l) && l.startsWith('import'))
+    expect(providerImportLines.length).toBe(1)
+
+    // The user-rewritten useContext import survives alongside.
+    expect(tpl.content).toMatch(
+      /import \{[^}]*\buseContext\b[^}]*\} from '@barefootjs\/hono\/client-shim'/,
+    )
+
+    // Provider's static string value renders quoted, not as raw identifier.
+    expect(tpl.content).toContain('provideContextSSR(Ctx, "hi"')
+  })
+})

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -48,6 +48,18 @@ export interface TemplateAdapter {
    * Required for adapters that look up templates by filename (e.g. Mojolicious).
    */
   templatesPerComponent?: boolean
+  /**
+   * Module specifier of the SSR shim for `@barefootjs/client` (and
+   * `/runtime`). When set, the compiler rewrites client-package imports in
+   * SSR templates to point at this shim instead of stripping them. The shim
+   * is expected to provide SSR-safe stubs for `useContext`, `provideContext`,
+   * pure helpers (`splitProps`, `unwrap`, ...), and throwing stubs for
+   * reactive primitives that the compiler should never reach at SSR.
+   *
+   * When undefined, the compiler keeps the legacy whole-package strip
+   * behaviour for adapters that do not run JS at SSR (e.g. go-template).
+   */
+  clientShimSource?: string
 
   // Main entry point - generates complete template from IR
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -20,6 +20,14 @@ export interface TemplateSections {
   types: string
   component: string
   defaultExport: string
+  /**
+   * Module-scope statements (e.g. SSR-side context bindings emitted by the
+   * Hono adapter). Placed between `imports` and `types` in the assembled
+   * template. Multi-component compilation dedupes this section by exact
+   * string equality — adapters must emit the same content for every
+   * component in a source file.
+   */
+  moduleConstants?: string
 }
 
 export interface AdapterOutput {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -7,6 +7,7 @@
 import type {
   ComponentIR,
   ImportInfo,
+  ImportSpecifier,
   IRMetadata,
   CompileOptions,
   CompileResult,
@@ -28,16 +29,59 @@ export interface CompileOptionsWithAdapter extends CompileOptions {
 }
 
 /**
- * Client-side package sources that should be excluded from template imports.
- * These packages are only needed by client JS, not by server-side templates.
+ * Client-side package sources that need adapter-specific SSR handling.
+ * When the adapter provides a `clientShimSource`, imports from these paths
+ * are rewritten to that shim. Otherwise (e.g. go-template, which has no JS
+ * runtime at SSR), the imports are stripped wholesale.
  */
 const CLIENT_PACKAGE_SOURCES = new Set([
   '@barefootjs/client',
   '@barefootjs/client/runtime',
 ])
 
-function filterTemplateImports(imports: ImportInfo[]): ImportInfo[] {
-  return imports.filter(imp => !CLIENT_PACKAGE_SOURCES.has(imp.source))
+function rewriteTemplateImports(
+  imports: ImportInfo[],
+  shimSource: string | undefined,
+): ImportInfo[] {
+  if (!shimSource) {
+    return imports.filter(imp => !CLIENT_PACKAGE_SOURCES.has(imp.source))
+  }
+  const merged = new Map<string, ImportInfo>()
+  const result: ImportInfo[] = []
+  for (const imp of imports) {
+    if (!CLIENT_PACKAGE_SOURCES.has(imp.source)) {
+      result.push(imp)
+      continue
+    }
+    // Rewrite to the shim source. Multiple original sources collapse into a
+    // single import statement so the SSR template stays clean.
+    const existing = merged.get(shimSource)
+    if (existing) {
+      // Merge specifiers, deduplicating by (name, alias, isDefault, isNamespace)
+      const seen = new Set(existing.specifiers.map(specKey))
+      for (const spec of imp.specifiers) {
+        if (!seen.has(specKey(spec))) {
+          existing.specifiers.push(spec)
+          seen.add(specKey(spec))
+        }
+      }
+      // Type-only stays only if every contributing import is type-only
+      existing.isTypeOnly = existing.isTypeOnly && imp.isTypeOnly
+    } else {
+      const rewritten: ImportInfo = {
+        ...imp,
+        source: shimSource,
+        specifiers: imp.specifiers.map(s => ({ ...s })),
+      }
+      merged.set(shimSource, rewritten)
+      result.push(rewritten)
+    }
+  }
+  return result
+}
+
+function specKey(s: ImportSpecifier): string {
+  return `${s.isDefault ? 'd' : ''}${s.isNamespace ? 'n' : ''}:${s.name}:${s.alias ?? ''}`
 }
 
 /**
@@ -90,7 +134,7 @@ export async function compileJSX(
 
   const componentIR: ComponentIR = {
     version: '0.1',
-    metadata: buildMetadata(ctx),
+    metadata: buildMetadata(ctx, options.adapter.clientShimSource),
     root: ir,
     errors: [],
   }
@@ -199,7 +243,7 @@ function compileMultipleComponentsSync(
 
     const componentIR: ComponentIR = {
       version: '0.1',
-      metadata: buildMetadata(ctx),
+      metadata: buildMetadata(ctx, options.adapter.clientShimSource),
       root: ir,
       errors: [],
     }
@@ -486,7 +530,8 @@ async function compileMultipleComponents(
 // =============================================================================
 
 export function buildMetadata(
-  ctx: ReturnType<typeof analyzeComponent>
+  ctx: ReturnType<typeof analyzeComponent>,
+  clientShimSource?: string
 ): IRMetadata {
   return {
     componentName: ctx.componentName || 'Unknown',
@@ -505,7 +550,7 @@ export function buildMetadata(
     onMounts: ctx.onMounts,
     initStatements: ctx.initStatements,
     imports: ctx.imports,
-    templateImports: filterTemplateImports(ctx.imports),
+    templateImports: rewriteTemplateImports(ctx.imports, clientShimSource),
     namedExports: ctx.namedExports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
@@ -549,7 +594,7 @@ export function compileJSXSync(
 
   const componentIR: ComponentIR = {
     version: '0.1',
-    metadata: buildMetadata(ctx),
+    metadata: buildMetadata(ctx, options.adapter.clientShimSource),
     root: ir,
     errors: [],
   }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -164,7 +164,7 @@ export async function compileJSX(
   if (adapterOutput.sections) {
     const s = adapterOutput.sections
     const component = applyExportKeyword(s.component, componentIR)
-    content = [s.imports, s.types, moduleExports, component]
+    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, component]
       .filter(Boolean).join('\n\n') + (s.defaultExport || '')
   } else {
     content = adapterOutput.template
@@ -273,6 +273,14 @@ function compileMultipleComponentsSync(
     }
   }
 
+  // Module-scope statements (e.g. SSR-side context bindings) are file-wide:
+  // every component in the same source file generates the same block, so we
+  // collect via exact-string dedup and emit once at the file level rather
+  // than per component (per-line dedup of imports drops repeated lines like
+  // closing `})` that recur across multiple multi-line bindings).
+  const moduleConstantsSet = new Set<string>()
+  const moduleConstantsOrdered: string[] = []
+
   for (const { componentIR } of entries) {
     const scriptBaseName = !componentIR.metadata.hasDefaultExport && defaultExportName ? defaultExportName : undefined
     const adapterOutput = adapter.generate(componentIR, { scriptBaseName })
@@ -288,6 +296,11 @@ function compileMultipleComponentsSync(
       imports = s.imports
       types = s.types
       component = applyExportKeyword(s.component, componentIR) + (s.defaultExport || '')
+      const mc = s.moduleConstants
+      if (mc && !moduleConstantsSet.has(mc)) {
+        moduleConstantsSet.add(mc)
+        moduleConstantsOrdered.push(mc)
+      }
     } else {
       // Fallback: parse template string (for adapters without sections)
       const lines = adapterOutput.template.split('\n')
@@ -429,6 +442,7 @@ function compileMultipleComponentsSync(
   // Combine all components
   const combinedTemplate = [
     mergedImports,
+    moduleConstantsOrdered.join('\n\n'),
     uniqueTypes.join('\n\n'),
     uniqueModuleExports.length > 0 ? uniqueModuleExports.join('\n') : '',
     ...allOutputs.map(o => o.component),
@@ -624,7 +638,7 @@ export function compileJSXSync(
   if (adapterOutput.sections) {
     const s = adapterOutput.sections
     const component = applyExportKeyword(s.component, componentIR)
-    content = [s.imports, s.types, moduleExports, component]
+    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, component]
       .filter(Boolean).join('\n\n') + (s.defaultExport || '')
   } else {
     content = adapterOutput.template


### PR DESCRIPTION
## Summary

Implements Option B from #1084: replace the wholesale `@barefootjs/client` strip in SSR templates with an adapter-aware import rewrite, and ship a Hono-side shim that bridges BarefootJS Context objects to Hono's per-render context stack.

- `TemplateAdapter` gains `clientShimSource?: string`. When set, the compiler rewrites `@barefootjs/client` (and `/runtime`) imports in SSR templates to that shim source instead of stripping them. When unset (e.g. `go-template`), the legacy strip is preserved.
- New module `@barefootjs/hono/client-shim` exports SSR-safe stubs:
  - `useContext` reads from Hono's per-render context stack via a lazily-created Hono context bridged 1:1 with each BarefootJS Context.
  - `provideContextSSR(bfCtx, value, children)` is a compiler-emitted helper that wraps children with the bridged Hono `Context.Provider` so descendants see the provided value.
  - `provideContext` is a no-op at SSR (imperative client-init calls are unreachable from SSR templates).
  - Reactive primitives (`createSignal`/`createMemo`/etc.) throw if they reach SSR — the compiler is expected to rewrite those call sites away.
  - Pure helpers (`createContext`, `splitProps`, `forwardProps`, `unwrap`, `__slot`) re-export the real implementations.
- `HonoAdapter` renders `IRProvider` as `<>{provideContextSSR(Ctx, value, <>...children...</>)}</>` and auto-injects the shim import.
- Module-level `const Ctx = createContext()` bindings are now emitted at module scope of the SSR template so the producer/consumer in the same render share the same Context object identity.

## Why

The chart-primitive migration in step 2 of #1080 needs primitives that read parent scales via `useContext` inside `createMemo`. Before this PR, the wholesale strip meant the compiled SSR file imported nothing from `@barefootjs/client`, while the surviving `const ctx = useContext(BarChartContext)` line crashed with `ReferenceError: useContext is not defined`. The only workaround was `/* @client */` on every dynamic JSX expression, which collapsed SSR output to an empty placeholder — defeating the point of going JSX-native.

With this PR, the SSR HTML for context-consuming primitives reflects the provided value (e.g. real `<line y1=\"10\">` markup for chart grids) instead of crashing or emitting an empty shell.

## Tests

- New `packages/jsx/src/__tests__/ssr-client-shim-rewrite.test.ts`: compiler rewrite contract — adapter-keyed shim source, TestAdapter legacy strip preserved, provider IR emits `provideContextSSR(...)`, multi-component dedupe.
- New `packages/adapter-hono/src/__tests__/ssr-context-bridge.test.ts`: end-to-end Hono SSR — `useContext` returns the provider value at SSR, falls back to default when no provider is in scope, and a memo body that depends on a context value renders three real `<line>` elements (mirrors the chart primitive scenario from the issue).
- All 1883 existing tests still pass.

## Test plan

- [x] `bun run --filter '@barefootjs/client' --filter '@barefootjs/jsx' --filter '@barefootjs/hono' --filter '@barefootjs/go-template' build`
- [x] `bun run --filter '*' build` (only pre-existing `table-demo.tsx` BF023 warning surfaces — unrelated)
- [x] `bun run test` (1883 pass / 0 fail)
- [ ] Manual smoke-test with `bun run --cwd site/ui server.tsx` against a chart route once #1080 step 2 lands a real consumer

## Notes / follow-ups

- This PR keeps `@barefootjs/client` Hono-free; the shim lives in the Hono adapter package. Other adapters that compile to JS at SSR can ship their own shim by setting `clientShimSource`.
- Exported module-level `createContext` bindings (`export const Ctx = ...`) are out of scope — only unexported module-level ones are emitted at SSR module scope. Easy follow-up if the chart migration needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>