### PR TITLE
ci(deploy): pin Node 22 for wrangler in all deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           bun-version: latest
 
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install dependencies
         run: bun install
 
@@ -75,6 +82,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Install dependencies
         run: bun install
@@ -115,6 +129,13 @@ jobs:
         with:
           bun-version: latest
 
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install dependencies
         run: bun install
 
@@ -145,6 +166,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Install dependencies
         run: bun install
@@ -179,6 +207,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary

- `bunx wrangler deploy` exited immediately on every job in [run 25218607021](https://github.com/piconic-ai/barefootjs/actions/runs/25218607021) (push of merged PR #1164), failing all five `deploy-*` jobs at step 7 with exit code 1.
- Same root cause as c7b8c85 fixed for `e2e-hono`: wrangler 4.x shells out to Node and requires v22+, but the runner's default Node 20 makes `bunx wrangler` exit immediately.
- Added `actions/setup-node@v4` with `node-version: '22'` after Setup Bun in `deploy-core`, `deploy-ui`, `deploy-integrations-{hono,echo,mojolicious}`.

## Test plan

- [ ] Once merged, the next push to `main` should produce a green Deploy Sites run with all five `deploy-*` jobs succeeding through step 7.
- [ ] Manual `workflow_dispatch` trigger of `deploy.yml` reaches the wrangler deploy step without an immediate exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xWZBP4A5JQAYFPgo7x6An)_