### PR TITLE
fix(jsx): pass JSX children to renderChild() in CSR templates

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -31,6 +31,12 @@ runAdapterConformanceTests({
   // HTML differs, so the Hono-derived `expectedHtml` doesn't match.
   // `return-map` uses the `data-key` serialisation that differs
   // between Hono (runtime helper) and Go (template variable).
+  // `component-with-jsx-children` exercises forwarding JSX children
+  // through `renderChild()` for `'use client'` parent → `'use client'`
+  // child. The CSR-template fix in #1196 lands that path on the client;
+  // the Go template emitter still drops the children entry, so the
+  // child component renders an empty slot. Out of scope for #1196 —
+  // tracked separately for the Go adapter.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',
@@ -38,6 +44,7 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
+    'component-with-jsx-children',
   ],
   // Go's template runtime can render only callees the adapter
   // explicitly maps to a Go template function via `templatePrimitives`.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -31,12 +31,10 @@ runAdapterConformanceTests({
   // HTML differs, so the Hono-derived `expectedHtml` doesn't match.
   // `return-map` uses the `data-key` serialisation that differs
   // between Hono (runtime helper) and Go (template variable).
-  // `component-with-jsx-children` exercises forwarding JSX children
-  // through `renderChild()` for `'use client'` parent → `'use client'`
-  // child. The CSR-template fix in #1196 lands that path on the client;
-  // the Go template emitter still drops the children entry, so the
-  // child component renders an empty slot. Out of scope for #1196 —
-  // tracked separately for the Go adapter.
+  // `component-with-jsx-children` — the Go template emitter drops
+  // JSX children when emitting the parent's `renderChild()` call, so
+  // the child renders an empty slot. Forwarding is implemented for
+  // CSR templates only; the Go-template path is tracked separately.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -31,14 +31,10 @@ runAdapterConformanceTests({
   // `return-logical-or` / `return-nullish-coalescing` reference
   // `$label` / `$banner` directly; `return-map` iterates over `$items`
   // without a `my` declaration.
-  // `component-with-jsx-children` exercises forwarding JSX children
-  // through `renderChild()` for `'use client'` parent → `'use client'`
-  // child. The CSR-template fix in #1196 lands that path on the client;
-  // the Mojo template emitter still references `$children` without a
-  // `my $children = ...` declaration in the child template, so Perl
-  // rejects the template ("Global symbol '$children' requires explicit
-  // package name"). Same class of Perl-scoping divergence already
-  // listed below — out of scope for #1196.
+  // `component-with-jsx-children` — the Mojo child template references
+  // `$children` without a `my $children = ...` declaration, so Perl
+  // rejects it ("Global symbol '$children' requires explicit package
+  // name"). Same Perl-scoping divergence as the entries above.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -31,6 +31,14 @@ runAdapterConformanceTests({
   // `return-logical-or` / `return-nullish-coalescing` reference
   // `$label` / `$banner` directly; `return-map` iterates over `$items`
   // without a `my` declaration.
+  // `component-with-jsx-children` exercises forwarding JSX children
+  // through `renderChild()` for `'use client'` parent → `'use client'`
+  // child. The CSR-template fix in #1196 lands that path on the client;
+  // the Mojo template emitter still references `$children` without a
+  // `my $children = ...` declaration in the child template, so Perl
+  // rejects the template ("Global symbol '$children' requires explicit
+  // package name"). Same class of Perl-scoping divergence already
+  // listed below — out of scope for #1196.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',
@@ -40,6 +48,7 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
+    'component-with-jsx-children',
   ],
   // Mojo's template runtime is Perl's Mojolicious — the adapter has no
   // `templatePrimitives` registered yet (#1189). Every positive-

