### PR TITLE
refactor(cli): typed `select` cancellation + nit cleanup

### DIFF
--- a/packages/cli/src/__tests__/select.test.ts
+++ b/packages/cli/src/__tests__/select.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { select } from '../lib/select'
+import { select, SelectCancelled } from '../lib/select'
 
 // The interactive arrow-key path is hard to drive in unit tests (it
 // expects a raw-mode TTY); these tests pin the deterministic
@@ -64,5 +64,22 @@ describe('select short-circuit behavior', () => {
       output: fakeOutput,
     })
     expect(result).toBe('fallback')
+  })
+})
+
+describe('SelectCancelled', () => {
+  test('is an Error subclass with a typed name', () => {
+    const cancelled = new SelectCancelled('sigint')
+    expect(cancelled).toBeInstanceOf(Error)
+    expect(cancelled.name).toBe('SelectCancelled')
+    // Reason ends up in the message so log output includes it.
+    expect(cancelled.message).toContain('sigint')
+  })
+
+  test('distinguishes a user cancel from other errors via instanceof', () => {
+    const generic: unknown = new Error('boom')
+    const cancelled: unknown = new SelectCancelled('escape')
+    expect(generic instanceof SelectCancelled).toBe(false)
+    expect(cancelled instanceof SelectCancelled).toBe(true)
   })
 })

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,7 +16,7 @@ import {
   type AdapterTemplate,
 } from '../lib/templates'
 import { detectPackageManager, commandsFor, type PackageManager } from '../lib/pm'
