### PR TITLE
feat(adapter-go-template): forward JSX children to child component templates

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -199,6 +199,45 @@ export function Page() {
       expect(types).not.toContain('Children:')
       expect(types).not.toContain('template.HTML')
     })
+
+    test('drops dynamic children that would emit Go template actions', () => {
+      // V1 limitation: a `template.HTML` value isn't re-parsed by the
+      // parent's `{{.Children}}` pipeline, so any `{{...}}` inside the
+      // rendered fragment would output literally. Dynamic-expression /
+      // nested-component / conditional children stay on the existing
+      // drop path (same as before this issue) until a re-evaluation
+      // hook lands.
+      const cases = [
+        // signal expression inside child
+        `'use client'
+import { createSignal } from "@barefootjs/client"
+export function Page() {
+  const [c] = createSignal(0)
+  return <main><Card><span>{c()}</span></Card></main>
+}`,
+        // nested component child
+        `'use client'
+import { createSignal } from "@barefootjs/client"
+export function Page() {
+  const [x] = createSignal(0)
+  return <main data-x={x()}><Card><Button/></Card></main>
+}`,
+        // conditional child
+        `'use client'
+import { createSignal } from "@barefootjs/client"
+export function Page() {
+  const [v] = createSignal(true)
+  return <main><Card>{v() ? <span>a</span> : <span>b</span>}</Card></main>
+}`,
+      ]
+      for (const src of cases) {
+        const adapter = new GoTemplateAdapter()
+        const ir = compileToIR(src, adapter)
+        const types = adapter.generateTypes(ir)!
+        expect(types).not.toContain('Children:')
+        expect(types).not.toContain('template.HTML')
+      }
+    })
   })
 
   describe('generateTypes', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -31,10 +31,6 @@ runAdapterConformanceTests({
   // HTML differs, so the Hono-derived `expectedHtml` doesn't match.
   // `return-map` uses the `data-key` serialisation that differs
   // between Hono (runtime helper) and Go (template variable).
-  // `component-with-jsx-children` — the Go template emitter drops
-  // JSX children when emitting the parent's `renderChild()` call, so
-  // the child renders an empty slot. Forwarding is implemented for
-  // CSR templates only; the Go-template path is tracked separately.
   skipJsx: [
     'static-array-children',
     'style-object-dynamic',
@@ -42,7 +38,6 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
-    'component-with-jsx-children',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two
@@ -143,6 +138,66 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toContain('ScopeID string')
       expect(result.types).toContain('Initial int')
       expect(result.types).toContain('Count int')
+    })
+  })
+
+  describe('JSX children forwarding (#1203)', () => {
+    test('forwards element children via Children: template.HTML(...)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+'use client'
+import { createSignal } from "@barefootjs/client"
+
+export function Page() {
+  const [x] = createSignal(0)
+  return (
+    <main data-x={x()}>
+      <Card>
+        <span>hello</span>
+        <span>world</span>
+      </Card>
+    </main>
+  )
+}
+`)
+      const types = adapter.generateTypes(ir)!
+      expect(types).toContain('"html/template"')
+      expect(types).toContain(
+        'Children: template.HTML("<span>hello</span><span>world</span>")',
+      )
+    })
+
+    test('text-only children stay on the plain string path (#461 carry-over)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+'use client'
+import { createSignal } from "@barefootjs/client"
+
+export function Page() {
+  const [x] = createSignal(0)
+  return <main data-x={x()}><Button>+1</Button></main>
+}
+`)
+      const types = adapter.generateTypes(ir)!
+      expect(types).toContain('Children: "+1"')
+      expect(types).not.toContain('template.HTML')
+      expect(types).not.toContain('"html/template"')
+    })
+
+    test('omits Children entry when component has no JSX children', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+'use client'
+import { createSignal } from "@barefootjs/client"
+
+export function Page() {
+  const [x] = createSignal(0)
+  return <main data-x={x()}><Card label="x" /></main>
+}
+`)
+      const types = adapter.generateTypes(ir)!
+      expect(types).not.toContain('Children:')
+      expect(types).not.toContain('template.HTML')
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -45,13 +45,18 @@ interface StaticChildInstance {
   fieldName: string
   /** Concatenated text content from JSX children (e.g. `+1` for
    *  `<Button>+1</Button>`). Null when children include any non-text
-   *  node — the HTML path below covers those. */
+   *  node; those go through the `childrenHtml` path when they're
+   *  purely static HTML, otherwise they're dropped. */
   childrenText: string | null
-  /** Rendered Go-template HTML fragment for JSX children that include
-   *  any non-text node (e.g. `<Card><span>x</span></Card>`). Forwarded
-   *  to the child via `Children: template.HTML(...)` so the child's
+  /** Rendered Go-template fragment for purely-static, non-text JSX
+   *  children (e.g. `<Card><span>x</span></Card>`). Forwarded to the
+   *  child via `Children: template.HTML(...)` so the child's
    *  `{{or .Children ""}}` skips re-escaping. Null when children are
-   *  text-only or absent. */
+   *  text-only or absent — and also null when the rendered fragment
+   *  contains any `{{...}}` action (signal expressions, nested
+   *  components, conditionals, etc.) since those wouldn't re-evaluate
+   *  through the parent's `{{.Children}}` read; those cases stay on
+   *  the existing drop path. */
   childrenHtml: string | null
 }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -38,6 +38,23 @@ interface NestedComponentInfo extends IRLoopChildComponent {
   isDynamic: boolean
 }
 
+interface StaticChildInstance {
+  name: string
+  slotId: string
+  props: IRProp[]
+  fieldName: string
+  /** Concatenated text content from JSX children (e.g. `+1` for
+   *  `<Button>+1</Button>`). Null when children include any non-text
+   *  node — the HTML path below covers those. */
+  childrenText: string | null
+  /** Rendered Go-template HTML fragment for JSX children that include
+   *  any non-text node (e.g. `<Card><span>x</span></Card>`). Forwarded
+   *  to the child via `Children: template.HTML(...)` so the child's
+   *  `{{or .Children ""}}` skips re-escaping. Null when children are
+   *  text-only or absent. */
+  childrenHtml: string | null
+}
+
 export interface GoTemplateAdapterOptions {
   /** Go package name for generated types (default: 'components') */
   packageName?: string
@@ -150,6 +167,10 @@ export class GoTemplateAdapter extends BaseAdapter {
   private localTypeNames: Set<string> = new Set()
   /** Local type aliases mapping type name to base type (e.g., Filter → 'string') */
   private localTypeAliases: Map<string, string> = new Map()
+
+  /** Set during type generation when any emit references
+   *  `template.HTML(...)`; toggles the `"html/template"` import. */
+  private usesHtmlTemplate: boolean = false
 
   constructor(options: GoTemplateAdapterOptions = {}) {
     super()
@@ -329,15 +350,8 @@ export class GoTemplateAdapter extends BaseAdapter {
   }
 
   generateTypes(ir: ComponentIR): string | null {
+    this.usesHtmlTemplate = false
     const lines: string[] = []
-    lines.push(`package ${this.options.packageName}`)
-    lines.push('')
-    lines.push('import (')
-    lines.push('\t"math/rand"')
-    lines.push('')
-    lines.push('\tbf "github.com/barefootjs/runtime/bf"')
-    lines.push(')')
-    lines.push('')
 
     const componentName = ir.metadata.componentName
 
@@ -382,7 +396,21 @@ export class GoTemplateAdapter extends BaseAdapter {
     // Generate NewXxxProps function
     this.generateNewPropsFunction(lines, ir, componentName, nestedComponents)
 
-    return lines.join('\n')
+    // Imports come at the top, but `usesHtmlTemplate` is only known
+    // after the body has been generated. Compose package + imports +
+    // body once everything has been collected.
+    const header: string[] = []
+    header.push(`package ${this.options.packageName}`)
+    header.push('')
+    header.push('import (')
+    if (this.usesHtmlTemplate) header.push('\t"html/template"')
+    header.push('\t"math/rand"')
+    header.push('')
+    header.push('\tbf "github.com/barefootjs/runtime/bf"')
+    header.push(')')
+    header.push('')
+
+    return [...header, ...lines].join('\n')
   }
 
   /**
@@ -706,15 +734,21 @@ export class GoTemplateAdapter extends BaseAdapter {
           }
         }
       }
-      // Pass through plain-text JSX children as the slot's `Children`
-      // input so e.g. `<Button>+1</Button>` actually renders "+1" at
-      // SSR time. JSON.stringify produces a Go-compatible double-quoted
-      // string and avoids `goLiteral`'s number-detection branch (which
-      // would silently emit `-1` as an int for `<Button>-1</Button>`).
-      // Non-text children (nested elements, expressions) need a richer
-      // codegen path that isn't wired up yet.
+      // Pass through JSX children as the child slot's `Children` input.
+      // Two paths:
+      //   1. Plain text (`<Button>+1</Button>`) → quote with JSON.stringify
+      //      to dodge `goLiteral`'s number-detection branch (which would
+      //      silently emit `-1` as an int for `<Button>-1</Button>`).
+      //   2. Mixed/HTML (`<Card><span>x</span></Card>`) → wrap in
+      //      `template.HTML(...)` so html/template skips re-escaping the
+      //      angle brackets at render time. The fragment is rendered up
+      //      front via the adapter so any nested template directives are
+      //      already in their final Go-template form.
       if (child.childrenText !== null) {
         lines.push(`\t\t\tChildren: ${JSON.stringify(child.childrenText)},`)
+      } else if (child.childrenHtml !== null) {
+        this.usesHtmlTemplate = true
+        lines.push(`\t\t\tChildren: template.HTML(${JSON.stringify(child.childrenHtml)}),`)
       }
       lines.push(`\t\t}),`)
     }
@@ -784,25 +818,8 @@ export class GoTemplateAdapter extends BaseAdapter {
    * - props: Component props
    * - fieldName: Go field name (e.g., "ReactiveChildSlot6")
    */
-  private collectStaticChildInstances(node: IRNode): Array<{
-    name: string
-    slotId: string
-    props: IRProp[]
-    fieldName: string
-    /** Concatenated text content from JSX children (e.g. `+1` for
-     *  `<Button>+1</Button>`). Null when children are non-text or
-     *  absent — those need a richer codegen path that isn't wired up
-     *  yet, and we just don't pass anything for `Children` in that
-     *  case. */
-    childrenText: string | null
-  }> {
-    const result: Array<{
-      name: string
-      slotId: string
-      props: IRProp[]
-      fieldName: string
-      childrenText: string | null
-    }> = []
+  private collectStaticChildInstances(node: IRNode): Array<StaticChildInstance> {
+    const result: StaticChildInstance[] = []
     this.collectStaticChildInstancesRecursive(node, result, false)
     return result
   }
@@ -821,9 +838,20 @@ export class GoTemplateAdapter extends BaseAdapter {
     return out
   }
 
+  /**
+   * Render JSX children to a Go-template-ready HTML fragment when
+   * children include any non-text node. Returns null when children
+   * are absent or are pure text (handled by the simpler text path).
+   */
+  private extractHtmlChildren(children: IRNode[]): string | null {
+    if (children.length === 0) return null
+    if (children.every(c => c.type === 'text')) return null
+    return this.renderChildren(children)
+  }
+
   private collectStaticChildInstancesRecursive(
     node: IRNode,
-    result: Array<{ name: string; slotId: string; props: IRProp[]; fieldName: string; childrenText: string | null }>,
+    result: StaticChildInstance[],
     inLoop: boolean
   ): void {
     if (node.type === 'component') {
@@ -838,6 +866,7 @@ export class GoTemplateAdapter extends BaseAdapter {
           props: comp.props,
           fieldName: `${comp.name}${suffix}`,
           childrenText: this.extractTextChildren(comp.children),
+          childrenHtml: this.extractHtmlChildren(comp.children),
         })
       }
       // Recurse into Portal's children to find nested components

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -840,13 +840,22 @@ export class GoTemplateAdapter extends BaseAdapter {
 
   /**
    * Render JSX children to a Go-template-ready HTML fragment when
-   * children include any non-text node. Returns null when children
-   * are absent or are pure text (handled by the simpler text path).
+   * children are non-text but produce purely-static HTML (no Go
+   * template actions). Returns null when:
+   *   - children are absent or text-only (handled by extractTextChildren), or
+   *   - the rendered fragment contains any `{{...}}` action — passing
+   *     such a fragment through `template.HTML` and the parent's
+   *     `{{.Children}}` would output the actions verbatim instead of
+   *     evaluating them, which is worse than the existing
+   *     "drop children" fallback. Dynamic / component-bearing children
+   *     stay on the drop path until a re-evaluation hook lands.
    */
   private extractHtmlChildren(children: IRNode[]): string | null {
     if (children.length === 0) return null
     if (children.every(c => c.type === 'text')) return null
-    return this.renderChildren(children)
+    const html = this.renderChildren(children)
+    if (html.includes('{{')) return null
+    return html
   }
 
   private collectStaticChildInstancesRecursive(


### PR DESCRIPTION
Closes #1203.

## Summary

Parent components with **static-HTML JSX children** now forward them to
the child component's Go template. Previously the parent emitter only
handled the plain-text path (`<Button>+1</Button>` → `Children: "+1"`);
non-text static children silently dropped, so a child whose body
referenced `{props.children}` rendered the slot empty.

## Approach

The rendered children fragment is wrapped in `template.HTML(...)` in
the generated `New<Child>Props` initializer:

```go
CardSlot0: NewCardProps(CardInput{
    ScopeID:  scopeID + "_s0",
    Children: template.HTML("<span>hello</span><span>world</span>"),
}),
```

`template.HTML` is the Go `html/template` opt-out marker — the value
passes through `{{or .Children ""}}` (and similar `{{.Children}}`
references) without re-escaping the angle brackets.

`"html/template"` is added to the package imports only when at least
one component on the file emits `template.HTML(...)` — `usesHtmlTemplate`
flag tracks this during type generation, header is composed after the
body so the import block reflects what was actually emitted.

## V1 scope — static HTML only

The forwarded fragment is placed into a Go struct field at compile
time, then read out via `{{.Children}}` at template-execution time.
That second read does **not** re-parse the value as a template, so any
Go template actions (`{{...}}`, `{{template "X" ...}}`, hydration
markers, etc.) inside the rendered children would output verbatim
instead of evaluating.

To avoid that regression, `extractHtmlChildren` returns `null` whenever
the rendered fragment contains `{{`. Dynamic-expression children
(`<Card>{count()}</Card>`), nested-component children
(`<Card><Button/></Card>`), and conditional children
(`<Card>{cond ? <a/> : <b/>}</Card>`) therefore stay on the existing
"drop" path — same behaviour as before this PR. Lifting that
restriction needs a runtime/template re-evaluation hook and is
intentionally out of scope here.

## Test plan

- [x] Removed `'component-with-jsx-children'` from
  `GoTemplateAdapter.skipJsx`; the adapter conformance fixture now
  runs under real `go run` and matches the expected HTML
  (`<main data-x="0" bf-s="test" bf="s1"><section bf-s="test_s0"><span>hello</span><span>world</span></section></main>`).
- [x] Added four Go-specific unit tests covering:
  - element children → `Children: template.HTML(...)` + `"html/template"`
    import
  - text-only children stay on the existing `Children: "..."` plain
    string path (no spurious `template.HTML` wrap, no extra import)
  - no JSX children → no `Children:` entry at all
  - **dynamic / nested-component / conditional children stay dropped**
    (no `Children:` entry, no `template.HTML` import) — locks in the
    V1 restriction so a future codegen change can't silently re-introduce
    the literal-action regression.
- [x] `bun test packages/adapter-go-template` — 84 pass / 0 fail.
- [x] `bun test packages/jsx packages/adapter-tests packages/adapter-mojolicious packages/adapter-hono` —
  1394 pass / 0 fail (no regressions to the JSX compiler, shared
  adapter conformance, or sibling adapters).