### PR TITLE
feat(jsx): support /* @client */ on attribute and component-prop positions (#1187 phase 7)

### DIFF
--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -315,4 +315,51 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
 
     expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
   })
+
+  test('/* @client */ on element-attribute defers BF061 (init-local in attr)', () => {
+    // The `<details open={shouldOpen}>` shape: `shouldOpen` is an
+    // init-local computed from props. Wrapping the initializer in
+    // `/* @client */` defers the attribute to a hydrate-time
+    // createEffect (collect-elements pushes into reactiveAttrs); the
+    // SSR template skips the attribute entirely. Diagnostic gate
+    // mirrors the routing — clientOnly attrs aren't risky.
+    const { errors, templateBody } = compile(`
+      interface Props { items: string[]; current: string }
+
+      export function Foo(props: Props) {
+        const hasActive = props.items.includes(props.current)
+        const shouldOpen = hasActive
+        return <details open={/* @client */ shouldOpen}>x</details>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
+    // SSR template must not carry the attribute; init's createEffect
+    // is the sole authority. The element still carries a `bf=` slot
+    // marker so the runtime can find it.
+    expect(templateBody).not.toContain('open=')
+    expect(templateBody).toContain('<details')
+  })
+
+  test('/* @client */ on component-prop defers BF061 (init-local as prop)', () => {
+    // The `<Calendar maxDate={today}>` shape: `today` is an init-local.
+    // `/* @client */` strips the prop from the SSR `renderChild` call;
+    // `initChild`'s `propsExpr` getter still evaluates in init scope,
+    // so the value reaches the child component once init runs.
+    const { errors, templateBody } = compile(`
+      'use client'
+      import { Calendar } from './calendar'
+
+      interface Props { offsetDays: number }
+
+      export function Foo(props: Props) {
+        const today = new Date()
+        return <Calendar fromDate={today} toDate={/* @client */ new Date(today.getTime() + props.offsetDays * 86400000)} />
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
+    // SSR renderChild props don't carry toDate.
+    expect(templateBody).not.toContain('toDate')
+  })
 })

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -316,14 +316,14 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
   })
 
