### PR TITLE
xyflow: introduce JSX-native Flow container (Step 8 of #1081)

### DIFF
--- a/packages/xyflow/src/__tests__/flow.test.ts
+++ b/packages/xyflow/src/__tests__/flow.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderToTest } from '@barefootjs/test'
+
+// IR-level test for the JSX-native Flow container (#1081 step 8). Verifies
+// the four-level container tree (.bf-flow > .bf-flow__viewport > {<svg>
+// edges + .bf-flow__nodes}) and the per-edge / per-node mapArray bodies.
+const source = readFileSync(resolve(__dirname, '../components/flow.tsx'), 'utf-8')
+
+describe('Flow JSX shape (#1081 step 8)', () => {
+  const result = renderToTest(source, 'flow.tsx', 'Flow')
+
+  test('JSX → IR pipeline reports no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('component is recognized as a client component', () => {
+    expect(result.isClient).toBe(true)
+  })
+
+  test('declares viewportTransform / visibleEdges / visibleNodes memos', () => {
+    expect(result.memos).toContain('viewportTransform')
+    expect(result.memos).toContain('visibleEdges')
+    expect(result.memos).toContain('visibleNodes')
+  })
+
+  test('renders the .bf-flow root <div>', () => {
+    const root = result.find({ tag: 'div' })
+    expect(root).not.toBeNull()
+    expect(root!.classes).toContain('bf-flow')
+  })
+
+  test('renders the viewport <div> with reactive transform', () => {
+    const viewport = result.findAll({ tag: 'div' }).find(d =>
+      d.classes.includes('bf-flow__viewport'),
+    )
+    expect(viewport).toBeDefined()
+    // The full style string is composed in JSX via a template literal,
+    // so the IR exposes the expression as the bound style value rather
+    // than a parsed object.
+    expect(typeof viewport!.props['style']).toBe('string')
+  })
+
+  test('renders the edges <svg> at full viewport with pointer-events:none', () => {
+    const svg = result.find({ tag: 'svg' })
+    expect(svg).not.toBeNull()
+    expect(svg!.classes).toContain('bf-flow__edges')
+  })
+
+  test('renders the nodes container <div>', () => {
+    const nodesContainer = result.findAll({ tag: 'div' }).find(d =>
+      d.classes.includes('bf-flow__nodes'),
+    )
+    expect(nodesContainer).toBeDefined()
+  })
+
+  test('mounts SimpleEdge and NodeWrapper components', () => {
+    const simpleEdge = result.find({ componentName: 'SimpleEdge' })
+    const nodeWrapper = result.find({ componentName: 'NodeWrapper' })
+    expect(simpleEdge).not.toBeNull()
+    expect(nodeWrapper).not.toBeNull()
+  })
+})

