### PR TITLE
fix(theme-switcher): icon grows after toggle on ui.barefootjs.dev

### DIFF
--- a/site/shared/components/theme-switcher.tsx
+++ b/site/shared/components/theme-switcher.tsx
@@ -47,23 +47,6 @@ function writeThemeCookie(theme: Theme): void {
   document.cookie = parts.join('; ')
 }
 
-function SunIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
-    </svg>
-  )
-}
-
-function MoonIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-    </svg>
-  )
-}
-
 export function ThemeSwitcher(props: ThemeSwitcherProps) {
   const [theme, setTheme] = createSignal<Theme>('light')
   const [initialized, setInitialized] = createSignal(false)
@@ -121,7 +104,16 @@ export function ThemeSwitcher(props: ThemeSwitcherProps) {
       className={props.className || "inline-flex items-center justify-center w-9 h-9 rounded-md text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-colors"}
       aria-label={isDark() ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      {isDark() ? <SunIcon /> : <MoonIcon />}
+      {isDark() ? (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
     </button>
   )
 }

--- a/site/ui/e2e/theme-switcher.spec.ts
+++ b/site/ui/e2e/theme-switcher.spec.ts
@@ -96,6 +96,22 @@ test.describe('ThemeSwitcher', () => {
     expect(themeCookie?.value).toBe('dark')
   })
 
+  test('icon stays 20x20 after toggle', async ({ page }) => {
+    // Regression: site/ui registers its own SunIcon/MoonIcon under
+    // ui/components/ui/icon, so when ThemeSwitcher's icons were registered
+    // as components with the same name they collided in the global
+    // component registry, and the swap rendered the lucide-style icon
+    // without width/height attributes (sized to fill the button).
+    const themeSwitcher = page.locator('header button[aria-label*="mode"]')
+    const initial = await themeSwitcher.locator('svg').boundingBox()
+    expect(initial?.width).toBe(20)
+    expect(initial?.height).toBe(20)
+    await themeSwitcher.click()
+    const afterToggle = await themeSwitcher.locator('svg').boundingBox()
+    expect(afterToggle?.width).toBe(20)
+    expect(afterToggle?.height).toBe(20)
+  })
+
   test('header contains logo and UI link', async ({ page }) => {
     await expect(page.locator('header a:has(svg)').first()).toBeVisible()
     await expect(page.locator('header a:has-text("UI")')).toBeVisible()


### PR DESCRIPTION
## Summary
ThemeSwitcher's inner `SunIcon` / `MoonIcon` JSX components were compiled into globally-registered children. site/ui already registers identically-named icons under `ui/components/ui/icon` (lucide-style, no `width`/`height` when used without a `size` prop). At runtime, `renderChild('SunIcon')` returned the wrong component, and the swapped SVG had no size attributes — sizing to fill the button (~36×36).

Symptoms:
- Toggling the theme on `https://ui.barefootjs.dev/` made the icon grow.
- `barefootjs.dev` (site/core) was unaffected because it doesn't register a colliding `SunIcon`/`MoonIcon`.
- Reloading restored the correct size because the SSR template hard-codes the right icon — only the runtime swap was broken.

Fix: inline the two SVGs directly in `ThemeSwitcher`'s JSX. The compiler now emits raw `<svg>` markup in the `insert()` branch templates instead of going through the global component registry, so the collision can't happen.

Added a regression e2e (`icon stays 20x20 after toggle`) that asserts the SVG bounding box is 20×20 both before and after the click.

## Test plan
- [x] `site/ui` clean build
- [x] `bun test --cwd . __tests__` — 1883 pass / 0 fail
- [x] `site/ui` theme-switcher e2e — 7/7 pass (incl. new regression test)
- [x] Manual: navigate to local site/ui, click ThemeSwitcher, confirm icon stays 20×20

🤖 Generated with [Claude Code](https://claude.com/claude-code)