-  test('/* @client */ on element-attribute defers BF061 (init-local in attr)', () => {
+  test('/* @client */ on element-attribute defers BF061 + wires hydrate createEffect', () => {
     // The `<details open={shouldOpen}>` shape: `shouldOpen` is an
     // init-local computed from props. Wrapping the initializer in
     // `/* @client */` defers the attribute to a hydrate-time
     // createEffect (collect-elements pushes into reactiveAttrs); the
     // SSR template skips the attribute entirely. Diagnostic gate
     // mirrors the routing — clientOnly attrs aren't risky.
-    const { errors, templateBody } = compile(`
+    const { errors, templateBody, initBody } = compile(`
       interface Props { items: string[]; current: string }
 
       export function Foo(props: Props) {
@@ -339,14 +339,23 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     // marker so the runtime can find it.
     expect(templateBody).not.toContain('open=')
     expect(templateBody).toContain('<details')
+    expect(templateBody).toMatch(/bf="s\d+"/)
+    // Init body wires a `createEffect` that applies the value at
+    // hydrate. `<details open>` is a boolean property attr so emit
+    // uses the property-assignment shape (`_s0.open = !!(...)`)
+    // rather than `setAttribute`. The bug we pin: SSR-strip without
+    // the corresponding effect would leave the attribute
+    // permanently unset.
+    expect(initBody).toContain('createEffect')
+    expect(initBody).toMatch(/\.open\s*=|setAttribute\(['"]open['"]/)
   })
 
-  test('/* @client */ on component-prop defers BF061 (init-local as prop)', () => {
+  test('/* @client */ on component-prop defers BF061 + wires initChild getter', () => {
     // The `<Calendar maxDate={today}>` shape: `today` is an init-local.
     // `/* @client */` strips the prop from the SSR `renderChild` call;
     // `initChild`'s `propsExpr` getter still evaluates in init scope,
     // so the value reaches the child component once init runs.
-    const { errors, templateBody } = compile(`
+    const { errors, templateBody, initBody } = compile(`
       'use client'
       import { Calendar } from './calendar'
 
@@ -361,5 +370,172 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
     // SSR renderChild props don't carry toDate.
     expect(templateBody).not.toContain('toDate')
+    // Init's initChild propsExpr exposes a getter for `toDate` so the
+    // child sees the value once init runs.
+    expect(initBody).toContain('initChild')
+    expect(initBody).toMatch(/get toDate\(\)/)
+  })
+
+  test('/* @client */ attr inside a conditional branch wires the per-branch effect (regression: collectBranchReactiveAttrs)', () => {
+    // The branch-level reactive-attr collector has its own gate that
+    // independently of the main `element` handler decides whether to
+    // emit a hydrate-time binding. Without honoring `clientOnly`, the
+    // SSR strip (in html-template) and the per-branch bindEvents
+    // would disagree, leaving the attribute permanently unset. This
+    // test pins both halves of the contract.
+    const { templateBody, clientJs } = compile(`
+      interface Props { items: string[]; current: string; show: boolean }
+
+      export function Foo(props: Props) {
+        const hasActive = props.items.includes(props.current)
+        const shouldOpen = hasActive
+        return (
+          <div>
+            {props.show ? <details open={/* @client */ shouldOpen}>x</details> : null}
+          </div>
+        )
+      }
+    `)
+
+    expect(templateBody).not.toContain('open=')
+    // The branch's `bindEvents` callback (emitted via `insert(...)`)
+    // must contain a `createDisposableEffect` that applies `open`.
+    // Same property-vs-attribute split as the top-level case —
+    // accept either form.
+    expect(clientJs).toContain('createDisposableEffect')
+    expect(clientJs).toMatch(/\.open\s*=|setAttribute\(['"]open['"]/)
+  })
+
+  test('/* @client */ promotes a no-"use client" component to a hydrating client component', () => {
+    // A component without `'use client'` would normally compile to a
+    // pure server-render shape (no init, no hydrate). The directive
+    // demands hydrate-time wiring, which forces the compiler to emit
+    // an init function — otherwise the SSR-stripped attribute would
+    // be permanently unset. Pin this so a future refactor doesn't
+    // accidentally silently drop the directive on no-"use client"
+    // components.
+    const { errors, templateBody, initBody } = compile(`
+      interface Props { items: string[]; current: string }
+
+      export function Foo(props: Props) {
+        const hasActive = props.items.includes(props.current)
+        return <details open={/* @client */ hasActive}>x</details>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF06'))).toBeUndefined()
+    expect(templateBody).not.toContain('open=')
+    // Directive forced init emission even without `'use client'`.
+    expect(initBody).not.toBe('')
+    expect(initBody).toMatch(/\.open\s*=|setAttribute\(['"]open['"]/)
+  })
+
+  test('/* @client */ on attribute inside .map() loop wires per-item effect', () => {
+    // Loop bodies allocate per-item slots; clientOnly attrs on loop
+    // children must still route through the reactive-attr machinery
+    // so each rendered item gets its hydrate-time binding.
+    const { templateBody, clientJs } = compile(`
+      'use client'
+      interface Props { rows: { id: string; raw: string }[] }
+
+      export function Foo(props: Props) {
+        return (
+          <ul>
+            {props.rows.map(row => {
+              const computed = row.raw.toUpperCase()
+              return <li key={row.id} data-tag={/* @client */ computed}>{row.id}</li>
+            })}
+          </ul>
+        )
+      }
+    `)
+
+    expect(templateBody).not.toContain('data-tag=')
+    expect(clientJs).toMatch(/setAttribute\(['"]data-tag['"]/)
+  })
+
+  test('/* @client */ on multiple attrs of the same element each wire their own effect', () => {
+    const { templateBody, initBody } = compile(`
+      'use client'
+      interface Props { ax: string; bx: string }
+
+      export function Foo(props: Props) {
+        const a = props.ax + '!'
+        const b = props.bx + '!'
+        return <div data-a={/* @client */ a} data-b={/* @client */ b}>x</div>
+      }
+    `)
+
+    expect(templateBody).not.toContain('data-a=')
+    expect(templateBody).not.toContain('data-b=')
+    // Both attributes get their own setAttribute call inside init's
+    // createEffect block.
+    expect(initBody).toMatch(/setAttribute\(['"]data-a['"]/)
+    expect(initBody).toMatch(/setAttribute\(['"]data-b['"]/)
+  })
+
+  test('/* @client */ on signal-bearing attr does not double-push reactiveAttrs', () => {
+    // The wrap heuristic would already wrap a signal-bearing attr
+    // (`<div data-x={count()}>`). Adding `/* @client */` shouldn't
+    // emit a duplicate binding — the OR gate in collect-elements
+    // unions the two, it doesn't sum them.
+    const { initBody } = compile(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props {}
+
+      export function Foo(_props: Props) {
+        const [count, _set] = createSignal(0)
+        return <div data-x={/* @client */ count()}>x</div>
+      }
+    `)
+
+    const matches = initBody.match(/setAttribute\(['"]data-x['"]/g) ?? []
+    expect(matches).toHaveLength(1)
+  })
+
+  test('/* @client */ on event handler is a no-op (handlers are init-body anyway)', () => {
+    // Event handlers are pulled out of attrs in jsx-to-ir before
+    // clientOnly detection runs. The directive is silently ignored
+    // — the handler is wired up via the existing event-delegation
+    // path. Pin this so we spot a behaviour drift.
+    const { initBody } = compile(`
+      'use client'
+      interface Props {}
+
+      export function Foo(_props: Props) {
+        const handleClick = () => {}
+        return <button onClick={/* @client */ handleClick}>x</button>
+      }
+    `)
+
+    // Handler is wired via the standard bindEvents path — exact form
+    // varies by adapter, but the handler name should appear inside
+    // the init body.
+    expect(initBody).toContain('handleClick')
+  })
+
+  test('/* @client */ component-prop with JSX subtree value: directive ignored (jsxChildren branch returns early)', () => {
+    // `processComponentProps` treats `<MyComp content={<Bar />}>` via
+    // a separate `jsxChildren` path that returns before the
+    // clientOnly detection. The prop is structurally a child subtree,
+    // not a deferred init-body value, so silent ignore is correct.
+    // Pin this so a future refactor doesn't accidentally start
+    // honouring the directive there.
+    const { errors } = compile(`
+      'use client'
+      import { Wrapper } from './wrapper'
+      import { Inner } from './inner'
+
+      interface Props {}
+
+      export function Foo(_props: Props) {
+        return <Wrapper content={/* @client */ <Inner />} />
+      }
+    `)
+
+    // No diagnostic noise either way.
+    expect(errors.find(e => e.startsWith('[BF06'))).toBeUndefined()
   })
 })

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -516,6 +516,45 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     expect(initBody).toContain('handleClick')
   })
 
+  test('"@client" inside string literal does NOT trigger clientOnly routing (false-positive guard)', () => {
+    // Regression for a Copilot review concern (#1199): prior to the
+    // shared `hasLeadingClientDirective` helper, detection used
+    // `getFullText().includes('@client')`, which would also match a
+    // bare `"@client"` substring inside the expression — silently
+    // stripping the attribute from SSR. Pin the tightened detection
+    // (leading block-comment trivia matching the directive shape
+    // exactly) by checking that the SSR template still emits the
+    // attribute when no leading comment is present.
+    const { templateBody } = compile(`
+      'use client'
+      interface Props {}
+
+      export function Foo(_props: Props) {
+        return <div data-x={'@client tag'}>x</div>
+      }
+    `)
+
+    expect(templateBody).toContain('data-x=')
+  })
+
+  test('/* @client */ as TRAILING comment does NOT trigger clientOnly routing (leading-only)', () => {
+    // The directive is a position-sensitive marker — `<div data-x={x
+    // /* @client */}>` is an inline annotation about the expression,
+    // not a deferral request. Tightened detection only honours
+    // *leading* trivia, so the SSR template must still emit the
+    // attribute.
+    const { templateBody } = compile(`
+      'use client'
+      interface Props { tag: string }
+
+      export function Foo(props: Props) {
+        return <div data-x={props.tag /* @client */}>x</div>
+      }
+    `)
+
+    expect(templateBody).toContain('data-x=')
+  })
+
   test('/* @client */ component-prop with JSX subtree value: directive ignored (jsxChildren branch returns early)', () => {
     // `processComponentProps` treats `<MyComp content={<Bar />}>` via
     // a separate `jsxChildren` path that returns before the

--- a/packages/jsx/src/ir-to-client-js/build-references.ts
+++ b/packages/jsx/src/ir-to-client-js/build-references.ts
@@ -257,6 +257,12 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
   const visitor: WalkerVisitor<null> = {
     element: ({ node: el, descend }) => {
       for (const attr of el.attrs) {
+        // `/* @client */` attrs route through `reactiveAttrs` (an
+        // init-body createEffect), not the template closure — the
+        // SSR template skips them entirely. Mirrors the JSX-child
+        // `clientOnly` carve-out below so usage-aware diagnostics
+        // (BF060/BF061) don't false-positive against them.
+        if (attr.clientOnly) continue
         if (attr.dynamic && attr.value) {
           const v = typeof attr.value === 'string' ? attr.value : attrValueToString(attr.value)
           if (v) addExprEdges(ROOT_SOURCE, v, 'template-closure')
@@ -267,6 +273,11 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
     },
     component: ({ node: c, descend, descendJsxChildren }) => {
       for (const prop of c.props) {
+        // `/* @client */` props are stripped from `renderChild` and
+        // populated via `initChild`'s getter — the value lives in
+        // init scope, not template scope, so no template-closure
+        // edge.
+        if (prop.clientOnly) continue
         if (prop.dynamic) addExprEdges(ROOT_SOURCE, prop.value, 'template-closure')
       }
       descend()

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -694,7 +694,13 @@ function collectBranchReactiveAttrs(node: IRNode, ctx: ClientJsContext): Conditi
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx)
-        if (!decideWrapForAttr(expanded, ctx, attr).wrap) continue
+        // Mirror the main-path gate (collectElements.element handler):
+        // `/* @client */` always defers via createEffect regardless of
+        // the wrap heuristic — without this carve-out, a clientOnly
+        // attr inside a conditional branch would be skipped at SSR
+        // (html-template strips it) AND never get a hydrate-time
+        // binding emitted, leaving the attribute permanently unset.
+        if (!attr.clientOnly && !decideWrapForAttr(expanded, ctx, attr).wrap) continue
         attrs.push({
           slotId: el.slotId,
           attrName: attr.name,

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -646,7 +646,13 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
         // they can't false-match call-like substrings inside string
         // literals (e.g. `style={{ color: 'hsl(221 83% 53%)' }}`) and
         // don't depend on the expansion order of local constants.
-        if (decideWrapForAttr(expandedValueStr, ctx, attr).wrap) {
+        // `/* @client */` forces the attribute through the
+        // `reactiveAttrs` path regardless of the wrap heuristic —
+        // the SSR template won't emit the attribute (see
+        // html-template.ts), so init's `createEffect` is the only
+        // authority that ever sets it. Without this push the
+        // attribute would be silently dropped.
+        if (attr.clientOnly || decideWrapForAttr(expandedValueStr, ctx, attr).wrap) {
           // Slots inside a conditional branch are collected per-branch by
           // `collectBranchReactiveAttrs` and emitted inside `insert()`
           // bindEvents — keeping them out of init-level `ctx.reactiveAttrs`

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -304,6 +304,11 @@ function collectTemplateRiskyNames(irRoot: IRNode): Set<string> {
       // hydrate adds the attribute, producing a flash, and any code
       // that reads the attribute pre-hydrate sees nothing. Real bug.
       for (const attr of el.attrs) {
+        // `/* @client */` attrs are stripped from the SSR template
+        // (see html-template.ts) and applied by init's `createEffect`,
+        // so their identifiers never reach a risky template
+        // position. Same carve-out the build-references walker uses.
+        if (attr.clientOnly) continue
         if (!attr.dynamic || !attr.value) continue
         const text = typeof attr.value === 'string'
           ? (attr.templateValue ?? attr.value)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -155,6 +155,8 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          // `/* @client */` defers the prop to hydrate via initChild.
+          if (p.clientOnly) return null
           // JSX prop: render children inline as template literal
           if (p.jsxChildren?.length) {
             const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
@@ -163,6 +165,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
           return `${quotePropName(p.name)}: ${p.value}`
         })
+        .filter((entry): entry is string => entry !== null)
       // Include children as a prop for renderChild() template rendering
       if (node.children.length > 0) {
         const childHtml = node.children.map(recurse).join('')
@@ -489,6 +492,10 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
+          // `/* @client */` defers the attribute to hydrate via
+          // `reactiveAttrs`. Skip from the SSR template so init's
+          // createEffect is the sole authority on the attribute.
+          if (a.clientOnly) return ''
           if (a.name === '...') {
             const spreadValue = attrValueToString(a.value, { useTemplate: true })
             if (!spreadValue) return ''
@@ -557,6 +564,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          // `/* @client */` defers the prop to hydrate via initChild.
+          if (p.clientOnly) return null
           if (p.jsxChildren?.length) {
             const childHtml = p.jsxChildren.map(recurse).join('')
             return `${quotePropName(p.name)}: \`${childHtml}\``
@@ -565,6 +574,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           const valueStr = attrValueToString(p.value, { useTemplate: true })
           return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr, p.templateValue) : JSON.stringify(p.value)}`
         })
+        .filter((entry): entry is string => entry !== null)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
@@ -796,6 +806,13 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
+          // `/* @client */` defers the attribute to hydrate. The
+          // `reactiveAttrs` push in collect-elements wires a
+          // `createEffect` that sets the attribute via the existing
+          // hydrate-time path; the SSR template must not race that
+          // by emitting an initial value, so skip the attribute
+          // entirely here.
+          if (a.clientOnly) return ''
           if (a.name === '...') {
             const spreadValue = attrValueToString(a.value, { useTemplate: true })
             if (!spreadValue) return ''
@@ -866,6 +883,11 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         .filter(p => p.name !== '...' && !p.name.startsWith('...') && p.name !== 'key')
         .filter(p => !(p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()))
         .map(p => {
+          // `/* @client */` defers the prop to hydrate. Drop from the
+          // SSR `renderChild` props — `initChild`'s `propsExpr` getter
+          // (built in collect-elements) reads the value once init
+          // runs, mirroring the existing UNSAFE strip path below.
+          if (p.clientOnly) return null
           if (p.jsxChildren?.length) {
             const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
             return `${quotePropName(p.name)}: \`${childHtml}\``

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -471,7 +471,14 @@ export function collectLoopChildReactiveAttrs(
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx)
-        if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') continue
+        // `/* @client */` always defers via per-item createEffect
+        // regardless of the reactivity classifier — matches the
+        // top-level `collectElements.element` and the conditional
+        // `collectBranchReactiveAttrs` carve-outs. Without this, the
+        // SSR template strips the attribute (html-template) and no
+        // hydrate-time binding is emitted, leaving the per-item
+        // attribute permanently unset.
+        if (!attr.clientOnly && classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') continue
         attrs.push({
           childSlotId: el.slotId,
           attrName: attr.name,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -70,6 +70,41 @@ interface TransformContext {
 }
 
 /**
+ * Detect a leading `/* @client *​/` directive on the given expression
+ * node. Scans only the leading trivia (the slice between `pos` and
+ * `getStart`, which excludes the expression's own text) and requires
+ * the comment interior to match the directive shape exactly, so:
+ *
+ *   - `@client` as a substring inside a string literal in the
+ *     expression itself doesn't false-positive
+ *   - a trailing `/* @client *​/` after the expression doesn't trigger
+ *   - an unrelated block comment like `/* @client-flag *​/` doesn't
+ *     trigger
+ *
+ * Used at three sites for consistency across positions:
+ *
+ *   - JSX child: `<div>{/* @client *​/ x}</div>`
+ *   - Element attribute initializer: `<div data-x={/* @client *​/ x}>`
+ *   - Component prop initializer: `<MyComp prop={/* @client *​/ x}>`
+ *
+ * Note: `ts.getLeadingCommentRanges` doesn't return comments inside
+ * a JsxExpression's curly braces (TypeScript handles JSX trivia
+ * specially), so we read the trivia text directly and parse block
+ * comments out of it.
+ */
+const CLIENT_DIRECTIVE_INTERIOR_RE = /^\s*@client\s*$/
+const BLOCK_COMMENT_RE = /\/\*([\s\S]*?)\*\//g
+function hasLeadingClientDirective(expr: ts.Expression, sourceFile: ts.SourceFile): boolean {
+  const trivia = sourceFile.text.slice(expr.pos, expr.getStart(sourceFile))
+  BLOCK_COMMENT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = BLOCK_COMMENT_RE.exec(trivia)) !== null) {
+    if (CLIENT_DIRECTIVE_INTERIOR_RE.test(m[1])) return true
+  }
+  return false
+}
+
+/**
  * Walk an expression AST to check if it calls any known signal getter or memo.
  * Uses a pre-built Set for O(1) lookup per call expression.
  */
@@ -913,12 +948,12 @@ function transformExpression(
   // Check for bare signal/memo identifier (BF044)
   checkBareSignalOrMemoIdentifier(expr, ctx)
 
-  // Check for @client directive in prefix style: {/* @client */ expr}
-  // getFullText() includes leading trivia (comments, whitespace). This is a
-  // JsxExpression-level concern — the core dispatcher never sees the comment —
-  // so detection and post-processing stay in the wrapper.
-  const fullText = node.getFullText(ctx.sourceFile)
-  const isClientOnly = fullText.includes('@client')
+  // Check for @client directive in prefix style: {/* @client */ expr}.
+  // Detection is centralised in `hasLeadingClientDirective` so JSX-child,
+  // attribute, and component-prop positions agree — a substring match on
+  // `getFullText()` would false-positive on string literals or trailing
+  // comments containing "@client".
+  const isClientOnly = hasLeadingClientDirective(expr, ctx.sourceFile)
 
   // #547: Inline a JSX constant referenced by identifier. Unique to JSX-child
   // position — conditional branches and return position don't resolve
@@ -2518,13 +2553,12 @@ function processAttributes(
         templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
       }
       // `/* @client */` in attribute initializer position: defer the
-      // attribute to hydrate. Same detection as JSX-child position
-      // (see `transformExpression`) — `getFullText` includes leading
-      // trivia (comments, whitespace) so the directive is visible
-      // here. Element vs component-prop routing happens downstream:
-      // collect-elements wires this into `reactiveAttrs` for elements,
-      // html-template strips it from `renderChild` for components.
-      if (attr.initializer.getFullText(ctx.sourceFile).includes('@client')) {
+      // attribute to hydrate. Detection routed through the shared
+      // helper so it agrees with JSX-child / component-prop sites.
+      // Downstream routing: collect-elements wires this into
+      // `reactiveAttrs` for elements; html-template strips it from
+      // the SSR template (and from `renderChild` for components).
+      if (hasLeadingClientDirective(attr.initializer.expression, ctx.sourceFile)) {
         clientOnly = true
       }
     }
@@ -3018,10 +3052,12 @@ function processComponentProps(
         propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
       }
       // `/* @client */` in component-prop initializer position: defer
-      // to hydrate. html-template strips the prop from `renderChild`;
-      // `initChild`'s `propsExpr` already runs in init scope so the
-      // value reaches the child component once init runs.
-      if (attr.initializer.getFullText(ctx.sourceFile).includes('@client')) {
+      // to hydrate. Detection routed through the shared helper so it
+      // agrees with JSX-child / element-attr sites. Downstream:
+      // html-template strips the prop from `renderChild`; `initChild`'s
+      // `propsExpr` already runs in init scope so the value reaches
+      // the child component once init runs.
+      if (hasLeadingClientDirective(attr.initializer.expression, ctx.sourceFile)) {
         clientOnly = true
       }
     }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2512,8 +2512,21 @@ function processAttributes(
     const attrResult = getAttributeValue(attr, ctx)
     const { value, dynamic, isLiteral } = attrResult
     let templateValue: string | undefined
-    if (dynamic && typeof value === 'string' && attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
+    let clientOnly: boolean | undefined
+    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+      if (dynamic && typeof value === 'string') {
+        templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
+      }
+      // `/* @client */` in attribute initializer position: defer the
+      // attribute to hydrate. Same detection as JSX-child position
+      // (see `transformExpression`) — `getFullText` includes leading
+      // trivia (comments, whitespace) so the directive is visible
+      // here. Element vs component-prop routing happens downstream:
+      // collect-elements wires this into `reactiveAttrs` for elements,
+      // html-template strips it from `renderChild` for components.
+      if (attr.initializer.getFullText(ctx.sourceFile).includes('@client')) {
+        clientOnly = true
+      }
     }
 
     attrs.push({
@@ -2522,6 +2535,7 @@ function processAttributes(
       templateValue,
       dynamic,
       isLiteral,
+      clientOnly,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
@@ -2998,8 +3012,18 @@ function processComponentProps(
     const propValue = templateLiteralToString(value) ?? 'true'
 
     let propTemplateValue: string | undefined
-    if (dynamic && typeof value === 'string' && attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
+    let clientOnly: boolean | undefined
+    if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+      if (dynamic && typeof value === 'string') {
+        propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
+      }
+      // `/* @client */` in component-prop initializer position: defer
+      // to hydrate. html-template strips the prop from `renderChild`;
+      // `initChild`'s `propsExpr` already runs in init scope so the
+      // value reaches the child component once init runs.
+      if (attr.initializer.getFullText(ctx.sourceFile).includes('@client')) {
+        clientOnly = true
+      }
     }
 
     props.push({
@@ -3008,6 +3032,7 @@ function processComponentProps(
       templateValue: propTemplateValue,
       dynamic,
       isLiteral,
+      clientOnly,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
@@ -3228,6 +3253,10 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
   for (const attr of attrs) {
     // Skip key — it's used for loop reconciliation, not rendered to DOM
     if (attr.name === 'key') continue
+    // `/* @client */` always defers via the reactiveAttrs path, so the
+    // element MUST have a slotId for runtime lookup — even if the
+    // expression itself doesn't trip the signal/memo/prop heuristics.
+    if (attr.clientOnly) return true
     if (attr.dynamic && attr.value) {
       const valueToCheck = getAttributeValueAsString(attr.value)
       if (!valueToCheck) continue

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -605,6 +605,15 @@ export interface IRAttribute extends AttrMeta {
   callsReactiveGetters?: boolean
   /** When true, attr expression contains any `identifier()` pattern (computed from AST). (#940 DRY consolidation) */
   hasFunctionCalls?: boolean
+  /**
+   * Set when the JSX initializer carries a leading `/* @client *\/`
+   * comment. The CSR template emitter omits the attribute from SSR
+   * HTML; collect-elements pushes the value into `reactiveAttrs` so a
+   * `createEffect`-wrapped binding sets it at hydrate. Mirrors the
+   * existing JSX-child `clientOnly` semantic — same opt-out, applied
+   * to element-attribute position.
+   */
+  clientOnly?: boolean
 }
 
 export interface IREvent {
@@ -628,6 +637,15 @@ export interface IRProp extends AttrMeta {
   callsReactiveGetters?: boolean
   /** When true, prop expression contains any `identifier()` pattern (computed from AST). (#942 DRY consolidation) */
   hasFunctionCalls?: boolean
+  /**
+   * Set when the JSX initializer carries a leading `/* @client *\/`
+   * comment. The CSR template emitter omits the prop from
+   * `renderChild`; `initChild`'s `propsExpr` getters already evaluate
+   * in init scope, so the value still reaches the child component
+   * once init runs. No SSR markup carries the value, mirroring the
+   * existing JSX-child / element-attribute `clientOnly` semantic.
+   */
+  clientOnly?: boolean
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -607,11 +607,12 @@ export interface IRAttribute extends AttrMeta {
   hasFunctionCalls?: boolean
   /**
    * Set when the JSX initializer carries a leading `/* @client *\/`
-   * comment. The CSR template emitter omits the attribute from SSR
-   * HTML; collect-elements pushes the value into `reactiveAttrs` so a
-   * `createEffect`-wrapped binding sets it at hydrate. Mirrors the
-   * existing JSX-child `clientOnly` semantic — same opt-out, applied
-   * to element-attribute position.
+   * comment. `html-template.ts`'s template generators omit the
+   * attribute from the SSR output; `collect-elements.ts` pushes the
+   * value into `reactiveAttrs` (top-level, conditional-branch, and
+   * loop-child paths) so a `createEffect` binding applies it at
+   * hydrate. Mirrors the existing JSX-child `clientOnly` semantic —
+   * same opt-out, applied to element-attribute position.
    */
   clientOnly?: boolean
 }
@@ -639,11 +640,12 @@ export interface IRProp extends AttrMeta {
   hasFunctionCalls?: boolean
   /**
    * Set when the JSX initializer carries a leading `/* @client *\/`
-   * comment. The CSR template emitter omits the prop from
-   * `renderChild`; `initChild`'s `propsExpr` getters already evaluate
-   * in init scope, so the value still reaches the child component
-   * once init runs. No SSR markup carries the value, mirroring the
-   * existing JSX-child / element-attribute `clientOnly` semantic.
+   * comment. `html-template.ts`'s template generators omit the prop
+   * from the `renderChild` arguments in the SSR output;
+   * `initChild`'s `propsExpr` getters (built in `collect-elements.ts`)
+   * still evaluate in init scope, so the value reaches the child
+   * component once init runs. Mirrors the JSX-child / element-
+   * attribute `clientOnly` semantic.
    */
   clientOnly?: boolean
 }

--- a/site/ui/components/calendar-demo.tsx
+++ b/site/ui/components/calendar-demo.tsx
@@ -92,6 +92,7 @@ export function CalendarFormDemo() {
  */
 export function CalendarWithConstraintsDemo() {
   const today = new Date()
+  const maxDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 30)
   const [date, setDate] = createSignal<Date | undefined>(undefined)
 
   // Disable weekends (Saturday=6, Sunday=0)
@@ -113,7 +114,7 @@ export function CalendarWithConstraintsDemo() {
         selected={date()}
         onSelect={setDate}
         fromDate={today}
-        toDate={new Date(today.getFullYear(), today.getMonth(), today.getDate() + 30)}
+        toDate={/* @client */ maxDate}
         disabled={isWeekend}
       />
       <p className="text-sm text-muted-foreground">{formattedDate()}</p>

--- a/site/ui/components/calendar-usage-demo.tsx
+++ b/site/ui/components/calendar-usage-demo.tsx
@@ -11,12 +11,13 @@ import { Calendar } from '@ui/components/ui/calendar'
 
 function CalendarUsageDemo(_props: {}) {
   const today = new Date()
+  const thirtyDaysLater = new Date(today.getTime() + 30 * 86400000)
 
   return (
     <div className="flex flex-wrap gap-8">
       <Calendar mode="single" />
       <Calendar mode="range" numberOfMonths={2} />
-      <Calendar mode="single" fromDate={today} toDate={new Date(today.getTime() + 30 * 86400000)} />
+      <Calendar mode="single" fromDate={today} toDate={/* @client */ thirtyDaysLater} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes the gap surfaced by phase 6 (#1198): BF060/BF061 are hard errors at element-attribute positions, but `/* @client */` was previously detected only on JSX child expressions. Users had no in-line escape hatch — the only fix was restructuring (inline-the-expression, hoist-to-module-scope).

This PR extends `/* @client */` to attribute and component-prop initializer positions, mirroring the JSX-child semantic: defer evaluation to hydrate, skip from the SSR shape.

```tsx
// element attribute — defers via createEffect at hydrate
<details open={/* @client */ shouldOpen}>...</details>

// component prop — stripped from renderChild, populated by initChild getter
<Calendar toDate={/* @client */ maxDate} />
```

## Pipeline changes

| File | Change |
|---|---|
| `jsx-to-ir.ts` | Detect `@client` in attribute / component-prop initializer leading trivia. Element with any clientOnly attr gets a slotId. |
| `collect-elements.ts` | clientOnly attr → push into `reactiveAttrs` regardless of wrap heuristic (init's createEffect is the sole authority). |
| `html-template.ts` | All four CSR / renderChild emit paths skip clientOnly attrs and props. |
| `build-references.ts` | clientOnly attrs / props don't contribute `template-closure` edges. |
| `compute-inlinability.ts` | clientOnly attrs are excluded from `templateRiskyNames`. |
| `types.ts` | `IRAttribute.clientOnly` / `IRProp.clientOnly` added. |

## Routing summary

| Position | clientOnly = true | Hydrate path |
|---|---|---|
| Element attribute | SSR template skips attribute | `reactiveAttrs` → `createEffect` setAttribute |
| Component prop | Stripped from `renderChild` props | `initChild`'s getter on `propsExpr` |

Both reuse mechanisms that already exist in the runtime — no new emit code beyond plumbing the flag.

## Tests

New pinning tests in `staged-ir/10-stage-diagnostics`:

- **Element attribute**: `<details open={/* @client */ shouldOpen}>` — BF061 doesn't fire and `open=` is absent from SSR template body.
- **Component prop**: `<Calendar toDate={/* @client */ ...}>` — BF061 doesn't fire and `toDate` is absent from `renderChild`'s props object.

## site/ui workaround refactors

Phase 6 had to inline two chained-const computations to dodge the diagnostic. With the directive available those revert to the natural named-const form:

```tsx
// calendar-demo / calendar-usage-demo
const maxDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 30)
<Calendar toDate={/* @client */ maxDate} />
```

Two other phase-6 changes stay as-is:
- `date-picker-demo`: `addDays` is a pure helper, module scope is the right home regardless.
- `sidebar-page-nav`: server component (no hydration), `/* @client */` semantics don't apply.

## Test plan

- [x] jsx: 999 pass (+2 from new pinning tests)
- [x] adapter-hono: 96 pass
- [x] site/ui builds clean (no BF060/BF061; pre-existing BF023 on `table-demo` unchanged)
- [x] CalendarWithConstraintsDemo SSR output: `toDate` absent from `renderChild` props

Refs #1187

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4jyJXynN2jpGvKZ8U7Y36)_