### PR TITLE
fix(cli): hoist transitive .ts inlines to parent's top-level scope (#1153)

### DIFF
--- a/packages/cli/src/__tests__/inline-imports-collision.test.ts
+++ b/packages/cli/src/__tests__/inline-imports-collision.test.ts
@@ -8,6 +8,11 @@
 // TypeScript-AST-based parsing handles (multi-line / trailing-comma /
 // commented imports & exports, type-only decls, string literals containing
 // `import` / `export`).
+//
+// Updated for #1153: each unique inlined `.ts` module now emits exactly
+// one IIFE wrap at the parent bundle's top level
+// (`const __bf_inline_N = (() => { … })()`); each consumer's import line
+// (parent's or transitive's) becomes `const { … } = __bf_inline_N`.
 
 import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
 import { resolveRelativeImports } from '../lib/resolve-imports'
@@ -75,9 +80,13 @@ initZoomBar(document.body)
     // a Script (top-level `const BAR_STYLE` twice would be a SyntaxError).
     expect(() => new Function(result.replace(/document\./g, 'undefined?.'))).not.toThrow()
     // Imported names should be destructured at top level so the parent's
-    // bare references resolve.
-    expect(result).toMatch(/const \{\s*initCanvasActions\s*\}\s*=\s*\(\(\) =>/)
-    expect(result).toMatch(/const \{\s*initZoomBar\s*\}\s*=\s*\(\(\) =>/)
+    // bare references resolve. Each module emits its own top-level IIFE
+    // (`__bf_inline_N`); the parent's import becomes a destructure pulling
+    // from that identifier.
+    expect(result).toMatch(/const \{\s*initCanvasActions\s*\}\s*=\s*__bf_inline_\d+/)
+    expect(result).toMatch(/const \{\s*initZoomBar\s*\}\s*=\s*__bf_inline_\d+/)
+    // Each module's IIFE wrap is at top level.
+    expect(countMatches(result, /const __bf_inline_\d+\s*=\s*\(\(\) =>/g)).toBe(2)
     // Both imports stripped.
     expect(result).not.toContain("from './CanvasActions'")
     expect(result).not.toContain("from './ZoomBar'")
@@ -147,12 +156,14 @@ console.log(middleExport)
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-trans.js')).text()
     // Both INNER_PRIVATE decls exist inside their respective IIFE bodies.
     expect(countMatches(result, /\bconst INNER_PRIVATE\b/g)).toBe(2)
-    // Parent destructures only `middleExport`.
-    expect(result).toMatch(/const \{\s*middleExport\s*\}\s*=\s*\(\(\) =>/)
-    // Inner IIFE surfaces only `innerExport` to the middle module's scope.
+    // Parent destructures only `middleExport` from the top-level binding.
+    expect(result).toMatch(/const \{\s*middleExport\s*\}\s*=\s*__bf_inline_\d+/)
+    // Inner IIFE surfaces only `innerExport` to its top-level binding.
     expect(result).toMatch(/return \{\s*innerExport\s*\}/)
     // Outer IIFE surfaces only `middleExport`.
     expect(result).toMatch(/return \{\s*middleExport\s*\}/)
+    // Two top-level IIFEs total (one per unique module: inner + middle).
+    expect(countMatches(result, /const __bf_inline_\d+\s*=\s*\(\(\) =>/g)).toBe(2)
     // Bundle parses as a Script — would throw if both INNER_PRIVATE were
     // at top level (the regression we're guarding against).
     expect(() => new Function(result)).not.toThrow()
@@ -176,8 +187,9 @@ console.log(renamed())
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-a.js')).text()
-    // Destructure remaps origName -> renamed at the splice site.
-    expect(result).toMatch(/const \{\s*origName:\s*renamed\s*\}\s*=\s*\(\(\) =>/)
+    // Destructure remaps origName -> renamed at the splice site (pulls
+    // from the per-module top-level binding emitted at top of bundle).
+    expect(result).toMatch(/const \{\s*origName:\s*renamed\s*\}\s*=\s*__bf_inline_\d+/)
     expect(result).toMatch(/return \{\s*origName\s*\}/)
   })
 
@@ -202,8 +214,9 @@ console.log(ns.a, ns.b(), new ns.C())
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-ns.js')).text()
-    // ns binding is set up at the splice site.
-    expect(result).toMatch(/const ns\s*=\s*\(\(\) =>/)
+    // ns binding is set up at the splice site (aliased to the module's
+    // top-level IIFE result).
+    expect(result).toMatch(/const ns\s*=\s*__bf_inline_\d+/)
     // All top-level exported names appear in the return object.
     expect(result).toMatch(/return \{[^}]*\ba\b[^}]*\}/)
     expect(result).toMatch(/return \{[^}]*\bb\b[^}]*\}/)
@@ -377,7 +390,7 @@ console.log(valueA, valueB)
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-cx.js')).text()
-    expect(result).toMatch(/const \{\s*valueA,\s*valueB\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).toMatch(/const \{\s*valueA,\s*valueB\s*\}\s*=\s*__bf_inline_\d+/)
     expect(result).not.toMatch(/^\s*export\s/m)
     expect(() => new Function(result)).not.toThrow()
   })
