### PR TITLE
fix(site/ui): widen mobile body horizontal padding to match site/core

### DIFF
--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -113,7 +113,7 @@ export const renderer = jsxRenderer(
             <link rel="stylesheet" href="/static/uno.css" />
             <style>{`
               body {
-                padding: 5rem 0.3rem 3rem;
+                padding: 5rem 1rem 3rem;
               }
               @media (min-width: 640px) {
                 body {


### PR DESCRIPTION
## Summary

The site/ui top page was rendering tight against the viewport edges on mobile, so we align it with the same horizontal padding used by the site/core landing page.

- In `site/ui/renderer.tsx`, change the body padding on mobile (< 640px) from `0.3rem` → `1rem`.
- This matches site/core's `.hero-b` mobile padding (`4rem 1rem 2rem`) on the horizontal axis.

The `>= 640px` padding (`1.5rem`) is unchanged.

## Test plan

- [ ] Run `bun --cwd site/ui run dev`, open `/` in a mobile viewport (e.g. 375px), and confirm there is ~1rem of horizontal breathing room.
- [ ] Confirm the layout at `>= 640px` still uses the previous `1.5rem` padding.
- [ ] Confirm subpages such as `/components` and `/components/button` still render without overflow.