### PR TITLE
xyflow: wire JSX compilation infra into package (Step 1 of #1081)

### DIFF
--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -23,8 +23,9 @@
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
     "build:browser": "bun build ./src/index.ts --outdir ./dist --entry-naming 'xyflow.browser.min.[ext]' --format esm --minify --sourcemap --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
-    "test": "bun test src/",
+    "test": "bun test src/ && bun run typecheck:tests",
     "test:e2e": "bunx playwright test",
+    "typecheck:tests": "tsgo --noEmit -p src/__tests__/tsconfig.json",
     "clean": "rm -rf dist"
   },
   "keywords": [
@@ -44,12 +45,15 @@
     "directory": "packages/xyflow"
   },
   "peerDependencies": {
-    "@barefootjs/client": ">=0.0.1"
+    "@barefootjs/client": ">=0.0.1",
+    "@barefootjs/jsx": ">=0.0.1"
   },
   "dependencies": {
     "@xyflow/system": "^0.0.76"
   },
   "devDependencies": {
+    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/test": "workspace:*",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/xyflow/src/__tests__/jsx-smoke.test.ts
+++ b/packages/xyflow/src/__tests__/jsx-smoke.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// Smoke test for #1081 step 1: JSX infra wired into @barefootjs/xyflow.
+// We feed `jsx-smoke.tsx` (a real JSX file living inside this package's
+// source tree) through the JSX → IR pipeline and assert the analyzer
+// accepts it. If the package's tsconfig or `@barefootjs/jsx` JSX runtime
+// resolution regresses, this test fails.
+const smokeSource = readFileSync(resolve(__dirname, 'jsx-smoke.tsx'), 'utf-8')
+
+describe('JSX infra smoke (#1081 step 1)', () => {
+  const result = renderToTest(smokeSource, 'jsx-smoke.tsx', 'JsxSmoke')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('createSignal is tracked as a reactive signal', () => {
+    expect(result.signals).toContain('count')
+  })
+
+  test('IR exposes the rendered <button>', () => {
+    const button = result.find({ tag: 'button' })
+    expect(button).not.toBeNull()
+    expect(button!.props['type']).toBe('button')
+  })
+})

--- a/packages/xyflow/src/__tests__/jsx-smoke.tsx
+++ b/packages/xyflow/src/__tests__/jsx-smoke.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+// JSX infra smoke component for the @barefootjs/xyflow package.
+//
+// This file is the proof that the package's tsconfig accepts JSX with
+// `@barefootjs/jsx` as the JSX import source — see #1081 step 1.
+// It is not exported from `src/index.ts`; it exists only so `jsx-smoke.test.ts`
+// can feed it through `renderToTest()` and assert the JSX → IR pipeline
+// accepts a "use client" component declared inside this package.
+//
+// Real renderer migrations (Flow, Background, MiniMap, Controls, Handle,
+// Edge, NodeWrapper) land in subsequent steps of #1081.
+
+import { createSignal } from '@barefootjs/client'
+
+export function JsxSmoke() {
+  const [count, setCount] = createSignal(0)
+  return (
+    <button type="button" onClick={() => setCount(count() + 1)}>
+      count: {count()}
+    </button>
+  )
+}

--- a/packages/xyflow/src/__tests__/tsconfig.json
+++ b/packages/xyflow/src/__tests__/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@barefootjs/jsx",
+    "types": ["bun"],
+    "paths": {
+      "@barefootjs/jsx": ["../../../jsx/src"],
+      "@barefootjs/jsx/jsx-runtime": ["../../../jsx/src/jsx-runtime/index.d.ts"],
+      "@barefootjs/jsx/jsx-dev-runtime": ["../../../jsx/src/jsx-dev-runtime/index.d.ts"],
+      "@barefootjs/client": ["../../../client/src"],
+      "@barefootjs/test": ["../../../test/src"]
+    }
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/packages/xyflow/tsconfig.json
+++ b/packages/xyflow/tsconfig.json
@@ -11,7 +11,14 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@barefootjs/jsx",
+    "paths": {
+      "@barefootjs/jsx": ["../jsx/src"],
+      "@barefootjs/jsx/jsx-runtime": ["../jsx/src/jsx-runtime/index.d.ts"],
+      "@barefootjs/jsx/jsx-dev-runtime": ["../jsx/src/jsx-dev-runtime/index.d.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/__tests__"]


### PR DESCRIPTION
## Summary

Sets up `@barefootjs/xyflow` so the package can host `"use client"` JSX
components alongside its existing imperative entry points (`initFlow`,
`createNodeWrapper`, ...). This is **step 1** of #1081 — pure
infrastructure, no renderer migrations. The actual renderer
translations (Edge, Background, Controls, Handle, NodeWrapper, MiniMap,
Flow) land in subsequent steps.

## Changes

- **`packages/xyflow/tsconfig.json`** — enable `jsx: "react-jsx"` with
  `jsxImportSource: "@barefootjs/jsx"` and add `paths` mappings for the
  JSX runtime so `src/*.tsx` files resolve the JSX namespace from
  `packages/jsx/src`.
- **`packages/xyflow/package.json`** — declare `@barefootjs/jsx` as a
  peer dependency alongside `@barefootjs/client`, and add
  `@barefootjs/jsx` + `@barefootjs/test` to `devDependencies`. Add a
  `typecheck:tests` script (`tsgo --noEmit`) wired into `bun test`.
- **`packages/xyflow/src/__tests__/tsconfig.json`** — dedicated
  test-only tsconfig mirroring `packages/jsx/__tests__/tsconfig.json`:
  JSX-aware, `noEmit: true`, with `paths` so `renderToTest` and the
  JSX runtime resolve from source.
- **`packages/xyflow/src/__tests__/jsx-smoke.{tsx,test.ts}`** — minimal
  `"use client"` JSX component fed through `renderToTest`. Asserts:
    - no compiler errors,
    - `isClient === true`,
    - the `count` signal is tracked,
    - the rendered `<button>` is reachable in the IR.

  Proves the JSX → IR pipeline accepts a component declared inside the
  package.

## Acceptance criteria addressed (from #1081)

- [x] JSX compilation pipeline wired up for `packages/xyflow`.
- [x] Trivial `"use client"` JSX component compiles inside the package.

The remaining acceptance criteria (every renderer exported as JSX-native,
no `document.createElementNS` left, `init*` removed, IR tests per
component, all e2e specs passing) are scoped to subsequent steps.

## Test plan

- [x] `cd packages/xyflow && bun run test` — 42 unit tests + smoke pass,
      `tsgo --noEmit` over `__tests__` clean.
- [x] `cd packages/xyflow && bun run clean && bun run build` — esm,
      browser, and `.d.ts` outputs build cleanly. No test files leak
      into `dist/`.
- [x] `tsgo --noEmit` over the main package tsconfig is clean.

## Related

- Tracks #1081
- Mirrors the chart migration in #1080 (different package, same pattern)