### PR TITLE
fix(cli): inline sibling .ts helpers into client JS instead of stripping (#1133)

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -213,4 +213,54 @@ console.log(formatDate(new Date()))
     expect(result).toContain('function formatDate(d)')
     expect(result).not.toContain("from './helpers'")
   })
+
+  // Regression: bf#1133 — a 'use client' component importing a sibling .ts
+  // helper at its OWN source location (not under any global sourceDir) had
+  // its import line stripped because the resolver only searched the dist dir.
+  // The fix is to thread each manifest entry's source directory through
+  // sourceDirsByManifestKey so the helper can be located and inlined.
+  test('resolves sibling .ts via sourceDirsByManifestKey (bf#1133)', async () => {
+    // Source layout: src/components/canvas/{DeskCanvas.tsx,useYjs.ts}
+    const SRC_CANVAS = resolve(SOURCE_DIR, 'components', 'canvas')
+    mkdirSync(SRC_CANVAS, { recursive: true })
+    writeFileSync(resolve(SRC_CANVAS, 'useYjs.ts'), `
+export function useYjs(roomId: string, readOnly: boolean) {
+  return { roomId, readOnly }
+}
+`)
+
+    // Dist layout: dist/components/canvas/DeskCanvas-abc.js (no sibling useYjs there)
+    const DIST_CANVAS = resolve(COMPONENTS_DIR, 'canvas')
+    mkdirSync(DIST_CANVAS, { recursive: true })
+    const clientJs = `import { useYjs } from './useYjs'
+import { hydrate } from '@barefootjs/client/runtime'
+export function initDeskCanvas(__scope, _p = {}) {
+  const yjs = useYjs(_p.roomId, _p.readOnly)
+  return yjs
+}
+`
+    writeFileSync(resolve(DIST_CANVAS, 'DeskCanvas-abc.js'), clientJs)
+
+    const manifest = {
+      DeskCanvas: {
+        clientJs: 'components/canvas/DeskCanvas-abc.js',
+        markedTemplate: 'components/canvas/DeskCanvas.tsx',
+      },
+    }
+
+    await resolveRelativeImports({
+      distDir: DIST_DIR,
+      manifest,
+      sourceDirsByManifestKey: { DeskCanvas: [SRC_CANVAS] },
+    })
+
+    const result = await Bun.file(resolve(DIST_CANVAS, 'DeskCanvas-abc.js')).text()
+    // Helper inlined — both the function and its call site are present.
+    expect(result).toContain('function useYjs(roomId, readOnly)')
+    expect(result).toContain('useYjs(_p.roomId, _p.readOnly)')
+    // Original import line stripped (replaced by inlined declaration).
+    expect(result).not.toContain("from './useYjs'")
+    // Untouched module imports stay.
+    expect(result).toContain("from '@barefootjs/client/runtime'")
+  })
 })

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -570,8 +570,24 @@ export async function build(
     }
   }
 
