### PR TITLE
compiler: scope non-exported component names to source file

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1890,7 +1890,8 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // Stateless component must register a template so renderChild() can find it
+      // Stateless component must register a template so renderChild() can find it.
+      // CheckIcon is exported here so the registry key stays unscoped.
       expect(content).toContain("hydrate('CheckIcon',")
       expect(content).toContain('template:')
 
@@ -2019,17 +2020,20 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // Both icon components must have templates registered
-      expect(content).toContain("hydrate('CopyIcon',")
-      expect(content).toContain("hydrate('CheckIcon',")
+      // Both icon components must have templates registered. They're
+      // non-exported helpers so they get a file-scoped registry key
+      // (`CopyIcon__<hash>`) — the parent's `renderChild` call uses
+      // the same key, so the lookup still resolves locally.
+      expect(content).toMatch(/hydrate\('CopyIcon(?:__[a-f0-9]+)?',/)
+      expect(content).toMatch(/hydrate\('CheckIcon(?:__[a-f0-9]+)?',/)
 
       // Both should have template functions
-      expect(content).toMatch(/hydrate\('CopyIcon',\s*\{[^}]*template:/)
-      expect(content).toMatch(/hydrate\('CheckIcon',\s*\{[^}]*template:/)
+      expect(content).toMatch(/hydrate\('CopyIcon(?:__[a-f0-9]+)?',\s*\{[^}]*template:/)
+      expect(content).toMatch(/hydrate\('CheckIcon(?:__[a-f0-9]+)?',\s*\{[^}]*template:/)
 
-      // Parent should use renderChild for the icons
-      expect(content).toContain("renderChild('CheckIcon'")
-      expect(content).toContain("renderChild('CopyIcon'")
+      // Parent should use renderChild for the icons (with the same scoped key).
+      expect(content).toMatch(/renderChild\('CheckIcon(?:__[a-f0-9]+)?'/)
+      expect(content).toMatch(/renderChild\('CopyIcon(?:__[a-f0-9]+)?'/)
     })
 
     test('regression: AST-based identifier extraction distinguishes property keys from ternary branches', () => {
@@ -2060,11 +2064,12 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // Both child components must have templates registered
-      expect(content).toContain("hydrate('StatusOn',")
-      expect(content).toContain("hydrate('StatusOff',")
-      expect(content).toContain("renderChild('StatusOn'")
-      expect(content).toContain("renderChild('StatusOff'")
+      // Both child components must have templates registered. Local
+      // helpers are file-scoped — see the previous test for context.
+      expect(content).toMatch(/hydrate\('StatusOn(?:__[a-f0-9]+)?',/)
+      expect(content).toMatch(/hydrate\('StatusOff(?:__[a-f0-9]+)?',/)
+      expect(content).toMatch(/renderChild\('StatusOn(?:__[a-f0-9]+)?'/)
+      expect(content).toMatch(/renderChild\('StatusOff(?:__[a-f0-9]+)?'/)
     })
 
     test('component event handler props are not bound as native DOM events (#551)', () => {

--- a/packages/jsx/src/__tests__/component-scope.test.ts
+++ b/packages/jsx/src/__tests__/component-scope.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Compiler-level coverage for file-scoped component name disambiguation.
+ *
+ * Locks in the invariant that originally fired the
+ * "ThemeSwitcher icon grows after toggle" production bug
+ * (https://github.com/piconic-ai/barefootjs/pull/1093):
+ *
+ *   - non-exported helpers in two different files MUST register under
+ *     distinct hydrate keys, so the runtime registry can't be clobbered
+ *     by a same-named component from another module
+ *   - exported components MUST keep their original name so
+ *     `<Imported />` JSX in a third file still resolves the same way
+ *   - within a single file, non-exported helpers' hydrate / renderChild
+ *     keys must agree (otherwise the local lookup itself breaks)
+ *
+ * All three are direct consequences of the rewrite in
+ * `ir-to-client-js/component-scope.ts`; the regressions they prevent
+ * are silent (wrong template returned, no error thrown), so unit
+ * coverage at the compiler boundary is more valuable than relying on
+ * downstream e2e to catch them.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { computeFileScope } from '../ir-to-client-js/component-scope'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJs(result: ReturnType<typeof compileJSXSync>): string {
+  const file = result.files.find((f) => f.type === 'clientJs')
+  if (!file) throw new Error('expected clientJs output')
+  return file.content
+}
+
+const themeSwitcherSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+
+  function SunIcon() {
+    return <svg width="20" height="20"><path d="sun" /></svg>
+  }
+
+  function MoonIcon() {
+    return <svg width="20" height="20"><path d="moon" /></svg>
+  }
+
+  export function ThemeSwitcher() {
+    const [dark, setDark] = createSignal(false)
+    return (
+      <button onClick={() => setDark(v => !v)}>
+        {dark() ? <SunIcon /> : <MoonIcon />}
+      </button>
+    )
+  }
+`
+
+// Same component identifiers as themeSwitcherSource, but exported as
+// the public API of an icon library — the production collision shape.
+const iconLibrarySource = `
+  'use client'
+  export function SunIcon() {
+    return <svg><path d="lucide-sun" /></svg>
+  }
+  export function MoonIcon() {
+    return <svg><path d="lucide-moon" /></svg>
+  }
+`
+
+describe('component-scope: file-scoped registry keys for non-exported helpers', () => {
+  test('non-exported helpers in two files register under distinct hydrate keys', () => {
+    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+    const iconJs = clientJs(compileJSXSync(iconLibrarySource, 'ui/components/ui/icon/index.tsx', { adapter }))
+
+    // Theme switcher's local SunIcon is private — must NOT register the
+    // bare name (which would race with the icon library's export).
+    expect(themeJs).not.toMatch(/hydrate\('SunIcon',/)
+    expect(themeJs).toMatch(/hydrate\('SunIcon__[a-f0-9]{8}',/)
+    expect(themeJs).toMatch(/hydrate\('MoonIcon__[a-f0-9]{8}',/)
+
+    // Icon library's exported SunIcon stays unscoped — that's how
+    // cross-file `<SunIcon />` JSX continues to resolve it.
+    expect(iconJs).toMatch(/hydrate\('SunIcon',/)
+    expect(iconJs).toMatch(/hydrate\('MoonIcon',/)
+    expect(iconJs).not.toMatch(/hydrate\('SunIcon__/)
+  })
+
+  test('exported main component is not scoped even when it has non-exported siblings', () => {
+    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+    expect(themeJs).toMatch(/hydrate\('ThemeSwitcher',/)
+    expect(themeJs).not.toMatch(/hydrate\('ThemeSwitcher__/)
+  })
+
+  test('within one file, hydrate / renderChild / initChild use the same scoped key', () => {
+    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+
+    // Pull the suffix from the hydrate registration so the assertion
+    // fails loudly if the rewrite ever drifts between emit points.
+    const suffix = themeJs.match(/hydrate\('SunIcon(__[a-f0-9]{8})',/)?.[1]
+    expect(suffix).toBeDefined()
+    expect(themeJs).toContain(`renderChild('SunIcon${suffix}'`)
+    expect(themeJs).toContain(`initChild('SunIcon${suffix}'`)
+    expect(themeJs).toContain(`renderChild('MoonIcon${suffix}'`)
+    expect(themeJs).toContain(`initChild('MoonIcon${suffix}'`)
+  })
+
+  test('different file paths produce different scope hashes', () => {
+    const a = computeFileScope('site/shared/components/theme-switcher.tsx')
+    const b = computeFileScope('ui/components/ui/icon/index.tsx')
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^[a-f0-9]{8}$/)
+    expect(b).toMatch(/^[a-f0-9]{8}$/)
+  })
+
+  test('same path produces a stable scope hash', () => {
+    const path = 'site/shared/components/theme-switcher.tsx'
+    expect(computeFileScope(path)).toBe(computeFileScope(path))
+  })
+
+  test('paths sharing a common suffix still hash distinctly', () => {
+    // The xorshift mix in computeFileScope exists specifically so
+    // `a/index.tsx` and `b/index.tsx` don't collapse to neighboring
+    // hashes that share a hex prefix.
+    const a = computeFileScope('packages/foo/src/index.tsx')
+    const b = computeFileScope('packages/bar/src/index.tsx')
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/jsx/src/__tests__/hydrate-template.test.ts
+++ b/packages/jsx/src/__tests__/hydrate-template.test.ts
@@ -87,8 +87,10 @@ describe('hydrate() template generation for signal-bearing components', () => {
     expect(clientJs).toBeDefined()
     const content = clientJs!.content
 
-    // Stateless Child gets a static template (always useful)
-    expect(content).toContain("hydrate('Child', { init: initChild, template:")
+    // Stateless Child gets a static template (always useful).
+    // Non-exported helpers are file-scoped (`Child__<hash>`) so they
+    // cannot collide with same-named components in other modules.
+    expect(content).toMatch(/hydrate\('Child(?:__[a-f0-9]+)?', \{ init: initChild, template:/)
 
     // Parent also gets CSR fallback template for cross-file conditional use
     expect(content).toMatch(/hydrate\('Parent',.*template:/)

--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -332,7 +332,7 @@ describe('plain nested loops without conditional wrapper', () => {
     // before `initChild('MyChild', ...)` runs. `it` is the raw item here
     // (forEach, not mapArray) so the preamble is emitted unwrapped.
     expect(js).toMatch(
-      /\.forEach\(\(it, __innerIdx\) => \{[\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild'/
+      /\.forEach\(\(it, __innerIdx\) => \{[\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild(?:__[a-f0-9]+)?'/
     )
     // No `ReferenceError` shape: the `initChild('MyChild', ...)` getter must
     // reach a declared `lbl` — the static body cannot rely on the outer
@@ -342,7 +342,7 @@ describe('plain nested loops without conditional wrapper', () => {
       js.indexOf('hydrate(\'StaticGrid\''),
     )
     expect(staticSection).toMatch(/const\s+lbl\s*=/)
-    expect(staticSection).toMatch(/initChild\('MyChild'/)
+    expect(staticSection).toMatch(/initChild\('MyChild(?:__[a-f0-9]+)?'/)
     expect(staticSection.indexOf('const lbl')).toBeLessThan(staticSection.indexOf('initChild'))
   })
 
@@ -386,7 +386,7 @@ describe('plain nested loops without conditional wrapper', () => {
       js.indexOf('__childScopes.forEach'),
       js.indexOf('hydrate(\'FlatList\''),
     )
-    expect(section).toMatch(/const\s+it\s*=\s*items\[__idx\][\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild'/)
+    expect(section).toMatch(/const\s+it\s*=\s*items\[__idx\][\s\S]*?const\s+lbl\s*=\s*`item-\$\{it\.n\}`[\s\S]*?initChild\('MyChild(?:__[a-f0-9]+)?'/)
     expect(section.indexOf('const lbl')).toBeLessThan(section.indexOf('initChild'))
   })
 

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -17,6 +17,7 @@ import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listComponentFunctions, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'
+import { setActiveComponentScope, computeFileScope } from './ir-to-client-js/component-scope'
 import { generateModuleExports, collectInlineExportedNames } from './module-exports'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
 
@@ -186,24 +187,38 @@ export async function compileJSX(
   }
 
   const clientJsPath = entryPath.replace(/\.tsx?$/, '.client.js')
-  if (options.sourceMaps) {
-    const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
-      sourceMaps: true,
-      generatedFileName: clientJsPath.split('/').pop(),
-    })
-    errors.push(...componentIR.errors)
-    if (result.code) {
-      files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
-      if (result.sourceMap) {
-        files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+  // Single-component file: only the component itself can collide. Scope it
+  // when it's non-exported so a private helper can't be overwritten by an
+  // identically-named exported component in another file.
+  const singleScope = {
+    fileScope: computeFileScope(entryPath),
+    nonExportedSiblings: componentIR.metadata.isExported
+      ? new Set<string>()
+      : new Set([componentIR.metadata.componentName]),
+  }
+  setActiveComponentScope(singleScope)
+  try {
+    if (options.sourceMaps) {
+      const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
+        sourceMaps: true,
+        generatedFileName: clientJsPath.split('/').pop(),
+      })
+      errors.push(...componentIR.errors)
+      if (result.code) {
+        files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
+        if (result.sourceMap) {
+          files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+        }
+      }
+    } else {
+      const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
+      errors.push(...componentIR.errors)
+      if (clientJs) {
+        files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
       }
     }
-  } else {
-    const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
-    errors.push(...componentIR.errors)
-    if (clientJs) {
-      files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
-    }
+  } finally {
+    setActiveComponentScope(null)
   }
 
   return { files, errors }
@@ -281,6 +296,22 @@ function compileMultipleComponentsSync(
   const moduleConstantsSet = new Set<string>()
   const moduleConstantsOrdered: string[] = []
 
+  // Component-name scope: rewrite `hydrate` / `renderChild` / `initChild` /
+  // `createComponent` / `upsertChild` keys for non-exported helpers
+  // (`function SunIcon` inside theme-switcher.tsx) so they cannot collide
+  // with same-named components from another file in the global runtime
+  // registry. Exported components keep their original name — their cross-
+  // file consumers still resolve them as before.
+  const fileScope = computeFileScope(filePath)
+  const nonExportedSiblings = new Set<string>()
+  for (const { componentIR } of entries) {
+    if (!componentIR.metadata.isExported) {
+      nonExportedSiblings.add(componentIR.metadata.componentName)
+    }
+  }
+  setActiveComponentScope({ fileScope, nonExportedSiblings })
+  try {
+
   for (const { componentIR } of entries) {
     const scriptBaseName = !componentIR.metadata.hasDefaultExport && defaultExportName ? defaultExportName : undefined
     const adapterOutput = adapter.generate(componentIR, { scriptBaseName })
@@ -342,6 +373,9 @@ function compileMultipleComponentsSync(
       adapterTypes: adapterOutput.types || undefined,
     })
     errors.push(...componentIR.errors)
+  }
+  } finally {
+    setActiveComponentScope(null)
   }
 
   if (allOutputs.length === 0) {
@@ -660,24 +694,35 @@ export function compileJSXSync(
   }
 
   const clientJsPath = filePath.replace(/\.tsx?$/, '.client.js')
-  if (options.sourceMaps) {
-    const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
-      sourceMaps: true,
-      generatedFileName: clientJsPath.split('/').pop(),
-    })
-    errors.push(...componentIR.errors)
-    if (result.code) {
-      files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
-      if (result.sourceMap) {
-        files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+  const syncSingleScope = {
+    fileScope: computeFileScope(filePath),
+    nonExportedSiblings: componentIR.metadata.isExported
+      ? new Set<string>()
+      : new Set([componentIR.metadata.componentName]),
+  }
+  setActiveComponentScope(syncSingleScope)
+  try {
+    if (options.sourceMaps) {
+      const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
+        sourceMaps: true,
+        generatedFileName: clientJsPath.split('/').pop(),
+      })
+      errors.push(...componentIR.errors)
+      if (result.code) {
+        files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
+        if (result.sourceMap) {
+          files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
+        }
+      }
+    } else {
+      const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
+      errors.push(...componentIR.errors)
+      if (clientJs) {
+        files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
       }
     }
-  } else {
-    const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
-    errors.push(...componentIR.errors)
-    if (clientJs) {
-      files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
-    }
+  } finally {
+    setActiveComponentScope(null)
   }
 
   return { files, errors }

--- a/packages/jsx/src/ir-to-client-js/component-scope.ts
+++ b/packages/jsx/src/ir-to-client-js/component-scope.ts
@@ -1,0 +1,80 @@
+/**
+ * File-scoped component name disambiguation for the runtime registry.
+ *
+ * Background: every `hydrate('Name', ...)` call shares one global
+ * registry keyed by string name. Two files defining a non-exported
+ * helper with the same identifier (e.g. an internal `<SunIcon>` in
+ * `theme-switcher.tsx` and the public lucide-style `<SunIcon>` in
+ * `ui/components/ui/icon`) overwrite each other at module load time;
+ * the `<SunIcon />` JSX usage then resolves to whichever registration
+ * happened to load last.
+ *
+ * The fix is to rewrite the registry key for components that are
+ * **not exported** — they are private to their source file and can
+ * never legitimately appear in another module — into a file-scoped
+ * form `${name}__${fileScope}` where `fileScope` is a stable 8-char
+ * hash of the entry path. Exported components keep their original
+ * name so cross-file `<Imported />` JSX still resolves the same way
+ * it always has.
+ */
+
+import type { ClientJsContext } from './types'
+
+/**
+ * Compute a stable 8-char hex hash for a source file path.
+ * Uses a simple FNV-1a 32-bit hash so the compiler does not need to
+ * pull in `node:crypto` (the package is bundled for browser-friendly
+ * environments via the playground worker, where node built-ins are
+ * unavailable).
+ */
+export function computeFileScope(entryPath: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < entryPath.length; i++) {
+    h ^= entryPath.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  // Mix once more (FNV-1a + xorshift) to widen the entropy of the
+  // 8-char prefix when paths share a common suffix like
+  // `/index.tsx`.
+  h ^= h >>> 13
+  h = Math.imul(h, 0x5bd1e995)
+  return (h >>> 0).toString(16).padStart(8, '0')
+}
+
+/**
+ * Return the registry key for a component reference.
+ *
+ * - Sibling component that is non-exported → `${name}__${fileScope}`
+ * - Anything else (sibling that is exported, imported, or no file scope
+ *   supplied) → `name` unchanged.
+ */
+export function applyComponentScope(name: string, ctx: ClientJsContext): string {
+  if (!ctx.fileScope) return name
+  if (!ctx.nonExportedSiblings.has(name)) return name
+  return `${name}__${ctx.fileScope}`
+}
+
+/**
+ * Module-level "active scope" used by html-template emission, where
+ * threading a `ctx` through every recursive helper (irToHtmlTemplate,
+ * irToPlaceholderTemplate, irChildrenToJsExpr, generateCsrTemplate, …)
+ * would touch every call site in this package.
+ *
+ * The compiler sets the scope before generating client JS for a file
+ * and clears it on the way out. `nameForRegistryRef(name)` reads the
+ * current scope and rewrites non-exported siblings; everything else
+ * passes through unchanged.
+ */
+let _activeScope: { fileScope: string; nonExportedSiblings: Set<string> } | null = null
+
+export function setActiveComponentScope(scope: { fileScope: string; nonExportedSiblings: Set<string> } | null): void {
+  _activeScope = scope
+}
+
+/** Resolve a component name to its registry key under the active file scope. */
+export function nameForRegistryRef(name: string): string {
+  if (!_activeScope) return name
+  if (!_activeScope.fileScope) return name
+  if (!_activeScope.nonExportedSiblings.has(name)) return name
+  return `${name}__${_activeScope.fileScope}`
+}

--- a/packages/jsx/src/ir-to-client-js/component-scope.ts
+++ b/packages/jsx/src/ir-to-client-js/component-scope.ts
@@ -16,9 +16,14 @@
  * hash of the entry path. Exported components keep their original
  * name so cross-file `<Imported />` JSX still resolves the same way
  * it always has.
+ *
+ * Concurrency note: the active scope below is module-level mutable
+ * state. The compiler is single-threaded today (sync per-file inside
+ * a sequential loop in `compileMultipleComponentsSync`), so this is
+ * safe. If a future build path ever invokes `compileJSX` concurrently
+ * for multiple files in the same process, the scope must be threaded
+ * through the call chain or stashed per-call instead.
  */
-
-import type { ClientJsContext } from './types'
 
 /**
  * Compute a stable 8-char hex hash for a source file path.
@@ -39,19 +44,6 @@ export function computeFileScope(entryPath: string): string {
   h ^= h >>> 13
   h = Math.imul(h, 0x5bd1e995)
   return (h >>> 0).toString(16).padStart(8, '0')
-}
-
-/**
- * Return the registry key for a component reference.
- *
- * - Sibling component that is non-exported → `${name}__${fileScope}`
- * - Anything else (sibling that is exported, imported, or no file scope
- *   supplied) → `name` unchanged.
- */
-export function applyComponentScope(name: string, ctx: ClientJsContext): string {
-  if (!ctx.fileScope) return name
-  if (!ctx.nonExportedSiblings.has(name)) return name
-  return `${name}__${ctx.fileScope}`
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
@@ -17,6 +17,7 @@ import type { IRLoopChildComponent, LoopParamBinding } from '../../types'
 import { quotePropName, wrapLoopParamAsAccessor, exprReferencesIdent } from '../utils'
 import { irChildrenToJsExpr } from '../html-template'
 import { emitListenerBlock } from './stringify/event-listener'
+import { nameForRegistryRef } from '../component-scope'
 
 /**
  * Build the `keyFn` argument for mapArray / reconcileElements. `null` when
@@ -224,7 +225,7 @@ export function emitComponentAndEventSetup(
     const slotIdLit = comp.slotId ? `'${comp.slotId}'` : 'null'
     const keyProp = comp.props.find(p => p.name === 'key')
     const keyArg = keyProp ? `, ${wrap(keyProp.value)}` : ''
-    const upsertCall = `upsertChild(${elVar}, '${comp.name}', ${slotIdLit}, ${propsExpr}${keyArg})`
+    const upsertCall = `upsertChild(${elVar}, '${nameForRegistryRef(comp.name)}', ${slotIdLit}, ${propsExpr}${keyArg})`
 
     if (childrenRefsLoop) {
       const wrappedChildren = wrap(rawChildrenExpr!)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
@@ -32,6 +32,7 @@
 
 import { stringifyReactiveEffects } from './reactive-effects'
 import type { ComponentLoopPlan, NestedComponentInit } from '../plan/types'
+import { nameForRegistryRef } from '../../component-scope'
 
 export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan): void {
   const {
@@ -51,16 +52,18 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
   lines.push(`  mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   if (paramUnwrap) lines.push(`    ${paramUnwrap}`)
 
+  const scopedComp = nameForRegistryRef(componentName)
+
   if (nestedComps.length === 0) {
-    lines.push(`    if (__existing) { initChild('${componentName}', __existing, ${componentPropsExpr}); return __existing }`)
-    lines.push(`    return createComponent('${componentName}', ${componentPropsExpr}, ${keyExpr})`)
+    lines.push(`    if (__existing) { initChild('${scopedComp}', __existing, ${componentPropsExpr}); return __existing }`)
+    lines.push(`    return createComponent('${scopedComp}', ${componentPropsExpr}, ${keyExpr})`)
     lines.push(`  })`)
     return
   }
 
   // SSR side
   lines.push(`    if (__existing) {`)
-  lines.push(`      initChild('${componentName}', __existing, ${componentPropsExpr})`)
+  lines.push(`      initChild('${scopedComp}', __existing, ${componentPropsExpr})`)
   for (const nc of nestedComps) emitNestedInit(lines, '      ', '__existing', nc)
   if (childConditionalEffects) {
     stringifyReactiveEffects(lines, childConditionalEffects, { indent: '      ', elVar: '__existing' })
@@ -69,7 +72,7 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
   lines.push(`    }`)
 
   // CSR side
-  lines.push(`    const __csrEl = createComponent('${componentName}', ${componentPropsExpr}, ${keyExpr})`)
+  lines.push(`    const __csrEl = createComponent('${scopedComp}', ${componentPropsExpr}, ${keyExpr})`)
   for (const nc of nestedComps) emitNestedInit(lines, '    ', '__csrEl', nc)
   if (childConditionalEffects) {
     stringifyReactiveEffects(lines, childConditionalEffects, { indent: '    ', elVar: '__csrEl' })
@@ -79,9 +82,10 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
 }
 
 function emitNestedInit(lines: string[], indent: string, parentVar: string, nc: NestedComponentInit): void {
+  const scopedNc = nameForRegistryRef(nc.componentName)
   if (nc.childrenTextEffect) {
-    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) { initChild('${nc.componentName}', __c, ${nc.propsExpr}); createEffect(() => { const __v = ${nc.childrenTextEffect.wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
+    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) { initChild('${scopedNc}', __c, ${nc.propsExpr}); createEffect(() => { const __v = ${nc.childrenTextEffect.wrappedChildren}; __c.textContent = Array.isArray(__v) ? __v.join('') : String(__v ?? '') }) } }`)
   } else {
-    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) initChild('${nc.componentName}', __c, ${nc.propsExpr}) }`)
+    lines.push(`${indent}{ const __c = qsa(${parentVar}, '${nc.selector}'); if (__c) initChild('${scopedNc}', __c, ${nc.propsExpr}) }`)
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -33,6 +33,7 @@ import { emitAttrUpdate } from '../../emit-reactive'
 import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types'
 import { stringifyBranchLoops } from './branch-loop'
 import { emitListenerLine } from './event-listener'
+import { nameForRegistryRef } from '../../component-scope'
 
 export interface StringifyInsertOptions {
   /** Indent on the `insert(` line itself. */
@@ -114,7 +115,7 @@ function emitArmBody(
     const varName = `__c${i}`
     const selectorArg = comp.slotId || comp.name
     lines.push(`${indent}const [${varName}] = $c(__branchScope, '${selectorArg}')`)
-    lines.push(`${indent}if (${varName}) initChild('${comp.name}', ${varName}, ${comp.propsExpr})`)
+    lines.push(`${indent}if (${varName}) initChild('${nameForRegistryRef(comp.name)}', ${varName}, ${comp.propsExpr})`)
   }
 
   // 4. Disposable section: reactive attrs + text effects + branch loops + nested conditionals.

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -15,6 +15,7 @@ import { varSlotId, DATA_BF_PH, keyAttrName } from '../../utils'
 import { emitComponentAndEventSetup } from '../shared'
 import { templateRootIsSvg } from './template-parse'
 import { emitListenerLine } from './event-listener'
+import { nameForRegistryRef } from '../../component-scope'
 import type {
   BranchChildComponentInitsPlan,
   BranchEventBindingsPlan,
@@ -64,7 +65,7 @@ export function stringifyBranchChildComponentInits(
   indent: string,
 ): void {
   for (const init of plan) {
-    lines.push(`${indent}{ let __c = qsa(__branchScope, '${init.selector}'); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${init.placeholderId}"]'); if (__ph) { __c = createComponent('${init.name}', ${init.propsExpr}); __ph.replaceWith(__c) } } if (__c) initChild('${init.name}', __c, ${init.propsExpr}) }`)
+    lines.push(`${indent}{ let __c = qsa(__branchScope, '${init.selector}'); if (!__c) { const __ph = __branchScope.querySelector('[${DATA_BF_PH}="${init.placeholderId}"]'); if (__ph) { __c = createComponent('${nameForRegistryRef(init.name)}', ${init.propsExpr}); __ph.replaceWith(__c) } } if (__c) initChild('${nameForRegistryRef(init.name)}', __c, ${init.propsExpr}) }`)
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -9,6 +9,7 @@ import type { ClientJsContext } from './types'
 import { PROPS_PARAM, inferDefaultValue, exprReferencesIdent } from './utils'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, createStringProtector } from './html-template'
+import { nameForRegistryRef } from './component-scope'
 
 /**
  * Resolve chained references within a constants map.
@@ -250,5 +251,5 @@ export function emitRegistrationAndHydration(
     defParts.push('comment: true')
   }
 
-  return `hydrate('${name}', { ${defParts.join(', ')} })`
+  return `hydrate('${nameForRegistryRef(name)}', { ${defParts.join(', ')} })`
 }

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -6,6 +6,7 @@ import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, BF_LOOP_START, BF_LOOP_END, exprReferencesIdent, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
+import { nameForRegistryRef } from './component-scope'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -163,7 +164,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       const keyArg = keyProp ? `, ${keyProp.value}` : ''
       // Pass slotId as suffix so $c() can find the child component by slot after branch swap
       const slotArg = node.slotId ? `, '${node.slotId}'` : ''
-      return `\${renderChild('${node.name}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
+      return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
     }
 
     case 'loop': {
@@ -349,7 +350,7 @@ function irNodeToJsExprs(node: IRNode): string[] {
       }
 
       const propsExpr = propsEntries.length > 0 ? `{ ${propsEntries.join(', ')} }` : '{}'
-      return [`createComponent('${node.name}', ${propsExpr})`]
+      return [`createComponent('${nameForRegistryRef(node.name)}', ${propsExpr})`]
     }
 
     case 'expression':
@@ -544,7 +545,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
-      return `\${renderChild('${node.name}', ${propsExpr}${keyArg})}`
+      return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg})}`
     }
 
     case 'loop': {
@@ -830,7 +831,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
       const slotArg = (!insideLoop && node.slotId) ? `, '${node.slotId}'` : ''
-      return `\${renderChild('${node.name}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
+      return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
     }
 
     case 'loop': {

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -13,6 +13,7 @@ import { addConstantPropRefsToSet } from './init-declarations'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
 import { PROPS_PARAM } from './utils'
 import { buildInlinableConstants, buildSignalAndMemoMaps, buildCsrInlinableConstants } from './emit-registration'
+import { nameForRegistryRef } from './component-scope'
 import { IMPORT_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports } from './imports'
 import { buildSourceMapFromIR, type SourceMapV3 } from './source-map'
 
@@ -21,9 +22,25 @@ export interface ClientJsResult {
   sourceMap?: SourceMapV3
 }
 
+/**
+ * Optional component-name scope info. When supplied, the generator
+ * disambiguates non-exported siblings by rewriting their registry key
+ * to `${name}__${fileScope}` so private helpers can't collide across
+ * files. See component-scope.ts for the full rationale.
+ */
+export interface ScopeInfo {
+  fileScope: string
+  nonExportedSiblings: Set<string>
+}
+
 /** Public entry point: IR → client JS string. Returns '' if no client JS is needed. */
-export function generateClientJs(ir: ComponentIR, siblingComponents?: string[], localImportPrefixes?: string[]): string {
-  return generateClientJsWithSourceMap(ir, siblingComponents, localImportPrefixes).code
+export function generateClientJs(
+  ir: ComponentIR,
+  siblingComponents?: string[],
+  localImportPrefixes?: string[],
+  scope?: ScopeInfo,
+): string {
+  return generateClientJsWithSourceMap(ir, siblingComponents, localImportPrefixes, undefined, scope).code
 }
 
 /**
@@ -35,8 +52,9 @@ export function generateClientJsWithSourceMap(
   siblingComponents?: string[],
   localImportPrefixes?: string[],
   options?: { sourceMaps?: boolean; generatedFileName?: string },
+  scope?: ScopeInfo,
 ): ClientJsResult {
-  const ctx = createContext(ir)
+  const ctx = createContext(ir, scope)
   const siblingOffsets = computeLoopSiblingOffsets(ir.root)
   collectElements(ir.root, ctx, siblingOffsets)
   ir.errors.push(...ctx.warnings)
@@ -64,7 +82,7 @@ export function generateClientJsWithSourceMap(
  * so the adapter can use the results to optimize bf-p serialization.
  */
 export function analyzeClientNeeds(ir: ComponentIR): { needsInit: boolean; usedProps: string[] } {
-  const ctx = createContext(ir)
+  const ctx = createContext(ir, undefined)
   const siblingOffsets = computeLoopSiblingOffsets(ir.root)
   collectElements(ir.root, ctx, siblingOffsets)
 
@@ -99,9 +117,11 @@ export function analyzeClientNeeds(ir: ComponentIR): { needsInit: boolean; usedP
 }
 
 /** Initialize an empty ClientJsContext from component IR metadata. */
-function createContext(ir: ComponentIR): ClientJsContext {
+function createContext(ir: ComponentIR, scope?: ScopeInfo): ClientJsContext {
   return {
     componentName: ir.metadata.componentName,
+    fileScope: scope?.fileScope ?? '',
+    nonExportedSiblings: scope?.nonExportedSiblings ?? new Set(),
     signals: ir.metadata.signals,
     memos: ir.metadata.memos,
     effects: ir.metadata.effects,
@@ -190,13 +210,14 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   }
 
   const name = ctx.componentName
+  const registryKey = nameForRegistryRef(name)
   const lines: string[] = []
 
   lines.push(IMPORT_PLACEHOLDER)
   lines.push('')
   lines.push(`function init${name}() {}`)
   lines.push('')
-  lines.push(`hydrate('${name}', { init: init${name}, template: (${PROPS_PARAM}) => \`${templateHtml}\` })`)
+  lines.push(`hydrate('${registryKey}', { init: init${name}, template: (${PROPS_PARAM}) => \`${templateHtml}\` })`)
 
   const generatedCode = lines.join('\n')
   const usedImports = detectUsedImports(generatedCode)

--- a/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
@@ -13,6 +13,7 @@
 
 import type { ClientJsContext } from '../types'
 import { varSlotId } from '../utils'
+import { nameForRegistryRef } from '../component-scope'
 
 export function emitProviderAndChildInits(lines: string[], ctx: ClientJsContext): void {
   if (ctx.providerSetups.length > 0) {
@@ -28,7 +29,7 @@ export function emitProviderAndChildInits(lines: string[], ctx: ClientJsContext)
     lines.push(`  // Initialize child components with props`)
     for (const child of ctx.childInits) {
       const scopeRef = child.slotId ? `_${varSlotId(child.slotId)}` : '__scope'
-      lines.push(`  initChild('${child.name}', ${scopeRef}, ${child.propsExpr})`)
+      lines.push(`  initChild('${nameForRegistryRef(child.name)}', ${scopeRef}, ${child.propsExpr})`)
     }
   }
 }

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -56,6 +56,7 @@ import type {
   StaticArrayChildInitPlan,
   StaticArrayChildInitsPlan,
 } from '../plan/static-array-child-init'
+import { nameForRegistryRef } from '../component-scope'
 
 export function stringifyStaticArrayChildInits(
   lines: string[],
@@ -93,7 +94,7 @@ function emitSingleComp(lines: string[], plan: SingleCompInitPlan): void {
   for (const stmt of outerPreludeStatements) {
     lines.push(`      ${stmt}`)
   }
-  lines.push(`      initChild('${componentName}', childScope, ${propsExpr})`)
+  lines.push(`      initChild('${nameForRegistryRef(componentName)}', childScope, ${propsExpr})`)
   lines.push(`    })`)
   lines.push(`  }`)
   lines.push('')
@@ -114,7 +115,7 @@ function emitOuterNested(lines: string[], plan: OuterNestedInitPlan): void {
     lines.push(`        ${stmt}`)
   }
   lines.push(`        const __compEl = __iterEl.querySelector('${selector}')`)
-  lines.push(`        if (__compEl) initChild('${componentName}', __compEl, ${propsExpr})`)
+  lines.push(`        if (__compEl) initChild('${nameForRegistryRef(componentName)}', __compEl, ${propsExpr})`)
   lines.push(`      }`)
   lines.push(`    })`)
   lines.push(`  }`)
@@ -162,7 +163,7 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
   }
   for (const comp of comps) {
     lines.push(`        const __compEl = __innerEl.querySelector('${comp.selector}')`)
-    lines.push(`        if (__compEl) initChild('${comp.componentName}', __compEl, ${comp.propsExpr})`)
+    lines.push(`        if (__compEl) initChild('${nameForRegistryRef(comp.componentName)}', __compEl, ${comp.propsExpr})`)
   }
   lines.push(`      })`)
   lines.push(`    })`)

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -19,6 +19,22 @@ import type {
 
 export interface ClientJsContext {
   componentName: string
+  /**
+   * Stable 8-char hash for the source file (e.g., from `entryPath`).
+   * Combined with a component's name, it disambiguates same-name
+   * non-exported helpers across files in the global runtime registry.
+   * Empty string when no file scope was supplied (single-file unit
+   * tests, legacy callers).
+   */
+  fileScope: string
+  /**
+   * Names of components defined in the SAME source file that are NOT
+   * exported. Their `hydrate(...)` registration and every cross-call
+   * (`renderChild`, `initChild`, `createComponent`, …) inside this file
+   * is rewritten to `${name}__${fileScope}` so private helpers cannot
+   * collide with same-named exports from other modules.
+   */
+  nonExportedSiblings: Set<string>
   signals: SignalInfo[]
   memos: MemoInfo[]
   effects: EffectInfo[]

--- a/site/ui/e2e/theme-switcher.spec.ts
+++ b/site/ui/e2e/theme-switcher.spec.ts
@@ -96,6 +96,23 @@ test.describe('ThemeSwitcher', () => {
     expect(themeCookie?.value).toBe('dark')
   })
 
+  test('icon stays 20x20 after toggle', async ({ page }) => {
+    // Regression: site/ui re-exports a SunIcon / MoonIcon under
+    // ui/components/ui/icon (lucide-style, no width/height when used
+    // without a `size` prop). Without compiler-level scoping the local
+    // ThemeSwitcher helpers of the same name collided in the global
+    // component registry, and the swap rendered the lucide icon (no
+    // size attrs) instead — sized to fill the 36px button.
+    const themeSwitcher = page.locator('header button[aria-label*="mode"]')
+    const initial = await themeSwitcher.locator('svg').boundingBox()
+    expect(initial?.width).toBe(20)
+    expect(initial?.height).toBe(20)
+    await themeSwitcher.click()
+    const afterToggle = await themeSwitcher.locator('svg').boundingBox()
+    expect(afterToggle?.width).toBe(20)
+    expect(afterToggle?.height).toBe(20)
+  })
+
   test('header contains logo and UI link', async ({ page }) => {
     await expect(page.locator('header a:has(svg)').first()).toBeVisible()
     await expect(page.locator('header a:has-text("UI")')).toBeVisible()


### PR DESCRIPTION
## Summary

Fixes the root cause of the ThemeSwitcher icon-grows-on-toggle bug on ui.barefootjs.dev (the workaround in #1092 has been closed in favor of this).

## The bug

The runtime component registry is keyed by the JSX identifier alone. `theme-switcher.tsx` defined a non-exported `function SunIcon` (and `MoonIcon`) for use by the `<SunIcon />` JSX inside the same file. site/ui's `ui/components/ui/icon/index.tsx` also exports a `SunIcon` (lucide-style — no `width`/`height` when used without a `size` prop). Both files registered as `hydrate('SunIcon', …)` in the global registry; whichever loaded last won. After hydration, the `insert()` runtime branch swap looked up `'SunIcon'` and returned the lucide template (no size attrs) — resulting in a 36×36 SVG instead of 20×20.

The same collision can fire for any same-named non-exported helper in any pair of files.

## The fix

Rewrite the registry key for components that are **not exported** into `${name}__${fileScope}` where `fileScope` is a stable 8-char FNV hash of the source file path. Exported components keep their original name — cross-file `<Imported />` JSX still resolves identically to before.

The rewrite covers every emit point that reads or writes the registry:
- `hydrate(...)` — registration (emit-registration.ts, index.ts templateOnlyMount)
- `renderChild(...)` — template evaluation (html-template.ts × 3)
- `createComponent(...)` — CSR composite reconciliation (html-template.ts, component-loop.ts, loop-child-arm.ts)
- `initChild(...)` — hydration init (provider-and-child-inits.ts, static-array-child-init.ts × 3, insert.ts, component-loop.ts × N, loop-child-arm.ts)
- `upsertChild(...)` — branch-swap inserts (control-flow/shared.ts)

Resolver lives in `packages/jsx/src/ir-to-client-js/component-scope.ts`. The compiler sets a module-level "active scope" once per file (multi-component path) and clears it via try/finally on the way out, so the threadsafe shape that runtime emitters expect is preserved without threading `ctx` through every recursive HTML helper.

## Behavior

| Component shape | Before | After |
|-----------------|--------|-------|
| `function SunIcon` (non-exported, in `theme-switcher.tsx`) | `hydrate('SunIcon', …)` | `hydrate('SunIcon__8dd5b36a', …)` |
| `export function SunIcon` (in `ui/components/ui/icon`) | `hydrate('SunIcon', …)` | `hydrate('SunIcon', …)` (unchanged) |
| `<SunIcon />` JSX inside `theme-switcher.tsx` | `renderChild('SunIcon', …)` | `renderChild('SunIcon__8dd5b36a', …)` |
| `<SunIcon />` JSX in a file that imports from `icon/index.tsx` | `renderChild('SunIcon', …)` | `renderChild('SunIcon', …)` (unchanged) |

Cross-file collisions between two files exporting the same name remain a separate concern (rare, user-fixable by renaming).

## Test plan

- [x] `bun test --cwd . __tests__` — 1883 pass / 0 fail (3 test files relaxed unscoped-name regexes for the non-exported-helper case)
- [x] `site/ui` clean build emits scoped keys for non-exported helpers, unscoped for exports
- [x] `site/ui` full e2e — 1085/1085 pass (no regressions)
- [x] Manual reproduction with `theme-switcher.tsx`'s original (non-inlined) `SunIcon` / `MoonIcon` — toggle keeps the icon at 20×20
- [x] Added regression e2e: `ThemeSwitcher › icon stays 20x20 after toggle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)