### PR TITLE
feat(jsx): surface staged-IR fallbacks (BF061) by default

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1427,7 +1427,11 @@ describe('Client JS generation', () => {
       `
 
       const result = compileJSX(source, 'MyForm.tsx', { adapter })
-      expect(result.errors).toHaveLength(0)
+      // `form` contains an arrow literal so it can't inline into the
+      // template; `emailField.value` falls back to `undefined` and init
+      // repaints. That surfaces a BF061 warning now — the test cares
+      // about compile success and declaration ordering, not silence.
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 
       const clientJs = result.files.find(f => f.type === 'clientJs')!
       expect(clientJs).toBeDefined()

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -4,11 +4,14 @@
  * formed warnings, and the messages reference the offending binding
  * by name.
  *
- * Default emission policy is OFF — silent fallback at template scope
- * is the documented design (#1128). The diagnostic factory exists so
- * an opt-in caller (a future `strictStageBoundaries` mode, IDE
- * tooling) can surface BF060/BF061 to users without breaking the
- * default contract.
+ * Emission policy is now **default-on as warnings**: `compute-inlinability`
+ * calls `recordStageDiagnostics` for every const it classifies, so any
+ * relocate fallback (init-local or signal/memo getter pulled into
+ * template scope) surfaces in `result.errors` with `severity: 'warning'`.
+ * The build still succeeds — there's no severity filter in compileJSX —
+ * but consumers can now see the silent fallbacks instead of having to
+ * reason about staged-IR internals to find them. A future
+ * `strictStageBoundaries` mode would flip the warnings to hard errors.
  *
  * BF060: signal/memo getter referenced from template scope
  * BF061: init-scope local referenced from template scope
@@ -20,6 +23,7 @@ import { ErrorCodes } from '../../errors'
 import { recordStageDiagnostics } from '../../ir-to-client-js/compute-inlinability'
 import type { ConstantInfo, CompilerError } from '../../types'
 import type { RelocateDecision } from '../../relocate'
+import { compile } from './helpers'
 
 const dummyLoc = {
   file: 'Test.tsx',
@@ -104,5 +108,74 @@ describe('recordStageDiagnostics', () => {
     ]
     recordStageDiagnostics(constInfo('cls'), decisions, warnings)
     expect(warnings).toHaveLength(1)
+  })
+})
+
+// End-to-end check that the production pipeline now wires the diagnostic
+// in. The wiring lives in `computeInlinability`, so the surfaced cases
+// are the chained-const ones: a localConstant whose value references an
+// init-scope-only binding through another local const. JSX expressions
+// that reference an init-local directly go through a separate template
+// emit path (`transformExpr` in html-template.ts) and aren't wired yet —
+// out of scope for this PR.
+describe('compileJSX surfaces stage-violation warnings by default', () => {
+  test('chained const referencing init-local → BF061', () => {
+    const { errors } = compile(`
+      'use client'
+      import { useSettings } from './nodes'
+
+      interface Props { roomId: string }
+
+      export function Foo(props: Props) {
+        const setting = useSettings()
+        const view = JSON.stringify(setting)
+        return <div data-view={view}>hi</div>
+      }
+    `)
+
+    const bf061 = errors.find(e => e.startsWith('[BF061]'))
+    expect(bf061).toBeDefined()
+    expect(bf061).toContain('setting')
+    expect(bf061).toContain('view')
+  })
+
+  test('chained const reading a signal also surfaces as BF061', () => {
+    // The signal getter itself is classified `reactive-read` (early return,
+    // no decisions captured), but the chained const that reads it is then
+    // classified as an init-local in the template-scope relocate pass —
+    // so the user-visible diagnostic is BF061 ("init-scope local") rather
+    // than BF060. The fallback shape is the same either way.
+    const { errors } = compile(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props { x: string }
+
+      export function Foo(props: Props) {
+        const [count] = createSignal(0)
+        const cur = count()
+        const view = 'val:' + cur
+        return <div data-view={view}>hi</div>
+      }
+    `)
+
+    const bf061 = errors.find(e => e.startsWith('[BF061]'))
+    expect(bf061).toBeDefined()
+    expect(bf061).toContain('cur')
+  })
+
+  test('clean component (no fallbacks) emits no BF060/BF061', () => {
+    const { errors } = compile(`
+      'use client'
+
+      interface Props { name: string }
+
+      export function Foo(props: Props) {
+        return <div>{props.name}</div>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF060]'))).toBeUndefined()
+    expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
   })
 })

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -76,6 +76,15 @@ export type FunctionInlinability =
 export interface InlinabilityAnalysis {
   constants: Map<string, ConstantInlinability>
   functions: Map<string, FunctionInlinability>
+  /**
+   * Per-const relocate decisions captured during initial classification.
+   * Used by `toLegacyInlinability` to emit BF060/BF061 only for constants
+   * that remain unsafe after chain resolution — emitting at classification
+   * time would produce false positives for chains that resolve cleanly
+   * (e.g. `classes = 'tag-' + color` where `color` itself resolves to a
+   * prop-based expression downstream).
+   */
+  decisionsByName: Map<string, RelocateDecision[]>
 }
 
 // JavaScript built-in identifiers that are always available at any scope.
@@ -162,18 +171,21 @@ export function computeInlinability(
     localConstants: ctx.localConstants,
   })
 
+  const decisionsByName = new Map<string, RelocateDecision[]>()
   for (const c of ctx.localConstants) {
-    constants.set(c.name, classifyConstantInitial(
+    const { status, decisions } = classifyConstantInitial(
       c,
       graph.declaredNames,
       signalGetters,
       signalSetters,
       memoNames,
       env,
-    ))
+    )
+    constants.set(c.name, status)
+    decisionsByName.set(c.name, decisions)
   }
 
-  return { constants, functions }
+  return { constants, functions, decisionsByName }
 }
 
 /**
@@ -222,17 +234,17 @@ function classifyConstantInitial(
   signalSetters: Set<string>,
   memoNames: Set<string>,
   env: RelocateEnv,
-): ConstantInlinability {
-  if (c.isJsx) return { kind: 'jsx-inline' }
-  if (!c.value) return { kind: 'placeholder-let' }
-  if (c.containsArrow) return { kind: 'arrow-literal' }
-  if (c.systemConstructKind) return { kind: 'system-construct' }
+): { status: ConstantInlinability; decisions: RelocateDecision[] } {
+  if (c.isJsx) return { status: { kind: 'jsx-inline' }, decisions: [] }
+  if (!c.value) return { status: { kind: 'placeholder-let' }, decisions: [] }
+  if (c.containsArrow) return { status: { kind: 'arrow-literal' }, decisions: [] }
+  if (c.systemConstructKind) return { status: { kind: 'system-construct' }, decisions: [] }
 
   const freeIds = c.freeIdentifiers
   if (freeIds) {
     for (const id of freeIds) {
       if (signalGetters.has(id) || signalSetters.has(id) || memoNames.has(id)) {
-        return { kind: 'reactive-read' }
+        return { status: { kind: 'reactive-read' }, decisions: [] }
       }
     }
     // Stage-1 graph eligibility — legacy gate. Kept because chain
@@ -241,7 +253,7 @@ function classifyConstantInitial(
     // would over-reject the chained-inlining test (#366).
     for (const id of freeIds) {
       if (JS_BUILTINS.has(id) || declaredNames.has(id)) continue
-      return { kind: 'external-name' }
+      return { status: { kind: 'external-name' }, decisions: [] }
     }
   }
 
@@ -259,12 +271,20 @@ function classifyConstantInitial(
   // const dependency graph (#366). Using `rewrittenValue` here would
   // freeze init-local refs into `undefined` fallbacks before the
   // chain resolver gets a chance to replace them.
-  const { ok } = isInlinableInTemplate(c.value, env)
-  if (!ok) return { kind: 'external-name' }
+  //
+  // `decisions` is returned alongside so the caller can surface the
+  // staged-IR diagnostics (BF060/BF061) the relocate pass observed —
+  // including the `ok: true` cases where a fallback rewrite happened
+  // but didn't disqualify inlining.
+  const { ok, decisions } = isInlinableInTemplate(c.value, env)
+  if (!ok) return { status: { kind: 'external-name' }, decisions }
 
   return {
-    kind: 'inlinable',
-    value: c.templateValue?.trim() ?? c.value.trim(),
+    status: {
+      kind: 'inlinable',
+      value: c.templateValue?.trim() ?? c.value.trim(),
+    },
+    decisions,
   }
 }
 
@@ -347,6 +367,21 @@ export function toLegacyInlinability(
   for (const name of toRemove) {
     inlinableConstants.delete(name)
     unsafeLocalNames.add(name)
+  }
+
+  // Surface BF060/BF061 for constants that ended up unsafe AFTER chain
+  // resolution — emitting earlier would false-positive on chains that
+  // resolve to safe prop-based expressions. `recordStageDiagnostics`
+  // filters decisions by kind, so it's a no-op for constants whose
+  // unsafety came from non-stage causes (arrow-literal, system-construct,
+  // function references etc.).
+  const constsByName = new Map(ctx.localConstants.map(c => [c.name, c]))
+  for (const name of unsafeLocalNames) {
+    const c = constsByName.get(name)
+    const decisions = analysis.decisionsByName.get(name)
+    if (c && decisions && decisions.length > 0) {
+      recordStageDiagnostics(c, decisions, ctx.warnings)
+    }
   }
 
   return { inlinableConstants, unsafeLocalNames }

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -58,14 +58,20 @@ export function generateClientJsWithSourceMap(
   const ctx = createContext(ir, scope)
   const siblingOffsets = computeLoopSiblingOffsets(ir.root)
   collectElements(ir.root, ctx, siblingOffsets)
-  ir.errors.push(...ctx.warnings)
 
+  // Both `generateTemplateOnlyMount` and `generateInitFunction` run inline
+  // analysis passes (buildInlinableConstants → computeInlinability) that
+  // can add to `ctx.warnings` — most notably the BF060/BF061 stage-violation
+  // diagnostics. Flush warnings to `ir.errors` AFTER those passes so the
+  // diagnostics survive to the caller.
   if (!needsClientJs(ctx)) {
     const code = generateTemplateOnlyMount(ir, ctx)
+    ir.errors.push(...ctx.warnings)
     return { code }
   }
 
   const code = generateInitFunction(ir, ctx, siblingComponents, localImportPrefixes)
+  ir.errors.push(...ctx.warnings)
 
   if (options?.sourceMaps && code) {
     const fileName = options.generatedFileName ?? `${ir.metadata.componentName}.client.js`


### PR DESCRIPTION
## Summary

Health-check finding #2: `recordStageDiagnostics` was reachable from production only on paper — the call site in `computeInlinability` was missing, so init-locals and signal reads that fell back to `undefined` at template scope produced silent SSR repaints with no diagnostic anywhere. The unit tests pinned the function's behaviour, but no end-to-end test could ever fire because the caller didn't exist.

This PR wires it up. BF061 now surfaces as a `severity: 'warning'` in `result.errors` whenever a chained const ends up unsafe at template scope after chain resolution. The build still succeeds (no severity filter in `compileJSX`); consumers (CLI, IDE) can decide when to fail. A future `strictStageBoundaries` flag can flip the warnings to hard errors without touching this wiring.

## Changes

- `compute-inlinability.ts`
  - `classifyConstantInitial` returns the `RelocateDecision[]` that `isInlinableInTemplate` already produced, alongside the `ConstantInlinability` status.
  - `InlinabilityAnalysis` adds `decisionsByName: Map<string, RelocateDecision[]>`.
  - `toLegacyInlinability` emits `recordStageDiagnostics` **after** chain resolution and demotion, scoped to the constants that ended up in `unsafeLocalNames`. Emitting at the per-const classification step would false-positive on chains like `classes = 'tag-' + color` where `color` resolves cleanly downstream.
- `ir-to-client-js/index.ts` — flush `ctx.warnings` into `ir.errors` **after** `generateInitFunction` / `generateTemplateOnlyMount` rather than before. Those are the passes that actually populate the warnings, so the previous flush position dropped them on the floor.

## Test impact

One existing test fixed:
- `client-js-generation.test.ts` `#508 declaration-ordering` used a `form = createForm({ onSubmit: async (...) => {...} })` pattern that correctly surfaces BF061 — the const has an arrow literal so it can't inline, and `emailField.value` template-falls-back to undefined. Switched the assertion from `errors.length === 0` to filter on `severity: 'error'` since the test is about ordering, not silence.

Three new tests in `__tests__/staged-ir/10-stage-diagnostics.test.ts`:
1. Chained init-local — `setting = useSettings()` + `view = JSON.stringify(setting)` → BF061 on `view`.
2. Chained signal-reading const — `cur = count()` + `view = 'val:' + cur` → also BF061 on `view`. The signal getter itself early-returns at `reactive-read` (no decisions captured), but the chained const that reads it gets classified as init-local in the relocate pass, so the user-visible diagnostic is BF061. Same fallback shape; pinning so a future refactor doesn't regress.
3. Clean component — no warnings.

## Out of scope

JSX expressions that reference an init-local **directly** (e.g. `<div data-x={someInitLocal}>`) go through `html-template.ts:transformExpr`, not `computeInlinability`. They still fall back silently. Wiring that path needs a separate warning channel into the template-emit walkers — separate PR.

The original Plan agent also flagged that `OriginInfo` is set on `ConstantInfo` / `InitStatementInfo` but read by no production code, and that `IRExpression.origin` is never set. Those remain dead-ish: this PR uses the existing `RelocateDecision` channel because it's already wired through and produces the right semantics. Filling out `OriginInfo` reads is only valuable once a consumer (strict-stage mode, IDE diagnostics) actually wants it.

## Test plan

- [x] `bun run build` — clean
- [x] `bun run typecheck:tests` — clean
- [x] `bun test` — 965 pass, 4 pre-existing unrelated failures in `primitive-resolver-alias` / resolver-migration suites (verified failing on `main`)
- [x] `bun test src/__tests__/staged-ir/` — 80 pass

https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_