### PR TITLE
fix(jsx): preserve async modifier when lowering function declarations to const arrows (#1130)

### DIFF
--- a/packages/jsx/src/__tests__/async-function-arrow-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/async-function-arrow-rewrite.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Pins the lowering of `async function` declarations inside a `'use client'`
+ * component body to a `const <name> = async (...) => { ... }` arrow.
+ *
+ * Without preserving the `async` modifier on the rewritten arrow, any `await`
+ * inside the body throws `SyntaxError: Unexpected reserved word` at parse
+ * time in the browser, because the lowered arrow is no longer an async
+ * function. See piconic-ai/barefootjs#1130.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('async function declarations → async const arrow rewrite (#1130)', () => {
+  test('async function inside component body keeps `async` modifier on the lowered arrow', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Page() {
+        const [items, setItems] = createSignal<string[]>([])
+
+        async function fetchItems(forceRefresh = false) {
+          const res = await fetch('/api/items?force=' + forceRefresh)
+          const data = await res.json()
+          setItems(data)
+        }
+
+        return (
+          <div>
+            <button onClick={() => fetchItems(true)}>Reload</button>
+            {items().length}
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // The arrow form must keep `async` so the `await` inside it parses.
+    expect(content).toMatch(/const\s+fetchItems\s*=\s*async\s*\(/)
+    // It must NOT lower to a plain (non-async) arrow.
+    expect(content).not.toMatch(/const\s+fetchItems\s*=\s*\(forceRefresh\s*=\s*false\)\s*=>/)
+  })
+
+  test('non-async function still lowers to a plain const arrow (no spurious `async`)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Page() {
+        const [count, setCount] = createSignal(0)
+
+        function bump(by = 1) {
+          setCount(count() + by)
+        }
+
+        return <button onClick={() => bump(2)}>{count()}</button>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // Non-async functions still lower to a plain arrow — must not gain an
+    // `async` keyword by accident.
+    expect(content).toMatch(/const\s+bump\s*=\s*\(/)
+    expect(content).not.toMatch(/const\s+bump\s*=\s*async\b/)
+  })
+})

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -165,7 +165,8 @@ export abstract class JsxAdapter extends BaseAdapter {
       const body = preserveTypes
         ? (func.typedBody ?? func.body)
         : func.body
-      lines.push(`  function ${func.name}(${params}) ${body}`)
+      const asyncKw = func.isAsync ? 'async ' : ''
+      lines.push(`  ${asyncKw}function ${func.name}(${params}) ${body}`)
     }
 
     return lines.join('\n')

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1513,6 +1513,8 @@ function collectFunction(
     }
   }
 
