### PR TITLE
xyflow: introduce JSX-native SimpleEdge (Step 2 of #1081)

### DIFF
--- a/packages/xyflow/src/__tests__/simple-edge.test.ts
+++ b/packages/xyflow/src/__tests__/simple-edge.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// IR-level test for the JSX-native SimpleEdge (#1081 step 2). Verifies the
+// shape of the JSX matches the imperative `mountSimpleEdge` it replaces:
+// two <path> elements (hit area + visible) with the right data attributes
+// and reactive bindings.
+const source = readFileSync(resolve(__dirname, '../simple-edge.tsx'), 'utf-8')
+
+describe('SimpleEdge JSX shape (#1081 step 2)', () => {
+  const result = renderToTest(source, 'simple-edge.tsx', 'SimpleEdge')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('declares selected, animated, pathD, visibleClass memos', () => {
+    // Per-field memos are the per-edge isolation contract carried over
+    // from edge-renderer.ts: each one dedupes on Object.is so unrelated
+    // edge updates do not re-run this edge's effects.
+    expect(result.memos).toContain('selected')
+    expect(result.memos).toContain('animated')
+    expect(result.memos).toContain('pathD')
+    expect(result.memos).toContain('visibleClass')
+  })
+
+  test('renders two <path> elements (hit area + visible)', () => {
+    const paths = result.findAll({ tag: 'path' })
+    expect(paths.length).toBe(2)
+  })
+
+  test('hit-area path carries data-hit-id and transparent stroke', () => {
+    const paths = result.findAll({ tag: 'path' })
+    const hit = paths.find(p => 'data-hit-id' in p.props)
+    expect(hit).toBeDefined()
+    expect(hit!.props['stroke']).toBe('transparent')
+    expect(hit!.props['stroke-width']).toBe('20')
+    expect(hit!.props['fill']).toBe('none')
+  })
+
+  test('visible path carries data-id and a reactive className memo', () => {
+    const paths = result.findAll({ tag: 'path' })
+    const visible = paths.find(p => 'data-id' in p.props)
+    expect(visible).toBeDefined()
+    // The full class string is computed inside the visibleClass memo,
+    // so the IR records the memo call as the binding rather than
+    // expanding the static token list. The reactivity contract is
+    // therefore "visibleClass()" appearing as a class entry.
+    expect(visible!.classes).toContain('visibleClass()')
+    expect(visible!.props['fill']).toBe('none')
+  })
+})

--- a/packages/xyflow/src/edge-path.ts
+++ b/packages/xyflow/src/edge-path.ts
@@ -1,0 +1,89 @@
+// Pure path-geometry helpers shared between the imperative edge renderer
+// (edge-renderer.ts) and the JSX-native simple-edge component (simple-edge.tsx).
+// Extracted in #1081 step 2 so the JSX path computes geometry the same way
+// the imperative path does, avoiding subtle divergence during the migration.
+
+import {
+  getBezierPath,
+  getSmoothStepPath,
+  getStraightPath,
+  getEdgePosition,
+  ConnectionMode,
+  Position,
+} from '@xyflow/system'
+import type { EdgeBase, EdgePosition, InternalNodeBase } from '@xyflow/system'
+
+export type EdgePathTuple = [string, number, number, number, number]
+
+/**
+ * Compute endpoint positions for an edge, falling back to a node-center
+ * straight line when no handle bounds are available yet (e.g. before the
+ * first measure has populated `nodeLookup`).
+ */
+export function computeEdgePosition(
+  edge: EdgeBase,
+  sourceNode: InternalNodeBase,
+  targetNode: InternalNodeBase,
+): EdgePosition | null {
+  const hasHandleIds = !!(edge.sourceHandle || edge.targetHandle)
+  const edgePos = getEdgePosition({
+    id: edge.id,
+    sourceNode,
+    sourceHandle: edge.sourceHandle ?? null,
+    targetNode,
+    targetHandle: edge.targetHandle ?? null,
+    connectionMode: hasHandleIds ? ConnectionMode.Strict : ConnectionMode.Loose,
+  })
+
+  if (edgePos) return edgePos
+
+  const sw = sourceNode.measured.width ?? 150
+  const sh = sourceNode.measured.height ?? 40
+  const tw = targetNode.measured.width ?? 150
+  const sourcePos = sourceNode.internals.positionAbsolute
+  const targetPos = targetNode.internals.positionAbsolute
+
+  return {
+    sourceX: sourcePos.x + sw / 2,
+    sourceY: sourcePos.y + sh,
+    targetX: targetPos.x + tw / 2,
+    targetY: targetPos.y,
+    sourcePosition: Position.Bottom,
+    targetPosition: Position.Top,
+  }
+}
+
+/**
+ * Calculate edge path based on edge type. Returns
+ * `[d, labelX, labelY, offsetX, offsetY]` or `null`.
+ */
+export function getEdgePath(
+  edge: EdgeBase,
+  pos: EdgePosition,
+): EdgePathTuple | null {
+  const params = {
+    sourceX: pos.sourceX,
+    sourceY: pos.sourceY,
+    sourcePosition: pos.sourcePosition,
+    targetX: pos.targetX,
+    targetY: pos.targetY,
+    targetPosition: pos.targetPosition,
+  }
+
+  const edgeType = edge.type ?? 'default'
+
+  switch (edgeType) {
+    case 'straight':
+      return getStraightPath(params) as EdgePathTuple
+    case 'smoothstep':
+    case 'step':
+      return getSmoothStepPath({
+        ...params,
+        borderRadius: edgeType === 'step' ? 0 : undefined,
+      }) as EdgePathTuple
+    case 'default':
+    case 'bezier':
+    default:
+      return getBezierPath(params)
+  }
+}

--- a/packages/xyflow/src/edge-renderer.ts
+++ b/packages/xyflow/src/edge-renderer.ts
@@ -5,23 +5,14 @@ import {
   onCleanup,
   untrack,
 } from '@barefootjs/client'
-import {
-  getBezierPath,
-  getSmoothStepPath,
-  getStraightPath,
-  getEdgePosition,
-  ConnectionMode,
-  Position,
-} from '@xyflow/system'
 import type {
   NodeBase,
   EdgeBase,
-  EdgePosition,
-  InternalNodeBase,
 } from '@xyflow/system'
 import type { FlowStore, EdgeComponentProps } from './types'
 import { SVG_NS } from './constants'
 import { attachReconnectionHandler } from './connection'
+import { computeEdgePosition, getEdgePath } from './edge-path'
 
 /**
  * Renders all edges as SVG paths via per-edge `createRoot` scopes — the
@@ -368,43 +359,6 @@ function mountCustomEdge<
 }
 
 /**
- * Compute endpoint positions for an edge, falling back to node-center
- * positioning when no handle bounds are available.
- */
-function computeEdgePosition(
-  edge: EdgeBase,
-  sourceNode: InternalNodeBase,
-  targetNode: InternalNodeBase,
-): EdgePosition | null {
-  const hasHandleIds = !!(edge.sourceHandle || edge.targetHandle)
-  const edgePos = getEdgePosition({
-    id: edge.id,
-    sourceNode,
-    sourceHandle: edge.sourceHandle ?? null,
-    targetNode,
-    targetHandle: edge.targetHandle ?? null,
-    connectionMode: hasHandleIds ? ConnectionMode.Strict : ConnectionMode.Loose,
-  })
-
-  if (edgePos) return edgePos
-
-  const sw = sourceNode.measured.width ?? 150
-  const sh = sourceNode.measured.height ?? 40
-  const tw = targetNode.measured.width ?? 150
-  const sourcePos = sourceNode.internals.positionAbsolute
-  const targetPos = targetNode.internals.positionAbsolute
-
-  return {
-    sourceX: sourcePos.x + sw / 2,
-    sourceY: sourcePos.y + sh,
-    targetX: targetPos.x + tw / 2,
-    targetY: targetPos.y,
-    sourcePosition: Position.Bottom,
-    targetPosition: Position.Top,
-  }
-}
-
-/**
  * Create a reconnection handle circle and wire it up.
  * The element is appended to `reconnectGroup` (the overlay above nodes),
  * but the hover effect targets the visible path inside `edgeGroup`.
@@ -549,37 +503,3 @@ export function createEdgeLabelRenderer<
   })
 }
 
-/**
- * Calculate edge path based on edge type.
- * Returns [path, labelX, labelY, offsetX, offsetY] or null.
- */
-function getEdgePath(
-  edge: EdgeBase,
-  pos: EdgePosition,
-): [string, number, number, number, number] | null {
-  const params = {
-    sourceX: pos.sourceX,
-    sourceY: pos.sourceY,
-    sourcePosition: pos.sourcePosition,
-    targetX: pos.targetX,
-    targetY: pos.targetY,
-    targetPosition: pos.targetPosition,
-  }
-
-  const edgeType = edge.type ?? 'default'
-
-  switch (edgeType) {
-    case 'straight':
-      return getStraightPath(params) as [string, number, number, number, number]
-    case 'smoothstep':
-    case 'step':
-      return getSmoothStepPath({
-        ...params,
-        borderRadius: edgeType === 'step' ? 0 : undefined,
-      }) as [string, number, number, number, number]
-    case 'default':
-    case 'bezier':
-    default:
-      return getBezierPath(params)
-  }
-}

--- a/packages/xyflow/src/simple-edge.tsx
+++ b/packages/xyflow/src/simple-edge.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+// JSX-native simple-edge component (#1081 step 2).
+//
+// Translates the per-edge `mountSimpleEdge` scope from edge-renderer.ts
+// (the #1078 PoC translation target) into the JSX form
+// `edges().map(e => <path d={...} />)`. The component renders the two
+// `<path>` elements that make up a simple edge:
+//   - A wide invisible hit-area path (stroke=transparent, stroke-width=20)
+//     that captures `mousedown` for selection.
+//   - The visible edge path with `bf-flow__edge` plus the per-edge
+//     `--selected` / `--animated` modifier classes.
+//
+// Custom-edge rendering and the reconnect-handle overlay deliberately
+// stay imperative (`mountCustomEdge` / `createReconnectHandle`) — see
+// #1081 "Stays imperative" section. The reconnect overlay lives in a
+// sibling SVG above the nodes layer; modeling it as JSX would require
+// a separate JSX-native overlay container that sits outside the edge
+// loop, which is out of scope for this step.
+//
+// **Wiring status:** this component is the canonical JSX form. Production
+// edge mounting still goes through `mountSimpleEdge` in `edge-renderer.ts`
+// — replacing that call site is the cutover step that lands once every
+// renderer has its JSX-native counterpart (final step of #1081).
+
+import { createMemo, useContext } from '@barefootjs/client'
+import { FlowContext } from './context'
+import { computeEdgePosition, getEdgePath } from './edge-path'
+import type { FlowStore } from './types'
+
+export interface SimpleEdgeProps {
+  /** Stable id of the edge inside `store.edgeLookup()`. */
+  edgeId: string
+}
+
+export function SimpleEdge(props: SimpleEdgeProps) {
+  // The compiler requires `props.xxx` access (no destructuring) so the
+  // reactive read survives. Pulled out as a memo just so downstream
+  // memos can read it without each one re-doing the lookup.
+  const store = useContext(FlowContext) as FlowStore | undefined
+
+  // Per-field memos. createSignal/createMemo dedupe on Object.is, so
+  // a memo over a primitive (boolean) only fires when its value
+  // actually changes. This isolates per-edge property updates: toggling
+  // another edge's `selected` does not re-run this edge's class memo.
+  const selected = createMemo(() => !!store?.edgeLookup().get(props.edgeId)?.selected)
+  const animated = createMemo(() => !!store?.edgeLookup().get(props.edgeId)?.animated)
+
+  // Path memo. BOTH `positionEpoch` and `nodes()` reads are required —
+  // see edge-renderer.ts for the rAF-batched drag commit explanation.
+  const pathD = createMemo(() => {
+    if (!store) return ''
+    const edge = store.edgeLookup().get(props.edgeId)
+    if (!edge) return ''
+    store.positionEpoch()
+    store.nodes()
+    const nodeLookup = store.nodeLookup()
+    const sourceNode = nodeLookup.get(edge.source)
+    const targetNode = nodeLookup.get(edge.target)
+    if (!sourceNode || !targetNode) return ''
+    const edgePos = computeEdgePosition(edge, sourceNode, targetNode)
+    if (!edgePos) return ''
+    const result = getEdgePath(edge, edgePos)
+    return result ? result[0] : ''
+  })
+
+  // Class string: base + modifier flags. Concatenation is intentional —
+  // the compiler can split this into per-class reactive bindings the
+  // same way it does for `chart` primitives.
+  const visibleClass = createMemo(() => {
+    let cls = 'bf-flow__edge'
+    if (selected()) cls += ' bf-flow__edge--selected'
+    if (animated()) cls += ' bf-flow__edge--animated'
+    return cls
+  })
+
+  function selectThisEdge(e: MouseEvent) {
+    e.stopPropagation()
+    if (!store) return
+    const container = store.domNode()
+    if (container) container.focus()
+    store.unselectNodesAndEdges()
+    const edgeId = props.edgeId
+    store.setEdges((prev) =>
+      prev.map((ed) => (ed.id === edgeId ? { ...ed, selected: true } : ed)),
+    )
+  }
+
+  return (
+    <>
+      {/* Invisible wide hit area — pointer-events on stroke only so the
+          path receives clicks but underlying SVG remains transparent. */}
+      <path
+        data-hit-id={props.edgeId}
+        fill="none"
+        stroke="transparent"
+        stroke-width="20"
+        d={pathD()}
+        style="cursor: pointer; pointer-events: stroke;"
+        onMouseDown={selectThisEdge}
+      />
+      {/* Visible edge path. Class string concatenation, not class:foo
+          binding, mirrors the chart primitives' single-class pattern. */}
+      <path
+        className={visibleClass()}
+        data-id={props.edgeId}
+        fill="none"
+        d={pathD()}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Step 2 of #1081 — translates the per-edge `mountSimpleEdge` scope from
the #1078 PoC into a JSX-native `<SimpleEdge edgeId={id} />` component
(the canonical JSX form for `edges().map(e => <path d={...} />)`).

> ⚠️ Stacked on #1105 (Step 1). Set the base back to `main` after that
> merges.

## Changes

- **`packages/xyflow/src/simple-edge.tsx`** — new `"use client"`
  JSX-native component. Renders the two simple-edge `<path>` elements
  (invisible wide hit area + visible edge path) with per-field memos
  (`selected`, `animated`, `pathD`, `visibleClass`). Mirrors the
  per-edge isolation contract of the imperative renderer (memos dedupe
  on Object.is, so toggling another edge's `selected` does not re-run
  this edge's class memo).
- **`packages/xyflow/src/edge-path.ts`** — extracts `computeEdgePosition`
  and `getEdgePath` from `edge-renderer.ts` so the JSX component and
  the imperative renderer compute geometry the same way during the
  gradual migration.
- **`packages/xyflow/src/edge-renderer.ts`** — drops the duplicated
  geometry helpers, imports them from `edge-path.ts`. No behavior
  change.
- **`packages/xyflow/src/__tests__/simple-edge.test.ts`** — IR test:
  no compiler errors, `isClient=true`, the four memos are tracked,
  two `<path>` elements, and the `data-hit-id` / `data-id` contract
  that `connection.ts` queries.

## Out of scope (kept imperative per #1081)

- Custom-edge rendering (`mountCustomEdge`) — user supplies the render
  function.
- Reconnect-handle overlay (`createReconnectHandle`) — sibling SVG
  above the nodes layer + pointer-paced hover; JSX gives it no leverage.

## Wiring status

Production edge mounting still goes through `mountSimpleEdge` in
`edge-renderer.ts`. The JSX `<SimpleEdge>` is the canonical form that
gets type-checked + IR-tested today; replacing the runtime call site
is the consolidation step that lands once every renderer has its
JSX-native counterpart (final step of #1081, after Steps 3-7 deliver
Background, Controls, Handle, NodeWrapper, MiniMap, Flow).

## Test plan

- [x] `cd packages/xyflow && bun run test` — 48/48 (was 42; +6 IR tests).
- [x] `cd packages/xyflow && bun run clean && bun run build` — esm,
      browser, and `.d.ts` outputs build cleanly. No tsx test files
      leak into `dist/`.
- [x] `tsgo --noEmit` clean for both the main package tsconfig and
      the test tsconfig.

## Related

- Refs #1081
- Builds on #1105 (Step 1: JSX infra setup)
- Translates #1078 (per-edge `createRoot` PoC)