### PR TITLE
P4: emit reads isGenerator + needsLeadingSemi from IR (#1138)

### DIFF
--- a/packages/jsx/src/__tests__/staged-ir/03-modifier-preservation.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/03-modifier-preservation.test.ts
@@ -60,6 +60,33 @@ describe('Modifier preservation: async / generator / etc. survive form rewrites'
     expectValidJs(clientJs)
   })
 
+  test('generator function (`function*`) keeps generator semantics', () => {
+    // The function → const arrow rewrite cannot preserve `function*`
+    // (arrow functions can't be generators). Emit must keep the
+    // `function*` declaration form when isGenerator is true on the IR.
+    const { clientJs, errors } = compile(`
+      'use client'
+
+      export function Foo() {
+        function* idGen() {
+          let i = 0
+          while (true) yield i++
+        }
+        idGen()
+        return <div>hi</div>
+      }
+    `)
+
+    expect(errors).toEqual([])
+    // Acceptable as long as it parses as a generator: `function* name`,
+    // `const name = function*`, or `var name = name ?? function*` (the
+    // module-level emission form). NOT acceptable: `const name = () =>`
+    // form, which would SyntaxError on `yield`.
+    expect(clientJs).toMatch(/function\s*\*/)
+    expect(clientJs).not.toMatch(/const\s+idGen\s*=\s*\(/)
+    expectValidJs(clientJs)
+  })
+
   test('await inside async function body is preserved', () => {
     const { clientJs, errors } = compile(`
       'use client'

--- a/packages/jsx/src/__tests__/staged-ir/09-asi-hazard.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/09-asi-hazard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pins the **ASI hazard contract** for emitted client JS. JavaScript's
+ * automatic semicolon insertion fails to insert between certain
+ * statement pairs — when the next statement starts with `(`, `[`, `\``,
+ * `+`, `-`, `/`, the parser fuses it with the previous expression as
+ * a call, member access, or template tag.
+ *
+ * Example from #1138:
+ *
+ *   ```js
+ *   provideContext(ctx)        // intended: statement
+ *   (globalThis)               // intended: another statement
+ *   ```
+ *
+ *   The parser reads this as `provideContext(ctx)(globalThis)` — a
+ *   single call expression — silently dropping the second statement.
+ *
+ * The staged-IR design tracks `needsLeadingSemi` on `InitStatementInfo`
+ * (added in P1). P4 populates the field at analyzer time and reads it
+ * at emit time so the hazard is closed structurally rather than relying
+ * on minifier behavior.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compile, expectValidJs } from './helpers'
+
+describe('ASI hazard: leading-`;` preserved on hazardous init statements', () => {
+  test('init statement starting with `(` survives emission with leading `;`', () => {
+    // Two top-level imperative statements where ASI would fuse:
+    //   provideContext(ctx)
+    //   (globalThis as any).__inited = true
+    // Without a leading `;` on the second, the parser treats the
+    // whole thing as `provideContext(ctx)(globalThis as any)`.
+    const { clientJs, errors } = compile(`
+      'use client'
+      import { provideContext } from '@barefootjs/client'
+      import { ctx } from './ctx'
+
+      export function Foo() {
+        provideContext(ctx)
+        ;(globalThis).__inited = true
+        return <div>hi</div>
+      }
+    `)
+
+    expect(errors).toEqual([])
+    expectValidJs(clientJs)
+    // Either the second statement appears with a leading `;`, or the
+    // statements are placed on lines such that ASI can't fuse them
+    // (e.g. an explicit semicolon on the prior). The test accepts
+    // either — what's banned is the fused single-call form.
+    expect(clientJs).not.toMatch(/provideContext\([^)]*\)\s*\(globalThis/)
+  })
+})

--- a/packages/jsx/src/__tests__/staged-ir/README.md
+++ b/packages/jsx/src/__tests__/staged-ir/README.md
@@ -28,6 +28,7 @@ This is the boundary that produced #1127 / #1128 / #1132 / #1137.
 - `04-type-stripping.test.ts` — TS-only constructs stripped at every nesting depth (#1131)
 - `05-import-preservation.test.ts` — Imports referenced by emitted code must be kept (#1133)
 - `06-multi-stage-soak.test.ts` — DeskCanvas-shape: every transition exercised in one component
+- `09-asi-hazard.test.ts` — leading-`;` preserved on statements that risk ASI fusion (#1138)
 
 Each file documents the stage transition it pins, so a future regression can be
 diagnosed as "transition X → Y broken" rather than "issue #NNNN regressed".

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1197,8 +1197,9 @@ function collectOnMount(node: ts.CallExpression, ctx: AnalyzerContext): void {
  * previously threw these statements away. See #930 (bug-2).
  */
 function collectInitStatement(node: ts.Statement, ctx: AnalyzerContext): void {
+  const body = ctx.getJS(node)
   ctx.initStatements.push({
-    body: ctx.getJS(node),
+    body,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     freeIdentifiers: extractFreeIdentifiersFromNode(node),
     assignedIdentifiers: extractAssignedIdentifiersFromNode(node),
@@ -1206,7 +1207,32 @@ function collectInitStatement(node: ts.Statement, ctx: AnalyzerContext): void {
     // belong to `init` scope. Phase is conservatively `hydrate` (run-once
     // at hydration). relocate() can refine this when consuming the field.
     origin: { phase: 'hydrate', scope: 'init', effect: 'pure' },
+    // ASI hazard: a statement starting with one of `(`, `[`, `\``, `+`,
+    // `-`, `/` can be fused with the previous expression by the parser.
+    // Tracking this in IR so emit can prepend `;` is the structural
+    // closure for the leading-`;` failure mode documented in #1138.
+    needsLeadingSemi: leadsWithAsiHazard(body),
   })
+}
+
+/**
+ * Detect characters that — at the start of a JS statement — invite
+ * automatic-semicolon-insertion fusion with the previous expression.
+ * The parser interprets:
+ *   - `(` / `[` as call / index continuation
+ *   - `` ` `` as a tagged template
+ *   - `+` / `-` as binary operator continuation
+ *   - `/` as division (or a regex follow-up)
+ * Whitespace at the start is ignored when scanning for the first
+ * non-space character.
+ */
+function leadsWithAsiHazard(body: string): boolean {
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i]
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') continue
+    return c === '(' || c === '[' || c === '`' || c === '+' || c === '-' || c === '/'
+  }
+  return false
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -53,7 +53,11 @@ export function emitModuleLevelDeclarations(
   for (const fn of moduleLevelFunctions) {
     const paramStr = fn.params.map(p => p.name).join(', ')
     const asyncKw = fn.isAsync ? 'async ' : ''
-    lines.push(`var ${fn.name} = ${fn.name} ?? ${asyncKw}function(${paramStr}) ${fn.body}`)
+    // Generator functions (`function*`) cannot be lowered to an arrow
+    // form (arrows can't yield) — preserve the `*` here so emit reads
+    // the modifier from IR rather than re-deriving from `fn.body` text.
+    const genStar = fn.isGenerator ? '*' : ''
+    lines.push(`var ${fn.name} = ${fn.name} ?? ${asyncKw}function${genStar}(${paramStr}) ${fn.body}`)
   }
   return lines.length > 0 ? lines.join('\n') + '\n' : ''
 }

--- a/packages/jsx/src/ir-to-client-js/phases/init-statements.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/init-statements.ts
@@ -22,7 +22,15 @@ export function emitInitStatements(lines: string[], ctx: ClientJsContext): void 
       .split('\n')
       .map((ln, i) => (i === 0 || ln === '' ? ln : '  ' + ln))
       .join('\n')
-    lines.push(`  ${indented}`)
+    // ASI hazard: when the body starts with `(`, `[`, `` ` ``, `+`, `-`,
+    // or `/`, the previous emitted line might fuse with this statement
+    // under automatic-semicolon-insertion (e.g. `provideContext(ctx)\n
+    // (globalThis)` parses as `provideContext(ctx)(globalThis)`).
+    // analyzer.collectInitStatement sets `needsLeadingSemi`; we honor
+    // it here so the hazard closes structurally rather than relying on
+    // minifier whitespace.
+    const prefix = stmt.needsLeadingSemi ? '  ;' : '  '
+    lines.push(`${prefix}${indented}`)
   }
   lines.push('')
 }


### PR DESCRIPTION
## Summary

Closes the two structural gaps in #1138 §5 where emit was reconstructing modifier and statement-boundary facts from text. The fix is small: read them from IR fields populated at analyzer time. Analyzer is the single source of truth; emit is a reader.

This is the P4 step of the staged-IR refactor. Builds on:
- #1142 (IR primitives + relocate skeleton, P0–P3 1-2/N)
- #1144 (relocate-driven inline classification, P3 3-7/N)

## What's broken (without this PR)

### Generator preservation (`function*`)

```ts
'use client'
export function Foo() {
  function* idGen() {
    let i = 0
    while (true) yield i++
  }
  idGen()
  return <div>hi</div>
}
```

compiled to:

```js
var idGen = idGen ?? function() {       // ← `*` dropped
  let i = 0
  while (true) yield i++                // ← SyntaxError: yield outside generator
}
```

`FunctionInfo.isGenerator` is populated by analyzer (P2) but emit's lowering form ignored it.

### ASI hazard

```ts
'use client'
export function Foo() {
  provideContext(ctx)
  ;(globalThis).__inited = true        // user-written `;`
  return <div>hi</div>
}
```

The user writes the leading `;` defensively. After analyzer collects the second statement and emit re-formats, whether the `;` survives depends on minifier whitespace handling. If lost, the parser reads:

```js
provideContext(ctx)(globalThis).__inited = true
```

— a single fused expression, not two statements. Silent semantic divergence.

`InitStatementInfo.needsLeadingSemi` was added to IR in P1 but never populated or read.

## Fixes

### `analyzer.ts/collectInitStatement`

Detects when a statement body starts with one of `(`, `[`, `` ` ``, `+`, `-`, `/` (the ASI-hazardous prefixes) and sets `needsLeadingSemi: true`.

### `ir-to-client-js/phases/init-statements.ts`

Prepends `;` to the emitted line when the IR flag is set. Hazard closes structurally — no minifier dependency.

### `ir-to-client-js/emit-module-level.ts`

Adds `*` to the function-expression lowering form when `fn.isGenerator` is true. Analogous to the existing `async ` handling.

## What's NOT in this PR

The bigger structural issue exposed during P4 work — `function* idGen()` declared inside a component body still gets `isModule: true` because the top-level analyzer walk reaches it before the component-body walk does. That misclassification is pre-existing and out of scope here. With the generator-preservation emit fix, the symptom goes away even when the misclassification persists.

The P5 step (BF060/061/062 stage-violation error codes) and P6 (DeskCanvas verification) remain.

## Test plan

- New fixtures:
  - `03-modifier-preservation/generator function (`function*`) keeps generator semantics`
  - `09-asi-hazard.test.ts` (new file) — leading-`;` preservation
- `bun test packages/jsx`: **943 pass / 0 fail** (was 941)
- Full suite across packages (jsx + adapter-hono + adapter-go-template + adapter-tests + client): **1533 pass / 0 fail**
- `bun run --filter '@barefootjs/jsx' build`: clean (tsgo no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)