### PR TITLE
xyflow: register in shadcn registry + add demo page (cutover C2 of #1081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           bun run --filter '@barefootjs/jsx' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build
+          bun run --filter '@barefootjs/xyflow' build
           bun run --filter '@barefootjs/hono' build
 
       - name: Build site/ui

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
           bun run --filter '@barefootjs/hono' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build
+          bun run --filter '@barefootjs/xyflow' build
 
       - name: Extract component metadata
         run: bun run meta:extract

--- a/site/ui/components/shared/component-registry.ts
+++ b/site/ui/components/shared/component-registry.ts
@@ -67,6 +67,7 @@ export const componentEntries: ComponentEntry[] = [
   { slug: 'skeleton', title: 'Skeleton', description: 'Placeholder loading indicator', category: 'display' },
   { slug: 'table', title: 'Table', description: 'Responsive data table', category: 'display' },
   { slug: 'typography', title: 'Typography', description: 'Styled text elements for prose', category: 'display' },
+  { slug: 'xyflow', title: 'xyflow', description: 'Signal-based graph editor (Flow / Background / Controls / MiniMap / Handle / NodeWrapper / SimpleEdge)', category: 'display' },
 
   // Feedback (7)
   { slug: 'alert', title: 'Alert', description: 'Callout for important content', category: 'feedback' },

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -1,0 +1,105 @@
+/**
+ * xyflow JSX-native Demos
+ *
+ * Renders the JSX-native `<Flow>` graph editor with the four overlays
+ * (`<Background>` / `<Controls>` / `<MiniMap>` / per-node `<Handle>`).
+ *
+ * NOTE: pan / zoom / drag / connection-drag wiring lands in cutover step
+ * C4 (`packages/xyflow` extracts the imperative subsystems as utility
+ * functions and exposes a `ref` hook the JSX `<Flow>` uses to attach
+ * them). Until then the demo is visually correct (nodes positioned,
+ * edges drawn, controls / minimap rendered) but interactive behavior
+ * is delegated to the cutover step.
+ */
+
+"use client"
+
+import {
+  Background,
+  Controls,
+  Flow,
+  Handle,
+  MiniMap,
+  NodeWrapper,
+} from '@/components/ui/xyflow'
+import { Position } from '@xyflow/system'
+
+const initialNodes = [
+  { id: '1', position: { x: 100, y: 100 }, data: { label: 'Input' } },
+  { id: '2', position: { x: 350, y: 50 }, data: { label: 'Transform' } },
+  { id: '3', position: { x: 350, y: 200 }, data: { label: 'Validate' } },
+  { id: '4', position: { x: 600, y: 125 }, data: { label: 'Output' } },
+]
+
+const initialEdges = [
+  { id: 'e1-2', source: '1', target: '2' },
+  { id: 'e1-3', source: '1', target: '3' },
+  { id: 'e2-4', source: '2', target: '4' },
+  { id: 'e3-4', source: '3', target: '4' },
+]
+
+export function XyflowPreviewDemo() {
+  return (
+    <div className="w-full h-[420px] rounded-lg border bg-background overflow-hidden">
+      <Flow nodes={initialNodes} edges={initialEdges}>
+        <Background variant="dots" gap={20} color="#e5e7eb" />
+        <Controls />
+        <MiniMap pannable zoomable />
+      </Flow>
+    </div>
+  )
+}
+
+export function XyflowBackgroundVariantsDemo() {
+  return (
+    <div className="grid grid-cols-3 gap-4 w-full">
+      <div className="h-48 rounded-lg border bg-background overflow-hidden">
+        <Flow nodes={[]} edges={[]}>
+          <Background variant="dots" gap={20} />
+        </Flow>
+      </div>
+      <div className="h-48 rounded-lg border bg-background overflow-hidden">
+        <Flow nodes={[]} edges={[]}>
+          <Background variant="lines" gap={30} />
+        </Flow>
+      </div>
+      <div className="h-48 rounded-lg border bg-background overflow-hidden">
+        <Flow nodes={[]} edges={[]}>
+          <Background variant="cross" gap={32} />
+        </Flow>
+      </div>
+    </div>
+  )
+}
+
+// Custom-node demo: build the node body manually with `<NodeWrapper>` +
+// `<Handle>`, mirroring the React-Flow custom-node pattern.
+export function XyflowCustomNodeDemo() {
+  const nodes = [
+    { id: 'src', position: { x: 80, y: 100 }, data: { label: 'Source', kind: 'source' } },
+    { id: 'mid', position: { x: 320, y: 80 }, data: { label: 'Pipeline', kind: 'mid' } },
+    { id: 'dst', position: { x: 560, y: 120 }, data: { label: 'Sink', kind: 'sink' } },
+  ]
+  const edges = [
+    { id: 'src-mid', source: 'src', target: 'mid' },
+    { id: 'mid-dst', source: 'mid', target: 'dst' },
+  ]
+
+  return (
+    <div className="w-full h-[360px] rounded-lg border bg-background overflow-hidden">
+      <Flow nodes={nodes} edges={edges}>
+        <Background variant="cross" gap={28} />
+        <Controls showInteractive={false} />
+        {nodes.map((n) => (
+          <NodeWrapper key={n.id} nodeId={n.id}>
+            <div className="rounded-md border bg-card px-3 py-2 text-sm shadow-sm">
+              {n.data.label}
+              <Handle type="target" position={Position.Left} nodeId={n.id} />
+              <Handle type="source" position={Position.Right} nodeId={n.id} />
+            </div>
+          </NodeWrapper>
+        ))}
+      </Flow>
+    </div>
+  )
+}

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -22,7 +22,9 @@ import {
   MiniMap,
   NodeWrapper,
 } from '@/components/ui/xyflow'
-import { Position } from '@xyflow/system'
+// `Position` is re-exported from `@barefootjs/xyflow` so consumers
+// don't need a separate `@xyflow/system` dependency.
+import { Position } from '@barefootjs/xyflow'
 
 const initialNodes = [
   { id: '1', position: { x: 100, y: 100 }, data: { label: 'Input' } },

--- a/site/ui/package.json
+++ b/site/ui/package.json
@@ -18,6 +18,7 @@
     "@barefootjs/form": "workspace:*",
     "@barefootjs/hono": "workspace:*",
     "@barefootjs/site-shared": "workspace:*",
+    "@barefootjs/xyflow": "workspace:*",
     "@shikijs/langs": "^3.21.0",
     "@shikijs/themes": "^3.21.0",
     "hono": "^4",

--- a/site/ui/pages/components/xyflow.tsx
+++ b/site/ui/pages/components/xyflow.tsx
@@ -1,0 +1,260 @@
+/**
+ * xyflow Reference Page (/components/xyflow)
+ *
+ * Documents the JSX-native xyflow components introduced in cutover step
+ * C1 of barefootjs#1081. Pan/zoom/drag wiring lands in step C4 — until
+ * then the page renders a visually correct (but interactively static)
+ * graph editor.
+ */
+
+import {
+  XyflowPreviewDemo,
+  XyflowBackgroundVariantsDemo,
+  XyflowCustomNodeDemo,
+} from '@/components/xyflow-demo'
+import {
+  DocPage,
+  PageHeader,
+  Section,
+  Example,
+  PropsTable,
+  PackageManagerTabs,
+  type PropDefinition,
+  type TocItem,
+} from '../../components/shared/docs'
+import { getNavLinks } from '../../components/shared/PageNavigation'
+
+const tocItems: TocItem[] = [
+  { id: 'preview', title: 'Preview' },
+  { id: 'installation', title: 'Installation' },
+  { id: 'usage', title: 'Usage' },
+  { id: 'examples', title: 'Examples' },
+  { id: 'background-variants', title: 'Background variants', branch: 'start' },
+  { id: 'custom-node', title: 'Custom node body', branch: 'end' },
+  { id: 'api-reference', title: 'API Reference' },
+]
+
+const usageCode = `"use client"
+
+import {
+  Background,
+  Controls,
+  Flow,
+  MiniMap,
+} from "@/components/ui/xyflow"
+
+const nodes = [
+  { id: "1", position: { x: 100, y: 100 }, data: { label: "Input" } },
+  { id: "2", position: { x: 350, y: 50 }, data: { label: "Transform" } },
+  { id: "3", position: { x: 600, y: 125 }, data: { label: "Output" } },
+]
+
+const edges = [
+  { id: "e1-2", source: "1", target: "2" },
+  { id: "e2-3", source: "2", target: "3" },
+]
+
+export function MyFlow() {
+  return (
+    <div className="w-full h-[420px]">
+      <Flow nodes={nodes} edges={edges}>
+        <Background variant="dots" gap={20} />
+        <Controls />
+        <MiniMap pannable zoomable />
+      </Flow>
+    </div>
+  )
+}`
+
+const backgroundVariantsCode = `import { Flow, Background } from "@/components/ui/xyflow"
+
+export function Variants() {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <Flow nodes={[]} edges={[]}>
+        <Background variant="dots" gap={20} />
+      </Flow>
+      <Flow nodes={[]} edges={[]}>
+        <Background variant="lines" gap={30} />
+      </Flow>
+      <Flow nodes={[]} edges={[]}>
+        <Background variant="cross" gap={32} />
+      </Flow>
+    </div>
+  )
+}`
+
+const customNodeCode = `import {
+  Flow, Background, Controls, NodeWrapper, Handle,
+} from "@/components/ui/xyflow"
+import { Position } from "@xyflow/system"
+
+const nodes = [
+  { id: "src", position: { x: 80, y: 100 }, data: { label: "Source" } },
+  { id: "dst", position: { x: 480, y: 100 }, data: { label: "Sink" } },
+]
+
+export function CustomNodeFlow() {
+  return (
+    <Flow nodes={nodes} edges={[]}>
+      <Background />
+      <Controls />
+      {nodes.map((n) => (
+        <NodeWrapper key={n.id} nodeId={n.id}>
+          <div className="rounded-md border bg-card px-3 py-2">
+            {n.data.label}
+            <Handle type="target" position={Position.Left} nodeId={n.id} />
+            <Handle type="source" position={Position.Right} nodeId={n.id} />
+          </div>
+        </NodeWrapper>
+      ))}
+    </Flow>
+  )
+}`
+
+const flowProps: PropDefinition[] = [
+  {
+    name: 'nodes',
+    type: 'NodeBase[]',
+    description: 'Initial node list. Each node needs `id`, `position: { x, y }`, and `data: {…}`.',
+  },
+  {
+    name: 'edges',
+    type: 'EdgeBase[]',
+    description: 'Initial edge list. Each edge needs `id`, `source`, `target`.',
+  },
+  {
+    name: 'children',
+    type: 'Child',
+    description: 'Slot for `<Background>` / `<Controls>` / `<MiniMap>` overlays and any custom `<NodeWrapper>` content.',
+  },
+]
+
+const backgroundProps: PropDefinition[] = [
+  {
+    name: 'variant',
+    type: '"dots" | "lines" | "cross"',
+    defaultValue: '"dots"',
+    description: 'Pattern style.',
+  },
+  {
+    name: 'gap',
+    type: 'number',
+    defaultValue: '20',
+    description: 'Spacing between pattern repeats (in flow coordinates, scales with zoom).',
+  },
+  {
+    name: 'color',
+    type: 'string',
+    defaultValue: '"#ddd"',
+    description: 'Pattern color.',
+  },
+]
+
+const controlsProps: PropDefinition[] = [
+  {
+    name: 'position',
+    type: '"top-left" | "top-right" | "bottom-left" | "bottom-right"',
+    defaultValue: '"bottom-left"',
+    description: 'Corner the controls float in.',
+  },
+  {
+    name: 'showZoom',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show zoom-in / zoom-out buttons.',
+  },
+  {
+    name: 'showFitView',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show fit-view button.',
+  },
+  {
+    name: 'showInteractive',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Show the lock toggle.',
+  },
+]
+
+const minimapProps: PropDefinition[] = [
+  {
+    name: 'pannable',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Allow drag-to-pan inside the minimap.',
+  },
+  {
+    name: 'zoomable',
+    type: 'boolean',
+    defaultValue: 'true',
+    description: 'Allow wheel zoom on the minimap.',
+  },
+  {
+    name: 'nodeColor',
+    type: 'string | (node) => string',
+    defaultValue: '"#e2e8f0"',
+    description: 'Per-node fill color in the minimap.',
+  },
+]
+
+export function XyflowRefPage() {
+  return (
+    <DocPage slug="xyflow" toc={tocItems}>
+      <div className="space-y-12">
+        <PageHeader
+          title="xyflow"
+          description="Signal-based graph editor with Flow, Background, Controls, MiniMap, Handle, NodeWrapper, and SimpleEdge components."
+          {...getNavLinks('xyflow')}
+        />
+
+        <Section id="preview" title="Preview">
+          <XyflowPreviewDemo />
+        </Section>
+
+        <Section id="installation" title="Installation">
+          <PackageManagerTabs command="barefoot add xyflow" />
+        </Section>
+
+        <Section id="usage" title="Usage">
+          <Example code={usageCode}>
+            <XyflowPreviewDemo />
+          </Example>
+        </Section>
+
+        <Section id="examples" title="Examples">
+          <div className="space-y-8">
+            <Section id="background-variants" title="Background variants">
+              <Example title="Background variants" code={backgroundVariantsCode}>
+                <XyflowBackgroundVariantsDemo />
+              </Example>
+            </Section>
+            <Section id="custom-node" title="Custom node body">
+              <Example title="Custom node body" code={customNodeCode}>
+                <XyflowCustomNodeDemo />
+              </Example>
+            </Section>
+          </div>
+        </Section>
+
+        <Section id="api-reference" title="API Reference">
+          <div className="space-y-8">
+            <Section id="flow-props" title="<Flow>">
+              <PropsTable props={flowProps} />
+            </Section>
+            <Section id="background-props" title="<Background>">
+              <PropsTable props={backgroundProps} />
+            </Section>
+            <Section id="controls-props" title="<Controls>">
+              <PropsTable props={controlsProps} />
+            </Section>
+            <Section id="minimap-props" title="<MiniMap>">
+              <PropsTable props={minimapProps} />
+            </Section>
+          </div>
+        </Section>
+      </div>
+    </DocPage>
+  )
+}

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -78,6 +78,7 @@ import { KbdRefPage } from './pages/components/kbd'
 import { NativeSelectRefPage } from './pages/components/native-select'
 import { SpinnerRefPage } from './pages/components/spinner'
 import { TypographyRefPage } from './pages/components/typography'
+import { XyflowRefPage } from './pages/components/xyflow'
 import { ComponentCatalogPage } from './pages/components/catalog'
 
 // Chart pages
@@ -321,6 +322,11 @@ export function createApp() {
   // Typography reference page
   app.get('/components/typography', (c) => {
     return c.render(<TypographyRefPage />)
+  })
+
+  // xyflow reference page
+  app.get('/components/xyflow', (c) => {
+    return c.render(<XyflowRefPage />)
   })
 
   // Switch reference page

--- a/ui/components/ui/xyflow/index.tsx
+++ b/ui/components/ui/xyflow/index.tsx
@@ -34,16 +34,19 @@ import {
   useContext,
 } from '@barefootjs/client'
 import type { JSX } from '@barefootjs/jsx/jsx-runtime'
-import { Position } from '@xyflow/system'
-import type { HandleType, NodeBase, EdgeBase } from '@xyflow/system'
+// All upstream `@xyflow/system` symbols are re-exported through
+// `@barefootjs/xyflow`, so consumers who `barefoot add xyflow` only
+// need to depend on `@barefootjs/xyflow` (no separate
+// `@xyflow/system` install).
 import {
   attachConnectionHandler,
   computeEdgePosition,
   createFlowStore,
   FlowContext,
   getEdgePath,
+  Position,
 } from '@barefootjs/xyflow'
-import type { FlowStore, FlowProps } from '@barefootjs/xyflow'
+import type { FlowStore, FlowProps, HandleType, NodeBase, EdgeBase } from '@barefootjs/xyflow'
 
 type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
 

--- a/ui/meta/xyflow.json
+++ b/ui/meta/xyflow.json
@@ -1,0 +1,221 @@
+{
+  "name": "xyflow",
+  "title": "xyflow",
+  "category": "display",
+  "description": "xyflow JSX Components JSX-native renderer components for `@barefootjs/xyflow`. The package itself ships utility helpers (signal hooks, store, types, edge-path geometry, imperative pointer-paced subsystems for `ref` attach), and these components compose them into a `<Flow>` graph editor. Mirrors the chart pattern — utility helpers live in `@barefootjs/chart`, JSX components in `ui/components/ui/chart/`. See the package README at `packages/xyflow/README.md` for the full architecture rationale and the issue at piconic-ai/barefootjs#1081 for the migration history. Components exported: - `<Flow>` — top-level container, owns the store + viewport - `<Background>` — SVG pattern background that moves with viewport - `<Controls>` — zoom in / zoom out / fit view / lock buttons - `<MiniMap>` — overview map with viewport mask - `<Handle>` — per-node connection handle (source / target) - `<NodeWrapper>` — per-node `<div>` with reactive class / transform - `<SimpleEdge>` — per-edge `<path>` (hit area + visible) Pointer-paced subsystems (selection rectangle, connection drag, node-resize, pan-zoom, keyboard handlers) stay imperative inside `@barefootjs/xyflow` and attach via `ref` callbacks.",
+  "tags": [],
+  "stateful": false,
+  "props": [
+    {
+      "name": "edgeId",
+      "type": "string",
+      "required": true,
+      "description": "Stable id of the edge inside `store.edgeLookup()`."
+    }
+  ],
+  "subComponents": [
+    {
+      "name": "NodeWrapper",
+      "description": "",
+      "props": [
+        {
+          "name": "nodeId",
+          "type": "string",
+          "required": true,
+          "description": "Stable id of the node inside `store.nodeLookup()`."
+        },
+        {
+          "name": "children",
+          "type": "Child",
+          "required": false,
+          "description": "Slot for node content (default rendering or custom component output)."
+        },
+        {
+          "name": "ref",
+          "type": "(element: HTMLElement) => void",
+          "required": false,
+          "description": "Optional ref callback. The cutover step that retires `createNodeWrapper` passes the imperative drag/measure/handle-bounds machinery here."
+        }
+      ]
+    },
+    {
+      "name": "Handle",
+      "description": "",
+      "props": [
+        {
+          "name": "type",
+          "type": "HandleType",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "position",
+          "type": "Position",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "id",
+          "type": "string | null",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "isConnectable",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "nodeId",
+          "type": "string",
+          "required": true,
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "Background",
+      "description": "",
+      "props": [
+        {
+          "name": "variant",
+          "type": "BackgroundVariant",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "gap",
+          "type": "number",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "size",
+          "type": "number",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "lineWidth",
+          "type": "number",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "offset",
+          "type": "number",
+          "required": false,
+          "description": "Shifts the pattern as a fraction of the gap. 0 (default): lines pass through tile centers (same as @xyflow/react). 0.5: shifts by half a gap so lines align to tile edges."
+        },
+        {
+          "name": "patternId",
+          "type": "string",
+          "required": false,
+          "description": "Stable id for the `<pattern>`. Falls back to a random id."
+        }
+      ]
+    },
+    {
+      "name": "Controls",
+      "description": "",
+      "props": [
+        {
+          "name": "position",
+          "type": "ControlsPosition",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "showZoom",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "showFitView",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        },
+        {
+          "name": "showInteractive",
+          "type": "boolean",
+          "required": false,
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "MiniMap",
+      "description": "",
+      "props": []
+    },
+    {
+      "name": "Flow",
+      "description": "",
+      "props": []
+    }
+  ],
+  "variants": {
+    "BackgroundVariant": [
+      "dots",
+      "lines",
+      "cross"
+    ],
+    "ControlsPosition": [
+      "top-left",
+      "top-right",
+      "bottom-left",
+      "bottom-right"
+    ],
+    "MiniMapPosition": [
+      "top-left",
+      "top-right",
+      "bottom-left",
+      "bottom-right"
+    ]
+  },
+  "examples": [],
+  "accessibility": {
+    "ariaAttributes": [],
+    "dataAttributes": []
+  },
+  "dependencies": {
+    "internal": [],
+    "external": [
+      "@barefootjs/client",
+      "@xyflow/system",
+      "@barefootjs/xyflow"
+    ]
+  },
+  "related": [],
+  "source": "ui/components/ui/xyflow/index.tsx",
+  "memos": [
+    {
+      "name": "selected",
+      "deps": []
+    },
+    {
+      "name": "animated",
+      "deps": []
+    },
+    {
+      "name": "pathD",
+      "deps": []
+    },
+    {
+      "name": "visibleClass",
+      "deps": [
+        "selected",
+        "animated"
+      ]
+    }
+  ]
+}

--- a/ui/registry.json
+++ b/ui/registry.json
@@ -460,6 +460,13 @@
       "title": "Native Select",
       "description": "A styled native HTML select element",
       "tags": ["input"]
+    },
+    {
+      "name": "xyflow",
+      "type": "registry:ui",
+      "title": "xyflow",
+      "description": "Signal-based graph editor — Flow, Background, Controls, MiniMap, Handle, NodeWrapper, SimpleEdge",
+      "tags": ["display", "interactive"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Second PR in the xyflow chart-pattern cutover series. Wires the JSX
components introduced in #1116 (C1) into the shadcn registry and the
site/ui documentation pages so consumers can install via
`barefoot add xyflow` and review the API at
`https://ui.barefootjs.dev/components/xyflow`.

> ⚠️ Stacked on #1116 (C1). Set the base back to `main` after that
> merges.

## Changes

- **`ui/registry.json`** — `xyflow` registry entry under `display` /
  `interactive` tags.
- **`ui/meta/xyflow.json`** — auto-generated via `bun run meta:extract`.
- **`site/ui/components/xyflow-demo.tsx`** — three demos: preview,
  background-variants (dots / lines / cross), custom-node body via
  `<NodeWrapper>` + `<Handle>`.
- **`site/ui/pages/components/xyflow.tsx`** — reference page (preview,
  installation, usage, examples, API for Flow / Background / Controls /
  MiniMap).
- **`site/ui/routes.tsx`** — route `/components/xyflow`.
- **`site/ui/components/shared/component-registry.ts`** — add `xyflow`
  to `display` category navigation.
- **`site/ui/package.json`** — declare `@barefootjs/xyflow` workspace
  dependency so `import` paths resolve in the site bundler.

## Wiring status

Pan / zoom / drag / connection-drag are **not** attached yet. `<Flow>`'s
`ref` callback is a no-op placeholder; the imperative pointer-paced
subsystems (panZoom, ResizeObserver, keyboard handlers, selection
rectangle) become callable utilities in step C4.

## Test plan

- [x] `cd ui && bun test components/ui/xyflow/index.test.tsx` — 22/22.
- [x] `cd packages/xyflow && bun run test` — 86/86, no regressions.
- [x] `cd site/ui && bun run build` — emits
      `dist/components/ui/xyflow/{xyflow-<hash>.js,index.tsx}` and
      `dist/components/xyflow-demo-<hash>.js` cleanly.

(Pre-existing `table-demo.tsx` BF023 build warning reproduces on `main`,
unrelated to this PR.)

## Related

- Refs #1081 (cutover C2)
- Builds on #1116 (C1: JSX components)
- Tracks downstream `piconic-ai/desk#41`