### PR TITLE
compiler: skip member accesses when inlining signals/memos (#1100)

### DIFF
--- a/packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts
+++ b/packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression for #1100: a local `const`/memo whose name matches a property
+ * read off a `useContext()` value (e.g. local `bars` while the body also
+ * calls `ctx.bars()`) used to corrupt the CSR template that the compiler
+ * embeds inside `hydrate(name, { template })`.
+ *
+ * The corruption was a textual rewrite that did not respect member access:
+ *   - `ctx` was inlined to `(useContext(Context))`
+ *   - then `bars()` was matched again — even after the new `.` — and replaced
+ *     a second time, producing `(useContext(Context)).<memo body IIFE>()`,
+ *     which is not valid JavaScript.
+ *
+ * The fix is to make the signal-getter and memo-name regex replacements
+ * skip member accesses (negative lookbehind for `.` / `-`), the same way
+ * `inlinableConstants` already does at the call site in html-template.ts.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+
+const onlyErrors = (errors: { severity?: string }[]) =>
+  errors.filter((e) => e.severity === 'error')
+
+/**
+ * Extract the back-tick template that follows `template:` in the emitted
+ * `hydrate(name, { ..., template: `...` })` call. The template body itself
+ * may contain nested template literals (loop bodies emit their own
+ * back-tick string), so this scanner tracks back-tick depth via the
+ * standard JS template-literal grammar:
+ *   - `\`` opens a template; another `\`` at the same depth closes it
+ *   - `${` inside a template opens an expression context where another
+ *     `\`` increases depth
+ *   - `}` returns to template context only when balanced against `${`
+ */
+const findTemplateLiteral = (clientJs: string): string => {
+  const idx = clientJs.indexOf('template:')
+  expect(idx).toBeGreaterThanOrEqual(0)
+  const start = clientJs.indexOf('`', idx)
+  expect(start).toBeGreaterThanOrEqual(0)
+  let i = start + 1
+  // Stack of contexts: 'tpl' = inside template, 'expr' = inside ${...}
+  const stack: Array<'tpl' | 'expr'> = ['tpl']
+  // Brace counter for the current expr frame; one per 'expr' on the stack.
+  const braceCounts: number[] = []
+  while (i < clientJs.length) {
+    const ch = clientJs[i]
+    const top = stack[stack.length - 1]
+    if (top === 'tpl') {
+      if (ch === '\\') { i += 2; continue }
+      if (ch === '`') {
+        stack.pop()
+        if (stack.length === 0) return clientJs.slice(start, i + 1)
+        i++
+        continue
+      }
+      if (ch === '$' && clientJs[i + 1] === '{') {
+        stack.push('expr')
+        braceCounts.push(0)
+        i += 2
+        continue
+      }
+      i++
+    } else {
+      // expr context: skip strings, count braces
+      if (ch === '\\') { i += 2; continue }
+      if (ch === '`') { stack.push('tpl'); i++; continue }
+      if (ch === "'" || ch === '"') {
+        const quote = ch
+        i++
+        while (i < clientJs.length && clientJs[i] !== quote) {
+          if (clientJs[i] === '\\') i += 2
+          else i++
+        }
+        i++
+        continue
+      }
+      if (ch === '{') { braceCounts[braceCounts.length - 1]++; i++; continue }
+      if (ch === '}') {
+        if (braceCounts[braceCounts.length - 1] === 0) {
+          stack.pop()
+          braceCounts.pop()
+          i++
+          continue
+        }
+        braceCounts[braceCounts.length - 1]--
+        i++
+        continue
+      }
+      i++
+    }
+  }
+  throw new Error('unterminated template literal')
+}
+
+describe('CSR template: shadowed ctx.<method>() (#1100)', () => {
+  test('local memo `bars` does not corrupt ctx.bars() in the template', () => {
+    const source = `
+      'use client'
+      import { createMemo, useContext } from '@barefootjs/client'
+      import { BarChartContext } from './bar-chart-context'
+
+      export function Bar(props) {
+        const ctx = useContext(BarChartContext)
+
+        const bars = createMemo(() => {
+          const xs = ctx.xScale()
+          const ys = ctx.yScale()
+          if (!xs || !ys) return []
+          const allBars = ctx.bars()
+          return allBars
+        })
+
+        return (
+          <g class="bar">
+            {bars().map((b, i) => (
+              <rect key={i} x={b.x} y={b.y} width={b.w} height={b.h} />
+            ))}
+          </g>
+        )
+      }
+    `
+    const result = compileJSXSync(source, 'Bar.tsx', { adapter: new HonoAdapter() })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const tpl = findTemplateLiteral(clientJs!.content)
+
+    // The bug emitted `(useContext(BarChartContext)).((() => {...})())`
+    // — a `.` followed immediately by a `(` is the smoking gun.
+    expect(tpl).not.toMatch(/\)\)\.\(\(/)
+    expect(tpl).not.toMatch(/\)\)\.\(/)
+
+    // The correct rewrite preserves the property access.
+    expect(tpl).toContain('(useContext(BarChartContext)).bars()')
+
+    // And the embedded template literal must parse as valid JavaScript.
+    expect(() => new Function(`return ${tpl}`)).not.toThrow()
+  })
+
+  test('local signal getter shadowed by a ctx method survives intact', () => {
+    const source = `
+      'use client'
+      import { createSignal, useContext } from '@barefootjs/client'
+      import { CountContext } from './count-context'
+
+      export function Counter(props) {
+        const ctx = useContext(CountContext)
+        const [count, setCount] = createSignal(0)
+        return <div>{ctx.count()} / {count()}</div>
+      }
+    `
+    const result = compileJSXSync(source, 'Counter.tsx', { adapter: new HonoAdapter() })
+    expect(onlyErrors(result.errors)).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const tpl = findTemplateLiteral(clientJs!.content)
+
+    // ctx.count() must remain a member call, not be replaced with the signal's
+    // initial value. The local `count()` getter inlines to `(0)`.
+    expect(tpl).toContain('(useContext(CountContext)).count()')
+    expect(tpl).not.toMatch(/\)\)\.\(0\)/)
+    expect(() => new Function(`return ${tpl}`)).not.toThrow()
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -131,9 +131,11 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
         expr = body
       }
     }
