### PR TITLE
refactor(jsx): DRY-ify spread + reactivity-flag handling between processAttributes and processComponentProps

### DIFF
--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2385,6 +2385,70 @@ interface ProcessedAttributes {
   ref: string | null
 }
 
+// Spread expansion: shared between HTML attrs and component props. When the
+// analyzer can statically enumerate the rest-prop key list, the spread is
+// unrolled per key; otherwise it's emitted as a single `...` entry that the
+// runtime expands. The shape returned satisfies both IRAttribute and IRProp
+// (string value, dynamic, isLiteral=false).
+function expandSpreadAttribute(
+  attr: ts.JsxSpreadAttribute,
+  ctx: TransformContext,
+): Array<{
+  name: string
+  value: string
+  templateValue?: string
+  dynamic: true
+  isLiteral: false
+  loc: SourceLocation
+}> {
+  const spreadExpr = ctx.getJS(attr.expression)
+  const expandedKeys = ctx.analyzer.restPropsExpandedKeys
+  const restName = ctx.analyzer.restPropsName
+  const loc = getSourceLocation(attr, ctx.sourceFile, ctx.filePath)
+
+  if (expandedKeys.length > 0 && restName && spreadExpr === restName) {
+    return expandedKeys.map(key => ({
+      name: key,
+      value: `${restName}.${key}`,
+      dynamic: true,
+      isLiteral: false,
+      loc,
+    }))
+  }
+
+  return [{
+    name: '...',
+    value: spreadExpr,
+    templateValue: ctx.getTemplateJS(attr.expression),
+    dynamic: true,
+    isLiteral: false,
+    loc,
+  }]
+}
+
+// AST-derived reactivity flags for the Solid-style wrap-by-default fallback
+// (#940 / #942 DRY consolidation). Computed on the source JSX expression so
+// collect-elements.ts can decide wrapping structurally instead of regex-
+// scanning the expanded value string — a regex can false-match call-like
+// substrings inside string literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`).
+function computeReactivityFlags(
+  attr: ts.JsxAttribute,
+  ctx: TransformContext,
+): { callsReactiveGetters?: boolean; hasFunctionCalls?: boolean } {
+  if (
+    !attr.initializer
+    || !ts.isJsxExpression(attr.initializer)
+    || !attr.initializer.expression
+  ) {
+    return {}
+  }
+  const expr = attr.initializer.expression
+  return {
+    callsReactiveGetters: exprCallsReactiveGetters(expr, ctx) || undefined,
+    hasFunctionCalls: exprHasFunctionCalls(expr) || undefined,
+  }
+}
+
 function processAttributes(
   attributes: ts.JsxAttributes,
   ctx: TransformContext
@@ -2394,34 +2458,8 @@ function processAttributes(
   let ref: string | null = null
 
   for (const attr of attributes.properties) {
-    // Spread attribute: {...props}
     if (ts.isJsxSpreadAttribute(attr)) {
-      const spreadExpr = ctx.getJS(attr.expression)
-      const expandedKeys = ctx.analyzer.restPropsExpandedKeys
-      const restName = ctx.analyzer.restPropsName
-
-      // Expand spread if keys are statically known (closed type)
-      if (expandedKeys.length > 0 && restName && spreadExpr === restName) {
-        const loc = getSourceLocation(attr, ctx.sourceFile, ctx.filePath)
-        for (const key of expandedKeys) {
-          attrs.push({
-            name: key,
-            value: `${restName}.${key}`,
-            dynamic: true,
-            isLiteral: false,
-            loc,
-          })
-        }
-      } else {
-        attrs.push({
-          name: '...',
-          value: spreadExpr,
-          templateValue: ctx.getTemplateJS(attr.expression),
-          dynamic: true,
-          isLiteral: false,
-          loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-        })
-      }
+      attrs.push(...expandSpreadAttribute(attr, ctx))
       continue
     }
 
@@ -2429,7 +2467,6 @@ function processAttributes(
 
     const name = attr.name.getText(ctx.sourceFile)
 
-    // Ref attribute
     if (name === 'ref') {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         ref = ctx.getJS(attr.initializer.expression)
@@ -2437,7 +2474,6 @@ function processAttributes(
       continue
     }
 
-    // Event handler: onClick, onChange, etc.
     if (/^on[A-Z]/.test(name)) {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         const eventName = name.slice(2).toLowerCase()
@@ -2451,28 +2487,11 @@ function processAttributes(
       continue
     }
 
-    // Regular attribute
     const attrResult = getAttributeValue(attr, ctx)
     const { value, dynamic, isLiteral } = attrResult
-    // Compute templateValue for dynamic string attributes
     let templateValue: string | undefined
     if (dynamic && typeof value === 'string' && attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
       templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
-    }
-
-    // AST-derived reactivity flags for Solid-style wrap-by-default fallback
-    // (#940 DRY consolidation). Lets collect-elements.ts decide wrapping
-    // structurally instead of regex-scanning the expanded value string —
-    // a regex can false-match call-like substrings inside string literals
-    // (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and is forced to
-    // re-strip quotes every time. Flags are computed on the source JSX
-    // expression before local-const expansion, matching the structural
-    // guarantee #942 / #952 established for `IRProp`.
-    let callsReactive = false
-    let hasCalls = false
-    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      callsReactive = exprCallsReactiveGetters(attr.initializer.expression, ctx)
-      hasCalls = exprHasFunctionCalls(attr.initializer.expression)
     }
 
     attrs.push({
@@ -2482,8 +2501,7 @@ function processAttributes(
       dynamic,
       isLiteral,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-      callsReactiveGetters: callsReactive || undefined,
-      hasFunctionCalls: hasCalls || undefined,
+      ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
     })
   }
@@ -2913,34 +2931,8 @@ function processComponentProps(
   const props: IRProp[] = []
 
   for (const attr of attributes.properties) {
-    // Spread props: {...props}
     if (ts.isJsxSpreadAttribute(attr)) {
-      const spreadExpr = ctx.getJS(attr.expression)
-      const expandedKeys = ctx.analyzer.restPropsExpandedKeys
-      const restName = ctx.analyzer.restPropsName
-
-      // Expand spread if keys are statically known (closed type)
-      if (expandedKeys.length > 0 && restName && spreadExpr === restName) {
-        const loc = getSourceLocation(attr, ctx.sourceFile, ctx.filePath)
-        for (const key of expandedKeys) {
-          props.push({
-            name: key,
-            value: `${restName}.${key}`,
-            dynamic: true,
-            isLiteral: false,
-            loc,
-          })
-        }
-      } else {
-        props.push({
-          name: '...',
-          value: spreadExpr,
-          templateValue: ctx.getTemplateJS(attr.expression),
-          dynamic: true,
-          isLiteral: false,
-          loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-        })
-      }
+      props.push(...expandSpreadAttribute(attr, ctx))
       continue
     }
 
@@ -2948,11 +2940,11 @@ function processComponentProps(
 
     const name = attr.name.getText(ctx.sourceFile)
 
-    // Detect JSX element/fragment as prop value: controls={<select ... />}
-    // Also handle parenthesized JSX: controls={(<div>...</div>)}
+    // JSX element/fragment as prop value: controls={<select />} or
+    // controls={(<div/>)}. Stored on `jsxChildren` so the adapter can render
+    // it inline rather than passing a string.
     if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
       let jsxExpr = attr.initializer.expression
-      // Unwrap parenthesized expression: controls={(<div>...</div>)}
       while (ts.isParenthesizedExpression(jsxExpr)) {
         jsxExpr = jsxExpr.expression
       }
@@ -2978,28 +2970,14 @@ function processComponentProps(
     const attrResult = getAttributeValue(attr, ctx)
     const { value, dynamic, isLiteral } = attrResult
 
-    // For component props, convert IRTemplateLiteral back to string expression
-    // since props are passed to components as-is
+    // Components receive props as runtime values, so collapse IRTemplateLiteral
+    // back to a JS expression and fall back to 'true' for boolean shorthand
+    // (`<X disabled />` → `disabled={true}`).
     const propValue = templateLiteralToString(value) ?? 'true'
 
-    // Compute templateValue for dynamic string props
     let propTemplateValue: string | undefined
     if (dynamic && typeof value === 'string' && attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
       propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
-    }
-
-    // AST-derived reactivity flags for Solid-style wrap-by-default fallback
-    // (#942 DRY consolidation). Lets collect-elements.ts decide wrapping
-    // structurally instead of regex-scanning the expanded string — a regex
-    // over expression text can false-match call-like substrings inside
-    // string literals (e.g. `'hsl(221 83% 53%)'`). JSX-as-prop is handled
-    // above via `jsxChildren` and string-literal attrs have no expression
-    // to analyze; only regular dynamic expression attrs carry flags.
-    let callsReactive = false
-    let hasCalls = false
-    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      callsReactive = exprCallsReactiveGetters(attr.initializer.expression, ctx)
-      hasCalls = exprHasFunctionCalls(attr.initializer.expression)
     }
 
     props.push({
@@ -3009,8 +2987,7 @@ function processComponentProps(
       dynamic,
       isLiteral,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-      callsReactiveGetters: callsReactive || undefined,
-      hasFunctionCalls: hasCalls || undefined,
+      ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
     })
   }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2385,11 +2385,22 @@ interface ProcessedAttributes {
   ref: string | null
 }
 
-// Spread expansion: shared between HTML attrs and component props. When the
-// analyzer can statically enumerate the rest-prop key list, the spread is
-// unrolled per key; otherwise it's emitted as a single `...` entry that the
-// runtime expands. The shape returned satisfies both IRAttribute and IRProp
-// (string value, dynamic, isLiteral=false).
+// Spread expansion: shared between HTML attrs and component props.
+//
+// When the spread target is the destructured rest-prop and the analyzer
+// closed its key set (e.g. `function X({ a, ...rest }: { a: A; b: B; c: C })`),
+// we unroll into one entry per known key. Adapters can then emit each as a
+// separate slot — this is what lets static keys stay static and dynamic
+// keys keep their per-key reactivity. The catch-all `...` entry forces the
+// runtime to spread at hydration time, which loses that per-key resolution
+// and is reserved for cases where the key set isn't statically known.
+//
+// The `spreadExpr === restName` check is what restricts unrolling to the
+// rest-prop itself: arbitrary `{...someObject}` spreads can't be unrolled
+// because we don't have a static key list for them.
+//
+// The shape returned satisfies both IRAttribute and IRProp (string value,
+// dynamic, isLiteral=false).
 function expandSpreadAttribute(
   attr: ts.JsxSpreadAttribute,
   ctx: TransformContext,
@@ -2427,10 +2438,13 @@ function expandSpreadAttribute(
 }
 
 // AST-derived reactivity flags for the Solid-style wrap-by-default fallback
-// (#940 / #942 DRY consolidation). Computed on the source JSX expression so
-// collect-elements.ts can decide wrapping structurally instead of regex-
-// scanning the expanded value string — a regex can false-match call-like
-// substrings inside string literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`).
+// (#940 / #942). Computed from the source JSX expression rather than the
+// expanded value string because a regex over the expanded string would
+// false-match call-like substrings inside string literals — most notoriously
+// CSS like `style={{ color: 'hsl(221 83% 53%)' }}`. Boolean shorthand
+// (`<X disabled />`) and string literals have no expression to analyze, so
+// they get the empty-flags fallback below; collect-elements.ts then treats
+// them as static.
 function computeReactivityFlags(
   attr: ts.JsxAttribute,
   ctx: TransformContext,
@@ -2467,6 +2481,10 @@ function processAttributes(
 
     const name = attr.name.getText(ctx.sourceFile)
 
+    // ref is captured separately (not pushed into `attrs`) because it never
+    // appears in the rendered HTML — it's a compile-time binding from the
+    // JSX call site to the runtime DOM element, surfaced via the IRElement
+    // `ref` field for the client-JS emitter.
     if (name === 'ref') {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         ref = ctx.getJS(attr.initializer.expression)
@@ -2474,6 +2492,10 @@ function processAttributes(
       continue
     }
 
+    // Event handlers are pulled out of `attrs` for the same reason as ref:
+    // they're wired up at hydration time (delegated event registration) and
+    // must not leak into rendered HTML. The DOM event name is lowercase
+    // (`click`, not `Click`), so strip the `on` prefix and downcase.
     if (/^on[A-Z]/.test(name)) {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         const eventName = name.slice(2).toLowerCase()


### PR DESCRIPTION
## Summary

Health-check finding #2: `processAttributes` (HTML elements, line 2388) and `processComponentProps` (component props, line 2909) carried two near-identical blocks — ~30 lines of spread expansion and ~5 lines of AST-derived reactivity-flag computation. Every change had to be mirrored in both places, and the in-tree comments referenced overlapping but slightly different issue numbers (#940 / #942), making it ambiguous which was the source of truth.

This PR extracts the duplicated logic into two helpers and threads them through both callers. Behaviour is unchanged.

## Changes

- `expandSpreadAttribute(attr, ctx)` — both call sites now do `entries.push(...expandSpreadAttribute(attr, ctx))`. The helper handles both branches: the analyzer-known-keys unroll and the catch-all `...` entry. Returns a shape compatible with `IRAttribute` and `IRProp` (string value, `dynamic: true`, `isLiteral: false`).
- `computeReactivityFlags(attr, ctx)` — returns `{ callsReactiveGetters?, hasFunctionCalls? }` from the source JSX expression. Spread into the pushed entry to match the original `|| undefined` shape.
- Per-call-site logic kept in place: `ref` / event-handler branches in `processAttributes`, JSX-as-prop / `templateLiteralToString` / `'true'` boolean fallback in `processComponentProps`. These weren't shared and shouldn't be forced.

Net: 74 insertions, 97 deletions (23 fewer lines). Tightened a few stale `// (#940 DRY consolidation)` style comments by collapsing them into a single header on each helper.

## Out of scope

This is item #2 of the jsx-area health-check (after #1183 ErrorCode unification). Remaining: finishing the staged-IR `OriginInfo` emit so BF060/BF061 can flip default-on, and a separate health-check pass over `ir-to-client-js/`.

## Test plan

- [x] `bun run build` — clean
- [x] `bun run typecheck:tests` — clean
- [x] `bun test` — 962 pass; same 4 pre-existing unrelated failures in `primitive-resolver-alias` / resolver-migration suites (verified failing on `main`)

https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_