### PR TITLE
refactor(jsx): consolidate compileJSX and compileJSXSync

### DIFF
--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -40,7 +40,7 @@ description: How the BarefootJS compiler transforms JSX into marked templates an
 compileJSX(entryPath: string, readFile: ReadFileFn, options: CompileOptions): Promise<CompileResult>
 
 // Sync — source string input
-compileJSXSync(source: string, filePath: string, options: CompileOptions): CompileResult
+compileJSX(source: string, filePath: string, options: CompileOptions): CompileResult
 ```
 
 Both support multi-component files.
@@ -319,7 +319,7 @@ export function IconButton(props: IconButtonProps) { ... }
 ### View the IR
 
 ```typescript
-const result = compileJSXSync(source, 'file.tsx', { adapter })
+const result = compileJSX(source, 'file.tsx', { adapter })
 console.log(JSON.stringify(result.ir, null, 2))
 ```
 

--- a/docs/core/advanced/ir-schema.md
+++ b/docs/core/advanced/ir-schema.md
@@ -50,9 +50,9 @@ Defined in [`packages/jsx/src/types.ts`](../../../packages/jsx/src/types.ts):
 Pass `outputIR: true` to inspect the IR:
 
 ```typescript
-import { compileJSXSync } from '@barefootjs/jsx'
+import { compileJSX } from '@barefootjs/jsx'
 
