### PR TITLE
docs(jsx): improve BF060/BF061 messages with /* @client */ workaround (#1187 phase 5 prep)

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1428,8 +1428,8 @@ describe('Client JS generation', () => {
 
       const result = compileJSX(source, 'MyForm.tsx', { adapter })
       // `form` contains an arrow literal so it can't inline into the
-      // template; `emailField.value` falls back to `undefined` and init
-      // repaints. That surfaces a BF061 warning now — the test cares
+      // template; `emailField.value` falls back to `undefined` and
+      // init repaints. That surfaces a BF061 warning — the test cares
       // about compile success and declaration ordering, not silence.
       expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
 

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -1,17 +1,17 @@
 /**
  * Pins the **stage-violation diagnostic infrastructure**: BF060/BF061/
  * BF062 codes are registered, `recordStageDiagnostics` produces well-
- * formed warnings, and the messages reference the offending binding
- * by name.
+ * formed warnings, and the messages reference the offending binding by
+ * name and recommend `/* @client *\/` as the workaround.
  *
- * Emission policy is now **default-on as warnings**: `compute-inlinability`
+ * Emission policy is **default-on as warnings**: `compute-inlinability`
  * calls `recordStageDiagnostics` for every const it classifies, so any
- * relocate fallback (init-local or signal/memo getter pulled into
- * template scope) surfaces in `result.errors` with `severity: 'warning'`.
- * The build still succeeds — there's no severity filter in compileJSX —
- * but consumers can now see the silent fallbacks instead of having to
- * reason about staged-IR internals to find them. A future
- * `strictStageBoundaries` mode would flip the warnings to hard errors.
+ * relocate fallback surfaces in `result.errors` with
+ * `severity: 'warning'`. Promoting to hard error needs usage-aware
+ * emission first — the diagnostic fires at const-declaration time and
+ * ignores whether all JSX usages are already deferred via
+ * `/* @client *\/`, so a strict flip would false-positive on code that
+ * has already migrated. Tracked as a follow-up.
  *
  * BF060: signal/memo getter referenced from template scope
  * BF061: init-scope local referenced from template scope
@@ -49,45 +49,50 @@ describe('Stage-violation diagnostic codes (BF060/BF061/BF062)', () => {
 
 describe('recordStageDiagnostics', () => {
   test('signal-getter decision → BF060 warning', () => {
-    const warnings: CompilerError[] = []
+    const out: CompilerError[] = []
     const decisions: RelocateDecision[] = [
       { name: 'count', kind: 'signal-getter', action: 'fallback', rewrittenAs: 'undefined' },
     ]
-    recordStageDiagnostics(constInfo('cls'), decisions, warnings)
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]?.code).toBe('BF060')
-    expect(warnings[0]?.severity).toBe('warning')
-    expect(warnings[0]?.message).toContain('count')
-    expect(warnings[0]?.message).toContain('cls')
+    recordStageDiagnostics(constInfo('cls'), decisions, out)
+    expect(out).toHaveLength(1)
+    expect(out[0]?.code).toBe('BF060')
+    expect(out[0]?.severity).toBe('warning')
+    expect(out[0]?.message).toContain('count')
+    expect(out[0]?.message).toContain('cls')
+    expect(out[0]?.message).toContain('/* @client */')
   })
 
   test('memo-getter decision → BF060 warning', () => {
-    const warnings: CompilerError[] = []
+    const out: CompilerError[] = []
     const decisions: RelocateDecision[] = [
       { name: 'doubled', kind: 'memo-getter', action: 'fallback', rewrittenAs: 'undefined' },
     ]
-    recordStageDiagnostics(constInfo('view'), decisions, warnings)
-    expect(warnings[0]?.code).toBe('BF060')
+    recordStageDiagnostics(constInfo('view'), decisions, out)
+    expect(out[0]?.code).toBe('BF060')
+    expect(out[0]?.severity).toBe('warning')
   })
 
   test('init-local decision → BF061 warning', () => {
-    const warnings: CompilerError[] = []
+    const out: CompilerError[] = []
     const decisions: RelocateDecision[] = [
       { name: 'cachedViewport', kind: 'init-local', action: 'fallback', rewrittenAs: 'undefined' },
     ]
-    recordStageDiagnostics(constInfo('view'), decisions, warnings)
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]?.code).toBe('BF061')
-    expect(warnings[0]?.message).toContain('cachedViewport')
+    recordStageDiagnostics(constInfo('view'), decisions, out)
+    expect(out).toHaveLength(1)
+    expect(out[0]?.code).toBe('BF061')
+    expect(out[0]?.severity).toBe('warning')
+    expect(out[0]?.message).toContain('cachedViewport')
+    expect(out[0]?.message).toContain('/* @client */')
   })
 
   test('sub-init-local decision → BF061 warning', () => {
-    const warnings: CompilerError[] = []
+    const out: CompilerError[] = []
     const decisions: RelocateDecision[] = [
       { name: 'tmp', kind: 'sub-init-local', action: 'fallback', rewrittenAs: 'undefined' },
     ]
-    recordStageDiagnostics(constInfo('val'), decisions, warnings)
-    expect(warnings[0]?.code).toBe('BF061')
+    recordStageDiagnostics(constInfo('val'), decisions, out)
+    expect(out[0]?.code).toBe('BF061')
+    expect(out[0]?.severity).toBe('warning')
   })
 
   test('pass-through and lift decisions emit nothing', () => {
@@ -100,25 +105,26 @@ describe('recordStageDiagnostics', () => {
     expect(warnings).toHaveLength(0)
   })
 
-  test('per-name de-dup: duplicate ref emits one warning, not many', () => {
-    const warnings: CompilerError[] = []
+  test('per-name de-dup: duplicate ref emits one error, not many', () => {
+    const out: CompilerError[] = []
     const decisions: RelocateDecision[] = [
       { name: 'flag', kind: 'init-local', action: 'fallback', rewrittenAs: 'undefined' },
       { name: 'flag', kind: 'init-local', action: 'fallback', rewrittenAs: 'undefined' },
     ]
-    recordStageDiagnostics(constInfo('cls'), decisions, warnings)
-    expect(warnings).toHaveLength(1)
+    recordStageDiagnostics(constInfo('cls'), decisions, out)
+    expect(out).toHaveLength(1)
   })
 })
 
-// End-to-end check that the production pipeline now wires the diagnostic
-// in. The wiring lives in `computeInlinability`, so the surfaced cases
-// are the chained-const ones: a localConstant whose value references an
+// End-to-end: the production pipeline surfaces stage-violation
+// diagnostics in `result.errors` (severity warning today, see header).
+// The wiring lives in `computeInlinability`, so the surfaced cases are
+// the chained-const ones: a localConstant whose value references an
 // init-scope-only binding through another local const. JSX expressions
 // that reference an init-local directly go through a separate template
-// emit path (`transformExpr` in html-template.ts) and aren't wired yet —
-// out of scope for this PR.
-describe('compileJSX surfaces stage-violation warnings by default', () => {
+// emit path (`transformExpr` in html-template.ts) and aren't wired
+// yet — separate follow-up.
+describe('compileJSX surfaces stage-violation diagnostics by default', () => {
   test('chained const referencing init-local → BF061', () => {
     const { errors } = compile(`
       'use client'

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -51,13 +51,16 @@ export const ErrorCodes = {
   // Init statement errors (BF052)
   UNDECLARED_INIT_STATEMENT_REFERENCE: 'BF052',
 
-  // Stage-violation errors (BF060-BF069) — cross-scope references that
-  // the staged-IR refactor (#1138) surfaces structurally rather than
-  // hiding behind silent `undefined` fallbacks. Emit policy: BF060/061
-  // are diagnostics today (warnings), reserved as hard errors for an
-  // opt-in strict-stage mode the compiler can flip later. BF062 is a
-  // hard error because its semantic divergence (await runs at hydrate
-  // time, not at SSR) cannot be silently fallback-ed.
+  // Stage-violation errors (BF060-BF069) — cross-scope references the
+  // staged-IR refactor (#1138) surfaces structurally rather than
+  // hiding behind silent `undefined` fallbacks. BF060/061 currently
+  // ship as warnings; the runtime fallback (template renders
+  // `undefined`, init's effect repaints) is observable and the
+  // suggested workaround is `/* @client */`. Promoting them to hard
+  // errors needs usage-aware emission first — the diagnostic fires at
+  // const-declaration time and ignores whether all JSX usages are
+  // already deferred via `/* @client */`. BF062 is a hard error
+  // because cross-stage await can't be silently fallback-ed.
   STAGE_REACTIVE_IN_TEMPLATE: 'BF060',
   STAGE_INIT_LOCAL_IN_TEMPLATE: 'BF061',
   STAGE_AWAIT_IN_TEMPLATE: 'BF062',
@@ -119,10 +122,10 @@ const errorMessages: Record<ErrorCode, string> = {
     'Init statement references an undeclared identifier. Declare it at module scope, inside the component, or import it — otherwise ESM strict mode throws ReferenceError at runtime.',
 
   [ErrorCodes.STAGE_REACTIVE_IN_TEMPLATE]:
-    'Reactive binding (signal getter or memo) referenced from template scope. The template lambda runs at hydrate-entry without the reactive context, so the value falls back to undefined; init\'s createEffect repaints once hydration runs. If a non-reactive initial value is wanted at SSR, capture it into a const before the template references the binding.',
+    'Reactive binding (signal getter or memo) referenced from template scope. The template lambda runs at module scope without the reactive context, so the value cannot be evaluated at SSR. Wrap the JSX expression in /* @client */ to defer it to hydrate, or restructure so the template uses a prop or static value.',
 
   [ErrorCodes.STAGE_INIT_LOCAL_IN_TEMPLATE]:
-    'Init-scope local referenced from template scope. The template lambda runs at module scope (via render() / renderChild()) and cannot reach init-body locals, so the value falls back to undefined; init\'s effect repaints. Lift the const to module scope, inline a literal, or accept the SSR fallback.',
+    'Init-scope local referenced from template scope. The template lambda runs at module scope (via render() / renderChild()) and cannot reach init-body locals. Wrap the JSX expression in /* @client */, or lift the value to a prop or module-scope const.',
 
   [ErrorCodes.STAGE_AWAIT_IN_TEMPLATE]:
     'AwaitExpression in template scope. The hydrate-time template lambda is synchronous; awaiting here would hang first render. Move the await into a server-side handler and pass the resolved value as a prop.',

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -241,11 +241,11 @@ export function recordStageDiagnostics(
     seen.add(d.name)
     if (d.kind === 'signal-getter' || d.kind === 'signal-setter' || d.kind === 'memo-getter') {
       warnings.push(createWarning(ErrorCodes.STAGE_REACTIVE_IN_TEMPLATE, c.loc, {
-        message: `Reactive binding '${d.name}' referenced from template scope (via const '${c.name}'). Falls back to undefined; init's createEffect repaints.`,
+        message: `Reactive binding '${d.name}' referenced from template scope (via const '${c.name}'). The template lambda runs at module scope and cannot reach reactive bindings; the value falls back to undefined and init's createEffect repaints. Wrap the JSX expression in /* @client */ to defer evaluation, or restructure so the template uses a prop or static value.`,
       }))
     } else if (d.kind === 'init-local' || d.kind === 'sub-init-local') {
       warnings.push(createWarning(ErrorCodes.STAGE_INIT_LOCAL_IN_TEMPLATE, c.loc, {
-        message: `Init-scope local '${d.name}' referenced from template scope (via const '${c.name}'). Falls back to undefined; init's effect repaints.`,
+        message: `Init-scope local '${d.name}' referenced from template scope (via const '${c.name}'). The template lambda runs at module scope and cannot reach init-body locals; the value falls back to undefined and init's effect repaints. Wrap the JSX expression in /* @client */ to defer evaluation, or lift the value to a prop or module-scope const.`,
       }))
     }
   }


### PR DESCRIPTION
## Summary

**Originally** aimed to flip BF060/BF061 from `severity: 'warning'` to `severity: 'error'` per #1187 phase 5. Hit a structural issue and downscoped to "improve diagnostic messages" only — explained below.

## What landed

- BF060/BF061 messages now spell out the cause and prescribe the workaround:
  ```
  Init-scope local 'cached' referenced from template scope (via const
  'view'). The template lambda runs at module scope and cannot reach
  init-body locals; the value falls back to undefined and init's effect
  repaints. Wrap the JSX expression in /* @client */ to defer
  evaluation, or lift the value to a prop or module-scope const.
  ```
- `errors.ts` BF06X comment block documents the hard-error blocker.
- `10-stage-diagnostics.test.ts` keeps `severity: 'warning'` but adds an assertion that the message contains `/* @client */` so the workaround stays pinned in tests.

## Why the strict flip backed out

The diagnostic fires at **const-declaration time** (`compute-inlinability` inspects the const's value to classify), but the suggested workaround `/* @client */` applies at **JSX-usage time**. A user who has already deferred every usage to `@client` still gets a hard error because the const declaration is unchanged. Strict-mode flip would false-positive on already-migrated code and break `site/ui`'s build.

This was caught by the e2e-site-ui CI failure: 6 site/ui files emit BF061 from chained-const patterns (`form.field('name')` style and `today` / `addDays` chains). Adding `/* @client */` to JSX usages doesn't suppress the const-level emission.

## Required to land the flip (follow-up)

1. Track which JSX usages are inside `@client` scope.
2. Skip BF060/BF061 emission when every reference to the const is inside a deferred (`@client`) expression.
3. Migrate `site/ui` patterns that don't yet use `@client` (validation-demo.tsx, create-form-demo.tsx, calendar-demo.tsx, calendar-usage-demo.tsx, date-picker-demo.tsx, sidebar-page-nav.tsx).

## Test plan

- [x] `cd packages/jsx && bun test` — 992 pass
- [x] `cd packages/adapter-tests && bun test` — clean
- [x] `cd packages/adapter-hono && bun test` — 3 pre-existing failures (SSR context bridge)
- [x] `cd packages/adapter-go-template && bun test` — clean
- [x] `cd packages/adapter-mojolicious && bun test` — clean
- [x] `bun run --cwd site/ui build` — only pre-existing `table-demo.tsx` BF023 (missing key) remains; no Phase-5-introduced regressions
- [x] `bun run build` — clean

Related: #1187 (parent), #1186 (BF061 default-on warning baseline)

https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36