### PR TITLE
fix(client/runtime): set currentScope before init in hydrateComponent

### DIFF
--- a/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
@@ -1,0 +1,38 @@
+/** `hydrateComponent` must mirror `createComponent`'s currentScope wrap so child `useContext` resolves. */
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
+})
+
+describe('hydrate sets currentScope before calling init', () => {
+  test('child init resolves a parent-provided context value', async () => {
+    const { createContext, provideContext, useContext, setCurrentScope } = await import('../../src/runtime/context')
+    const { hydrate } = await import('../../src/runtime/hydrate')
+
+    const Theme = createContext<string>()
+
+    const parent = document.createElement('section')
+    parent.setAttribute('bf-s', 'Parent_root')
+    document.body.appendChild(parent)
+
+    const prevScope = setCurrentScope(parent)
+    provideContext(Theme, 'dark')
+    setCurrentScope(prevScope)
+
+    const child = document.createElement('div')
+    child.setAttribute('bf-s', 'Child_inst')
+    parent.appendChild(child)
+
+    let observedTheme: string | undefined
+    hydrate('Child', {
+      init: () => {
+        observedTheme = useContext(Theme)
+      },
+      template: () => '<div></div>',
+    })
+
+    expect(observedTheme).toBe('dark')
+  })
+})

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -5,6 +5,7 @@
  * Single entry point for compiler-generated code.
  */
 
+import { setCurrentScope } from './context'
 import { commentScopeRegistry } from './scope'
 import { hydratedScopes } from './hydration-state'
 import { registerComponent } from './registry'
@@ -127,7 +128,11 @@ function hydrateCommentScopes(
       }
       const props = (parsed[name] ?? {}) as Record<string, unknown>
 
+      // Mirror createComponent (component.ts) so context hooks inside init
+      // resolve from this scope.
+      const prevScope = setCurrentScope(proxyEl)
       init(proxyEl, props)
+      setCurrentScope(prevScope)
     }
   }
 }
@@ -192,6 +197,10 @@ function hydrateComponent(name: string, def: ComponentDef): void {
       }
     }
 
+    // Mirror createComponent (component.ts) so context hooks inside init
+    // resolve from this scope.
+    const prevScope = setCurrentScope(scopeEl)
     def.init(scopeEl, props)
+    setCurrentScope(prevScope)
   }
 }


### PR DESCRIPTION
## Summary

- `hydrateComponent` now wraps `init(scopeEl, props)` with `setCurrentScope(scopeEl)` / `setCurrentScope(prevScope)` (DOM walker path *and* comment-scope path), mirroring the same set/init/restore pattern `createComponent` already uses in `component.ts`.
- New unit test `packages/client/__tests__/runtime/hydrate-current-scope.test.ts` verifies a parent-provided context resolves from a top-level-hydrated child.
- `bun test packages/` — 2069 pass, 0 fail.

## Why

`createComponent` already wraps the registered `init` call with `setCurrentScope(element)` so `useContext` / `provideContext` inside `init` resolve via the DOM ancestor walk relative to the new component's own element. `hydrateComponent` — the DOM walker path that picks up top-level scope elements at hydrate time — didn't.

So when a component's `bf-s="Name_…"` marker landed inside an existing parent scope's DOM, the child's `init` ran with a stale `currentScope` (whatever the last component touched, or `null`). `useContext` then walked from the wrong anchor and missed every ancestor-provided value.

The concrete shape we hit downstream: a `<Flow renderNode={Fn}>` bridge whose JSX is emitted by Flow's compiled SSR template into NodeWrapper's children carries its own top-level `bf-s` marker — Flow's SSR template calls `props.renderNode(node)` as a plain function, no `__bfChild` / `__bfScope` are threaded through, and the bridge's SSR template emits a top-level scope. The DOM walker then hydrates it. Inside the bridge, `useContext(FlowContext)` (= `useFlow()`) returned `undefined` on the initial paint — so the bridge couldn't see the store, and consumers had to walk up to `.bf-flow.__bfFlowStore` (added in #1166) as a fallback.

With this fix the walk in `useContext` starts from the bridge's own element, traverses up to `.bf-flow` via `parentElement`, finds the FlowContext value Flow stamped there (via `provideContext` during its own init), and returns it. No fallback needed.

## Implementation

Both paths get the same wrap. `setCurrentScope` returns the previous scope so the restore is a single sequential statement after `init` — same shape as `createComponent`. No `try`/`finally`: an `init` that throws was already going to leave the system in an inconsistent state (signals/effects half-attached), and `createComponent` doesn't defend against that either, so adding it only here would be inconsistent for no benefit.

## Test plan

- [x] new `hydrate-current-scope.test.ts` — 1 case: child init resolves parent-provided context
- [x] `bun test packages/` — 2069 pass, 0 fail
- [ ] Real-world consumer (desk's `/dev/catalog/{axis,box,svg,issue-card}`) drops the `setTimeout` walk-up fallback in NodeBridge and resolves `useFlow()` directly.

## Relationship to #1166 / #1169

- #1166's host-element store stamp stays — still the right escape for *imperative* code that needs the store outside any component init (e.g. desk's DrawingOverlay imperative subsystem mounted from a non-component ref where `useContext` can't be called).
- #1169's callable shim stays — covers the runtime reactive path where `props.renderNode(node)` is invoked by `setNodes` reactivity through `createComponent`.
- This PR fixes the third leg: the initial paint where the DOM walker hydrates an orphan-shaped scope. With all three together, JSX render-prop consumers can use `useFlow()` directly without DOM walk-up gymnastics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)