-import { select } from '../lib/select'
+import { select, SelectCancelled } from '../lib/select'
 
 interface InitFlags {
   name?: string
@@ -102,8 +102,8 @@ async function resolveAdapter(flag: string | undefined): Promise<string> {
   const options = Object.entries(ADAPTERS).map(([value, t]) => ({ value, label: t.label }))
   try {
     return await select({ message: 'Choose an adapter:', options, defaultValue: DEFAULT_ADAPTER })
-  } catch {
-    process.exit(1)
+  } catch (err) {
+    bailOnSelectError(err)
   }
 }
 
@@ -119,9 +119,29 @@ async function resolveCssLibrary(flag: string | undefined): Promise<string> {
   const options = Object.entries(CSS_LIBRARIES).map(([value, t]) => ({ value, label: t.label }))
   try {
     return await select({ message: 'Choose a CSS library:', options, defaultValue: DEFAULT_CSS_LIBRARY })
-  } catch {
-    process.exit(1)
+  } catch (err) {
+    bailOnSelectError(err)
   }
+}
+
+/**
+ * Centralised exit path for the interactive selector. A user-driven
+ * cancel (`SelectCancelled`) reads as a calm "nothing scaffolded"
+ * message, while anything else (lost stdin, render error, ...) gets
+ * surfaced with its underlying message so the failure mode is
+ * actually debuggable.
+ *
+ * Returns `never` so callers can use it as the catch-block tail
+ * without TypeScript complaining about a missing return.
+ */
+function bailOnSelectError(err: unknown): never {
+  if (err instanceof SelectCancelled) {
+    console.error('Cancelled — nothing scaffolded.')
+  } else {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(`Error during interactive selection: ${msg}`)
+  }
+  process.exit(1)
 }
 
 async function probeRegistry(url: string): Promise<void> {

--- a/packages/cli/src/lib/select.ts
+++ b/packages/cli/src/lib/select.ts
@@ -1,11 +1,28 @@
 // Tiny arrow-key selector for interactive CLI prompts.
 //
 // Renders a list, lets the user move with ↑/↓ (or k/j) and confirm with
-// Enter. Cancels with Ctrl-C / Esc. Falls back to returning the default
-// value when stdin is not a TTY (e.g. piped input or CI), so callers can
-// safely use this in non-interactive contexts.
+// Enter. Cancels with Ctrl-C / Esc, surfacing a `SelectCancelled`
+// rejection so callers can distinguish a user abort from a real error.
+//
+// Falls back to returning the default value when **either** stdin or
+// stdout is not a TTY (piped input, CI, redirected output) — arrow-key
+// navigation has no rendering surface in those contexts, and any
+// callers that want a deterministic value get one without hanging.
 
 import readline from 'node:readline'
+
+/**
+ * Thrown (well, rejected) by `select()` when the user dismisses the
+ * prompt with Ctrl-C or Esc. Callers catching `select()`'s Promise
+ * can `instanceof`-check this to tell a deliberate cancel from a
+ * real failure (lost stdin, render error, etc.).
+ */
+export class SelectCancelled extends Error {
+  constructor(reason: 'sigint' | 'escape') {
+    super(`select cancelled by user (${reason})`)
+    this.name = 'SelectCancelled'
+  }
+}
 
 export interface SelectOption<T extends string = string> {
   value: T
@@ -38,8 +55,11 @@ export async function select<T extends string = string>(args: SelectArgs<T>): Pr
     return args.defaultValue
   }
 
-  const startIdx = Math.max(0, args.options.findIndex(o => o.value === args.defaultValue))
-  let cursor = startIdx === -1 ? 0 : startIdx
+  // `findIndex` returns -1 when the default isn't in the list; fall
+  // back to the first option in that case so the cursor still has a
+  // legal starting position.
+  const defaultIdx = args.options.findIndex(o => o.value === args.defaultValue)
+  let cursor = defaultIdx === -1 ? 0 : defaultIdx
 
   const render = (firstPaint: boolean): void => {
     if (!firstPaint) {
@@ -63,6 +83,9 @@ export async function select<T extends string = string>(args: SelectArgs<T>): Pr
     input.setRawMode?.(true)
     input.resume()
 
+    // Invariant: every resolve / reject path in this Promise must
+    // call `cleanup()` first so we never leave the input in raw mode
+    // or leak the keypress listener.
     const cleanup = (): void => {
       input.setRawMode?.(false)
       input.pause()
@@ -75,13 +98,13 @@ export async function select<T extends string = string>(args: SelectArgs<T>): Pr
         cleanup()
         // Mimic shell SIGINT: blank line, then bail.
         output.write('\n')
-        reject(new Error('cancelled'))
+        reject(new SelectCancelled('sigint'))
         return
       }
       if (key.name === 'escape') {
         cleanup()
         output.write('\n')
-        reject(new Error('cancelled'))
+        reject(new SelectCancelled('escape'))
         return
       }
       if (key.name === 'up' || key.name === 'k') {


### PR DESCRIPTION
## Summary

Follow-ups from the PR #1174 review pass. Three small nits in
`packages/cli/src/lib/select.ts` and one matching wiring change in
`init.ts`. None of these change observable behaviour for a successful
prompt — they're readability / future-proofing improvements.

- **Typed cancellation.** Replaces `reject(new Error('cancelled'))`
  with a dedicated `class SelectCancelled extends Error` carrying the
  reason (`'sigint' | 'escape'`). `init.ts` centralises its catch
  path in `bailOnSelectError(err): never`:
  - User-driven cancel (`SelectCancelled`) → calm
    `Cancelled — nothing scaffolded.` and exit 1.
  - Anything else (lost stdin, render error, ...) → surfaces the
    underlying message so the failure mode is actually debuggable.
- **Dead-code prune.** Drops the `startIdx === -1` branch that was
  unreachable after `Math.max(0, findIndex(...))`. Replaces with a
  direct `findIndex` + `-1` fallback.
- **Comment sharpening.** The `select()` header now spells out that
  *both* `stdin` and `stdout` need to be a TTY — the original wording
  only mentioned stdin even though the short-circuit checks both. Adds
  a `cleanup()` invariant note so future additions to the keypress
  handler don't accidentally bypass it.

## Test plan

- [x] `bun test packages/cli/src/__tests__/select.test.ts` — 5 pass / 0 fail (existing 3 short-circuit tests + 2 new `SelectCancelled` tests covering Error-subclass shape and `instanceof` discrimination).
- [x] `bun test` (cli package) — 403 pass / 0 fail.
- [x] Smoke check: `bunx barefoot init </dev/null` (non-TTY) still falls through to the default adapter / CSS library and scaffolds correctly. `--adapter rails` still rejects with the available list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)