### PR TITLE
xyflow: introduce JSX-native Background (Step 3 of #1081)

### DIFF
--- a/packages/xyflow/src/__tests__/background.test.ts
+++ b/packages/xyflow/src/__tests__/background.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// IR-level test for the JSX-native Background (#1081 step 3). Verifies the
+// SVG > defs > pattern > {circle | path} > rect tree shape and reactive
+// memos that drive the pattern attributes.
+const source = readFileSync(resolve(__dirname, '../background.tsx'), 'utf-8')
+
+describe('Background JSX shape (#1081 step 3)', () => {
+  const result = renderToTest(source, 'background.tsx', 'Background')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('declares pattern geometry memos', () => {
+    expect(result.memos).toContain('patternBox')
+    expect(result.memos).toContain('patternWidth')
+    expect(result.memos).toContain('patternHeight')
+    expect(result.memos).toContain('patternX')
+    expect(result.memos).toContain('patternY')
+  })
+
+  test('declares variant-specific child memos', () => {
+    expect(result.memos).toContain('dotR')
+    expect(result.memos).toContain('dotCx')
+    expect(result.memos).toContain('dotCy')
+    expect(result.memos).toContain('linePathD')
+    expect(result.memos).toContain('crossPathD')
+  })
+
+  test('renders an outer <svg> with absolute positioning style', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+    expect(svg!.props['style']).toContain('position: absolute')
+    expect(svg!.props['style']).toContain('pointer-events: none')
+  })
+
+  test('declares <defs> > <pattern>', () => {
+    const pattern = result.find({ tag: 'pattern' })
+    expect(pattern).not.toBeNull()
+    expect(pattern!.props['patternUnits']).toBe('userSpaceOnUse')
+  })
+
+  test('renders a fill rect at 100% x 100%', () => {
+    const rect = result.find({ tag: 'rect' })
+    expect(rect).not.toBeNull()
+    expect(rect!.props['width']).toBe('100%')
+    expect(rect!.props['height']).toBe('100%')
+  })
+})