--- a/packages/adapter-tests/fixtures/component-with-jsx-children.ts
+++ b/packages/adapter-tests/fixtures/component-with-jsx-children.ts
@@ -30,8 +30,6 @@ export function Card(props: { children?: Child }) {
 `,
   },
   expectedHtml: `
-    <main data-x="0" bf-s="test" bf="s1">
-      <section bf-s="test_s0"><span>hello</span><span>world</span></section>
-    </main>
+    <main data-x="0" bf-s="test" bf="s1"><section bf-s="test_s0"><span>hello</span><span>world</span></section></main>
   `,
 })

--- a/packages/adapter-tests/fixtures/component-with-jsx-children.ts
+++ b/packages/adapter-tests/fixtures/component-with-jsx-children.ts
@@ -1,0 +1,37 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'component-with-jsx-children',
+  description: 'Parent passes JSX children to a child component that renders props.children',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { Card } from './card'
+export function Page() {
+  const [x] = createSignal(0)
+  return (
+    <main data-x={x()}>
+      <Card>
+        <span>hello</span>
+        <span>world</span>
+      </Card>
+    </main>
+  )
+}
+`,
+  components: {
+    './card.tsx': `
+'use client'
+import type { JSX } from '@barefootjs/jsx/jsx-runtime'
+type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
+export function Card(props: { children?: Child }) {
+  return <section>{props.children ?? ''}</section>
+}
+`,
+  },
+  expectedHtml: `
+    <main data-x="0" bf-s="test" bf="s1">
+      <section bf-s="test_s0"><span>hello</span><span>world</span></section>
+    </main>
+  `,
+})