--- a/packages/xyflow/src/components/flow.tsx
+++ b/packages/xyflow/src/components/flow.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+// JSX-native Flow container (#1081 step 8).
+//
+// Translates the rendering portion of `initFlow(scope, props)` into a
+// `<Flow>` JSX component. The container tree is now declarative:
+//
+//   <div class="bf-flow">
+//     <div class="bf-flow__viewport" style="transform: translate(...) scale(...)">
+//       <svg class="bf-flow__edges">{edges().map(e => <SimpleEdge ... />)}</svg>
+//       <div class="bf-flow__nodes">{nodes().map(n => <NodeWrapper ... />)}</div>
+//     </div>
+//     {props.children}  // Background / Controls / MiniMap slot
+//   </div>
+//
+// All pointer-paced subsystems (XYPanZoom, ResizeObserver, keyboard
+// handlers, selection rectangle, pane click detection) stay imperative.
+// They attach via the outer-`<div>` `ref` callback in the consolidation
+// step that swaps `initFlow` for `<Flow>` in the public API.
+//
+// **Wiring status:** the imperative `initFlow` in `flow.ts` is still the
+// production code path. The JSX `<Flow>` is the canonical form that
+// IR-tests today. The runtime cutover (replace `initFlow` callers with
+// `<Flow>` and delete the imperative renderer files) is a follow-up
+// PR — keeping it separate so reviewers can validate the JSX shape
+// before pulling the rug on production.
+
+import {
+  createMemo,
+  createSignal,
+  provideContext,
+} from '@barefootjs/client'
+import type { JSX } from '@barefootjs/jsx/jsx-runtime'
+import type { NodeBase, EdgeBase } from '@xyflow/system'
+import { createFlowStore } from '../store'
+import { FlowContext } from '../context'
+import type { FlowProps } from '../types'
+import { SimpleEdge } from './simple-edge'
+import { NodeWrapper } from './node-wrapper'
+
+type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
+
+export interface FlowComponentProps<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+> extends FlowProps<NodeType, EdgeType> {
+  /** Slot for `<Background>` / `<Controls>` / `<MiniMap>` overlays. */
+  children?: Child
+}
+
+export function Flow<
+  NodeType extends NodeBase = NodeBase,
+  EdgeType extends EdgeBase = EdgeBase,
+>(props: FlowComponentProps<NodeType, EdgeType>) {
+  // Store creation happens once, on first render. The store owns the
+  // reactive node/edge state — `provideContext` makes it available to
+  // descendant `<NodeWrapper>` / `<SimpleEdge>` / `<Background>` /
+  // `<Controls>` / `<MiniMap>` instances.
+  const store = createFlowStore<NodeType, EdgeType>(props)
+  provideContext(FlowContext, store as never)
+
+  // Pan/zoom transform memo. Re-runs only when viewport changes.
+  const viewportTransform = createMemo(() => {
+    const vp = store.viewport()
+    return `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
+  })
+
+  // Edge list memo. Per-edge `<SimpleEdge>` mounts with a stable key
+  // so the analyzer's BF023 invariant is satisfied and the runtime
+  // can reconcile DOM via `mapArray` instead of unmount/remount.
+  const visibleEdges = createMemo(() =>
+    store.edges().filter((e) => !e.hidden),
+  )
+  const visibleNodes = createMemo(() => store.nodes())
+
+  // Imperative subsystem attach point (panZoom, ResizeObserver,
+  // keyboard handlers, selection rectangle, pane click detection).
+  // The cutover step in flow.ts will pass a ref callback that wires
+  // these in via `attachImperativeSubsystems(el, store, props)`.
+  // Keeping it as a no-op signal here makes the JSX shape testable
+  // in isolation.
+  const [_paneRef] = createSignal<HTMLElement | null>(null)
+  function attachPane(el: HTMLElement) {
+    // wired in consolidation step
+    void el
+  }
+
+  return (
+    <div
+      ref={attachPane}
+      className="bf-flow"
+      style="position: relative; overflow: hidden; width: 100%; height: 100%;"
+    >
+      <div
+        className="bf-flow__viewport xyflow__viewport"
+        style={`position: absolute; top: 0; left: 0; width: 100%; height: 100%; transform-origin: 0 0; transform: ${viewportTransform()};`}
+      >
+        <svg
+          className="bf-flow__edges"
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;"
+        >
+          {visibleEdges().map((edge) => (
+            <SimpleEdge key={edge.id} edgeId={edge.id} />
+          ))}
+        </svg>
+        <div
+          className="bf-flow__nodes"
+          style="position: absolute; top: 0; left: 0;"
+        >
+          {visibleNodes().map((node) => (
+            <NodeWrapper key={node.id} nodeId={node.id} />
+          ))}
+        </div>
+      </div>
+      {props.children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Step 8 of #1081 — translates the rendering portion of
`initFlow(scope, props)` into a `<Flow>` JSX component, closing
the JSX migration scaffolding.

> ⚠️ Stacked on #1113 (Step 7). Set the base back to `main` after that
> merges.

## Container tree

```jsx
<div class="bf-flow">
  <div class="bf-flow__viewport" style={`transform: translate(...) scale(${zoom})`}>
    <svg class="bf-flow__edges">
      {edges().filter(!hidden).map(e => <SimpleEdge edgeId={e.id} key={e.id} />)}
    </svg>
    <div class="bf-flow__nodes">
      {nodes().map(n => <NodeWrapper nodeId={n.id} key={n.id} />)}
    </div>
  </div>
  {props.children}  {/* Background / Controls / MiniMap slot */}
</div>
```

## Changes

- **`packages/xyflow/src/components/flow.tsx`** — JSX-native Flow.
  Both `.map()` bodies use stable `key`s (BF023 satisfied). Store is
  created once on first render and shared via
  `provideContext(FlowContext, store)`, so descendant
  `<NodeWrapper>` / `<SimpleEdge>` / `<Background>` / `<Controls>` /
  `<MiniMap>` see the same store via `useContext`. Pointer-paced
  subsystems (XYPanZoom, ResizeObserver, keyboard handlers, selection
  rectangle, pane click detection) stay imperative and attach via
  the outer-`<div>` `ref` callback in the runtime cutover step.
- **`packages/xyflow/src/__tests__/flow.test.ts`** — IR test:
  8 assertions on no compiler errors, `isClient=true`, the three
  memos, the four-level container tree, and the `SimpleEdge` /
  `NodeWrapper` component instances inside the loops.

## What this closes / what's next

- ✅ All seven renderer components have JSX-native counterparts:
  Background (#1109), Controls (#1110), Handle (#1111),
  NodeWrapper (#1112), MiniMap (#1113), SimpleEdge (#1108),
  Flow (this PR).
- ⏳ The runtime cutover (replace `initFlow` callers with `<Flow>`
  and remove the imperative renderer files) is a follow-up PR. That
  step is what flips the acceptance criterion "No
  `document.createElementNS` / `document.createElement` calls remain
  in the renderer files."
- ⏳ `piconic-ai/desk` migration tracked separately once the cutover
  ships.

## Test plan

- [x] `cd packages/xyflow && bun run test` — 86/86 (was 78; +8 IR tests).
- [x] `cd packages/xyflow && bun run clean && bun run build` — all
      outputs build cleanly. The bundled `index.js` continues to
      ship the imperative `initFlow` (verified via grep).
- [x] `tsgo --noEmit` clean for both tsconfigs.

## Related

- Refs #1081
- Builds on #1113 (Step 7: MiniMap)
- Closes the JSX scaffolding for the seven renderer components.