### PR TITLE
xyflow: document src/components/ JSX-vs-imperative split (follow-up to #1081)

### DIFF
--- a/packages/xyflow/README.md
+++ b/packages/xyflow/README.md
@@ -1,0 +1,100 @@
+# @barefootjs/xyflow
+
+Signal-based wrapper around [@xyflow/system](https://www.npmjs.com/package/@xyflow/system) for BarefootJS.
+Provides graph editor primitives (Flow, Background, Controls, Handle,
+NodeWrapper, MiniMap, Edge) with both an imperative `init*` API and
+JSX-native `"use client"` components.
+
+## Source layout
+
+```
+src/
+├── index.ts                    re-exports the public API
+├── flow.ts                     imperative initFlow + container DOM
+├── background.ts               imperative initBackground
+├── controls.ts                 imperative initControls
+├── handle.ts                   imperative initHandle / createHandle
+├── node-wrapper.ts             imperative createNodeWrapper / createNodeRenderer
+├── edge-renderer.ts            imperative createEdgeRenderer (per-edge createRoot)
+├── minimap.ts                  imperative initMiniMap
+├── connection.ts               pointer-paced — stays imperative
+├── selection.ts                pointer-paced — stays imperative
+├── node-resizer.ts             pointer-paced — stays imperative
+├── compat.ts                   React Flow API shim (no DOM)
+├── store.ts / hooks.ts / context.ts / types.ts / constants.ts / utils.ts
+├── edge-path.ts                geometry helpers shared between imperative + JSX
+└── components/                 JSX-native counterparts (#1081)
+    ├── flow.tsx
+    ├── background.tsx
+    ├── controls.tsx
+    ├── handle.tsx
+    ├── node-wrapper.tsx
+    ├── minimap.tsx
+    └── simple-edge.tsx
+```
+
+### Why JSX components live under `src/components/` (not `src/`)
+
+`packages/xyflow/src/index.ts` re-exports the imperative API with
+**bare specifiers** (`from './background'`, `from './controls'`, ...).
+With both `background.ts` and `background.tsx` present in the same
+directory, Bun's resolver may pick the `.tsx` file for a bare specifier.
+That pulls `@barefootjs/jsx/jsx-dev-runtime` (a types-only subpath
+exported as `.d.ts` only) into Bun's bundler graph, and the build fails:
+
+```
+error: Could not resolve: "../jsx-runtime"
+    at packages/jsx/src/jsx-dev-runtime/index.d.ts:7:21
+```
+
+Two structural fixes were considered:
+
+1. **Add explicit `.ts` extensions in `index.ts`** (`from './background.ts'`).
+   Works for `bun build`, but `tsc` / `tsgo` do not rewrite `.ts` to `.js`
+   in declaration output even with `rewriteRelativeImportExtensions: true`
+   under `moduleResolution: "bundler"`. Consumers would get
+   `dist/index.d.ts` containing `from './flow.ts';` and reject it.
+2. **Move JSX files into `src/components/`** so the bare specifiers in
+   `index.ts` always resolve to a `.ts` file unambiguously. No
+   resolver-priority dependency, no consumer-side fallout.
+
+We use approach 2. The directory boundary is the contract:
+
+- **`src/*.ts`** — imperative entry points, owned by `index.ts`.
+- **`src/components/*.tsx`** — JSX-native components, **not yet exported**
+  from `index.ts`. The runtime cutover that swaps the `init*` callers
+  for `<Flow>` lives in a follow-up to #1081 and will decide the public
+  re-export shape (e.g. `import { Flow } from '@barefootjs/xyflow'` vs
+  a separate `@barefootjs/xyflow/components` subpath).
+
+When adding a new JSX-native component:
+
+- Place the `.tsx` file under `src/components/`.
+- Place its IR test under `src/__tests__/` and read the source via
+  `readFileSync(resolve(__dirname, '../components/<name>.tsx'), ...)`.
+- Do **not** colocate a `.tsx` next to its `.ts` namesake under `src/`
+  unless `src/index.ts` is updated to disambiguate.
+
+## Imperative subsystems that stay imperative
+
+Per the #1081 migration plan, three subsystems are deliberately kept
+imperative — JSX bindings give them no leverage:
+
+- **`connection.ts`** — pointer capture + temporary preview path +
+  `elementFromPoint` hit-testing. Lifecycle-bound to a pointer cycle,
+  not a reactive signal.
+- **`selection.ts`** — global pointer capture, drag-rect math,
+  viewport hit-testing.
+- **`node-resizer.ts`** — pointer capture + dimension math + heavy
+  DOM measurement.
+
+These attach to JSX components via `ref` callbacks at the cutover.
+
+## See also
+
+- Issue #1081 — JSX-native migration plan (steps 1-8).
+- PR #1078 — per-edge `createRoot` PoC (translation target for
+  `<SimpleEdge>`).
+- Issue #1080 — chart JSX migration (parallel effort, different
+  package layout choice: chart utilities in `packages/chart`, JSX in
+  `ui/components/ui/chart/`).

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -1,3 +1,17 @@
+// Public API for @barefootjs/xyflow.
+//
+// All re-exports use bare specifiers (no `.ts` extension) and
+// resolve to the imperative entry points under `src/*.ts`. JSX-native
+// counterparts live under `src/components/*.tsx` — they are NOT
+// re-exported here today; the runtime cutover that exposes them as
+// `<Flow>` / `<Background>` / etc. is a follow-up to #1081.
+//
+// Do not place a `.tsx` next to its `.ts` namesake under `src/`. With
+// both files present, `bun build` may resolve a bare specifier to
+// `.tsx`, pull `@barefootjs/jsx/jsx-dev-runtime` (types-only subpath)
+// into the bundler graph, and break the build. See `README.md` for
+// the full rationale.
+
 // Core
 export { initFlow } from './flow'
 export { createFlowStore } from './store'


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the #1081 migration. Records the
rationale for the `src/components/` directory boundary introduced in
#1110 (Step 4) so the next person adding a JSX-native component does
not re-discover the trap.