+  const isAsync = node.modifiers?.some(m => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false
+
   ctx.localFunctions.push({
     name,
     params,
@@ -1521,6 +1523,7 @@ function collectFunction(
     returnType,
     containsJsx,
     isExported,
+    isAsync: isAsync || undefined,
     isModule: _isModule || undefined,
     isJsxFunction: isJsxFunction || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -52,7 +52,8 @@ export function emitModuleLevelDeclarations(
   // cross-module use case arises.
   for (const fn of moduleLevelFunctions) {
     const paramStr = fn.params.map(p => p.name).join(', ')
-    lines.push(`var ${fn.name} = ${fn.name} ?? function(${paramStr}) ${fn.body}`)
+    const asyncKw = fn.isAsync ? 'async ' : ''
+    lines.push(`var ${fn.name} = ${fn.name} ?? ${asyncKw}function(${paramStr}) ${fn.body}`)
   }
   return lines.length > 0 ? lines.join('\n') + '\n' : ''
 }

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -70,6 +70,7 @@ export function buildDeclarationEmitPlan(
         name: fn.name,
         paramList: fn.params.map(p => p.name).join(', '),
         body: fn.body,
+        isAsync: fn.isAsync ?? false,
       }
     }
   }

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -61,6 +61,8 @@ export interface FunctionEmitPlan {
   paramList: string
   /** Arrow body — verbatim from the IR (block statement or expression). */
   body: string
+  /** When true, the lowered arrow keeps the `async` modifier (#1130). */
+  isAsync: boolean
 }
 
 export type DeclarationEmitPlan =

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -8,6 +8,7 @@
  *   constant (bare):        <kw> <name>
  *   memo:                   const <name> = createMemo(<computationExpr>)
  *   function:               const <name> = (<paramList>) => <body>
+ *   async function:         const <name> = async (<paramList>) => <body>
  *
  *   signal (no setter):     const [<getter>] = createSignal(<initialValueExpr>)
  *   signal (with setter):   const [<getter>, <setter>] = createSignal(<initialValueExpr>)
@@ -81,5 +82,6 @@ function emitMemo(lines: string[], plan: MemoEmitPlan): void {
 }
 
 function emitFunction(lines: string[], plan: FunctionEmitPlan): void {
-  lines.push(`  const ${plan.name} = (${plan.paramList}) => ${plan.body}`)
+  const asyncKw = plan.isAsync ? 'async ' : ''
+  lines.push(`  const ${plan.name} = ${asyncKw}(${plan.paramList}) => ${plan.body}`)
 }

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -36,7 +36,8 @@ export function generateModuleExports(
   for (const func of ir.metadata.localFunctions) {
     if (!func.isExported) continue
     const params = func.params.map(formatParamWithType).join(', ')
-    lines.push(`export function ${func.name}(${params}) ${func.body}`)
+    const asyncKw = func.isAsync ? 'async ' : ''
+    lines.push(`export ${asyncKw}function ${func.name}(${params}) ${func.body}`)
   }
 
   const inlineExported = collectInlineExportedNames(ir)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -597,6 +597,8 @@ export interface FunctionInfo {
   returnType: TypeInfo | null
   containsJsx: boolean
   isExported?: boolean
+  /** When true, the source `function` declaration carries the `async` modifier (#1130). */
+  isAsync?: boolean
   /** When true, declared at module level (outside the component function). */
   isModule?: boolean
   /** When true, this function returns JSX and is inlined at call sites (#569). */


### PR DESCRIPTION
## Summary

Closes #1130.

`async function` declarations inside a `'use client'` component body were
lowered to a non-async const arrow, dropping the `async` keyword. Any
`await` inside the body then threw `SyntaxError: Unexpected reserved word`
in the browser the moment the parser hit it.

```ts
// source
async function fetchItems(forceRefresh = false) {
  const res = await fetch(...)
}

// before — emitted client JS
const fetchItems = (forceRefresh) => {           // dropped `async`
  const res = await fetch(...)                   // SyntaxError at parse time
}

// after
const fetchItems = async (forceRefresh) => {
  const res = await fetch(...)
}
```

## Fix location

- `packages/jsx/src/analyzer.ts` — detect `AsyncKeyword` modifier in `collectFunction` and carry it on `FunctionInfo`.
- `packages/jsx/src/types.ts` — new `FunctionInfo.isAsync` flag.
- `packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts` + `plan/build-declaration-emit.ts` — propagate through the emit plan.
- `packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts` — prepend `async ` on the lowered arrow.
- `packages/jsx/src/ir-to-client-js/emit-module-level.ts`, `packages/jsx/src/module-exports.ts`, `packages/jsx/src/adapters/jsx-adapter.ts` — same fix on the three other places that re-emit a function declaration (module-level `var x = x ?? function`, re-emitted top-level `export function`, SSR `function`).

## Test plan

- [x] `bun test packages/jsx/src/__tests__/async-function-arrow-rewrite.test.ts` — new test passes.
- [x] `bun test packages/jsx/src/__tests__/` — same 4 pre-existing failures (`createMemo` / `createEffect` / `onMount` resolver migration, `primitive-resolver-alias` checker path) as `main`; no new failures introduced.
- [x] Full repo `bun test` baseline preserved (3094 pass / 124 fail vs `main` 3092 / 124, delta is the +2 new tests).