### PR TITLE
fix(client/runtime): walk hydrate scopes in document order

### DIFF
--- a/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-current-scope.test.ts
@@ -32,6 +32,7 @@ describe('hydrate sets currentScope before calling init', () => {
       },
       template: () => '<div></div>',
     })
+    await Promise.resolve()
 
     expect(observedTheme).toBe('dark')
   })

--- a/packages/client/__tests__/runtime/hydrate-document-order.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-document-order.test.ts
@@ -85,4 +85,44 @@ describe('hydrate walks elements in document order', () => {
 
     expect(observed).toEqual(['hi', 'hi'])
   })
+
+  test('comment-scope parent inits before element-scope descendant in same doc', async () => {
+    // Regression: an earlier draft of this PR ran the element-scope pass
+    // first and the comment-scope pass second, which meant a comment-
+    // rooted parent that called `provideContext()` only became visible
+    // *after* every element-scope descendant had already missed it.
+    // The unified TreeWalker(SHOW_ELEMENT | SHOW_COMMENT) pass below
+    // must hydrate the parent (the comment) before the descendant
+    // (the element) because that's true document order.
+    const { createContext, provideContext, useContext } = await import('../../src/runtime/context')
+    const { hydrate } = await import('../../src/runtime/hydrate')
+
+    const Store = createContext<string | undefined>(undefined)
+
+    document.body.innerHTML =
+      `<!--bf-scope:DocOrderCommentParent_root|{"DocOrderCommentParent":{}}-->` +
+      `<div bf-s="~DocOrderCommentParent_root_proxy">` +
+        `<div bf-s="DocOrderCommentChild_leaf"></div>` +
+      `</div>`
+
+    let observed: string | undefined
+
+    // Register child first (mimics bundled-output ordering).
+    hydrate('DocOrderCommentChild', {
+      init: () => {
+        observed = useContext(Store)
+      },
+    })
+
+    hydrate('DocOrderCommentParent', {
+      init: () => {
+        provideContext(Store, 'from-comment-parent')
+      },
+      comment: true,
+    })
+
+    await Promise.resolve()
+
+    expect(observed).toBe('from-comment-parent')
+  })
 })

--- a/packages/client/__tests__/runtime/hydrate-document-order.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-document-order.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression: when a child component's `hydrate()` registers BEFORE its
+ * parent's, the document-order walker should still init the parent first
+ * so the child's `useContext` resolves on the very first hydrate pass.
+ *
+ * Mirrors the bundled-module-order failure from
+ * `worker/components/canvas/catalog/AxisCatalog.tsx` in piconic-ai/desk —
+ * `hydrate('NodeBridge', ...)` lands in the bundle output before
+ * `hydrate('AxisCatalog', ...)`, so a per-name walk would init the
+ * descendant before the ancestor's `provideContext` had run.
+ *
+ * Issue: doc-order-hydrate follow-up to #1166 / #1169 / #1171.
+ */
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
+})
+
+describe('hydrate walks elements in document order', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('descendant useContext resolves when parent hydrate() registers AFTER child', async () => {
+    const { createContext, provideContext, useContext } = await import('../../src/runtime/context')
+    const { hydrate } = await import('../../src/runtime/hydrate')
+
+    const Store = createContext<{ value: number } | undefined>(undefined)
+
+    document.body.innerHTML =
+      `<div bf-s="DocOrderParent_root">` +
+        `<div bf-s="DocOrderChild_leaf"></div>` +
+      `</div>`
+
+    let observed: { value: number } | undefined
+
+    // Register child FIRST — mimics bundle output where the renderNode
+    // component lands above its `<Flow>` parent in module exec order.
+    hydrate('DocOrderChild', {
+      init: () => {
+        observed = useContext(Store)
+      },
+    })
+
+    hydrate('DocOrderParent', {
+      init: () => {
+        provideContext(Store, { value: 7 })
+      },
+    })
+
+    await Promise.resolve()
+
+    expect(observed).toEqual({ value: 7 })
+  })
+
+  test('multiple descendants under the same parent all see provided context', async () => {
+    const { createContext, provideContext, useContext } = await import('../../src/runtime/context')
+    const { hydrate } = await import('../../src/runtime/hydrate')
+
+    const Store = createContext<string | undefined>(undefined)
+
+    document.body.innerHTML =
+      `<div bf-s="DocOrderParent2_root">` +
+        `<div bf-s="DocOrderChild2_a"></div>` +
+        `<div bf-s="DocOrderChild2_b"></div>` +
+      `</div>`
+
+    const observed: Array<string | undefined> = []
+
+    hydrate('DocOrderChild2', {
+      init: () => {
+        observed.push(useContext(Store))
+      },
+    })
+
+    hydrate('DocOrderParent2', {
+      init: () => {
+        provideContext(Store, 'hi')
+      },
+    })
+
+    await Promise.resolve()
+
+    expect(observed).toEqual(['hi', 'hi'])
+  })
+})

--- a/packages/client/__tests__/runtime/hydrate-document-order.test.ts
+++ b/packages/client/__tests__/runtime/hydrate-document-order.test.ts
@@ -86,6 +86,59 @@ describe('hydrate walks elements in document order', () => {
     expect(observed).toEqual(['hi', 'hi'])
   })
 
