### PR TITLE
feat(xyflow): expose Flow store on host element via __bfFlowStore

### DIFF
--- a/packages/xyflow/src/__tests__/host-element-store.test.ts
+++ b/packages/xyflow/src/__tests__/host-element-store.test.ts
@@ -1,0 +1,33 @@
+/**
+ * `<Flow renderNode={Fn}>` hydrates the rendered bridge as a top-level
+ * scope outside Flow's `FlowContext.Provider`, so consumers that look up
+ * the store via `useFlow()` get back `undefined`. As an escape hatch,
+ * `attachFlowSubsystems` stamps the host `<div class="bf-flow">` with
+ * `__bfFlowStore` so children can walk up the DOM and read the store
+ * without going through the context system.
+ */
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
+})
+
+describe('attachFlowSubsystems exposes the store on the host element', () => {
+  test('sets `__bfFlowStore` on the element it attaches to', async () => {
+    // Lazy import so happy-dom globals are in place before xyflow loads.
+    const { attachFlowSubsystems } = await import('../flow-subsystems')
+    const { createFlowStore } = await import('../store')
+
+    const el = document.createElement('div')
+    el.className = 'bf-flow'
+    document.body.appendChild(el)
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal props for unit test
+    const store = createFlowStore({} as any)
+    // biome-ignore lint/suspicious/noExplicitAny: minimal props for unit test
+    attachFlowSubsystems(el, store as any, {} as any)
+
+    expect((el as HTMLElement & { __bfFlowStore?: unknown }).__bfFlowStore).toBe(store)
+  })
+})

--- a/packages/xyflow/src/flow-subsystems.ts
+++ b/packages/xyflow/src/flow-subsystems.ts
@@ -45,6 +45,14 @@ export function attachFlowSubsystems<
   el.style.overflow = 'hidden'
 
   store.setDomNode(el)
+  // Expose the store on the host `<div class="bf-flow">` element so
+  // descendants that miss `FlowContext` — e.g. children passed through
+  // `<Flow renderNode={Fn}>` whose returned JSX is hydrated as a
+  // top-level scope outside of Flow's `FlowContext.Provider` — can
+  // still locate the store via `el.closest('.bf-flow').__bfFlowStore`.
+  // Always-set, even on hot remount, so callers can rely on a single
+  // canonical reference.
+  ;(el as HTMLElement & { __bfFlowStore?: typeof store }).__bfFlowStore = store
   store.setWidth(el.offsetWidth)
   store.setHeight(el.offsetHeight)
 


### PR DESCRIPTION
## Summary

- Stamp the host `<div class="bf-flow">` element with a `__bfFlowStore` reference from `attachFlowSubsystems`, so descendants that miss `FlowContext` can recover the store via `el.closest('.bf-flow').__bfFlowStore`.
- Add a unit test verifying the property is set.

## Why

`<Flow renderNode={Fn}>` invokes `Fn(node)` from Flow's render loop, but the JSX it returns is compiled as a top-level `'use client'` component (`hydrate('NodeBridge', ...)`). At hydrate time the runtime walks the DOM for `[bf-s^="NodeBridge_"]` and calls `init` outside Flow's effect scope, so `useFlow()` returns `undefined`.

Today there is no first-class way for the bridge component to recover the store. `store.domNode()` is the reverse direction (store → element); the parent `.bf-flow__node` carries `data-id` but not a store handle. Consumers had to either patch barefoot or reach into framework internals.

This change adds the smallest possible escape hatch — a single property write — so a renderNode bridge can fall back to walking up the DOM:

```tsx
const flowEl = el.closest('.bf-flow') as
  HTMLElement & { __bfFlowStore?: FlowStore } | null
const store = flowEl?.__bfFlowStore
```

It does not change any public API surface and keeps the existing context path untouched. The right longer-term fix is to thread `node` through hydration so `<Flow renderNode={Fn}>` invokes `Fn` inside the FlowContext-providing scope; this PR is the minimal unblocker until that lands.

## Test plan

- [x] `bun test src/` in `packages/xyflow` (31 pass, including the new `host-element-store.test.ts`)
- [ ] Real-world consumer (desk's `/dev/catalog/{axis,box,svg,issue-card,drawing-overlay}`) renders the imperative node renderer using this fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)