### PR TITLE
fix(jsx): strip inline type / interface declarations from function bodies (#1131)

### DIFF
--- a/packages/jsx/src/__tests__/inline-type-decl-stripping.test.ts
+++ b/packages/jsx/src/__tests__/inline-type-decl-stripping.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test for #1131: inline `type` aliases and `interface`
+ * declarations placed inside an arrow function body (or any nested
+ * function body) must be stripped from the emitted client JS.
+ *
+ * At the top level the analyzer collects `type X = ...` and
+ * `interface X { ... }` via dedicated handlers and never includes the
+ * statement text in `getJS()` output. But when those declarations appear
+ * inside a function body, the body itself is reproduced verbatim via
+ * `ctx.getJS(node.body)` and the AST-driven type-stripper had no rule
+ * for `TypeAliasDeclaration` / `InterfaceDeclaration` — so the
+ * TS-only statements survived into the emitted client JS and produced
+ * a runtime SyntaxError.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('inline type / interface declarations inside function bodies (#1131)', () => {
+  test('strips an inline `type` alias inside an arrow function body', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Issue {
+        id: string
+      }
+
+      interface Props {
+        org: string
+      }
+
+      export function DeskCanvas(props: Props) {
+        const [count, setCount] = createSignal(0)
+        const fetchItems = async (forceRefresh = false) => {
+          type ItemsResponse = {
+            items: Issue[]
+          }
+          let data: ItemsResponse | null = null
+          data = null
+          return data
+        }
+        return <div onClick={() => fetchItems().then(() => setCount(count() + 1))}>{count()}</div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'DeskCanvas.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // The TS-only `type ItemsResponse = { ... }` declaration must be gone.
+    expect(content).not.toMatch(/type\s+ItemsResponse\b/)
+    // The surrounding real code must survive — note the `: ItemsResponse | null`
+    // type annotation should also be stripped, leaving `let data = null`.
+    expect(content).toMatch(/let\s+data\s*=\s*null/)
+  })
+
+  test('strips a nested `interface` declaration inside a regular function body', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Page() {
+        const [count, setCount] = createSignal(0)
+        function compute() {
+          interface InnerShape {
+            value: number
+          }
+          let snapshot: InnerShape | null = null
+          snapshot = null
+          return snapshot
+        }
+        return <button onClick={() => { compute(); setCount(count() + 1) }}>{count()}</button>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // The inline `interface InnerShape { ... }` must be erased.
+    expect(content).not.toMatch(/interface\s+InnerShape\b/)
+    // The surrounding code (with type annotation stripped) must survive.
+    expect(content).toMatch(/let\s+snapshot\s*=\s*null/)
+  })
+
+  test('strips a deeply nested `type` alias (arrow inside arrow)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Nested() {
+        const [count, setCount] = createSignal(0)
+        const outer = async () => {
+          const inner = async () => {
+            type DeepResponse = {
+              ok: boolean
+            }
+            let result: DeepResponse | null = null
+            result = null
+            return result
+          }
+          return inner()
+        }
+        return <div onClick={() => outer().then(() => setCount(count() + 1))}>{count()}</div>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Nested.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    expect(content).not.toMatch(/type\s+DeepResponse\b/)
+    expect(content).toMatch(/let\s+result\s*=\s*null/)
+  })
+})

--- a/packages/jsx/src/strip-types.ts
+++ b/packages/jsx/src/strip-types.ts
@@ -191,6 +191,27 @@ function collectTypeRanges(
     }
   }
 