-  // 6b. Resolve relative imports (idempotent — writeIfChanged keeps it quiet)
-  await resolveRelativeImports({ distDir: config.outDir, manifest })
+  // 6b. Resolve relative imports (idempotent — writeIfChanged keeps it quiet).
+  //     Each manifest entry's source-file directory is threaded through so
+  //     that a 'use client' component importing a sibling .ts helper (e.g.
+  //     `import { useYjs } from './useYjs'` from `src/components/canvas/`)
+  //     can locate the helper at its source path and inline it. Without
+  //     this the resolver would only search the dist file's directory,
+  //     find nothing, and silently strip the import line. See bf#1133.
+  const sourceDirsByManifestKey: Record<string, string[]> = {}
+  for (const [sourcePath, entry] of Object.entries(nextEntries)) {
+    if (entry.manifestKey && !sourcePath.startsWith('bundle:')) {
+      sourceDirsByManifestKey[entry.manifestKey] = [dirname(sourcePath)]
+    }
+  }
+  await resolveRelativeImports({
+    distDir: config.outDir,
+    manifest,
+    sourceDirsByManifestKey,
+  })
 
   // 6c. Rewrite bare @barefootjs/client imports to relative barefoot.js path,
   //     then dedupe if a file ends up with multiple imports from the same

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -15,6 +15,18 @@ export interface ResolveRelativeImportsOptions {
   manifest: Record<string, { clientJs?: string; markedTemplate: string }>
   /** Source directories to search for modules (checked after the client JS file's own directory) */
   sourceDirs?: string[]
+  /**
+   * Per-entry source directories, keyed by manifest key. Searched after the
+   * client JS file's own directory but before the global `sourceDirs`.
+   *
+   * The compiler emits relative imports against the source layout (e.g. a
+   * `'use client'` component at `src/components/canvas/DeskCanvas.tsx`
+   * importing `./useYjs` resolves to `src/components/canvas/useYjs.ts`).
+   * The dist file lives at a different path with no sibling helper, so
+   * without this map the resolver would silently strip the import. See
+   * piconic-ai/barefootjs#1133.
+   */
+  sourceDirsByManifestKey?: Record<string, string[]>
 }
 
 /**
@@ -131,9 +143,9 @@ async function inlineRelativeImports(
  * - Not found / already inlined: strip
  */
 export async function resolveRelativeImports(options: ResolveRelativeImportsOptions): Promise<void> {
-  const { distDir, manifest, sourceDirs = [] } = options
+  const { distDir, manifest, sourceDirs = [], sourceDirsByManifestKey = {} } = options
 
-  for (const [, entry] of Object.entries(manifest)) {
+  for (const [name, entry] of Object.entries(manifest)) {
     if (!entry.clientJs) continue
     const filePath = resolve(distDir, entry.clientJs)
     let content: string
@@ -143,10 +155,11 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       continue
     }
 
+    const perEntryDirs = sourceDirsByManifestKey[name] ?? []
     const inlinedPaths = new Set<string>()
     const next = await inlineRelativeImports(
       content,
-      [dirname(filePath), ...sourceDirs],
+      [dirname(filePath), ...perEntryDirs, ...sourceDirs],
       inlinedPaths,
       entry.clientJs,
     )


### PR DESCRIPTION
## Summary

Fixes #1133.

A `'use client'` component importing a sibling `.ts` helper via a relative path —

```tsx
'use client'
import { useYjs } from './useYjs'

export function DeskCanvas(props: Props) {
  const yjs = useYjs(props.roomId, props.readOnly)
  // …
}
```

— had its import line silently stripped during `barefoot build`, leaving the call site behind and producing `ReferenceError: useYjs is not defined` at hydration time.

## Root cause

`compileJSX` correctly emits `import { useYjs } from './useYjs'`. The post-compile pipeline (`resolveRelativeImports` in `packages/cli/src/lib/resolve-imports.ts`) already knows how to inline `.ts` helpers — but its search dirs were `[dirname(distFilePath)]` only. The source helper lives next to the source `.tsx`, not next to the dist `.js`, so resolution fell through to `{ kind: 'missing' }` and the line was dropped while the call site stayed.

## Fix

- Added a `sourceDirsByManifestKey?: Record<string, string[]>` option to `resolveRelativeImports`. Each manifest entry's source directory is searched after the dist file's own directory but before the global `sourceDirs`.
- `build.ts` builds this map from `nextEntries` (keyed by source path) so both freshly-compiled and cached entries are covered, and threads it into the resolver call.

The existing `.ts` inlining path then picks up the helper and splices it into the client bundle — matching the behavior already exercised by the `inlines pure .ts module` and `recursively inlines transitive .ts imports` tests.

## Test plan

- [x] New regression test `resolves sibling .ts via sourceDirsByManifestKey (bf#1133)` added to `packages/cli/src/__tests__/resolve-imports.test.ts` — fails on `main`, passes after the fix.
- [x] All `packages/cli` tests pass (313/313).
- [x] All `packages/jsx` tests pass (870/870).
- [x] Full `packages/` test suite passes (1946/1946).
- [x] Clean `@barefootjs/cli` build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)