### PR TITLE
add `create-barefootjs`: `npm create barefootjs@latest <dir>` entrypoint

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -48,6 +48,7 @@ jobs:
           bun run --filter '@barefootjs/go-template' build
           bun run --filter '@barefootjs/mojolicious' build
           bun run --filter '@barefootjs/cli' build
+          bun run --filter 'create-barefootjs' build
 
       # Single invocation across all preview-publishable packages.
       # `@barefootjs/preview` is private and `@barefootjs/adapter-tests` is an
@@ -65,5 +66,6 @@ jobs:
             './packages/adapter-go-template' \
             './packages/adapter-mojolicious' \
             './packages/cli' \
+            './packages/create-barefootjs' \
             './packages/shared' \
             './packages/streaming'

--- a/packages/create-barefootjs/package.json
+++ b/packages/create-barefootjs/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "create-barefootjs",
+  "version": "0.0.1",
+  "description": "Scaffold a new BarefootJS app — `npm create barefootjs@latest <dir>`",
+  "type": "module",
+  "main": "./dist/index.js",
+  "bin": {
+    "create-barefootjs": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "node ./scripts/build.mjs",
+    "clean": "rm -rf dist",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@barefootjs/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0",
+    "@types/node": "^22.0.0"
+  },
+  "keywords": [
+    "barefootjs",
+    "create",
+    "starter",
+    "scaffold"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piconic-ai/barefootjs",
+    "directory": "packages/create-barefootjs"
+  },
+  "license": "MIT"
+}

--- a/packages/create-barefootjs/scripts/build.mjs
+++ b/packages/create-barefootjs/scripts/build.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Bundle create-barefootjs into a single file for npm distribution.
+//
+// - Entry: src/index.ts
+// - Output: dist/index.js (ESM, single file with shebang)
+// - All deps are bundle-internal except @barefootjs/cli, which is left
+//   external so `require.resolve('@barefootjs/cli/dist/index.js')` at
+//   runtime hits the consumer's installed CLI bin.
+
+import { build } from 'esbuild'
+import { chmodSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgDir = resolve(here, '..')
+const entry = resolve(pkgDir, 'src/index.ts')
+const outfile = resolve(pkgDir, 'dist/index.js')
+
+await build({
+  entryPoints: [entry],
+  outfile,
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node22',
+  external: ['@barefootjs/cli'],
+  legalComments: 'none',
+  logLevel: 'info',
+})
+
+chmodSync(outfile, 0o755)
+console.log(`Built: ${outfile}`)

--- a/packages/create-barefootjs/src/index.ts
+++ b/packages/create-barefootjs/src/index.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+//
+// `create-barefootjs` — entrypoint for `npm create barefootjs@latest`.
+//
+// Thin wrapper around the existing `barefoot init` command:
+//   1. Pick the target directory from the first positional arg (or default
+//      to "my-barefoot-app" if omitted).
+//   2. Refuse to scaffold into a non-empty directory.
+//   3. Spawn `node <@barefootjs/cli bin> init` inside the target so init
+//      writes its files there, forwarding any --adapter / --name flags.
+
+import { existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+function usage(): never {
+  console.log(`Usage: npm create barefootjs@latest [<project-name>] [-- --adapter <name>]
+
+Scaffolds a runnable BarefootJS app in <project-name> (or "my-barefoot-app").
+
+Options forwarded to \`barefoot init\`:
+  --adapter <name>    Adapter to use (default: hono)
+  --registry-only     Scaffold a component-registry-only project
+  --from <url>        Initialize from a Studio URL (token overrides + components)
+
+After scaffolding:
+  cd <project-name>
+  npm install
+  npm run dev
+`)
+  process.exit(0)
+}
+
+function fail(msg: string): never {
+  console.error(`Error: ${msg}`)
+  process.exit(1)
+}
+
+const args = process.argv.slice(2)
+if (args.includes('--help') || args.includes('-h')) usage()
+
+const positional = args.find((a) => !a.startsWith('-')) ?? 'my-barefoot-app'
+const passthrough = args.filter((a) => a !== positional)
+
+const targetDir = resolve(process.cwd(), positional)
+if (existsSync(targetDir)) {
+  const entries = readdirSync(targetDir).filter((e) => !e.startsWith('.'))
+  if (entries.length > 0) {
+    fail(`target directory "${positional}" exists and is not empty.`)
+  }
+} else {
+  mkdirSync(targetDir, { recursive: true })
+}
+
+let cliBin: string
+try {
+  cliBin = require.resolve('@barefootjs/cli/dist/index.js')
+} catch {
+  fail(
+    'unable to resolve @barefootjs/cli. ' +
+      'Reinstall create-barefootjs or report this if it persists.',
+  )
+}
+
+console.log(`\nScaffolding BarefootJS app in ${targetDir}\n`)
+
+const initArgs = ['--name', positional]
+// Forward only flags that init itself recognizes; let it surface its own
+// errors for anything unknown rather than guessing here.
+for (const arg of passthrough) initArgs.push(arg)
+
+const result = spawnSync('node', [cliBin, 'init', ...initArgs], {
+  cwd: targetDir,
+  stdio: 'inherit',
+})
+
+process.exit(result.status ?? 1)

--- a/packages/create-barefootjs/tsconfig.json
+++ b/packages/create-barefootjs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a `create-barefootjs` package so users can run `npm create barefootjs@latest my-app` and have a runnable BarefootJS app scaffolded in one step.
- The package is a thin wrapper around the existing `barefoot init` command — picks a target directory, refuses non-empty dirs, and spawns the bundled `@barefootjs/cli` `init` inside it (forwarding `--adapter` / `--name` / `--registry-only` / `--from`).
- Wires the new package into `.github/workflows/pkg-pr-new.yml` so pkg.pr.new previews include it alongside the others.

## Why

Today, trying out the project means installing `@barefootjs/cli` somewhere first (locally or globally), then running `barefoot init`. Most modern frontend starters land on `npm create <name>@latest` because npm itself rewrites that to `npx create-<name>@latest` and handles tarball download + execution in a temp dir. This PR fits BarefootJS into that idiom.

End-state UX:

```sh
npm create barefootjs@latest my-app
cd my-app
npm install
npm run dev      # → http://localhost:3000
```

## Why is the base branch `improve-init-onboarding`, not `main`?

Without #1089 the wrapper just forwards to the registry-only `barefoot init`, which doesn't deliver "a working app." Stacking on top of #1089 makes the e2e demo coherent today. Once #1089 merges, this PR rebases onto main and retargets.

## Test plan

- [x] `node packages/create-barefootjs/dist/index.js my-app` in an empty tmp dir scaffolds the runnable starter app (Counter + Button + server.tsx + barefoot.config.ts + npm scripts).
- [x] Refuses to scaffold into a non-empty directory.
- [x] `--help` / `-h` prints usage.
- [ ] After cr-tracked → pkg.pr.new publishes both `@barefootjs/cli@<sha>` and `create-barefootjs@<sha>`; `npm create barefootjs@<sha> my-app` works end-to-end.

## Notes

- Single-file ESM bundle (~2 kB) with shebang. `@barefootjs/cli` is left external so `require.resolve` finds it via the consumer's installed `node_modules` rather than embedding a duplicate copy.
- Bun's `workspace:*` will be rewritten by `pkg-pr-new` at publish time so the install graph resolves to the same PR build of `@barefootjs/cli`.