### PR TITLE
fix(cli): detect bun invocation in `init` next-step suggestions

### DIFF
--- a/packages/cli/src/__tests__/pm.test.ts
+++ b/packages/cli/src/__tests__/pm.test.ts
@@ -2,7 +2,12 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
 import path from 'path'
 import os from 'os'
-import { detectPackageManager, commandsFor } from '../lib/pm'
+import { detectPackageManager, detectInvokingPackageManager, commandsFor } from '../lib/pm'
+
+// Empty env keeps lockfile-detection tests independent of how the test
+// runner itself was launched (e.g. `bun test` sets npm_config_user_agent).
+const EMPTY_ENV = {} as NodeJS.ProcessEnv
+const EMPTY_VERSIONS = {} as { bun?: string }
 
 describe('detectPackageManager', () => {
   let tmpDir: string
@@ -16,39 +21,99 @@ describe('detectPackageManager', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  test('returns npm when no lockfile is present', () => {
-    expect(detectPackageManager(tmpDir)).toBe('npm')
+  test('returns npm when no lockfile and no user agent', () => {
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('npm')
   })
 
   test('detects bun via bun.lock', () => {
     writeFileSync(path.join(tmpDir, 'bun.lock'), '')
-    expect(detectPackageManager(tmpDir)).toBe('bun')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('bun')
   })
 
   test('detects bun via bun.lockb', () => {
     writeFileSync(path.join(tmpDir, 'bun.lockb'), '')
-    expect(detectPackageManager(tmpDir)).toBe('bun')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('bun')
   })
 
   test('detects pnpm via pnpm-lock.yaml', () => {
     writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
-    expect(detectPackageManager(tmpDir)).toBe('pnpm')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('pnpm')
   })
 
   test('detects yarn via yarn.lock', () => {
     writeFileSync(path.join(tmpDir, 'yarn.lock'), '')
-    expect(detectPackageManager(tmpDir)).toBe('yarn')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('yarn')
   })
 
   test('detects npm via package-lock.json', () => {
     writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
-    expect(detectPackageManager(tmpDir)).toBe('npm')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('npm')
   })
 
   test('prefers bun over npm when both lockfiles exist', () => {
     writeFileSync(path.join(tmpDir, 'bun.lock'), '')
     writeFileSync(path.join(tmpDir, 'package-lock.json'), '{}')
-    expect(detectPackageManager(tmpDir)).toBe('bun')
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('bun')
+  })
+
+  test('falls back to invoking PM (bunx) when no lockfile is present', () => {
+    const env = { npm_config_user_agent: 'bun/1.1.0 npm/? node/v22.0.0 darwin arm64' } as NodeJS.ProcessEnv
+    expect(detectPackageManager(tmpDir, env)).toBe('bun')
+  })
+
+  test('falls back to invoking PM (pnpm dlx) when no lockfile is present', () => {
+    const env = { npm_config_user_agent: 'pnpm/9.0.0 npm/? node/v22.0.0 darwin arm64' } as NodeJS.ProcessEnv
+    expect(detectPackageManager(tmpDir, env)).toBe('pnpm')
+  })
+
+  test('lockfile wins over invoking PM', () => {
+    writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '')
+    const env = { npm_config_user_agent: 'bun/1.1.0' } as NodeJS.ProcessEnv
+    expect(detectPackageManager(tmpDir, env)).toBe('pnpm')
+  })
+
+  test('falls back to bun runtime when env has no UA (e.g. `bun ./cli.js`)', () => {
+    expect(detectPackageManager(tmpDir, EMPTY_ENV, { bun: '1.3.0' })).toBe('bun')
+  })
+
+  test('UA wins over bun runtime when both are present', () => {
+    const env = { npm_config_user_agent: 'pnpm/9.0.0' } as NodeJS.ProcessEnv
+    expect(detectPackageManager(tmpDir, env, { bun: '1.3.0' })).toBe('pnpm')
+  })
+})
+
+describe('detectInvokingPackageManager', () => {
+  test('returns null when user agent is missing and not on bun', () => {
+    expect(detectInvokingPackageManager(EMPTY_ENV, EMPTY_VERSIONS)).toBeNull()
+  })
+
+  test('detects bun', () => {
+    const env = { npm_config_user_agent: 'bun/1.1.0' } as NodeJS.ProcessEnv
+    expect(detectInvokingPackageManager(env, EMPTY_VERSIONS)).toBe('bun')
+  })
+
+  test('detects npm', () => {
+    const env = { npm_config_user_agent: 'npm/10.0.0 node/v22.0.0' } as NodeJS.ProcessEnv
+    expect(detectInvokingPackageManager(env, EMPTY_VERSIONS)).toBe('npm')
+  })
+
+  test('detects pnpm', () => {
+    const env = { npm_config_user_agent: 'pnpm/9.0.0 npm/? node/v22.0.0' } as NodeJS.ProcessEnv
+    expect(detectInvokingPackageManager(env, EMPTY_VERSIONS)).toBe('pnpm')
+  })
+
+  test('detects yarn', () => {
+    const env = { npm_config_user_agent: 'yarn/4.0.0 npm/? node/v22.0.0' } as NodeJS.ProcessEnv
+    expect(detectInvokingPackageManager(env, EMPTY_VERSIONS)).toBe('yarn')
+  })
+
+  test('returns null for unknown user agent (not on bun)', () => {
+    const env = { npm_config_user_agent: 'deno/1.0.0' } as NodeJS.ProcessEnv
+    expect(detectInvokingPackageManager(env, EMPTY_VERSIONS)).toBeNull()
+  })
+
+  test('detects bun runtime when UA is absent', () => {
+    expect(detectInvokingPackageManager(EMPTY_ENV, { bun: '1.3.0' })).toBe('bun')
   })
 })
 

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -1,5 +1,13 @@
-// Detect the user's package manager from lockfiles in `dir`.
-// Returns 'npm' as a safe default when no lockfile is found.
+// Detect the user's package manager.
+//
+// Two signals, strongest first:
+//   1. A lockfile in `dir` — the user has already committed to a tool.
+//   2. The package manager that spawned this CLI, read from
+//      `npm_config_user_agent` (set by npm/bun/pnpm/yarn). Catches the
+//      common `bunx barefoot init` in an empty directory case where there
+//      is no lockfile yet but the user clearly wants bun.
+//
+// Falls back to 'npm' when neither signal is available.
 
 import { existsSync } from 'fs'
 import path from 'path'
@@ -13,13 +21,43 @@ const LOCKFILES: Record<PackageManager, string[]> = {
   npm: ['package-lock.json'],
 }
 
-export function detectPackageManager(dir: string): PackageManager {
+export function detectPackageManager(
+  dir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  versions: { bun?: string } = process.versions as { bun?: string },
+): PackageManager {
   for (const pm of ['bun', 'pnpm', 'yarn', 'npm'] as const) {
     for (const file of LOCKFILES[pm]) {
       if (existsSync(path.join(dir, file))) return pm
     }
   }
+  const invoked = detectInvokingPackageManager(env, versions)
+  if (invoked) return invoked
   return 'npm'
+}
+
+// Two cooperating signals identify the invoking PM:
+//   - `npm_config_user_agent`: every major PM sets this to a
+//     `<name>/<version> ...` string when it spawns a child. Reliable for
+//     `bunx <published-pkg>`, `npx`, `pnpm dlx`, `yarn dlx`.
+//   - `process.versions.bun`: present whenever the bun runtime is in
+//     use (covers local-path invocations like `bun ./dist/cli.js` or
+//     a `#!/usr/bin/env bun` shebang, where the UA is not set). pnpm
+//     and yarn share node's runtime, so they fall through to the UA
+//     path only.
+export function detectInvokingPackageManager(
+  env: NodeJS.ProcessEnv = process.env,
+  versions: { bun?: string } = process.versions as { bun?: string },
+): PackageManager | null {
+  const ua = env.npm_config_user_agent
+  if (ua) {
+    if (ua.startsWith('bun/')) return 'bun'
+    if (ua.startsWith('pnpm/')) return 'pnpm'
+    if (ua.startsWith('yarn/')) return 'yarn'
+    if (ua.startsWith('npm/')) return 'npm'
+  }
+  if (versions.bun) return 'bun'
+  return null
 }
 
 export interface PmCommands {


### PR DESCRIPTION
## Summary

- `barefoot init` printed `npm install` / `npm run dev` next steps even when the user clearly invoked the CLI via bun (e.g. `bunx barefoot init` in an empty directory). Detection only inspected lockfiles in the project directory and silently fell back to `npm` for empty projects — the most common starter scenario.
- Added a second signal layer in `detectPackageManager`: when no lockfile is present, infer the invoking PM from `npm_config_user_agent` (set by every major PM when spawning a child) and from `process.versions.bun` (covers `bun ./dist/cli.js` and `#!/usr/bin/env bun` shebangs where the UA is not propagated).
- Precedence is now **lockfile > invoking PM > `'npm'` default**, so an existing project that committed to a tool keeps its current recommendation.

## Test plan

- [x] `bun test packages/cli/src/__tests__/pm.test.ts` — 23 pass, including new cases for bunx UA, pnpm dlx UA, lockfile-wins precedence, bun-runtime fallback, and UA-wins-over-runtime precedence.
- [x] `bun test` (cli package) — 379 pass / 0 fail.
- [x] Manual: `bun /…/packages/cli/dist/index.js init` in an empty directory now reports `(detected package manager: bun)` and suggests `bun install` / `bun run dev` / `bunx barefoot …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)