### PR TITLE
compiler: lift mapArray key from uniform conditional bodies (#1098)

### DIFF
--- a/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
+++ b/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
@@ -1,0 +1,160 @@
+/**
+ * BarefootJS Compiler — mapArray key extraction across ternary branches (#1098).
+ *
+ * `.map(item => cond ? <A key={X}/> : <B key={X}/>)` used to fall through to
+ * mapArray's index-based reconciliation because the IR-side key extractor
+ * only inspected the loop body's first child as a single element/component.
+ * A conditional first child slipped past the lookup, the keyFn was emitted
+ * as `null`, and a `kind: 'a' → 'b'` flip mutated attributes on the wrong
+ * tag instead of replacing the DOM node. Surfaced by `PolarGrid` on
+ * #1086 step 2 of #1080 (`<polygon>` → `<circle>` switch never took
+ * effect).
+ *
+ * Fix: when every branch of an `IRConditional` declares the same key
+ * expression (string-equal after whitespace normalisation), lift it out
+ * to mapArray's keyFn argument.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJs(source: string, file = 'CondKey.tsx'): string {
+  const result = compileJSXSync(source, file, { adapter })
+  expect(result.errors.filter((e) => (e as { severity?: string }).severity === 'error')).toHaveLength(0)
+  const cjs = result.files.find((f) => f.type === 'clientJs')
+  expect(cjs).toBeDefined()
+  return cjs!.content
+}
+
+function mapArrayCalls(content: string): string[] {
+  return content
+    .split('\n')
+    .map((ln) => ln.trim())
+    .filter((ln) => ln.startsWith('mapArray('))
+}
+
+describe('mapArray key extraction across conditional branches (#1098)', () => {
+  test('two-branch ternary, both branches share `key={item.key}`', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { key: string; kind: 'a' | 'b' }
+      export function CondMap() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((it) =>
+              it.kind === 'a'
+                ? <span key={it.key} data-kind="a" />
+                : <span key={it.key} data-kind="b" />
+            )}
+          </div>
+        )
+      }
+    `
+    const calls = mapArrayCalls(clientJs(source))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('(it) => String(it.key)')
+    expect(calls[0]).not.toContain('null,')
+  })
+
+  test('three-way nested ternary (PolarGrid: polygon | circle | line)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Shape = { key: string; kind: 'circle' | 'polygon' | 'line' }
+      export function PolarLike() {
+        const [items] = createSignal<Shape[]>([])
+        return (
+          <svg>
+            {items().map((s) =>
+              s.kind === 'circle'
+                ? <circle key={s.key} cx="0" cy="0" r="10" />
+                : s.kind === 'polygon'
+                  ? <polygon key={s.key} points="0,0" />
+                  : <line key={s.key} x1="0" y1="0" x2="1" y2="1" />
+            )}
+          </svg>
+        )
+      }
+    `
+    const calls = mapArrayCalls(clientJs(source))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('(s) => String(s.key)')
+  })
+
+  test('whitespace-only differences in the key expression still unify', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { key: string; kind: 'a' | 'b' }
+      export function CondMap() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((it) =>
+              it.kind === 'a'
+                ? <span key={ it.key } />
+                : <span key={it.key} />
+            )}
+          </div>
+        )
+      }
+    `
+    const calls = mapArrayCalls(clientJs(source))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('String(')
+    expect(calls[0]).not.toMatch(/_s\d+, null,/)
+  })
+
+  test('mismatched key expressions fall back to null reconciliation', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { id: string; otherId: string; kind: 'a' | 'b' }
+      export function CondMap() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <div>
+            {items().map((it) =>
+              it.kind === 'a'
+                ? <span key={it.id} />
+                : <span key={it.otherId} />
+            )}
+          </div>
+        )
+      }
+    `
+    const calls = mapArrayCalls(clientJs(source))
+    expect(calls).toHaveLength(1)
+    // No key extracted — heterogeneous branches must not over-unify.
+    expect(calls[0]).toMatch(/_s\d+, null,/)
+  })
+
+  // Note: a ternary with one branch missing `key` is a hard BF023/BF024 error
+  // (`checkLoopKey` walks each branch independently). Users see the diagnostic
+  // before reaching the IR-side `extractLoopKey`, so the "missing-on-one-side"
+  // case never compiles and isn't asserted here.
+
+  test('non-conditional bodies still extract keys (no regression)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Item = { key: string; label: string }
+      export function PlainMap() {
+        const [items] = createSignal<Item[]>([])
+        return (
+          <ul>
+            {items().map((it) => <li key={it.key}>{it.label}</li>)}
+          </ul>
+        )
+      }
+    `
+    const calls = mapArrayCalls(clientJs(source))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('(it) => String(it.key)')
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1637,6 +1637,81 @@ function findKeyJsxAttribute(
   return undefined
 }
 
+/**
+ * Recover the loop's `keyFn` source expression from the first child of a
+ * `.map(...)` body.
+ *
+ * Direct cases (`element`, `component`) read the `key` attribute / prop
+ * directly. Conditional bodies (`<cond ? <a key={X}/> : <b key={X}/>>`,
+ * #1098) recurse into both branches: if every branch resolves to the same
+ * key expression — compared after stripping insignificant whitespace —
+ * that expression is lifted to mapArray's keyFn argument. Heterogeneous
+ * keys, missing branches, or a non-string key value bail to `null` and
+ * mapArray falls back to index-based reconciliation as before.
+ *
+ * The string-equality check is intentionally conservative: a reactive
+ * conditional whose branches read `it.key` only one branch would silently
+ * pick the wrong reconciliation strategy if we tried to unify them, so we
+ * accept identical text and reject everything else.
+ */
+function extractLoopKey(node: IRNode): string | null {
+  if (node.type === 'element') {
+    const keyAttr = node.attrs.find((a) => a.name === 'key')
+    if (!keyAttr || !keyAttr.value || typeof keyAttr.value !== 'string') return null
+    return keyAttr.value
+  }
+  if (node.type === 'component') {
+    const keyProp = node.props.find((p) => p.name === 'key')
+    if (!keyProp || !keyProp.value || typeof keyProp.value !== 'string') return null
+    return keyProp.value
+  }
+  if (node.type === 'conditional') {
+    const a = extractLoopKey(node.whenTrue)
+    if (a === null) return null
+    const b = extractLoopKey(node.whenFalse)
+    if (b === null) return null
+    return normalizeKeyExpr(a) === normalizeKeyExpr(b) ? a : null
+  }
+  return null
+}
+
+/**
+ * Collapse insignificant whitespace so equivalent expressions written
+ * with different formatting (`it.key` vs `it .key`) compare equal.
+ * Whitespace inside string literals is preserved.
+ */
+function normalizeKeyExpr(expr: string): string {
+  let out = ''
+  let i = 0
+  while (i < expr.length) {
+    const ch = expr[i]
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch
+      out += ch
+      i++
+      while (i < expr.length) {
+        const c = expr[i]
+        if (c === '\\' && i + 1 < expr.length) {
+          out += c + expr[i + 1]
+          i += 2
+          continue
+        }
+        out += c
+        i++
+        if (c === quote) break
+      }
+      continue
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i++
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
 type KeyProblem = 'missing' | 'literal-undefined' | 'literal-null' | 'nullable-type'
 
 /**
@@ -2059,20 +2134,13 @@ function transformMapCall(
     checkLoopKey(node.arguments[0], ctx, isNested)
   }
 
-  // Look for key prop in first child (element or component)
-  let key: string | null = null
-  if (children.length > 0 && children[0].type === 'element') {
-    const keyAttr = children[0].attrs.find((a) => a.name === 'key')
-    // Key should be a simple string expression, not a template literal
-    if (keyAttr && keyAttr.value && typeof keyAttr.value === 'string') {
-      key = keyAttr.value
-    }
-  } else if (children.length > 0 && children[0].type === 'component') {
-    const keyProp = children[0].props.find((p) => p.name === 'key')
-    if (keyProp && keyProp.value) {
-      key = keyProp.value
-    }
-  }
+  // Look for the loop's keyFn source on the first child. `extractLoopKey`
+  // handles direct elements, child components, and — crucially — ternary
+  // bodies (#1098): when every branch of an `IRConditional` declares the
+  // same `key={EXPR}`, that EXPR is lifted out to mapArray's keyFn so a
+  // shape change (e.g. `<polygon>` ↔ `<circle>`) replaces the DOM node
+  // instead of mutating attributes on the wrong tag.
+  const key = children.length > 0 ? extractLoopKey(children[0]) : null
 
   // Extract childComponent info if the loop body is a single component
   // This enables createComponent-based rendering with proper prop passing


### PR DESCRIPTION
## Summary

Fix #1098: when a `.map(...)` callback body is a ternary (e.g. `cond ? <A key={X}/> : <B key={X}/>`), the compiler now lifts the shared key expression out to mapArray's keyFn argument instead of falling back to index-based reconciliation.

## What was wrong

`transformMapCall` (`packages/jsx/src/jsx-to-ir.ts`) only knew how to read `key={...}` off a *single* element / component first child. A ternary's first child is an `IRConditional`, the lookup short-circuited, `loop.key` ended up `null`, and the emitted mapArray was `mapArray(() => xs(), parent, null, ...)`. With null keyFn, items reconcile by index, so a `kind: 'a' → 'b'` flip mutated attributes on the existing `<polygon>` instead of replacing it with a `<circle>` — the symptom that broke `PolarGrid` in #1086 step 2 of #1080.

## What changed

- New `extractLoopKey(node)` helper. Direct `element` / `component` cases are unchanged; `IRConditional` recurses into both branches and returns the shared expression only when both sides agree (string-equal after stripping insignificant whitespace). Heterogeneous keys bail to `null`, preserving the existing fallback.
- Whitespace normaliser preserves string-literal contents so we don't accidentally collapse meaningfully-different quoted keys.
- `checkLoopKey` (BF023/BF024) already walks each branch's `key` attribute independently, so a missing-on-one-side ternary is rejected upstream and never reaches `extractLoopKey`.

## Tests

`packages/jsx/src/__tests__/conditional-mapArray-key.test.ts`:

- two-branch ternary, both branches share `key={item.key}` → `String(item.key)` extracted ✓
- 3-way nested ternary (PolarGrid: `polygon | circle | line`) → `String(s.key)` extracted ✓
- whitespace-equivalent key expressions still unify ✓
- mismatched key expressions fall back to `null` (no over-unification) ✓
- non-conditional bodies still extract keys (regression guard) ✓

Pre-existing failures in `packages/jsx` (4 tests around aliased reactive primitives via the TS checker) reproduce on `main` and are unrelated to this change.

## Why a parent-issue?

#1086 step 2 of #1080 — the last failing chart e2e (`radar-chart.spec.ts:65 — changing gridType switches to circle grid`) was unfixable until the keyFn made it through. With this in place the polygons unmount and circles mount on `gridType` flip, the test passes, and the `PolarGrid` workaround in #1086 can stay simple (single keyed list).

## Test plan

- [x] `bun test packages/jsx/src/__tests__/conditional-mapArray-key.test.ts` — 5 new tests pass
- [x] `bun test packages/jsx` — same 4 pre-existing alias failures as `main`, no new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)