### PR TITLE
feat(jsx): add TemplatePrimitiveRegistry types to TemplateAdapter (#1187 phase 0)

### DIFF
--- a/packages/jsx/src/__tests__/adapter-template-primitives.test.ts
+++ b/packages/jsx/src/__tests__/adapter-template-primitives.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Pins the shape of the `templatePrimitives` / `acceptsTemplateCall` API
+ * added to `TemplateAdapter` (#1187 phase 0). These fields aren't yet
+ * consulted by the compiler — this test only verifies the type plumbing
+ * compiles and that adapters can declare registries without breaking the
+ * existing interface.
+ *
+ * Behavioural wiring (relocate consults the registry, strict error fires
+ * when a callee is unregistered, etc.) lands in subsequent phases.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { TestAdapter } from '../adapters/test-adapter'
+import type {
+  TemplateAdapter,
+  TemplatePrimitiveRegistry,
+  TemplatePrimitiveEmit,
+  TemplateCallAcceptor,
+} from '../adapters/interface'
+
+describe('TemplateAdapter.templatePrimitives (phase 0 type plumbing)', () => {
+  test('existing adapters compile without declaring templatePrimitives', () => {
+    // TestAdapter doesn't set the optional fields — must still satisfy the interface.
+    const a: TemplateAdapter = new TestAdapter()
+    expect(a.templatePrimitives).toBeUndefined()
+    expect(a.acceptsTemplateCall).toBeUndefined()
+  })
+
+  test('an adapter can declare a registry of identifier-path callees', () => {
+    const registry: TemplatePrimitiveRegistry = {
+      'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+      'Math.floor': (args) => `Math.floor(${args[0]})`,
+      'String': (args) => `String(${args[0]})`,
+    }
+
+    const emit: TemplatePrimitiveEmit = registry['JSON.stringify']
+    expect(emit(['x'])).toBe('JSON.stringify(x)')
+    expect(registry['Math.floor'](['1.5'])).toBe('Math.floor(1.5)')
+  })
+
+  test('an adapter can declare a broad-acceptance predicate (full JS runtime)', () => {
+    // Hono / CSR-style: accept anything that isn't an obvious DOM/async leak.
+    // Predicate semantics are MVP-loose for now; refinement is downstream work.
+    const acceptsTemplateCall: TemplateCallAcceptor = (callee) => !callee.startsWith('document.')
+
+    expect(acceptsTemplateCall('JSON.stringify')).toBe(true)
+    expect(acceptsTemplateCall('Math.floor')).toBe(true)
+    expect(acceptsTemplateCall('document.querySelector')).toBe(false)
+  })
+
+  test('a server-template adapter declares only an explicit registry (no acceptor)', () => {
+    // Go-template-style: explicit list, no broad acceptance.
+    const registry: TemplatePrimitiveRegistry = {
+      'JSON.stringify': (args) => `{{ json ${args[0]} }}`,
+    }
+
+    // Shape check via assignment — the absence of acceptsTemplateCall is the point.
+    const partial: Pick<TemplateAdapter, 'templatePrimitives' | 'acceptsTemplateCall'> = {
+      templatePrimitives: registry,
+    }
+
+    expect(partial.templatePrimitives).toBeDefined()
+    expect(partial.acceptsTemplateCall).toBeUndefined()
+  })
+})

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -47,6 +47,40 @@ export interface AdapterGenerateOptions {
   scriptBaseName?: string
 }
 
+/**
+ * Emit a registered primitive call into the template. Receives the already-
+ * rewritten argument expressions (as strings) and returns the substituted
+ * template-side call expression.
+ *
+ * Examples:
+ *   Hono: `(args) => \`JSON.stringify(\${args[0]})\``
+ *   Go:   `(args) => \`{{ json \${args[0]} }}\``
+ */
+export type TemplatePrimitiveEmit = (args: string[]) => string
+
+/**
+ * Maps callee identifier paths to adapter-specific template emit functions.
+ * Keys are the textual callee path as it appears in the JSX expression
+ * (`JSON.stringify`, `Math.floor`, `String`).
+ *
+ * V1 scope: identifier-path callees only. Method calls on values whose type
+ * the analyzer must resolve (`props.name.toUpperCase()`) are out of scope —
+ * see #1187 R1. Users can fall back to `/* @client *\/` for those.
+ */
+export type TemplatePrimitiveRegistry = Record<string, TemplatePrimitiveEmit>
+
+/**
+ * Optional broad-acceptance predicate for adapters whose template runtime is
+ * a full JS engine (Hono SSR, CSR adapter). When the callee isn't found in
+ * `templatePrimitives`, the compiler consults this predicate; returning true
+ * means "inline the call as-is in the template, the runtime can execute it".
+ *
+ * Adapters whose template runtime can't execute arbitrary JS (Go, Perl,
+ * other server-side template languages) should leave this undefined and
+ * rely on the explicit `templatePrimitives` map alone.
+ */
+export type TemplateCallAcceptor = (calleeName: string) => boolean
+
 export interface TemplateAdapter {
   name: string
   extension: string
@@ -68,6 +102,35 @@ export interface TemplateAdapter {
    * behaviour for adapters that do not run JS at SSR (e.g. go-template).
    */
   clientShimSource?: string
+
+  /**
+   * Pure JS callees the adapter promises it can render in template scope.
+   * The compiler consults this map when classifying expressions for
+   * template-scope safety: a call whose callee is registered is treated as
+   * lift-safe instead of forcing the surrounding expression into init scope.
+   *
+   * Contract: the emit function must produce template-side code whose value
+   * is **value-equivalent** to the JS reference implementation given the
+   * same input. Order/whitespace differences are acceptable for non-string-
+   * compared outputs (CSS class lists, JSON-decoded objects). See #1187
+   * registry contract for details.
+   *
+   * V1 scope is identifier-path callees (`JSON.stringify`, `Math.floor`,
+   * `String`). Method calls on values whose receiver type the analyzer
+   * must resolve are out of scope; users can fall back to `/* @client *\/`.
+   */
+  templatePrimitives?: TemplatePrimitiveRegistry
+
+  /**
+   * Broad-acceptance predicate for adapters whose template runtime is a
+   * full JS engine (Hono SSR, CSR). Consulted when a callee isn't in
+   * `templatePrimitives`. Returning true means the runtime can execute the
+   * call as-is — the compiler keeps the call inlined in the template.
+   *
+   * Server-side template languages (Go, Perl) should leave this undefined
+   * and rely on the explicit `templatePrimitives` map.
+   */
+  acceptsTemplateCall?: TemplateCallAcceptor
 
   // Main entry point - generates complete template from IR
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput


### PR DESCRIPTION
## Summary

First step of #1187 (silent data loss → strict error + adapter primitive registry). **Type plumbing only; no behavioural wiring yet.**

Adds two optional fields to `TemplateAdapter`:

- `templatePrimitives?: Record<string, (args) => string>` — explicit registry of pure JS callees the adapter can render in template scope. Each entry maps an identifier-path callee (`JSON.stringify`, `Math.floor`) to an emit function returning the adapter-side rewritten call.
- `acceptsTemplateCall?: (calleeName) => boolean` — broad-acceptance predicate for adapters whose template runtime is a full JS engine (Hono SSR, future CSR adapter). Consulted when a callee isn't in `templatePrimitives`.

The split (explicit map + optional predicate) reflects the two adapter capability tiers from #1187:

| Adapter tier | Strategy |
|---|---|
| Server-template (Go #1188, Perl #1189) | `templatePrimitives` map only — explicit list |
| Full JS runtime (Hono, CSR) | `acceptsTemplateCall` predicate, optionally with `templatePrimitives` overrides |

## Scope

V1 covers identifier-path callees only. Method calls on values whose receiver type the analyzer must resolve (`props.name.toUpperCase()`) are out of scope — users fall back to `/* @client */` per the existing escape hatch (#1187 R1).

## What's *not* in this PR

Subsequent phases of #1187:
- Phase 1: dry-run measurement of strict-error patterns in `site/`
- Phase 2: relocate consults the registry
- Phase 3: Hono adapter populates the predicate
- Phase 4: cross-adapter conformance test infrastructure
- Phase 5: strict error on unregistered callees
- Phase 6: workaround messaging (`/* @client */` as primary suggestion)
- Phase 7: `site/` migration

Sub-issues for non-Hono adapters: #1188 (Go), #1189 (Perl placeholder).

## Test plan

- [x] `bun run build` — clean
- [x] `bun run typecheck:tests` — clean
- [x] `bun test` — 965 pass, 4 pre-existing unrelated failures (`primitive-resolver-alias` / resolver-migration suites, verified failing on `main`)
- [x] New `adapter-template-primitives.test.ts` — 4 pass, pins both adapter tiers and confirms existing `TestAdapter` still satisfies the interface without declaring the optional fields

Related: #1187 (parent), #1186 (BF061 default-on, prerequisite)

https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_