### PR TITLE
feat(jsx): emit callable shim for 'use client' components

### DIFF
--- a/packages/jsx/src/__tests__/component-callable-shim.test.ts
+++ b/packages/jsx/src/__tests__/component-callable-shim.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Each `'use client'` component compiles to:
+ *   - `init${Name}` (declarative init function)
+ *   - `hydrate('${Name}', { init, template })`
+ *   - **`export function ${Name}(props, key) { return createComponent(...) }`**
+ *
+ * The shim lets consumers pass a JSX-defined client component as a
+ * value — `<Flow renderNode={Bridge}>` and similar higher-order
+ * patterns — without the bare `Bridge` reference becoming a free
+ * variable. When the holding closure (e.g. Flow's reactive children
+ * getter) later calls `Bridge(node)`, the shim returns a real DOM
+ * element with the right scope so context, props, and the registered
+ * template all line up.
+ */
+import { describe, expect, test } from 'bun:test'
+import { TestAdapter } from '../adapters/test-adapter'
+import { compileJSXSync } from '../compiler'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string, fileName: string): string {
+  const result = compileJSXSync(source, fileName, { adapter })
+  expect(result.errors).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe("'use client' component callable shim", () => {
+  const source = `
+    'use client'
+    import { createSignal } from '@barefootjs/client'
+    export function Bridge(props: { label: string }) {
+      const [open, setOpen] = createSignal(false)
+      return (
+        <button type="button" onClick={() => setOpen(!open())}>
+          {open() ? 'closed' : props.label}
+        </button>
+      )
+    }
+  `
+
+  test('emits an exported callable function with the component name', () => {
+    const js = clientJsFor(source, 'Bridge.tsx')
+    expect(js).toContain('export function Bridge(')
+    // The shim body delegates to createComponent against the registry.
+    expect(js).toMatch(/export function Bridge\([^)]*\)\s*\{\s*return createComponent\(['"]Bridge['"]/)
+  })
+
+  test('shim sits after the hydrate registration, not inside init', () => {
+    const js = clientJsFor(source, 'Bridge.tsx')
+    const hydrateIdx = js.indexOf("hydrate('Bridge'")
+    const shimIdx = js.indexOf('export function Bridge(')
+    expect(hydrateIdx).toBeGreaterThan(0)
+    expect(shimIdx).toBeGreaterThan(hydrateIdx)
+  })
+
+  test('imports createComponent from the runtime', () => {
+    const js = clientJsFor(source, 'Bridge.tsx')
+    expect(js).toMatch(/import\s*\{[^}]*\bcreateComponent\b[^}]*\}\s*from\s*['"]@barefootjs\/client\/runtime['"]/)
+  })
+})

--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -98,8 +98,15 @@ describe('composite loops inside conditional branches (#724)', () => {
     // Should use mapArray for per-item reactivity
     expect(js).toContain('mapArray(')
 
-    // Should NOT use createComponent (no child components)
-    expect(js).not.toContain('createComponent(')
+    // Should NOT use createComponent inside the init body (no child
+    // components in this fixture). The CLI also emits a callable shim
+    // `export function ${name}(props) { return createComponent(...) }`
+    // for *this* component so consumers can pass it as a value; the
+    // shim's createComponent is fine. Filter to occurrences before the
+    // shim's `export function` declaration.
+    const shimStart = js.indexOf('\nexport function ')
+    const initBody = shimStart >= 0 ? js.slice(0, shimStart) : js
+    expect(initBody).not.toContain('createComponent(')
   })
 
   test('simple loop with onClick inside conditional generates event delegation (#766)', () => {
@@ -147,8 +154,15 @@ describe('composite loops inside conditional branches (#724)', () => {
     expect(js).toContain('target.closest')
     expect(js).toContain('handleDelete(item.id)')
 
-    // Should NOT use createComponent (no child components)
-    expect(js).not.toContain('createComponent(')
+    // Should NOT use createComponent inside the init body (no child
+    // components in this fixture). The CLI also emits a callable shim
+    // `export function ${name}(props) { return createComponent(...) }`
+    // for *this* component so consumers can pass it as a value; the
+    // shim's createComponent is fine. Filter to occurrences before the
+    // shim's `export function` declaration.
+    const shimStart = js.indexOf('\nexport function ')
+    const initBody = shimStart >= 0 ? js.slice(0, shimStart) : js
+    expect(initBody).not.toContain('createComponent(')
   })
 
   test('SSR hydration: composite branch loop initializes child components via initChild', () => {

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -305,5 +305,33 @@ export function emitRegistrationAndHydration(
     defParts.push('comment: true')
   }
 
-  return `hydrate('${nameForRegistryRef(name)}', { ${defParts.join(', ')} })`
+  const registryKey = nameForRegistryRef(name)
+  const hydrateLine = `hydrate('${registryKey}', { ${defParts.join(', ')} })`
+
+  // Emit a callable shim with the original component name so consumers
+  // can use the component as a *value* — e.g. `<Flow renderNode={Bridge}>`
+  // or any other higher-order pattern where a JSX-defined `'use client'`
+  // component is passed around and later invoked as a function.
+  //
+  // Without the shim, the CLI compiles `function Bridge(props) {...}` to
+  // `function initBridge(__scope, _p) {...}` + `hydrate('Bridge', ...)`,
+  // and the bare `Bridge` reference becomes a free variable (silent
+  // ReferenceError when the holding closure runs). Holders that read it
+  // synchronously (Flow's reactive children getter, called from
+  // `setNodes` updates) crash.
+  //
+  // The shim delegates to `createComponent`, which:
+  //   - looks up the registered template + init for `${registryKey}`
+  //   - generates a fresh DOM element
+  //   - sets `currentScope` so `provideContext` / `useContext` inside
+  //     the init resolve relative to *this* element (i.e. inside the
+  //     calling parent's reactive scope, not at the top level)
+  //   - wires the props through and calls init
+  //
+  // Net effect: `renderNode={Bridge}` works for both the static SSR
+  // path (parent renders the bridge as children of NodeWrapper) and the
+  // runtime reactive path (mapArray → renderNode getter → real call).
+  const shimLine = `export function ${name}(${PROPS_PARAM}, __bfKey) { return createComponent('${registryKey}', ${PROPS_PARAM}, __bfKey) }`
+
+  return `${hydrateLine}\n${shimLine}`
 }

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -269,6 +269,11 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   lines.push(`function init${name}() {}`)
   lines.push('')
   lines.push(`hydrate('${registryKey}', { init: init${name}, template: (${PROPS_PARAM}) => \`${templateHtml}\` })`)
+  // See `emitRegistrationAndHydration` (./emit-registration.ts) for the
+  // rationale on why the component is also emitted as a callable
+  // shim. The same applies for template-only components since they
+  // can still be referenced as values (e.g. `<Parent slot={Comp}>`).
+  lines.push(`export function ${name}(${PROPS_PARAM}, __bfKey) { return createComponent('${registryKey}', ${PROPS_PARAM}, __bfKey) }`)
 
   const generatedCode = lines.join('\n')
   const usedImports = detectUsedImports(generatedCode)


### PR DESCRIPTION
## Summary

- `'use client'` components compile to `init\${Name}` + `hydrate('\${Name}', { init, template })`, but **no top-level `function \${Name}`** is emitted. JSX usage `<Name>` is rewritten to `createComponent('\${Name}', ...)` at compile time, so the missing function is invisible until a consumer captures the component as a *value* — render-prop / HOC patterns.
- This PR emits a thin callable shim alongside `init\${Name}` and `hydrate(...)`:

  ```js
  export function ${Name}(_p, __bfKey) {
    return createComponent('${Name}', _p, __bfKey)
  }
  ```

- New tests + existing tests adjusted to recognize the intentional `createComponent` reference in the shim.

## Why

The render-prop pattern is exactly the case where the missing function bites:

```tsx
<Flow renderNode={NodeBridge}>
```

The compiler emits `renderNode: NodeBridge`. As long as the closure never runs at runtime (e.g. a static graph served straight out of SSR HTML), nobody notices. The first reactive re-render that re-evaluates the prop — `store.setNodes(...)` from a drag handler, an axis resize tick, a drawing layer being added — calls `_p.renderNode(node)`, hits `NodeBridge` as a free variable, throws `ReferenceError`, and silently corrupts the canvas (live preview disappears, persisted strokes vanish, axis chrome flashes default white because the re-render never finishes).

Today's workarounds in desk all paper over consequences of this:
- a `:has([data-bf-bridge])` CSS rule because the failing re-render never re-applies the consumer-added `bf-flow__node--custom` class
- a `setTimeout` walk-up to `.bf-flow.__bfFlowStore` (the host-element store stamp from piconic-ai/barefootjs#1166) because `useFlow()` returns undefined when the bridge is hydrated outside Flow's effect scope
- reading `node.id` from the parent `.bf-flow__node[data-id]` because `bf-p` is empty for the bridge

The shim collapses all of that. `createComponent` already exists in the runtime — it looks up the registered template + init, generates a fresh element, sets `currentScope` so `provideContext` / `useContext` inside the init resolve relative to *this* element, wires the props through, calls init, and returns the element. So:

- `props.renderNode(node)` returns a real DOM element wired into the calling parent's reactive graph.
- `node` is passed straight through as the bridge's `_p`, so `_p.id` / `_p.data` / `_p.type` are real — no DOM walk-up.
- `useFlow()` inside the bridge resolves via `currentScope` — no `__bfFlowStore` escape needed.
- The function reference is stable, top-level, bound at module load — works across reactive re-renders.

## Implementation

Both emission paths get the shim:
- `emitRegistrationAndHydration` (full-init path): components that need a runtime init function
- `generateTemplateOnlyMount` (template-only path): components whose entire body collapses into a template literal — they can still be referenced as values (e.g. `<Parent slot={Comp}>`)

`createComponent` is already in `RUNTIME_IMPORT_CANDIDATES` and `detectUsedImports` picks it up automatically based on the `createComponent(` pattern in the emitted shim.

## Test plan

- [x] New `packages/jsx/src/__tests__/component-callable-shim.test.ts` (3 cases: function emitted, placement after hydrate, `createComponent` imported)
- [x] Updated `composite-branch-loop.test.ts` — its "should NOT use `createComponent`" assertions now scope to the init body only, since the shim's `createComponent` is intentional
- [x] `bun test packages/` (2068 pass, 0 fail)
- [ ] Real-world: desk drops the `:has([data-bf-bridge])` CSS rule, the `tryMount` setTimeout walk-up, and the `data-bf-bridge` attribute on the bridge — replaced by direct `_p.id` / `useFlow()` access in the bridge

## Relationship to #1166

The host-element store stamp from piconic-ai/barefootjs#1166 stays — it's still the right escape for *imperative* code that needs the store outside any component init. The new path here makes it unnecessary for the JSX render-prop case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)