### PR TITLE
fix(cli): mix lockfile hash into build cache globalHash

### DIFF
--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -8,6 +8,7 @@ import {
   vendorChunkFilename,
   processExternals,
   processBundleEntries,
+  computeGlobalHash,
 } from '../lib/build'
 import { emptyCache, type BuildCache, type CacheEntry } from '../lib/build-cache'
 import { mkdirSync, writeFileSync, rmSync, existsSync, statSync, readFileSync, realpathSync } from 'fs'
@@ -588,6 +589,117 @@ export function __bf_init_Counter(el, props) {
     expect(result).toContain('counter')
     // Hydration hook identifier must survive minification
     expect(result).toContain('__bf_init_Counter')
+  })
+})
+
+// ── computeGlobalHash ─────────────────────────────────────────────────────
+
+describe('computeGlobalHash', () => {
+  const mockAdapter = { name: 'mock', extension: '.mock' } as any
+
+  function makeTmpDir(label = 'global-hash') {
+    const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    mkdirSync(dir, { recursive: true })
+    return realpathSync(dir)
+  }
+
+  function makeConfig(projectDir: string, extra: Record<string, any> = {}) {
+    return {
+      projectDir,
+      adapter: mockAdapter,
+      componentDirs: [],
+      outDir: projectDir,
+      minify: false,
+      contentHash: false,
+      clientOnly: false,
+      ...extra,
+    } as any
+  }
+
+  test('is stable across calls when nothing changes', async () => {
+    const projectDir = makeTmpDir()
+    try {
+      writeFileSync(resolve(projectDir, 'bun.lock'), 'lockfile contents v1\n')
+      const config = makeConfig(projectDir)
+      const h1 = await computeGlobalHash(config)
+      const h2 = await computeGlobalHash(config)
+      expect(h1).toBe(h2)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  // Regression: piconic-ai/barefootjs#1179 — bumping a git-ref dependency via
+  // `bun install` rewrote bun.lock but did not invalidate the build cache,
+  // so stale `*.client.js` bundles missing new hydrations were served.
+  test('changes when lockfile content changes', async () => {
+    const projectDir = makeTmpDir()
+    try {
+      const lockPath = resolve(projectDir, 'bun.lock')
+      writeFileSync(lockPath, 'lockfile contents v1\n')
+      const config = makeConfig(projectDir)
+      const before = await computeGlobalHash(config)
+
+      writeFileSync(lockPath, 'lockfile contents v2\n')
+      const after = await computeGlobalHash(config)
+      expect(after).not.toBe(before)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('differs when lockfile filename differs but content is identical', async () => {
+    // bun.lock vs yarn.lock with the same bytes still represents a different
+    // package manager state, so the hash must distinguish them.
+    const dirA = makeTmpDir('lock-a')
+    const dirB = makeTmpDir('lock-b')
+    try {
+      writeFileSync(resolve(dirA, 'bun.lock'), 'identical-bytes\n')
+      writeFileSync(resolve(dirB, 'yarn.lock'), 'identical-bytes\n')
+      const hA = await computeGlobalHash(makeConfig(dirA))
+      const hB = await computeGlobalHash(makeConfig(dirB))
+      expect(hA).not.toBe(hB)
+    } finally {
+      rmSync(dirA, { recursive: true, force: true })
+      rmSync(dirB, { recursive: true, force: true })
+    }
+  })
+
+  test('finds lockfile in a parent directory (monorepo workspace)', async () => {
+    const root = makeTmpDir('monorepo')
+    try {
+      const lockPath = resolve(root, 'bun.lock')
+      writeFileSync(lockPath, 'workspace lock v1\n')
+      const pkgDir = resolve(root, 'packages/inner')
+      mkdirSync(pkgDir, { recursive: true })
+
+      const config = makeConfig(realpathSync(pkgDir))
+      const before = await computeGlobalHash(config)
+
+      // Mutating the workspace-root lockfile must still invalidate.
+      writeFileSync(lockPath, 'workspace lock v2\n')
+      const after = await computeGlobalHash(config)
+      expect(after).not.toBe(before)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns a well-formed, stable hash regardless of lockfile presence', async () => {
+    // We deliberately do not assert anything about *which* lockfile is mixed
+    // in here: the temp directory lives outside any project, but the walk-up
+    // search may still pick up a lockfile higher in the filesystem on some
+    // hosts. The contract this test pins down is that the result is a stable
+    // hex hash — the change-detection assertions above cover invalidation.
+    const projectDir = makeTmpDir('no-lock-asserted')
+    try {
+      const config = makeConfig(projectDir)
+      const h = await computeGlobalHash(config)
+      expect(h).toMatch(/^[0-9a-f]+$/)
+      expect(await computeGlobalHash(config)).toBe(h)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -17,7 +17,7 @@ import {
   type CacheEntry,
 } from './build-cache'
 import { writeIfChanged } from './fs-utils'
-import { fileExists, readBytes, readText, transpile } from './runtime'
+import { fileExists, hashBytes, readBytes, readText, transpile } from './runtime'
 import { build as esbuildBuild } from 'esbuild'
 
 export { resolveRelativeImports } from './resolve-imports'
@@ -208,6 +208,43 @@ async function findCliPackageJson(): Promise<string | null> {
 }
 
 /**
+ * Lockfile names checked, in order of preference. All matching files found while
+ * walking up from `projectDir` are mixed into the global hash, so any
+ * dependency upgrade — including ones that only touch transitive deps under
+ * `node_modules/@barefootjs/*` — invalidates stale per-entry caches. See
+ * piconic-ai/barefootjs#1179 for the original incident: bumping barefootjs to
+ * a new git ref via `bun install` did not invalidate cached `*.client.js`
+ * outputs that were missing freshly registered hydrations.
+ */
+const LOCKFILE_NAMES = [
+  'bun.lock',
+  'bun.lockb',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+] as const
+
+/**
+ * Walk up from `projectDir` to the filesystem root and return the absolute
+ * path of the nearest lockfile, or null if none is found. In a monorepo the
+ * lockfile typically lives at the workspace root rather than inside the
+ * package directory that hosts `barefoot.config.ts`.
+ */
+async function findNearestLockfile(projectDir: string): Promise<string | null> {
+  let dir = projectDir
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    for (const name of LOCKFILE_NAMES) {
+      const candidate = resolve(dir, name)
+      if (await fileExists(candidate)) return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
  * Compute the invalidation hash shared by every cache entry. Captures the
  * configuration surface that would change build output globally (so a shift
  * here invalidates the whole cache, not a single entry).
@@ -216,6 +253,12 @@ async function findCliPackageJson(): Promise<string | null> {
  * therefore any change to the cache schema that ships with it — implicitly
  * invalidates the on-disk cache without needing a hand-maintained version
  * counter.
+ *
+ * The nearest lockfile is also mixed in so any `bun install` (or equivalent)
+ * that changes installed dependencies — including bumping a git-ref pin of
+ * `barefootjs` itself — discards the cache. Per-entry `deps` only track
+ * consumer source files, so without this the cache has no signal that
+ * `node_modules` content has changed.
  */
 export async function computeGlobalHash(config: BuildConfig): Promise<string> {
   const parts: string[] = [
@@ -239,6 +282,11 @@ export async function computeGlobalHash(config: BuildConfig): Promise<string> {
       parts.push(await readText(cand))
       break
     }
+  }
+  const lockfile = await findNearestLockfile(config.projectDir)
+  if (lockfile) {
+    const bytes = await readBytes(lockfile)
+    parts.push(`lockfile:${basename(lockfile)}:${hashBytes(bytes)}`)
   }
   return hashContent(parts.join('\x00'))
 }

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -57,6 +57,14 @@ export function hashString(content: string): string {
   return createHash('sha256').update(content).digest('hex').slice(0, 16)
 }
 
+/**
+ * Byte-exact variant of `hashString` for files that may not be valid UTF-8
+ * (notably `bun.lockb`, which is binary).
+ */
+export function hashBytes(content: Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 16)
+}
+
 export interface TranspileOptions {
   /** Source loader. Defaults to 'js'. */
   loader?: 'ts' | 'tsx' | 'js' | 'jsx'


### PR DESCRIPTION
## Summary

- Mix the nearest lockfile's content hash into `computeGlobalHash` so any `bun install` (including bumping a git-ref pin of `barefootjs` itself) discards stale `.buildcache.json` entries.
- Walk up from `projectDir` to find the lockfile, so monorepo workspaces detect their workspace-root lockfile.
- Add `hashBytes` for the binary `bun.lockb` case.

## Why

Per-entry cache `deps` only contain consumer source files — zero `node_modules` paths. The old `globalHash` only mixed in the CLI's own pinned `package.json`, which never moves when the consumer pulls a new git ref of `barefootjs`. So upgrading barefootjs left the cache reporting hits and emitting `*.client.js` bundles missing newly registered `hydrate(...)` calls. This bit `piconic-ai/desk` after the #1175 merge: the canvas page rendered an empty `<div id=\"canvas-root\">` because hydrations for `Flow` / `Background` / `MiniMap` were missing from the cached bundle.

Lockfile-as-invalidation matches what bun's `--watch` resolver, Vite, Next.js, and Turbopack already do.

## Test plan

- [x] `bun test --cwd . __tests__` — 2099 pass / 0 fail
- [x] `bun test packages/cli` — 613 pass / 0 fail (5 new `computeGlobalHash` tests cover: content change, filename change with identical bytes, walk-up to a parent workspace, stability under no-op calls, well-formed output with no lockfile)
- [x] `bun run build` (repo root) — clean

Fixes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)