### PR TITLE
fix(client): thread parent scope ID into template() call from render() (#1160)

### DIFF
--- a/packages/client/src/runtime/render.ts
+++ b/packages/client/src/runtime/render.ts
@@ -7,6 +7,7 @@
  */
 
 import { BF_SCOPE } from '@barefootjs/shared'
+import { setParentScopeId } from './component'
 import { hydratedScopes } from './hydration-state'
 import { getComponentInit } from './registry'
 import { getTemplate, type TemplateFn } from './template'
@@ -69,7 +70,19 @@ export function render(
     }
   }
 
-  const html = template(props).trim()
+  // Generate the parent scope ID up front so renderChild calls inside
+  // template() can stamp `bf-s="~${parentScopeId}_sN"` on child scopes,
+  // matching what the compiler-emitted `$c(__scope, 'sN')` lookup later
+  // expects. Without this, renderChild falls back to `${childName}_${randomId}`
+  // and `$c` returns null, silently breaking child hydration. (#1160)
+  const scopeId = `${name}_${Math.random().toString(36).slice(2, 8)}`
+  setParentScopeId(scopeId)
+  let html: string
+  try {
+    html = template(props).trim()
+  } finally {
+    setParentScopeId(null)
+  }
 
   const tpl = document.createElement('template')
   tpl.innerHTML = html
@@ -80,8 +93,7 @@ export function render(
   }
 
   if (!element.getAttribute(BF_SCOPE)) {
-    const id = Math.random().toString(36).slice(2, 8)
-    element.setAttribute(BF_SCOPE, `${name}_${id}`)
+    element.setAttribute(BF_SCOPE, scopeId)
   }
 
   container.innerHTML = ''


### PR DESCRIPTION
## Summary

`render(container, name, props)` (CSR entry, `packages/client/src/runtime/render.ts`) was calling `template(props)` without setting `_parentScopeId` first. `renderChild('Child', props, undefined, 'sN')` invoked from inside that template fell into its random-ID fallback and stamped the child scope as `~${childName}_${random}_sN`.

The parent's compiler-emitted `const _sN = $c(__scope, 'sN')[0]` then looked for `[bf-s$="${parentScopeId}_sN"]` and got null. `initChild('Child', null, ...)` bailed on the null check, the child's init never ran, and the entire child subtree was silently inert (no `onInit`, no `ref` callbacks, no event wiring).

The same threading already exists for conditional template re-renders (`component.ts` ≈ line 1600 / 1631) — only the top-level `render()` entry was missing it.

## Fix

Generate the scope ID up front, `setParentScopeId(scopeId)` around the template call, reuse the same ID when stamping `bf-s` on the inserted element. `try/finally` ensures the parent scope ID gets cleared even if template throws.

## Test plan

- [x] `bun test packages/client` — 217 / 0 (no regression)
- [x] Verified live in piconic-ai/desk: `<Flow>` inside DeskCanvas now hydrates correctly. `onFlowInit` callback fires (confirmed via title-prefix instrument), `flowStore` is populated, node-build effect runs. (Subsequent issue #1161 — unguarded `ref` call on optional prop — is now visible because hydration progresses past the previous block.)

## Context

Surfaced during P6 verification of #1138 staged-IR refactor; the staged-IR + JSX-native compiler are unaffected — they emit correct `$c(__scope, 'sN')` lookups. The mismatch was purely in the runtime's `render()` not threading the parent scope ID into `renderChild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)