### PR TITLE
fix(client/runtime): set currentScope before init in hydrateComponent

### DIFF
--- a/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `hydrateComponent` (the DOM walker that picks up top-level scope
+ * elements at hydrate time) sets `currentScope` to the scope element
+ * before calling `init`. Without it, a component nested inside a
+ * parent scope's DOM but hydrated as a top-level scope (e.g. a
+ * `<Flow renderNode={Fn}>` bridge whose JSX is rendered by Flow's
+ * SSR template into Flow's children but emits its own
+ * `bf-s="ChildName_…"` marker) would call `useContext` against a
+ * stale `currentScope` and miss every provided value upstream.
+ *
+ * The fix mirrors `createComponent`'s `setCurrentScope(element)`
+ * around `init`, so `useContext`'s DOM ancestor walk starts from the
+ * right anchor and finds the parent's `provideContext` value via
+ * `parentElement` traversal.
+ */
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
+})
+
+describe('hydrate sets currentScope before calling init', () => {
+  test('child init can resolve a parent-provided context value', async () => {
+    const { createContext, provideContext, useContext, setCurrentScope } = await import('../../src/runtime/context')
+    const { hydrate } = await import('../../src/runtime/hydrate')
+
+    const Theme = createContext<string>()
+
+    // Build a SSR-shaped DOM where the parent's scope element has a
+    // child whose `bf-s` marker triggers the top-level walker. The
+    // parent provides `Theme` synchronously via `provideContext` before
+    // the hydrate call so the value is on its CONTEXT_KEY map.
+    const parent = document.createElement('section')
+    parent.setAttribute('bf-s', 'Parent_root')
+    document.body.appendChild(parent)
+
+    // Provide on the parent element's CONTEXT_KEY map.
+    const prevScope = setCurrentScope(parent)
+    try {
+      provideContext(Theme, 'dark')
+    } finally {
+      setCurrentScope(prevScope)
+    }
+
+    const child = document.createElement('div')
+    child.setAttribute('bf-s', 'Child_inst')
+    parent.appendChild(child)
+
+    let observedTheme: string | undefined
+    hydrate('Child', {
+      init: (_el, _props) => {
+        observedTheme = useContext(Theme)
+      },
+      template: () => '<div></div>',
+    })
+
+    expect(observedTheme).toBe('dark')
+  })
+})

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -5,6 +5,7 @@
  * Single entry point for compiler-generated code.
  */
 
+import { setCurrentScope } from './context'
 import { commentScopeRegistry } from './scope'
 import { hydratedScopes } from './hydration-state'
 import { registerComponent } from './registry'
@@ -127,7 +128,20 @@ function hydrateCommentScopes(
       }
       const props = (parsed[name] ?? {}) as Record<string, unknown>
 
-      init(proxyEl, props)
+      // Mirror `createComponent`: set `currentScope` so `useContext` /
+      // `provideContext` calls inside `init` resolve via DOM ancestor
+      // walk relative to *this* element. Without it, a top-level
+      // hydrate of a component nested inside a parent scope (e.g. a
+      // `<Flow renderNode={Fn}>` bridge whose returned JSX is hydrated
+      // by the DOM walker rather than by `initChild`) would call
+      // `useContext` against a stale `currentScope` and miss every
+      // ancestor-provided value.
+      const prevScope = setCurrentScope(proxyEl)
+      try {
+        init(proxyEl, props)
+      } finally {
+        setCurrentScope(prevScope)
+      }
     }
   }
 }
@@ -192,6 +206,19 @@ function hydrateComponent(name: string, def: ComponentDef): void {
       }
     }
 
-    def.init(scopeEl, props)
+    // Mirror `createComponent`: set `currentScope` so `useContext` /
+    // `provideContext` calls inside `init` resolve via DOM ancestor
+    // walk relative to *this* element. Without it, a top-level
+    // hydrate of a component nested inside a parent scope (e.g. a
+    // `<Flow renderNode={Fn}>` bridge whose returned JSX is hydrated
+    // by the DOM walker rather than by `initChild`) would call
+    // `useContext` against a stale `currentScope` and miss every
+    // ancestor-provided value.
+    const prevScope = setCurrentScope(scopeEl)
+    try {
+      def.init(scopeEl, props)
+    } finally {
+      setCurrentScope(prevScope)
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `hydrateComponent` now wraps its `init(scopeEl, props)` call with `setCurrentScope(scopeEl)` (DOM-walker path *and* comment-scope path), mirroring what `createComponent` already does.
- New unit test in `packages/client/__tests__/runtime/hydrate-current-scope.test.ts` covering "parent-provided context resolves from a top-level-hydrated child".
- Full package tests stay green (2069 pass).

## Why

`createComponent` already wraps the registered `init` call with `setCurrentScope(element)` so `useContext` / `provideContext` inside `init` resolve via DOM ancestor walk relative to the new component's own element. `hydrateComponent` — the DOM-walker path that picks up top-level scope elements at hydrate time — didn't.

So when a component's `bf-s="Name_…"` marker landed inside an existing parent scope's DOM, the child's `init` ran with a stale `currentScope` (from whatever component last touched it, or `null`). `useContext` then walked from the wrong anchor and missed every ancestor-provided value.

The concrete shape we hit downstream: a `<Flow renderNode={Fn}>` bridge whose JSX is emitted by Flow's SSR template into the children of `NodeWrapper` carries its own top-level `bf-s` marker (no `~` prefix because the SSR template's `props.renderNode(node)` call doesn't pass `__bfChild`). The DOM walker hydrates it as top-level. Inside the bridge, `useFlow()` (= `useContext(FlowContext)`) returned `undefined` on the initial paint — so the bridge couldn't access the store, and consumers had to walk up to a host-element property (`.bf-flow.__bfFlowStore`, added in #1166) as a workaround. With this PR, that workaround becomes unnecessary on the initial-paint path: the walk in `useContext` starts from the bridge's own element, traverses up to `.bf-flow` via `parentElement`, finds the FlowContext value Flow stamped there, and returns it.

## Implementation

Both `hydrateComponent` paths receive the same `setCurrentScope` wrap — DOM-walker (line 195) and comment-scope (line 130). `setCurrentScope` returns the previous scope for `try`/`finally` restore so a synchronous `init` that throws can't poison the scope for the next component.

## Test plan

- [x] `bun test packages/client/__tests__/runtime/hydrate-current-scope.test.ts` — 1 pass (new)
- [x] `bun test packages/` — 2069 pass, 0 fail
- [ ] Real-world consumer (desk's `/dev/catalog/{axis,box,svg,issue-card}`) renders without the `useFlow()`-walk-up fallback; the bridges resolve `useFlow()` directly.

## Relationship to #1166 / #1169

- #1166's host-element store stamp stays — still the right escape for *imperative* code that needs the store from outside any component init (e.g. desk's DrawingOverlay imperative subsystem mounted from a non-component ref).
- #1169's callable shim stays — covers the runtime reactive path where `props.renderNode(node)` is invoked on an `setNodes` update.
- This PR fixes the third leg: the initial paint where the DOM walker hydrates an orphan scope. With all three together, JSX render-prop consumers can use `useFlow()` directly without DOM walk-up gymnastics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)