--- a/packages/adapter-tests/fixtures/component-with-jsx-children.ts
+++ b/packages/adapter-tests/fixtures/component-with-jsx-children.ts
@@ -22,9 +22,7 @@ export function Page() {
   components: {
     './card.tsx': `
 'use client'
-import type { JSX } from '@barefootjs/jsx/jsx-runtime'
-type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
-export function Card(props: { children?: Child }) {
+export function Card(props: { children?: unknown }) {
   return <section>{props.children ?? ''}</section>
 }
 `,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -51,6 +51,7 @@ import { fixture as returnNullishCoalescing } from './return-nullish-coalescing'
 import { fixture as returnMap } from './return-map'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
+import { fixture as componentWithJsxChildren } from './component-with-jsx-children'
 import { fixture as multipleInstances } from './multiple-instances'
 import { fixture as staticArrayChildren } from './static-array-children'
 // Priority 8: CSR conformance
@@ -114,6 +115,7 @@ export const jsxFixtures: JSXFixture[] = [
   returnMap,
   // Priority 7: Multi-file composition
   childComponent,
+  componentWithJsxChildren,
   multipleInstances,
   staticArrayChildren,
   // Priority 8: CSR conformance

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -36,16 +36,6 @@ const VOID_ELEMENTS = new Set([
   'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
 ])
 
-/**
- * If the IR component node has JSX children, return a `children: \`...\``
- * prop entry that forwards their rendered HTML to the child component's
- * template at runtime; otherwise return null.
- *
- * Shared by every component-emitting path (static, CSR, reconcile) so the
- * children-forwarding contract stays in one place — without this entry the
- * child component receives `props.children === undefined` and renders an
- * empty `props.children ?? ''` slot.
- */
 function childrenPropEntry(
   children: IRNode[],
   recurse: (n: IRNode) => string,

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -37,6 +37,24 @@ const VOID_ELEMENTS = new Set([
 ])
 
 /**
+ * If the IR component node has JSX children, return a `children: \`...\``
+ * prop entry that forwards their rendered HTML to the child component's
+ * template at runtime; otherwise return null.
+ *
+ * Shared by every component-emitting path (static, CSR, reconcile) so the
+ * children-forwarding contract stays in one place — without this entry the
+ * child component receives `props.children === undefined` and renders an
+ * empty `props.children ?? ''` slot.
+ */
+function childrenPropEntry(
+  children: IRNode[],
+  recurse: (n: IRNode) => string,
+): string | null {
+  if (children.length === 0) return null
+  return `children: \`${children.map(recurse).join('')}\``
+}
+
+/**
  * Sentinel returned by the CSR template's `transformExpr` when the expression
  * references an init-body-only name (#1128). Equality with this sentinel is
  * how downstream emit sites decide to drop a renderChild prop, swap a loop
@@ -163,11 +181,8 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
           return `${quotePropName(p.name)}: ${p.value}`
         })
-      // Include children as a prop for renderChild() template rendering
-      if (node.children.length > 0) {
-        const childHtml = node.children.map(recurse).join('')
-        propsEntries.push(`children: \`${childHtml}\``)
-      }
+      const childrenEntry = childrenPropEntry(node.children, recurse)
+      if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${keyProp.value}` : ''
@@ -565,15 +580,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           const valueStr = attrValueToString(p.value, { useTemplate: true })
           return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr, p.templateValue) : JSON.stringify(p.value)}`
         })
-      // Include JSX children as a `children` prop so renderChild() can pass
-      // them through to the child component's template at runtime. Mirrors
-      // the static-template path in irToHtmlTemplate; without this, parent
-      // CSR templates emit a renderChild() call with no children and the
-      // child component's `props.children ?? ''` slot stays empty.
-      if (node.children.length > 0) {
-        const childHtml = node.children.map(recurse).join('')
-        propsEntries.push(`children: \`${childHtml}\``)
-      }
+      const childrenEntry = childrenPropEntry(node.children, recurse)
+      if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
@@ -890,15 +898,8 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           return `${quotePropName(p.name)}: ${transformed}`
         })
         .filter((entry): entry is string => entry !== null)
-      // Include JSX children as a `children` prop so renderChild() can pass
-      // them through to the child component's template at runtime. Mirrors
-      // the static-template path in irToHtmlTemplate; without this, parent
-      // CSR templates emit a renderChild() call with no children and the
-      // child component's `props.children ?? ''` slot stays empty.
-      if (node.children.length > 0) {
-        const childHtml = node.children.map(recurse).join('')
-        propsEntries.push(`children: \`${childHtml}\``)
-      }
+      const childrenEntry = childrenPropEntry(node.children, recurse)
+      if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -565,6 +565,15 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           const valueStr = attrValueToString(p.value, { useTemplate: true })
           return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr, p.templateValue) : JSON.stringify(p.value)}`
         })
+      // Include JSX children as a `children` prop so renderChild() can pass
+      // them through to the child component's template at runtime. Mirrors
+      // the static-template path in irToHtmlTemplate; without this, parent
+      // CSR templates emit a renderChild() call with no children and the
+      // child component's `props.children ?? ''` slot stays empty.
+      if (node.children.length > 0) {
+        const childHtml = node.children.map(recurse).join('')
+        propsEntries.push(`children: \`${childHtml}\``)
+      }
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
@@ -881,6 +890,15 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           return `${quotePropName(p.name)}: ${transformed}`
         })
         .filter((entry): entry is string => entry !== null)
+      // Include JSX children as a `children` prop so renderChild() can pass
+      // them through to the child component's template at runtime. Mirrors
+      // the static-template path in irToHtmlTemplate; without this, parent
+      // CSR templates emit a renderChild() call with no children and the
+      // child component's `props.children ?? ''` slot stays empty.
+      if (node.children.length > 0) {
+        const childHtml = node.children.map(recurse).join('')
+        propsEntries.push(`children: \`${childHtml}\``)
+      }
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''


### PR DESCRIPTION
## Summary

`irToComponentTemplate` and `generateCsrTemplate` both build the
`renderChild()` props object from `node.props` only — they never consult
`node.children`. Parent components compiled through these two paths
therefore emit `renderChild('Child', { ...props })` calls with no
`children` entry, and any child component whose body uses
`props.children` ends up rendering an empty slot at SSR / CSR time.

The static-template emitter `irToHtmlTemplate` already handles this
correctly (lines 167–170): when `node.children.length > 0`, it pushes
`` children: `...` `` onto `propsEntries` so the rendered HTML of the
JSX children is forwarded to the child component's template.

This PR mirrors that block into the two emitters that were missing it.

## Symptom in the wild

In `piconic-ai/desk`, the canvas page renders `<Flow>` with two
`<Background>` children plus a conditional `<MiniMap>`:

```tsx
<Flow ...>
  <Background variant="cross" gap={24} ... />
  <Background variant="cross" gap={240} ... />
  {miniMapVisible() ? <div><MiniMap ... /></div> : null}
</Flow>
```

The compiled `DeskCanvas.client.js` template emits:

```js
${renderChild("Flow", { nodes: [], edges: [], ... }, void 0, "s4")}
```

— note the missing `children`. As a result, `<Flow>`'s body
(`{props.children ?? ''}`) renders nothing, so the SVG `<pattern>` /
`<rect>` injected by `<Background>` never reaches the DOM and the
canvas grid disappears entirely.

After the fix the same template emits:

```js
${renderChild("Flow", { nodes: [], edges: [], children: `${renderChild("Background", ...)}${renderChild("Background", ...)}${...?...:...}`, ... }, void 0, "s4")}
```

and the children render as expected.

## Test plan

- [x] `bun test packages/adapter-tests packages/jsx` (1216 pass, 0 fail)
- [x] New fixture `component-with-jsx-children` exercises the
      `'use client'` parent → `'use client'` child path with JSX children
      across both CSR conformance and SSR-hydration contract suites
- [x] All existing adapter-tests / jsx tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)