### PR TITLE
cli: add `barefoot studio apply &lt;url&gt;` for Studio token sync

### DIFF
--- a/packages/cli/src/__tests__/studio.test.ts
+++ b/packages/cli/src/__tests__/studio.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import path from 'path'
+import os from 'os'
+import {
+  parseStudioUrl,
+  applyTokenOverrides,
+  appendCSSOverrides,
+  type StudioConfig,
+} from '../commands/studio'
+
+// ── parseStudioUrl ──
+
+describe('parseStudioUrl', () => {
+  test('extracts and decodes ?c= param', () => {
+    const config: StudioConfig = { style: 'Sharp', radius: '0' }
+    const encoded = encodeURIComponent(btoa(JSON.stringify(config)))
+    const url = `https://ui.barefootjs.dev/studio?c=${encoded}`
+    expect(parseStudioUrl(url)).toEqual(config)
+  })
+
+  test('returns undefined when no ?c= param', () => {
+    expect(parseStudioUrl('https://ui.barefootjs.dev/studio')).toBeUndefined()
+  })
+
+  test('returns undefined for malformed Base64', () => {
+    expect(parseStudioUrl('https://ui.barefootjs.dev/studio?c=!!!invalid!!!')).toBeUndefined()
+  })
+
+  test('returns undefined for invalid URL', () => {
+    expect(parseStudioUrl('not-a-url')).toBeUndefined()
+  })
+})
+
+// ── applyTokenOverrides ──
+
+describe('applyTokenOverrides', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-studio-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeTokens(data: any): string {
+    const p = path.join(tmpDir, 'tokens.json')
+    writeFileSync(p, JSON.stringify(data, null, 2))
+    return p
+  }
+
+  function readTokens(p: string): any {
+    return JSON.parse(readFileSync(p, 'utf-8'))
+  }
+
+  test('applies color overrides to colors array (bare names)', () => {
+    const tokensPath = writeTokens({
+      colors: [
+        { name: 'primary', value: 'oklch(0.205 0 0)', dark: 'oklch(0.35 0 0)' },
+        { name: 'secondary', value: 'oklch(0.97 0 0)', dark: 'oklch(0.269 0 0)' },
+      ],
+    })
+
+    applyTokenOverrides(tokensPath, {
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)', dark: 'oklch(0.7 0.15 240)' },
+      },
+    })
+
+    const result = readTokens(tokensPath)
+    expect(result.colors[0].value).toBe('oklch(0.5 0.2 240)')
+    expect(result.colors[0].dark).toBe('oklch(0.7 0.15 240)')
+    expect(result.colors[1].value).toBe('oklch(0.97 0 0)')
+  })
+
+  test('applies spacing override', () => {
+    const tokensPath = writeTokens({
+      spacing: [{ name: 'spacing', value: '0.25rem' }],
+    })
+
+    applyTokenOverrides(tokensPath, { spacing: '0.3rem' })
+
+    expect(readTokens(tokensPath).spacing[0].value).toBe('0.3rem')
+  })
+
+  test('applies radius override', () => {
+    const tokensPath = writeTokens({
+      borderRadius: [{ name: 'radius', value: '0.625rem' }],
+    })
+
+    applyTokenOverrides(tokensPath, { radius: '0' })
+
+    expect(readTokens(tokensPath).borderRadius[0].value).toBe('0')
+  })
+
+  test('applies font override with key mapping', () => {
+    const tokensPath = writeTokens({
+      typography: {
+        fontFamily: [{ name: 'font-sans', value: '-apple-system, sans-serif' }],
+      },
+    })
+
+    applyTokenOverrides(tokensPath, { font: 'inter' })
+
+    expect(readTokens(tokensPath).typography.fontFamily[0].value).toBe('"Inter", sans-serif')
+  })
+
+  test('applies shadow presets for Sharp style', () => {
+    const tokensPath = writeTokens({
+      shadows: [
+        { name: 'shadow-sm', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
+        { name: 'shadow', value: '0 1px 3px 0 rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-md', value: '0 4px 6px -1px rgb(0 0 0 / 0.1)' },
+        { name: 'shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
+      ],
+    })
+
+    applyTokenOverrides(tokensPath, { style: 'Sharp' })
+
+    const result = readTokens(tokensPath)
+    expect(result.shadows[0].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.04)')
+    expect(result.shadows[1].value).toBe('0 1px 2px 0 rgb(0 0 0 / 0.06)')
+  })
+
+  test('ignores unknown style names', () => {
+    const tokensPath = writeTokens({
+      shadows: [{ name: 'shadow-sm', value: 'original' }],
+    })
+
+    applyTokenOverrides(tokensPath, { style: 'Unknown' })
+
+    expect(readTokens(tokensPath).shadows[0].value).toBe('original')
+  })
+})
+
+// ── appendCSSOverrides ──
+
+describe('appendCSSOverrides', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-studio-css-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('appends --spacing to :root block', () => {
+    const cssPath = path.join(tmpDir, 'tokens.css')
+    writeFileSync(cssPath, ':root {\n  --radius: 0.625rem;\n}\n')
+
+    appendCSSOverrides(cssPath, { spacing: '0.3rem' })
+
+    const result = readFileSync(cssPath, 'utf-8')
+    expect(result).toContain('--spacing: 0.3rem;')
+    expect(result).toContain('Studio overrides')
+    expect(result).toContain('--radius: 0.625rem;')
+  })
+
+  test('does nothing when no spacing override', () => {
+    const cssPath = path.join(tmpDir, 'tokens.css')
+    const original = ':root {\n  --radius: 0.625rem;\n}\n'
+    writeFileSync(cssPath, original)
+
+    appendCSSOverrides(cssPath, { style: 'Sharp' })
+
+    expect(readFileSync(cssPath, 'utf-8')).toBe(original)
+  })
+})
+
+// ── Round-trip ──
+
+describe('round-trip encoding', () => {
+  test('encode → URL → decode produces same config', () => {
+    const original: StudioConfig = {
+      style: 'Soft',
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)' },
+        destructive: { light: 'oklch(0.6 0.3 30)', dark: 'oklch(0.7 0.2 30)' },
+      },
+      spacing: '0.3rem',
+      radius: '1rem',
+      font: 'figtree',
+    }
+
+    const encoded = encodeURIComponent(btoa(JSON.stringify(original)))
+    const url = `https://ui.barefootjs.dev/studio?c=${encoded}`
+    expect(parseStudioUrl(url)).toEqual(original)
+  })
+})

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1,0 +1,256 @@
+// `barefoot studio apply <url>` — Apply a Studio-encoded token config
+// (from a `?c=...` URL) onto an existing project's tokens.
+//
+// Reads `paths.tokens` from `barefoot.config.ts`, then:
+//   1. Patches `<tokens>/tokens.json` with color / spacing / radius / font /
+//      shadow overrides decoded from the Studio URL.
+//   2. Regenerates `<tokens>/tokens.css` from the patched JSON if the
+//      monorepo's token module is reachable (skipped silently otherwise).
+//   3. Appends CSS variable overrides that aren't represented in
+//      tokens.json (e.g. `--spacing`) to `<tokens>/tokens.css`.
+
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+
+export interface StudioConfig {
+  style?: string
+  tokens?: Record<string, { light?: string; dark?: string }>
+  spacing?: string
+  radius?: string
+  font?: string
+}
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const sub = args[0]
+  if (sub !== 'apply') {
+    printUsage()
+    process.exit(sub ? 1 : 0)
+  }
+
+  const url = args[1]
+  if (!url) {
+    console.error('Error: studio apply requires a Studio URL.')
+    console.error('Usage: barefoot studio apply <url>')
+    process.exit(1)
+  }
+
+  if (!ctx.config || !ctx.projectDir) {
+    console.error('Error: project config not found. Run `barefoot init` first.')
+    process.exit(1)
+  }
+
+  const studioConfig = parseStudioUrl(url)
+  if (!studioConfig) {
+    console.error('Error: could not decode Studio config from the URL (no `?c=` param or malformed payload).')
+    process.exit(1)
+  }
+
+  const tokensDir = path.resolve(ctx.projectDir, ctx.config.paths.tokens)
+  const tokensJsonPath = path.join(tokensDir, 'tokens.json')
+  const tokensCssPath = path.join(tokensDir, 'tokens.css')
+
+  if (!existsSync(tokensJsonPath)) {
+    console.error(`Error: ${path.relative(ctx.projectDir, tokensJsonPath)} not found.`)
+    console.error('       Studio overrides need an existing tokens.json to patch.')
+    process.exit(1)
+  }
+
+  applyTokenOverrides(tokensJsonPath, studioConfig)
+  console.log(`  Patched ${path.relative(ctx.projectDir, tokensJsonPath)}`)
+
+  await generateTokensCSS(ctx.root, tokensJsonPath, tokensDir, ctx.config.paths.tokens)
+
+  appendCSSOverrides(tokensCssPath, studioConfig)
+}
+
+function printUsage(): void {
+  console.log(`Usage: barefoot studio <subcommand>
+
+Subcommands:
+  apply <url>    Apply a Studio token config (\`?c=...\` URL) to this project's tokens
+`)
+}
+
+// ── URL parsing ──
+
+export function parseStudioUrl(url: string): StudioConfig | undefined {
+  try {
+    const parsed = new URL(url)
+    const encoded = parsed.searchParams.get('c')
+    if (!encoded) return undefined
+    const json = atob(decodeURIComponent(encoded))
+    return JSON.parse(json)
+  } catch {
+    return undefined
+  }
+}
+
+// ── Token override logic ──
+
+export function applyTokenOverrides(tokensJsonPath: string, config: StudioConfig): void {
+  const raw = readFileSync(tokensJsonPath, 'utf-8')
+  const tokensData = JSON.parse(raw)
+
+  if (config.tokens) {
+    for (const [name, values] of Object.entries(config.tokens)) {
+      applyColorOverride(tokensData, name, values)
+    }
+  }
+
+  if (config.spacing) {
+    applySimpleOverride(tokensData, '--spacing', config.spacing)
+  }
+
+  if (config.radius) {
+    applySimpleOverride(tokensData, '--radius', config.radius)
+  }
+
+  if (config.font) {
+    // Font key → font-family value mapping (mirrors Studio's font picker).
+    const fontMap: Record<string, string> = {
+      system: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
+      inter: '"Inter", sans-serif',
+      'noto-sans': '"Noto Sans", sans-serif',
+      'nunito-sans': '"Nunito Sans", sans-serif',
+      figtree: '"Figtree", sans-serif',
+    }
+    const fontValue = fontMap[config.font] || config.font
+    applySimpleOverride(tokensData, '--font-sans', fontValue)
+  }
+
+  if (config.style) {
+    applyShadowPreset(tokensData, config.style)
+  }
+
+  writeFileSync(tokensJsonPath, JSON.stringify(tokensData, null, 2) + '\n')
+}
+
+function applyColorOverride(
+  tokensData: any,
+  name: string,
+  values: { light?: string; dark?: string },
+): void {
+  const varName = `--${name}`
+  if (Array.isArray(tokensData.colors)) {
+    for (const token of tokensData.colors) {
+      if (token.name === varName || token.name === name) {
+        if (values.light) token.value = values.light
+        if (values.dark) token.dark = values.dark
+        return
+      }
+    }
+  }
+  if (Array.isArray(tokensData.tokens)) {
+    for (const token of tokensData.tokens) {
+      if (token.name === varName || token.name === name) {
+        if (values.light) token.value = values.light
+        if (values.dark) token.dark = values.dark
+        return
+      }
+    }
+  }
+}
+
+function applySimpleOverride(tokensData: any, name: string, value: string): void {
+  // tokens.json uses bare names (e.g. "radius") without the `--` prefix.
+  const bareName = name.startsWith('--') ? name.slice(2) : name
+
+  const sections = [
+    tokensData.colors, tokensData.spacing, tokensData.borderRadius,
+    tokensData.shadows, tokensData.layout,
+  ]
+  if (tokensData.typography) {
+    for (const arr of Object.values(tokensData.typography)) {
+      if (Array.isArray(arr)) sections.push(arr as any[])
+    }
+  }
+
+  for (const arr of sections) {
+    if (!Array.isArray(arr)) continue
+    for (const token of arr) {
+      if (token.name === bareName || token.name === name) {
+        token.value = value
+        return
+      }
+    }
+  }
+}
+
+function applyShadowPreset(tokensData: any, styleName: string): void {
+  // Preset names mirror Studio's stylePresets. Bare keys to match tokens.json.
+  const presets: Record<string, Record<string, string>> = {
+    Sharp: {
+      'shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
+      'shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
+      'shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
+      'shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
+    },
+    Soft: {
+      'shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
+      'shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
+      'shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
+      'shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
+    },
+    Compact: {
+      'shadow-sm': 'none',
+      'shadow': 'none',
+      'shadow-md': 'none',
+      'shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+    },
+  }
+
+  const shadows = presets[styleName]
+  if (!shadows) return
+
+  for (const [name, value] of Object.entries(shadows)) {
+    applySimpleOverride(tokensData, name, value)
+  }
+}
+
+/**
+ * Append CSS variable overrides that aren't part of tokens.json
+ * (e.g., `--spacing` is a Tailwind v4 variable, not in our token schema).
+ */
+export function appendCSSOverrides(cssPath: string, config: StudioConfig): void {
+  if (!existsSync(cssPath)) return
+
+  const lines: string[] = []
+  if (config.spacing) {
+    lines.push(`  --spacing: ${config.spacing};`)
+  }
+
+  if (lines.length === 0) return
+
+  const existing = readFileSync(cssPath, 'utf-8')
+  const rootCloseIdx = existing.indexOf('}')
+  if (rootCloseIdx === -1) return
+
+  const patched = existing.slice(0, rootCloseIdx) +
+    `\n  /* ── Studio overrides ── */\n${lines.join('\n')}\n` +
+    existing.slice(rootCloseIdx)
+
+  writeFileSync(cssPath, patched)
+}
+
+async function generateTokensCSS(
+  root: string,
+  tokensJsonPath: string,
+  tokensDir: string,
+  tokensRelDir: string,
+): Promise<void> {
+  try {
+    const { loadTokens, generateCSS } = await import(
+      path.resolve(root, 'site/shared/tokens/index')
+    )
+    const tokenSet = await loadTokens(tokensJsonPath)
+    const css = generateCSS(tokenSet)
+    writeFileSync(path.join(tokensDir, 'tokens.css'), css)
+    console.log(`  Regenerated ${tokensRelDir}/tokens.css`)
+  } catch {
+    // Token generation requires the monorepo's `site/shared/tokens` module.
+    // In a published CLI bundle this is unreachable; the user re-runs their
+    // build pipeline to project tokens.json into tokens.css.
+    console.log(`  Skipped tokens.css regeneration (run your tokens build pipeline)`)
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ Commands:
   build [--minify] [--force] [--watch]  Compile components using barefoot.config.ts
   init [--name <name>] [--adapter <name>]  Initialize a new BarefootJS project
   add <component...> [--force] [--registry <url>] Add components to your project
+  studio apply <url>          Apply Studio token overrides to this project's tokens
   search <query> [--dir <path>] [--registry <url>] Search components and documentation
   ui <component>              Show component documentation (props, examples, a11y)
   core [document]             Show core documentation (concepts, API, guides)
@@ -63,6 +64,12 @@ switch (command) {
 
   case 'add': {
     const { run } = await import('./commands/add')
+    await run(commandArgs, ctx)
+    break
+  }
+
+  case 'studio': {
+    const { run } = await import('./commands/studio')
     await run(commandArgs, ctx)
     break
   }


### PR DESCRIPTION
Follow-up to #1123. The YAGNI cleanup there removed the `--from <url>` Studio integration along with `--registry-only`; this restores Studio-token sync as a standalone command so it works against any existing project, not just freshly-initialized ones.

## Usage

```
barefoot studio apply <studio-url>
```

Reads `paths.tokens` from `barefoot.config.ts`, then:

1. Patches `<tokens>/tokens.json` with color / spacing / radius / font / shadow overrides decoded from the `?c=` payload.
2. Regenerates `<tokens>/tokens.css` from the patched JSON when the monorepo's `site/shared/tokens` module is reachable; falls back to a "run your tokens build pipeline" message in published-CLI mode.
3. Appends CSS variable overrides (e.g. `--spacing`) that aren't represented in the tokens.json schema.

## Why a separate command (not `barefoot ui ...`)

`ui` is the component-doc namespace (`barefoot ui button`); mixing token mutation in there overloads it. `studio` flags the source-of-truth explicitly: this bridge is for Studio output specifically, not arbitrary token edits.

## Diff

- New: `packages/cli/src/commands/studio.ts` — single subcommand `apply`, plus the URL-parsing and override helpers ported verbatim from the deleted init-from path.
- New: `packages/cli/src/__tests__/studio.test.ts` — 13 tests, all the original coverage for `parseStudioUrl`, `applyTokenOverrides`, `appendCSSOverrides`, plus a round-trip.
- Modified: `packages/cli/src/index.ts` — register `studio` in the dispatcher and help text.

## Base

Targeted at `claude/fix-cli-init-json-5k9T7` (PR #1123) since this depends on its cleanup. **Retarget to `main` once #1123 merges.**

## Test plan

- [x] `bun test src/__tests__/studio.test.ts` — 13/13 pass.
- [x] Full CLI suite — 244 pass, 10 fail (all pre-existing `why-wrap` module-resolution failures, unaffected by this change).
- [x] Smoke: ran `barefoot studio apply <url>` against a tmp project with a hand-written `barefoot.config.ts` + `tokens.json` + `tokens.css`. tokens.json picked up primary color + radius overrides, tokens.css got the `--spacing` append.
- [ ] Manual: run against a real `barefoot init` project once online.

https://claude.ai/code/session_01V3CTtUEyo96ViKKA1gSNAf

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3CTtUEyo96ViKKA1gSNAf)_