### PR TITLE
xyflow: introduce JSX-native Handle (Step 5 of #1081)

### DIFF
--- a/packages/xyflow/src/__tests__/handle.test.ts
+++ b/packages/xyflow/src/__tests__/handle.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// IR-level test for the JSX-native Handle (#1081 step 5). Verifies the
+// data attributes that connection.ts and @xyflow/system query against,
+// the position-derived inline style, and the className shape.
+const source = readFileSync(resolve(__dirname, '../components/handle.tsx'), 'utf-8')
+
+describe('Handle JSX shape (#1081 step 5)', () => {
+  const result = renderToTest(source, 'handle.tsx', 'Handle')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('declares handleType, position, className, style memos', () => {
+    expect(result.memos).toContain('handleType')
+    expect(result.memos).toContain('position')
+    expect(result.memos).toContain('className')
+    expect(result.memos).toContain('style')
+  })
+
+  test('renders a single positioned <div>', () => {
+    const divs = result.findAll({ tag: 'div' })
+    expect(divs.length).toBe(1)
+  })
+
+  test('div carries data-* attributes that @xyflow/system queries', () => {
+    const div = result.find({ tag: 'div' })!
+    // The compiler records the binding source as the prop key after
+    // camelCase normalization. Reading the keys is enough to confirm
+    // the IR exposes each attribute (the values are reactive memos).
+    const keys = Object.keys(div.props)
+    expect(keys).toContain('data-handle-type')
+    expect(keys).toContain('data-handlepos')
+    expect(keys).toContain('data-handle-position')
+    expect(keys).toContain('data-node-id')
+    expect(keys).toContain('data-handleid')
+  })
+})

--- a/packages/xyflow/src/components/handle.tsx
+++ b/packages/xyflow/src/components/handle.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+// JSX-native Handle component (#1081 step 5).
+//
+// Translates `initHandle(scope, props)` (and the underlying
+// `createHandle`) into a `<Handle />` JSX component. Renders a single
+// positioned `<div>` with the data attributes that connection.ts and
+// @xyflow/system query against:
+//   - className: bf-flow__handle / bf-flow__handle--{type} / {type}
+//     (the bare `source` / `target` class is what
+//     @xyflow/system.getHandleBounds queries to compute edge endpoints)
+//   - data-handle-type, data-handlepos, data-handle-position, data-node-id
+//   - data-handleid (only when a stable id is supplied)
+// Connection dragging stays imperative — `attachConnectionHandler`
+// captures pointer events directly on the DOM element via a `ref`
+// callback, which keeps the existing drag implementation in
+// connection.ts untouched.
+//
+// **Wiring status:** the imperative `initHandle` / `createHandle` in
+// `handle.ts` is still the production code path. Replacing the call
+// site happens in the consolidation step at the end of #1081.
+
+import { createMemo, useContext } from '@barefootjs/client'
+import { Position } from '@xyflow/system'
+import type { HandleType } from '@xyflow/system'
+import { FlowContext } from '../context'
+import { attachConnectionHandler } from '../connection'
+import type { FlowStore } from '../types'
+
+export interface HandleComponentProps {
+  type?: HandleType
+  position?: Position
+  id?: string | null
+  isConnectable?: boolean
+  nodeId: string
+}
+
+const HANDLE_SIZE = 8
+
+function positionStyle(position: Position): string {
+  switch (position) {
+    case Position.Top:
+      return 'left: 50%; top: 0; transform: translate(-50%, -50%);'
+    case Position.Bottom:
+      return 'left: 50%; bottom: 0; top: auto; transform: translate(-50%, 50%);'
+    case Position.Left:
+      return 'left: 0; top: 50%; transform: translate(-50%, -50%);'
+    case Position.Right:
+      return 'right: 0; left: auto; top: 50%; transform: translate(50%, -50%);'
+    default:
+      return ''
+  }
+}
+
+const BASE_STYLE =
+  `position: absolute; width: ${HANDLE_SIZE}px; height: ${HANDLE_SIZE}px; border-radius: 50%; background-color: #1a192b; border: 1px solid #fff; cursor: crosshair; pointer-events: all; z-index: 1;`
+
+export function Handle(props: HandleComponentProps) {
+  const store = useContext(FlowContext) as FlowStore | undefined
+
+  const handleType = createMemo<HandleType>(() => props.type ?? 'source')
+  const position = createMemo<Position>(() => props.position ?? Position.Top)
+
+  const className = createMemo(() => {
+    const t = handleType()
+    return `bf-flow__handle bf-flow__handle--${t} ${t}`
+  })
+
+  const style = createMemo(() => `${BASE_STYLE} ${positionStyle(position())}`)
+
+  // Connection dragging is pointer-paced (per #1081 "Stays imperative").
+  // We wire `attachConnectionHandler` from a `ref` callback so the
+  // imperative drag handler still owns the pointer lifecycle without
+  // duplicating its logic in JSX.
+  function attachConnection(el: HTMLElement) {
+    if (!store) return
+    const container = store.domNode()
+    const edgesSvg = container?.querySelector('.bf-flow__edges') as SVGSVGElement | null
+    if (container && edgesSvg) {
+      attachConnectionHandler(el, props.nodeId, handleType(), container, edgesSvg, store)
+    }
+  }
+
+  return (
+    <div
+      ref={attachConnection}
+      className={className()}
+      style={style()}
+      data-handle-type={handleType()}
+      data-handlepos={position()}
+      data-handle-position={position()}
+      data-node-id={props.nodeId}
+      data-handleid={props.id ?? undefined}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Step 5 of #1081 — translates `initHandle(scope, props)` (and the
underlying `createHandle`) into a `<Handle />` JSX component.

> ⚠️ Stacked on #1110 (Step 4). Set the base back to `main` after that
> merges.

## Changes

- **`packages/xyflow/src/components/handle.tsx`** — JSX-native Handle.
  Single positioned `<div>` with reactive `className` /
  `style` memos and the data attributes that connection.ts and
  `@xyflow/system.getHandleBounds` query against (the bare `source` /
  `target` class is load-bearing here). Connection dragging stays
  imperative via a `ref` callback that calls
  `attachConnectionHandler` — pointer-paced, gets no leverage from
  JSX (per #1081 "Stays imperative").
- **`packages/xyflow/src/__tests__/handle.test.ts`** — IR test:
  5 assertions on memos, single `<div>`, and the data attribute
  contract.

## Wiring status

Production handle creation still goes through `initHandle` /
`createHandle` in `handle.ts`. Replacing the call site happens in the
consolidation step at the end of #1081 (after Steps 6-7 deliver
NodeWrapper, MiniMap, Flow).

## Test plan

- [x] `cd packages/xyflow && bun run test` — 67/67 (was 62; +5 IR tests).
- [x] `cd packages/xyflow && bun run clean && bun run build` — all
      outputs build cleanly.
- [x] `tsgo --noEmit` clean for both tsconfigs.

## Related

- Refs #1081
- Builds on #1110 (Step 4: Controls + src/components/ convention)