@@ -406,7 +419,7 @@ console.log(pickColor('red'))
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-to.js')).text()
-    expect(result).toMatch(/const \{\s*pickColor\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).toMatch(/const \{\s*pickColor\s*\}\s*=\s*__bf_inline_\d+/)
     expect(result).not.toMatch(/^\s*import\s/m)
     expect(result).not.toMatch(/^\s*export\s/m)
     expect(() => new Function(result)).not.toThrow()
@@ -431,7 +444,7 @@ console.log(renamedA, bbb)
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-wd.js')).text()
-    expect(result).toMatch(/const \{\s*aaa:\s*renamedA,\s*bbb\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).toMatch(/const \{\s*aaa:\s*renamedA,\s*bbb\s*\}\s*=\s*__bf_inline_\d+/)
     expect(result).toMatch(/return \{\s*aaa,\s*bbb\s*\}/)
     expect(() => new Function(result)).not.toThrow()
   })
@@ -601,8 +614,9 @@ console.log(mid)
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-bp5.js')).text()
     // No `import './…'` line should sneak back to the top.
     expect(result).not.toMatch(/^\s*import\s+.*\sfrom\s+['"]\.\.?\//m)
-    // The relative import was IIFE-replaced, so the binding is destructured.
-    expect(result).toMatch(/const \{\s*leaf\s*\}\s*=\s*\(\(\) =>/)
-    expect(result).toMatch(/const \{\s*mid\s*\}\s*=\s*\(\(\) =>/)
+    // The relative imports were replaced with destructures pulling from
+    // each module's top-level IIFE binding (`__bf_inline_N`).
+    expect(result).toMatch(/const \{\s*leaf\s*\}\s*=\s*__bf_inline_\d+/)
+    expect(result).toMatch(/const \{\s*mid\s*\}\s*=\s*__bf_inline_\d+/)
   })
 })

