### PR TITLE
feat(jsx): wire RelocateEnv to consult adapter template-primitive registry (#1187 phase 2)

### DIFF
--- a/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pins the wiring added in #1187 phase 2: `RelocateEnv.templatePrimitives`
+ * and `acceptsTemplateCall` let the inline-safety checks in
+ * `isInlinableInTemplate` bypass the bridged-arg / zero-arg shape
+ * rejections for callees the adapter promises it can render in template
+ * scope.
+ *
+ * No adapter populates the registry yet — the wiring is exercised here
+ * via hand-built env objects. Phase 3 will fill the Hono predicate.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import type { RelocateEnv } from '../../relocate'
+import { isInlinableInTemplate } from '../../relocate'
+import type { BindingKind } from '../../types'
+
+function envWith(
+  bindings: Array<[string, BindingKind]>,
+  options?: Partial<RelocateEnv>,
+): RelocateEnv {
+  return {
+    bindings: new Map(bindings),
+    inlinable: options?.inlinable ?? new Map(),
+    propsForLift: new Set(
+      bindings.filter(([, k]) => k === 'prop').map(([n]) => n),
+    ),
+    propsObjectName: options?.propsObjectName ?? 'props',
+    allowFallback: options?.allowFallback ?? true,
+    templatePrimitives: options?.templatePrimitives,
+    acceptsTemplateCall: options?.acceptsTemplateCall,
+  }
+}
+
+describe('isInlinableInTemplate — adapter-aware acceptance (#1187 phase 2)', () => {
+  describe('zero-arg calls', () => {
+    test('without a registry, a bare zero-arg call is rejected (baseline)', () => {
+      const env = envWith([['readItems', 'module-import']])
+      const r = isInlinableInTemplate('readItems()', env)
+      expect(r.ok).toBe(false)
+    })
+
+    test('a callee in templatePrimitives bypasses the zero-arg rejection', () => {
+      const env = envWith([['readItems', 'module-import']], {
+        templatePrimitives: {
+          readItems: () => 'readItems()',
+        },
+      })
+      const r = isInlinableInTemplate('readItems()', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('acceptsTemplateCall returning true bypasses the zero-arg rejection', () => {
+      const env = envWith([['readItems', 'module-import']], {
+        acceptsTemplateCall: (name) => name === 'readItems',
+      })
+      const r = isInlinableInTemplate('readItems()', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('acceptsTemplateCall returning false leaves the zero-arg rejection intact', () => {
+      const env = envWith([['readItems', 'module-import']], {
+        acceptsTemplateCall: () => false,
+      })
+      const r = isInlinableInTemplate('readItems()', env)
+      expect(r.ok).toBe(false)
+    })
+  })
+
+  describe('bridged-arg calls (call with prop-derived argument)', () => {
+    test('without a registry, a call with a bridged arg is rejected (baseline)', () => {
+      const env = envWith(
+        [
+          ['stringify', 'module-import'],
+          ['name', 'prop'],
+        ],
+        { propsObjectName: null },
+      )
+      const r = isInlinableInTemplate('stringify(name)', env)
+      expect(r.ok).toBe(false)
+    })
+
+    test('a registered callee with a bridged arg is accepted', () => {
+      const env = envWith(
+        [
+          ['stringify', 'module-import'],
+          ['name', 'prop'],
+        ],
+        {
+          propsObjectName: null,
+          templatePrimitives: {
+            stringify: (args) => `stringify(${args.join(', ')})`,
+          },
+        },
+      )
+      const r = isInlinableInTemplate('stringify(name)', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('property-access callees resolve by full path (`JSON.stringify`)', () => {
+      const env = envWith([['name', 'prop']], {
+        propsObjectName: null,
+        templatePrimitives: {
+          'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+        },
+      })
+      const r = isInlinableInTemplate('JSON.stringify(name)', env)
+      expect(r.ok).toBe(true)
+    })
+  })
+
+  describe('nested calls', () => {
+    test('outer call accepted, inner zero-arg call unregistered → still rejected', () => {
+      const env = envWith([['readItems', 'module-import']], {
+        templatePrimitives: {
+          'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+        },
+      })
+      const r = isInlinableInTemplate('JSON.stringify(readItems())', env)
+      expect(r.ok).toBe(false)
+    })
+
+    test('outer and inner both accepted → ok', () => {
+      const env = envWith([['readItems', 'module-import']], {
+        templatePrimitives: {
+          'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+          readItems: () => 'readItems()',
+        },
+      })
+      const r = isInlinableInTemplate('JSON.stringify(readItems())', env)
+      expect(r.ok).toBe(true)
+    })
+  })
+
+  describe('predicate vs explicit registry interaction', () => {
+    test('explicit entry takes priority over predicate', () => {
+      // Predicate would reject, but explicit entry accepts.
+      const env = envWith([['JSON', 'global']], {
+        templatePrimitives: {
+          'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+        },
+        acceptsTemplateCall: () => false,
+      })
+      const r = isInlinableInTemplate('JSON.stringify(1)', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('predicate is consulted only when entry is absent', () => {
+      const env = envWith([['Math', 'global']], {
+        // No explicit Math.floor entry.
+        acceptsTemplateCall: (name) => name === 'Math.floor',
+      })
+      const r = isInlinableInTemplate('Math.floor(1)', env)
+      expect(r.ok).toBe(true)
+    })
+  })
+})

--- a/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/11-template-primitive-registry.test.ts
@@ -153,4 +153,106 @@ describe('isInlinableInTemplate — adapter-aware acceptance (#1187 phase 2)', (
       expect(r.ok).toBe(true)
     })
   })
+
+  describe('shadow guard — local bindings must not activate the registry', () => {
+    test('local const shadowing a global registry entry is rejected', () => {
+      // User has `const JSON = ...` in init scope (or similar local
+      // binding). `JSON.stringify` here is the local's `.stringify`
+      // member, NOT the global. Registry must not fire.
+      const env = envWith(
+        [
+          ['JSON', 'init-local'], // shadows the global
+          ['name', 'prop'],
+        ],
+        {
+          propsObjectName: null,
+          templatePrimitives: {
+            'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+          },
+        },
+      )
+      const r = isInlinableInTemplate('JSON.stringify(name)', env)
+      expect(r.ok).toBe(false) // bridged-arg fires because shadow guard kept the rejection in play
+    })
+
+    test('module-import binding: registry still applies', () => {
+      // Module imports are stable enough to register against.
+      const env = envWith(
+        [
+          ['JSON', 'module-import'],
+          ['name', 'prop'],
+        ],
+        {
+          propsObjectName: null,
+          templatePrimitives: {
+            'JSON.stringify': (args) => `JSON.stringify(${args[0]})`,
+          },
+        },
+      )
+      const r = isInlinableInTemplate('JSON.stringify(name)', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('module-local binding: registry still applies', () => {
+      // A pure helper defined at module scope (not imported) is still a
+      // valid registration target — outside component-instance scope.
+      const env = envWith(
+        [
+          ['format', 'module-local'],
+          ['name', 'prop'],
+        ],
+        {
+          propsObjectName: null,
+          templatePrimitives: {
+            format: (args) => `format(${args[0]})`,
+          },
+        },
+      )
+      const r = isInlinableInTemplate('format(name)', env)
+      expect(r.ok).toBe(true)
+    })
+
+    test('signal-getter shadowing: registry must not fire', () => {
+      // Even more obvious shadow case — `count` is a signal getter, the
+      // registry has `count` as a registered primitive. Local wins.
+      const env = envWith([['count', 'signal-getter']], {
+        templatePrimitives: {
+          count: () => 'count()',
+        },
+      })
+      const r = isInlinableInTemplate('count()', env)
+      expect(r.ok).toBe(false) // zero-arg rejection still fires
+    })
+  })
+
+  describe('out-of-scope per #1187 R1: method calls on values', () => {
+    test('method call on a prop value is not registry-resolvable', () => {
+      // `name.toUpperCase()` — receiver type isn't part of the textual
+      // callee path. Registry can only key on identifier paths, not on
+      // type-anchored prototype methods (`String.prototype.toUpperCase`).
+      // Pin so this limitation doesn't accidentally regress: the user
+      // should fall back to `/* @client */`.
+      const env = envWith([['name', 'prop']], {
+        propsObjectName: null,
+        templatePrimitives: {
+          // A speculative future encoding the compiler doesn't understand:
+          'String.prototype.toUpperCase': () => 'whatever',
+        },
+      })
+      const r = isInlinableInTemplate('name.toUpperCase()', env)
+      expect(r.ok).toBe(false) // bridged-arg fires (name is a prop)
+    })
+
+    test('non-identifier callee shape (`(getX())()`) returns null path → no registry hit', () => {
+      // Even if a `getX` entry existed, the dynamic-dispatch shape
+      // `(getX())()` doesn't expose a stable identifier path.
+      const env = envWith([['getX', 'module-import']], {
+        templatePrimitives: {
+          getX: () => 'getX()',
+        },
+      })
+      const r = isInlinableInTemplate('(getX())()', env)
+      expect(r.ok).toBe(false) // outer call has no identifier path → unaccepted, zero-arg fires
+    })
+  })
 })

--- a/packages/jsx/src/relocate.ts
+++ b/packages/jsx/src/relocate.ts
@@ -328,6 +328,13 @@ export function isInlinableInTemplate(
  * `Math.floor`, `String`, `obj.method`. Returns null when the callee shape
  * isn't a plain identifier or property-access chain (e.g. `(cond ? a : b)()`,
  * computed access `obj['method']()`). Keeps the registry lookup deterministic.
+ *
+ * Note: this resolves the *textual* path only. It does not know whether
+ * `obj` is a value of a particular TypeScript type, so method calls on
+ * arbitrary receivers (`props.name.toUpperCase()`) cannot be matched
+ * against type-anchored registry keys like `String.prototype.toUpperCase`.
+ * This is the V1 limitation #1187 R1 records — users fall back to
+ * `/* @client *\/` for those cases.
  */
 function getCalleeIdentifierPath(callee: ts.Expression): string | null {
   if (ts.isIdentifier(callee)) return callee.text
@@ -340,9 +347,44 @@ function getCalleeIdentifierPath(callee: ts.Expression): string | null {
 }
 
 /**
+ * Walk to the leftmost identifier of a callee path. For `JSON.stringify`
+ * returns `JSON`, for `obj.method.deeper` returns `obj`, for a bare
+ * `foo()` returns `foo`. Used by `isCallAcceptedByAdapter` to decide
+ * whether the callee is a *truly* global / imported name vs a local
+ * binding that happens to share its name with a registered primitive
+ * (the shadowing case — the registry must not fire then).
+ */
+function getCalleeLeftmostIdentifier(callee: ts.Expression): string | null {
+  if (ts.isIdentifier(callee)) return callee.text
+  if (ts.isPropertyAccessExpression(callee)) {
+    return getCalleeLeftmostIdentifier(callee.expression)
+  }
+  return null
+}
+
+/**
+ * Binding kinds whose names safely escape component-scope shadowing —
+ * the registry can apply when the callee's leftmost identifier resolves
+ * to one of these. Local-ish kinds (`prop`, `signal-*`, `init-local`,
+ * etc.) are explicitly excluded: a local const named `JSON` shadows the
+ * global, so `JSON.stringify` in that scope must not be accepted just
+ * because the registry has a `JSON.stringify` entry.
+ */
+const REGISTRY_SAFE_BINDING_KINDS: ReadonlySet<BindingKind> = new Set([
+  'global',
+  'module-import',
+  'module-local',
+])
+
+/**
  * Whether `env`'s adapter promises it can render this call in template
  * scope. Resolves the callee path and consults `templatePrimitives` first,
  * then `acceptsTemplateCall`. Either match returns true.
+ *
+ * Shadow guard: rejects when the leftmost identifier of the callee
+ * resolves to a local-ish binding kind. This prevents a local variable
+ * named after a registered primitive (e.g. `const JSON = props.config`)
+ * from accidentally activating the registry.
  */
 function isCallAcceptedByAdapter(
   call: ts.CallExpression,
@@ -350,6 +392,17 @@ function isCallAcceptedByAdapter(
 ): boolean {
   const name = getCalleeIdentifierPath(call.expression)
   if (name === null) return false
+
+  // Shadow guard. `undefined` (not in bindings) means truly global —
+  // safe; we let it through. A tracked binding must be in the safe set.
+  const leftmost = getCalleeLeftmostIdentifier(call.expression)
+  if (leftmost !== null) {
+    const kind = env.bindings.get(leftmost)
+    if (kind !== undefined && !REGISTRY_SAFE_BINDING_KINDS.has(kind)) {
+      return false
+    }
+  }
+
   if (env.templatePrimitives && env.templatePrimitives[name]) return true
   if (env.acceptsTemplateCall && env.acceptsTemplateCall(name)) return true
   return false

--- a/packages/jsx/src/relocate.ts
+++ b/packages/jsx/src/relocate.ts
@@ -15,6 +15,10 @@ import type { Scope, BindingKind, IRMetadata } from './types'
 import { isVisibleIn } from './types'
 import type { AnalyzerContext } from './analyzer-context'
 import { PROPS_PARAM } from './ir-to-client-js/utils'
+import type {
+  TemplatePrimitiveRegistry,
+  TemplateCallAcceptor,
+} from './adapters/interface'
 
 export interface RelocateEnv {
   /**
@@ -44,6 +48,23 @@ export interface RelocateEnv {
   propsObjectName: string | null
   /** When true, unreachable refs are replaced with `undefined` / `[]`. */
   allowFallback: boolean
+  /**
+   * Adapter-supplied list of pure JS callees that can be safely rendered in
+   * template scope. When a call's callee is in this map, the inline-safety
+   * checks below (`hasCallWithBridgedArg`, `hasZeroArgCall`) treat that call
+   * as accepted instead of rejecting it. The emit function itself isn't
+   * called from relocate — the substitution happens later in adapter render.
+   *
+   * Empty / undefined behaves identically to pre-#1187: every call is
+   * subject to the bridged-arg / zero-arg shape rejections.
+   */
+  templatePrimitives?: TemplatePrimitiveRegistry
+  /**
+   * Broad-acceptance predicate for adapters whose template runtime is a
+   * full JS engine (Hono SSR, future CSR). Consulted when a callee isn't
+   * in `templatePrimitives`. Returning true marks the call as accepted.
+   */
+  acceptsTemplateCall?: TemplateCallAcceptor
 }
 
 export interface RelocateResult {
@@ -279,10 +300,10 @@ export function isInlinableInTemplate(
   if (!r.ok) return { ok: false, rewrittenValue: r.text, decisions: r.decisions }
 
   if (valueNode) {
-    if (hasCallWithBridgedArg(valueNode, r.decisions)) {
+    if (hasCallWithBridgedArg(valueNode, r.decisions, env)) {
       return { ok: false, rewrittenValue: r.text, decisions: r.decisions }
     }
-    if (hasZeroArgCall(valueNode)) {
+    if (hasZeroArgCall(valueNode, env)) {
       // Zero-arg calls (`readItems()`, `count()`) read runtime state.
       // Inlining them runs the call at template-eval time when the
       // surrounding scope (init body) hasn't yet provided whatever the
@@ -291,11 +312,47 @@ export function isInlinableInTemplate(
       // the long-standing `${[].map(...)}` fallback for cases like
       // `const items = readItems()` keeps producing a stable empty
       // initial render and lets init's effect populate the real value.
+      //
+      // Calls whose callee is registered as a template primitive (#1187)
+      // bypass this rejection — the adapter has promised it can render
+      // the call at template scope safely.
       return { ok: false, rewrittenValue: r.text, decisions: r.decisions }
     }
   }
 
   return { ok: true, rewrittenValue: r.text, decisions: r.decisions }
+}
+
+/**
+ * Resolve the textual identifier path of a call's callee — `JSON.stringify`,
+ * `Math.floor`, `String`, `obj.method`. Returns null when the callee shape
+ * isn't a plain identifier or property-access chain (e.g. `(cond ? a : b)()`,
+ * computed access `obj['method']()`). Keeps the registry lookup deterministic.
+ */
+function getCalleeIdentifierPath(callee: ts.Expression): string | null {
+  if (ts.isIdentifier(callee)) return callee.text
+  if (ts.isPropertyAccessExpression(callee)) {
+    const left = getCalleeIdentifierPath(callee.expression)
+    if (left === null) return null
+    return `${left}.${callee.name.text}`
+  }
+  return null
+}
+
+/**
+ * Whether `env`'s adapter promises it can render this call in template
+ * scope. Resolves the callee path and consults `templatePrimitives` first,
+ * then `acceptsTemplateCall`. Either match returns true.
+ */
+function isCallAcceptedByAdapter(
+  call: ts.CallExpression,
+  env: RelocateEnv,
+): boolean {
+  const name = getCalleeIdentifierPath(call.expression)
+  if (name === null) return false
+  if (env.templatePrimitives && env.templatePrimitives[name]) return true
+  if (env.acceptsTemplateCall && env.acceptsTemplateCall(name)) return true
+  return false
 }
 
 /**
@@ -332,6 +389,7 @@ function parseExpressionNode(text: string): ts.Node | null {
 function hasCallWithBridgedArg(
   node: ts.Node,
   decisions: RelocateDecision[],
+  env: RelocateEnv,
 ): boolean {
   const bridged = new Set<string>()
   for (const d of decisions) {
@@ -343,12 +401,18 @@ function hasCallWithBridgedArg(
   function visit(n: ts.Node): void {
     if (found) return
     if (ts.isCallExpression(n) || ts.isNewExpression(n)) {
-      const args = n.arguments
-      if (args) {
-        for (const arg of args) {
-          if (containsAnyIdentifier(arg, bridged)) {
-            found = true
-            return
+      // If the adapter accepts this call as a template primitive, the
+      // bridged-arg risk doesn't apply to *this* call — but nested calls
+      // inside its arguments still need checking.
+      const accepted = ts.isCallExpression(n) && isCallAcceptedByAdapter(n, env)
+      if (!accepted) {
+        const args = n.arguments
+        if (args) {
+          for (const arg of args) {
+            if (containsAnyIdentifier(arg, bridged)) {
+              found = true
+              return
+            }
           }
         }
       }
@@ -366,13 +430,20 @@ function hasCallWithBridgedArg(
  * scope. Mirrors the `/\b\w+\(\)/` regex the legacy CSR re-promotion
  * path used.
  */
-function hasZeroArgCall(node: ts.Node): boolean {
+function hasZeroArgCall(node: ts.Node, env: RelocateEnv): boolean {
   let found = false
   function visit(n: ts.Node): void {
     if (found) return
     if (ts.isCallExpression(n) && n.arguments.length === 0) {
-      found = true
-      return
+      // Adapter-accepted callees (e.g. `Date.now`, `Math.random` if the
+      // adapter chose to promise SSR↔CSR equivalence) bypass the zero-arg
+      // rejection. Nested zero-arg calls inside the call's expression
+      // (none for a plain `foo()`, but possible for `(getFn())()`) are
+      // still walked.
+      if (!isCallAcceptedByAdapter(n, env)) {
+        found = true
+        return
+      }
     }
     ts.forEachChild(n, visit)
   }
@@ -477,9 +548,24 @@ export function buildRelocateEnv(ctx: AnalyzerContext): RelocateEnv {
  * `IRMetadata`-based variant. Used at emit time when the analyzer
  * context is no longer available — emit reconstructs the env from
  * IR. Both builders produce identical results.
+ *
+ * `options` carries adapter-supplied template-scope capabilities that
+ * aren't part of the IR (registry of pure callees, broad-acceptance
+ * predicate). They flow through to the inline-safety checks in
+ * `isInlinableInTemplate` so a registered call escapes the bridged-arg
+ * / zero-arg rejections.
  */
-export function buildRelocateEnvFromIR(metadata: IRMetadata): RelocateEnv {
-  return buildRelocateEnvFromFields(metadata)
+export function buildRelocateEnvFromIR(
+  metadata: IRMetadata,
+  options?: {
+    templatePrimitives?: TemplatePrimitiveRegistry
+    acceptsTemplateCall?: TemplateCallAcceptor
+  },
+): RelocateEnv {
+  const env = buildRelocateEnvFromFields(metadata)
+  if (options?.templatePrimitives) env.templatePrimitives = options.templatePrimitives
+  if (options?.acceptsTemplateCall) env.acceptsTemplateCall = options.acceptsTemplateCall
+  return env
 }
 
 interface EnvFields {


### PR DESCRIPTION
## Summary

Phase 2 of #1187. Wires the relocate-side acceptance check so a callee registered with the adapter (`templatePrimitives` map or `acceptsTemplateCall` predicate, both added by #1190) bypasses the bridged-arg and zero-arg rejections in `isInlinableInTemplate`.

**No adapter populates the registry yet** — that's the next phase (Hono predicate). With every existing call site passing the env without the new fields, behaviour is unchanged.

## Changes

- `RelocateEnv`: two new optional fields, `templatePrimitives` and `acceptsTemplateCall`. Types come from the adapter interface added in #1190.
- `hasCallWithBridgedArg` / `hasZeroArgCall`: take `env`, consult `isCallAcceptedByAdapter(call, env)` before rejecting. Nested calls inside an accepted call's arguments are still walked — registry acceptance applies per-call, not per-subtree.
- `getCalleeIdentifierPath`: resolves the textual callee path (`JSON.stringify`, `Math.floor`) used as the registry key. Returns null for non-identifier-shaped callees (computed access, IIFE'd callees) so the lookup stays deterministic.
- `buildRelocateEnvFromIR`: optional `options` arg threads the adapter capabilities into the env.

## What's not in this PR

- Plumbing through `compileJSX` → `generateClientJs` → compute-inlinability so the adapter's actual registry reaches relocate. That lands in the Hono adapter PR (next).
- Hono / Go / TestAdapter populating their registries.
- `site/` migration.

## Tests

New `11-template-primitive-registry.test.ts` pins:
- baseline rejection still fires when no registry is present
- explicit entries override bridged-arg / zero-arg rejection
- the predicate is consulted as a fallback
- nested unregistered zero-arg calls still get rejected even when the outer call is accepted
- explicit entries beat the predicate

## Test plan

- [x] `bun run build` — clean
- [x] `bun run typecheck:tests` — clean
- [x] `bun test` — 980 pass; 4 pre-existing unrelated failures (`primitive-resolver-alias` / resolver-migration suites, verified failing on `main`)
- [x] `bun test src/__tests__/staged-ir/11-template-primitive-registry.test.ts` — 11 pass

Related: #1187 (parent), #1190 (phase 0)

https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_