### PR TITLE
fix(jsx): guard ref={props.optional} prop-access calls (#1161)

### DIFF
--- a/packages/jsx/src/__tests__/ref-prop-optional.test.ts
+++ b/packages/jsx/src/__tests__/ref-prop-optional.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pins the ref-binding emit shape for `<el ref={...}>`.
+ *
+ * #1161: when `ref={props.someRef}` and `someRef?:` is optional, consumers
+ * may omit the prop, in which case `_p.someRef` is `undefined` and the
+ * emitted call `(_p.someRef)(_s0)` throws `TypeError: ... is not a function`.
+ *
+ * Fix: emit optional-call (`?.()`) for prop-access ref bindings so an
+ * undefined prop degrades to a no-op. Local-bound refs (a `const` arrow in
+ * the component body) keep the unguarded call — the function is always
+ * defined there.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSXSync } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('ref={...} emit shape (#1161)', () => {
+  test('ref={props.optionalRef} emits an optional-call guard', () => {
+    const source = `
+      'use client'
+      interface Props {
+        someRef?: (el: HTMLElement) => void
+      }
+      export function Foo(props: Props) {
+        return <div ref={props.someRef} />
+      }
+    `
+
+    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // Optional-call form: `(_p.someRef)?.(_s0)` — undefined prop no-ops.
+    expect(content).toMatch(/\(_p\.someRef\)\?\.\(_s0\)/)
+
+    // The unguarded `(_p.someRef)(_s` form must NOT appear — it's the
+    // exact pattern that throws when the consumer omits the ref.
+    expect(content).not.toMatch(/\(_p\.someRef\)\(_s/)
+  })
+
+  test('ref={props.requiredRef} also emits an optional-call guard', () => {
+    // Even when the prop type marks `ref` as required, the emit still
+    // guards with `?.()`. Rationale: prop-access could resolve to
+    // undefined at runtime regardless of the source typing (consumers
+    // can pass `as any`, the type can drift, …). The guard mirrors the
+    // way callable handlers like `onClick={props.onClick}` typically
+    // degrade to no-op when the prop is missing.
+    const source = `
+      'use client'
+      interface Props {
+        someRef: (el: HTMLElement) => void
+      }
+      export function Foo(props: Props) {
+        return <div ref={props.someRef} />
+      }
+    `
+
+    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    expect(content).toMatch(/\(_p\.someRef\)\?\.\(_s0\)/)
+    expect(content).not.toMatch(/\(_p\.someRef\)\(_s/)
+  })
+
+  test('ref={localFn} where localFn is a const in the component body stays unguarded', () => {
+    // A bare-identifier callback resolves to a local binding declared in
+    // the component body — it is always defined. Keep the unguarded call
+    // so a typo / dead binding fails loud instead of silently no-op'ing.
+    const source = `
+      'use client'
+      export function Foo() {
+        const attachPane = (el: HTMLElement) => { void el }
+        return <div ref={attachPane} />
+      }
+    `
+
+    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    // Unguarded form: `(attachPane)(_s0)`.
+    expect(content).toMatch(/\(attachPane\)\(_s0\)/)
+    // No optional-call sneaking in for the local binding.
+    expect(content).not.toMatch(/\(attachPane\)\?\.\(/)
+  })
+
+  test('ref={props.someRef} inside a conditional branch is also guarded', () => {
+    // The conditional-branch insert path has its own ref emitter; this
+    // test pins that it agrees with the top-level emitter on guarding
+    // prop-access callbacks. Without the fix, `<el ref={props.someRef}>`
+    // inside a conditional branch would still throw on the first show.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Props {
+        someRef?: (el: HTMLElement) => void
+      }
+      export function Foo(props: Props) {
+        const [show] = createSignal(true)
+        return <>{show() ? <div ref={props.someRef} /> : <span />}</>
+      }
+    `
+
+    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs?.content ?? ''
+
+    expect(content).toMatch(/\(_p\.someRef\)\?\.\(/)
+    expect(content).not.toMatch(/\(_p\.someRef\)\(_s/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -28,7 +28,7 @@
  * preserve it; a follow-up PR can fix it now that the indent is data-driven.
  */
 
-import { varSlotId } from '../../utils'
+import { emitRefCall, varSlotId } from '../../utils'
 import { emitAttrUpdate } from '../../emit-reactive'
 import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types'
 import { stringifyBranchLoops } from './branch-loop'
@@ -106,7 +106,7 @@ function emitArmBody(
 
   for (const ref of body.refs) {
     const v = varSlotId(ref.slotId)
-    lines.push(`${indent}if (_${v}) (${ref.callback})(_${v})`)
+    lines.push(`${indent}if (_${v}) ${emitRefCall(ref.callback, `_${v}`)}`)
   }
 
   // 3. Child component initializations from the branch swap.

--- a/packages/jsx/src/ir-to-client-js/phases/ref-callbacks.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/ref-callbacks.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ClientJsContext } from '../types'
-import { varSlotId } from '../utils'
+import { emitRefCall, varSlotId } from '../utils'
 
 export function emitRefCallbacks(
   lines: string[],
@@ -16,6 +16,6 @@ export function emitRefCallbacks(
   for (const elem of ctx.refElements) {
     if (conditionalSlotIds.has(elem.slotId)) continue
     const v = varSlotId(elem.slotId)
-    lines.push(`  if (_${v}) (${elem.callback})(_${v})`)
+    lines.push(`  if (_${v}) ${emitRefCall(elem.callback, `_${v}`)}`)
   }
 }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -200,6 +200,34 @@ export function wrapHandlerInBlock(handler: string): string {
   return trimmed
 }
 
+/**
+ * Emit a ref-binding call `(callback)(elementVar)`, optionally guarded so the
+ * call no-ops when the callback is undefined.
+ *
+ * Background: `<el ref={props.onMount} />` where `onMount?:` is optional in the
+ * prop type compiles to `(_p.onMount)(_s0)`. Consumers that omit the prop pass
+ * `undefined` and the call throws `TypeError: _p.onMount is not a function`
+ * (#1161). Local-bound callbacks like `<el ref={attachPane} />` are always
+ * defined — `attachPane` is a `const` in the component body — so they keep the
+ * unguarded call.
+ *
+ * Heuristic: a single bare identifier (e.g. `attachPane`) is a local binding;
+ * anything else (member access, call, arrow, …) is treated as a possibly-
+ * undefined source and emitted with optional-call (`?.()`).
+ */
+export function emitRefCall(callback: string, elementVar: string): string {
+  const trimmed = callback.trim()
+  const isBareIdent = /^[a-zA-Z_$][\w$]*$/.test(trimmed)
+  if (isBareIdent) {
+    return `(${callback})(${elementVar})`
+  }
+  // Wrap non-identifier expressions in parens so `?.()` binds to the whole
+  // expression (e.g. `(_p.onMount)?.(_s0)` not `_p.onMount?.(_s0)` — both
+  // parse the same here, but the parens preserve the legacy emit shape's
+  // intent and stay safe for arbitrary callback expressions).
+  return `(${callback})?.(${elementVar})`
+}
+
 /** Infer a sensible JS default value literal from a type descriptor. */
 export function inferDefaultValue(type: { kind: string; primitive?: string }): string {
   if (type.kind === 'primitive') {


### PR DESCRIPTION
## Summary

- `<el ref={props.someRef} />` where `someRef` is declared optional (`ref?: (el) => void`) compiled to an unguarded `(_p.someRef)(_s0)` call. When consumers omitted the ref, `_p.someRef` was `undefined` and hydration threw `TypeError: _p.someRef is not a function`, breaking every instance of the affected component.
- Fix: emit `(_p.someRef)?.(_s0)` for non-bare-identifier ref bindings (prop access, member chains, calls, …) so an undefined source degrades to a no-op. Bare-identifier callbacks (e.g. `<div ref={attachPane}>` where `attachPane` is a `const` in the component body) keep their unguarded call — the binding is always defined there, and a typo / dead binding should still fail loud.
- Two emit sites updated to share a small `emitRefCall(callback, elementVar)` helper:
  - `packages/jsx/src/ir-to-client-js/phases/ref-callbacks.ts` (top-level refs)
  - `packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts` (refs inside conditional branches)

Live repro: `barefootjs/ui/components/ui/xyflow/NodeWrapper` declares `ref?: (el) => void` and is instantiated by `<Flow>` without passing `ref`. Surfaced in piconic-ai/desk's `DeskCanvas` after #1162 (parent scope ID threading in `render()`) made the chain visible.

## Test plan

- [x] New tests in `packages/jsx/src/__tests__/ref-prop-optional.test.ts` (4 cases):
  - `ref={props.optionalRef}` emits `(_p.someRef)?.(_s0)` and never the unguarded form.
  - `ref={props.requiredRef}` is also guarded — prop-access can resolve to undefined regardless of the source typing.
  - `ref={localFn}` (bare identifier const in component body) stays unguarded.
  - `ref={props.someRef}` inside a conditional branch goes through the `insert.ts` emit path and is also guarded.
- [x] `bun test packages/jsx/src/__tests__/` — 774 pass / 13 fail. The 13 failures are pre-existing in baseline (`ac13f348`): 4 named (`primitive-resolver-{all,alias}.test.ts` — alias resolution) + 9 file-load failures from a workspace `@barefootjs/jsx` resolution issue. Net delta from this PR: +3 pass, −3 fail. No new failures.
- [x] `bun test packages/client` — 217 / 0, no regression.

## Sibling context

- #1162 (parent scope ID threading in `render()`) — merged, made this issue reachable.
- #1160 (test additions in `packages/client/__tests__/runtime/`) — sibling worktree task in flight; orthogonal scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)