### PR TITLE
feat(adapter-mojolicious): forward JSX children to child component templates

### DIFF
--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -88,6 +88,11 @@ sub register_child_renderer ($self, $name, $renderer) {
 sub render_child ($self, $name, %props) {
     my $renderer = $self->_child_renderers->{$name};
     die "No renderer registered for child component '$name'" unless $renderer;
+    # JSX children come in via Mojo `begin %>...<% end` capture, which
+    # produces a CODE ref returning a Mojo::ByteStream. Materialize it
+    # before handing the props to the child renderer so the child
+    # template sees `$children` as already-rendered HTML.
+    $props{children} = $props{children}->() if ref($props{children}) eq 'CODE';
     return $renderer->(\%props);
 }
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -31,10 +31,6 @@ runAdapterConformanceTests({
   // `return-logical-or` / `return-nullish-coalescing` reference
   // `$label` / `$banner` directly; `return-map` iterates over `$items`
   // without a `my` declaration.
-  // `component-with-jsx-children` — the Mojo child template references
-  // `$children` without a `my $children = ...` declaration, so Perl
-  // rejects it ("Global symbol '$children' requires explicit package
-  // name"). Same Perl-scoping divergence as the entries above.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',
@@ -44,7 +40,6 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
-    'component-with-jsx-children',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining
@@ -164,6 +159,34 @@ export function Static() {
 }
 `)
     expect(result.template).not.toContain("bf->register_script")
+  })
+
+  test('forwards JSX children via begin/end capture (#1202)', () => {
+    const result = compileAndGenerate(`
+'use client'
+export function Page() {
+  return <main><Card><span>hello</span><span>world</span></Card></main>
+}
+`)
+    // Capture lives in its own action so the inner `%>` can't close
+    // the outer render_child tag.
+    expect(result.template).toMatch(/<% my \$bf_children_\w+ = begin %>/)
+    expect(result.template).toContain('<span>hello</span><span>world</span>')
+    expect(result.template).toContain('<% end %>')
+    expect(result.template).toMatch(
+      /bf->render_child\('card'.*children => \$bf_children_\w+\)/,
+    )
+  })
+
+  test('omits children entry when component has no JSX children', () => {
+    const result = compileAndGenerate(`
+'use client'
+export function Page() {
+  return <main><Card label="x" /></main>
+}
+`)
+    expect(result.template).not.toContain('begin %>')
+    expect(result.template).not.toContain('children =>')
   })
 })
 

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -118,6 +118,7 @@ export class MojoAdapter extends BaseAdapter {
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.errors = []
+    this.childrenCaptureCounter = 0
 
     const templateBody = ir.root.type === 'if-statement'
       ? this.renderIfStatement(ir.root as IRIfStatement)
@@ -397,8 +398,24 @@ export class MojoAdapter extends BaseAdapter {
       propParts.push(`_bf_slot => '${comp.slotId}'`)
     }
     const propsStr = propParts.length > 0 ? ', ' + propParts.join(', ') : ''
-    return `<%== bf->render_child('${this.toTemplateName(comp.name)}'${propsStr}) %>`
+    const tplName = this.toTemplateName(comp.name)
+    if (comp.children.length > 0) {
+      // Forward JSX children via Mojo's `begin %>...<% end` capture so
+      // dynamic segments inside the children (signals, conditionals)
+      // get evaluated in the parent's template scope before reaching
+      // the child renderer. The capture has to live in a separate
+      // action — embedding it inside the `<%== ... %>` that wraps
+      // `render_child` would let the inner `%>` close the outer tag.
+      // `render_child` materializes the resulting CODE ref into the
+      // captured Mojo::ByteStream.
+      const childrenBody = this.renderChildren(comp.children)
+      const varName = `$bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+      return `<% my ${varName} = begin %>${childrenBody}<% end %><%== bf->render_child('${tplName}'${propsStr}, children => ${varName}) %>`
+    }
+    return `<%== bf->render_child('${tplName}'${propsStr}) %>`
   }
+
+  private childrenCaptureCounter = 0
 
   private toTemplateName(componentName: string): string {
     // Convert PascalCase to snake_case for Mojo template naming


### PR DESCRIPTION
Closes #1202.

## Summary

Parent components with JSX children now forward them through to the child
component's `.html.ep` template. Previously `MojoAdapter.renderComponent()`
ignored `comp.children`, so any child whose body referenced
`{props.children}` rendered the slot as `undef` and Perl rejected the
template:

```
Global symbol '$children' requires explicit package name
(did you forget to declare 'my $children'?)
```

## Approach

Forwarding uses Mojo's `begin %>...<% end` capture so dynamic segments
inside the children (signals, conditionals, expressions) get evaluated
in the parent's template scope before reaching the child renderer:

```ep
<% my $bf_children_s0 = begin %><span>hello</span><span>world</span><% end %>
<%== bf->render_child('card', _bf_slot => 's0', children => $bf_children_s0) %>
```

The capture has to live in its own `<% ... %>` action — embedding
`begin %>...<% end` inside the outer `<%== bf->render_child(...) %>`
lets the inner `%>` close the outer tag prematurely, which Mojo
rejects with a mid-expression syntax error.

Runtime hook (`BarefootJS::render_child`) materializes the captured
CODE ref into the `Mojo::ByteStream` the closure produces, so the
child's `vars => 1` rendering sees `$children` as already-rendered
HTML and skips re-escaping.

## V1 scope

Static and dynamic JSX children (the capture is a normal Mojo template
fragment, so `<%= $signal %>`, `% if`, `% for`, etc. inside the
children all work). Reactive-tree forwarding for client-only paths
remains a CSR-side concern, already handled by #1196.

## Test plan

- [x] Removed `'component-with-jsx-children'` from
  `MojoAdapter.skipJsx`; the adapter conformance fixture now runs
  under real Perl + Mojolicious and matches the expected HTML.
- [x] Added two Mojo-specific unit tests covering the new emit shape
  (`begin %>...<% end` + variable threading) and the no-children path
  (no spurious `children =>` entry).
- [x] `bun test packages/adapter-mojolicious` — 65 pass / 0 fail.
- [x] `bun test packages/jsx packages/adapter-tests` — 1232 pass / 0
  fail (no regressions to JSX-compiler-side or shared adapter
  conformance).

---
_Generated by [Claude Code](https://claude.ai/code/session_011wcpXuD1AyrBevTxDgj1qC)_