### PR TITLE
fix(jsx): block CSR-inline of values with bare props refs (#1137)

### DIFF
--- a/packages/jsx/src/__tests__/template-closure.test.ts
+++ b/packages/jsx/src/__tests__/template-closure.test.ts
@@ -264,3 +264,81 @@ describe('#1128 — template body never reaches init-scope identifiers', () => {
     expect(clientJs).toMatch(/cacheKey\s*=\s*`desk-\$\{_p\.org\}-\$\{_p\.projectNumber\}`/)
   })
 })
+
+describe('#1137 — memo body that closes over init-scope identifiers must not leak into the template', () => {
+  test('memo whose body reads an init-scope const does NOT inline the const declaration into the template', () => {
+    const source = `
+      'use client'
+      import { createMemo } from '@barefootjs/client'
+      import { makeStore } from './store'
+
+      interface Props { x: number }
+
+      export function Foo(props: Props) {
+        const store = makeStore(props)
+        const transform = createMemo(() => \`T(\${store.read()})\`)
+        return <div data-x={transform()} />
+      }
+    `
+    const clientJs = compileClient(source, 'Foo.tsx')
+    const tpl = templateBody(clientJs)
+
+    // The init-scope const \`store\` must never reach the template — its
+    // initializer \`makeStore(props)\` would re-run on every render AND leak
+    // a bare \`props\` reference that ReferenceErrors at template-call time.
+    expect(tpl).not.toMatch(/\bmakeStore\s*\(/)
+    expect(tpl).not.toMatch(/\bstore\b/)
+    // Bare \`props\` must never be visible at module scope. The template lambda
+    // parameter is \`_p\` — any \`props\` token in the body is a leak.
+    expect(tpl).not.toMatch(/\bprops\b/)
+  })
+
+  test('memo whose body closes over an init-scope const renders an empty placeholder initially (init effect repaints)', () => {
+    const source = `
+      'use client'
+      import { createMemo } from '@barefootjs/client'
+      import { makeStore } from './store'
+
+      interface Props { x: number }
+
+      export function Foo(props: Props) {
+        const store = makeStore(props)
+        const transform = createMemo(() => \`T(\${store.read()})\`)
+        return <div data-x={transform()} />
+      }
+    `
+    const clientJs = compileClient(source, 'Foo.tsx')
+    const tpl = templateBody(clientJs)
+
+    // The dynamic-attribute envelope around an unsafe expression collapses to
+    // an empty attribute on the initial render — same pattern as plain
+    // init-scope refs (#1128). A reactive effect inside init repaints.
+    expect(tpl).toMatch(/\$\{\(undefined\)\s*!=\s*null\s*\?\s*'data-x="/)
+    // The init body still has the real memo binding so the effect can repaint.
+    expect(clientJs).toMatch(/transform\s*=\s*createMemo/)
+  })
+
+  test('memo whose body is purely signal-driven (no init-scope refs) keeps inlining the initial value', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      interface Props { initial: number }
+
+      export function Foo(props: Props) {
+        const [count] = createSignal(props.initial)
+        const doubled = createMemo(() => count() * 2)
+        return <div data-doubled={doubled()} />
+      }
+    `
+    const clientJs = compileClient(source, 'Foo.tsx')
+    const tpl = templateBody(clientJs)
+
+    // No init-scope closure → keep current behavior: inline the memo body
+    // with signal initial value substituted in. This preserves correct
+    // initial render for the common case.
+    expect(tpl).toMatch(/_p\.initial/)
+    expect(tpl).toMatch(/\*\s*2/)
+    expect(tpl).not.toMatch(/\$\{\(undefined\)\s*!=\s*null\s*\?\s*'data-doubled/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -173,6 +173,18 @@ export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
  * Build an expanded inlinable constants map for CSR template generation.
  * Re-promotes constants that were demoted to unsafeLocalNames by resolving
  * signal/memo call expressions with their initial values.
+ *
+ * `propsObjectName`, when supplied, is the source-level name the user gave
+ * the props parameter (e.g. `props`). A re-promoted value that still
+ * contains a bare reference to it (`makeStore(props)`) is rejected: the
+ * template lambda's regex-based `propsObjectName.x → _p.x` rewrite only
+ * catches the dotted form, so a bare `props` token would survive into the
+ * module-scope template and ReferenceError at template-call time (#1137).
+ * The init-body path uses `rewritePropsObjectRef` (AST-based) which
+ * handles bare refs correctly, but that rewrite isn't applied to the
+ * template body — the constant must instead stay in `unsafeLocalNames`,
+ * letting `expressionReferencesAny` swap the getter call for the
+ * `UNSAFE_TEMPLATE_EXPR` sentinel and init's `createEffect` repaint.
  */
 export function buildCsrInlinableConstants(
   ctx: ClientJsContext,
@@ -180,8 +192,12 @@ export function buildCsrInlinableConstants(
   unsafeLocalNames: Set<string>,
   signalMap: Map<string, string>,
   memoMap: Map<string, string>,
+  propsObjectName?: string | null,
 ): Map<string, string> {
   const csrInlinableConstants = new Map(inlinableConstants)
+  // `props` not followed by `.` — the dotted form is caught by the
+  // template lambda's existing `propsObjectName.x → _p.x` rewrite.
+  const barePropsRe = propsObjectName ? new RegExp(`\\b${propsObjectName}\\b(?!\\.)`) : null
   for (const constant of ctx.localConstants) {
     if (unsafeLocalNames.has(constant.name) && constant.value && !constant.containsArrow) {
       let value = constant.value.trim()
@@ -193,7 +209,15 @@ export function buildCsrInlinableConstants(
       for (const [memoName, computation] of memoMap) {
         value = value.replace(new RegExp(`(?<![-.])\\b${memoName}\\(\\)`, 'g'), `(${computation})`)
       }
-      if (!/\b\w+\(\)/.test(value)) {
+      // The legacy `\b\w+\(\)` filter rejected zero-arg getter calls only.
+      // Calls with arguments (e.g. `makeStore(props)`) used to pass through
+      // and inline into the template, leaking a bare `props` reference at
+      // module scope (#1137). Reject when a bare prop reference would
+      // survive into the template — keep zero-arg `()` rejection too so the
+      // existing `useContext(SomeContext)` re-promotion (no bare props) is
+      // preserved (#1100).
+      const hasBareProps = barePropsRe ? barePropsRe.test(value) : false
+      if (!hasBareProps && !/\b\w+\(\)/.test(value)) {
         csrInlinableConstants.set(constant.name, value)
       }
     }
@@ -243,7 +267,7 @@ export function emitRegistrationAndHydration(
     // Components may be imported and used in conditional branches in other files,
     // where renderChild() needs a registered template to render HTML correctly.
     const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
+    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap, ctx.propsObjectName)
 
     const templateHtml = generateCsrTemplate(
       _ir.root, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -198,7 +198,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   // nested child components or loops), try generateCsrTemplate() (#536).
   if (!templateHtml) {
     const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap)
+    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap, ctx.propsObjectName)
 
     templateHtml = generateCsrTemplate(
       ir.root, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames


### PR DESCRIPTION
## Summary

- Closes #1137 — fixes a `ReferenceError: props is not defined` thrown at CSR template-call time when an init-scope `const` whose value contains a bare `props` reference (e.g. `const store = makeStore(props)`) is referenced — directly or via a memo body — from JSX. Surfaced by `piconic-ai/desk`'s xyflow `<Flow>` after #1128 merged.
- The CSR template's `propsObjectName.x → _p.x` rewrite is regex-based on the dotted form only; the init body's AST-based `rewritePropsObjectRef` handled bare `props` correctly. `buildCsrInlinableConstants` was re-promoting `store` to `inlinableConstants` (its `\b\w+\(\)` gate rejected zero-arg getters only, so `makeStore(props)` slipped through), which then inlined the bare `props` token into module scope.
- New gate: reject re-promotion when the substituted value still carries a bare prop reference (`\bprops\b(?!\.)`). The constant stays in `unsafeLocalNames`; the existing `expressionReferencesAny` guard swaps the surviving getter call for `UNSAFE_TEMPLATE_EXPR`; init's `createEffect` repaints once init runs — same pattern #1128 established.

The `useContext(SomeContext)` re-promotion path from #1100 keeps working: those values carry no bare `props` reference, so the new gate lets them through unchanged.

Verified end-to-end against `ui/components/ui/xyflow/index.tsx`'s `Flow`: the previously-buggy `style="...transform: ${(() => { const vp = createFlowStore(props).viewport(); ... })()}"` emit is now `${((v) => v != null ? 'style="' + v + '"' : '')(styleToCss(undefined))}` — no module-scope `props` token, init's effect repaints the real value at hydration.

## Test plan

- [x] New CSR-template fixtures in `packages/jsx/src/__tests__/template-closure.test.ts` covering: (a) memo body that closes over an init-scope const does NOT leak `makeStore(props)` / `store` / `props` into the template; (b) the dynamic-attr envelope collapses to an empty attr on initial render; (c) memo whose body is purely signal-driven keeps the existing inline behavior (regression guard).
- [x] `packages/jsx` test suite: 873 pass / 0 fail.
- [x] `packages/adapter-tests` suite: 219 pass / 0 fail.
- [x] `packages/client` suite: 215 pass / 0 fail.
- [x] #1100 `csr-template-context-method-shadow.test.ts` still passes (`(useContext(CountContext)).count()` survives).
- [x] Clean `bun run build` succeeds; no new errors vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)