### PR TITLE
fix(xyflow): drop `@barefootjs/jsx` paths overrides leaking `.d.ts` into jsx/src

### DIFF
--- a/packages/xyflow/tsconfig.json
+++ b/packages/xyflow/tsconfig.json
@@ -13,12 +13,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "jsx": "react-jsx",
-    "jsxImportSource": "@barefootjs/jsx",
-    "paths": {
-      "@barefootjs/jsx": ["../jsx/src"],
-      "@barefootjs/jsx/jsx-runtime": ["../jsx/src/jsx-runtime/index.d.ts"],
-      "@barefootjs/jsx/jsx-dev-runtime": ["../jsx/src/jsx-dev-runtime/index.d.ts"]
-    }
+    "jsxImportSource": "@barefootjs/jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/__tests__"]


### PR DESCRIPTION
## Summary

- `bun run build` at the workspace root produced two stray files inside the jsx package source tree on every run:
  - `packages/jsx/src/html-types.d.ts`
  - `packages/jsx/src/html-types.d.ts.map`
- Root cause: `packages/xyflow/tsconfig.json` had `paths` overrides aliasing `@barefootjs/jsx` (and its `jsx-runtime` / `jsx-dev-runtime` subpaths) to `../jsx/src`. This made `tsgo --emitDeclarationOnly` (xyflow's `build:types`) treat `packages/jsx/src/html-types.ts` as a program input. Because that file lives outside xyflow's `rootDir`, tsgo emitted the `.d.ts` next to the source rather than into `xyflow/dist`.
- Removed the overrides. `@barefootjs/jsx` is a workspace dependency (symlinked in `node_modules`) and its `exports` map already points at the prebuilt `dist/index.d.ts` plus the hand-written `src/jsx-runtime/` type entries, so package-name resolution covers the same surface — but keeps the jsx types ambient to xyflow's program (no re-emit).

## Test plan

- [x] `bun run --filter '@barefootjs/xyflow' build` — completes; `packages/jsx/src/html-types.d.ts*` are no longer created.
- [x] `bun run build` (root) — completes; no stray `.d.ts` files appear under `packages/*/src/` other than the hand-written `jsx-runtime/index.d.ts` entries.
- [x] `bun test` (xyflow package) — 31 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)