--- a/packages/cli/src/__tests__/inline-imports-dedup-shadowing.test.ts
+++ b/packages/cli/src/__tests__/inline-imports-dedup-shadowing.test.ts
@@ -1,0 +1,265 @@
+// Tests for piconic-ai/barefootjs#1153 — when the parent directly imports
+// `./foo` and a transitive sibling has already pulled `./foo` in, the
+// parent's own import line USED to be silently stripped (dedup via
+// `inlinedPaths.has`) without producing any top-level binding. The result
+// was a `ReferenceError: foo is not defined` at hydration because the
+// inlined module's IIFE wrap lived inside the sibling's IIFE.
+//
+// The fix hoists every inlined `.ts` module's IIFE to the parent bundle's
+// top level (one IIFE per unique path, in topological order). Each direct
+// import — parent's or transitive's — becomes a destructure pulling from
+// the per-module top-level binding (`__bf_inline_N`), so closure resolves
+// the binding correctly regardless of where the import line lived.
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { resolveRelativeImports } from '../lib/resolve-imports'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+const TEST_DIR = resolve(tmpdir(), `bf-test-inline-dedup-${Date.now()}`)
+const DIST_DIR = resolve(TEST_DIR, 'dist')
+const COMPONENTS_DIR = resolve(DIST_DIR, 'components', 'canvas')
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+  mkdirSync(COMPONENTS_DIR, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+function countMatches(s: string, re: RegExp): number {
+  return [...s.matchAll(re)].length
+}
+
+describe('resolveRelativeImports — top-level hoisting + dedup (bf#1153)', () => {
+  test('parent direct import + transitive import of same .ts: parent body sees the binding', async () => {
+    // Bug repro shape: parent imports `usePresence` (which transitively
+    // imports `readOnlyContext`), AND parent imports `readOnlyContext`
+    // directly. Old behaviour silently stripped the parent's line.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'readOnlyContext.ts'),
+      `export const readOnlyContext = { kind: 'ctx', value: false }
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'usePresence.ts'),
+      `import { readOnlyContext } from './readOnlyContext'
+export function usePresence() { return readOnlyContext.value }
+`,
+    )
+    // Source order: usePresence FIRST (transitive pull), readOnlyContext SECOND.
+    const clientJs = `import { usePresence } from './usePresence'
+import { readOnlyContext } from './readOnlyContext'
+function initDeskCanvas() {
+  return { ctx: readOnlyContext, presence: usePresence() }
+}
+globalThis.__test_init = initDeskCanvas
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DeskCanvas-1.js'), clientJs)
+
+    const manifest = {
+      DeskCanvas: { clientJs: 'components/canvas/DeskCanvas-1.js', markedTemplate: 'components/canvas/DeskCanvas.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'DeskCanvas-1.js')).text()
+    // Parent's `readOnlyContext` import must NOT be silently stripped — it
+    // either becomes an inline IIFE or destructures from the top-level
+    // binding hoisted out of usePresence's recursion.
+    expect(result).toMatch(/const \{\s*readOnlyContext\s*\}\s*=\s*__bf_inline_\d+/)
+    // Parent's `usePresence` import resolved as well.
+    expect(result).toMatch(/const \{\s*usePresence\s*\}\s*=\s*__bf_inline_\d+/)
+    // Exactly one top-level IIFE wrap for `readOnlyContext` (deduped).
+    const ctxIifes = countMatches(result, /const __bf_inline_\d+ = \(\(\) => \{\s*const readOnlyContext\b/g)
+    expect(ctxIifes).toBe(1)
+    // Bundle parses as a Script (top-level redeclarations would throw here).
+    expect(() => new Function(result)).not.toThrow()
+    // Runtime: the parent's bare `readOnlyContext` reference resolves and
+    // matches what the transitive helper sees — no ReferenceError.
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.ctx).toBeDefined()
+    expect(out.ctx.kind).toBe('ctx')
+    expect(out.presence).toBe(false)
+  })
+
+  test('reverse source order: parent direct import BEFORE transitive sibling', async () => {
+    // Mirror of the first test, with the import lines swapped. The bundle
+    // shape should be identical: `readOnlyContext` still appears as ONE
+    // top-level IIFE; both parent body and transitive helper see it.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'readOnlyContext.ts'),
+      `export const readOnlyContext = { kind: 'ctx', value: false }
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'usePresence.ts'),
+      `import { readOnlyContext } from './readOnlyContext'
+export function usePresence() { return readOnlyContext.value }
+`,
+    )
+    // Source order: readOnlyContext FIRST, usePresence SECOND.
+    const clientJs = `import { readOnlyContext } from './readOnlyContext'
+import { usePresence } from './usePresence'
+function initDeskCanvas() {
+  return { ctx: readOnlyContext, presence: usePresence() }
+}
+globalThis.__test_init = initDeskCanvas
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DeskCanvas-2.js'), clientJs)
+
+    const manifest = {
+      DeskCanvas: { clientJs: 'components/canvas/DeskCanvas-2.js', markedTemplate: 'components/canvas/DeskCanvas.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'DeskCanvas-2.js')).text()
+    // Same shape regardless of order.
+    expect(result).toMatch(/const \{\s*readOnlyContext\s*\}\s*=\s*__bf_inline_\d+/)
+    expect(result).toMatch(/const \{\s*usePresence\s*\}\s*=\s*__bf_inline_\d+/)
+    expect(countMatches(result, /const __bf_inline_\d+ = \(\(\) => \{\s*const readOnlyContext\b/g)).toBe(1)
+    expect(() => new Function(result)).not.toThrow()
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.ctx).toBeDefined()
+    expect(out.presence).toBe(false)
+  })
+
+  test('three-level chain: parent imports A and B; A imports B; B imports C', async () => {
+    // C is the leaf. B uses C. A uses B. Parent imports A AND B directly.
+    // After fix: each module emits exactly one top-level IIFE; everything
+    // resolves via closure.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'C.ts'),
+      `export const cVal = 'c-leaf'
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'B.ts'),
+      `import { cVal } from './C'
+export const bVal = 'b:' + cVal
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'A.ts'),
+      `import { bVal } from './B'
+export const aVal = 'a:' + bVal
+`,
+    )
+    const clientJs = `import { aVal } from './A'
+import { bVal } from './B'
+function init() { return { aVal, bVal } }
+globalThis.__test_init = init
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-3level.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-3level.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-3level.js')).text()
+    // Three unique top-level IIFEs (one per .ts module).
+    expect(countMatches(result, /const __bf_inline_\d+\s*=\s*\(\(\) =>/g)).toBe(3)
+    // Parent's destructures both resolve to top-level bindings.
+    expect(result).toMatch(/const \{\s*aVal\s*\}\s*=\s*__bf_inline_\d+/)
+    expect(result).toMatch(/const \{\s*bVal\s*\}\s*=\s*__bf_inline_\d+/)
+    // Topological order: C's IIFE must precede B's; B's must precede A's.
+    const cIdx = result.search(/const cVal = ['"]c-leaf['"]/)
+    const bIdx = result.search(/const bVal = ['"]b:['"]/)
+    const aIdx = result.search(/const aVal = ['"]a:['"]/)
+    expect(cIdx).toBeGreaterThan(-1)
+    expect(bIdx).toBeGreaterThan(cIdx)
+    expect(aIdx).toBeGreaterThan(bIdx)
+    expect(() => new Function(result)).not.toThrow()
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.aVal).toBe('a:b:c-leaf')
+    expect(out.bVal).toBe('b:c-leaf')
+  })
+
+  test('two transitive siblings each importing the same .ts: dedup, exactly one IIFE', async () => {
+    // Sibling A and Sibling B both import `./shared`. Parent imports A and B.
+    // The fix must dedup `./shared` to a single top-level IIFE.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'shared.ts'),
+      `export const sharedConst = 'shared-value'
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'sibA.ts'),
+      `import { sharedConst } from './shared'
+export const fromA = 'A:' + sharedConst
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'sibB.ts'),
+      `import { sharedConst } from './shared'
+export const fromB = 'B:' + sharedConst
+`,
+    )
+    const clientJs = `import { fromA } from './sibA'
+import { fromB } from './sibB'
+function init() { return { fromA, fromB } }
+globalThis.__test_init = init
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-2sib.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-2sib.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-2sib.js')).text()
+    // Exactly one top-level IIFE for `./shared` (deduped across siblings).
+    expect(countMatches(result, /const sharedConst\b/g)).toBe(1)
+    // Three modules total, three top-level IIFEs.
+    expect(countMatches(result, /const __bf_inline_\d+\s*=\s*\(\(\) =>/g)).toBe(3)
+    expect(() => new Function(result)).not.toThrow()
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.fromA).toBe('A:shared-value')
+    expect(out.fromB).toBe('B:shared-value')
+  })
+
+  test('side-effect-only import does not redeclare its top-level binding twice', async () => {
+    // Parent imports a module both as side-effect AND for a named export.
+    // The fix path that pushes a "side-effect" shape into consumerShapes
+    // must not cause the IIFE to be built twice or the binding to clash.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'effect.ts'),
+      `let counter = 0
+export function bump() { counter += 1; return counter }
+globalThis.__bf_effect_ran = true
+`,
+    )
+    const clientJs = `import './effect'
+import { bump } from './effect'
+function init() { return { ran: globalThis.__bf_effect_ran, n: bump() } }
+globalThis.__test_init = init
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Comp-eff.js'), clientJs)
+
+    const manifest = {
+      Comp: { clientJs: 'components/canvas/Comp-eff.js', markedTemplate: 'components/canvas/Comp.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-eff.js')).text()
+    // The effect module must be wrapped in exactly one top-level IIFE.
+    expect(countMatches(result, /const __bf_inline_\d+\s*=\s*\(\(\) =>/g)).toBe(1)
+    expect(() => new Function(result)).not.toThrow()
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.ran).toBe(true)
+    expect(out.n).toBe(1)
+  })
+})

--- a/packages/cli/src/__tests__/inline-imports-directory.test.ts
+++ b/packages/cli/src/__tests__/inline-imports-directory.test.ts
@@ -49,10 +49,11 @@ console.log(nodeTypes)
     await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'DeskCanvas-dir.js')).text()
-    // Imported name destructured from an IIFE at top level so the parent's
-    // bare `nodeTypes` reference resolves at hydration.
-    expect(result).toMatch(/const \{\s*nodeTypes\s*\}\s*=\s*\(\(\) =>/)
-    // Import line stripped (inlined into the IIFE).
+    // Imported name destructured from a top-level IIFE binding
+    // (`__bf_inline_N`), so the parent's bare `nodeTypes` reference resolves
+    // at hydration.
+    expect(result).toMatch(/const \{\s*nodeTypes\s*\}\s*=\s*__bf_inline_\d+/)
+    // Import line stripped (inlined into the top-level IIFE).
     expect(result).not.toContain("from './nodes'")
     // Body contents present (transpile may flip quote style).
     expect(result).toContain("nodeTypes")
@@ -85,7 +86,8 @@ console.log('hi')
     // Import line removed.
     expect(result).not.toContain("from './widget'")
     // No IIFE wrap (server-component path strips without inlining).
-    expect(result).not.toMatch(/const \{\s*Widget\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).not.toMatch(/const \{\s*Widget\s*\}\s*=/)
+    expect(result).not.toMatch(/__bf_inline_/)
     // Body unchanged otherwise.
     expect(result).toContain("console.log('hi')")
   })
@@ -121,7 +123,7 @@ console.log(SOURCE)
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Comp-flat-wins.js')).text()
     expect(result).toMatch(/['"]flat['"]/)
     expect(result).not.toMatch(/['"]directory['"]/)
-    expect(result).toMatch(/const \{\s*SOURCE\s*\}\s*=\s*\(\(\) =>/)
+    expect(result).toMatch(/const \{\s*SOURCE\s*\}\s*=\s*__bf_inline_\d+/)
   })
 
   test('./foo resolves to neither flat nor directory — strip + warn', async () => {

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -249,66 +249,80 @@ function stripImportsAndExports(body: string): { body: string; hoistedImports: s
 }
 
 /**
- * Wrap an inlined module's body in an IIFE that re-exports only the names
- * the parent bundle actually references, then destructure those at the
- * splice site. This isolates module-private decls (e.g. two siblings each
- * with their own `const BAR_STYLE`) so they cannot collide in the parent's
- * top-level scope.
+ * Build the destructure clause that binds an `import` statement's locals
+ * to a per-module top-level binding (`__bf_inline_N`). Unlike the legacy
+ * inline-IIFE form, this assumes the IIFE itself is emitted ONCE at the
+ * parent bundle's top level (see #1153) and the consumer just pulls the
+ * names it needs out of the resulting object.
+ */
+function buildConsumerBinding(shape: ImportShape | null, topLevelId: string): string {
+  if (!shape) {
+    // Side-effect import: nothing to bind, but the IIFE body still ran at
+    // top level when `topLevelId` was declared.
+    return ''
+  }
+  if (shape.namespace) {
+    return `const ${shape.namespace} = ${topLevelId};`
+  }
+  if (shape.named.length === 0) {
+    return ''
+  }
+  const entries = shape.named.map(({ local, imported }) =>
+    local === imported ? local : `${imported}: ${local}`,
+  )
+  return `const { ${entries.join(', ')} } = ${topLevelId};`
+}
+
+/**
+ * Build the top-level IIFE wrap for an inlined module. The IIFE returns
+ * the union of every name any consumer (parent or transitive) needs from
+ * the module: explicit named imports plus, if any consumer used `* as ns`,
+ * every top-level value-exported name. Module-private decls stay scoped
+ * inside the IIFE arrow body — they cannot collide with parent or
+ * sibling-IIFE decls.
  *
- *   const { foo, bar } = (() => {
- *     /* inlined body, with `export` keywords stripped *\/
- *     return { foo, bar }
+ *   const __bf_inline_N = (() => {
+ *     /* body, with `export` modifiers stripped and relative imports replaced
+ *        by destructures pulling from other __bf_inline_M variables *\/
+ *     return { foo, bar, ...allExportsIfNamespace }
  *   })()
  *
- * For `import * as ns from './x'`, the IIFE returns every top-level
- * exported name. For side-effect-only `import './x'`, the IIFE has no
- * destructure on the outside and no return, but the body still runs.
- *
- * Default exports are out of scope: `stripImportsAndExports` reduces
- * `export default <expr>` to a bare expression, which is fine inside the
- * IIFE.
- *
- * `originalSource` is the pre-transpile TS source of the inlined module,
- * used by `collectExportedNames` so type-only exports are correctly
- * excluded from the namespace IIFE return.
+ * `originalSource` is the pre-transpile TS source, used by
+ * `collectExportedNames` to enumerate all value exports for the namespace
+ * case (so type-only exports stay excluded).
  */
-function wrapInIIFE(body: string, shape: ImportShape | null, originalSource: string): { wrapped: string; hoistedImports: string[] } {
+function buildTopLevelIIFE(
+  topLevelId: string,
+  body: string,
+  shapesNeeded: ImportShape[],
+  originalSource: string,
+): { wrapped: string; hoistedImports: string[] } {
   const { body: stripped, hoistedImports } = stripImportsAndExports(body)
 
-  if (!shape) {
-    // Side-effect import: no bound names. Still scope-isolate.
-    return { wrapped: `;(() => {\n${stripped}\n})();`, hoistedImports }
+  // Union of names any consumer needs from this module. If any consumer
+  // wants the namespace shape, we have to surface every value export.
+  const wantsNamespace = shapesNeeded.some(s => !!s.namespace)
+  const namesNeeded = new Set<string>()
+  if (wantsNamespace) {
+    for (const n of collectExportedNames(originalSource)) namesNeeded.add(n)
+  }
+  for (const shape of shapesNeeded) {
+    for (const { imported } of shape.named) namesNeeded.add(imported)
   }
 
-  const returnEntries: string[] = []
-  const destructureEntries: string[] = []
-
-  if (shape.namespace) {
-    // Build a single `const ns = (() => { ...; return { a, b, ... } })()`.
-    // Parse the original TS source so type-only exports are excluded.
-    const exported = collectExportedNames(originalSource)
-    const ret = exported.length ? `{ ${exported.join(', ')} }` : '{}'
-    return { wrapped: `const ${shape.namespace} = (() => {\n${stripped}\nreturn ${ret};\n})();`, hoistedImports }
+  if (namesNeeded.size === 0) {
+    // No bound names to surface (side-effect-only consumer). Run the body
+    // for its effects and bind the top-level id to an empty object so any
+    // dedup destructure later still parses.
+    return {
+      wrapped: `const ${topLevelId} = (() => {\n${stripped}\nreturn {};\n})();`,
+      hoistedImports,
+    }
   }
 
-  for (const { local, imported } of shape.named) {
-    returnEntries.push(imported)
-    destructureEntries.push(local === imported ? local : `${imported}: ${local}`)
-  }
-  if (shape.default) {
-    // `import D from './x'` — surface the default binding via the IIFE.
-    // `stripImportsAndExports` reduces `export default <expr>` to a bare
-    // expression statement, which is then dead. Out of scope for this fix;
-    // covered by the issue's "leave defaults out of scope" note.
-  }
-
-  if (returnEntries.length === 0) {
-    // No bound names we know how to surface. Still IIFE-scope the body.
-    return { wrapped: `;(() => {\n${stripped}\n})();`, hoistedImports }
-  }
-
+  const ret = `{ ${[...namesNeeded].join(', ')} }`
   return {
-    wrapped: `const { ${destructureEntries.join(', ')} } = (() => {\n${stripped}\nreturn { ${returnEntries.join(', ')} };\n})();`,
+    wrapped: `const ${topLevelId} = (() => {\n${stripped}\nreturn ${ret};\n})();`,
     hoistedImports,
   }
 }
@@ -378,22 +392,43 @@ async function resolveSourceFile(importPath: string, searchDirs: string[]): Prom
 }
 
 /**
- * Process a single file's relative imports, mutating `content` in place.
- * Recurses into transitively-imported `.ts` modules so that, e.g.,
- * `client.tsx → nav-data.ts → component-registry.ts` all end up inlined
- * in the right declaration order.
+ * One inlined module collected during the graph walk. Becomes one
+ * top-level IIFE in the emitted bundle.
+ */
+interface InlinedModule {
+  path: string                  // resolved absolute source path
+  topLevelId: string            // `__bf_inline_N` — stable per-module identifier
+  transpiledBody: string        // transpile output, before its own imports are processed
+  originalSource: string        // pre-transpile TS source (for namespace export collection)
+  searchDirs: string[]          // search dirs anchored at this module's directory
+  consumerShapes: ImportShape[] // every consumer's import shape (parent + transitive)
+  imports: Set<string>          // resolved paths of `.ts` modules this module imports
+}
+
+/**
+ * Walk relative imports in `content` and collect every transitively-reachable
+ * `.ts` module. Replaces each direct relative import line in `content` with
+ * a destructure pulling from a per-module top-level identifier — the IIFE
+ * itself is emitted ONCE at the parent bundle's top level after the walk
+ * finishes, regardless of how deep the original import was. piconic-ai/barefootjs#1153.
  *
- * `hoistedAcc` is a mutable accumulator shared with all recursive calls:
+ * Stripping vs. emitting the destructure: a side-effect-only import
+ * (`import './x'`) leaves the body in place via the top-level IIFE but emits
+ * no consumer-side binding. Named/namespace imports emit a destructure that
+ * resolves at the consumer's site (parent body or another module's IIFE
+ * arrow body) via closure to the top-level binding.
+ *
+ * `hoistedAcc` is a mutable accumulator shared with every recursive call:
  * bare-package imports stripped from any inlined module body bubble up
  * here so the outer entry point can prepend them, deduped, to the parent
  * bundle's top level. piconic-ai/barefootjs#1148.
  */
-async function inlineRelativeImports(
+async function walkAndCollect(
   content: string,
   searchDirs: string[],
-  inlinedPaths: Set<string>,
+  modules: Map<string, InlinedModule>,
+  visiting: Set<string>,
   loggingPath: string,
-  hoistedAcc: string[],
 ): Promise<string> {
   const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
   const matches = [...content.matchAll(re)]
@@ -416,53 +451,151 @@ async function inlineRelativeImports(
       continue
     }
 
-    if (inlinedPaths.has(result.path)) {
-      content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-      continue
-    }
-
     if (result.path.endsWith('.tsx')) {
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
       console.log(`Stripped server component import: ${importPath} from ${loggingPath}`)
       continue
     }
 
-    inlinedPaths.add(result.path)
-    const sourceContent = await readText(result.path)
-    let jsCode = transpile(sourceContent, { loader: 'ts' })
-
-    // Recursively resolve relative imports inside the inlined module before
-    // stripping its import lines. Resolution is anchored to the source file's
-    // own directory so transitive paths (e.g. './component-registry') resolve
-    // correctly regardless of where the parent client JS lives.
-    //
-    // The inner inline replaces each transitive import with an IIFE-wrapped
-    // splice (see wrapInIIFE), so the inner module's private decls stay
-    // hidden from the outer module's scope. The outer wrapInIIFE call below
-    // then hides the OUTER module's privates from the parent. Composition:
-    // privates only ever leak one frame outward, never to top level.
-    jsCode = await inlineRelativeImports(
-      jsCode,
-      [dirname(result.path), ...searchDirs.slice(1)],
-      inlinedPaths,
-      loggingPath,
-      hoistedAcc,
-    )
-
-    // Wrap the inlined body in an IIFE that re-exports only the names the
-    // parent imported (see wrapInIIFE for shape rules). This scopes
-    // module-private decls so two siblings declaring the same identifier
-    // (e.g. `const BAR_STYLE`) don't collide in the parent's top-level
-    // scope. piconic-ai/barefootjs#1141.
     const shape = parseImportShape(fullMatch)
-    const { wrapped, hoistedImports } = wrapInIIFE(jsCode, shape, sourceContent)
-    for (const h of hoistedImports) hoistedAcc.push(h)
+    let mod = modules.get(result.path)
+    if (!mod) {
+      // Cycle guard: a `.ts` module that ends up in its own descendants
+      // already broke TS itself. We can't safely topo-sort circular IIFEs.
+      if (visiting.has(result.path)) {
+        console.warn(`Skipping circular relative import: ${importPath} from ${loggingPath}`)
+        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+        continue
+      }
+      visiting.add(result.path)
+      const sourceContent = await readText(result.path)
+      const jsCode = transpile(sourceContent, { loader: 'ts' })
+      mod = {
+        path: result.path,
+        topLevelId: `__bf_inline_${modules.size}`,
+        transpiledBody: jsCode,
+        originalSource: sourceContent,
+        searchDirs: [dirname(result.path), ...searchDirs.slice(1)],
+        consumerShapes: [],
+        imports: new Set(),
+      }
+      modules.set(result.path, mod)
+      // Recurse so transitive consumers are recorded against the inner
+      // modules' shapesNeeded BEFORE we build IIFE returns.
+      const replacedBody = await walkAndCollect(
+        mod.transpiledBody,
+        mod.searchDirs,
+        modules,
+        visiting,
+        loggingPath,
+      )
+      mod.transpiledBody = replacedBody
+      visiting.delete(result.path)
+      console.log(`Inlined: ${importPath} into ${loggingPath}`)
+    }
 
-    content = content.replace(fullMatch, wrapped)
-    console.log(`Inlined: ${importPath} into ${loggingPath}`)
+    if (shape) mod.consumerShapes.push(shape)
+    else mod.consumerShapes.push({ named: [] }) // side-effect import counts too
+
+    // Replace the consumer's import line with a destructure pulling from
+    // the per-module top-level identifier. Side-effect imports just drop
+    // the line — the IIFE has already executed at top level.
+    const binding = buildConsumerBinding(shape, mod.topLevelId)
+    if (binding) {
+      content = content.replace(fullMatch, binding)
+    } else {
+      content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+    }
   }
 
   return content
+}
+
+/**
+ * Topological order over the collected import graph. A module that imports
+ * another must appear AFTER its dependency in the emitted top-level IIFE
+ * stream so the dependency's `__bf_inline_N` binding exists when the
+ * dependent's IIFE arrow body evaluates. Post-order DFS, deduped by path.
+ */
+function topoSort(modules: Map<string, InlinedModule>): InlinedModule[] {
+  const visited = new Set<string>()
+  const order: InlinedModule[] = []
+  function visit(path: string): void {
+    if (visited.has(path)) return
+    visited.add(path)
+    const mod = modules.get(path)
+    if (!mod) return
+    for (const dep of mod.imports) visit(dep)
+    order.push(mod)
+  }
+  for (const path of modules.keys()) visit(path)
+  return order
+}
+
+/**
+ * Process a single file's relative imports. Two-pass:
+ *   1. `walkAndCollect` walks the entire transitive graph, collecting one
+ *      `InlinedModule` per unique path and rewriting consumer-side import
+ *      lines (parent's AND transitive's) to destructures pulling from a
+ *      per-module top-level identifier.
+ *   2. After the walk, build each module's IIFE wrap (one per unique path,
+ *      in topological order) and prepend them to the parent content. Each
+ *      IIFE's return surfaces the union of every name any consumer needs.
+ *
+ * This guarantees every inlined `.ts` module appears as exactly one
+ * top-level IIFE in the parent bundle, regardless of which sibling first
+ * imported it. piconic-ai/barefootjs#1153.
+ */
+async function inlineRelativeImports(
+  content: string,
+  searchDirs: string[],
+  loggingPath: string,
+  hoistedAcc: string[],
+): Promise<string> {
+  const modules = new Map<string, InlinedModule>()
+  const visiting = new Set<string>()
+  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath)
+
+  if (modules.size === 0) return parentContent
+
+  // Now resolve each module's transitive import edges — the body has
+  // already been rewritten with destructures, so the only paths left to
+  // sort by are the modules that the body's destructures reference. We
+  // walked recursively, so every `walkAndCollect` call inside a module's
+  // body has populated `modules` with that module's deps. We tag those
+  // edges by re-walking the body for `__bf_inline_N` references? No —
+  // simpler: a module's `imports` set is the set of paths it directly
+  // references. Track that during the walk via `consumerShapes` in
+  // reverse — every consumer that pushed a shape onto module M's list
+  // had its own path; we just didn't record the edge there. Instead,
+  // populate `imports` from the destructure references textually: each
+  // `__bf_inline_N` token in the body identifies a dependency.
+  for (const mod of modules.values()) {
+    const tokenRe = /__bf_inline_(\d+)\b/g
+    for (const m of mod.transpiledBody.matchAll(tokenRe)) {
+      const id = `__bf_inline_${m[1]}`
+      for (const other of modules.values()) {
+        if (other.topLevelId === id && other.path !== mod.path) {
+          mod.imports.add(other.path)
+        }
+      }
+    }
+  }
+
+  const ordered = topoSort(modules)
+  const iifes: string[] = []
+  for (const mod of ordered) {
+    const { wrapped, hoistedImports } = buildTopLevelIIFE(
+      mod.topLevelId,
+      mod.transpiledBody,
+      mod.consumerShapes,
+      mod.originalSource,
+    )
+    iifes.push(wrapped)
+    for (const h of hoistedImports) hoistedAcc.push(h)
+  }
+
+  return iifes.join('\n') + '\n' + parentContent
 }
 
 /**
@@ -487,12 +620,10 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
     }
 
     const perEntryDirs = sourceDirsByManifestKey[name] ?? []
-    const inlinedPaths = new Set<string>()
     const hoistedAcc: string[] = []
     let next = await inlineRelativeImports(
       content,
       [dirname(filePath), ...perEntryDirs, ...sourceDirs],
-      inlinedPaths,
       entry.clientJs,
       hoistedAcc,
     )


### PR DESCRIPTION
## Summary

Fixes piconic-ai/barefootjs#1153.

`inlineRelativeImports`'s depth-first recursion produced nested IIFEs: when a parent imports `./usePresence` (which transitively imports `./readOnlyContext`), the `readOnlyContext` IIFE wrap landed INSIDE the `usePresence` IIFE body. If the parent ALSO directly imported `./readOnlyContext`, the dedup branch (`inlinedPaths.has`) stripped the parent's line — leaving its bare references with nothing in scope (the binding was hidden inside `usePresence`'s IIFE).

This PR adopts strategy 2 from the issue's "Suggested fix" section: never nest one inlined module's IIFE inside another. Each unique inlined `.ts` module emits exactly **one** top-level IIFE wrap (`const __bf_inline_N = (() => { … })()`) in topological order. Every direct import line — parent's or transitive's — becomes a destructure that pulls from the per-module `__bf_inline_N` binding. The IIFE return surfaces the **union** of every name any consumer (parent or transitive) requested.

The dedup ordering bug disappears entirely because there's no inner-vs-outer to dedup against anymore.

### How it works

1. **Walk + collect (`walkAndCollect`)**: recurse the import graph from the parent. Each unique `.ts` path becomes one `InlinedModule`. Each consumer's import line (parent's or transitive's) is rewritten to a destructure pulling from `__bf_inline_N`.
2. **Topological sort (`topoSort`)**: post-order DFS over the dependency edges discovered from `__bf_inline_N` references in each module's body. Cycles trigger a warn-and-strip (TS itself already disallows them in source).
3. **Emit (`buildTopLevelIIFE`)**: for each module in topo order, build the IIFE wrap. The return surfaces every name any consumer requested; if any consumer used `* as ns`, all top-level value exports are surfaced.

### Edge cases preserved

- Bare-package import hoisting (#1148) still bubbles up via `hoistedAcc` and prepends to the parent.
- Server-component (`.tsx`) imports still strip without inlining.
- Type-only imports/exports continue to be erased by transpile / `collectExportedNames`.
- Aliased imports (`import { foo as bar }`) still produce a `const { foo: bar } = …` destructure at the consumer site.
- Namespace imports (`import * as ns`) bind `const ns = __bf_inline_N` since the IIFE return is already namespace-shaped.

### Context

Sibling work merged: #1141, #1148, #1151, #1154. In-flight: #1152 (touches a different file). Not a dependency of this PR.

## Test plan

- [x] New tests in `packages/cli/src/__tests__/inline-imports-dedup-shadowing.test.ts` (5 tests):
  - Parent direct import + transitive import of same `.ts`: parent body's bare reference resolves at runtime.
  - Reverse source order: parent's direct import comes BEFORE the transitive sibling.
  - Three-level chain (A → B → C, parent imports A and B): topological emission, no `ReferenceError`.
  - Two transitive siblings each importing the same `.ts`: dedup → exactly one IIFE.
  - Side-effect-only import + named import of same module: single IIFE, no double-evaluation.
- [x] Existing tests updated: `inline-imports-collision.test.ts`, `inline-imports-directory.test.ts` — regex assertions adjusted from inline-IIFE shape (`const { x } = (() =>`) to top-level shape (`const { x } = __bf_inline_N`). Runtime correctness assertions (`new Function(result)` parse checks, body content checks) unchanged.
- [x] CLI: 335 → 340 (335 baseline + 5 new).
- [x] JSX: 950 / 0 unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)