--- a/packages/xyflow/src/background.tsx
+++ b/packages/xyflow/src/background.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+// JSX-native Background component (#1081 step 3).
+//
+// Translates `initBackground(scope, props)` into a `<Background />` JSX
+// component. The pattern + rect tree is now expressed declaratively, with
+// pattern attributes (width / height / x / y) and per-variant child
+// attributes (circle.r/cx/cy or path.d) bound to memos that depend on
+// `store.viewport()`. Same exact rendering — moves the side-effects from
+// imperative `setAttribute` calls to JSX attribute bindings.
+//
+// **Wiring status:** the imperative `initBackground` in `background.ts`
+// is still the production code path. Replacing the call site happens in
+// the consolidation step at the end of #1081.
+
+import { createMemo, useContext } from '@barefootjs/client'
+import { FlowContext } from './context'
+import type { FlowStore } from './types'
+
+export type BackgroundVariant = 'dots' | 'lines' | 'cross'
+
+export interface BackgroundProps {
+  variant?: BackgroundVariant
+  gap?: number
+  size?: number
+  color?: string
+  lineWidth?: number
+  /**
+   * Shifts the pattern as a fraction of the gap.
+   * 0 (default): lines pass through tile centers (same as @xyflow/react default).
+   * 0.5: shifts by half a gap so lines align to tile edges.
+   */
+  offset?: number
+  /** Stable id for the `<pattern>`. Falls back to a random id. */
+  patternId?: string
+}
+
+export function Background(props: BackgroundProps) {
+  const store = useContext(FlowContext) as FlowStore | undefined
+
+  // Per-instance pattern id. Random fallback matches initBackground; an
+  // explicit prop is honored so demos can opt into a stable id.
+  const patternId = props.patternId ?? `bf-bg-${Math.random().toString(36).slice(2, 8)}`
+
+  // Defaults are inlined as memos so they stay reactive if the consumer
+  // ever passes signal-backed props.
+  const variant = createMemo(() => props.variant ?? 'dots')
+  const gap = createMemo(() => props.gap ?? 20)
+  const size = createMemo(() => props.size ?? 1)
+  const color = createMemo(() => props.color ?? '#ddd')
+  const lineWidth = createMemo(() => props.lineWidth ?? 1)
+  const offset = createMemo(() => props.offset ?? 0)
+
+  // Pattern geometry — re-runs when viewport zoom/translate changes.
+  // Returns null when scaledGap is non-finite so `<pattern>` keeps the
+  // last valid attributes (matches imperative early-return behavior).
+  const patternBox = createMemo(() => {
+    if (!store) return null
+    const vp = store.viewport()
+    const scaledGap = gap() * vp.zoom
+    if (!scaledGap || !Number.isFinite(scaledGap)) return null
+    return {
+      width: scaledGap,
+      height: scaledGap,
+      x: (vp.x % scaledGap) - scaledGap * offset(),
+      y: (vp.y % scaledGap) - scaledGap * offset(),
+      scaledGap,
+      zoom: vp.zoom,
+    }
+  })
+
+  // Variant-specific child attribute memos. Each memo is independent so a
+  // variant switch only re-runs the affected child binding.
+  const dotR = createMemo(() => {
+    const box = patternBox()
+    if (!box) return 0
+    return size() * Math.max(box.zoom, 0.5)
+  })
+  const dotCx = createMemo(() => {
+    const box = patternBox()
+    return box ? box.scaledGap / 2 : 0
+  })
+  const dotCy = createMemo(() => {
+    const box = patternBox()
+    return box ? box.scaledGap / 2 : 0
+  })
+  const linePathD = createMemo(() => {
+    const box = patternBox()
+    if (!box) return ''
+    return `M${box.scaledGap / 2} 0 V${box.scaledGap}`
+  })
+  const crossPathD = createMemo(() => {
+    const box = patternBox()
+    if (!box) return ''
+    const half = box.scaledGap / 2
+    return `M${half} 0 V${box.scaledGap} M0 ${half} H${box.scaledGap}`
+  })
+
+  const patternWidth = createMemo(() => String(patternBox()?.width ?? 0))
+  const patternHeight = createMemo(() => String(patternBox()?.height ?? 0))
+  const patternX = createMemo(() => String(patternBox()?.x ?? 0))
+  const patternY = createMemo(() => String(patternBox()?.y ?? 0))
+
+  return (
+    <svg
+      style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0;"
+    >
+      <defs>
+        <pattern
+          id={patternId}
+          patternUnits="userSpaceOnUse"
+          width={patternWidth()}
+          height={patternHeight()}
+          x={patternX()}
+          y={patternY()}
+        >
+          {variant() === 'dots' ? (
+            <circle
+              r={String(dotR())}
+              cx={String(dotCx())}
+              cy={String(dotCy())}
+              fill={color()}
+            />
+          ) : variant() === 'lines' ? (
+            <path
+              d={linePathD()}
+              stroke={color()}
+              stroke-width={String(lineWidth())}
+              fill="none"
+            />
+          ) : (
+            <path
+              d={crossPathD()}
+              stroke={color()}
+              stroke-width={String(lineWidth())}
+              fill="none"
+            />
+          )}
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${patternId})`} />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

Step 3 of #1081 — translates `initBackground(scope, props)` into a
`<Background />` JSX component with reactive pattern + rect bindings.

> ⚠️ Stacked on #1108 (Step 2). Set the base back to `main` after that
> merges.

## Changes

- **`packages/xyflow/src/background.tsx`** — new `"use client"`
  JSX-native Background component. Same SVG > defs > pattern > {circle |
  path} > rect tree as `initBackground`, but every dynamic attribute
  (`width` / `height` / `x` / `y` on `<pattern>`, `r` / `cx` / `cy` on
  the dots `<circle>`, `d` on the lines/cross `<path>`) is bound to a
  per-attribute memo derived from `store.viewport()`. Per-variant child
  rendering uses a nested ternary on `variant()` so the analyzer keeps
  all three branches visible in the IR.
- **`packages/xyflow/src/__tests__/background.test.ts`** — IR test:
  no compiler errors, `isClient=true`, all 10 memos (5 pattern + 5
  variant), outer `<svg>` styling, `<defs>` > `<pattern>` with
  `patternUnits="userSpaceOnUse"`, fill `<rect>` at 100% x 100%.

## Wiring status

Production background mounting still goes through `initBackground`.
Replacing the call site happens in the consolidation step at the end
of #1081 (after Steps 4–7 deliver Controls, Handle, NodeWrapper,
MiniMap, Flow).

## Test plan

- [x] `cd packages/xyflow && bun run test` — 55/55 (was 48; +7 IR tests).
- [x] `cd packages/xyflow && bun run clean && bun run build` — esm,
      browser, and `.d.ts` outputs build cleanly.
- [x] `tsgo --noEmit` clean for both the main package tsconfig and
      the test tsconfig.

(Pre-existing `barefootjs-components` build warning about
`table-demo.tsx` "Missing key attribute in list rendering" reproduces
on `main` — unrelated to this PR.)

## Related

- Refs #1081
- Builds on #1108 (Step 2: SimpleEdge)