+  test('flushHydration() drains pending walk synchronously', async () => {
+    const { hydrate, flushHydration } = await import('../../src/runtime/hydrate')
+
+    document.body.innerHTML = `<div bf-s="DocOrderFlush_1"></div>`
+
+    let initRan = false
+
+    hydrate('DocOrderFlush', {
+      init: () => {
+        initRan = true
+      },
+    })
+
+    // Without flushHydration this would still be false until microtask
+    // flush — that's the documented post-#1172 behaviour.
+    expect(initRan).toBe(false)
+
+    flushHydration()
+
+    expect(initRan).toBe(true)
+
+    // The queued microtask / rAF callbacks now treat themselves as
+    // already-run and skip; no double-init even after we await.
+    let rerunCount = 0
+    hydrate('DocOrderFlush', {
+      init: () => {
+        rerunCount += 1
+      },
+    })
+    flushHydration()
+    await Promise.resolve()
+    // Single hydrated element + WeakSet membership means re-running
+    // the walk is a no-op for that scope.
+    expect(rerunCount).toBe(0)
+  })
+
+  test('flushHydration() with nothing pending is a no-op', async () => {
+    const { hydrate, flushHydration } = await import('../../src/runtime/hydrate')
+
+    document.body.innerHTML = `<div bf-s="DocOrderFlushNoop_1"></div>`
+    let initCount = 0
+
+    hydrate('DocOrderFlushNoop', { init: () => initCount++ })
+    flushHydration()
+    expect(initCount).toBe(1)
+
+    // No further hydrate() / rehydrateAll() — flushHydration must not
+    // re-walk the DOM, which would be wasted work but also wouldn't
+    // re-init (already in WeakSet).
+    flushHydration()
+    expect(initCount).toBe(1)
+  })
+
   test('comment-scope parent inits before element-scope descendant in same doc', async () => {
     // Regression: an earlier draft of this PR ran the element-scope pass
     // first and the comment-scope pass second, which meant a comment-

--- a/packages/client/__tests__/runtime/hydrate.test.ts
+++ b/packages/client/__tests__/runtime/hydrate.test.ts
@@ -37,11 +37,50 @@ describe('hydrate', () => {
     expect(initialized[0].scope.getAttribute('bf-s')).toBe('Counter_abc')
   })
 
-  test('skips nested component scopes with same component type', async () => {
+  test('parent that calls initChild claims its same-name nested scope', async () => {
+    const { initChild } = await import('../../src/runtime/registry')
     const initialized: Element[] = []
 
-    // Counter nested inside another Counter should be skipped
-    // (parent component is responsible for initializing its children)
+    // The walker visits both scopes in document order. When the outer
+    // Counter's init calls `initChild('Counter', innerEl)` for its
+    // nested same-name child, that initChild marks the inner scope as
+    // hydrated — so the walker's later visit short-circuits. The
+    // assertion below is on initialized order: outer first, then inner
+    // via initChild, then nothing more (walker skip).
+    document.body.innerHTML = `
+      <div bf-s="Counter_1">
+        <div bf-s="Counter_nested">nested</div>
+      </div>
+    `
+
+    hydrate('Counter', {
+      init: (scope) => {
+        initialized.push(scope)
+        // Outer claims its nested same-name child. Inner Counter has
+        // no children of its own to claim — its init is a no-op
+        // (no recursive initChild). Without this branching the test
+        // would loop forever via mutual hydration.
+        if (scope.getAttribute('bf-s') === 'Counter_1') {
+          const inner = scope.querySelector('[bf-s="Counter_nested"]')
+          if (inner) initChild('Counter', inner)
+        }
+      },
+    })
+    await flush()
+
+    expect(initialized.length).toBe(2)
+    expect(initialized[0].getAttribute('bf-s')).toBe('Counter_1')
+    expect(initialized[1].getAttribute('bf-s')).toBe('Counter_nested')
+  })
+
+  test('walker hydrates same-name nested scope when parent does NOT claim it', async () => {
+    const initialized: Element[] = []
+
+    // Same DOM as above, but this time the outer's init is a no-op:
+    // it does not call initChild for the inner. The walker, having no
+    // ancestor-name guard anymore, treats the inner as a top-level
+    // scope and hydrates it too. This is what makes nesting depth a
+    // non-concern (the previous walker silently dropped inner inits).
     document.body.innerHTML = `
       <div bf-s="Counter_1">
         <div bf-s="Counter_nested">nested</div>
@@ -51,9 +90,11 @@ describe('hydrate', () => {
     hydrate('Counter', { init: (scope) => initialized.push(scope) })
     await flush()
 
-    // Only the outer Counter_1 should be initialized, not the nested one
-    expect(initialized.length).toBe(1)
-    expect(initialized[0].getAttribute('bf-s')).toBe('Counter_1')
+    expect(initialized.length).toBe(2)
+    expect(initialized.map((el) => el.getAttribute('bf-s'))).toEqual([
+      'Counter_1',
+      'Counter_nested',
+    ])
   })
 
   test('initializes nested component with different parent type', async () => {

--- a/packages/client/__tests__/runtime/hydrate.test.ts
+++ b/packages/client/__tests__/runtime/hydrate.test.ts
@@ -8,12 +8,17 @@ beforeAll(() => {
   }
 })
 
+// `hydrate()` schedules a document-order walk on the next microtask, so
+// every test below awaits a microtask flush before asserting on init
+// results. See packages/client/src/runtime/hydrate.ts for the rationale.
+const flush = () => Promise.resolve()
+
 describe('hydrate', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
 
-  test('initializes root components with props', () => {
+  test('initializes root components with props', async () => {
     const initialized: Array<{ props: Record<string, unknown>; scope: Element }> = []
 
     document.body.innerHTML = `
@@ -25,13 +30,14 @@ describe('hydrate', () => {
         initialized.push({ props, scope })
       }
     })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].props).toEqual({ count: 5 })
     expect(initialized[0].scope.getAttribute('bf-s')).toBe('Counter_abc')
   })
 
-  test('skips nested component scopes with same component type', () => {
+  test('skips nested component scopes with same component type', async () => {
     const initialized: Element[] = []
 
     // Counter nested inside another Counter should be skipped
@@ -43,13 +49,14 @@ describe('hydrate', () => {
     `
 
     hydrate('Counter', { init: (scope) => initialized.push(scope) })
+    await flush()
 
     // Only the outer Counter_1 should be initialized, not the nested one
     expect(initialized.length).toBe(1)
     expect(initialized[0].getAttribute('bf-s')).toBe('Counter_1')
   })
 
-  test('initializes nested component with different parent type', () => {
+  test('initializes nested component with different parent type', async () => {
     const initialized: Element[] = []
 
     // Counter nested inside Parent (different type) should NOT be skipped
@@ -61,12 +68,13 @@ describe('hydrate', () => {
     `
 
     hydrate('Counter', { init: (scope) => initialized.push(scope) })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].getAttribute('bf-s')).toBe('Counter_nested')
   })
 
-  test('initializes multiple instances', () => {
+  test('initializes multiple instances', async () => {
     const initialized: Element[] = []
 
     document.body.innerHTML = `
@@ -75,11 +83,12 @@ describe('hydrate', () => {
     `
 
     hydrate('Counter', { init: (scope) => initialized.push(scope) })
+    await flush()
 
     expect(initialized.length).toBe(2)
   })
 
-  test('handles missing props script', () => {
+  test('handles missing props script', async () => {
     const initialized: Array<{ props: Record<string, unknown> }> = []
 
     document.body.innerHTML = `
@@ -91,12 +100,13 @@ describe('hydrate', () => {
         initialized.push({ props })
       }
     })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].props).toEqual({})
   })
 
-  test('without comment flag does not hydrate comment-based scopes', () => {
+  test('without comment flag does not hydrate comment-based scopes', async () => {
     const initialized: Element[] = []
 
     document.body.innerHTML = `
@@ -105,12 +115,13 @@ describe('hydrate', () => {
     `
 
     hydrate('FragComp', { init: (scope) => initialized.push(scope) })
+    await flush()
 
     // Without comment flag, comment-based scopes should be skipped
     expect(initialized.length).toBe(0)
   })
 
-  test('does not crash on invalid props JSON', () => {
+  test('does not crash on invalid props JSON', async () => {
     const initialized: Array<{ props: Record<string, unknown> }> = []
 
     document.body.innerHTML = `
@@ -122,12 +133,13 @@ describe('hydrate', () => {
         initialized.push({ props })
       }
     })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].props).toEqual({})
   })
 
-  test('does not crash on invalid comment props JSON', () => {
+  test('does not crash on invalid comment props JSON', async () => {
     const initialized: Array<{ props: Record<string, unknown> }> = []
 
     document.body.innerHTML = `
@@ -141,12 +153,13 @@ describe('hydrate', () => {
       },
       comment: true
     })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].props).toEqual({})
   })
 
-  test('with comment=true hydrates comment-based scopes', () => {
+  test('with comment=true hydrates comment-based scopes', async () => {
     const initialized: Array<{ props: Record<string, unknown>; scope: Element }> = []
 
     document.body.innerHTML = `
@@ -160,6 +173,7 @@ describe('hydrate', () => {
       },
       comment: true
     })
+    await flush()
 
     expect(initialized.length).toBe(1)
     expect(initialized[0].props).toEqual({ title: 'hello' })

--- a/packages/client/__tests__/runtime/issue-1156.test.ts
+++ b/packages/client/__tests__/runtime/issue-1156.test.ts
@@ -83,7 +83,7 @@ describe('issue #1156: useContext from inlined child template', () => {
     expect(() => render(container, 'Issue1156NoDefaultFlow', {})).not.toThrow()
   })
 
-  test('SSR hydrate flow: createEffect repaints child with parent-provided value', () => {
+  test('SSR hydrate flow: createEffect repaints child with parent-provided value', async () => {
     type Store = { value: number }
     const FlowContext = createContext<Store | undefined>(undefined)
 
@@ -112,6 +112,9 @@ describe('issue #1156: useContext from inlined child template', () => {
     })
 
     hydrate('Issue1156HydrFlow', def)
+    // Drain the initial scheduled walk before swapping the SSR markup in,
+    // so the doc-order pass we care about runs against that markup only.
+    await Promise.resolve()
 
     // Mimic SSR-rendered HTML with proper parent-child scope IDs.
     const parentId = 'Issue1156HydrFlow_ssr01'
@@ -123,6 +126,7 @@ describe('issue #1156: useContext from inlined child template', () => {
       `</div>`
 
     expect(() => hydrate('Issue1156HydrFlow', def)).not.toThrow()
+    await Promise.resolve()
     expect(document.body.textContent).toBe('42')
   })
 })

--- a/packages/client/__tests__/runtime/streaming.test.ts
+++ b/packages/client/__tests__/runtime/streaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test'
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { __bf_swap, setupStreaming } from '../../src/runtime/streaming'
 import { hydrate, rehydrateAll } from '../../src/runtime/hydrate'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
@@ -93,7 +93,7 @@ describe('rehydrateAll', () => {
     document.body.innerHTML = ''
   })
 
-  test('hydrates components added after initial hydration', () => {
+  test('hydrates components added after initial hydration', async () => {
     const initialized: string[] = []
 
     // Initial hydration
@@ -103,6 +103,8 @@ describe('rehydrateAll', () => {
     hydrate('Counter', {
       init: (scope) => { initialized.push(scope.getAttribute('bf-s')!) },
     })
+    // hydrate() schedules its walker on the next microtask.
+    await Promise.resolve()
 
     expect(initialized).toEqual(['Counter_1'])
 
@@ -119,7 +121,7 @@ describe('rehydrateAll', () => {
     expect(initialized).toEqual(['Counter_1', 'Counter_2'])
   })
 
-  test('does not re-hydrate already initialized elements', () => {
+  test('does not re-hydrate already initialized elements', async () => {
     let initCount = 0
 
     document.body.innerHTML = `
@@ -128,6 +130,7 @@ describe('rehydrateAll', () => {
     hydrate('Toggle', {
       init: () => { initCount++ },
     })
+    await Promise.resolve()
 
     expect(initCount).toBe(1)
 

--- a/packages/client/__tests__/runtime/streaming.test.ts
+++ b/packages/client/__tests__/runtime/streaming.test.ts
@@ -115,8 +115,11 @@ describe('rehydrateAll', () => {
     newEl.textContent = 'streamed'
     document.body.appendChild(newEl)
 
-    // Trigger re-hydration
+    // Trigger re-hydration. `rehydrateAll()` schedules a walk through
+    // the same microtask + rAF pipeline as `hydrate()`, so we await a
+    // microtask flush before asserting.
     rehydrateAll()
+    await Promise.resolve()
 
     expect(initialized).toEqual(['Counter_1', 'Counter_2'])
   })
@@ -136,6 +139,7 @@ describe('rehydrateAll', () => {
 
     // Re-hydrate should not re-initialize
     rehydrateAll()
+    await Promise.resolve()
     expect(initCount).toBe(1)
   })
 })

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -4,18 +4,35 @@
  * Combined component registration + template registration + hydration.
  * Single entry point for compiler-generated code.
  *
- * The walker is **document-order**: per-name `hydrate()` calls only register
- * a component definition; the actual init walk runs once per microtask flush
- * and visits every `[bf-s]` element in document order. Walking parents
- * before descendants is what makes `useFlow()` (and any other context
- * consumer) resolve on the very first hydrate pass — by the time a
- * descendant's init runs, every ancestor has already provided context.
+ * Design (post #1172):
  *
- * The previous per-name walk hydrated whichever component happened to be
- * registered first in bundled module order, so a `<Flow renderNode={Fn}>`
- * descendant that ran before its `<Flow>` parent would observe an
- * undefined context (piconic-ai/barefootjs#1175 follow-up to #1166/#1169/
- * #1171).
+ *   1. `hydrate(name, def)` only **registers** the def + template +
+ *      component-registry entry, then schedules a walk.
+ *   2. The walk visits every `[bf-s]` element in document order — a
+ *      single pass for every registered component, run once per
+ *      scheduling tick. Document order means a parent's init always
+ *      runs before any descendant's init, so context providers
+ *      resolve on the first hydrate pass.
+ *   3. Two scheduling phases, each capped to one in-flight callback:
+ *        - microtask: collapses every `hydrate()` call from the
+ *          bundled module body into a single walk on the next tick.
+ *        - rAF: catches scope elements that the streaming protocol
+ *          (Hono / `__bf_swap`) injects into the document *after*
+ *          the synchronous module body has finished.
+ *   4. `rehydrateAll()` and the comment-scope path both share this
+ *      walker, so streaming swaps and comment-rooted fragments enjoy
+ *      the same ordering guarantee.
+ *
+ * Same-name nesting (`<Counter>` inside `<Counter>`):
+ *   The walker's `hydratedScopes.has(el)` check is the *only* skip
+ *   guard. Parents that intentionally own their nested same-name
+ *   children call `initChild(...)` from their init body — initChild
+ *   marks the child scope as hydrated, so when the walker reaches it
+ *   later it short-circuits. Parents that *don't* call `initChild`
+ *   (the descendant is a coincidental same-name component, not a
+ *   structural child) get the descendant hydrated by the walker as a
+ *   normal top-level component. This makes nesting depth a non-issue
+ *   — the previous ancestor-walk guard is gone.
  */
 
 import { setCurrentScope } from './context'
@@ -33,23 +50,29 @@ import type { ComponentDef } from './types'
  */
 const registeredDefs = new Map<string, ComponentDef>()
 
-let walkScheduled = false
+let microtaskScheduled = false
+let rafScheduled = false
 
+/**
+ * Schedule the document-order walk once per tick (microtask) and once
+ * per frame (rAF). Both flags are cleared inside their respective
+ * callbacks, so a flood of `hydrate()` / `rehydrateAll()` calls can
+ * never queue more than two pending walks in total.
+ */
 function scheduleWalk(): void {
-  if (walkScheduled) return
-  walkScheduled = true
-  // Microtask: every synchronous `hydrate()` call from the bundled
-  // module body has registered its def by the time the walk runs, so
-  // the document-order walk sees a fully populated registry.
-  queueMicrotask(() => {
-    walkScheduled = false
-    walkAllInDocumentOrder()
-  })
-  // rAF: streaming protocol may move template content into the document
-  // after initial script execution. Re-walking once a frame later picks
-  // up scope elements that landed too late for the microtask.
-  if (typeof requestAnimationFrame === 'function') {
-    requestAnimationFrame(walkAllInDocumentOrder)
+  if (!microtaskScheduled) {
+    microtaskScheduled = true
+    queueMicrotask(() => {
+      microtaskScheduled = false
+      walkAllInDocumentOrder()
+    })
+  }
+  if (!rafScheduled && typeof requestAnimationFrame === 'function') {
+    rafScheduled = true
+    requestAnimationFrame(() => {
+      rafScheduled = false
+      walkAllInDocumentOrder()
+    })
   }
 }
 
@@ -82,26 +105,29 @@ export function hydrate(name: string, def: ComponentDef): void {
  * Re-hydrate all registered components.
  *
  * Called by the streaming resolver after swapping fallback content with
- * resolved content. Re-runs the document-order walker so newly-inserted
- * scope elements pick up their inits.
+ * resolved content. Goes through the same scheduler as `hydrate()` so
+ * back-to-back `__bf_swap` invocations or interleaved `hydrate()` calls
+ * collapse to a single walk per tick + per frame.
  */
 export function rehydrateAll(): void {
-  walkAllInDocumentOrder()
+  scheduleWalk()
 }
 
 /**
  * Document-order walk over every `[bf-s]` element in the page.
  *
  * Element-scope path:
- *   - Skip elements that are already hydrated.
- *   - Skip child-prefixed scopes (`~Foo_xxx`) — the parent's `initChild`
- *     owns those.
- *   - Skip nested same-name scopes — `<Counter>` inside `<Counter>` only
- *     hydrates the outer; the parent's init handles the inner.
+ *   - Skip elements already in `hydratedScopes`. This is the single
+ *     source of truth: children initialised via `initChild` mark their
+ *     scope here too, so the walker can rely on this check alone (no
+ *     ancestor-name lookup needed).
+ *   - Skip child-prefixed scopes (`~Foo_xxx`) outright — they were
+ *     emitted by `renderChild()` and are owned by the parent's
+ *     `initChild`/`upsertChild` flow.
  *   - Look up the def by the name encoded in the `bf-s` attribute. If
  *     the component hasn't registered yet, leave the element for a
  *     future walk.
- *   - Set currentScope, run init, restore scope.
+ *   - Set currentScope, run init, restore scope, mark as hydrated.
  *
  * Comment-scope path runs after the element pass and visits each
  * `<!--bf-scope:Name_xxx-->` comment in document order.
@@ -124,15 +150,10 @@ function walkAllInDocumentOrder(): void {
 
     const def = registeredDefs.get(name)
     if (!def) continue
-    // Comment-based components handle their own walk (the bf-s attribute
-    // here is on a proxy element and we'd double-init if we ran it twice).
+    // Comment-based components hydrate via the comment-scope path; their
+    // bf-s attribute (when present) sits on a proxy element that we'd
+    // otherwise double-init.
     if (def.comment) continue
-
-    // Nested same-name skip: a `<Counter>` rendered inside another
-    // `<Counter>` only hydrates the outer; the outer's init drives the
-    // inner via initChild. Match against any ancestor scope so deeply
-    // nested same-name pairs still skip.
-    if (hasAncestorWithSameName(el, name)) continue
 
     hydratedScopes.add(el)
 
@@ -155,17 +176,6 @@ function walkAllInDocumentOrder(): void {
   }
 
   walkCommentScopesInDocumentOrder()
-}
-
-function hasAncestorWithSameName(scopeEl: Element, name: string): boolean {
-  let parent: Element | null = scopeEl.parentElement?.closest(`[${BF_SCOPE}]`) ?? null
-  while (parent) {
-    const raw = parent.getAttribute(BF_SCOPE)
-    const id = raw?.startsWith(BF_CHILD_PREFIX) ? raw.slice(1) : raw
-    if (id?.startsWith(name + '_')) return true
-    parent = parent.parentElement?.closest(`[${BF_SCOPE}]`) ?? null
-  }
-  return false
 }
 
 /**

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -155,57 +155,37 @@ export function rehydrateAll(): void {
 /**
  * Run any pending hydration walk synchronously, right now.
  *
- * The default scheduler is microtask + rAF, which is the right
- * trade-off for production code (it lets the registry populate before
- * the walk and coalesces back-to-back `hydrate()` calls). But tests
- * and a handful of advanced consumers — for example imperative
- * mounting code that wants to read DOM state immediately after
- * `render(...)` — need a deterministic completion point.
- *
- * This helper flushes any pending phases (microtask / rAF) by running
- * the walk inline and clearing the scheduling flags. It's a no-op
- * when nothing is queued. The pending callbacks themselves still
- * fire later, but they observe their flags as false and skip — the
- * extra walk cost is bounded by the WeakSet membership check.
+ * The default scheduler is microtask + rAF — the right trade-off for
+ * production code (registry populates before the walk; back-to-back
+ * `hydrate()` calls coalesce). Tests and advanced consumers that need
+ * a deterministic completion point — e.g. imperative mounting code
+ * reading DOM state immediately after `render(...)` — call this
+ * helper instead of awaiting a microtask.
  *
  * @example
  *   hydrate('Counter', def)
  *   flushHydration()
- *   // now safe to read Counter's post-init DOM state
+ *   // safe to read Counter's post-init DOM state
  */
 export function flushHydration(): void {
-  // If neither phase is pending, no work has been scheduled since the
-  // last walk completed — bail without redoing the DOM scan.
   if (!microtaskScheduled && !rafScheduled) return
-
-  // Clear flags first so the queued microtask / rAF callbacks treat
-  // themselves as already-run (they check their own flag on entry).
   microtaskScheduled = false
   rafScheduled = false
   walkAllInDocumentOrder()
 }
 
 /**
- * Single document-order walk that visits both element scopes
- * (`[bf-s]`) and comment scopes (`<!--bf-scope:Name_xxx-->`)
- * interleaved by their actual DOM position. Parent inits — whichever
- * shape they take — always run before descendant inits, so a comment-
- * scope provider is visible to an element-scope descendant on the
- * first pass.
+ * Single document-order walk visiting element scopes (`[bf-s]`) and
+ * comment scopes (`<!--bf-scope:Name_xxx-->`) interleaved by their
+ * actual DOM position. The parent's init — whichever scope shape it
+ * takes — always runs before any descendant init, so a comment-scope
+ * provider is visible to an element-scope descendant on the first pass.
  *
- * Per node:
- *   - **Element scope**: skip if already hydrated or if `~`-prefixed
- *     (child component owned by parent's `initChild`). Otherwise mark
- *     as hydrated *before* running init — taking the slot prevents
- *     re-entrant `hydrate()` / `rehydrateAll()` calls from the init
- *     body (or from a synchronous effect they trigger) from racing
- *     into the same scope on the next scheduled walk.
- *   - **Comment scope**: skip if already initialised (per-comment
- *     `__bfInitialized` flag) or `~`-prefixed. Otherwise mark, set
- *     up the proxy element registry, then run init.
- *
- * If a scope's def hasn't registered yet the node is left untouched
- * for the next walk; nothing is mutated.
+ * Both paths skip `~`-prefixed scopes (owned by `initChild`) and mark
+ * the scope as hydrated *before* running init: re-entrant `hydrate()`
+ * / `rehydrateAll()` calls from the init body (or a synchronous effect
+ * they trigger) must see the slot already taken so the next scheduled
+ * walk doesn't re-enter the same scope.
  */
 function walkAllInDocumentOrder(): void {
   if (typeof document === 'undefined') return
@@ -225,50 +205,50 @@ function walkAllInDocumentOrder(): void {
   }
 }
 
+/** Component name segment of a scope ID (everything before the first `_`). */
+function scopeName(id: string): string | null {
+  const idx = id.indexOf('_')
+  return idx < 0 ? null : id.slice(0, idx)
+}
+
+function parseProps(json: string | null, where: string): Record<string, unknown> {
+  if (!json) return {}
+  try {
+    return JSON.parse(json) as Record<string, unknown>
+  } catch {
+    console.warn(`[BarefootJS] Invalid props JSON on ${where}:`, json)
+    return {}
+  }
+}
+
+function runInit(scope: Element, def: ComponentDef, props: Record<string, unknown>): void {
+  const prevScope = setCurrentScope(scope)
+  try {
+    def.init(scope, props)
+  } finally {
+    setCurrentScope(prevScope)
+  }
+}
+
 function hydrateElementScope(el: Element): void {
   if (hydratedScopes.has(el)) return
 
   const bfs = el.getAttribute(BF_SCOPE)
-  if (!bfs) return
-  if (bfs.startsWith(BF_CHILD_PREFIX)) return
+  if (!bfs || bfs.startsWith(BF_CHILD_PREFIX)) return
 
-  const underscoreIdx = bfs.indexOf('_')
-  if (underscoreIdx < 0) return
-  const name = bfs.slice(0, underscoreIdx)
+  const name = scopeName(bfs)
+  if (!name) return
 
   const def = registeredDefs.get(name)
   if (!def) return
-  // Comment-based components hydrate via the comment-scope path; their
-  // bf-s attribute (when present) sits on a proxy element that we'd
-  // otherwise double-init. Mark it hydrated so future walks skip the
-  // scope lookup entirely instead of re-resolving the same def.
-  if (def.comment) {
-    hydratedScopes.add(el)
-    return
-  }
 
-  // Mark BEFORE running init: if the init body synchronously triggers
-  // another scheduled walk (e.g. an effect calls `rehydrateAll()`),
-  // the WeakSet entry already exists when that walk arrives, so we
-  // never re-enter the same scope.
   hydratedScopes.add(el)
+  // Comment-based components hydrate via the comment-scope path; their
+  // bf-s attribute sits on a proxy element. Marking it above lets the
+  // next walk skip at the WeakSet check rather than re-resolving the def.
+  if (def.comment) return
 
-  const propsJson = el.getAttribute(BF_PROPS)
-  let props: Record<string, unknown> = {}
-  if (propsJson) {
-    try {
-      props = JSON.parse(propsJson)
-    } catch {
-      console.warn(`[BarefootJS] Invalid props JSON on ${bfs}:`, propsJson)
-    }
-  }
-
-  const prevScope = setCurrentScope(el)
-  try {
-    def.init(el, props)
-  } finally {
-    setCurrentScope(prevScope)
-  }
+  runInit(el, def, parseProps(el.getAttribute(BF_PROPS), bfs))
 }
 
 function hydrateCommentScope(comment: Comment): void {
@@ -278,59 +258,36 @@ function hydrateCommentScope(comment: Comment): void {
   const rest = value.slice(BF_SCOPE_COMMENT_PREFIX.length)
   if (rest.startsWith(BF_CHILD_PREFIX)) return
 
-  let scopeId = rest
-  let propsJson = ''
-  const pipeIdx = rest.indexOf('|')
-  if (pipeIdx >= 0) {
-    scopeId = rest.slice(0, pipeIdx)
-    propsJson = rest.slice(pipeIdx + 1)
-  }
-
-  const flagged = comment as unknown as Record<string, boolean>
+  const flagged = comment as unknown as { __bfInitialized?: boolean }
   if (flagged.__bfInitialized) return
 
-  const underscoreIdx = scopeId.indexOf('_')
-  if (underscoreIdx < 0) return
-  const name = scopeId.slice(0, underscoreIdx)
+  const pipeIdx = rest.indexOf('|')
+  const scopeId = pipeIdx >= 0 ? rest.slice(0, pipeIdx) : rest
+  const propsJson = pipeIdx >= 0 ? rest.slice(pipeIdx + 1) : ''
+
+  const name = scopeName(scopeId)
+  if (!name) return
 
   const def = registeredDefs.get(name)
   if (!def?.comment) return
 
-  // Mark before init for the same reentrancy reason as element scopes:
-  // see hydrateElementScope() above.
   flagged.__bfInitialized = true
 
-  let proxyEl: Element | null = null
-  let sibling: Node | null = comment.nextSibling
-  while (sibling) {
-    if (sibling.nodeType === Node.ELEMENT_NODE) {
-      proxyEl = sibling as Element
-      break
-    }
-    sibling = sibling.nextSibling
-  }
-  if (!proxyEl) proxyEl = comment.parentElement
+  const proxyEl = nextElementSibling(comment) ?? comment.parentElement
   if (!proxyEl) return
 
-  commentScopeRegistry.set(proxyEl, {
-    commentNode: comment,
-    scopeId,
-  })
+  commentScopeRegistry.set(proxyEl, { commentNode: comment, scopeId })
 
-  let parsed: Record<string, unknown> = {}
-  if (propsJson) {
-    try {
-      parsed = JSON.parse(propsJson)
-    } catch {
-      console.warn(`[BarefootJS] Invalid props JSON in comment scope ${scopeId}:`, propsJson)
-    }
-  }
+  const parsed = parseProps(propsJson || null, `comment scope ${scopeId}`)
   const props = (parsed[name] ?? {}) as Record<string, unknown>
+  runInit(proxyEl, def, props)
+}
 
-  const prevScope = setCurrentScope(proxyEl)
-  try {
-    def.init(proxyEl, props)
-  } finally {
-    setCurrentScope(prevScope)
+function nextElementSibling(node: Node): Element | null {
+  let sibling: Node | null = node.nextSibling
+  while (sibling) {
+    if (sibling.nodeType === Node.ELEMENT_NODE) return sibling as Element
+    sibling = sibling.nextSibling
   }
+  return null
 }

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -8,11 +8,13 @@
  *
  *   1. `hydrate(name, def)` only **registers** the def + template +
  *      component-registry entry, then schedules a walk.
- *   2. The walk visits every `[bf-s]` element in document order — a
- *      single pass for every registered component, run once per
- *      scheduling tick. Document order means a parent's init always
- *      runs before any descendant's init, so context providers
- *      resolve on the first hydrate pass.
+ *   2. The walk visits every scope in **true document order** — both
+ *      `[bf-s]` element scopes and `<!--bf-scope:Name_xxx-->` comment
+ *      scopes are interleaved by their actual DOM position. Parents
+ *      always init before descendants regardless of which kind of
+ *      scope each one is, so a comment-rooted parent that calls
+ *      `provideContext()` is visible to an element-rooted descendant
+ *      that calls `useContext()` on the very first hydrate pass.
  *   3. Two scheduling phases, each capped to one in-flight callback:
  *        - microtask: collapses every `hydrate()` call from the
  *          bundled module body into a single walk on the next tick.
@@ -54,6 +56,19 @@ let microtaskScheduled = false
 let rafScheduled = false
 
 /**
+ * Cross-runtime microtask scheduler. `queueMicrotask` is widely
+ * supported but absent in some test DOMs / older runtimes; fall back
+ * to `Promise.resolve().then(...)` so importing this module never
+ * throws on environments missing the global.
+ */
+const scheduleMicrotask: (cb: () => void) => void =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (cb) => {
+        Promise.resolve().then(cb)
+      }
+
+/**
  * Schedule the document-order walk once per tick (microtask) and once
  * per frame (rAF). Both flags are cleared inside their respective
  * callbacks, so a flood of `hydrate()` / `rehydrateAll()` calls can
@@ -62,7 +77,7 @@ let rafScheduled = false
 function scheduleWalk(): void {
   if (!microtaskScheduled) {
     microtaskScheduled = true
-    queueMicrotask(() => {
+    scheduleMicrotask(() => {
       microtaskScheduled = false
       walkAllInDocumentOrder()
     })
@@ -114,141 +129,151 @@ export function rehydrateAll(): void {
 }
 
 /**
- * Document-order walk over every `[bf-s]` element in the page.
+ * Single document-order walk that visits both element scopes
+ * (`[bf-s]`) and comment scopes (`<!--bf-scope:Name_xxx-->`)
+ * interleaved by their actual DOM position. Parent inits — whichever
+ * shape they take — always run before descendant inits, so a comment-
+ * scope provider is visible to an element-scope descendant on the
+ * first pass.
  *
- * Element-scope path:
- *   - Skip elements already in `hydratedScopes`. This is the single
- *     source of truth: children initialised via `initChild` mark their
- *     scope here too, so the walker can rely on this check alone (no
- *     ancestor-name lookup needed).
- *   - Skip child-prefixed scopes (`~Foo_xxx`) outright — they were
- *     emitted by `renderChild()` and are owned by the parent's
- *     `initChild`/`upsertChild` flow.
- *   - Look up the def by the name encoded in the `bf-s` attribute. If
- *     the component hasn't registered yet, leave the element for a
- *     future walk.
- *   - Set currentScope, run init, restore scope, mark as hydrated.
+ * Per node:
+ *   - **Element scope**: skip if already hydrated or if `~`-prefixed
+ *     (child component owned by parent's `initChild`). Otherwise mark
+ *     as hydrated *before* running init — taking the slot prevents
+ *     re-entrant `hydrate()` / `rehydrateAll()` calls from the init
+ *     body (or from a synchronous effect they trigger) from racing
+ *     into the same scope on the next scheduled walk.
+ *   - **Comment scope**: skip if already initialised (per-comment
+ *     `__bfInitialized` flag) or `~`-prefixed. Otherwise mark, set
+ *     up the proxy element registry, then run init.
  *
- * Comment-scope path runs after the element pass and visits each
- * `<!--bf-scope:Name_xxx-->` comment in document order.
+ * If a scope's def hasn't registered yet the node is left untouched
+ * for the next walk; nothing is mutated.
  */
 function walkAllInDocumentOrder(): void {
   if (typeof document === 'undefined') return
 
-  const all = document.querySelectorAll(`[${BF_SCOPE}]`)
+  const walker = document.createTreeWalker(
+    document,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT,
+  )
 
-  for (const el of all) {
-    if (hydratedScopes.has(el)) continue
-
-    const bfs = el.getAttribute(BF_SCOPE)
-    if (!bfs) continue
-    if (bfs.startsWith(BF_CHILD_PREFIX)) continue
-
-    const underscoreIdx = bfs.indexOf('_')
-    if (underscoreIdx < 0) continue
-    const name = bfs.slice(0, underscoreIdx)
-
-    const def = registeredDefs.get(name)
-    if (!def) continue
-    // Comment-based components hydrate via the comment-scope path; their
-    // bf-s attribute (when present) sits on a proxy element that we'd
-    // otherwise double-init.
-    if (def.comment) continue
-
-    hydratedScopes.add(el)
-
-    const propsJson = el.getAttribute(BF_PROPS)
-    let props: Record<string, unknown> = {}
-    if (propsJson) {
-      try {
-        props = JSON.parse(propsJson)
-      } catch {
-        console.warn(`[BarefootJS] Invalid props JSON on ${bfs}:`, propsJson)
-      }
+  while (walker.nextNode()) {
+    const node = walker.currentNode
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      hydrateElementScope(node as Element)
+    } else if (node.nodeType === Node.COMMENT_NODE) {
+      hydrateCommentScope(node as Comment)
     }
+  }
+}
 
-    const prevScope = setCurrentScope(el)
+function hydrateElementScope(el: Element): void {
+  if (hydratedScopes.has(el)) return
+
+  const bfs = el.getAttribute(BF_SCOPE)
+  if (!bfs) return
+  if (bfs.startsWith(BF_CHILD_PREFIX)) return
+
+  const underscoreIdx = bfs.indexOf('_')
+  if (underscoreIdx < 0) return
+  const name = bfs.slice(0, underscoreIdx)
+
+  const def = registeredDefs.get(name)
+  if (!def) return
+  // Comment-based components hydrate via the comment-scope path; their
+  // bf-s attribute (when present) sits on a proxy element that we'd
+  // otherwise double-init. Mark it hydrated so future walks skip the
+  // scope lookup entirely instead of re-resolving the same def.
+  if (def.comment) {
+    hydratedScopes.add(el)
+    return
+  }
+
+  // Mark BEFORE running init: if the init body synchronously triggers
+  // another scheduled walk (e.g. an effect calls `rehydrateAll()`),
+  // the WeakSet entry already exists when that walk arrives, so we
+  // never re-enter the same scope.
+  hydratedScopes.add(el)
+
+  const propsJson = el.getAttribute(BF_PROPS)
+  let props: Record<string, unknown> = {}
+  if (propsJson) {
     try {
-      def.init(el, props)
-    } finally {
-      setCurrentScope(prevScope)
+      props = JSON.parse(propsJson)
+    } catch {
+      console.warn(`[BarefootJS] Invalid props JSON on ${bfs}:`, propsJson)
     }
   }
 
-  walkCommentScopesInDocumentOrder()
+  const prevScope = setCurrentScope(el)
+  try {
+    def.init(el, props)
+  } finally {
+    setCurrentScope(prevScope)
+  }
 }
 
-/**
- * Walk every `<!--bf-scope:Name_xxx-->` comment in document order and
- * hydrate the matching def. Mirrors the element-scope pass: parents come
- * before descendants, so context providers resolve on the first run.
- */
-function walkCommentScopesInDocumentOrder(): void {
-  const prefix = BF_SCOPE_COMMENT_PREFIX
-  const walker = document.createTreeWalker(document, NodeFilter.SHOW_COMMENT)
+function hydrateCommentScope(comment: Comment): void {
+  const value = comment.nodeValue
+  if (!value?.startsWith(BF_SCOPE_COMMENT_PREFIX)) return
 
-  while (walker.nextNode()) {
-    const comment = walker.currentNode as Comment
-    const value = comment.nodeValue
-    if (!value?.startsWith(prefix)) continue
+  const rest = value.slice(BF_SCOPE_COMMENT_PREFIX.length)
+  if (rest.startsWith(BF_CHILD_PREFIX)) return
 
-    const rest = value.slice(prefix.length)
-    if (rest.startsWith(BF_CHILD_PREFIX)) continue
+  let scopeId = rest
+  let propsJson = ''
+  const pipeIdx = rest.indexOf('|')
+  if (pipeIdx >= 0) {
+    scopeId = rest.slice(0, pipeIdx)
+    propsJson = rest.slice(pipeIdx + 1)
+  }
 
-    let scopeId = rest
-    let propsJson = ''
-    const pipeIdx = rest.indexOf('|')
-    if (pipeIdx >= 0) {
-      scopeId = rest.slice(0, pipeIdx)
-      propsJson = rest.slice(pipeIdx + 1)
+  const flagged = comment as unknown as Record<string, boolean>
+  if (flagged.__bfInitialized) return
+
+  const underscoreIdx = scopeId.indexOf('_')
+  if (underscoreIdx < 0) return
+  const name = scopeId.slice(0, underscoreIdx)
+
+  const def = registeredDefs.get(name)
+  if (!def?.comment) return
+
+  // Mark before init for the same reentrancy reason as element scopes:
+  // see hydrateElementScope() above.
+  flagged.__bfInitialized = true
+
+  let proxyEl: Element | null = null
+  let sibling: Node | null = comment.nextSibling
+  while (sibling) {
+    if (sibling.nodeType === Node.ELEMENT_NODE) {
+      proxyEl = sibling as Element
+      break
     }
+    sibling = sibling.nextSibling
+  }
+  if (!proxyEl) proxyEl = comment.parentElement
+  if (!proxyEl) return
 
-    if ((comment as unknown as Record<string, boolean>).__bfInitialized) continue
+  commentScopeRegistry.set(proxyEl, {
+    commentNode: comment,
+    scopeId,
+  })
 
-    const underscoreIdx = scopeId.indexOf('_')
-    if (underscoreIdx < 0) continue
-    const name = scopeId.slice(0, underscoreIdx)
-
-    const def = registeredDefs.get(name)
-    if (!def?.comment) continue
-
-    ;(comment as unknown as Record<string, boolean>).__bfInitialized = true
-
-    let proxyEl: Element | null = null
-    let node: Node | null = comment.nextSibling
-    while (node) {
-      if (node.nodeType === Node.ELEMENT_NODE) {
-        proxyEl = node as Element
-        break
-      }
-      node = node.nextSibling
+  let parsed: Record<string, unknown> = {}
+  if (propsJson) {
+    try {
+      parsed = JSON.parse(propsJson)
+    } catch {
+      console.warn(`[BarefootJS] Invalid props JSON in comment scope ${scopeId}:`, propsJson)
     }
-    if (!proxyEl) {
-      proxyEl = comment.parentElement
-    }
+  }
+  const props = (parsed[name] ?? {}) as Record<string, unknown>
 
-    if (proxyEl) {
-      commentScopeRegistry.set(proxyEl, {
-        commentNode: comment,
-        scopeId,
-      })
-
-      let parsed: Record<string, unknown> = {}
-      if (propsJson) {
-        try {
-          parsed = JSON.parse(propsJson)
-        } catch {
-          console.warn(`[BarefootJS] Invalid props JSON in comment scope ${scopeId}:`, propsJson)
-        }
-      }
-      const props = (parsed[name] ?? {}) as Record<string, unknown>
-
-      const prevScope = setCurrentScope(proxyEl)
-      try {
-        def.init(proxyEl, props)
-      } finally {
-        setCurrentScope(prevScope)
-      }
-    }
+  const prevScope = setCurrentScope(proxyEl)
+  try {
+    def.init(proxyEl, props)
+  } finally {
+    setCurrentScope(prevScope)
   }
 }

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -72,12 +72,16 @@ const scheduleMicrotask: (cb: () => void) => void =
  * Schedule the document-order walk once per tick (microtask) and once
  * per frame (rAF). Both flags are cleared inside their respective
  * callbacks, so a flood of `hydrate()` / `rehydrateAll()` calls can
- * never queue more than two pending walks in total.
+ * never queue more than two pending walks in total. The callbacks
+ * also re-check their own flag on entry so that a synchronous
+ * `flushHydration()` between scheduling and firing turns the queued
+ * callback into a no-op.
  */
 function scheduleWalk(): void {
   if (!microtaskScheduled) {
     microtaskScheduled = true
     scheduleMicrotask(() => {
+      if (!microtaskScheduled) return
       microtaskScheduled = false
       walkAllInDocumentOrder()
     })
@@ -85,6 +89,7 @@ function scheduleWalk(): void {
   if (!rafScheduled && typeof requestAnimationFrame === 'function') {
     rafScheduled = true
     requestAnimationFrame(() => {
+      if (!rafScheduled) return
       rafScheduled = false
       walkAllInDocumentOrder()
     })
@@ -94,6 +99,23 @@ function scheduleWalk(): void {
 /**
  * Register a component and schedule a document-order hydration walk.
  * Combines registration + template setup + hydration in a single call.
+ *
+ * **Scheduling semantics** (changed in #1172): the walk runs on the
+ * next microtask, then again on the next animation frame. The init
+ * functions for registered components are *not* invoked synchronously
+ * inside `hydrate()`. Code that needs to observe init effects on the
+ * same tick — typically tests, but also advanced consumers wiring
+ * imperative bridges — should either:
+ *
+ *   - `await Promise.resolve()` after a batch of `hydrate()` calls, or
+ *   - call `flushHydration()` (see below) to drain any pending walks
+ *     synchronously.
+ *
+ * The deferral is what lets the doc-order walker see a fully populated
+ * registry: every `hydrate()` call from the bundled module body lands
+ * in the registry *before* the microtask flush kicks off the single
+ * walk, so parents always init before their descendants regardless of
+ * which file the parent's `hydrate()` was emitted into.
  *
  * @param name - Component name
  * @param def - Component definition (init function + optional template + comment flag)
@@ -122,10 +144,45 @@ export function hydrate(name: string, def: ComponentDef): void {
  * Called by the streaming resolver after swapping fallback content with
  * resolved content. Goes through the same scheduler as `hydrate()` so
  * back-to-back `__bf_swap` invocations or interleaved `hydrate()` calls
- * collapse to a single walk per tick + per frame.
+ * collapse to a single walk per tick + per frame. Like `hydrate()` this
+ * is asynchronous — see `flushHydration()` if you need a synchronous
+ * drain.
  */
 export function rehydrateAll(): void {
   scheduleWalk()
+}
+
+/**
+ * Run any pending hydration walk synchronously, right now.
+ *
+ * The default scheduler is microtask + rAF, which is the right
+ * trade-off for production code (it lets the registry populate before
+ * the walk and coalesces back-to-back `hydrate()` calls). But tests
+ * and a handful of advanced consumers — for example imperative
+ * mounting code that wants to read DOM state immediately after
+ * `render(...)` — need a deterministic completion point.
+ *
+ * This helper flushes any pending phases (microtask / rAF) by running
+ * the walk inline and clearing the scheduling flags. It's a no-op
+ * when nothing is queued. The pending callbacks themselves still
+ * fire later, but they observe their flags as false and skip — the
+ * extra walk cost is bounded by the WeakSet membership check.
+ *
+ * @example
+ *   hydrate('Counter', def)
+ *   flushHydration()
+ *   // now safe to read Counter's post-init DOM state
+ */
+export function flushHydration(): void {
+  // If neither phase is pending, no work has been scheduled since the
+  // last walk completed — bail without redoing the DOM scan.
+  if (!microtaskScheduled && !rafScheduled) return
+
+  // Clear flags first so the queued microtask / rAF callbacks treat
+  // themselves as already-run (they check their own flag on entry).
+  microtaskScheduled = false
+  rafScheduled = false
+  walkAllInDocumentOrder()
 }
 
 /**

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -3,6 +3,19 @@
  *
  * Combined component registration + template registration + hydration.
  * Single entry point for compiler-generated code.
+ *
+ * The walker is **document-order**: per-name `hydrate()` calls only register
+ * a component definition; the actual init walk runs once per microtask flush
+ * and visits every `[bf-s]` element in document order. Walking parents
+ * before descendants is what makes `useFlow()` (and any other context
+ * consumer) resolve on the very first hydrate pass — by the time a
+ * descendant's init runs, every ancestor has already provided context.
+ *
+ * The previous per-name walk hydrated whichever component happened to be
+ * registered first in bundled module order, so a `<Flow renderNode={Fn}>`
+ * descendant that ran before its `<Flow>` parent would observe an
+ * undefined context (piconic-ai/barefootjs#1175 follow-up to #1166/#1169/
+ * #1171).
  */
 
 import { setCurrentScope } from './context'
@@ -15,16 +28,34 @@ import type { ComponentDef } from './types'
 
 /**
  * Registry of all hydrated component definitions.
- * Used by rehydrateAll() to re-scan the DOM after streaming chunks arrive.
+ * Used by the walker to look up an element's init/def by name, and by
+ * rehydrateAll() to re-scan the DOM after streaming chunks arrive.
  */
 const registeredDefs = new Map<string, ComponentDef>()
 
+let walkScheduled = false
+
+function scheduleWalk(): void {
+  if (walkScheduled) return
+  walkScheduled = true
+  // Microtask: every synchronous `hydrate()` call from the bundled
+  // module body has registered its def by the time the walk runs, so
+  // the document-order walk sees a fully populated registry.
+  queueMicrotask(() => {
+    walkScheduled = false
+    walkAllInDocumentOrder()
+  })
+  // rAF: streaming protocol may move template content into the document
+  // after initial script execution. Re-walking once a frame later picks
+  // up scope elements that landed too late for the microtask.
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(walkAllInDocumentOrder)
+  }
+}
+
 /**
- * Register a component and hydrate all its instances on the page.
+ * Register a component and schedule a document-order hydration walk.
  * Combines registration + template setup + hydration in a single call.
- *
- * Finds scope elements and their corresponding props, then initializes each instance.
- * Supports Suspense streaming by using requestAnimationFrame for delayed re-hydration.
  *
  * @param name - Component name
  * @param def - Component definition (init function + optional template + comment flag)
@@ -34,7 +65,6 @@ export function hydrate(name: string, def: ComponentDef): void {
   // doesn't rely on def.init.name (which may be lost under minification).
   def.name = name
 
-  // Track for rehydrateAll() (streaming support)
   registeredDefs.set(name, def)
 
   // Register component for parent-child communication
@@ -45,25 +75,105 @@ export function hydrate(name: string, def: ComponentDef): void {
     registerTemplate(name, def.template)
   }
 
-  const doHydrate = () => hydrateComponent(name, def)
-
-  // Immediately hydrate elements already in DOM
-  doHydrate()
-
-  // Re-hydrate after next frame (for Suspense streaming support)
-  // Hono's streaming script moves template content into document after initial script execution
-  requestAnimationFrame(doHydrate)
+  scheduleWalk()
 }
 
 /**
- * Hydrate components using comment-based scope markers.
- * Walks all comments in the document looking for <!--bf-scope:Name_xxx--> markers.
+ * Re-hydrate all registered components.
+ *
+ * Called by the streaming resolver after swapping fallback content with
+ * resolved content. Re-runs the document-order walker so newly-inserted
+ * scope elements pick up their inits.
  */
-function hydrateCommentScopes(
-  name: string,
-  init: (scope: Element, props: Record<string, unknown>) => void,
-  alreadyInitialized: Set<string>
-): void {
+export function rehydrateAll(): void {
+  walkAllInDocumentOrder()
+}
+
+/**
+ * Document-order walk over every `[bf-s]` element in the page.
+ *
+ * Element-scope path:
+ *   - Skip elements that are already hydrated.
+ *   - Skip child-prefixed scopes (`~Foo_xxx`) — the parent's `initChild`
+ *     owns those.
+ *   - Skip nested same-name scopes — `<Counter>` inside `<Counter>` only
+ *     hydrates the outer; the parent's init handles the inner.
+ *   - Look up the def by the name encoded in the `bf-s` attribute. If
+ *     the component hasn't registered yet, leave the element for a
+ *     future walk.
+ *   - Set currentScope, run init, restore scope.
+ *
+ * Comment-scope path runs after the element pass and visits each
+ * `<!--bf-scope:Name_xxx-->` comment in document order.
+ */
+function walkAllInDocumentOrder(): void {
+  if (typeof document === 'undefined') return
+
+  const all = document.querySelectorAll(`[${BF_SCOPE}]`)
+
+  for (const el of all) {
+    if (hydratedScopes.has(el)) continue
+
+    const bfs = el.getAttribute(BF_SCOPE)
+    if (!bfs) continue
+    if (bfs.startsWith(BF_CHILD_PREFIX)) continue
+
+    const underscoreIdx = bfs.indexOf('_')
+    if (underscoreIdx < 0) continue
+    const name = bfs.slice(0, underscoreIdx)
+
+    const def = registeredDefs.get(name)
+    if (!def) continue
+    // Comment-based components handle their own walk (the bf-s attribute
+    // here is on a proxy element and we'd double-init if we ran it twice).
+    if (def.comment) continue
+
+    // Nested same-name skip: a `<Counter>` rendered inside another
+    // `<Counter>` only hydrates the outer; the outer's init drives the
+    // inner via initChild. Match against any ancestor scope so deeply
+    // nested same-name pairs still skip.
+    if (hasAncestorWithSameName(el, name)) continue
+
+    hydratedScopes.add(el)
+
+    const propsJson = el.getAttribute(BF_PROPS)
+    let props: Record<string, unknown> = {}
+    if (propsJson) {
+      try {
+        props = JSON.parse(propsJson)
+      } catch {
+        console.warn(`[BarefootJS] Invalid props JSON on ${bfs}:`, propsJson)
+      }
+    }
+
+    const prevScope = setCurrentScope(el)
+    try {
+      def.init(el, props)
+    } finally {
+      setCurrentScope(prevScope)
+    }
+  }
+
+  walkCommentScopesInDocumentOrder()
+}
+
+function hasAncestorWithSameName(scopeEl: Element, name: string): boolean {
+  let parent: Element | null = scopeEl.parentElement?.closest(`[${BF_SCOPE}]`) ?? null
+  while (parent) {
+    const raw = parent.getAttribute(BF_SCOPE)
+    const id = raw?.startsWith(BF_CHILD_PREFIX) ? raw.slice(1) : raw
+    if (id?.startsWith(name + '_')) return true
+    parent = parent.parentElement?.closest(`[${BF_SCOPE}]`) ?? null
+  }
+  return false
+}
+
+/**
+ * Walk every `<!--bf-scope:Name_xxx-->` comment in document order and
+ * hydrate the matching def. Mirrors the element-scope pass: parents come
+ * before descendants, so context providers resolve on the first run.
+ */
+function walkCommentScopesInDocumentOrder(): void {
   const prefix = BF_SCOPE_COMMENT_PREFIX
   const walker = document.createTreeWalker(document, NodeFilter.SHOW_COMMENT)
 
@@ -72,13 +182,9 @@ function hydrateCommentScopes(
     const value = comment.nodeValue
     if (!value?.startsWith(prefix)) continue
 
-    // Parse scope ID and props from comment value
-    let rest = value.slice(prefix.length)
-
-    // Skip child components (~ prefix)
+    const rest = value.slice(prefix.length)
     if (rest.startsWith(BF_CHILD_PREFIX)) continue
 
-    // Split scope ID from props JSON
     let scopeId = rest
     let propsJson = ''
     const pipeIdx = rest.indexOf('|')
@@ -87,17 +193,17 @@ function hydrateCommentScopes(
       propsJson = rest.slice(pipeIdx + 1)
     }
 
-    if (!scopeId.startsWith(`${name}_`)) continue
-
-    // Skip if already initialized
     if ((comment as unknown as Record<string, boolean>).__bfInitialized) continue
-    if (alreadyInitialized.has(scopeId)) continue
 
-    // Mark as initialized
+    const underscoreIdx = scopeId.indexOf('_')
+    if (underscoreIdx < 0) continue
+    const name = scopeId.slice(0, underscoreIdx)
+
+    const def = registeredDefs.get(name)
+    if (!def?.comment) continue
+
     ;(comment as unknown as Record<string, boolean>).__bfInitialized = true
-    alreadyInitialized.add(scopeId)
 
-    // Find the scope proxy element: first element sibling after the comment
     let proxyEl: Element | null = null
     let node: Node | null = comment.nextSibling
     while (node) {
@@ -117,7 +223,6 @@ function hydrateCommentScopes(
         scopeId,
       })
 
-      // Parse props from comment
       let parsed: Record<string, unknown> = {}
       if (propsJson) {
         try {
@@ -128,79 +233,12 @@ function hydrateCommentScopes(
       }
       const props = (parsed[name] ?? {}) as Record<string, unknown>
 
-      // Mirror createComponent (component.ts) so context hooks inside init
-      // resolve from this scope.
       const prevScope = setCurrentScope(proxyEl)
-      init(proxyEl, props)
-      setCurrentScope(prevScope)
-    }
-  }
-}
-
-/**
- * Re-hydrate all registered components.
- *
- * Called by the streaming resolver after swapping fallback content with
- * resolved content. Scans the DOM for any un-hydrated scope elements
- * belonging to previously registered components.
- */
-export function rehydrateAll(): void {
-  for (const [name, def] of registeredDefs) {
-    hydrateComponent(name, def)
-  }
-}
-
-/**
- * Hydrate a single component's un-initialized scope elements.
- * Extracted from hydrate() so it can be re-used by rehydrateAll().
- */
-function hydrateComponent(name: string, def: ComponentDef): void {
-  if (def.comment) {
-    hydrateCommentScopes(name, def.init, new Set())
-    return
-  }
-
-  const scopeEls = document.querySelectorAll(
-    `[${BF_SCOPE}^="${name}_"]`
-  )
-
-  const initializedScopes = new Set<string>()
-
-  for (const scopeEl of scopeEls) {
-    if (hydratedScopes.has(scopeEl)) continue
-    if (scopeEl.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) continue
-
-    const parentScope = scopeEl.parentElement?.closest(`[${BF_SCOPE}]`)
-    if (parentScope) {
-      const rawParentScopeId = parentScope.getAttribute(BF_SCOPE)
-      const parentScopeId = rawParentScopeId?.startsWith(BF_CHILD_PREFIX)
-        ? rawParentScopeId.slice(1)
-        : rawParentScopeId
-      if (parentScopeId?.startsWith(name + '_')) continue
-    }
-
-    const instanceId = scopeEl.getAttribute(BF_SCOPE)
-    if (!instanceId) continue
-
-    if (initializedScopes.has(instanceId)) continue
-    initializedScopes.add(instanceId)
-
-    hydratedScopes.add(scopeEl)
-
-    const propsJson = scopeEl.getAttribute(BF_PROPS)
-    let props: Record<string, unknown> = {}
-    if (propsJson) {
       try {
-        props = JSON.parse(propsJson)
-      } catch {
-        console.warn(`[BarefootJS] Invalid props JSON on ${instanceId}:`, propsJson)
+        def.init(proxyEl, props)
+      } finally {
+        setCurrentScope(prevScope)
       }
     }
-
-    // Mirror createComponent (component.ts) so context hooks inside init
-    // resolve from this scope.
-    const prevScope = setCurrentScope(scopeEl)
-    def.init(scopeEl, props)
-    setCurrentScope(prevScope)
   }
 }

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -76,7 +76,7 @@ export { styleToCss } from './style'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa } from './query'
-export { hydrate, rehydrateAll } from './hydrate'
+export { hydrate, rehydrateAll, flushHydration } from './hydrate'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry'
 export { insert, type BranchConfig } from './insert'
 export { updateClientMarker } from './client-marker'

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -32,19 +32,16 @@ const pendingChildInits = new Map<string, Array<{ scope: Element; props: Record<
 export function registerComponent(name: string, init: InitFn): void {
   componentRegistry.set(name, init)
 
-  // Process any pending child initializations for this component
+  // Drain any pending child initializations queued before this component
+  // registered. Re-enter through initChild so the same hydratedScopes
+  // bookkeeping + currentScope wrapping applies to deferred and immediate
+  // calls alike.
   const pending = pendingChildInits.get(name)
   if (pending) {
-    for (const { scope, props } of pending) {
-      // Skip if already initialized as a child component.
-      // When scope has no ~ prefix, it's a root component whose parent
-      // marked it during hydrate — still needs child init.
-      if (hydratedScopes.has(scope) && scope.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) {
-        continue
-      }
-      init(scope, props)
-    }
     pendingChildInits.delete(name)
+    for (const { scope, props } of pending) {
+      initChild(name, scope, props)
+    }
   }
 }
 
@@ -89,15 +86,31 @@ export function initChild(
     return
   }
 
-  // Skip if already initialized as a child component.
-  // When scope has no ~ prefix, it's a root component whose parent
-  // marked it during hydrate — still needs child init.
-  if (hydratedScopes.has(childScope) && childScope.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)) {
+  // Child-prefixed scopes (`~Foo_xxx`) are owned by the parent's initChild
+  // entirely — once we've run their init, never re-enter. Top-level scopes
+  // (no `~`) reach this path through `upsertChild` during reconcile, where
+  // re-invoking init is the documented way to deliver fresh closure-captured
+  // callback props to the child. So only short-circuit the prefixed case.
+  if (
+    hydratedScopes.has(childScope) &&
+    childScope.getAttribute(BF_SCOPE)?.startsWith(BF_CHILD_PREFIX)
+  ) {
     return
   }
+
   const prevScope = setCurrentScope(childScope)
-  init(childScope, props)
-  setCurrentScope(prevScope)
+  try {
+    init(childScope, props)
+  } finally {
+    setCurrentScope(prevScope)
+  }
+
+  // Mark the scope as hydrated AFTER init runs so the doc-order walker in
+  // hydrate.ts knows to skip this element on its later pass — the parent
+  // has just claimed responsibility for it. This is what lets the walker
+  // get away with a single `hydratedScopes.has(el)` check instead of an
+  // ancestor-name guard.
+  hydratedScopes.add(childScope)
 }
 
 /**

--- a/packages/client/src/runtime/streaming.ts
+++ b/packages/client/src/runtime/streaming.ts
@@ -38,8 +38,12 @@ export function __bf_swap(id: string): void {
   // Clean up the template element
   tmpl.remove()
 
-  // Trigger hydration for newly inserted content
-  requestAnimationFrame(rehydrateAll)
+  // Trigger hydration for newly inserted content. `rehydrateAll()`
+  // schedules its own microtask + rAF walk via `scheduleWalk()`, so the
+  // extra rAF wrapper that used to live here is redundant — calling
+  // through synchronously lets the microtask path catch the swap on
+  // the same tick.
+  rehydrateAll()
 }
 
 /**


### PR DESCRIPTION
## Summary

- `hydrate()` now batches into a single microtask + rAF-deferred walk over every `[bf-s]` in document order, so an ancestor's `provideContext` always runs before a descendant's `useContext`.
- Drops the per-name walk that hydrated whichever component happened to land first in bundled module order — that's what was leaving `<Flow renderNode={Fn}>` descendants with an undefined context on the initial hydrate pass.
- Comment-scope hydration (`def.comment === true`) and `rehydrateAll()` now share the walker, so the streaming swap path benefits from the same ordering guarantee.

## Why

Follow-up to #1166 / #1169 / #1171:

- #1166 stamped the store on the host `<div class="bf-flow">` so DOM walk-up could find it, but identity (`node.id`) still came from a separate path.
- #1169 emitted the callable shim so reactive re-renders go through `createComponent('NodeBridge', node)` — that's the post-mount path, not the initial hydrate.
- #1171 anchored `useContext`'s ancestor walk at `currentScope`, but the *order* of inits was still per-name: when `hydrate('NodeBridge', ...)` registers above `hydrate('AxisCatalog', ...)` / `hydrate('Flow', ...)` in the emitted bundle, the bridge's `init` runs *before* Flow's `provideContext`, so `useFlow()` returns `undefined`.

Doc-order walking sidesteps the registration-order question entirely: parent inits always run before descendant inits because the parent's `[bf-s]` element appears earlier in the document.

## Commits

### 1. `fix(client/runtime): walk hydrate scopes in document order`

Replaces the per-name walk with a microtask-batched, document-order walk over every `[bf-s]` element. Each `hydrate()` only registers a def + schedules; the walk runs once, sees a fully populated registry, visits parents before descendants.

### 2. `fix(client/runtime): collapse hydrate scheduling, drop ancestor-name guard`

Three follow-ups closing out review feedback about leftovers from the per-name era:

- **`rehydrateAll()` joins the scheduler.** Streaming chunk swaps and `hydrate()` calls now share one coalesced walk pipeline. `__bf_swap` drops its own `requestAnimationFrame` wrapper since `rehydrateAll()` schedules through microtask + rAF itself — the previous double-rAF was redundant.
- **The walker's `hasAncestorWithSameName` guard is gone.** `initChild()` now marks the child scope in `hydratedScopes` after running its init. That's the single source of truth the walker consults: parents that intentionally own their nested same-name child get the inner scope skipped on the walker's later visit; parents that don't call initChild get the inner scope hydrated as a normal top-level component instead of dropped silently. Nesting depth is no longer a special case.
- **Single `walkScheduled` flag split into `microtaskScheduled` / `rafScheduled`.** A flood of `hydrate()` calls can never queue more than one of each. Header doc explains the intent of the two phases (microtask = collapse same-tick calls; rAF = catch streaming-injected DOM).

`registerComponent()` drains its pending-init queue back through `initChild()` so deferred and immediate calls share the same currentScope wrapping + hydratedScopes bookkeeping.

## Tests

- `packages/client/__tests__/runtime/hydrate-document-order.test.ts` covers the parent-after-child registration order. Verified to fail on `main` and pass on this branch.
- `'skips nested component scopes with same component type'` is replaced by two cases: one where the parent claims its same-name child via `initChild` (only outer's body runs the claim), and one where the parent doesn't (walker hydrates both).
- Existing tests that asserted on init results synchronously now `await Promise.resolve()` once before asserting (the walker is microtask-deferred). `streaming.test.ts` does the same for `rehydrateAll()`.
- Full suite: `bun test packages/` → **2072 pass / 0 fail**.

## Test plan

- [x] `bun test packages/client` — 226/226 pass
- [x] `bun test packages/xyflow` — 31/31 pass
- [x] `bun test packages/` — 2072/2072 pass
- [x] Pulled into `piconic-ai/desk` (pin `090733b`) and verified `<Flow renderNode={NodeBridge}>` catalogs render with `useFlow()` resolving on the first init pass — Axis / Box / Svg / IssueCard / DrawingOverlay all show proper data, no console errors, no `undefined` artefacts in `.bf-flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)