### PR TITLE
fix(cli): rewrite all @barefootjs/client* specifiers, not just /runtime (#1148 follow-up)

### DIFF
--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -589,14 +589,11 @@ export async function build(
     sourceDirsByManifestKey,
   })
 
-  // 6c. Rewrite bare @barefootjs/client imports to relative barefoot.js path,
-  //     then dedupe if a file ends up with multiple imports from the same
-  //     source. Watch rebuilds can pull a freshly-compiled parent (still
-  //     using `@barefootjs/client/runtime`) together with a child that was
-  //     read back from disk in its previously-rewritten form (`./barefoot.js`).
-  //     Combine treats those as different sources and emits two import lines;
-  //     after the rewrite below they collapse to the same path, which is a
-  //     `SyntaxError: Identifier 'X' has already been declared` at runtime.
+  // 6c. Normalize @barefootjs/client* specifiers to the relative barefoot.js
+  //     path so the per-source dedup below can collapse multiple specifiers
+  //     pointing at the same runtime (watch-rebuild remnants, #1148-hoisted
+  //     bare imports). Without it, duplicate named bindings throw
+  //     `SyntaxError: Identifier 'X' has already been declared` at hydration.
   {
     const runtimeAbs = resolve(config.outDir, runtimeSubdir, 'barefoot.js')
     for (const [name, entry] of Object.entries(manifest)) {
@@ -613,7 +610,7 @@ export async function build(
         const before = content
         if (content.includes('@barefootjs/client')) {
           content = content.replace(
-            /from ['"]@barefootjs\/client\/runtime['"]/g,
+            /from ['"]@barefootjs\/client(?:\/[^'"]*)?['"]/g,
             `from '${rel}'`,
           )
         }


### PR DESCRIPTION
## Summary

Step 6c (post-\`resolveRelativeImports\`) only matched \`@barefootjs/client/runtime\`. After #1148 hoists bare-package imports from inlined \`.ts\` modules, the parent bundle can also receive \`@barefootjs/client\` (plain) and \`@barefootjs/client/reactive\` — three different specifiers all importmap-mapped to the same runtime file. The hoisted lines escaped the rewrite, so \`mergeDuplicateNamedImports\` saw them as separate sources and kept them, and the parent's own existing \`barefoot.js\` import collided in scope:

\`\`\`
SyntaxError: Identifier 'createEffect' has already been declared
\`\`\`

at hydration.

Extend the regex to \`@barefootjs/client(?:\\/[^'\"]*)?\` so any sub-path (including the bare specifier) gets folded into the same relative path before the dedup pass runs.

Verified end-to-end with \`piconic-ai/desk\`'s \`DeskCanvas\` bundle: post-fix, the parent has a single \`import { ... } from "../barefoot.js"\` that merges the parent's existing bindings with whatever the inlined modules brought in.

## Test plan

- [x] CLI tests still pass (\`bun test packages/cli/src/__tests__/\`): 331 / 0
- [x] JSX tests unchanged: 950 / 0
- [x] Live verification on \`piconic-ai/desk\`: no duplicate-decl SyntaxError at hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)