+  // Inline `type X = ...` alias and `interface X { ... }` declarations.
+  // At the top level the analyzer collects these via dedicated handlers
+  // (collectTypeAliasDefinition / collectInterfaceDefinition) and they
+  // never appear in any getJS() output. But when these declarations are
+  // nested inside a function body (any depth), the body text is reproduced
+  // verbatim by ctx.getJS(node.body) — and the TS-only statement would
+  // survive into emitted client JS, producing a runtime SyntaxError (#1131).
+  //
+  // The whole declaration is type-only, so erase its full text span. We
+  // also swallow any leading horizontal whitespace and the trailing
+  // newline so the excised statement doesn't leave behind a blank,
+  // dangling-indented line. Doing this for both top-level and nested
+  // occurrences is safe — they're entirely type-only either way.
+  if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+    ranges.push({
+      start: expandToLineStart(node.getStart(sourceFile), fullText),
+      end: expandThroughLineEnd(node.getEnd(), fullText),
+    })
+    return
+  }
+
   // Type-only nodes that are handled by parent patterns — skip recursion
   if (ts.isTypeNode(node)) return
 
@@ -198,6 +219,35 @@ function collectTypeRanges(
   ts.forEachChild(node, (child) => {
     collectTypeRanges(child, sourceFile, fullText, ranges)
   })
+}
+
+/**
+ * Walk back from `pos` over horizontal whitespace until the start of the line
+ * (or the previous newline). Used to swallow indentation in front of a
+ * type-only statement so its excised line collapses cleanly.
+ */
+function expandToLineStart(pos: number, fullText: string): number {
+  let i = pos
+  while (i > 0) {
+    const ch = fullText[i - 1]
+    if (ch === ' ' || ch === '\t') {
+      i--
+    } else {
+      break
+    }
+  }
+  return i
+}
+
+/**
+ * Walk forward from `pos` over the trailing newline (CRLF or LF) so the
+ * excised statement doesn't leave a blank line behind.
+ */
+function expandThroughLineEnd(pos: number, fullText: string): number {
+  let i = pos
+  if (fullText[i] === '\r') i++
+  if (fullText[i] === '\n') i++
+  return i
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1131 — a TypeScript inline `type X = ...` alias or `interface X { ... }` declaration placed inside an arrow function or regular function body survives into the emitted client JS, producing a runtime SyntaxError.

```ts
'use client'
export function DeskCanvas(props: Props) {
  const fetchItems = async (forceRefresh = false) => {
    type ItemsResponse = { items: Issue[] }   // leaked into client JS
    let data: ItemsResponse | null = null
  }
}
```

## Root cause

At the top level the analyzer collects type aliases / interfaces via dedicated handlers (`collectTypeAliasDefinition` / `collectInterfaceDefinition`) and they never appear in any `getJS()` output. But when these declarations are nested inside a function body, the body text is reproduced verbatim by `ctx.getJS(node.body)` — and the AST-driven type stripper in `packages/jsx/src/strip-types.ts` had no rule for `TypeAliasDeclaration` / `InterfaceDeclaration`, so the TS-only statements leaked through.

## Fix

Add a rule in `collectTypeRanges()` to push the full text span (plus leading horizontal whitespace and the trailing newline) of any `TypeAliasDeclaration` / `InterfaceDeclaration` into the exclude-range set, at any nesting depth. Safe to apply unconditionally — the declarations are entirely type-only at every level — and the stripper now mirrors what TypeScript itself erases.

Files changed:
- `packages/jsx/src/strip-types.ts` — recognise `TypeAliasDeclaration` / `InterfaceDeclaration` in `collectTypeRanges`.
- `packages/jsx/src/__tests__/inline-type-decl-stripping.test.ts` — new test covering the user's exact arrow-body repro, a regular-function-body `interface`, and an arrow-inside-arrow nested case.

## Context

Sibling PR #1134 (`fix/1130-async-function-arrow-rewrite`) touches the same compile pipeline but is independent — branched from `main`, not from #1134, so the two PRs can be reviewed and rebased independently.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/` — 854 pass / 4 fail (same 4 pre-existing failures as `main`: primitive-resolver-alias, createMemo / createEffect / onMount resolver migration). 3 new passing tests; no new failures.
- [x] New test fails on `main` (confirmed) and passes with the fix applied.