### PR TITLE
fix(xyflow): invoke props.onInit(store) so consumers can capture the store handle (#1158)

### DIFF
--- a/ui/components/ui/xyflow/index.test.tsx
+++ b/ui/components/ui/xyflow/index.test.tsx
@@ -230,4 +230,13 @@ describe('Flow', () => {
     expect(result.find({ componentName: 'SimpleEdge' })).not.toBeNull()
     expect(result.find({ componentName: 'NodeWrapper' })).not.toBeNull()
   })
+
+  test('invokes props.onInit(store) so consumers can capture the store handle', () => {
+    // Asserts the Flow body contains a `props.onInit(...)` call site
+    // (gated by `if (props.onInit)` to satisfy the JSX-native compiler's
+    // expression-statement preservation rules). If a future refactor
+    // drops it, downstream consumers (e.g. piconic-ai/desk's DeskCanvas)
+    // silently lose imperative access to the store.
+    expect(source).toMatch(/props\.onInit\(store/)
+  })
 })

--- a/ui/components/ui/xyflow/index.tsx
+++ b/ui/components/ui/xyflow/index.tsx
@@ -797,6 +797,15 @@ export function Flow<
     attachFlowSubsystems(el, store as InternalFlowStore<NodeType, EdgeType>, props)
   }
 
+  // Surface the store to consumers that need imperative access (e.g.
+  // calling `store.setNodes(...)` from outside the JSX subtree). Placed
+  // here (after all const decls and helper definitions) so the JSX
+  // compiler doesn't fold this expression statement into the const
+  // declaration chain above. Uses `if`-form rather than optional call —
+  // the compiler currently drops bare `props.X?.()` expression
+  // statements that have no JSX impact.
+  if (props.onInit) props.onInit(store as FlowStore<NodeType, EdgeType>)
+
   return (
     <FlowContext.Provider value={store as never}>
       <div


### PR DESCRIPTION
## Summary

The `Flow` JSX-native component declared `onInit` in its prop type but never called it — consumers passing `<Flow onInit={...}>` silently lost the callback, and any imperative `store.setNodes(...)` outside the JSX subtree was a no-op.

Surfaced during P6 verification in `piconic-ai/desk`: `DeskCanvas` passes `onInit={onFlowInit}` to capture the store, and a `createEffect` later does `store.setNodes(buildNodes(...))`. With the callback dropped, the effect bailed on `if (!flowStore) return` and 65 issue cards never rendered.

Fix: invoke `props.onInit?.(store as FlowStore<NodeType, EdgeType>)` synchronously after `createFlowStore(props)`, so the consumer's reference lands before any descendant `<Background>` / `<MiniMap>` / `<NodeWrapper>` renders. IR test pins the call site.

## Test plan

- [x] `bun test ui/components/ui/xyflow` — 23 / 0 (existing 22 + 1 new pin)
- [x] Verified live in piconic-ai/desk that `onFlowInit` is now invoked (next: cards render once #1156 + this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)