### PR TITLE
cli: merge barefoot.json into barefoot.config.ts (#1097)

### DIFF
--- a/packages/adapter-go-template/src/build.ts
+++ b/packages/adapter-go-template/src/build.ts
@@ -236,6 +236,7 @@ export function createConfig(options: GoTemplateBuildOptions = {}) {
 
   return {
     adapter: new GoTemplateAdapter(options.adapterOptions),
+    paths: options.paths,
     components: options.components,
     outDir: options.outDir,
     minify: options.minify,

--- a/packages/adapter-hono/src/build.ts
+++ b/packages/adapter-hono/src/build.ts
@@ -24,6 +24,7 @@ export function createConfig(options: HonoBuildOptions = {}) {
 
   return {
     adapter: new HonoAdapter(options.adapterOptions),
+    paths: options.paths,
     components: options.components,
     outDir: options.outDir,
     minify: options.minify,

--- a/packages/adapter-mojolicious/src/build.ts
+++ b/packages/adapter-mojolicious/src/build.ts
@@ -18,6 +18,7 @@ export interface MojoBuildOptions extends BuildOptions {
 export function createConfig(options: MojoBuildOptions = {}) {
   return {
     adapter: new MojoAdapter(options.adapterOptions),
+    paths: options.paths,
     components: options.components,
     outDir: options.outDir,
     minify: options.minify,

--- a/packages/cli/src/__tests__/core.test.ts
+++ b/packages/cli/src/__tests__/core.test.ts
@@ -9,7 +9,7 @@ describe('barefoot core', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/core')
-      const ctx = createContext(false)
+      const ctx = await createContext(false)
       run([], ctx)
 
       const output = logSpy.mock.calls.map(c => c[0]).join('\n')
@@ -25,7 +25,7 @@ describe('barefoot core', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/core')
-      const ctx = createContext(false)
+      const ctx = await createContext(false)
       run(['reactivity/create-signal'], ctx)
 
       const output = logSpy.mock.calls.map(c => c[0]).join('\n')
@@ -39,7 +39,7 @@ describe('barefoot core', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/core')
-      const ctx = createContext(false)
+      const ctx = await createContext(false)
       run(['create-signal'], ctx)
 
       const output = logSpy.mock.calls.map(c => c[0]).join('\n')
@@ -53,7 +53,7 @@ describe('barefoot core', () => {
     const logSpy = spyOn(console, 'log').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/core')
-      const ctx = createContext(true)
+      const ctx = await createContext(true)
       run(['create-signal'], ctx)
 
       const output = logSpy.mock.calls.map(c => c[0]).join('\n')
@@ -71,7 +71,7 @@ describe('barefoot core', () => {
     const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
     try {
       const { run } = await import('../commands/core')
-      const ctx = createContext(false)
+      const ctx = await createContext(false)
       expect(() => run(['nonexistent-doc'], ctx)).toThrow('exit')
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'))
     } finally {

--- a/packages/cli/src/__tests__/migrate.test.ts
+++ b/packages/cli/src/__tests__/migrate.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs'
+import path from 'path'
+import os from 'os'
+import { injectPathsIntoConfig } from '../commands/migrate'
+
+describe('injectPathsIntoConfig', () => {
+  test('inserts paths block at top of createConfig({...}) call', () => {
+    const source = `import { createConfig } from '@barefootjs/hono/build'
+
+export default createConfig({
+  components: ['components'],
+  outDir: 'dist',
+})
+`
+    const result = injectPathsIntoConfig(source, {
+      components: 'components/ui',
+      tokens: 'tokens',
+      meta: 'meta',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result).toContain('paths: {')
+    expect(result).toContain(`components: "components/ui"`)
+    expect(result).toContain(`tokens: "tokens"`)
+    expect(result).toContain(`meta: "meta"`)
+    // The original fields stay intact.
+    expect(result).toContain(`components: ['components']`)
+    expect(result).toContain(`outDir: 'dist'`)
+  })
+
+  test('matches the call-site indentation', () => {
+    const source = `export default createConfig({
+  outDir: 'dist',
+})`
+    const result = injectPathsIntoConfig(source, {
+      components: 'a', tokens: 'b', meta: 'c',
+    })!
+    // Inserted lines should use a 4-space indent (call sits at 0, child = 2).
+    expect(result).toMatch(/\n  paths: \{\n    components: "a",/)
+  })
+
+  test('also recognises defineConfig({...})', () => {
+    const source = `export default defineConfig({
+  outDir: 'dist',
+})`
+    const result = injectPathsIntoConfig(source, {
+      components: 'x', tokens: 'y', meta: 'z',
+    })
+    expect(result).not.toBeNull()
+    expect(result).toContain(`components: "x"`)
+  })
+
+  test('returns null when no createConfig call is found', () => {
+    const source = `export default { adapter: { name: 'x' } }`
+    const result = injectPathsIntoConfig(source, {
+      components: 'a', tokens: 'b', meta: 'c',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('migrate (e2e)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-migrate-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('migrates a project: paths injected, json deleted', async () => {
+    const tsPath = path.join(tmpDir, 'barefoot.config.ts')
+    const jsonPath = path.join(tmpDir, 'barefoot.json')
+
+    writeFileSync(
+      tsPath,
+      `import { createConfig } from '@barefootjs/hono/build'
+
+export default createConfig({
+  components: ['components'],
+  outDir: 'dist',
+})
+`,
+    )
+    writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        $schema: 'https://barefootjs.dev/schema/barefoot.json',
+        paths: { components: 'src/ui', tokens: 'src/tokens', meta: 'src/meta' },
+      }, null, 2),
+    )
+
+    // Switch cwd to the tmp project so findBarefootJson picks it up.
+    const prevCwd = process.cwd()
+    process.chdir(tmpDir)
+    try {
+      const { run } = await import('../commands/migrate')
+      // The codemod doesn't read ctx, only cwd.
+      await run([], { root: tmpDir, metaDir: tmpDir, jsonFlag: false, config: null, projectDir: tmpDir })
+    } finally {
+      process.chdir(prevCwd)
+    }
+
+    expect(existsSync(jsonPath)).toBe(false)
+    const patched = readFileSync(tsPath, 'utf-8')
+    expect(patched).toContain(`components: "src/ui"`)
+    expect(patched).toContain(`tokens: "src/tokens"`)
+    expect(patched).toContain(`meta: "src/meta"`)
+  })
+
+  test('--dry-run keeps both files in place', async () => {
+    const tsPath = path.join(tmpDir, 'barefoot.config.ts')
+    const jsonPath = path.join(tmpDir, 'barefoot.json')
+
+    const tsBefore = `export default createConfig({\n  outDir: 'dist',\n})\n`
+    writeFileSync(tsPath, tsBefore)
+    writeFileSync(
+      jsonPath,
+      JSON.stringify({ paths: { components: 'a', tokens: 'b', meta: 'c' } }),
+    )
+
+    const prevCwd = process.cwd()
+    process.chdir(tmpDir)
+    try {
+      const { run } = await import('../commands/migrate')
+      await run(['--dry-run'], { root: tmpDir, metaDir: tmpDir, jsonFlag: false, config: null, projectDir: tmpDir })
+    } finally {
+      process.chdir(prevCwd)
+    }
+
+    expect(existsSync(jsonPath)).toBe(true)
+    expect(readFileSync(tsPath, 'utf-8')).toBe(tsBefore)
+  })
+})

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -3,7 +3,7 @@
 import { existsSync, mkdirSync, copyFileSync, writeFileSync, readFileSync, readdirSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
-import { findBarefootJson, loadBarefootConfig, type BarefootConfig } from '../context'
+import type { BarefootConfig } from '../context'
 import { resolveDependencies } from '../lib/dependency-resolver'
 import type { MetaIndex, MetaIndexEntry, ComponentMeta, RegistryItem } from '../lib/types'
 
@@ -30,15 +30,14 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  // Load barefoot.json
-  const configPath = findBarefootJson(process.cwd())
-  if (!configPath) {
-    console.error('Error: barefoot.json not found. Run `barefoot init` first.')
+  if (!ctx.config || !ctx.projectDir) {
+    console.error('Error: project config not found. Run `barefoot init` first.')
+    console.error('       (looked for barefoot.config.ts and barefoot.json walking up from the cwd)')
     process.exit(1)
   }
 
-  const projectDir = path.dirname(configPath)
-  const config = loadBarefootConfig(configPath)
+  const projectDir = ctx.projectDir
+  const config = ctx.config
 
   if (registryUrl) {
     await addFromRegistry(componentNames, registryUrl, projectDir, config, force, false)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,11 +4,16 @@
 //
 //   1. Default (app mode): scaffold a runnable starter app for an adapter
 //      (currently Hono). Counter component + server + npm scripts so the
-//      user can `npm install && npm run dev` and see a working page.
+//      user can `npm install && npm run dev` and see a working page. The
+//      app emits a single `barefoot.config.ts` with `paths` and build
+//      options as the only project config.
 //
 //   2. --registry-only: scaffold just the component-registry directory
 //      layout (barefoot.json + tokens/ + meta/ + components/ui/), without
 //      a server. Useful for projects that only consume `barefoot add`.
+//      Registry-only projects keep `barefoot.json` because they have no
+//      adapter (and `barefoot.config.ts` requires one). `barefoot migrate`
+//      handles the upgrade once an adapter is added.
 
 import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync } from 'fs'
 import path from 'path'
@@ -58,15 +63,22 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const projectDir = process.cwd()
   const flags = parseFlags(args)
 
-  // Check if already initialized
-  const configPath = path.join(projectDir, 'barefoot.json')
-  if (existsSync(configPath)) {
+  // Detect prior initialization. App mode emits barefoot.config.ts as the
+  // canonical config; registry-only emits barefoot.json. Either presence
+  // counts as "already initialized" so we don't clobber an existing project.
+  const tsConfigPath = path.join(projectDir, 'barefoot.config.ts')
+  const jsonConfigPath = path.join(projectDir, 'barefoot.json')
+  if (existsSync(tsConfigPath)) {
+    console.error('Error: barefoot.config.ts already exists. Project is already initialized.')
+    process.exit(1)
+  }
+  if (existsSync(jsonConfigPath)) {
     console.error('Error: barefoot.json already exists. Project is already initialized.')
     process.exit(1)
   }
 
   if (flags.registryOnly) {
-    await runRegistryOnly(projectDir, configPath, flags, ctx)
+    await runRegistryOnly(projectDir, jsonConfigPath, flags, ctx)
     return
   }
 
@@ -102,7 +114,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   console.log(`Initializing BarefootJS app with the ${adapter.label} adapter...\n`)
 
-  await scaffoldApp(projectDir, configPath, adapter, flags, ctx)
+  await scaffoldApp(projectDir, adapter, flags, ctx)
   printAppNextSteps(projectDir, adapter)
 }
 
@@ -261,18 +273,20 @@ async function runRegistryOnly(
 
 async function scaffoldApp(
   projectDir: string,
-  configPath: string,
   adapter: AdapterTemplate,
   flags: InitFlags,
   _ctx: CliContext,
 ): Promise<void> {
-  // 1. barefoot.json — components live next to server.tsx by default for
-  //    apps. The registry-only mode keeps the original `components/ui`
-  //    convention; here we use plain `components/` so user code and
-  //    `barefoot add` output coexist cleanly (barefoot add lands in
-  //    `components/ui/` per the path config).
+  // The single source of truth is `barefoot.config.ts` (written below via
+  // adapter.files). It carries both `paths` (consumed by registry tooling)
+  // and the build options. We mirror the same defaults here as a plain
+  // BarefootConfig so the rest of init can reason about layout without
+  // re-loading the TS file.
+  //
+  // App mode places user-authored code in `components/` (next to server.tsx)
+  // and lands `barefoot add` output in `components/ui/` so the two coexist
+  // cleanly.
   const config: BarefootConfig = {
-    $schema: DEFAULT_CONFIG.$schema,
     paths: {
       components: 'components/ui',
       tokens: 'tokens',
@@ -280,10 +294,8 @@ async function scaffoldApp(
     },
   }
   if (flags.name) config.name = flags.name
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n')
-  console.log('  Created barefoot.json')
 
-  // 2. Adapter-contributed files (server, components/Counter, etc.)
+  // 2. Adapter-contributed files (server, components/Counter, barefoot.config.ts, etc.)
   for (const [relPath, contents] of Object.entries(adapter.files)) {
     const target = path.join(projectDir, relPath)
     if (existsSync(target)) {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,123 @@
+// `barefoot migrate` — fold a legacy `barefoot.json` into `barefoot.config.ts`.
+//
+// Background: until issue #1097 the project carried two configs. `paths`
+// lived in `barefoot.json` (consumed by registry tooling) and the adapter
+// + build options lived in `barefoot.config.ts`. The new layout merges
+// `paths` into `barefoot.config.ts` so the project has a single source of
+// truth.
+//
+// This command performs the upgrade:
+//
+//   1. Read the legacy `barefoot.json` (must exist).
+//   2. Read the existing `barefoot.config.ts` (must exist — registry-only
+//      projects have no adapter and stay on JSON until that changes).
+//   3. Inject a `paths: {...}` block into the `createConfig({...})` call
+//      in `barefoot.config.ts`. If a `paths` field already exists, leave
+//      the file alone and assume the user already migrated.
+//   4. Delete the legacy `barefoot.json`.
+//
+// We do not try to be clever with AST parsing here. The starter template
+// uses a stable shape (`createConfig({ ... })`) and the codemod is forgiving:
+// when the file shape is unrecognised we fail loudly rather than silently
+// producing bad output.
+
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+import { findBarefootJson, loadBarefootConfig } from '../context'
+
+export async function run(args: string[], _ctx: CliContext): Promise<void> {
+  const dryRun = args.includes('--dry-run')
+  const cwd = process.cwd()
+
+  const jsonPath = findBarefootJson(cwd)
+  if (!jsonPath) {
+    console.error('Error: no barefoot.json found in or above the current directory.')
+    console.error('       Nothing to migrate.')
+    process.exit(1)
+  }
+
+  const projectDir = path.dirname(jsonPath)
+  const tsPath = path.join(projectDir, 'barefoot.config.ts')
+
+  if (!existsSync(tsPath)) {
+    console.error(`Error: barefoot.config.ts not found at ${tsPath}.`)
+    console.error('       This is likely a `barefoot init --registry-only` project, which keeps')
+    console.error('       barefoot.json until an adapter is added. To migrate, first add an')
+    console.error('       adapter (e.g. write a barefoot.config.ts that imports `createConfig`')
+    console.error('       from `@barefootjs/hono/build`) and re-run `barefoot migrate`.')
+    process.exit(1)
+  }
+
+  const json = loadBarefootConfig(jsonPath)
+  const ts = readFileSync(tsPath, 'utf-8')
+
+  if (/(^|\W)paths\s*:/.test(ts)) {
+    console.log(`barefoot.config.ts already declares \`paths\` — assuming this project is already migrated.`)
+    console.log(`If that is wrong, edit the file by hand and delete barefoot.json.`)
+    process.exit(0)
+  }
+
+  const patched = injectPathsIntoConfig(ts, json.paths)
+  if (patched === null) {
+    console.error('Error: could not locate the `createConfig({ ... })` call in barefoot.config.ts.')
+    console.error('       The migrate codemod expects the starter template shape:')
+    console.error('')
+    console.error('         export default createConfig({')
+    console.error('           ...')
+    console.error('         })')
+    console.error('')
+    console.error('       Add a `paths: { components, tokens, meta }` field by hand and delete')
+    console.error('       barefoot.json.')
+    process.exit(1)
+  }
+
+  if (dryRun) {
+    console.log('--- barefoot.config.ts (after) ---')
+    console.log(patched)
+    console.log('---')
+    console.log(`Would delete: ${path.relative(cwd, jsonPath)}`)
+    return
+  }
+
+  writeFileSync(tsPath, patched)
+  console.log(`  Patched ${path.relative(cwd, tsPath)} — added \`paths\` block`)
+
+  unlinkSync(jsonPath)
+  console.log(`  Deleted ${path.relative(cwd, jsonPath)}`)
+
+  console.log('')
+  console.log('Migration complete. The project now reads paths from barefoot.config.ts.')
+}
+
+/**
+ * Insert a `paths: {...}` field at the top of the first `createConfig({...})`
+ * (or `defineConfig({...})`) call in the file. Returns null when no such call
+ * is found.
+ *
+ * Indentation is inferred from the line of the call site so the inserted
+ * block matches the surrounding code style. The function only edits the
+ * first matching call — the starter template never has more than one.
+ */
+export function injectPathsIntoConfig(source: string, paths: { components: string; tokens: string; meta: string }): string | null {
+  const match = /(createConfig|defineConfig)\s*\(\s*\{/.exec(source)
+  if (!match) return null
+
+  const callOpenBrace = match.index + match[0].length - 1
+  const insertPos = callOpenBrace + 1
+
+  // Infer the indent of the call site from the start of its line.
+  const lineStart = source.lastIndexOf('\n', match.index) + 1
+  const baseIndent = source.slice(lineStart, match.index).match(/^\s*/)?.[0] ?? ''
+  const childIndent = baseIndent + '  '
+
+  const block =
+    `\n${childIndent}// Project layout — read by \`barefoot add\`, \`search\`, \`meta:extract\`, etc.` +
+    `\n${childIndent}paths: {` +
+    `\n${childIndent}  components: ${JSON.stringify(paths.components)},` +
+    `\n${childIndent}  tokens: ${JSON.stringify(paths.tokens)},` +
+    `\n${childIndent}  meta: ${JSON.stringify(paths.meta)},` +
+    `\n${childIndent}},`
+
+  return source.slice(0, insertPos) + block + source.slice(insertPos)
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,15 @@
 // Build config types for barefoot.config.ts
 
-import type { TemplateAdapter, BuildOptions } from '@barefootjs/jsx'
+import type { TemplateAdapter, BuildOptions, BarefootPaths } from '@barefootjs/jsx'
+
+export type { BarefootPaths } from '@barefootjs/jsx'
+
+/** Default paths layout used when `paths` is omitted from barefoot.config.ts. */
+export const DEFAULT_PATHS: BarefootPaths = {
+  components: 'components/ui',
+  tokens: 'tokens',
+  meta: 'meta',
+}
 
 export interface BarefootBuildConfig extends BuildOptions {
   /** Adapter instance (e.g. HonoAdapter, GoTemplateAdapter) */

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -3,32 +3,69 @@
 import { existsSync, readFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'node:url'
+import type { BarefootBuildConfig } from './config'
+import { DEFAULT_PATHS, type BarefootPaths } from './config'
+import { loadBuildConfig } from './lib/config-loader'
 
 const thisDir = path.dirname(fileURLToPath(import.meta.url))
 
+/**
+ * Project-level config consumed by registry tooling (`barefoot add`,
+ * `search`, `meta:extract`, etc.). Source of truth is `barefoot.config.ts`;
+ * legacy `barefoot.json` is loaded as a fallback during migration.
+ */
 export interface BarefootConfig {
   $schema?: string
   name?: string
-  paths: {
-    components: string
-    tokens: string
-    meta: string
-  }
+  paths: BarefootPaths
 }
 
 export interface CliContext {
   root: string       // repo root (absolute)
   metaDir: string    // ui/meta/ (absolute)
   jsonFlag: boolean  // --json flag
-  /** barefoot.json config if found (null = monorepo mode). */
+  /** Project config if found (null = monorepo mode). */
   config: BarefootConfig | null
-  /** Directory containing barefoot.json (absolute). */
+  /** Directory containing the project config (absolute). */
   projectDir: string | null
 }
 
 /**
- * Search upward from startDir for barefoot.json.
- * Returns the absolute path to barefoot.json, or null if not found.
+ * Search upward from startDir for the first directory containing either
+ * `barefoot.config.ts` or `barefoot.json`. The TS config takes precedence
+ * when both exist in the same directory; legacy JSON-only projects keep
+ * working until they run `barefoot migrate`.
+ */
+export function findProjectConfig(startDir: string): {
+  dir: string
+  tsConfigPath: string | null
+  jsonConfigPath: string | null
+} | null {
+  let dir = path.resolve(startDir)
+  const { root: fsRoot } = path.parse(dir)
+  while (true) {
+    const ts = path.join(dir, 'barefoot.config.ts')
+    const json = path.join(dir, 'barefoot.json')
+    const tsExists = existsSync(ts)
+    const jsonExists = existsSync(json)
+    if (tsExists || jsonExists) {
+      return {
+        dir,
+        tsConfigPath: tsExists ? ts : null,
+        jsonConfigPath: jsonExists ? json : null,
+      }
+    }
+    if (dir === fsRoot) return null
+    dir = path.dirname(dir)
+  }
+}
+
+/**
+ * Search upward from startDir for `barefoot.json` only.
+ *
+ * Retained for the migration codemod and any tool that needs to detect a
+ * legacy JSON-only project. Day-to-day code should call `findProjectConfig`
+ * instead, which prefers `barefoot.config.ts`.
  */
 export function findBarefootJson(startDir: string): string | null {
   let dir = path.resolve(startDir)
@@ -42,33 +79,80 @@ export function findBarefootJson(startDir: string): string | null {
 }
 
 /**
- * Load and parse barefoot.json from the given path.
+ * Load and parse barefoot.json. Retained for the migration codemod; new
+ * code should prefer `loadBuildConfig` to read from barefoot.config.ts.
  */
 export function loadBarefootConfig(configPath: string): BarefootConfig {
   return JSON.parse(readFileSync(configPath, 'utf-8'))
 }
 
+// Per-cwd cache so `barefoot build` (which loads its own copy) and the
+// surrounding command (which loads via createContext) don't transpile the
+// config twice in one CLI invocation.
+const buildConfigCache = new Map<string, Promise<BarefootBuildConfig>>()
+
+/**
+ * Load `barefoot.config.ts` once per absolute path in this process and
+ * memoise the result. Returns the parsed `BarefootBuildConfig`.
+ */
+export function loadBuildConfigCached(configPath: string): Promise<BarefootBuildConfig> {
+  const abs = path.resolve(configPath)
+  let cached = buildConfigCache.get(abs)
+  if (!cached) {
+    cached = loadBuildConfig(abs)
+    buildConfigCache.set(abs, cached)
+  }
+  return cached
+}
+
 /**
  * Create a CliContext.
  *
- * 1. Search upward from cwd for barefoot.json.
- * 2. If found, use its paths configuration.
- * 3. Otherwise, fall back to monorepo-relative paths.
+ * Resolution order:
+ *   1. `barefoot.config.ts` (canonical) — read `paths` (or default).
+ *   2. Legacy `barefoot.json` — kept working until the project runs
+ *      `barefoot migrate`.
+ *   3. Monorepo fallback — used when neither config is present.
  */
-export function createContext(jsonFlag: boolean): CliContext {
-  const configPath = findBarefootJson(process.cwd())
+export async function createContext(jsonFlag: boolean): Promise<CliContext> {
+  const found = findProjectConfig(process.cwd())
+  const root = path.resolve(thisDir, '../../..')
 
-  if (configPath) {
-    const projectDir = path.dirname(configPath)
-    const config = loadBarefootConfig(configPath)
-    const metaDir = path.resolve(projectDir, config.paths.meta)
-    // root = monorepo root (for source lookups); projectDir = user project
-    const root = path.resolve(thisDir, '../../..')
-    return { root, metaDir, jsonFlag, config, projectDir }
+  if (found?.tsConfigPath) {
+    // Loading the TS config can fail in two practical situations:
+    //   - dependencies are not installed yet (esbuild can't resolve
+    //     `@barefootjs/hono/build` etc.)
+    //   - the config has a syntax error or imports that no longer resolve
+    // Migration / setup commands need to keep working in those cases. Fall
+    // through to the JSON fallback (or to no-config mode) when load fails.
+    try {
+      const buildConfig = await loadBuildConfigCached(found.tsConfigPath)
+      const paths: BarefootPaths = { ...DEFAULT_PATHS, ...(buildConfig.paths ?? {}) }
+      const config: BarefootConfig = { paths }
+      const metaDir = path.resolve(found.dir, paths.meta)
+      return { root, metaDir, jsonFlag, config, projectDir: found.dir }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`Warning: failed to load barefoot.config.ts (${msg}). Falling back to defaults.`)
+    }
+  }
+
+  if (found?.jsonConfigPath) {
+    const config = loadBarefootConfig(found.jsonConfigPath)
+    config.paths = { ...DEFAULT_PATHS, ...(config.paths ?? {}) }
+    const metaDir = path.resolve(found.dir, config.paths.meta)
+    return { root, metaDir, jsonFlag, config, projectDir: found.dir }
+  }
+
+  // If a TS config exists but failed to load, we still know the projectDir.
+  // Surface that to commands that don't need the parsed config (e.g. `migrate`).
+  if (found?.tsConfigPath) {
+    const paths = { ...DEFAULT_PATHS }
+    const metaDir = path.resolve(found.dir, paths.meta)
+    return { root, metaDir, jsonFlag, config: { paths }, projectDir: found.dir }
   }
 
   // Fallback: monorepo mode
-  const root = path.resolve(thisDir, '../../..')
   const metaDir = path.join(root, 'ui/meta')
   return { root, metaDir, jsonFlag, config: null, projectDir: null }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ const filteredArgs = args.filter(a => a !== '--json')
 const command = filteredArgs[0]
 const commandArgs = filteredArgs.slice(1)
 
-const ctx = createContext(jsonFlag)
+const ctx = await createContext(jsonFlag)
 
 function printUsage() {
   console.log(`Usage: barefoot <command> [options]
@@ -17,6 +17,7 @@ function printUsage() {
 Commands:
   build [--minify] [--force] [--watch]  Compile components using barefoot.config.ts
   init [--name <name>] [--from <url>]  Initialize a new BarefootJS project
+  migrate [--dry-run]         Migrate legacy barefoot.json into barefoot.config.ts
   add <component...> [--force] [--registry <url>] Add components to your project
   search <query> [--dir <path>] [--registry <url>] Search components and documentation
   ui <component>              Show component documentation (props, examples, a11y)
@@ -57,6 +58,12 @@ switch (command) {
 
   case 'init': {
     const { run } = await import('./commands/init')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'migrate': {
+    const { run } = await import('./commands/migrate')
     await run(commandArgs, ctx)
     break
   }

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -3,7 +3,7 @@
 // Resolution order:
 // 1. Direct file path (absolute or relative)
 // 2. ui/components/ui/<name>/index.tsx (monorepo layout)
-// 3. barefoot.json configured component directory
+// 3. project-config-derived component directory (paths.components from barefoot.config.ts)
 
 import { existsSync } from 'fs'
 import path from 'path'
@@ -29,7 +29,7 @@ export function resolveComponentSource(nameOrPath: string, ctx: CliContext): Res
     return { filePath: monoPath }
   }
 
-  // 3. barefoot.json configured directory
+  // 3. paths.components from barefoot.config.ts (or legacy barefoot.json)
   if (ctx.config && ctx.projectDir) {
     const configPath = path.join(ctx.projectDir, ctx.config.paths.components, nameOrPath, 'index.tsx')
     if (existsSync(configPath)) {

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -379,6 +379,13 @@ const COMPONENTS_MANIFEST_SEED = '{}\n'
 const HONO_BAREFOOT_CONFIG_TS = `import { createConfig } from '@barefootjs/hono/build'
 
 export default createConfig({
+  // Project layout — read by \`barefoot add\`, \`search\`, \`meta:extract\`, etc.
+  paths: {
+    components: 'components/ui',
+    tokens: 'tokens',
+    meta: 'meta',
+  },
+  // Build inputs and output
   components: ['components'],
   outDir: 'dist',
   scriptBasePath: '/static/components/',

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -126,7 +126,28 @@ export interface BundleEntry {
   externals?: string[]
 }
 
+/**
+ * Project layout paths used by registry tooling (`barefoot add`, `search`,
+ * `meta:extract`, `tokens`, `inspect`, etc.). These are consumed only by
+ * non-build tooling — the build pipeline ignores them — but they live in
+ * `barefoot.config.ts` so the project has a single source of truth.
+ */
+export interface BarefootPaths {
+  /** Component registry root (where `barefoot add` lands new components). */
+  components: string
+  /** Tokens directory (tokens.json, tokens.css). */
+  tokens: string
+  /** Meta directory (meta/index.json + per-component meta files). */
+  meta: string
+}
+
 export interface BuildOptions {
+  /**
+   * Project layout paths. Consumed by registry tooling, not the build pipeline.
+   * Defaults to `{ components: 'components/ui', tokens: 'tokens', meta: 'meta' }`
+   * when omitted.
+   */
+  paths?: BarefootPaths
   /** Source component directories relative to config file */
   components?: string[]
   /** Output directory relative to config file */


### PR DESCRIPTION
Closes #1097.

Implements **Option A** from the issue discussion: drop `barefoot.json`, fold `paths` into `barefoot.config.ts` so each project has a single source of truth for both registry tooling and build config.

## Summary

- Add `paths` to `BuildOptions` (`@barefootjs/jsx`) and forward it through every adapter's `createConfig` (Hono, Go template, Mojolicious).
- Refactor `createContext` to walk up for `barefoot.config.ts` first and fall back to legacy `barefoot.json`. Load failures degrade gracefully so `barefoot migrate` still works in projects whose deps aren't installed yet.
- `barefoot init` (app mode) emits `paths` inside the generated `barefoot.config.ts` and no longer writes `barefoot.json`. `--registry-only` keeps the legacy JSON layout for now (it has no adapter, so the TS config can't host it yet).
- New `barefoot migrate` codemod injects the `paths` block into an existing `barefoot.config.ts` from a sibling `barefoot.json` and deletes the JSON, with `--dry-run` for safe preview. Fails loud on unrecognised file shapes.

## Test plan

- [x] `bun test packages/cli/ packages/adapter-hono/ packages/adapter-go-template/ packages/adapter-mojolicious/` — 557 pass / 0 fail
- [x] New `migrate.test.ts` covers `injectPathsIntoConfig` (happy path, indent inference, `defineConfig`, no-match) and an end-to-end migrate run including `--dry-run`
- [x] Smoke-tested `barefoot init --registry-only` (still emits `barefoot.json`)
- [x] Smoke-tested `barefoot migrate` end-to-end on a tmp project — `paths` block injected, `barefoot.json` deleted
- [ ] Manual upgrade of an existing project to confirm the migration path before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)