-const result = compileJSXSync(source, 'Counter.tsx', {
+const result = compileJSX(source, 'Counter.tsx', {
   adapter: new HonoAdapter(),
   outputIR: true,
 })

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -8,7 +8,7 @@ import { describe, test, expect } from 'bun:test'
 import { GoTemplateAdapter } from '../adapter/go-template-adapter'
 import { runJSXConformanceTests } from '@barefootjs/adapter-tests'
 import { renderGoTemplateComponent, GoNotAvailableError } from '@barefootjs/go-template/test-render'
-import { compileJSXSync, type ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 
 // =============================================================================
 // JSX-Based Conformance Tests
@@ -60,7 +60,7 @@ runJSXConformanceTests({
  * Compile JSX source to ComponentIR using the GoTemplateAdapter.
  */
 function compileToIR(source: string, adapter?: GoTemplateAdapter): ComponentIR {
-  const result = compileJSXSync(source.trimStart(), 'test.tsx', {
+  const result = compileJSX(source.trimStart(), 'test.tsx', {
     adapter: adapter ?? new GoTemplateAdapter(),
     outputIR: true,
   })

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -5,7 +5,7 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSXSync } from '@barefootjs/jsx'
+import { compileJSX } from '@barefootjs/jsx'
 import type { TemplateAdapter, ComponentIR } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -67,7 +67,7 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   const childTypeBlocks: string[] = []
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
-      const childResult = compileJSXSync(childSource, filename, { adapter, outputIR: true })
+      const childResult = compileJSX(childSource, filename, { adapter, outputIR: true })
       const childErrors = childResult.errors.filter(e => e.severity === 'error')
       if (childErrors.length > 0) {
         throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
@@ -92,7 +92,7 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   }
 
   // Compile parent source
-  const result = compileJSXSync(source, 'component.tsx', { adapter, outputIR: true })
+  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-hono/src/test-render.ts
+++ b/packages/adapter-hono/src/test-render.ts
@@ -5,7 +5,7 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSXSync } from '@barefootjs/jsx'
+import { compileJSX } from '@barefootjs/jsx'
 import type { TemplateAdapter } from '@barefootjs/jsx'
 import { Hono } from 'hono'
 import { mkdir, rm } from 'node:fs/promises'
@@ -34,7 +34,7 @@ export async function renderHonoComponent(options: RenderOptions): Promise<strin
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
       componentKeys.add(filename)
-      const childResult = compileJSXSync(childSource, filename, { adapter })
+      const childResult = compileJSX(childSource, filename, { adapter })
       const childErrors = childResult.errors.filter(e => e.severity === 'error')
       if (childErrors.length > 0) {
         throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
@@ -48,7 +48,7 @@ export async function renderHonoComponent(options: RenderOptions): Promise<strin
   }
 
   // Compile parent source
-  const result = compileJSXSync(source, 'component.tsx', { adapter })
+  const result = compileJSX(source, 'component.tsx', { adapter })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -8,7 +8,7 @@ import { describe, test, expect } from 'bun:test'
 import { MojoAdapter } from '../adapter/mojo-adapter'
 import { runJSXConformanceTests } from '@barefootjs/adapter-tests'
 import { renderMojoComponent, PerlNotAvailableError } from '../test-render'
-import { compileJSXSync, type ComponentIR } from '@barefootjs/jsx'
+import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 
 // =============================================================================
 // JSX-Based Conformance Tests
@@ -54,7 +54,7 @@ runJSXConformanceTests({
 // =============================================================================
 
 function compileToIR(source: string, adapter?: MojoAdapter): ComponentIR {
-  const result = compileJSXSync(source.trimStart(), 'test.tsx', {
+  const result = compileJSX(source.trimStart(), 'test.tsx', {
     adapter: adapter ?? new MojoAdapter(),
     outputIR: true,
   })

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -5,7 +5,7 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSXSync } from '@barefootjs/jsx'
+import { compileJSX } from '@barefootjs/jsx'
 import type { ComponentIR } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -54,7 +54,7 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
   const childTemplates: Map<string, { template: string; ir: ComponentIR }> = new Map()
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
-      const childResult = compileJSXSync(childSource, filename, { adapter, outputIR: true })
+      const childResult = compileJSX(childSource, filename, { adapter, outputIR: true })
       const childErrors = childResult.errors.filter(e => e.severity === 'error')
       if (childErrors.length > 0) {
         throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
@@ -69,7 +69,7 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
   }
 
   // Compile parent source
-  const result = compileJSXSync(source, 'component.tsx', { adapter, outputIR: true })
+  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
+++ b/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
@@ -10,14 +10,14 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '@barefootjs/jsx'
+import { compileJSX } from '@barefootjs/jsx'
 import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { jsxFixtures } from '../../fixtures'
 
 const adapter = new HonoAdapter()
 
 function compileClientJs(fixture: (typeof jsxFixtures)[number]): string {
-  const result = compileJSXSync(fixture.source, 'Test.tsx', { adapter })
+  const result = compileJSX(fixture.source, 'Test.tsx', { adapter })
   return result.files.find(f => f.type === 'clientJs')?.content ?? ''
 }
 
@@ -160,7 +160,7 @@ export function Test() {
   return <div className="container"><span className="label">Text</span></div>
 }
 `
-      const result = compileJSXSync(source, 'Test.tsx', { adapter })
+      const result = compileJSX(source, 'Test.tsx', { adapter })
       const template = result.files.find(f => f.type === 'markedTemplate')!
 
       expect(template.content).toContain('className="container"')
@@ -178,7 +178,7 @@ export function Test() {
   return <div className={active() ? 'on' : 'off'}>Toggle</div>
 }
 `
-      const result = compileJSXSync(source, 'Test.tsx', { adapter })
+      const result = compileJSX(source, 'Test.tsx', { adapter })
       const template = result.files.find(f => f.type === 'markedTemplate')!
 
       expect(template.content).toContain('className=')

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1220,9 +1220,9 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
     deps[depPath] = hashContent(await readText(depPath))
   }
 
-  const result = await compileJSX(
+  const result = compileJSX(
+    sourceContent,
     entryPath,
-    async (path) => readText(path),
     { adapter: config.adapter, program: sharedProgram },
   )
 

--- a/packages/jsx/bench/compiler-bench.ts
+++ b/packages/jsx/bench/compiler-bench.ts
@@ -33,7 +33,7 @@ import ts from 'typescript'
 import { resolve, relative, dirname } from 'path'
 import { readdir, stat } from 'fs/promises'
 import {
-  compileJSXSync,
+  compileJSX,
   createProgramForFile,
   enableCompilerInstrumentation,
   disableCompilerInstrumentation,
@@ -149,7 +149,7 @@ async function runMode(mode: Mode, files: string[], top: number): Promise<void> 
       } else if (mode === 'shared') {
         program = sharedProgram
       }
-      const result = compileJSXSync(source, filePath, { adapter, program })
+      const result = compileJSX(source, filePath, { adapter, program })
       errors = result.errors.filter((e) => e.severity === 'error').length
     } catch (e) {
       errors = 1

--- a/packages/jsx/src/__tests__/adapter-output.test.ts
+++ b/packages/jsx/src/__tests__/adapter-output.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync, compileJSX } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
 import { resolve, dirname } from 'node:path'
@@ -20,10 +20,8 @@ describe('Adapter output', () => {
       const docsUiPath = resolve(dirname(import.meta.path), '../../../../site/ui')
       const buttonDemoPath = resolve(docsUiPath, 'components/button-demo.tsx')
 
-      const result = await compileJSX(buttonDemoPath, async (path) => {
-        const file = Bun.file(path)
-        return await file.text()
-      }, { adapter })
+      const source = await Bun.file(buttonDemoPath).text()
+      const result = compileJSX(source, buttonDemoPath, { adapter })
 
       // Should have no errors
       expect(result.errors).toHaveLength(0)
@@ -60,7 +58,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -84,7 +82,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -104,7 +102,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -121,7 +119,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -142,7 +140,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -166,7 +164,7 @@ describe('Adapter output', () => {
           return <input pattern={props.pattern ?? REGEXP_ONLY_DIGITS} />
         }
       `
-      const result = compileJSXSync(source, 'OTPInput.tsx', { adapter })
+      const result = compileJSX(source, 'OTPInput.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')
@@ -194,7 +192,7 @@ describe('Adapter output', () => {
           return <div>{INTERNAL_VALUE}</div>
         }
       `
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -221,7 +219,7 @@ describe('Adapter output', () => {
           return <div>{helperFn(count())}</div>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -249,7 +247,7 @@ describe('Adapter output', () => {
           return <input />
         }
       `
-      const result = compileJSXSync(source, 'InputField.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'InputField.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -277,7 +275,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Calendar.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Calendar.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -298,7 +296,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -322,7 +320,7 @@ describe('Adapter output', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'DatePicker.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'DatePicker.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -343,7 +341,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -361,7 +359,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -382,7 +380,7 @@ describe('Adapter output', () => {
           return <span>{formatNum(val())}</span>
         }
       `
-      const result = compileJSXSync(source, 'Display.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Display.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -402,7 +400,7 @@ describe('Adapter output', () => {
           return <div>{helperFn(val(), 'value: ')}</div>
         }
       `
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -422,7 +420,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -441,7 +439,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -476,7 +474,7 @@ describe('Adapter output', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'MembersPanel.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'MembersPanel.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -504,7 +502,7 @@ describe('Adapter output', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Display.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Display.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -523,7 +521,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -543,7 +541,7 @@ describe('Adapter output', () => {
           return <div class="logo">BarefootJS</div>
         }
       `
-      const result = compileJSXSync(source, 'Logo.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Logo.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -561,7 +559,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -588,7 +586,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -607,7 +605,7 @@ describe('Adapter output', () => {
           return <span>{items().length}</span>
         }
       `
-      const result = compileJSXSync(source, 'TodoList.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'TodoList.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -626,7 +624,7 @@ describe('Adapter output', () => {
           return <span>{ids().length}</span>
         }
       `
-      const result = compileJSXSync(source, 'Panel.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Panel.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!
@@ -647,7 +645,7 @@ describe('Adapter output', () => {
           return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')!

--- a/packages/jsx/src/__tests__/async-function-arrow-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/async-function-arrow-rewrite.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -38,7 +38,7 @@ describe('async function declarations → async const arrow rewrite (#1130)', ()
       }
     `
 
-    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    const result = compileJSX(source, 'Page.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -65,7 +65,7 @@ describe('async function declarations → async const arrow rewrite (#1130)', ()
       }
     `
 
-    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    const result = compileJSX(source, 'Page.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''

--- a/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/attribute-fallback-wrap.test.ts
@@ -22,13 +22,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/boolean-attributes.test.ts
+++ b/packages/jsx/src/__tests__/boolean-attributes.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { isBooleanAttr, BOOLEAN_ATTRS } from '../html-constants'
 
@@ -54,7 +54,7 @@ describe('boolean attributes', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Checkbox.tsx', { adapter })
+    const result = compileJSX(source, 'Checkbox.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -78,7 +78,7 @@ describe('boolean attributes', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Button.tsx', { adapter })
+    const result = compileJSX(source, 'Button.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -100,7 +100,7 @@ describe('boolean attributes', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Button.tsx', { adapter })
+    const result = compileJSX(source, 'Button.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -128,7 +128,7 @@ describe('boolean attributes', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 

--- a/packages/jsx/src/__tests__/branch-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/branch-loop-plain.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -49,7 +49,7 @@ describe('plain `.map()` inside a conditional branch (#1065)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CondList.tsx', { adapter })
+    const result = compileJSX(source, 'CondList.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -96,7 +96,7 @@ describe('plain `.map()` inside a conditional branch (#1065)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CondListD.tsx', { adapter })
+    const result = compileJSX(source, 'CondListD.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -151,7 +151,7 @@ describe('plain `.map()` inside a conditional branch (#1065)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CondListSL.tsx', { adapter })
+    const result = compileJSX(source, 'CondListSL.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -202,7 +202,7 @@ describe('plain `.map()` inside a conditional branch (#1065)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CondListSLD.tsx', { adapter })
+    const result = compileJSX(source, 'CondListSLD.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
 
@@ -25,7 +25,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'RadioGroup.tsx', { adapter })
+    const result = compileJSX(source, 'RadioGroup.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -48,7 +48,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'RadioGroup.tsx', { adapter })
+    const result = compileJSX(source, 'RadioGroup.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -74,7 +74,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -99,7 +99,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -122,7 +122,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -147,7 +147,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -190,7 +190,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'SelectionDemo.tsx', { adapter })
+    const result = compileJSX(source, 'SelectionDemo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -219,7 +219,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'RadioGroup.tsx', { adapter })
+    const result = compileJSX(source, 'RadioGroup.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -244,7 +244,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CardList.tsx', { adapter: honoAdapter })
+    const result = compileJSX(source, 'CardList.tsx', { adapter: honoAdapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find(f => f.type === 'markedTemplate')
@@ -270,7 +270,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'StaticList.tsx', { adapter: honoAdapter })
+    const result = compileJSX(source, 'StaticList.tsx', { adapter: honoAdapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find(f => f.type === 'markedTemplate')
@@ -297,7 +297,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+    const result = compileJSX(source, 'Parent.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -340,7 +340,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'DataTable.tsx', { adapter })
+    const result = compileJSX(source, 'DataTable.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -376,7 +376,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -405,7 +405,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'RadioGroup.tsx', { adapter })
+    const result = compileJSX(source, 'RadioGroup.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -437,7 +437,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'DataTable.tsx', { adapter })
+    const result = compileJSX(source, 'DataTable.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -472,7 +472,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -505,7 +505,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -534,7 +534,7 @@ describe('child components inside .map() (#344)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       // The .map() call should become an expression, not a loop with empty children
@@ -558,7 +558,7 @@ describe('child components inside .map() (#344)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -581,7 +581,7 @@ describe('child components inside .map() (#344)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -605,7 +605,7 @@ describe('child components inside .map() (#344)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'List.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'List.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')
@@ -635,7 +635,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'DynList.tsx', { adapter })
+    const result = compileJSX(source, 'DynList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -664,7 +664,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Header.tsx', { adapter })
+    const result = compileJSX(source, 'Header.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -692,7 +692,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Header.tsx', { adapter })
+    const result = compileJSX(source, 'Header.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -718,7 +718,7 @@ describe('child components inside .map() (#344)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
@@ -26,13 +26,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { analyzeComponent } from '../analyzer'
 import { TestAdapter } from '../adapters/test-adapter'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
@@ -13,7 +13,7 @@ import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-
 const adapter = new TestAdapter()
 
 describe('Client JS generation', () => {
-  describe('compileJSXSync', () => {
+  describe('compileJSX', () => {
     test('compiles simple component', () => {
       const source = `
         'use client'
@@ -29,7 +29,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
       expect(result.files).toHaveLength(2) // markedJsx + clientJs
@@ -57,7 +57,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      const result = compileJSX(source, 'Button.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -91,7 +91,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'CommandDisplay.tsx', { adapter })
+      const result = compileJSX(source, 'CommandDisplay.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -110,7 +110,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'App.tsx', { adapter, outputIR: true })
+      const result = compileJSX(source, 'App.tsx', { adapter, outputIR: true })
 
       const ir = result.files.find(f => f.type === 'ir')
       expect(ir).toBeDefined()
@@ -137,7 +137,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'AccordionItem.tsx', { adapter })
+      const result = compileJSX(source, 'AccordionItem.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -166,7 +166,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -194,7 +194,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -228,7 +228,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+      const result = compileJSX(source, 'Icon.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -254,7 +254,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Calculator.tsx', { adapter })
+      const result = compileJSX(source, 'Calculator.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -290,7 +290,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'PageNav.tsx', { adapter })
+      const result = compileJSX(source, 'PageNav.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
 
       expect(errors).toHaveLength(0)
@@ -331,7 +331,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'NavButton.tsx', { adapter })
+      const result = compileJSX(source, 'NavButton.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
 
       expect(errors).toHaveLength(0)
@@ -371,7 +371,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'ThemedBox.tsx', { adapter })
+      const result = compileJSX(source, 'ThemedBox.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
 
       expect(errors).toHaveLength(0)
@@ -396,7 +396,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      const result = compileJSX(source, 'Button.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -424,7 +424,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -451,7 +451,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -472,7 +472,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Modal.tsx', { adapter })
+      const result = compileJSX(source, 'Modal.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -495,7 +495,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -527,7 +527,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Form.tsx', { adapter })
+      const result = compileJSX(source, 'Form.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -547,7 +547,7 @@ describe('Client JS generation', () => {
           return <button onClick={() => console.log('hi')}>Click</button>
         }
       `
-      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      const result = compileJSX(source, 'Button.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -572,7 +572,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      const result = compileJSX(source, 'Button.tsx', { adapter })
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
       if (clientJs) {
@@ -598,7 +598,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+      const result = compileJSX(source, 'Wrapper.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -623,7 +623,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyItem.tsx', { adapter })
+      const result = compileJSX(source, 'MyItem.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -647,7 +647,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Badge.tsx', { adapter })
+      const result = compileJSX(source, 'Badge.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -672,7 +672,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Display.tsx', { adapter })
+      const result = compileJSX(source, 'Display.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -705,7 +705,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Display.tsx', { adapter })
+      const result = compileJSX(source, 'Display.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -727,7 +727,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyItem.tsx', { adapter })
+      const result = compileJSX(source, 'MyItem.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -758,7 +758,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyButton.tsx', { adapter })
+      const result = compileJSX(source, 'MyButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -788,7 +788,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Tag.tsx', { adapter })
+      const result = compileJSX(source, 'Tag.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -814,7 +814,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Card.tsx', { adapter })
+      const result = compileJSX(source, 'Card.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -839,7 +839,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Widget.tsx', { adapter })
+      const result = compileJSX(source, 'Widget.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -873,7 +873,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Toolbar.tsx', { adapter })
+      const result = compileJSX(source, 'Toolbar.tsx', { adapter })
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       expect(clientJs!.content).toContain('"aria-label"')
@@ -895,7 +895,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       expect(clientJs!.content).toContain('"data-testid"')
@@ -917,7 +917,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Toolbar.tsx', { adapter })
+      const result = compileJSX(source, 'Toolbar.tsx', { adapter })
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
       // camelCase props should NOT be quoted
@@ -994,7 +994,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'TypeScriptGuard.tsx', { adapter })
+      const result = compileJSX(source, 'TypeScriptGuard.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1056,7 +1056,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'ToggleGroup.tsx', { adapter })
+      const result = compileJSX(source, 'ToggleGroup.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1082,7 +1082,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1107,7 +1107,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -1135,7 +1135,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1179,7 +1179,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MultiInputSync.tsx', { adapter })
+      const result = compileJSX(source, 'MultiInputSync.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1205,7 +1205,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'DisabledInput.tsx', { adapter })
+      const result = compileJSX(source, 'DisabledInput.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1231,7 +1231,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'FragComp.tsx', { adapter })
+      const result = compileJSX(source, 'FragComp.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1257,7 +1257,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'SingleRoot.tsx', { adapter })
+      const result = compileJSX(source, 'SingleRoot.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1283,7 +1283,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+      const result = compileJSX(source, 'Wrapper.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1309,7 +1309,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1348,7 +1348,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Carousel.tsx', { adapter })
+      const result = compileJSX(source, 'Carousel.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1376,7 +1376,7 @@ describe('Client JS generation', () => {
       expect(letConstant!.declarationKind).toBe('let')
       expect(letConstant!.value).toBe('0')
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1402,7 +1402,7 @@ describe('Client JS generation', () => {
       expect(constConstant).toBeDefined()
       expect(constConstant!.declarationKind).toBe('const')
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1426,7 +1426,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyForm.tsx', { adapter })
+      const result = compileJSX(source, 'MyForm.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1455,7 +1455,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'ToggleGroup.tsx', { adapter })
+      const result = compileJSX(source, 'ToggleGroup.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1480,7 +1480,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1508,7 +1508,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1534,7 +1534,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -1562,7 +1562,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1582,7 +1582,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'StatusMessage.tsx', { adapter })
+      const result = compileJSX(source, 'StatusMessage.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1615,7 +1615,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'VerifyForm.tsx', { adapter })
+      const result = compileJSX(source, 'VerifyForm.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1644,7 +1644,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'SubmitButton.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'SubmitButton.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1675,7 +1675,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1707,7 +1707,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1735,7 +1735,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1777,7 +1777,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter, outputIR: true })
+      const result = compileJSX(source, 'List.tsx', { adapter, outputIR: true })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1821,7 +1821,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter })
+      const result = compileJSX(source, 'List.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1854,7 +1854,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'List.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'List.tsx', { adapter: honoAdapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -1883,7 +1883,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'CheckIcon.tsx', { adapter })
+      const result = compileJSX(source, 'CheckIcon.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1907,7 +1907,7 @@ describe('Client JS generation', () => {
           return <svg {...attrs} viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
         }
       `
-      const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+      const result = compileJSX(source, 'Icon.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1925,7 +1925,7 @@ describe('Client JS generation', () => {
           return <svg {...sizeAttrs} {...colorAttrs} viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
         }
       `
-      const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+      const result = compileJSX(source, 'Icon.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1949,7 +1949,7 @@ describe('Client JS generation', () => {
           return <button {...rest} onClick={() => setCount(c => c + 1)}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'Button.tsx', { adapter })
+      const result = compileJSX(source, 'Button.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -1980,7 +1980,7 @@ describe('Client JS generation', () => {
           return <div {...childProps} {...props} onClick={() => setCount(c => c + 1)}>{count()}</div>
         }
       `
-      const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+      const result = compileJSX(source, 'Wrapper.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2013,7 +2013,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'CopyButton.tsx', { adapter })
+      const result = compileJSX(source, 'CopyButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2057,7 +2057,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+      const result = compileJSX(source, 'Toggle.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2088,7 +2088,7 @@ describe('Client JS generation', () => {
           return <CustomInput onChange={setValue} />
         }
       `
-      const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+      const result = compileJSX(source, 'Parent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2124,7 +2124,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Badge.tsx', { adapter })
+      const result = compileJSX(source, 'Badge.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2155,7 +2155,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Text.tsx', { adapter })
+      const result = compileJSX(source, 'Text.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2181,7 +2181,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Text.tsx', { adapter })
+      const result = compileJSX(source, 'Text.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2208,7 +2208,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Tag.tsx', { adapter })
+      const result = compileJSX(source, 'Tag.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2232,7 +2232,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Greeting.tsx', { adapter })
+      const result = compileJSX(source, 'Greeting.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
       expect(errors).toHaveLength(0)
 
@@ -2270,7 +2270,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
       expect(errors).toHaveLength(0)
 
@@ -2301,7 +2301,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       const errors = result.errors.filter(e => e.severity === 'error')
       expect(errors).toHaveLength(0)
 
@@ -2331,7 +2331,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+      const result = compileJSX(source, 'Parent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2359,7 +2359,7 @@ describe('Client JS generation', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+      const result = compileJSX(source, 'Parent.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -2390,7 +2390,7 @@ describe('Client JS generation', () => {
           return <button disabled={props.disabled ?? false} className={props.className ?? ''}>{count()}</button>
         }
       `
-      const result = compileJSXSync(source, 'MyButton.tsx', { adapter })
+      const result = compileJSX(source, 'MyButton.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
@@ -2408,7 +2408,7 @@ describe('Client JS generation', () => {
           return <div>{count()}</div>
         }
       `
-      const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+      const result = compileJSX(source, 'Wrapper.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
     })
   })
@@ -2439,7 +2439,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Page.tsx', { adapter })
+      const result = compileJSX(source, 'Page.tsx', { adapter })
       expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
       const js = result.files.find(f => f.type === 'clientJs')!.content
       // The branch arm's mapArray call must live inside a
@@ -2467,7 +2467,7 @@ describe('Client JS generation', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'Page.tsx', { adapter })
+      const result = compileJSX(source, 'Page.tsx', { adapter })
       expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
       const js = result.files.find(f => f.type === 'clientJs')!.content
       // The inner insert() must live inside a createDisposableEffect that

--- a/packages/jsx/src/__tests__/client-only-loop-ssr-markers.test.ts
+++ b/packages/jsx/src/__tests__/client-only-loop-ssr-markers.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
 
 const adapter = new HonoAdapter()
@@ -36,7 +36,7 @@ export function ChatList() {
   )
 }
 `
-    const result = compileJSXSync(source, 'ChatList.tsx', { adapter })
+    const result = compileJSX(source, 'ChatList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -75,7 +75,7 @@ export function ItemList() {
   )
 }
 `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -104,7 +104,7 @@ export function ItemList() {
   )
 }
 `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -133,7 +133,7 @@ export function ClientOnly() {
   )
 }
 `
-    const result = compileJSXSync(source, 'Test.tsx', { adapter })
+    const result = compileJSX(source, 'Test.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -163,7 +163,7 @@ export function SiblingMaps() {
   )
 }
 `
-    const result = compileJSXSync(source, 'SiblingMaps.tsx', { adapter })
+    const result = compileJSX(source, 'SiblingMaps.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')

--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -7,12 +7,12 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '..'
+import { compileJSX } from '..'
 import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
 
 const adapter = new HonoAdapter()
 function compileClient(source: string, filename = 'Test.tsx') {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   return result.files.find(f => f.type === 'clientJs')?.content ?? ''
 }
 
@@ -198,7 +198,7 @@ describe('Compiler-Runtime Contract', () => {
     })
 
     test('key in HTML template uses data-key attribute name', () => {
-      const result = compileJSXSync(`
+      const result = compileJSX(`
         "use client"
         import { createSignal } from '@barefootjs/client'
         export function Test() {

--- a/packages/jsx/src/__tests__/component-body-init-statements.test.ts
+++ b/packages/jsx/src/__tests__/component-body-init-statements.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -30,7 +30,7 @@ describe('Component-body top-level imperative statements (#930, bug-2)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Badge.tsx', { adapter })
+    const result = compileJSX(source, 'Badge.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -57,7 +57,7 @@ describe('Component-body top-level imperative statements (#930, bug-2)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Widget.tsx', { adapter })
+    const result = compileJSX(source, 'Widget.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -84,7 +84,7 @@ describe('Component-body top-level imperative statements (#930, bug-2)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Live.tsx', { adapter })
+    const result = compileJSX(source, 'Live.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -109,7 +109,7 @@ describe('Component-body top-level imperative statements (#930, bug-2)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Logger.tsx', { adapter })
+    const result = compileJSX(source, 'Logger.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -132,7 +132,7 @@ describe('Component-body top-level imperative statements (#930, bug-2)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Safe.tsx', { adapter })
+    const result = compileJSX(source, 'Safe.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -161,7 +161,7 @@ describe('Init statements referencing module-scope declarations (#933)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Scoped.tsx', { adapter })
+    const result = compileJSX(source, 'Scoped.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -191,7 +191,7 @@ describe('Init statements referencing module-scope declarations (#933)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Persisted.tsx', { adapter })
+    const result = compileJSX(source, 'Persisted.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -215,7 +215,7 @@ describe('Init statements referencing module-scope declarations (#933)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Local.tsx', { adapter })
+    const result = compileJSX(source, 'Local.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
@@ -236,7 +236,7 @@ describe('Init statements referencing module-scope declarations (#933)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Broken.tsx', { adapter })
+    const result = compileJSX(source, 'Broken.tsx', { adapter })
     const bf052 = result.errors.find(e => e.code === 'BF052')
     expect(bf052).toBeDefined()
     expect(bf052!.severity).toBe('error')

--- a/packages/jsx/src/__tests__/component-callable-shim.test.ts
+++ b/packages/jsx/src/__tests__/component-callable-shim.test.ts
@@ -14,12 +14,12 @@
  */
 import { describe, expect, test } from 'bun:test'
 import { TestAdapter } from '../adapters/test-adapter'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 
 const adapter = new TestAdapter()
 
 function clientJsFor(source: string, fileName: string): string {
-  const result = compileJSXSync(source, fileName, { adapter })
+  const result = compileJSX(source, fileName, { adapter })
   expect(result.errors).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/component-scope.test.ts
+++ b/packages/jsx/src/__tests__/component-scope.test.ts
@@ -21,13 +21,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { computeFileScope } from '../ir-to-client-js/component-scope'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
-function clientJs(result: ReturnType<typeof compileJSXSync>): string {
+function clientJs(result: ReturnType<typeof compileJSX>): string {
   const file = result.files.find((f) => f.type === 'clientJs')
   if (!file) throw new Error('expected clientJs output')
   return file.content
@@ -69,8 +69,8 @@ const iconLibrarySource = `
 
 describe('component-scope: file-scoped registry keys for non-exported helpers', () => {
   test('non-exported helpers in two files register under distinct hydrate keys', () => {
-    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
-    const iconJs = clientJs(compileJSXSync(iconLibrarySource, 'ui/components/ui/icon/index.tsx', { adapter }))
+    const themeJs = clientJs(compileJSX(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+    const iconJs = clientJs(compileJSX(iconLibrarySource, 'ui/components/ui/icon/index.tsx', { adapter }))
 
     // Theme switcher's local SunIcon is private — must NOT register the
     // bare name (which would race with the icon library's export).
@@ -86,13 +86,13 @@ describe('component-scope: file-scoped registry keys for non-exported helpers', 
   })
 
   test('exported main component is not scoped even when it has non-exported siblings', () => {
-    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+    const themeJs = clientJs(compileJSX(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
     expect(themeJs).toMatch(/hydrate\('ThemeSwitcher',/)
     expect(themeJs).not.toMatch(/hydrate\('ThemeSwitcher__/)
   })
 
   test('within one file, hydrate / renderChild / initChild use the same scoped key', () => {
-    const themeJs = clientJs(compileJSXSync(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
+    const themeJs = clientJs(compileJSX(themeSwitcherSource, 'site/shared/components/theme-switcher.tsx', { adapter }))
 
     // Pull the suffix from the hydrate registration so the assertion
     // fails loudly if the rewrite ever drifts between emit points.

--- a/packages/jsx/src/__tests__/composite-branch-loop.test.ts
+++ b/packages/jsx/src/__tests__/composite-branch-loop.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -45,7 +45,7 @@ describe('composite loops inside conditional branches (#724)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CartDemo.tsx', { adapter })
+    const result = compileJSX(source, 'CartDemo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -88,7 +88,7 @@ describe('composite loops inside conditional branches (#724)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'SimpleList.tsx', { adapter })
+    const result = compileJSX(source, 'SimpleList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -139,7 +139,7 @@ describe('composite loops inside conditional branches (#724)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -192,7 +192,7 @@ describe('composite loops inside conditional branches (#724)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'TodoList.tsx', { adapter })
+    const result = compileJSX(source, 'TodoList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -239,7 +239,7 @@ describe('direct map call as conditional branch (#783)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'GroupList.tsx', { adapter })
+    const result = compileJSX(source, 'GroupList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -273,7 +273,7 @@ describe('direct map call as conditional branch (#783)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -305,7 +305,7 @@ describe('direct map call as conditional branch (#783)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'TagList.tsx', { adapter })
+    const result = compileJSX(source, 'TagList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -339,7 +339,7 @@ describe('mapPreamble in event delegation handlers (#851)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -380,7 +380,7 @@ describe('mapPreamble in event delegation handlers (#851)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/conditional-fallback-wrap.test.ts
@@ -20,13 +20,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
+++ b/packages/jsx/src/__tests__/conditional-mapArray-key.test.ts
@@ -16,13 +16,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function clientJs(source: string, file = 'CondKey.tsx'): string {
-  const result = compileJSXSync(source, file, { adapter })
+  const result = compileJSX(source, file, { adapter })
   expect(result.errors.filter((e) => (e as { severity?: string }).severity === 'error')).toHaveLength(0)
   const cjs = result.files.find((f) => f.type === 'clientJs')
   expect(cjs).toBeDefined()

--- a/packages/jsx/src/__tests__/conditional-reactive-binding-rebind.test.ts
+++ b/packages/jsx/src/__tests__/conditional-reactive-binding-rebind.test.ts
@@ -21,13 +21,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/controlled-prop-detection.test.ts
+++ b/packages/jsx/src/__tests__/controlled-prop-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -20,7 +20,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Slider.tsx', { adapter })
+    const result = compileJSX(source, 'Slider.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -44,7 +44,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Checkbox.tsx', { adapter })
+    const result = compileJSX(source, 'Checkbox.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -68,7 +68,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Slider.tsx', { adapter })
+    const result = compileJSX(source, 'Slider.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -94,7 +94,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Slider.tsx', { adapter })
+    const result = compileJSX(source, 'Slider.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -119,7 +119,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Checkbox.tsx', { adapter })
+    const result = compileJSX(source, 'Checkbox.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -144,7 +144,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Input.tsx', { adapter })
+    const result = compileJSX(source, 'Input.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -168,7 +168,7 @@ describe('controlled prop detection (#434)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Slider.tsx', { adapter })
+    const result = compileJSX(source, 'Slider.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts
+++ b/packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts
@@ -15,7 +15,7 @@
  * `inlinableConstants` already does at the call site in html-template.ts.
  */
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
 
 const onlyErrors = (errors: { severity?: string }[]) =>
@@ -119,7 +119,7 @@ describe('CSR template: shadowed ctx.<method>() (#1100)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Bar.tsx', { adapter: new HonoAdapter() })
+    const result = compileJSX(source, 'Bar.tsx', { adapter: new HonoAdapter() })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -150,7 +150,7 @@ describe('CSR template: shadowed ctx.<method>() (#1100)', () => {
         return <div>{ctx.count()} / {count()}</div>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter: new HonoAdapter() })
+    const result = compileJSX(source, 'Counter.tsx', { adapter: new HonoAdapter() })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/curried-event-handlers.test.ts
+++ b/packages/jsx/src/__tests__/curried-event-handlers.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -46,7 +46,7 @@ describe('curried event handlers in mapArray (#837)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'DragList.tsx', { adapter })
+    const result = compileJSX(source, 'DragList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -82,7 +82,7 @@ describe('curried event handlers in mapArray (#837)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'App.tsx', { adapter })
+    const result = compileJSX(source, 'App.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -127,7 +127,7 @@ describe('curried event handlers in mapArray (#837)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'NestedDragList.tsx', { adapter })
+    const result = compileJSX(source, 'NestedDragList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/destructured-from-props-localconst-value.test.ts
+++ b/packages/jsx/src/__tests__/destructured-from-props-localconst-value.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -44,7 +44,7 @@ describe('destructured-from-props-object → localConstants value rewrite', () =
       }
     `
 
-    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    const result = compileJSX(source, 'Page.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -72,7 +72,7 @@ describe('destructured-from-props-object → localConstants value rewrite', () =
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -97,7 +97,7 @@ describe('destructured-from-props-object → localConstants value rewrite', () =
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''

--- a/packages/jsx/src/__tests__/destructured-from-props-object-template.test.ts
+++ b/packages/jsx/src/__tests__/destructured-from-props-object-template.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -36,7 +36,7 @@ describe('destructured-from-props-object → template rewrite', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    const result = compileJSX(source, 'Page.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/destructured-map-params.test.ts
+++ b/packages/jsx/src/__tests__/destructured-map-params.test.ts
@@ -9,14 +9,14 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { ErrorCodes } from '../errors'
 
 const adapter = new TestAdapter()
 
 function compile(source: string, filename: string) {
-  return compileJSXSync(source, filename, { adapter })
+  return compileJSX(source, filename, { adapter })
 }
 
 function getClientJs(source: string, filename: string): string {

--- a/packages/jsx/src/__tests__/event-callbacks-stateless.test.ts
+++ b/packages/jsx/src/__tests__/event-callbacks-stateless.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
 import { analyzeClientNeeds } from '../ir-to-client-js'
@@ -21,7 +21,7 @@ describe('event callbacks on stateless components', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'SortHeader.tsx', { adapter })
+    const result = compileJSX(source, 'SortHeader.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -36,7 +36,7 @@ describe('event callbacks on stateless components', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'LogButton.tsx', { adapter })
+    const result = compileJSX(source, 'LogButton.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -96,7 +96,7 @@ describe('event callbacks on stateless components', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'StaticLabel.tsx', { adapter })
+    const result = compileJSX(source, 'StaticLabel.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -119,7 +119,7 @@ describe('event callbacks on stateless components', () => {
     // This should produce errors because signals require "use client"
     // The compiler itself doesn't throw, but the adapter will
     expect(() => {
-      compileJSXSync(source, 'Counter.tsx', { adapter })
+      compileJSX(source, 'Counter.tsx', { adapter })
     }).not.toThrow()
 
     // Verify the analyzer detects the issue
@@ -141,7 +141,7 @@ describe('event callbacks on stateless components', () => {
     `
 
     const honoAdapter = new HonoAdapter()
-    const result = compileJSXSync(source, 'SortHeader.tsx', { adapter: honoAdapter })
+    const result = compileJSX(source, 'SortHeader.tsx', { adapter: honoAdapter })
     expect(result.errors).toHaveLength(0)
 
     // Should produce client JS
@@ -166,7 +166,7 @@ describe('event callbacks on stateless components', () => {
 
     const honoAdapter = new HonoAdapter()
     expect(() => {
-      compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
     }).toThrow(/reactive primitives/)
   })
 })

--- a/packages/jsx/src/__tests__/event-delegation-depth-order.test.ts
+++ b/packages/jsx/src/__tests__/event-delegation-depth-order.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -40,7 +40,7 @@ describe('event delegation depth ordering (#774)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Table.tsx', { adapter })
+    const result = compileJSX(source, 'Table.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -81,7 +81,7 @@ describe('event delegation depth ordering (#774)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/event-delegation-loop-param-shadow.test.ts
+++ b/packages/jsx/src/__tests__/event-delegation-loop-param-shadow.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -51,7 +51,7 @@ describe('event delegation must not shadow user loop params (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Graph.tsx', { adapter })
+    const result = compileJSX(source, 'Graph.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -89,7 +89,7 @@ describe('event delegation must not shadow user loop params (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Graph.tsx', { adapter })
+    const result = compileJSX(source, 'Graph.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/hydrate-template.test.ts
+++ b/packages/jsx/src/__tests__/hydrate-template.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -22,7 +22,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -51,7 +51,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -80,7 +80,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+    const result = compileJSX(source, 'Parent.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -121,7 +121,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Dashboard.tsx', { adapter })
+    const result = compileJSX(source, 'Dashboard.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -150,7 +150,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Filtered.tsx', { adapter })
+    const result = compileJSX(source, 'Filtered.tsx', { adapter })
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
@@ -191,7 +191,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Icon.tsx', { adapter })
+    const result = compileJSX(source, 'Icon.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -232,7 +232,7 @@ describe('hydrate() template generation for signal-bearing components', () => {
         return <div className="chart-selected-label">{selectedLabel()}</div>
       }
     `
-    const result = compileJSXSync(source, 'ChartWidget.tsx', { adapter })
+    const result = compileJSX(source, 'ChartWidget.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/inline-type-decl-stripping.test.ts
+++ b/packages/jsx/src/__tests__/inline-type-decl-stripping.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -47,7 +47,7 @@ describe('inline type / interface declarations inside function bodies (#1131)', 
       }
     `
 
-    const result = compileJSXSync(source, 'DeskCanvas.tsx', { adapter })
+    const result = compileJSX(source, 'DeskCanvas.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -78,7 +78,7 @@ describe('inline type / interface declarations inside function bodies (#1131)', 
       }
     `
 
-    const result = compileJSXSync(source, 'Page.tsx', { adapter })
+    const result = compileJSX(source, 'Page.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -111,7 +111,7 @@ describe('inline type / interface declarations inside function bodies (#1131)', 
       }
     `
 
-    const result = compileJSXSync(source, 'Nested.tsx', { adapter })
+    const result = compileJSX(source, 'Nested.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''

--- a/packages/jsx/src/__tests__/ir-conditional-return.test.ts
+++ b/packages/jsx/src/__tests__/ir-conditional-return.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -21,7 +21,7 @@ describe('conditional JSX returns (if-statement)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -48,7 +48,7 @@ describe('conditional JSX returns (if-statement)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Disclosure.tsx', { adapter })
+    const result = compileJSX(source, 'Disclosure.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -75,7 +75,7 @@ describe('conditional JSX returns (if-statement)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Wrapper.tsx', { adapter })
+    const result = compileJSX(source, 'Wrapper.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -102,7 +102,7 @@ describe('top-level ternary return (#968)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'BadgeDemo.tsx', { adapter })
+    const result = compileJSX(source, 'BadgeDemo.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -136,7 +136,7 @@ describe('top-level ternary return (#968)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -156,7 +156,7 @@ describe('top-level ternary return (#968)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Paren.tsx', { adapter })
+    const result = compileJSX(source, 'Paren.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -184,7 +184,7 @@ describe('return-position dispatcher unification (#971)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Guard.tsx', { adapter })
+    const result = compileJSX(source, 'Guard.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const marked = result.files.find(f => f.type === 'markedTemplate')
@@ -213,7 +213,7 @@ describe('return-position dispatcher unification (#971)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Banner.tsx', { adapter })
+    const result = compileJSX(source, 'Banner.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const marked = result.files.find(f => f.type === 'markedTemplate')
@@ -234,7 +234,7 @@ describe('return-position dispatcher unification (#971)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'List.tsx', { adapter })
+    const result = compileJSX(source, 'List.tsx', { adapter })
     // Pre-refactor this threw "No marked template in compile output" because
     // the analyzer's recursion-fallback explicitly skips function bodies, so
     // `jsxReturn` never saw the `<li/>` inside the map callback. The

--- a/packages/jsx/src/__tests__/ir-jsx-props.test.ts
+++ b/packages/jsx/src/__tests__/ir-jsx-props.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import type { IRComponent, IRElement } from '../types'
 
@@ -157,7 +157,7 @@ describe('JSX props (#559)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -181,7 +181,7 @@ describe('JSX props (#559)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -202,7 +202,7 @@ describe('JSX props (#559)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -225,7 +225,7 @@ describe('JSX props (#559)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -250,7 +250,7 @@ describe('JSX props (#559)', () => {
           )
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -275,7 +275,7 @@ describe('JSX props (#559)', () => {
           return <Layout controls={<Button label="ok" />} />
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -293,7 +293,7 @@ describe('JSX props (#559)', () => {
           return <Layout controls={<input type="text" />} />
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -311,7 +311,7 @@ describe('JSX props (#559)', () => {
           return <Layout controls={<div><Button /></div>} />
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -329,7 +329,7 @@ describe('JSX props (#559)', () => {
           return <Layout controls={<Button label="ok" />} />
         }
       `
-      const result = compileJSXSync(source, 'App.tsx', { adapter })
+      const result = compileJSX(source, 'App.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -352,7 +352,7 @@ describe('JSX props (#559)', () => {
           return <div>{props.controls}</div>
         }
       `
-      const result = compileJSXSync(source, 'Layout.tsx', { adapter })
+      const result = compileJSX(source, 'Layout.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/ir-nested-ternary.test.ts
+++ b/packages/jsx/src/__tests__/ir-nested-ternary.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -15,7 +15,7 @@ describe('nested ternary (#495)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'StatusBadge.tsx', { adapter })
+    const result = compileJSX(source, 'StatusBadge.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -36,7 +36,7 @@ describe('nested ternary (#495)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'DeepTernary.tsx', { adapter })
+    const result = compileJSX(source, 'DeepTernary.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -54,7 +54,7 @@ describe('nested ternary (#495)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'StaticNested.tsx', { adapter })
+    const result = compileJSX(source, 'StaticNested.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     // Stateless components produce JSX templates — verify template is generated
@@ -76,7 +76,7 @@ describe('nested ternary (#495)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'AndInBranch.tsx', { adapter })
+    const result = compileJSX(source, 'AndInBranch.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/ir-nullish-coalescing.test.ts
+++ b/packages/jsx/src/__tests__/ir-nullish-coalescing.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -13,7 +13,7 @@ describe('nullish coalescing with JSX (#524)', () => {
       export { Separator }
     `
 
-    const result = compileJSXSync(source, 'Separator.tsx', { adapter })
+    const result = compileJSX(source, 'Separator.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find(f => f.type === 'markedTemplate')
@@ -32,7 +32,7 @@ describe('nullish coalescing with JSX (#524)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Fallback.tsx', { adapter })
+    const result = compileJSX(source, 'Fallback.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -52,7 +52,7 @@ describe('nullish coalescing with JSX (#524)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Nested.tsx', { adapter })
+    const result = compileJSX(source, 'Nested.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -72,7 +72,7 @@ describe('nullish coalescing with JSX (#524)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -89,7 +89,7 @@ describe('nullish coalescing with JSX (#524)', () => {
       export { Label }
     `
 
-    const result = compileJSXSync(source, 'Label.tsx', { adapter })
+    const result = compileJSX(source, 'Label.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find(f => f.type === 'markedTemplate')

--- a/packages/jsx/src/__tests__/ir-parent-owned-slots.test.ts
+++ b/packages/jsx/src/__tests__/ir-parent-owned-slots.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -86,7 +86,7 @@ describe('parent-owned slots (^ prefix)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Parent.tsx', { adapter })
+    const result = compileJSX(source, 'Parent.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/ir-provider.test.ts
+++ b/packages/jsx/src/__tests__/ir-provider.test.ts
@@ -5,7 +5,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -111,7 +111,7 @@ describe('Context.Provider JSX', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'DropdownMenu.tsx', { adapter })
+    const result = compileJSX(source, 'DropdownMenu.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -224,7 +224,7 @@ describe('Context.Provider JSX', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -253,7 +253,7 @@ describe('Context.Provider JSX', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Root.tsx', { adapter })
+    const result = compileJSX(source, 'Root.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!
@@ -283,7 +283,7 @@ describe('Context.Provider JSX', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Tabs.tsx', { adapter })
+    const result = compileJSX(source, 'Tabs.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!

--- a/packages/jsx/src/__tests__/jsx-constant-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-constant-inlining.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -185,7 +185,7 @@ describe('JSX constant inlining (#547)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -208,7 +208,7 @@ describe('JSX constant inlining (#547)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -238,7 +238,7 @@ describe('JSX constant inlining (#547)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Calendar.tsx', { adapter })
+      const result = compileJSX(source, 'Calendar.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 

--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -335,7 +335,7 @@ describe('JSX function inlining (#569)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -358,7 +358,7 @@ describe('JSX function inlining (#569)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'MyComponent.tsx', { adapter })
+      const result = compileJSX(source, 'MyComponent.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 
@@ -407,7 +407,7 @@ describe('JSX function inlining (#569)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Calendar.tsx', { adapter })
+      const result = compileJSX(source, 'Calendar.tsx', { adapter })
 
       expect(result.errors).toHaveLength(0)
 

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -26,13 +26,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/map-ternary-body.test.ts
+++ b/packages/jsx/src/__tests__/map-ternary-body.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -39,7 +39,7 @@ describe('.map() with ternary body', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Nav.tsx', { adapter })
+    const result = compileJSX(source, 'Nav.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find((f) => f.type === 'markedTemplate')
@@ -66,7 +66,7 @@ describe('.map() with ternary body', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Names.tsx', { adapter })
+    const result = compileJSX(source, 'Names.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     // Sanity: still compiles. No specific shape assertion — the JSX-element
     // body case is already valid without wrapping; this just guards against

--- a/packages/jsx/src/__tests__/missing-key-in-list.test.ts
+++ b/packages/jsx/src/__tests__/missing-key-in-list.test.ts
@@ -10,14 +10,14 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { ErrorCodes } from '../errors'
 
 const adapter = new TestAdapter()
 
 function compile(source: string, filename = 'Test.tsx') {
-  return compileJSXSync(source, filename, { adapter })
+  return compileJSX(source, filename, { adapter })
 }
 
 function errorsFor(code: string, source: string) {

--- a/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
+++ b/packages/jsx/src/__tests__/multi-return-jsx-helper.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -38,7 +38,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Shell.tsx', { adapter })
+    const result = compileJSX(source, 'Shell.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
@@ -67,7 +67,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Panel.tsx', { adapter })
+    const result = compileJSX(source, 'Panel.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
@@ -88,7 +88,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Host.tsx', { adapter })
+    const result = compileJSX(source, 'Host.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
@@ -113,7 +113,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
         return <button onClick={() => setOpen(!open())}>toggle</button>
       }
     `
-    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
@@ -132,7 +132,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Lister.tsx', { adapter })
+    const result = compileJSX(source, 'Lister.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')!.content
@@ -158,7 +158,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
 
       export { ButtonGroupText }
     `
-    const result = compileJSXSync(source, 'button-group.tsx', { adapter })
+    const result = compileJSX(source, 'button-group.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
     expect(markedTemplate).toBeDefined()
@@ -174,7 +174,7 @@ describe('Multi-return JSX helper preservation (#932)', () => {
         return <div>{children}</div>
       }
     `
-    const result = compileJSXSync(source, 'button-group.tsx', { adapter })
+    const result = compileJSX(source, 'button-group.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const markedTemplate = result.files.find(f => f.type === 'markedTemplate')
     expect(markedTemplate).toBeDefined()

--- a/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
+++ b/packages/jsx/src/__tests__/named-export-block-preservation.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getMarkedTemplate(source: string): string {
-  const result = compileJSXSync(source, 'index.tsx', { adapter })
+  const result = compileJSX(source, 'index.tsx', { adapter })
   expect(result.errors).toHaveLength(0)
   const out = result.files.find(f => f.type === 'markedTemplate')
   expect(out).toBeDefined()

--- a/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-conditional.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -54,7 +54,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'FileBrowser.tsx', { adapter })
+    const result = compileJSX(source, 'FileBrowser.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -113,7 +113,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'SocialFeed.tsx', { adapter })
+    const result = compileJSX(source, 'SocialFeed.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -168,7 +168,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'App.tsx', { adapter })
+    const result = compileJSX(source, 'App.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -209,7 +209,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'ToggleList.tsx', { adapter })
+    const result = compileJSX(source, 'ToggleList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -265,7 +265,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'InlineEditTable.tsx', { adapter })
+    const result = compileJSX(source, 'InlineEditTable.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -330,7 +330,7 @@ describe('nested loops/conditionals inside mapArray (#830, #839)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'FileBrowser.tsx', { adapter })
+    const result = compileJSX(source, 'FileBrowser.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/nested-loop-plain.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-plain.test.ts
@@ -40,7 +40,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -73,7 +73,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'GroupedList.tsx', { adapter })
+    const result = compileJSX(source, 'GroupedList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -121,7 +121,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'GroupedList.tsx', { adapter })
+    const result = compileJSX(source, 'GroupedList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -174,7 +174,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'T.tsx', { adapter })
+    const result = compileJSX(source, 'T.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -216,7 +216,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    const result = compileJSX(source, 'L.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -262,7 +262,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'GridDemo.tsx', { adapter })
+    const result = compileJSX(source, 'GridDemo.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -324,7 +324,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'StaticGrid.tsx', { adapter })
+    const result = compileJSX(source, 'StaticGrid.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -375,7 +375,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'FlatList.tsx', { adapter })
+    const result = compileJSX(source, 'FlatList.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -427,7 +427,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'OuterPreambleGrid.tsx', { adapter })
+    const result = compileJSX(source, 'OuterPreambleGrid.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 
@@ -476,7 +476,7 @@ describe('plain nested loops without conditional wrapper', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'MixedGrid.tsx', { adapter })
+    const result = compileJSX(source, 'MixedGrid.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
 

--- a/packages/jsx/src/__tests__/non-bubbling-event-delegation.test.ts
+++ b/packages/jsx/src/__tests__/non-bubbling-event-delegation.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -33,7 +33,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'HoverList.tsx', { adapter })
+    const result = compileJSX(source, 'HoverList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -63,7 +63,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'HoverList.tsx', { adapter })
+    const result = compileJSX(source, 'HoverList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -96,7 +96,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'PointerList.tsx', { adapter })
+    const result = compileJSX(source, 'PointerList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -129,7 +129,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'PointerList.tsx', { adapter })
+    const result = compileJSX(source, 'PointerList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -162,7 +162,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ClickList.tsx', { adapter })
+    const result = compileJSX(source, 'ClickList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -196,7 +196,7 @@ describe('non-bubbling event delegation (#852)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'FocusList.tsx', { adapter })
+    const result = compileJSX(source, 'FocusList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/primitive-resolver-all.test.ts
+++ b/packages/jsx/src/__tests__/primitive-resolver-all.test.ts
@@ -12,7 +12,7 @@ import { describe, test, expect } from 'bun:test'
 import path from 'path'
 import ts from 'typescript'
 import { analyzeComponent } from '../index'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const CLIENT_DIR = path.resolve(__dirname, '../../../client/src')
@@ -129,7 +129,7 @@ describe('createEffect — resolver migration', () => {
         return <button onClick={() => dispose()}>{n()}</button>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter: new TestAdapter() })
+    const result = compileJSX(source, 'Counter.tsx', { adapter: new TestAdapter() })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/prop-references.test.ts
+++ b/packages/jsx/src/__tests__/prop-references.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import type { IRExpression, IRConditional } from '../types'
 
@@ -225,7 +225,7 @@ describe('ClientJS generation with semantic prop refs', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -251,7 +251,7 @@ describe('ClientJS generation with semantic prop refs', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -275,7 +275,7 @@ describe('ClientJS generation with semantic prop refs', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -300,7 +300,7 @@ describe('ClientJS generation with semantic prop refs', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dialog.tsx', { adapter })
+    const result = compileJSX(source, 'Dialog.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
 
@@ -326,7 +326,7 @@ describe('Issue #257 regression', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'CommandDisplay.tsx', { adapter })
+    const result = compileJSX(source, 'CommandDisplay.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -356,7 +356,7 @@ describe('Issue #807 regression', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Example.tsx', { adapter })
+    const result = compileJSX(source, 'Example.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -385,7 +385,7 @@ describe('Issue #807 regression', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Example.tsx', { adapter })
+    const result = compileJSX(source, 'Example.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -415,7 +415,7 @@ describe('Issue #807 regression', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Example.tsx', { adapter })
+    const result = compileJSX(source, 'Example.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -439,7 +439,7 @@ describe('Issue #807 regression', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Separator.tsx', { adapter })
+    const result = compileJSX(source, 'Separator.tsx', { adapter })
 
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -30,7 +30,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'TagList.tsx', { adapter })
+    const result = compileJSX(source, 'TagList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -59,7 +59,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+    const result = compileJSX(source, 'ItemList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -86,7 +86,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'DynamicTagList.tsx', { adapter })
+    const result = compileJSX(source, 'DynamicTagList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -118,7 +118,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'TagList.tsx', { adapter })
+    const result = compileJSX(source, 'TagList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -156,7 +156,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'PivotTable.tsx', { adapter })
+    const result = compileJSX(source, 'PivotTable.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -192,7 +192,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'SimpleList.tsx', { adapter })
+    const result = compileJSX(source, 'SimpleList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -225,7 +225,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    const result = compileJSX(source, 'L.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const js = result.files.find(f => f.type === 'clientJs')!.content
     // Both effects must still be present.
@@ -261,7 +261,7 @@ describe('reactive attributes inside .map() callbacks', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    const result = compileJSX(source, 'L.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -41,7 +41,7 @@ describe('Reactive factory inlining (#931)', () => {
     expect(ctx.signals[0].getter).toBe('count')
     expect(ctx.signals[0].setter).toBe('setCount')
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')
     expect(clientJs).toBeDefined()
@@ -75,7 +75,7 @@ describe('Reactive factory inlining (#931)', () => {
     expect(ctx.signals.length).toBe(1)
     expect(ctx.signals[0].getter).toBe('value')
 
-    const result = compileJSXSync(source, 'Store.tsx', { adapter })
+    const result = compileJSX(source, 'Store.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
     // The body's custom setter should be emitted as a regular constant
@@ -106,7 +106,7 @@ describe('Reactive factory inlining (#931)', () => {
     const getters = ctx.signals.map(s => s.getter).sort()
     expect(getters).toEqual(['a', 'b'])
 
-    const result = compileJSXSync(source, 'Pair.tsx', { adapter })
+    const result = compileJSX(source, 'Pair.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
     // Both destructures should resolve to independent signals.
@@ -129,7 +129,7 @@ describe('Reactive factory inlining (#931)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
     // The argument expression must flow into the createSignal call.
@@ -148,7 +148,7 @@ describe('Reactive factory inlining (#931)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Gadget.tsx', { adapter })
+    const result = compileJSX(source, 'Gadget.tsx', { adapter })
     const bf110 = result.errors.find(e => e.code === 'BF110')
     expect(bf110).toBeDefined()
     expect(bf110!.message).toContain('useExternal')
@@ -170,7 +170,7 @@ describe('Reactive factory inlining (#931)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     const bf110 = result.errors.find(e => e.code === 'BF110')
     expect(bf110).toBeUndefined()
   })
@@ -187,7 +187,7 @@ describe('Reactive factory inlining (#931)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Comp.tsx', { adapter })
+    const result = compileJSX(source, 'Comp.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const bf110 = result.errors.find(e => e.code === 'BF110')
     expect(bf110).toBeUndefined()

--- a/packages/jsx/src/__tests__/ref-prop-optional.test.ts
+++ b/packages/jsx/src/__tests__/ref-prop-optional.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -29,7 +29,7 @@ describe('ref={...} emit shape (#1161)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -59,7 +59,7 @@ describe('ref={...} emit shape (#1161)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -80,7 +80,7 @@ describe('ref={...} emit shape (#1161)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''
@@ -108,7 +108,7 @@ describe('ref={...} emit shape (#1161)', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Foo.tsx', { adapter })
+    const result = compileJSX(source, 'Foo.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find((f) => f.type === 'clientJs')
     const content = clientJs?.content ?? ''

--- a/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/runtime-fallback-wrap.test.ts
@@ -18,13 +18,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function getClientJs(source: string, filename: string): string {
-  const result = compileJSXSync(source, filename, { adapter })
+  const result = compileJSX(source, filename, { adapter })
   expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   const clientJs = result.files.find(f => f.type === 'clientJs')
   expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
+++ b/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { ErrorCodes } from '../errors'
 import { TestAdapter } from '../adapters/test-adapter'
 
@@ -248,7 +248,7 @@ describe('Signal Getter Not Called (BF044)', () => {
       expect(ir!.type).toBe('element')
     })
 
-    test('compileJSXSync includes BF044 in result errors', () => {
+    test('compileJSX includes BF044 in result errors', () => {
       const source = `
         'use client'
         import { createSignal } from '@barefootjs/client'
@@ -259,7 +259,7 @@ describe('Signal Getter Not Called (BF044)', () => {
         }
       `
 
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       const bf044 = result.errors.filter(e => e.code === ErrorCodes.SIGNAL_GETTER_NOT_CALLED)
 
       expect(bf044).toHaveLength(1)

--- a/packages/jsx/src/__tests__/signal-index-access.test.ts
+++ b/packages/jsx/src/__tests__/signal-index-access.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -28,7 +28,7 @@ describe('signal index-access — pattern A (direct)', () => {
         return <div>{count()}</div>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -50,7 +50,7 @@ describe('signal index-access — pattern A (direct)', () => {
         return <button onClick={() => setCount(1)}>bump</button>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -70,7 +70,7 @@ describe('signal index-access — pattern A (direct)', () => {
         return <span>{label()}</span>
       }
     `
-    const result = compileJSXSync(source, 'Display.tsx', { adapter })
+    const result = compileJSX(source, 'Display.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find((f) => f.type === 'markedTemplate')
@@ -92,7 +92,7 @@ describe('signal index-access — pattern C (late extraction)', () => {
         return <div>{count()}</div>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -116,7 +116,7 @@ describe('signal index-access — pattern C (late extraction)', () => {
         return <button onClick={() => setCount(count() + 1)}>{count()}</button>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -136,7 +136,7 @@ describe('signal index-access — pattern C (late extraction)', () => {
         return <button onClick={() => setCount(count() + 1)}>{count()}</button>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -156,7 +156,7 @@ describe('signal index-access — pattern C (late extraction)', () => {
         return <div>{count()} {first}</div>
       }
     `
-    const result = compileJSXSync(source, 'Things.tsx', { adapter })
+    const result = compileJSX(source, 'Things.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')
@@ -182,7 +182,7 @@ describe('signal index-access — mixed patterns in one component', () => {
         return <div>{a()} {b()} {c()} <button onClick={() => setA(a() + 1)}>+</button></div>
       }
     `
-    const result = compileJSXSync(source, 'Mixed.tsx', { adapter })
+    const result = compileJSX(source, 'Mixed.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find((f) => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/signal-partial-destructure.test.ts
+++ b/packages/jsx/src/__tests__/signal-partial-destructure.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -28,7 +28,7 @@ describe('signal partial destructuring (getter only)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'ReadOnlyList.tsx', { adapter })
+    const result = compileJSX(source, 'ReadOnlyList.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
   })
 
@@ -42,7 +42,7 @@ describe('signal partial destructuring (getter only)', () => {
         return <div>{count()}</div>
       }
     `
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -64,7 +64,7 @@ describe('signal partial destructuring (getter only)', () => {
         return <span>{label()}</span>
       }
     `
-    const result = compileJSXSync(source, 'Display.tsx', { adapter })
+    const result = compileJSX(source, 'Display.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const template = result.files.find(f => f.type === 'markedTemplate')
@@ -84,7 +84,7 @@ describe('signal partial destructuring (getter only)', () => {
         return <div>{total()}</div>
       }
     `
-    const result = compileJSXSync(source, 'Summary.tsx', { adapter })
+    const result = compileJSX(source, 'Summary.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/source-maps.test.ts
+++ b/packages/jsx/src/__tests__/source-maps.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { SourceMapGenerator, buildSourceMapFromIR } from '../ir-to-client-js/source-map'
 import { analyzeComponent } from '../analyzer'
@@ -48,7 +48,7 @@ describe('VLQ encoding', () => {
 })
 
 describe('Source map generation via compiler', () => {
-  test('compileJSXSync with sourceMaps: true produces source map file', () => {
+  test('compileJSX with sourceMaps: true produces source map file', () => {
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -63,7 +63,7 @@ describe('Source map generation via compiler', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter, sourceMaps: true })
+    const result = compileJSX(source, 'Counter.tsx', { adapter, sourceMaps: true })
 
     expect(result.errors).toHaveLength(0)
 
@@ -81,7 +81,7 @@ describe('Source map generation via compiler', () => {
     expect(map.mappings.length).toBeGreaterThan(0)
   })
 
-  test('compileJSXSync without sourceMaps does not produce source map', () => {
+  test('compileJSX without sourceMaps does not produce source map', () => {
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -92,7 +92,7 @@ describe('Source map generation via compiler', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
 
     const sourceMap = result.files.find(f => f.type === 'sourceMap')
     expect(sourceMap).toBeUndefined()
@@ -114,7 +114,7 @@ describe('Source map generation via compiler', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Counter.tsx', { adapter, sourceMaps: true })
+    const result = compileJSX(source, 'Counter.tsx', { adapter, sourceMaps: true })
 
     const sourceMapFile = result.files.find(f => f.type === 'sourceMap')
     expect(sourceMapFile).toBeDefined()
@@ -139,7 +139,7 @@ describe('Source map generation via compiler', () => {
       }
     `
 
-    const result = compileJSXSync(source, 'Dashboard.tsx', { adapter, sourceMaps: true })
+    const result = compileJSX(source, 'Dashboard.tsx', { adapter, sourceMaps: true })
 
     const sourceMapFile = result.files.find(f => f.type === 'sourceMap')
     expect(sourceMapFile).toBeDefined()

--- a/packages/jsx/src/__tests__/ssr-client-shim-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/ssr-client-shim-rewrite.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
 
@@ -32,7 +32,7 @@ describe('SSR client-shim rewrite (#1084)', () => {
         return <g class="chart-grid">{lines().map((l) => <line key={l.y} y1={l.y} y2={l.y} />)}</g>
       }
     `
-    const result = compileJSXSync(source, 'CartesianGrid.tsx', { adapter: new HonoAdapter() })
+    const result = compileJSX(source, 'CartesianGrid.tsx', { adapter: new HonoAdapter() })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const tpl = result.files.find(f => f.type === 'markedTemplate')!
@@ -58,7 +58,7 @@ describe('SSR client-shim rewrite (#1084)', () => {
     const adapter = new TestAdapter()
     expect((adapter as { clientShimSource?: string }).clientShimSource).toBeUndefined()
 
-    const result = compileJSXSync(source, 'Box.tsx', { adapter })
+    const result = compileJSX(source, 'Box.tsx', { adapter })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const tpl = result.files.find(f => f.type === 'markedTemplate')!
@@ -80,7 +80,7 @@ describe('SSR client-shim rewrite (#1084)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Tabs.tsx', { adapter: new HonoAdapter() })
+    const result = compileJSX(source, 'Tabs.tsx', { adapter: new HonoAdapter() })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const tpl = result.files.find(f => f.type === 'markedTemplate')!
@@ -107,7 +107,7 @@ describe('SSR client-shim rewrite (#1084)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Outer.tsx', { adapter: new HonoAdapter() })
+    const result = compileJSX(source, 'Outer.tsx', { adapter: new HonoAdapter() })
     expect(onlyErrors(result.errors)).toHaveLength(0)
 
     const tpl = result.files.find(f => f.type === 'markedTemplate')!

--- a/packages/jsx/src/__tests__/staged-ir/helpers.ts
+++ b/packages/jsx/src/__tests__/staged-ir/helpers.ts
@@ -1,10 +1,10 @@
 /**
  * Shared helpers for staged-IR fixture tests. Centralizes the
- * `compileJSXSync` + adapter setup and the assertions about emitted
+ * `compileJSX` + adapter setup and the assertions about emitted
  * artifact shapes (template body extraction, init body extraction).
  */
 
-import { compileJSXSync } from '../../compiler'
+import { compileJSX } from '../../compiler'
 import { TestAdapter } from '../../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -17,7 +17,7 @@ export interface CompileResult {
 }
 
 export function compile(source: string, fileName = 'Component.tsx'): CompileResult {
-  const result = compileJSXSync(source, fileName, { adapter })
+  const result = compileJSX(source, fileName, { adapter })
   const clientJs = result.files.find((f) => f.type === 'clientJs')?.content ?? ''
   return {
     clientJs,

--- a/packages/jsx/src/__tests__/sub-component-compilation.test.ts
+++ b/packages/jsx/src/__tests__/sub-component-compilation.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { listComponentFunctions } from '../analyzer'
 import { TestAdapter } from '../adapters/test-adapter'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
@@ -56,7 +56,7 @@ describe('sub-component compilation (#786)', () => {
     })
 
     test('client JS has no raw jsxDEV calls', () => {
-      const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+      const result = compileJSX(source, 'ItemList.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -69,7 +69,7 @@ describe('sub-component compilation (#786)', () => {
 
     test('non-exported component should not have export keyword in Hono template', () => {
       const honoAdapter = new HonoAdapter()
-      const result = compileJSXSync(source, 'ItemList.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'ItemList.tsx', { adapter: honoAdapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')
@@ -83,7 +83,7 @@ describe('sub-component compilation (#786)', () => {
     })
 
     test('non-exported component should not have export keyword in test template', () => {
-      const result = compileJSXSync(source, 'ItemList.tsx', { adapter })
+      const result = compileJSX(source, 'ItemList.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const template = result.files.find(f => f.type === 'markedTemplate')
@@ -124,7 +124,7 @@ describe('sub-component compilation (#786)', () => {
     })
 
     test('client JS has no raw jsxDEV calls', () => {
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -159,7 +159,7 @@ describe('sub-component compilation (#786)', () => {
     `
 
     test('client JS has no raw jsxDEV calls', () => {
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -195,7 +195,7 @@ describe('sub-component compilation (#786)', () => {
     `
 
     test('compiles without errors', () => {
-      const result = compileJSXSync(source, 'StatusDisplay.tsx', { adapter })
+      const result = compileJSX(source, 'StatusDisplay.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -231,7 +231,7 @@ describe('sub-component compilation (#786)', () => {
 
     test('re-exported components have export keyword, non-exported do not', () => {
       const honoAdapter = new HonoAdapter()
-      const result = compileJSXSync(source, 'Counter.tsx', { adapter: honoAdapter })
+      const result = compileJSX(source, 'Counter.tsx', { adapter: honoAdapter })
 
       const template = result.files.find(f => f.type === 'markedTemplate')
       expect(template).toBeDefined()

--- a/packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts
+++ b/packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -27,7 +27,7 @@ describe('SVG attribute kebab-case emission (#135)', () => {
         return <path d="M0 0" strokeWidth={1.5} fillOpacity={0.5} markerEnd="url(#a)" textAnchor="middle" />
       }
     `
-    const result = compileJSXSync(source, 'Edge.tsx', { adapter })
+    const result = compileJSX(source, 'Edge.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -56,7 +56,7 @@ describe('SVG attribute kebab-case emission (#135)', () => {
         return <path d="M0 0" strokeWidth={width()} />
       }
     `
-    const result = compileJSXSync(source, 'Edge.tsx', { adapter })
+    const result = compileJSX(source, 'Edge.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -73,7 +73,7 @@ describe('SVG attribute kebab-case emission (#135)', () => {
         return <div className="foo" />
       }
     `
-    const result = compileJSXSync(source, 'Box.tsx', { adapter })
+    const result = compileJSX(source, 'Box.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -92,7 +92,7 @@ describe('SVG attribute kebab-case emission (#135)', () => {
         return <button tabIndex={0} autoFocus={true}>x</button>
       }
     `
-    const result = compileJSXSync(source, 'Btn.tsx', { adapter })
+    const result = compileJSX(source, 'Btn.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/svg-mapArray-namespace.test.ts
+++ b/packages/jsx/src/__tests__/svg-mapArray-namespace.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
@@ -38,7 +38,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Graph.tsx', { adapter })
+    const result = compileJSX(source, 'Graph.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -73,7 +73,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Pts.tsx', { adapter })
+    const result = compileJSX(source, 'Pts.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -101,7 +101,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'L.tsx', { adapter })
+    const result = compileJSX(source, 'L.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -141,7 +141,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'CondMap.tsx', { adapter })
+    const result = compileJSX(source, 'CondMap.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -181,7 +181,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'PolarGridLike.tsx', { adapter })
+    const result = compileJSX(source, 'PolarGridLike.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -214,7 +214,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Mixed.tsx', { adapter })
+    const result = compileJSX(source, 'Mixed.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')
@@ -245,7 +245,7 @@ describe('SVG mapArray namespace preservation (#135)', () => {
         )
       }
     `
-    const result = compileJSXSync(source, 'Toggle.tsx', { adapter })
+    const result = compileJSX(source, 'Toggle.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')

--- a/packages/jsx/src/__tests__/template-closure.test.ts
+++ b/packages/jsx/src/__tests__/template-closure.test.ts
@@ -12,13 +12,13 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 
 const adapter = new TestAdapter()
 
 function compileClient(source: string, fileName: string): string {
-  const result = compileJSXSync(source, fileName, { adapter })
+  const result = compileJSX(source, fileName, { adapter })
   expect(result.errors).toHaveLength(0)
   const clientJs = result.files.find((f) => f.type === 'clientJs')
   return clientJs?.content ?? ''

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { jsxToIR } from '../jsx-to-ir'
-import { compileJSXSync } from '../compiler'
+import { compileJSX } from '../compiler'
 import { ErrorCodes } from '../errors'
 import { TestAdapter } from '../adapters/test-adapter'
 
@@ -125,8 +125,8 @@ describe('Unsupported Expression Error (BF021)', () => {
     expect(ir!.type).toBe('element')
   })
 
-  test('compileJSXSync includes IR-phase BF021 errors in result', () => {
-    const result = compileJSXSync(unsupportedSource, 'TodoList.tsx', { adapter })
+  test('compileJSX includes IR-phase BF021 errors in result', () => {
+    const result = compileJSX(unsupportedSource, 'TodoList.tsx', { adapter })
     const bf021 = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
 
     expect(bf021).toHaveLength(1)

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -96,139 +96,10 @@ function applyExportKeyword(component: string, ir: ComponentIR): string {
 }
 
 // =============================================================================
-// Main Entry Point
-// =============================================================================
-
-export async function compileJSX(
-  entryPath: string,
-  readFile: (path: string) => Promise<string>,
-  options: CompileOptionsWithAdapter
-): Promise<CompileResult> {
-  const files: FileOutput[] = []
-  const errors: CompileResult['errors'] = []
-
-  // Read source file
-  const source = await readFile(entryPath)
-
-  // List all exported components in the file
-  const componentNames = listComponentFunctions(source, entryPath)
-
-  // If multiple components, compile each separately and combine
-  if (componentNames.length > 1) {
-    return compileMultipleComponents(source, entryPath, componentNames, options)
-  }
-
-  // Single component flow
-  const ctx = analyzeComponent(source, entryPath, undefined, options.program)
-
-  if (!ctx.jsxReturn) {
-    errors.push(...ctx.errors)  // Only analyzer errors
-    return { files, errors }
-  }
-
-  const ir = jsxToIR(ctx)
-  errors.push(...ctx.errors)  // All errors: analyzer + IR phase
-
-  if (!ir) {
-    return { files, errors }
-  }
-
-  const componentIR: ComponentIR = {
-    version: '0.1',
-    metadata: buildMetadata(ctx, options.adapter.clientShimSource),
-    root: ir,
-    errors: [],
-  }
-
-  // Pre-compute client JS analysis for adapter optimization
-  componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
-
-  // Apply CSS layer prefix if configured
-  if (options.cssLayerPrefix) {
-    applyCssLayerPrefix(componentIR, options.cssLayerPrefix)
-  }
-
-  if (options?.outputIR) {
-    files.push({
-      path: entryPath.replace(/\.tsx?$/, '.ir.json'),
-      content: JSON.stringify(componentIR, null, 2),
-      type: 'ir',
-    })
-  }
-
-  const adapter = options.adapter
-  const adapterOutput = adapter.generate(componentIR)
-  const moduleExports = generateModuleExports(componentIR)
-
-  // Use structured sections if available, otherwise fall back to template
-  let content: string
-  if (adapterOutput.sections) {
-    const s = adapterOutput.sections
-    const component = applyExportKeyword(s.component, componentIR)
-    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, component]
-      .filter(Boolean).join('\n\n') + (s.defaultExport || '')
-  } else {
-    content = adapterOutput.template
-  }
-
-  files.push({
-    path: entryPath.replace(/\.tsx?$/, adapter.extension),
-    content,
-    type: 'markedTemplate',
-  })
-
-  // Emit adapter types as a separate FileOutput
-  if (adapterOutput.types) {
-    files.push({
-      path: entryPath.replace(/\.tsx?$/, '.types'),
-      content: adapterOutput.types,
-      type: 'types',
-    })
-  }
-
-  const clientJsPath = entryPath.replace(/\.tsx?$/, '.client.js')
-  // Single-component file: only the component itself can collide. Scope it
-  // when it's non-exported so a private helper can't be overwritten by an
-  // identically-named exported component in another file.
-  const singleScope = {
-    fileScope: computeFileScope(entryPath),
-    nonExportedSiblings: componentIR.metadata.isExported
-      ? new Set<string>()
-      : new Set([componentIR.metadata.componentName]),
-  }
-  setActiveComponentScope(singleScope)
-  try {
-    if (options.sourceMaps) {
-      const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {
-        sourceMaps: true,
-        generatedFileName: clientJsPath.split('/').pop(),
-      })
-      errors.push(...componentIR.errors)
-      if (result.code) {
-        files.push({ path: clientJsPath, content: result.code, type: 'clientJs' })
-        if (result.sourceMap) {
-          files.push({ path: clientJsPath + '.map', content: JSON.stringify(result.sourceMap), type: 'sourceMap' as FileOutput['type'] })
-        }
-      }
-    } else {
-      const clientJs = generateClientJs(componentIR, undefined, options.localImportPrefixes)
-      errors.push(...componentIR.errors)
-      if (clientJs) {
-        files.push({ path: clientJsPath, content: clientJs, type: 'clientJs' })
-      }
-    }
-  } finally {
-    setActiveComponentScope(null)
-  }
-
-  return { files, errors }
-}
-
-// =============================================================================
 // Multiple Component Compilation
 // =============================================================================
 
-function compileMultipleComponentsSync(
+function compileMultipleComponents(
   source: string,
   filePath: string,
   componentNames: string[],
@@ -564,15 +435,6 @@ function compileMultipleComponentsSync(
   return { files, errors }
 }
 
-async function compileMultipleComponents(
-  source: string,
-  filePath: string,
-  componentNames: string[],
-  options: CompileOptionsWithAdapter
-): Promise<CompileResult> {
-  return compileMultipleComponentsSync(source, filePath, componentNames, options)
-}
-
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -606,10 +468,10 @@ export function buildMetadata(
 }
 
 // =============================================================================
-// Sync Version (for compatibility)
+// Main Entry Point
 // =============================================================================
 
-export function compileJSXSync(
+export function compileJSX(
   source: string,
   filePath: string,
   options: CompileOptionsWithAdapter
@@ -622,7 +484,7 @@ export function compileJSXSync(
 
   // If multiple components, compile each separately and combine
   if (componentNames.length > 1) {
-    return compileMultipleComponentsSync(source, filePath, componentNames, options)
+    return compileMultipleComponents(source, filePath, componentNames, options)
   }
 
   // Single component flow
@@ -694,13 +556,16 @@ export function compileJSXSync(
   }
 
   const clientJsPath = filePath.replace(/\.tsx?$/, '.client.js')
-  const syncSingleScope = {
+  // Single-component file: only the component itself can collide. Scope it
+  // when it's non-exported so a private helper can't be overwritten by an
+  // identically-named exported component in another file.
+  const singleScope = {
     fileScope: computeFileScope(filePath),
     nonExportedSiblings: componentIR.metadata.isExported
       ? new Set<string>()
       : new Set([componentIR.metadata.componentName]),
   }
-  setActiveComponentScope(syncSingleScope)
+  setActiveComponentScope(singleScope)
   try {
     if (options.sourceMaps) {
       const result = generateClientJsWithSourceMap(componentIR, undefined, options.localImportPrefixes, {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Main compiler API
-export { compileJSX, compileJSXSync, buildMetadata } from './compiler'
+export { compileJSX, buildMetadata } from './compiler'
 export type { CompileResult, CompileOptions, CompileOptionsWithAdapter, FileOutput } from './compiler'
 
 // Pure IR types

--- a/packages/preview/src/compile.ts
+++ b/packages/preview/src/compile.ts
@@ -91,9 +91,7 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     const sourceContent = await Bun.file(entryPath).text()
     if (!hasUseClientDirective(sourceContent)) continue
 
-    const result = await compileJSX(entryPath, async (path) => {
-      return await Bun.file(path).text()
-    }, { adapter })
+    const result = compileJSX(sourceContent, entryPath, { adapter })
 
     const errors = result.errors.filter(e => e.severity === 'error')
     const warnings = result.errors.filter(e => e.severity === 'warning')

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -89,9 +89,7 @@ for (const entryPath of componentFiles) {
   const sourceContent = await Bun.file(entryPath).text()
   if (!hasUseClientDirective(sourceContent)) continue
 
-  const result = await compileJSX(entryPath, async (path) => {
-    return await Bun.file(path).text()
-  }, { adapter })
+  const result = compileJSX(sourceContent, entryPath, { adapter })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   const warnings = result.errors.filter(e => e.severity === 'warning')

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -227,9 +227,7 @@ for (const entryPath of componentFiles) {
   const isSharedComponent = entryPath.startsWith(SHARED_COMPONENTS_DIR)
   const rootDir = isUiComponent ? UI_COMPONENTS_DIR : isSharedComponent ? SHARED_COMPONENTS_DIR : DOCS_COMPONENTS_DIR
 
-  const result = await compileJSX(entryPath, async (path) => {
-    return await Bun.file(path).text()
-  }, {
+  const result = compileJSX(sourceContent, entryPath, {
     adapter,
     cssLayerPrefix: isUiComponent ? 'components' : undefined,
     localImportPrefixes: ['@/', '@ui/'],

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -507,7 +507,7 @@ Each example's `playwright.config.ts` configures the webServer command, port, an
 
 ```typescript
 // ❌ Couples compiler test to adapter output format
-const result = compileJSXSync(source, { adapter: new HonoAdapter() })
+const result = compileJSX(source, { adapter: new HonoAdapter() })
 expect(result.files[0].content).toContain('<button onclick={handleClick}>')
 
 // ✅ Test IR structure instead (adapter-independent)


### PR DESCRIPTION
## Summary

`compileJSX` (async, `entryPath` + readFile callback) and `compileJSXSync` (sync, source string) had identical pipelines — the async wrapper existed only to await a `readFile` callback that none of the production callers actually needed (every caller already had the source in memory before invoking the compiler).

This PR drops the async overload, renames `compileJSXSync` → `compileJSX` (`(source, filePath, options)`), and removes the now-unused `compileMultipleComponents` async wrapper.

## Changes

- `packages/jsx/src/compiler.ts` — single sync `compileJSX`; the async overload and `compileMultipleComponentsSync` rename are gone (~140 LOC removed)
- `packages/jsx/src/index.ts` — drop `compileJSXSync` from the public API
- `packages/cli/src/lib/build.ts`, `packages/preview/src/compile.ts`, `site/{ui,core}/build.ts` — pass the already-read source instead of a readFile callback
- Bulk rename across tests + adapter test renderers + bench + docs

## Breaking change

`compileJSXSync` is removed; consumers should call `compileJSX(source, filePath, options)` synchronously. The async `(entryPath, readFile, options)` overload is also gone — callers should `await readFile(path)` themselves and pass the source.

## Test plan

- [x] `bunx tsc --noEmit` in `packages/jsx` — clean
- [x] `bun test` in `packages/{jsx,adapter-hono,adapter-go-template,adapter-mojolicious,adapter-tests,cli,client}` — all pass (1997 tests across affected packages)
- [x] `bun run build` (root + `site/ui`) — builds succeed


---
_Generated by [Claude Code](https://claude.ai/code/session_0159Xqu33ZfL9ZE3Qs25QrkT)_