### PR TITLE
fix(cli): hoist bare-package imports from inlined .ts modules to parent top (#1148)

### DIFF
--- a/packages/cli/src/__tests__/inline-imports-collision.test.ts
+++ b/packages/cli/src/__tests__/inline-imports-collision.test.ts
@@ -435,4 +435,174 @@ console.log(renamedA, bbb)
     expect(result).toMatch(/return \{\s*aaa,\s*bbb\s*\}/)
     expect(() => new Function(result)).not.toThrow()
   })
+
+  // ── Bare-package import hoisting (bf#1148) ────────────────────────────────
+  // Bare-package imports inside an inlined `.ts` module's body must rise to
+  // the parent bundle's top level (an `import` keyword inside an arrow body
+  // is a SyntaxError). Relative imports stay deleted because the recursive
+  // inliner already replaced them with IIFE wraps.
+
+  test('bare-package import is hoisted to parent top level', async () => {
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'uses-marked.ts'),
+      `import { marked } from 'marked'
+export function renderMd(s: string) { return marked.parse(s) }
+`,
+    )
+    const clientJs = `import { renderMd } from './uses-marked'
+console.log(renderMd('# hi'))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-bp1.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-bp1.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp1.js')).text()
+    // Exactly one top-level `import { marked } from 'marked'` line.
+    expect(countMatches(result, /import\s*\{\s*marked\s*\}\s*from\s*['"]marked['"]/g)).toBe(1)
+    // No `import` keyword anywhere inside the IIFE body. The `import` line
+    // must precede the `(() =>` IIFE opener — never follow it on a later line.
+    const iifeOpenIdx = result.indexOf('(() =>')
+    expect(iifeOpenIdx).toBeGreaterThan(-1)
+    // No top-level statement starting with `import` after the first IIFE
+    // opens (a stray hoisted import inside a body would still parse, but
+    // it'd appear AFTER the IIFE, which is the failure mode we're guarding).
+    const afterIife = result.slice(iifeOpenIdx)
+    expect(afterIife).not.toMatch(/^\s*import\b/m)
+    // The orphan reference is satisfied: the inlined body still calls marked.parse.
+    expect(result).toMatch(/marked\.parse/)
+  })
+
+  test('same bare-package import in two siblings is deduped', async () => {
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'uses-yjs-a.ts'),
+      `import * as Y from 'yjs'
+export function makeDocA() { return new Y.Doc() }
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'uses-yjs-b.ts'),
+      `import * as Y from 'yjs'
+export function makeDocB() { return new Y.Doc() }
+`,
+    )
+    const clientJs = `import { makeDocA } from './uses-yjs-a'
+import { makeDocB } from './uses-yjs-b'
+console.log(makeDocA(), makeDocB())
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-bp2.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-bp2.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp2.js')).text()
+    // Exactly one top-level `import * as Y from 'yjs'` line — deduped.
+    expect(countMatches(result, /import\s*\*\s*as\s*Y\s*from\s*['"]yjs['"]/g)).toBe(1)
+  })
+
+  test('different-shape imports from the same package are kept separate', async () => {
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'uses-pkg-foo.ts'),
+      `import { foo } from 'pkg'
+export function callFoo() { return foo() }
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'uses-pkg-bar.ts'),
+      `import { bar } from 'pkg'
+export function callBar() { return bar() }
+`,
+    )
+    const clientJs = `import { callFoo } from './uses-pkg-foo'
+import { callBar } from './uses-pkg-bar'
+console.log(callFoo(), callBar())
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-bp3.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-bp3.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp3.js')).text()
+    // Two distinct top-level lines — we don't try to merge bindings.
+    expect(result).toMatch(/import\s*\{\s*foo\s*\}\s*from\s*['"]pkg['"]/)
+    expect(result).toMatch(/import\s*\{\s*bar\s*\}\s*from\s*['"]pkg['"]/)
+    expect(countMatches(result, /from\s*['"]pkg['"]/g)).toBe(2)
+  })
+
+  test('transitive bare-package import bubbles up two levels to parent top', async () => {
+    // D imports a bare package; C imports D (relative); parent imports C.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'd-mod.ts'),
+      `import getStroke from 'perfect-freehand'
+export function makeStroke(pts: number[][]) { return getStroke(pts) }
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'c-mod.ts'),
+      `import { makeStroke } from './d-mod'
+export function strokeFor(pts: number[][]) { return makeStroke(pts) }
+`,
+    )
+    const clientJs = `import { strokeFor } from './c-mod'
+console.log(strokeFor([[0,0]]))
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-bp4.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-bp4.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp4.js')).text()
+    // The bare-package import must appear at the parent bundle's top level —
+    // before any IIFE — even though it originated two `.ts` levels deep.
+    expect(result).toMatch(/import\s+getStroke\s+from\s*['"]perfect-freehand['"]/)
+    const importIdx = result.search(/import\s+getStroke\s+from/)
+    const iifeOpenIdx = result.indexOf('(() =>')
+    expect(importIdx).toBeGreaterThan(-1)
+    expect(iifeOpenIdx).toBeGreaterThan(-1)
+    expect(importIdx).toBeLessThan(iifeOpenIdx)
+  })
+
+  test('relative imports in an inlined module are not hoisted to top level', async () => {
+    // After IIFE wrap there should be no top-level `import './…'` line.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'rel-leaf.ts'),
+      `export const leaf = 'leaf'
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'rel-mid.ts'),
+      `import { leaf } from './rel-leaf'
+export const mid = leaf + ':mid'
+`,
+    )
+    const clientJs = `import { mid } from './rel-mid'
+console.log(mid)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-bp5.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-bp5.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp5.js')).text()
+    // No `import './…'` line should sneak back to the top.
+    expect(result).not.toMatch(/^\s*import\s+.*\sfrom\s+['"]\.\.?\//m)
+    // The relative import was IIFE-replaced, so the binding is destructured.
+    expect(result).toMatch(/const \{\s*leaf\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).toMatch(/const \{\s*mid\s*\}\s*=\s*\(\(\) =>/)
+  })
 })

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -157,8 +157,16 @@ function collectExportedNames(source: string): string[] {
  *
  * Crucially, this leaves string-literal occurrences of `import` / `export`
  * untouched (they're not statement keywords in the AST).
+ *
+ * Bare-package imports (`import { marked } from 'marked'`) are still
+ * removed from the body — `import` statements are only legal at module
+ * top level, so they cannot survive inside the IIFE — but their original
+ * source text is also captured in `hoistedImports` so the caller can
+ * lift them to the parent bundle's top level. Relative imports (`./`,
+ * `../`) are dropped without hoisting because the recursive inliner has
+ * already replaced them with IIFE wraps upstream. piconic-ai/barefootjs#1148.
  */
-function stripImportsAndExports(body: string): string {
+function stripImportsAndExports(body: string): { body: string; hoistedImports: string[] } {
   const sourceFile = ts.createSourceFile(
     'body.ts',
     body,
@@ -169,11 +177,24 @@ function stripImportsAndExports(body: string): string {
 
   // Collect [start, end) spans to delete from the original text.
   const spans: Array<[number, number]> = []
+  const hoistedImports: string[] = []
 
   for (const stmt of sourceFile.statements) {
     if (ts.isImportDeclaration(stmt)) {
-      // Drop the whole `import …` statement.
-      spans.push([stmt.getStart(sourceFile), stmt.getEnd()])
+      // Drop the whole `import …` statement from the body. If it's a
+      // bare-package or absolute import, also capture its text so the
+      // caller can hoist it to the parent's top level.
+      const start = stmt.getStart(sourceFile)
+      const end = stmt.getEnd()
+      const specifier = stmt.moduleSpecifier
+      if (ts.isStringLiteral(specifier)) {
+        const path = specifier.text
+        const isRelative = path.startsWith('./') || path.startsWith('../')
+        if (!isRelative) {
+          hoistedImports.push(body.slice(start, end))
+        }
+      }
+      spans.push([start, end])
       continue
     }
 
@@ -216,7 +237,7 @@ function stripImportsAndExports(body: string): string {
     }
   }
 
-  if (spans.length === 0) return body.trim()
+  if (spans.length === 0) return { body: body.trim(), hoistedImports }
 
   // Apply spans in descending order so earlier offsets stay valid.
   spans.sort((a, b) => b[0] - a[0])
@@ -224,7 +245,7 @@ function stripImportsAndExports(body: string): string {
   for (const [start, end] of spans) {
     out = out.slice(0, start) + out.slice(end)
   }
-  return out.trim()
+  return { body: out.trim(), hoistedImports }
 }
 
 /**
@@ -251,12 +272,12 @@ function stripImportsAndExports(body: string): string {
  * used by `collectExportedNames` so type-only exports are correctly
  * excluded from the namespace IIFE return.
  */
-function wrapInIIFE(body: string, shape: ImportShape | null, originalSource: string): string {
-  const stripped = stripImportsAndExports(body)
+function wrapInIIFE(body: string, shape: ImportShape | null, originalSource: string): { wrapped: string; hoistedImports: string[] } {
+  const { body: stripped, hoistedImports } = stripImportsAndExports(body)
 
   if (!shape) {
     // Side-effect import: no bound names. Still scope-isolate.
-    return `;(() => {\n${stripped}\n})();`
+    return { wrapped: `;(() => {\n${stripped}\n})();`, hoistedImports }
   }
 
   const returnEntries: string[] = []
@@ -267,7 +288,7 @@ function wrapInIIFE(body: string, shape: ImportShape | null, originalSource: str
     // Parse the original TS source so type-only exports are excluded.
     const exported = collectExportedNames(originalSource)
     const ret = exported.length ? `{ ${exported.join(', ')} }` : '{}'
-    return `const ${shape.namespace} = (() => {\n${stripped}\nreturn ${ret};\n})();`
+    return { wrapped: `const ${shape.namespace} = (() => {\n${stripped}\nreturn ${ret};\n})();`, hoistedImports }
   }
 
   for (const { local, imported } of shape.named) {
@@ -283,10 +304,13 @@ function wrapInIIFE(body: string, shape: ImportShape | null, originalSource: str
 
   if (returnEntries.length === 0) {
     // No bound names we know how to surface. Still IIFE-scope the body.
-    return `;(() => {\n${stripped}\n})();`
+    return { wrapped: `;(() => {\n${stripped}\n})();`, hoistedImports }
   }
 
-  return `const { ${destructureEntries.join(', ')} } = (() => {\n${stripped}\nreturn { ${returnEntries.join(', ')} };\n})();`
+  return {
+    wrapped: `const { ${destructureEntries.join(', ')} } = (() => {\n${stripped}\nreturn { ${returnEntries.join(', ')} };\n})();`,
+    hoistedImports,
+  }
 }
 
 export interface ResolveRelativeImportsOptions {
@@ -352,12 +376,18 @@ async function resolveSourceFile(importPath: string, searchDirs: string[]): Prom
  * Recurses into transitively-imported `.ts` modules so that, e.g.,
  * `client.tsx → nav-data.ts → component-registry.ts` all end up inlined
  * in the right declaration order.
+ *
+ * `hoistedAcc` is a mutable accumulator shared with all recursive calls:
+ * bare-package imports stripped from any inlined module body bubble up
+ * here so the outer entry point can prepend them, deduped, to the parent
+ * bundle's top level. piconic-ai/barefootjs#1148.
  */
 async function inlineRelativeImports(
   content: string,
   searchDirs: string[],
   inlinedPaths: Set<string>,
-  loggingPath: string
+  loggingPath: string,
+  hoistedAcc: string[],
 ): Promise<string> {
   const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
   const matches = [...content.matchAll(re)]
@@ -403,6 +433,7 @@ async function inlineRelativeImports(
       [dirname(result.path), ...searchDirs.slice(1)],
       inlinedPaths,
       loggingPath,
+      hoistedAcc,
     )
 
     // Wrap the inlined body in an IIFE that re-exports only the names the
@@ -411,7 +442,8 @@ async function inlineRelativeImports(
     // (e.g. `const BAR_STYLE`) don't collide in the parent's top-level
     // scope. piconic-ai/barefootjs#1141.
     const shape = parseImportShape(fullMatch)
-    const wrapped = wrapInIIFE(jsCode, shape, sourceContent)
+    const { wrapped, hoistedImports } = wrapInIIFE(jsCode, shape, sourceContent)
+    for (const h of hoistedImports) hoistedAcc.push(h)
 
     content = content.replace(fullMatch, wrapped)
     console.log(`Inlined: ${importPath} into ${loggingPath}`)
@@ -443,12 +475,30 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
 
     const perEntryDirs = sourceDirsByManifestKey[name] ?? []
     const inlinedPaths = new Set<string>()
-    const next = await inlineRelativeImports(
+    const hoistedAcc: string[] = []
+    let next = await inlineRelativeImports(
       content,
       [dirname(filePath), ...perEntryDirs, ...sourceDirs],
       inlinedPaths,
       entry.clientJs,
+      hoistedAcc,
     )
+
+    // Prepend bare-package imports that bubbled up from inlined modules,
+    // deduped by exact statement text after whitespace normalization.
+    // ES modules hoist all `import` statements anyway, so placement is
+    // observationally identical. piconic-ai/barefootjs#1148.
+    if (hoistedAcc.length > 0) {
+      const seen = new Set<string>()
+      const unique: string[] = []
+      for (const stmt of hoistedAcc) {
+        const key = stmt.replace(/\s+/g, ' ').trim()
+        if (seen.has(key)) continue
+        seen.add(key)
+        unique.push(stmt)
+      }
+      next = unique.join('\n') + '\n' + next
+    }
 
     if (next !== content) {
       await writeText(filePath, next)


### PR DESCRIPTION
## Summary

Fixes piconic-ai/barefootjs#1148.

After #1146 landed, `stripImportsAndExports` in
`packages/cli/src/lib/resolve-imports.ts` removed **every**
`ImportDeclaration` from an inlined `.ts` module's body. That's correct
for relative imports (already replaced with IIFE wraps upstream), but
wrong for bare-package imports — the inlined body still references the
binding, but the parent bundle no longer has a top-level import for it.
Live symptom in piconic-ai/desk:
`ReferenceError: marked is not defined` at hydration.

The fix distinguishes the two cases by inspecting
`moduleSpecifier.text`:

- starts with `./` or `../` => DELETE (relative; already IIFE-replaced)
- otherwise => DELETE from the body AND extract the original statement
  text into `hoistedImports` so the caller can lift it to the parent's
  top level

`stripImportsAndExports` now returns `{ body, hoistedImports }`;
`wrapInIIFE` returns `{ wrapped, hoistedImports }`; and
`inlineRelativeImports` threads a mutable `hoistedAcc: string[]`
accumulator through recursion. The public entry point
`resolveRelativeImports` prepends the deduped (by whitespace-normalized
statement text) accumulator to the file's content before writing.
`import` statements only ever land at module top-level — never inside
an IIFE arrow body — and ES module spec hoists all imports anyway, so
the relative placement to the parent's own imports doesn't matter.

Sibling already-merged context (not a dependency, included for review
context only): #1141/#1146.

## Files changed

- `packages/cli/src/lib/resolve-imports.ts` — strip pass returns
  hoisted imports; IIFE wrap threads them through; outer entry
  prepends deduped set
- `packages/cli/src/__tests__/inline-imports-collision.test.ts` —
  five new tests under a `Bare-package import hoisting (bf#1148)`
  section

## Test plan

- [x] `bun test packages/cli/src/__tests__/` — 331 pass / 0 fail
  (was 326; +5 new tests for hoisting)
- [x] `bun test packages/jsx` — 950 pass / 0 fail (no regression)

New test coverage:

- Single bare-package import is hoisted to parent top, with no `import`
  keyword inside any IIFE body
- Same `import * as Y from 'yjs'` in two siblings is deduped to one
  top-level line
- Different-shape imports (`{ foo }` vs `{ bar }`) from the same
  package stay separate (no merge)
- Transitive: D imports `'perfect-freehand'`, C imports D (relative),
  parent imports C => `import getStroke from 'perfect-freehand'` lands
  at the parent's top, before the first IIFE
- Relative imports inside an inlined body do NOT sneak back to top
  level (they remain IIFE-replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)