### PR TITLE
xyflow: introduce JSX-native NodeWrapper (Step 6 of #1081)

### DIFF
--- a/packages/xyflow/src/__tests__/node-wrapper.test.ts
+++ b/packages/xyflow/src/__tests__/node-wrapper.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// IR-level test for the JSX-native NodeWrapper (#1081 step 6). Verifies the
+// per-node `<div>` shape: reactive class string, transform-based position,
+// `data-id`, and the children slot.
+const source = readFileSync(resolve(__dirname, '../components/node-wrapper.tsx'), 'utf-8')
+
+describe('NodeWrapper JSX shape (#1081 step 6)', () => {
+  const result = renderToTest(source, 'node-wrapper.tsx', 'NodeWrapper')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('declares the position/class/style memos', () => {
+    // node memo wraps both positionEpoch and nodes() reads — the same
+    // dual-tracking the imperative wrapper uses (positionEpoch for
+    // in-flight drag, nodes() for structural commits).
+    expect(result.memos).toContain('node')
+    expect(result.memos).toContain('transform')
+    expect(result.memos).toContain('zIndex')
+    expect(result.memos).toContain('className')
+    expect(result.memos).toContain('style')
+  })
+
+  test('renders a single wrapper <div>', () => {
+    const divs = result.findAll({ tag: 'div' })
+    expect(divs.length).toBe(1)
+  })
+
+  test('wrapper exposes data-id and reactive className', () => {
+    const div = result.find({ tag: 'div' })!
+    expect(div.props['data-id']).toBe('props.nodeId')
+    expect(div.classes).toContain('className()')
+  })
+})

--- a/packages/xyflow/src/components/node-wrapper.tsx
+++ b/packages/xyflow/src/components/node-wrapper.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+// JSX-native NodeWrapper component (#1081 step 6).
+//
+// Translates the wrapper portion of `createNodeWrapper` (the per-node
+// `<div>` element with reactive class + transform + selection state)
+// into a `<NodeWrapper />` JSX component. The complex bookkeeping
+// (dimension measurement via ResizeObserver, drag handler, handle
+// bounds via @xyflow/system.updateNodeInternals, auto-pan during
+// drag) stays imperative and is delegated through `ref` callbacks
+// in the consolidation step — those primitives are pointer-paced
+// and gain nothing from JSX bindings.
+//
+// Custom node content rendering (`store.nodeTypes[type]`) is the
+// consumer's escape hatch; this wrapper exposes it via `children`
+// so JSX-native callers can compose `<NodeWrapper>` with their own
+// content directly. The imperative path's "render via createElement
+// + render()" stays in node-wrapper.ts until the cutover.
+//
+// **Wiring status:** the imperative `createNodeWrapper` /
+// `createNodeRenderer` in `node-wrapper.ts` is still the production
+// code path. Replacing the call site happens in the consolidation
+// step at the end of #1081.
+
+import { createMemo, useContext } from '@barefootjs/client'
+import type { JSX } from '@barefootjs/jsx/jsx-runtime'
+import { FlowContext } from '../context'
+import type { FlowStore } from '../types'
+
+type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
+
+export interface NodeWrapperProps {
+  /** Stable id of the node inside `store.nodeLookup()`. */
+  nodeId: string
+  /** Slot for node content (default rendering or custom component output). */
+  children?: Child
+  /**
+   * Optional ref callback. The consolidation step in `node-wrapper.ts`
+   * uses this to attach the imperative drag/measure/handle-bounds
+   * machinery to the rendered element.
+   */
+  ref?: (element: HTMLElement) => void
+}
+
+export function NodeWrapper(props: NodeWrapperProps) {
+  const store = useContext(FlowContext) as FlowStore | undefined
+
+  const node = createMemo(() => {
+    if (!store) return null
+    // Reading `nodes()` AND `nodeLookup()` mirrors the imperative
+    // wrapper effect — `positionEpoch` covers in-flight drag updates,
+    // `nodes()` covers structural commits.
+    store.positionEpoch()
+    store.nodes()
+    return store.nodeLookup().get(props.nodeId) ?? null
+  })
+
+  const transform = createMemo(() => {
+    const n = node()
+    if (!n) return ''
+    const pos = n.internals.positionAbsolute
+    return `translate(${pos.x}px, ${pos.y}px)`
+  })
+
+  const zIndex = createMemo(() => String(node()?.internals.z ?? 0))
+
+  const className = createMemo(() => {
+    const n = node()
+    if (!store || !n) return 'bf-flow__node nopan'
+    const isParent = store.parentLookup().has(props.nodeId)
+    const isChild = !!n.internals.userNode.parentId
+    const selected = !!n.selected
+    let cls = 'bf-flow__node nopan'
+    if (isParent) cls += ' bf-flow__node--group'
+    if (isChild) cls += ' bf-flow__node--child'
+    if (selected) cls += ' bf-flow__node--selected'
+    return cls
+  })
+
+  const style = createMemo(
+    () =>
+      `position: absolute; transform-origin: 0 0; pointer-events: all; transform: ${transform()}; z-index: ${zIndex()};`,
+  )
+
+  return (
+    <div
+      ref={props.ref}
+      className={className()}
+      style={style()}
+      data-id={props.nodeId}
+    >
+      {props.children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Step 6 of #1081 — translates the wrapper portion of
`createNodeWrapper` into a `<NodeWrapper nodeId={id}>` JSX component.

> ⚠️ Stacked on #1111 (Step 5). Set the base back to `main` after that
> merges.

## Changes

- **`packages/xyflow/src/components/node-wrapper.tsx`** — JSX-native
  wrapper. The per-node `<div>` carries a reactive `className`
  (composed of `bf-flow__node` / `nopan` / `--group` / `--child` /
  `--selected`), `transform` derived from
  `nodeLookup().get(nodeId).internals.positionAbsolute`, and `z-index`
  derived from `internals.z`. Reads BOTH `positionEpoch` and
  `nodes()` so drag-time updates and structural commits both flow
  through (mirrors the imperative wrapper effect).
  Children prop is the content slot. The drag / measure / handle-bounds
  bookkeeping stays imperative and connects via the `ref` callback in
  the consolidation step.
- **`packages/xyflow/src/__tests__/node-wrapper.test.ts`** — IR test
  with 5 assertions on no errors, `isClient=true`, the five memos
  (`node`, `transform`, `zIndex`, `className`, `style`), single
  `<div>`, and the data-id / className bindings.

## Wiring status

Production node creation still goes through `createNodeWrapper` /
`createNodeRenderer` in `node-wrapper.ts`. Replacing the call site
happens in the consolidation step at the end of #1081 (after Step 7
delivers MiniMap and Step 8 delivers Flow).

## Test plan

- [x] `cd packages/xyflow && bun run test` — 72/72 (was 67; +5 IR tests).
- [x] `cd packages/xyflow && bun run clean && bun run build` — all
      outputs build cleanly.
- [x] `tsgo --noEmit` clean for both tsconfigs.

## Related

- Refs #1081
- Builds on #1111 (Step 5: Handle)