-    // Replace signal getter calls with initial values
+    // Replace signal getter calls with initial values.
+    // `(?<![-.])` skips member accesses (e.g. `ctx.count()`) so a local
+    // signal whose name matches a context method is preserved (#1100).
     for (const [getter, initial] of signalMap) {
-      expr = expr.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
+      expr = expr.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${initial})`)
     }
     memoMap.set(memo.name, expr)
   }
@@ -150,7 +152,9 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
       let newExpr = memoExpr
       for (const [otherName, otherExpr] of memoMap) {
         if (otherName === memoName) continue
-        const replaced = newExpr.replace(new RegExp(`\\b${otherName}\\(\\)`, 'g'), `(${otherExpr})`)
+        // `(?<![-.])` keeps the substitution off member accesses such as
+        // `ctx.bars()` when a local memo `bars` exists (#1100).
+        const replaced = newExpr.replace(new RegExp(`(?<![-.])\\b${otherName}\\(\\)`, 'g'), `(${otherExpr})`)
         if (replaced !== newExpr) {
           newExpr = replaced
           changed = true
@@ -181,11 +185,13 @@ export function buildCsrInlinableConstants(
   for (const constant of ctx.localConstants) {
     if (unsafeLocalNames.has(constant.name) && constant.value && !constant.containsArrow) {
       let value = constant.value.trim()
+      // `(?<![-.])` skips member accesses (e.g. `ctx.count()`) so a local
+      // signal/memo whose name matches a context method is preserved (#1100).
       for (const [getter, initial] of signalMap) {
-        value = value.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${initial})`)
+        value = value.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${initial})`)
       }
       for (const [memoName, computation] of memoMap) {
-        value = value.replace(new RegExp(`\\b${memoName}\\(\\)`, 'g'), `(${computation})`)
+        value = value.replace(new RegExp(`(?<![-.])\\b${memoName}\\(\\)`, 'g'), `(${computation})`)
       }
       if (!/\b\w+\(\)/.test(value)) {
         csrInlinableConstants.set(constant.name, value)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -705,17 +705,21 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     const { protect, restore } = createStringProtector()
     let result = protect(templateExpr ?? expr)
 
-    // Replace signal getter calls with initial values: count() → (props.initial ?? 0)
+    // Replace signal getter calls with initial values: count() → (props.initial ?? 0).
+    // The negative lookbehind `(?<![-.])` skips member accesses such as
+    // `ctx.count()` so a local signal whose name happens to match a
+    // context method does not corrupt the embedded template (#1100).
     if (signalMap && signalMap.size > 0) {
       for (const [getter, initialValue] of signalMap) {
-        result = result.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
       }
     }
 
-    // Replace memo getter calls with computation expressions
+    // Replace memo getter calls with computation expressions.
+    // Same lookbehind as above — see signalMap comment.
     if (memoMap && memoMap.size > 0) {
       for (const [name, computation] of memoMap) {
-        result = result.replace(new RegExp(`\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
       }
     }
 
@@ -729,12 +733,12 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     // Re-run signal/memo replacement after constant inlining.
     if (signalMap && signalMap.size > 0) {
       for (const [getter, initialValue] of signalMap) {
-        result = result.replace(new RegExp(`\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
       }
     }
     if (memoMap && memoMap.size > 0) {
       for (const [name, computation] of memoMap) {
-        result = result.replace(new RegExp(`\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
+        result = result.replace(new RegExp(`(?<![-.])\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
       }
     }
 


### PR DESCRIPTION
## Summary

- Fixes #1100. When a JSX-native `"use client"` component declares a local signal/memo whose name matches a property read off a `useContext()` value (e.g. `const bars = createMemo(...)` alongside `ctx.bars()`), the CSR template embedded in `hydrate(name, { template })` was corrupted into invalid JavaScript.
- The cause was the textual rewrite in `generateCsrTemplateWithOpts` (and the related `buildSignalAndMemoMaps` / `buildCsrInlinableConstants` helpers): the memo-name regex `\b${name}\(\)` happily matched `bars()` even after a `.`, because `\b` is a word boundary that fires at the dot. After `ctx` was inlined to `(useContext(Context))`, the memo-name pass matched the new `.bars()` and spliced the memo's IIFE body in as the property accessor — `(useContext(Context)).((() => {...})())`.
- The fix tightens the signal-getter and memo-name regexes with the same `(?<![-.])` lookbehind already used for inlinable constants, so member accesses are skipped on every pass.

## Test plan

- [x] New regression test `packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts` covers both the memo-shadow case from the report and an analogous signal-getter shadow; verifies the embedded template literal parses as valid JS.
- [x] Full `@barefootjs/jsx` test suite (851 tests) passes.
- [x] `@barefootjs/client`, `@barefootjs/hono`, `@barefootjs/go-template`, `@barefootjs/adapter-tests`, and the `ui/` IR tests all pass.
- [x] Clean build of `@barefootjs/chart` succeeds. (The pre-existing `table-demo.tsx` BF023 missing-key warnings in `site/ui` are unrelated to this fix and reproduce on `main`.)