## Background

Step 4 of #1081 moved JSX-native components into `src/components/` to
keep them from colliding with their imperative `.ts` namesakes under
`src/`. With both files present, `bun build ./src/index.ts` resolves
the bare specifier `from './background'` (in `src/index.ts`) to the
`.tsx` file. That pulls `@barefootjs/jsx/jsx-dev-runtime` — a
types-only subpath that ships only `.d.ts` — into the bundler graph,
and the build fails with:

```
error: Could not resolve: "../jsx-runtime"
    at packages/jsx/src/jsx-dev-runtime/index.d.ts:7:21
```

### Alternative considered (and rejected)

Add explicit `.ts` extensions in `index.ts` (`from './background.ts'`)
plus `allowImportingTsExtensions: true` +
`rewriteRelativeImportExtensions: true` in `tsconfig.json`.

This works for `bun build`, but tsc / tsgo do **not** apply the
extension rewrite to declaration output under
`moduleResolution: "bundler"`. `dist/index.d.ts` ends up containing:

```ts
export { initFlow } from './flow.ts';
```

Consumers' TypeScript rejects this. The directory boundary is the
robust fix; the extension rewrite path is unsupported by the current
tsc/tsgo behavior.

## Changes

- **`packages/xyflow/README.md`** (new) — source-layout map, the "why
  `src/components/`" section with the bun-resolver / tsc-rewrite
  reasoning, and a checklist for adding new JSX components.
- **`packages/xyflow/src/index.ts`** — short comment block at the top
  warning against colocating `.tsx` next to `.ts` under `src/`,
  pointing at the README.

## Test plan

- [x] `cd packages/xyflow && bun run test` — 86/86, no regressions.
- [x] `cd packages/xyflow && bun run clean && bun run build` — esm,
      browser, `.d.ts` outputs build cleanly.

## Related

- Refs #1081
- Documents the boundary set up by #1110 (Step 4)