### PR TITLE
fix(css): prevent iOS auto-zoom on input focus

### DIFF
--- a/integrations/shared/styles/ai-chat.css
+++ b/integrations/shared/styles/ai-chat.css
@@ -114,6 +114,11 @@
   outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
+@media (max-width: 768px) {
+  .chat-input {
+    font-size: 16px;
+  }
+}
 .chat-send {
   padding: 0.5rem 1rem;
   background: var(--primary);

--- a/site/core/styles/landing.css
+++ b/site/core/styles/landing.css
@@ -1100,6 +1100,12 @@ html.dark .shiki span {
   color: var(--muted-foreground);
 }
 
+@media (max-width: 768px) {
+  .ui-input {
+    font-size: 16px;
+  }
+}
+
 /* Preview Checkbox */
 .ui-checkbox-label {
   display: flex;


### PR DESCRIPTION
## Summary

Mobile Safari zooms in on focus whenever an input/textarea has `font-size < 16px`. Two custom CSS classes had this:

- `site/core/styles/landing.css` — `.ui-input` was `0.875rem` (14px)
- `integrations/shared/styles/ai-chat.css` — `.chat-input` was `0.9rem` (14.4px)

Added a `@media (max-width: 768px)` override on each to bump font-size to `16px` on mobile. Desktop sizing is unchanged.

The Barefoot UI `<Input>` / `<Textarea>` components were already fine — they use the `text-base md:text-sm` pattern (16px mobile, 14px desktop).

## Test plan

- [ ] Open the landing page on iOS Safari, focus the preview input — viewport should not zoom.
- [ ] Open the AI chat integration on iOS Safari, focus the chat input — viewport should not zoom.
- [ ] Verify desktop renders unchanged (input still appears at 14px on screens ≥ 769px).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HNmYdouRjoMPAYRWeAUnyW)_