### PR TITLE
feat(jsx): suppress BF060/BF061 when const is only referenced via /* @client */ (#1187 phase 5b)

### DIFF
--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -184,4 +184,55 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     expect(errors.find(e => e.startsWith('[BF060]'))).toBeUndefined()
     expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
   })
+
+  test('chained const referenced only inside /* @client */ does NOT fire BF061', () => {
+    // The classification still flags `view` as unsafe because its value
+    // contains an init-local. But the only template-side reference is
+    // wrapped in `/* @client */`, which routes through
+    // `clientOnlyElements` and doesn't add a `template-closure` edge to
+    // the references graph. `compute-inlinability` reads that graph and
+    // suppresses the diagnostic — the silent-fallback failure mode the
+    // diagnostic warns about can't manifest when every usage is
+    // already deferred to hydrate.
+    const { errors } = compile(`
+      'use client'
+      import { useSettings } from './nodes'
+
+      interface Props { roomId: string }
+
+      export function Foo(props: Props) {
+        const setting = useSettings()
+        const view = JSON.stringify(setting)
+        return <div>{/* @client */ view}</div>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
+  })
+
+  test('chained const with mixed usage fires BF061 (one /* @client */ ref is not enough)', () => {
+    // If ANY usage is outside `/* @client */`, the silent-fallback
+    // failure mode applies for that usage, so the diagnostic still
+    // fires. The user's fix is to wrap the remaining usages too, or
+    // restructure the const itself.
+    const { errors } = compile(`
+      'use client'
+      import { useSettings } from './nodes'
+
+      interface Props { roomId: string }
+
+      export function Foo(props: Props) {
+        const setting = useSettings()
+        const view = JSON.stringify(setting)
+        return (
+          <div>
+            <span>{/* @client */ view}</span>
+            <span>{view}</span>
+          </div>
+        )
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF061]'))).toBeDefined()
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/build-references.ts
+++ b/packages/jsx/src/ir-to-client-js/build-references.ts
@@ -273,6 +273,12 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
       descendJsxChildren()
     },
     expression: ({ node: ex }) => {
+      // `/* @client */` expressions route through `ctx.clientOnlyElements`
+      // (collect-elements.ts) and don't reach the regular template
+      // closure — adding a `template-closure` edge here would falsely
+      // mark the referenced names as template-reachable, defeating the
+      // usage-aware BF060/BF061 suppression in `compute-inlinability`.
+      if (ex.clientOnly) return
       addExprEdges(ROOT_SOURCE, ex.expr, 'template-closure')
     },
     conditional: ({ node: c, descend }) => {

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -128,6 +128,17 @@ export interface InlinabilityAnalysis {
    * prop-based expression downstream).
    */
   decisionsByName: Map<string, RelocateDecision[]>
+  /**
+   * Names referenced from regular template scope (a `template-closure`
+   * edge in the references graph). Used by `toLegacyInlinability` to
+   * skip BF060/BF061 emission for unsafe consts that have no such edge —
+   * either they're never referenced from template at all, or every
+   * reference is inside a `/* @client *\/` expression (which routes
+   * through `clientOnlyElements` and doesn't add a `template-closure`
+   * edge). Either way, the silent-fallback failure mode the diagnostic
+   * warns about can't manifest, so the warning is a false positive.
+   */
+  templateReferencedNames: Set<string>
 }
 
 // JavaScript built-in identifiers that are always available at any scope.
@@ -209,7 +220,22 @@ export function computeInlinability(
     decisionsByName.set(c.name, decisions)
   }
 
-  return { constants, functions, decisionsByName }
+  // Collect names that ROOT_SOURCE references from regular template
+  // scope — i.e. an edge whose context is `'template-closure'`. This
+  // intentionally excludes references that route through
+  // `clientOnlyElements` / `clientOnlyConditionals`, since those don't
+  // add `template-closure` edges. `toLegacyInlinability` uses the set
+  // to gate BF060/BF061 emission so a const whose only template-side
+  // usage is inside `/* @client */` doesn't produce a false-positive
+  // diagnostic.
+  const templateReferencedNames = new Set<string>()
+  for (const edge of graph.edges) {
+    if (edge.context === 'template-closure') {
+      templateReferencedNames.add(edge.to)
+    }
+  }
+
+  return { constants, functions, decisionsByName, templateReferencedNames }
 }
 
 /**
@@ -394,13 +420,21 @@ export function toLegacyInlinability(
   }
 
   // Surface BF060/BF061 for constants that ended up unsafe AFTER chain
-  // resolution — emitting earlier would false-positive on chains that
-  // resolve to safe prop-based expressions. `recordStageDiagnostics`
-  // filters decisions by kind, so it's a no-op for constants whose
-  // unsafety came from non-stage causes (arrow-literal, system-construct,
-  // function references etc.).
+  // resolution AND are actually referenced from a non-`@client` template
+  // position. The post-chain check avoids false-positives on chains
+  // that resolve to safe prop-based expressions; the template-reference
+  // check avoids false-positives on consts whose only template-side
+  // usage is inside `/* @client */` (those references go through
+  // `clientOnlyElements` and don't add a `template-closure` graph
+  // edge, so the silent-fallback failure mode the diagnostic warns
+  // about can't manifest).
+  //
+  // `recordStageDiagnostics` further filters decisions by kind, so it's
+  // a no-op for constants whose unsafety came from non-stage causes
+  // (arrow-literal, system-construct, function references etc.).
   const constsByName = new Map(ctx.localConstants.map(c => [c.name, c]))
   for (const name of unsafeLocalNames) {
+    if (!analysis.templateReferencedNames.has(name)) continue
     const c = constsByName.get(name)
     const decisions = analysis.decisionsByName.get(name)
     if (c && decisions && decisions.length > 0) {


### PR DESCRIPTION
## Summary

#1195 hit a structural blocker promoting BF060/BF061 to hard errors: the diagnostic fires at const-declaration time, but the suggested workaround (`/* @client */`) applies at JSX-usage time. A user who had migrated every usage to `@client` would still get a false-positive error because the const declaration is unchanged.

This PR adds **usage-aware emission** so the diagnostic only fires when the unsafe const is actually reachable from a non-deferred template position — i.e. there exists at least one regular `template-closure` edge in the references graph for the const's name. Consts referenced only via `/* @client */` (which routes through `ctx.clientOnlyElements` and intentionally skips `template-closure` edges) no longer produce noise.

## Changes

- `build-references.ts` IR walker: skip the `template-closure` edge for IRExpression nodes whose `clientOnly` flag is set. Those references reach `ctx.clientOnlyElements` instead, which doesn't contribute template-closure edges, so the bookkeeping stays consistent.
- `compute-inlinability.ts`: `InlinabilityAnalysis` carries a new `templateReferencedNames: Set<string>` populated from `graph.edges`. `toLegacyInlinability` consults it before calling `recordStageDiagnostics`, skipping the BF060/BF061 push when the const isn't in the set.
- New tests pin the suppression: a chained const referenced only inside `/* @client */` no longer fires BF061; mixed usage (some `@client`, some not) still fires (one regular reference is enough).

## Why this matters

Unblocks the future strict-mode flip: with usage-aware emission in place, promoting BF060/BF061 to `severity: 'error'` no longer false-positives on already-migrated code. Component-prop migration (e.g. `<Calendar maxDate={x}>`) still needs separate work — `@client` on a component-prop expression doesn't route through `clientOnlyElements` today; that's a separate gap and the strict flip will need to wait until it's closed.

## Test plan

- [x] jsx: 994 pass (+2 from new tests), no regressions
- [x] adapter-tests / adapter-hono / adapter-go-template / adapter-mojolicious: clean
- [x] site/ui build: same warning surface as before; warnings are no longer fired for files that have migrated to `@client` (none of the current 6 site/ui files use `@client` yet, so no observable change there)

Refs #1187

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_