### PR TITLE
compiler: wrap mapArray ternary bodies in <svg> when all branches are SVG

### DIFF
--- a/packages/jsx/src/__tests__/svg-mapArray-namespace.test.ts
+++ b/packages/jsx/src/__tests__/svg-mapArray-namespace.test.ts
@@ -112,4 +112,147 @@ describe('SVG mapArray namespace preservation (#135)', () => {
     expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
     expect(content).not.toContain('<svg>')
   })
+
+  /**
+   * #1088: when a `.map()` body is a ternary whose branches are all SVG
+   * tags, the wrap heuristic must still apply. Without the fix, the
+   * `__tpl.innerHTML = `${cond ? `<circle/>` : `<rect/>`}`` clone path
+   * produced HTMLUnknownElements in xhtml namespace and the elements were
+   * invisible. Surfaced by `PolarGrid` (#1086 step 2) where polygon /
+   * circle / line shapes are flattened into one keyed list.
+   */
+  test('SVG ternary body wraps when both branches are SVG-rooted', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Shape = { key: string; kind: 'circle' | 'rect'; size: number }
+
+      export function CondMap() {
+        const [shapes] = createSignal<Shape[]>([])
+        return (
+          <svg viewBox="0 0 100 100">
+            {shapes().map((s) =>
+              s.kind === 'circle'
+                ? <circle key={s.key} cx="50" cy="50" r={String(s.size)} fill="red" />
+                : <rect key={s.key} x="10" y="10" width={String(s.size)} height={String(s.size)} fill="blue" />
+            )}
+          </svg>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'CondMap.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Wrap with <svg>...</svg> for foreign-content parsing
+    expect(content).toMatch(/__tpl\.innerHTML = `<svg>\$\{/)
+    expect(content).toMatch(/\}<\/svg>`/)
+    // Descend one extra level
+    expect(content).toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('SVG 3-way ternary wraps recursively (PolarGrid pattern)', () => {
+    // PolarGrid flattens concentric grid shapes (polygon / circle) and
+    // radial spokes (line) into one list and renders them with a 3-way
+    // ternary. The compiler nests the inner conditional inside
+    // `<!--bf-cond-start:sX-->` markers, so the wrap heuristic must skip
+    // those and recurse into the inner `${...}`.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Shape = { key: string; kind: 'polygon' | 'circle' | 'line' }
+
+      export function PolarGridLike() {
+        const [shapes] = createSignal<Shape[]>([])
+        return (
+          <svg>
+            {shapes().map((s) =>
+              s.kind === 'polygon'
+                ? <polygon key={s.key} points="0,0 1,1 2,0" fill="none" />
+                : s.kind === 'circle'
+                  ? <circle key={s.key} cx="0" cy="0" r="5" fill="none" />
+                  : <line key={s.key} x1="0" y1="0" x2="1" y2="1" />
+            )}
+          </svg>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'PolarGridLike.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toMatch(/__tpl\.innerHTML = `<svg>\$\{/)
+    expect(content).toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('mixed-namespace ternary body falls through to no-wrap', () => {
+    // Conservative: if either branch is HTML, do not wrap. Wrapping in
+    // <svg> would force the HTML branch into foreign-content parsing,
+    // which is its own kind of namespace bug.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { key: string; useSvg: boolean }
+
+      export function Mixed() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((i) =>
+              i.useSvg
+                ? <circle key={i.key} cx="0" cy="0" r="5" />
+                : <span key={i.key}>x</span>
+            )}
+          </div>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Mixed.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Plain (non-SVG-wrapped) clone path must be used
+    expect(content).toContain('.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('HTML ternary body is unchanged (no wrap)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { key: string; isPrimary: boolean }
+
+      export function Toggle() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((i) =>
+              i.isPrimary
+                ? <li key={i.key}>primary</li>
+                : <li key={i.key}>secondary</li>
+            )}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    expect(content).toContain('.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('.firstElementChild.firstElementChild.cloneNode(true)')
+    expect(content).not.toContain('<svg>')
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -39,21 +39,194 @@ const SVG_ROOT_TAGS = new Set([
  * Looks at the first opening tag in the literal. The check is purely
  * lexical so that interpolations inside attribute values do not
  * confuse it.
+ *
+ * Three shapes are recognised:
+ *   1. Direct element root — `<circle .../>`
+ *   2. Conditional body (#1088) — `${cond ? `<circle .../>` : `<rect .../>`}`
+ *      where every result-position template literal starts with an SVG
+ *      tag. The compiler emits this shape for `.map(s => cond ? <a/> : <b/>)`
+ *      bodies; without the wrap the cloned element ends up in the xhtml
+ *      namespace and renders nothing.
+ *   3. Reactive-conditional body — a branch wrapped in `<!--bf-cond-start:sX-->`
+ *      / `<!--bf-cond-end:sX-->` markers (emitted for nested reactive
+ *      conditionals). The check skips leading HTML comments and recurses
+ *      into the inner `${...}`.
+ *
+ * Mixed-namespace branches (one HTML, one SVG) intentionally fall through
+ * to no-wrap so the user sees the same broken output as before instead of
+ * a silent over-wrap into a `<foreignObject>`-style mismatch.
  */
 export function templateRootIsSvg(template: string): boolean {
-  // Skip leading whitespace and comments. `template` is a raw string
-  // before backtick wrapping, so it should already start with `<` for
-  // an element root.
-  const m = template.trimStart().match(/^<\s*([A-Za-z][A-Za-z0-9-]*)/)
-  if (!m) return false
-  // SVG element names are case-sensitive in JSX (e.g., `linearGradient`)
-  // and arrive lowercased to the renderer for the kebab-cased forms;
-  // match case-insensitively against the canonical lower-case set, but
-  // keep the canonical name's casing in the lookup table so JSX names
-  // like `clipPath` still match.
-  const tag = m[1]
-  if (SVG_ROOT_TAGS.has(tag)) return true
-  return SVG_ROOT_TAGS.has(tag.toLowerCase())
+  const stripped = stripLeadingNonContent(template)
+
+  // Shape 1: direct element root.
+  const m = stripped.match(/^<\s*([A-Za-z][A-Za-z0-9-]*)/)
+  if (m) {
+    // SVG element names are case-sensitive in JSX (e.g., `linearGradient`)
+    // and arrive lowercased to the renderer for the kebab-cased forms;
+    // match case-insensitively against the canonical lower-case set, but
+    // keep the canonical name's casing in the lookup table so JSX names
+    // like `clipPath` still match.
+    const tag = m[1]
+    if (SVG_ROOT_TAGS.has(tag)) return true
+    return SVG_ROOT_TAGS.has(tag.toLowerCase())
+  }
+
+  // Shapes 2 & 3: single `${...}` interpolation whose result-position
+  // template literals all (recursively) resolve to SVG roots (Option A in
+  // #1088).
+  const branches = extractConditionalBranchTemplates(stripped)
+  if (branches === null || branches.length === 0) return false
+  return branches.every(templateRootIsSvg)
+}
+
+/**
+ * Strip leading whitespace and HTML comment markers (`<!-- ... -->`) so
+ * that a branch like `<!--bf-cond-start:s0-->${...}<!--bf-cond-end:s0-->`
+ * is inspected at its first content node — the inner `${...}`.
+ */
+function stripLeadingNonContent(template: string): string {
+  let s = template.trimStart()
+  while (s.startsWith('<!--')) {
+    const end = s.indexOf('-->')
+    if (end < 0) return s
+    s = s.slice(end + 3).trimStart()
+  }
+  return s
+}
+
+/**
+ * If `template` begins with a `${jsExpr}` interpolation, return the
+ * contents of every backtick template literal that appears at the top of
+ * `jsExpr` — these are the result branches of a conditional like
+ * `cond ? `<a/>` : `<b/>``. "Top of `jsExpr`" excludes backticks nested
+ * inside another template literal's own `${...}`. Trailing HTML (typically
+ * a `<!--bf-cond-end:sX-->` marker, all-whitespace) is ignored.
+ *
+ * Returns `null` when the shape doesn't match (no leading interpolation,
+ * or the parser hits an unbalanced delimiter, or there is non-comment
+ * trailing content) so callers conservatively bail to no-wrap.
+ */
+function extractConditionalBranchTemplates(template: string): string[] | null {
+  if (!template.startsWith('${')) return null
+
+  const exprEnd = findInterpolationEnd(template, 2)
+  if (exprEnd < 0) return null
+
+  // Anything after the closing `}` other than HTML comments / whitespace
+  // means the template carries sibling HTML alongside the interpolation —
+  // out of scope for the wrap heuristic.
+  const trailing = stripLeadingNonContent(template.slice(exprEnd + 1))
+  if (trailing.length > 0) return null
+
+  const expr = template.slice(2, exprEnd)
+  return findTopLevelTemplateLiterals(expr)
+}
+
+/**
+ * Find the index of the `}` that closes a `${` opened immediately before
+ * `start` in `template`. Tracks nested braces, strings, and template
+ * literals so attribute-value interpolations don't trip the matcher.
+ * Returns -1 on unbalanced input.
+ */
+function findInterpolationEnd(template: string, start: number): number {
+  let depth = 1
+  let i = start
+  while (i < template.length) {
+    const ch = template[i]
+    if (ch === '\\') { i += 2; continue }
+    if (ch === "'" || ch === '"') {
+      i = skipString(template, i + 1, ch)
+      if (i < 0) return -1
+      continue
+    }
+    if (ch === '`') {
+      i = skipTemplateLiteral(template, i + 1)
+      if (i < 0) return -1
+      continue
+    }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  return -1
+}
+
+function skipString(template: string, start: number, quote: string): number {
+  let i = start
+  while (i < template.length) {
+    const ch = template[i]
+    if (ch === '\\') { i += 2; continue }
+    if (ch === quote) return i + 1
+    i++
+  }
+  return -1
+}
+
+function skipTemplateLiteral(template: string, start: number): number {
+  let i = start
+  while (i < template.length) {
+    const ch = template[i]
+    if (ch === '\\') { i += 2; continue }
+    if (ch === '`') return i + 1
+    if (ch === '$' && template[i + 1] === '{') {
+      const end = findInterpolationEnd(template, i + 2)
+      if (end < 0) return -1
+      i = end + 1
+      continue
+    }
+    i++
+  }
+  return -1
+}
+
+/**
+ * Walk a JS expression string and return the contents of every backtick
+ * template literal that appears at the top level — i.e., not nested
+ * inside another template literal. Parentheses are transparent so
+ * `cond ? (`<a/>`) : (`<b/>`)` still surfaces both branches.
+ *
+ * Returns `null` if the parser sees an unbalanced delimiter; callers
+ * treat that as "shape doesn't qualify for the wrap".
+ */
+function findTopLevelTemplateLiterals(expr: string): string[] | null {
+  const out: string[] = []
+  let i = 0
+  while (i < expr.length) {
+    const ch = expr[i]
+    if (ch === '\\') { i += 2; continue }
+    if (ch === '/' && expr[i + 1] === '/') {
+      const nl = expr.indexOf('\n', i + 2)
+      i = nl < 0 ? expr.length : nl + 1
+      continue
+    }
+    if (ch === '/' && expr[i + 1] === '*') {
+      const end = expr.indexOf('*/', i + 2)
+      if (end < 0) return null
+      i = end + 2
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      const next = skipString(expr, i + 1, ch)
+      if (next < 0) return null
+      i = next
+      continue
+    }
+    if (ch === '`') {
+      const literalStart = i + 1
+      const literalEnd = skipTemplateLiteral(expr, literalStart)
+      if (literalEnd < 0) return null
+      // literalEnd is the index just past the closing backtick.
+      out.push(expr.slice(literalStart, literalEnd - 1))
+      i = literalEnd
+      continue
+    }
+    i++
+  }
+  return out
 }
 
 /**


### PR DESCRIPTION
Fixes #1088.

## Summary

`templateRootIsSvg` only matched a direct opening SVG tag, so a `.map()` body shaped like a ternary (`cond ? <circle/> : <rect/>`) — which the compiler emits as `${cond ? \`<circle/>\` : \`<rect/>\`}` — fell through to the plain HTML clone path. The cloned element ended up as `HTMLUnknownElement` in the xhtml namespace, the SVG renderer ignored it, and `getBoundingClientRect()` returned 0×0. Surfaced by `PolarGrid` on #1086 step 2 (3-way ternary over `<polygon>` / `<circle>` / `<line>`).

Implements **Option A** from the issue: extract the result-position template literals from the leading `${...}` interpolation and recurse — every branch must resolve to an SVG-rooted template for the wrap to apply. Mixed-namespace ternaries (one HTML, one SVG) intentionally fall through to no-wrap.

Reactive nested conditionals carry `<!--bf-cond-start:sX-->` / `<!--bf-cond-end:sX-->` markers around their inner `${...}`; the heuristic skips those comments so 3-way patterns (PolarGrid / RadialBar) are recognised.

## Behavior matrix

| Body shape | Before | After |
| --- | --- | --- |
| `<circle/>` (single SVG tag) | wrap | wrap (unchanged) |
| `cond ? <circle/> : <rect/>` | **no wrap (bug)** | wrap |
| `a ? <polygon/> : (b ? <circle/> : <line/>)` (3-way) | **no wrap (bug)** | wrap |
| `cond ? <circle/> : <span/>` (mixed namespace) | no wrap | no wrap (unchanged) |
| `cond ? <li/> : <li/>` (HTML only) | no wrap | no wrap (unchanged) |

## Test plan

- [x] Compiler unit tests in `packages/jsx/src/__tests__/svg-mapArray-namespace.test.ts` cover the new ternary, recursive 3-way, mixed-namespace negative, and HTML-only negative cases (4 new tests, all 7 in the file pass).
- [x] Full `packages/jsx`, `packages/adapter-tests`, and `packages/client` test suites pass (no regressions; the four pre-existing `resolver migration` failures are unrelated).
- [x] Clean `bun run build` succeeds (the pre-existing `table-demo.tsx` "missing key attribute" warning also reproduces on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)