### PR TITLE
docs(landing): fix hero copy — Hono/Echo aren't template languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <strong>TSX in. Your template language out.</strong><br>
-  Barefoot compiles signal-based TSX into Hono, Echo, or your favorite template language.<br>
+  <strong>TSX in. Your stack out.</strong><br>
+  Barefoot compiles signal-based TSX into Hono, Echo, or whatever stack you ship on.<br>
   No virtual DOM. No SPA required.
 </p>
 

--- a/site/core/landing/components/hero.tsx
+++ b/site/core/landing/components/hero.tsx
@@ -276,10 +276,10 @@ export async function Hero() {
           <div className="hero-b-left">
             <div className="hero-b-text">
               <h1 className="hero-b-heading fade-in">
-                TSX in. <span className="hero-b-accent">Your template language out.</span>
+                TSX in. <span className="hero-b-accent">Your stack out.</span>
               </h1>
               <p className="hero-b-body fade-in-1">
-                Barefoot compiles signal-based TSX into <strong>Hono</strong>, <strong>Echo</strong>, or your favorite template language.
+                Barefoot compiles signal-based TSX into <strong>Hono</strong>, <strong>Echo</strong>, or whatever stack you ship on.
                 <br />
                 No virtual DOM. No SPA required.
               </p>


### PR DESCRIPTION
## Summary

The hero copy called Hono and Echo "template languages," but Hono is a TypeScript web framework and Echo is a Go web framework — neither is a template language, so this was a category error. Reframed the pitch around the stack the user actually ships on, and kept `README.md` and the Hero component (`site/core/landing/components/hero.tsx`) in sync.

- Heading: `TSX in. Your template language out.` → `TSX in. Your stack out.`
- Body: `... or your favorite template language.` → `... or whatever stack you ship on.`

## Test plan

- [ ] Open the landing page locally and confirm the Hero heading / body show the new copy
- [ ] Confirm the top of `README.md` shows the new copy
- [ ] No layout regressions (text length is roughly the same as before)

https://claude.ai/code/session_018PYmotvuSDDBfDJ4qkFfde