### PR TITLE
fix(jsx): hoist inline JSX-in-arrow callbacks into synthesized components

### DIFF
--- a/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
+++ b/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Inline JSX-in-arrow-callback compilation (#1211).
+ *
+ * Without preprocessing, `renderNode={(n) => <div>{n.data.label}</div>}`
+ * leaks raw JSX into the client bundle and breaks `Function`/parser
+ * loading with `SyntaxError: Unexpected token '<'`. The fix hoists
+ * the inline arrow into a synthesized PascalCase component that the
+ * regular pipeline compiles into init + hydrate + a callable shim.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { TestAdapter } from '../adapters/test-adapter'
+import { compileJSX } from '../compiler'
+
+const adapter = new TestAdapter()
+
+function clientJs(source: string, fileName = 'Demo.tsx'): string {
+  const result = compileJSX(source, fileName, { adapter })
+  expect(result.errors).toEqual([])
+  const file = result.files.find(f => f.type === 'clientJs')
+  expect(file).toBeDefined()
+  return file!.content
+}
+
+describe('inline JSX in arrow callback (#1211)', () => {
+  test('rewrites renderNode={(n) => <jsx/>} into a synthesized component reference', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => <div>{n.data.label}</div>}
+          />
+        )
+      }
+    `
+    const js = clientJs(source)
+    // The arrow body's JSX must NOT survive as live JS (which would
+    // crash the parser). Template literals inside synthesized
+    // `template:` strings are fine — those are just strings.
+    expect(js).not.toMatch(/=>\s*<div\b/)
+    expect(js).not.toMatch(/=>\s*\(\s*<div\b/)
+    expect(js).not.toMatch(/return\s*<div\b/)
+
+    // The synthesized component is registered and exported as a callable shim.
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+    expect(js).toMatch(/export function BFInlineJsxCallback1\b/)
+
+    // The Demo's renderNode prop value references the synthesized name.
+    expect(js).toContain('BFInlineJsxCallback1')
+  })
+
+  test('emits the synthesized component init alongside the host component', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => <span class="badge">{n.data.label}</span>}
+          />
+        )
+      }
+    `
+    const js = clientJs(source)
+    expect(js).toMatch(/function init(?:BFInlineJsxCallback1|_BFInlineJsxCallback1)\b/)
+  })
+
+  test('multiple inline arrows in the same source get distinct names', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <div>
+            <Flow nodes={[]} edges={[]} renderNode={(a) => <span>{a.id}</span>} />
+            <Flow nodes={[]} edges={[]} renderNode={(b) => <em>{b.id}</em>} />
+          </div>
+        )
+      }
+    `
+    const js = clientJs(source)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback2(?:__|['"])/)
+  })
+
+  test('block-body arrow with JSX return is rewritten the same way', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => {
+              return <article>{n.data.label}</article>
+            }}
+          />
+        )
+      }
+    `
+    const js = clientJs(source)
+    expect(js).not.toMatch(/=>\s*\{[\s\S]*<article>/)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+  })
+
+  test('arrows whose body is not JSX are left alone', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        )
+      }
+    `
+    const js = clientJs(source)
+    // No synthesized component should be emitted for plain event handlers.
+    expect(js).not.toContain('BFInlineJsxCallback')
+  })
+
+  test('reports BF080 when the inline arrow captures a non-module identifier', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        const [tone, setTone] = createSignal('blue')
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => <div class={tone()}>{n.data.label}</div>}
+          />
+        )
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors.some(e => e.code === 'BF080')).toBe(true)
+    const bf080 = result.errors.find(e => e.code === 'BF080')!
+    expect(bf080.message).toContain('tone')
+  })
+
+  test('module-scope identifiers do not trigger BF080', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      const PREFIX = 'badge-'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => <span>{PREFIX + n.id}</span>}
+          />
+        )
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors.filter(e => e.code === 'BF080')).toEqual([])
+  })
+
+  test('non-use-client files are left untouched', () => {
+    const source = `
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => <div>{n.data.label}</div>}
+          />
+        )
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    // No BF080 — but no synthesis either; the file just doesn't ship a
+    // client bundle and its arrow stays inert in the SSR template.
+    expect(result.errors.filter(e => e.code === 'BF080')).toEqual([])
+  })
+})

--- a/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
+++ b/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
@@ -175,6 +175,84 @@ describe('inline JSX in arrow callback (#1211)', () => {
     expect(result.errors.filter(e => e.code === 'BF080')).toEqual([])
   })
 
+  test('nested inline JSX-returning arrows are hoisted via fixpoint iteration', () => {
+    // The outer renderNode arrow returns JSX that itself contains a
+    // <Wrapper render={(x) => <Inner/>}> — the inner arrow must also
+    // be lifted, otherwise its raw JSX leaks into the synthesized
+    // outer component's body.
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+      import { Wrapper } from '@/components/ui/wrapper'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => (
+              <Wrapper render={(x) => <em>{x.id}</em>}>
+                {n.data.label}
+              </Wrapper>
+            )}
+          />
+        )
+      }
+    `
+    const js = clientJs(source)
+    expect(js).not.toMatch(/=>\s*<em\b/)
+    expect(js).not.toMatch(/=>\s*\(\s*<em\b/)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback2(?:__|['"])/)
+  })
+
+  test('locally-declared destructure / function / class bindings are not flagged as captures', () => {
+    const source = `
+      'use client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n) => {
+              const { id, data } = n
+              function fmt(s: string) { return s.toUpperCase() }
+              class Helper { static k = 'k' }
+              return <div data-id={id} data-k={Helper.k}>{fmt(data.label)}</div>
+            }}
+          />
+        )
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors.filter(e => e.code === 'BF080')).toEqual([])
+  })
+
+  test('captures via parameter default initializer are flagged as BF080', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Flow } from '@/components/ui/xyflow'
+
+      export function Demo() {
+        const [tone, setTone] = createSignal('blue')
+        return (
+          <Flow
+            nodes={[]}
+            edges={[]}
+            renderNode={(n, t = tone()) => <div class={t}>{n.id}</div>}
+          />
+        )
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors.some(e => e.code === 'BF080')).toBe(true)
+    const bf080 = result.errors.find(e => e.code === 'BF080')!
+    expect(bf080.message).toContain('tone')
+  })
+
   test('non-use-client files are left untouched', () => {
     const source = `
       import { Flow } from '@/components/ui/xyflow'

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -20,6 +20,7 @@ import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } f
 import { setActiveComponentScope, computeFileScope } from './ir-to-client-js/component-scope'
 import { generateModuleExports, collectInlineExportedNames } from './module-exports'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
+import { preprocessInlineJsxCallbacks } from './preprocess-inline-jsx-callbacks'
 
 /**
  * Extended compile options with required adapter
@@ -499,16 +500,28 @@ export function compileJSX(
   const files: FileOutput[] = []
   const errors: CompileResult['errors'] = []
 
+  // Inline JSX-callback preprocessing (#1211): hoist
+  // `renderNode={(n) => <div/>}` style arrows into synthesized
+  // `'use client'` components before downstream parsing. Without this
+  // the arrows survive as raw JSX in the emitted client bundle and
+  // crash the parser.
+  const preprocessed = preprocessInlineJsxCallbacks(source, filePath)
+  errors.push(...preprocessed.errors)
+  if (preprocessed.errors.length > 0) {
+    return { files, errors }
+  }
+  const compileSource = preprocessed.source
+
   // List all exported components
-  const componentNames = listComponentFunctions(source, filePath)
+  const componentNames = listComponentFunctions(compileSource, filePath)
 
   // If multiple components, compile each separately and combine
   if (componentNames.length > 1) {
-    return compileMultipleComponents(source, filePath, componentNames, options)
+    return compileMultipleComponents(compileSource, filePath, componentNames, options)
   }
 
   // Single component flow
-  const ctx = analyzeComponent(source, filePath, undefined, options.program)
+  const ctx = analyzeComponent(compileSource, filePath, undefined, options.program)
 
   if (!ctx.jsxReturn) {
     errors.push(...ctx.errors)  // Only analyzer errors

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -66,6 +66,12 @@ export const ErrorCodes = {
   STAGE_INIT_LOCAL_IN_TEMPLATE: 'BF061',
   STAGE_AWAIT_IN_TEMPLATE: 'BF062',
 
+  // Inline JSX-callback synthesis errors (BF080-BF089) — raised by the
+  // preprocess-inline-jsx-callbacks pass (#1211) when an inline JSX-
+  // returning arrow cannot be safely hoisted into a synthesized
+  // module-scope component.
+  INLINE_JSX_CALLBACK_CAPTURE: 'BF080',
+
   // Reactive factory errors (BF110-BF119)
   UNRECOGNIZED_REACTIVE_FACTORY: 'BF110',
 } as const
@@ -130,6 +136,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.STAGE_AWAIT_IN_TEMPLATE]:
     'AwaitExpression in template scope. The hydrate-time template lambda is synchronous; awaiting here would hang first render. Move the await into a server-side handler and pass the resolved value as a prop.',
+
+  [ErrorCodes.INLINE_JSX_CALLBACK_CAPTURE]:
+    "Inline JSX-returning arrow function captures a non-module identifier. Extract the callback into a top-level 'use client' component (e.g. `function MyNode(n) { return <div/> }` then `renderNode={MyNode}`) or pass captured values via component props.",
 
   [ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY]:
     'Tuple destructuring of a non-reactive factory call. The compiler only recognizes createSignal / createMemo calls and same-file helpers that wrap them with a single `return [a, b]` exit.',

--- a/packages/jsx/src/preprocess-inline-jsx-callbacks.ts
+++ b/packages/jsx/src/preprocess-inline-jsx-callbacks.ts
@@ -1,0 +1,363 @@
+/**
+ * Inline JSX callback preprocessor (#1211).
+ *
+ * Detects arrow functions whose body contains JSX when they appear as
+ * JsxAttribute initializer values (e.g. `renderNode={(n) => <div/>}`).
+ * Without this pre-pass the downstream `getAttributeValue` /
+ * `processComponentProps` paths emit the arrow's source text verbatim
+ * via `ctx.getJS(expr)`, leaking raw JSX into the client bundle and
+ * crashing the parser with `SyntaxError: Unexpected token '<'`.
+ *
+ * Strategy: hoist each inline arrow into a freshly synthesized PascalCase
+ * component declaration appended to the source. Replace the inline arrow
+ * with a reference to the new name. The downstream pipeline already knows
+ * how to compile a named `'use client'` component into
+ * `init${Name}` + `hydrate('${Name}')` + a `createComponent` callable
+ * shim — the same machinery that makes `<Flow renderNode={Bridge}>`
+ * (where `Bridge` is a regular component) work today.
+ *
+ * Limitations (v1):
+ *   - The synthesized component cannot capture variables from the
+ *     surrounding closure. Arrow params and module-scope identifiers
+ *     are fine; anything else triggers BF080.
+ *   - Only triggers in `'use client'` source files (the resulting
+ *     component must reach the client runtime to have meaning).
+ */
+
+import ts from 'typescript'
+import type { CompilerError } from './types'
+
+export interface PreprocessResult {
+  /** Source after rewriting; identical to the input when no inline arrows are found. */
+  source: string
+  /** Errors raised during preprocessing (e.g. BF080 closure capture). */
+  errors: CompilerError[]
+  /** Names of the synthesized components, in declaration order. */
+  syntheticNames: string[]
+}
+
+const SYNTHETIC_PREFIX = 'BFInlineJsxCallback'
+
+/**
+ * Walk the parsed source for arrow functions in JsxAttribute initializer
+ * positions whose body contains JSX. For each match, synthesize a named
+ * component declaration and rewrite the call site to reference it.
+ */
+export function preprocessInlineJsxCallbacks(
+  source: string,
+  filePath: string
+): PreprocessResult {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+
+  const hasUseClient = sourceFile.statements.some(stmt =>
+    ts.isExpressionStatement(stmt) &&
+    ts.isStringLiteral(stmt.expression) &&
+    (stmt.expression.text === 'use client' || stmt.expression.text === "'use client'")
+  )
+
+  // Without `'use client'` the synthesized component has nowhere to
+  // hydrate; bail out so SSR-only files keep their existing behaviour
+  // (they don't have a client bundle to crash anyway).
+  if (!hasUseClient) {
+    return { source, errors: [], syntheticNames: [] }
+  }
+
+  const moduleScope = collectModuleScopeNames(sourceFile)
+  const usedNames = new Set<string>(moduleScope)
+  const errors: CompilerError[] = []
+  const syntheticNames: string[] = []
+  const replacements: { start: number; end: number; text: string }[] = []
+  const synthesizedDecls: string[] = []
+
+  let counter = 0
+
+  function nextName(): string {
+    while (true) {
+      counter += 1
+      const candidate = `${SYNTHETIC_PREFIX}${counter}`
+      if (!usedNames.has(candidate)) {
+        usedNames.add(candidate)
+        return candidate
+      }
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isJsxAttribute(node) && node.initializer && ts.isJsxExpression(node.initializer) && node.initializer.expression) {
+      let expr: ts.Expression = node.initializer.expression
+      while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+      if (ts.isArrowFunction(expr) && arrowBodyContainsJsx(expr)) {
+        handleInlineArrow(expr)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  function handleInlineArrow(arrow: ts.ArrowFunction): void {
+    const paramNames = collectArrowParamNames(arrow)
+    const free = collectFreeIdentifiers(arrow)
+    const captures: string[] = []
+    for (const id of free) {
+      if (paramNames.has(id)) continue
+      if (moduleScope.has(id)) continue
+      captures.push(id)
+    }
+    if (captures.length > 0) {
+      const start = sourceFile.getLineAndCharacterOfPosition(arrow.getStart(sourceFile))
+      const end = sourceFile.getLineAndCharacterOfPosition(arrow.getEnd())
+      errors.push({
+        code: 'BF080',
+        severity: 'error',
+        message:
+          `Inline JSX-returning arrow function captures non-module identifier(s): ` +
+          `${captures.sort().join(', ')}. ` +
+          `Extract the callback into a top-level '\\'use client\\'' component (e.g. ` +
+          `\`function MyNode(n) { return <div/> }\` then \`renderNode={MyNode}\`) ` +
+          `or pass captured values via component props.`,
+        loc: {
+          file: filePath,
+          start: { line: start.line + 1, column: start.character },
+          end: { line: end.line + 1, column: end.character },
+        },
+      })
+      return
+    }
+
+    const name = nextName()
+    syntheticNames.push(name)
+
+    const decl = buildSyntheticDeclaration(name, arrow, sourceFile)
+    synthesizedDecls.push(decl)
+
+    const arrowStart = arrow.getStart(sourceFile)
+    const arrowEnd = arrow.getEnd()
+    // Reference the synthesized component by name. The shim emitted by
+    // ir-to-client-js (`export function ${name}(props, key) { ... }`)
+    // is callable as `${name}(node)` so the holding parent's runtime
+    // (e.g. Flow's `props.renderNode(node)`) keeps working unchanged.
+    replacements.push({ start: arrowStart, end: arrowEnd, text: name })
+  }
+
+  ts.forEachChild(sourceFile, visit)
+
+  if (replacements.length === 0) {
+    return { source, errors, syntheticNames }
+  }
+
+  // Apply replacements in reverse order so earlier offsets stay valid.
+  replacements.sort((a, b) => b.start - a.start)
+  let rewritten = source
+  for (const r of replacements) {
+    rewritten = rewritten.slice(0, r.start) + r.text + rewritten.slice(r.end)
+  }
+
+  // Append synthesized declarations at the end so they're available
+  // module-wide. PascalCase + `'use client'` makes `listComponentFunctions`
+  // pick them up as ordinary components, so they receive the standard
+  // init/hydrate/shim treatment.
+  const trailing = rewritten.endsWith('\n') ? '' : '\n'
+  rewritten = `${rewritten}${trailing}\n${synthesizedDecls.join('\n\n')}\n`
+
+  return { source: rewritten, errors, syntheticNames }
+}
+
+function arrowBodyContainsJsx(arrow: ts.ArrowFunction): boolean {
+  if (ts.isBlock(arrow.body)) {
+    return blockReturnsJsx(arrow.body)
+  }
+  let body: ts.Expression = arrow.body
+  while (ts.isParenthesizedExpression(body)) body = body.expression
+  return isJsxLike(body)
+}
+
+function blockReturnsJsx(block: ts.Block): boolean {
+  let found = false
+  function visit(n: ts.Node): void {
+    if (found) return
+    if (ts.isReturnStatement(n) && n.expression) {
+      let e: ts.Expression = n.expression
+      while (ts.isParenthesizedExpression(e)) e = e.expression
+      if (isJsxLike(e)) {
+        found = true
+        return
+      }
+    }
+    // Don't dive into nested function bodies — their returns belong to
+    // those inner functions, not to the outer arrow.
+    if (ts.isArrowFunction(n) || ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n)) return
+    ts.forEachChild(n, visit)
+  }
+  ts.forEachChild(block, visit)
+  return found
+}
+
+function isJsxLike(expr: ts.Expression): boolean {
+  return ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)
+}
+
+function collectArrowParamNames(arrow: ts.ArrowFunction): Set<string> {
+  const names = new Set<string>()
+  function visitName(name: ts.BindingName): void {
+    if (ts.isIdentifier(name)) {
+      names.add(name.text)
+    } else if (ts.isObjectBindingPattern(name)) {
+      name.elements.forEach(el => visitName(el.name))
+    } else if (ts.isArrayBindingPattern(name)) {
+      name.elements.forEach(el => {
+        if (!ts.isOmittedExpression(el)) visitName(el.name)
+      })
+    }
+  }
+  for (const p of arrow.parameters) visitName(p.name)
+  return names
+}
+
+/**
+ * Collect identifiers referenced inside the arrow's body (or its
+ * parameter type annotations) that are not bound by the arrow's own
+ * parameters or by any nested binding within the body. Mirrors the
+ * spirit of `extractFreeIdentifiersFromNode` in analyzer.ts but runs
+ * before the analyzer is wired up.
+ */
+function collectFreeIdentifiers(arrow: ts.ArrowFunction): Set<string> {
+  const ids = new Set<string>()
+  const bound: string[] = []
+
+  function pushBindings(name: ts.BindingName): void {
+    if (ts.isIdentifier(name)) bound.push(name.text)
+    else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => pushBindings(e.name))
+    else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
+      if (!ts.isOmittedExpression(e)) pushBindings(e.name)
+    })
+  }
+
+  for (const p of arrow.parameters) pushBindings(p.name)
+
+  function isBound(name: string): boolean {
+    return bound.includes(name)
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) {
+      const parent = node.parent
+      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return
+      if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return
+      if (parent && ts.isPropertySignature(parent) && parent.name === node) return
+      if (parent && ts.isParameter(parent) && parent.name === node) return
+      if (parent && ts.isVariableDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isJsxAttribute(parent) && parent.name === node) return
+      if (parent && ts.isJsxOpeningElement(parent) && parent.tagName === node) {
+        // JSX intrinsic like <div> uses an Identifier as tagName whose
+        // first letter determines intrinsic vs component. Lowercase
+        // tags resolve at the runtime as strings, not identifiers.
+        if (/^[a-z]/.test(node.text)) return
+      }
+      if (parent && ts.isJsxClosingElement(parent) && parent.tagName === node) {
+        if (/^[a-z]/.test(node.text)) return
+      }
+      if (isBound(node.text)) return
+      ids.add(node.text)
+      return
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      bound.push(node.name.text)
+      ts.forEachChild(node, visit)
+      const idx = bound.lastIndexOf(node.name.text)
+      if (idx >= 0) bound.splice(idx, 1)
+      return
+    }
+    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) {
+      const innerBound: string[] = []
+      for (const p of node.parameters) {
+        const params: string[] = []
+        ;(function collect(name: ts.BindingName): void {
+          if (ts.isIdentifier(name)) params.push(name.text)
+          else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => collect(e.name))
+          else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
+            if (!ts.isOmittedExpression(e)) collect(e.name)
+          })
+        })(p.name)
+        innerBound.push(...params)
+      }
+      bound.push(...innerBound)
+      ts.forEachChild(node, visit)
+      for (let i = 0; i < innerBound.length; i++) bound.pop()
+      return
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(arrow.body)
+  return ids
+}
+
+/**
+ * Collect identifier names declared at module scope (top-level imports,
+ * function/class/variable declarations, named binding patterns). Used to
+ * recognize "the user already had this name" so we can pick a synthetic
+ * name that doesn't collide, *and* to recognize free identifiers that
+ * resolve to module-scope rather than to an enclosing closure (those are
+ * fine — the synthesized component sees the same module-scope bindings).
+ */
+function collectModuleScopeNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>()
+
+  function pushBinding(name: ts.BindingName): void {
+    if (ts.isIdentifier(name)) names.add(name.text)
+    else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => pushBinding(e.name))
+    else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
+      if (!ts.isOmittedExpression(e)) pushBinding(e.name)
+    })
+  }
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) names.add(stmt.name.text)
+    else if (ts.isClassDeclaration(stmt) && stmt.name) names.add(stmt.name.text)
+    else if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) pushBinding(decl.name)
+    } else if (ts.isImportDeclaration(stmt) && stmt.importClause) {
+      const ic = stmt.importClause
+      if (ic.name) names.add(ic.name.text)
+      if (ic.namedBindings) {
+        if (ts.isNamespaceImport(ic.namedBindings)) names.add(ic.namedBindings.name.text)
+        else for (const e of ic.namedBindings.elements) names.add(e.name.text)
+      }
+    } else if (ts.isTypeAliasDeclaration(stmt)) names.add(stmt.name.text)
+    else if (ts.isInterfaceDeclaration(stmt)) names.add(stmt.name.text)
+    else if (ts.isEnumDeclaration(stmt)) names.add(stmt.name.text)
+  }
+
+  return names
+}
+
+/**
+ * Build the synthesized component declaration source. Preserves the
+ * arrow's original parameter syntax (including type annotations) and
+ * its body verbatim — relying on the host file's TypeScript context
+ * for any imported types referenced in the annotations.
+ */
+function buildSyntheticDeclaration(
+  name: string,
+  arrow: ts.ArrowFunction,
+  sourceFile: ts.SourceFile
+): string {
+  const paramsText = arrow.parameters.length === 0
+    ? ''
+    : arrow.parameters.map(p => p.getText(sourceFile)).join(', ')
+
+  let bodyText: string
+  if (ts.isBlock(arrow.body)) {
+    bodyText = arrow.body.getText(sourceFile)
+  } else {
+    const expr = arrow.body.getText(sourceFile)
+    bodyText = `{ return ${expr} }`
+  }
+
+  return `function ${name}(${paramsText}) ${bodyText}`
+}

--- a/packages/jsx/src/preprocess-inline-jsx-callbacks.ts
+++ b/packages/jsx/src/preprocess-inline-jsx-callbacks.ts
@@ -16,6 +16,12 @@
  * shim — the same machinery that makes `<Flow renderNode={Bridge}>`
  * (where `Bridge` is a regular component) work today.
  *
+ * Nested inline arrows (an arrow whose body itself contains another
+ * inline JSX-returning arrow in JsxAttribute position) are handled by
+ * iterating the pass to a fixpoint: each iteration hoists one outer
+ * level into a new module-scope synthesized component, and the next
+ * iteration sees the inner arrow at module scope.
+ *
  * Limitations (v1):
  *   - The synthesized component cannot capture variables from the
  *     surrounding closure. Arrow params and module-scope identifiers
@@ -25,7 +31,8 @@
  */
 
 import ts from 'typescript'
-import type { CompilerError } from './types'
+import type { CompilerError, SourceLocation } from './types'
+import { ErrorCodes, createError } from './errors'
 
 export interface PreprocessResult {
   /** Source after rewriting; identical to the input when no inline arrows are found. */
@@ -37,16 +44,48 @@ export interface PreprocessResult {
 }
 
 const SYNTHETIC_PREFIX = 'BFInlineJsxCallback'
+const MAX_FIXPOINT_ITERATIONS = 16
 
 /**
- * Walk the parsed source for arrow functions in JsxAttribute initializer
- * positions whose body contains JSX. For each match, synthesize a named
- * component declaration and rewrite the call site to reference it.
+ * Run the single-pass preprocessor to a fixpoint so nested inline
+ * JSX-returning arrows are all hoisted (each iteration lifts one
+ * level of nesting to module scope).
  */
 export function preprocessInlineJsxCallbacks(
   source: string,
   filePath: string
 ): PreprocessResult {
+  const errors: CompilerError[] = []
+  const syntheticNames: string[] = []
+  let counter = 0
+  let current = source
+
+  for (let iteration = 0; iteration < MAX_FIXPOINT_ITERATIONS; iteration++) {
+    const pass = runSinglePass(current, filePath, counter)
+    errors.push(...pass.errors)
+    syntheticNames.push(...pass.syntheticNames)
+    counter = pass.counterAfter
+    if (pass.errors.length > 0 || pass.syntheticNames.length === 0) {
+      // Stop on errors (no successful rewrite to iterate on) or when
+      // the pass produced no new replacements (fixpoint reached).
+      current = pass.source
+      break
+    }
+    current = pass.source
+  }
+
+  return { source: current, errors, syntheticNames }
+}
+
+interface SinglePassResult extends PreprocessResult {
+  counterAfter: number
+}
+
+function runSinglePass(
+  source: string,
+  filePath: string,
+  startingCounter: number
+): SinglePassResult {
   const sourceFile = ts.createSourceFile(
     filePath,
     source,
@@ -65,7 +104,7 @@ export function preprocessInlineJsxCallbacks(
   // hydrate; bail out so SSR-only files keep their existing behaviour
   // (they don't have a client bundle to crash anyway).
   if (!hasUseClient) {
-    return { source, errors: [], syntheticNames: [] }
+    return { source, errors: [], syntheticNames: [], counterAfter: startingCounter }
   }
 
   const moduleScope = collectModuleScopeNames(sourceFile)
@@ -75,7 +114,7 @@ export function preprocessInlineJsxCallbacks(
   const replacements: { start: number; end: number; text: string }[] = []
   const synthesizedDecls: string[] = []
 
-  let counter = 0
+  let counter = startingCounter
 
   function nextName(): string {
     while (true) {
@@ -93,13 +132,19 @@ export function preprocessInlineJsxCallbacks(
       let expr: ts.Expression = node.initializer.expression
       while (ts.isParenthesizedExpression(expr)) expr = expr.expression
       if (ts.isArrowFunction(expr) && arrowBodyContainsJsx(expr)) {
-        handleInlineArrow(expr)
+        const handled = handleInlineArrow(expr)
+        if (handled) {
+          // Don't dive into the arrow's body in this pass — the next
+          // fixpoint iteration will see the synthesized component at
+          // module scope and process any nested inline arrows there.
+          return
+        }
       }
     }
     ts.forEachChild(node, visit)
   }
 
-  function handleInlineArrow(arrow: ts.ArrowFunction): void {
+  function handleInlineArrow(arrow: ts.ArrowFunction): boolean {
     const paramNames = collectArrowParamNames(arrow)
     const free = collectFreeIdentifiers(arrow)
     const captures: string[] = []
@@ -111,22 +156,14 @@ export function preprocessInlineJsxCallbacks(
     if (captures.length > 0) {
       const start = sourceFile.getLineAndCharacterOfPosition(arrow.getStart(sourceFile))
       const end = sourceFile.getLineAndCharacterOfPosition(arrow.getEnd())
-      errors.push({
-        code: 'BF080',
-        severity: 'error',
-        message:
-          `Inline JSX-returning arrow function captures non-module identifier(s): ` +
-          `${captures.sort().join(', ')}. ` +
-          `Extract the callback into a top-level '\\'use client\\'' component (e.g. ` +
-          `\`function MyNode(n) { return <div/> }\` then \`renderNode={MyNode}\`) ` +
-          `or pass captured values via component props.`,
-        loc: {
-          file: filePath,
-          start: { line: start.line + 1, column: start.character },
-          end: { line: end.line + 1, column: end.character },
-        },
-      })
-      return
+      const loc: SourceLocation = {
+        file: filePath,
+        start: { line: start.line + 1, column: start.character },
+        end: { line: end.line + 1, column: end.character },
+      }
+      const baseMessage = errorMessageForCapture(captures)
+      errors.push(createError(ErrorCodes.INLINE_JSX_CALLBACK_CAPTURE, loc, { message: baseMessage }))
+      return false
     }
 
     const name = nextName()
@@ -142,12 +179,13 @@ export function preprocessInlineJsxCallbacks(
     // is callable as `${name}(node)` so the holding parent's runtime
     // (e.g. Flow's `props.renderNode(node)`) keeps working unchanged.
     replacements.push({ start: arrowStart, end: arrowEnd, text: name })
+    return true
   }
 
   ts.forEachChild(sourceFile, visit)
 
   if (replacements.length === 0) {
-    return { source, errors, syntheticNames }
+    return { source, errors, syntheticNames, counterAfter: counter }
   }
 
   // Apply replacements in reverse order so earlier offsets stay valid.
@@ -164,7 +202,17 @@ export function preprocessInlineJsxCallbacks(
   const trailing = rewritten.endsWith('\n') ? '' : '\n'
   rewritten = `${rewritten}${trailing}\n${synthesizedDecls.join('\n\n')}\n`
 
-  return { source: rewritten, errors, syntheticNames }
+  return { source: rewritten, errors, syntheticNames, counterAfter: counter }
+}
+
+function errorMessageForCapture(captures: string[]): string {
+  return (
+    `Inline JSX-returning arrow function captures non-module identifier(s): ` +
+    `${captures.sort().join(', ')}. ` +
+    `Extract the callback into a top-level '\\'use client\\'' component (e.g. ` +
+    `\`function MyNode(n) { return <div/> }\` then \`renderNode={MyNode}\`) ` +
+    `or pass captured values via component props.`
+  )
 }
 
 function arrowBodyContainsJsx(arrow: ts.ArrowFunction): boolean {
@@ -203,41 +251,57 @@ function isJsxLike(expr: ts.Expression): boolean {
 
 function collectArrowParamNames(arrow: ts.ArrowFunction): Set<string> {
   const names = new Set<string>()
-  function visitName(name: ts.BindingName): void {
-    if (ts.isIdentifier(name)) {
-      names.add(name.text)
-    } else if (ts.isObjectBindingPattern(name)) {
-      name.elements.forEach(el => visitName(el.name))
-    } else if (ts.isArrayBindingPattern(name)) {
-      name.elements.forEach(el => {
-        if (!ts.isOmittedExpression(el)) visitName(el.name)
-      })
-    }
-  }
-  for (const p of arrow.parameters) visitName(p.name)
+  for (const p of arrow.parameters) collectBindingNames(p.name, names)
   return names
 }
 
+function collectBindingNames(name: ts.BindingName, out: Set<string> | string[]): void {
+  const push = Array.isArray(out)
+    ? (n: string) => out.push(n)
+    : (n: string) => out.add(n)
+  if (ts.isIdentifier(name)) {
+    push(name.text)
+  } else if (ts.isObjectBindingPattern(name)) {
+    name.elements.forEach(el => collectBindingNames(el.name, out))
+  } else if (ts.isArrayBindingPattern(name)) {
+    name.elements.forEach(el => {
+      if (!ts.isOmittedExpression(el)) collectBindingNames(el.name, out)
+    })
+  }
+}
+
 /**
- * Collect identifiers referenced inside the arrow's body (or its
- * parameter type annotations) that are not bound by the arrow's own
- * parameters or by any nested binding within the body. Mirrors the
- * spirit of `extractFreeIdentifiersFromNode` in analyzer.ts but runs
- * before the analyzer is wired up.
+ * Collect identifiers referenced inside the arrow's body or its
+ * parameter default-initializers that are not bound by the arrow's
+ * own parameters or by any nested binding within the body.
+ *
+ * Tracked binding forms inside the body:
+ *   - VariableDeclaration with identifier OR destructure pattern name
+ *   - FunctionDeclaration / ClassDeclaration
+ *   - Catch clause variable
+ *   - Inner arrow / function expression / function declaration parameters
  */
 function collectFreeIdentifiers(arrow: ts.ArrowFunction): Set<string> {
   const ids = new Set<string>()
   const bound: string[] = []
 
-  function pushBindings(name: ts.BindingName): void {
-    if (ts.isIdentifier(name)) bound.push(name.text)
-    else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => pushBindings(e.name))
-    else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
-      if (!ts.isOmittedExpression(e)) pushBindings(e.name)
-    })
+  // Arrow parameter names — bound for the entire walk.
+  for (const p of arrow.parameters) {
+    const names: string[] = []
+    collectBindingNames(p.name, names)
+    bound.push(...names)
   }
 
-  for (const p of arrow.parameters) pushBindings(p.name)
+  function pushBindings(name: ts.BindingName): string[] {
+    const names: string[] = []
+    collectBindingNames(name, names)
+    bound.push(...names)
+    return names
+  }
+
+  function popN(n: number): void {
+    for (let i = 0; i < n; i++) bound.pop()
+  }
 
   function isBound(name: string): boolean {
     return bound.includes(name)
@@ -249,13 +313,27 @@ function collectFreeIdentifiers(arrow: ts.ArrowFunction): Set<string> {
       if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return
       if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return
       if (parent && ts.isPropertySignature(parent) && parent.name === node) return
+      if (parent && ts.isPropertyDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isMethodDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isMethodSignature(parent) && parent.name === node) return
+      if (parent && ts.isGetAccessorDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isSetAccessorDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isEnumMember(parent) && parent.name === node) return
+      if (parent && ts.isBindingElement(parent) && parent.propertyName === node) return
+      if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === node) {
+        // Shorthand `{ foo }` — `foo` IS a value reference; treat as a free id.
+        if (!isBound(node.text)) ids.add(node.text)
+        return
+      }
       if (parent && ts.isParameter(parent) && parent.name === node) return
       if (parent && ts.isVariableDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isFunctionDeclaration(parent) && parent.name === node) return
+      if (parent && ts.isClassDeclaration(parent) && parent.name === node) return
       if (parent && ts.isJsxAttribute(parent) && parent.name === node) return
       if (parent && ts.isJsxOpeningElement(parent) && parent.tagName === node) {
-        // JSX intrinsic like <div> uses an Identifier as tagName whose
-        // first letter determines intrinsic vs component. Lowercase
-        // tags resolve at the runtime as strings, not identifiers.
+        // Lowercase tag names are intrinsic HTML elements (the runtime
+        // resolves them as strings). Uppercase tags are component refs
+        // and DO read from the surrounding scope.
         if (/^[a-z]/.test(node.text)) return
       }
       if (parent && ts.isJsxClosingElement(parent) && parent.tagName === node) {
@@ -265,32 +343,72 @@ function collectFreeIdentifiers(arrow: ts.ArrowFunction): Set<string> {
       ids.add(node.text)
       return
     }
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-      bound.push(node.name.text)
-      ts.forEachChild(node, visit)
-      const idx = bound.lastIndexOf(node.name.text)
-      if (idx >= 0) bound.splice(idx, 1)
+
+    if (ts.isVariableDeclaration(node)) {
+      const declared = pushBindings(node.name)
+      if (node.initializer) visit(node.initializer)
+      // Bindings stay in scope for sibling declarations and the rest
+      // of the enclosing block; rely on the outer block-scope unbind.
+      // Don't pop here — popping happens at block end.
+      // To avoid leaking out of the parent scope we record the count
+      // at block entry and pop on exit; see Block handling below.
+      // Re-push consumed names: this branch already pushed them.
+      ;(declared)
       return
     }
-    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) {
-      const innerBound: string[] = []
-      for (const p of node.parameters) {
-        const params: string[] = []
-        ;(function collect(name: ts.BindingName): void {
-          if (ts.isIdentifier(name)) params.push(name.text)
-          else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => collect(e.name))
-          else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
-            if (!ts.isOmittedExpression(e)) collect(e.name)
-          })
-        })(p.name)
-        innerBound.push(...params)
-      }
-      bound.push(...innerBound)
-      ts.forEachChild(node, visit)
-      for (let i = 0; i < innerBound.length; i++) bound.pop()
+
+    if (ts.isFunctionDeclaration(node)) {
+      if (node.name) bound.push(node.name.text)
+      visitInsideNewScope(node)
+      // Function name stays bound in the enclosing block; popped on block exit.
       return
     }
+
+    if (ts.isClassDeclaration(node)) {
+      if (node.name) bound.push(node.name.text)
+      // Visit class members for free identifiers inside method bodies.
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+      visitInsideNewScope(node)
+      return
+    }
+
+    if (ts.isCatchClause(node)) {
+      const before = bound.length
+      if (node.variableDeclaration) pushBindings(node.variableDeclaration.name)
+      ts.forEachChild(node, visit)
+      popN(bound.length - before)
+      return
+    }
+
+    if (ts.isBlock(node)) {
+      const before = bound.length
+      ts.forEachChild(node, visit)
+      popN(bound.length - before)
+      return
+    }
+
     ts.forEachChild(node, visit)
+  }
+
+  function visitInsideNewScope(fn: ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration): void {
+    const before = bound.length
+    for (const p of fn.parameters) {
+      pushBindings(p.name)
+      if (p.initializer) visit(p.initializer)
+    }
+    if (fn.body) visit(fn.body)
+    popN(bound.length - before)
+  }
+
+  // Walk the arrow's parameter default-initializers (e.g.
+  // `(n = tone()) => ...`) at the OUTER scope so refs there count as
+  // free relative to the synthesized module-scope component.
+  for (const p of arrow.parameters) {
+    if (p.initializer) visit(p.initializer)
   }
 
   visit(arrow.body)
@@ -308,19 +426,11 @@ function collectFreeIdentifiers(arrow: ts.ArrowFunction): Set<string> {
 function collectModuleScopeNames(sourceFile: ts.SourceFile): Set<string> {
   const names = new Set<string>()
 
-  function pushBinding(name: ts.BindingName): void {
-    if (ts.isIdentifier(name)) names.add(name.text)
-    else if (ts.isObjectBindingPattern(name)) name.elements.forEach(e => pushBinding(e.name))
-    else if (ts.isArrayBindingPattern(name)) name.elements.forEach(e => {
-      if (!ts.isOmittedExpression(e)) pushBinding(e.name)
-    })
-  }
-
   for (const stmt of sourceFile.statements) {
     if (ts.isFunctionDeclaration(stmt) && stmt.name) names.add(stmt.name.text)
     else if (ts.isClassDeclaration(stmt) && stmt.name) names.add(stmt.name.text)
     else if (ts.isVariableStatement(stmt)) {
-      for (const decl of stmt.declarationList.declarations) pushBinding(decl.name)
+      for (const decl of stmt.declarationList.declarations) collectBindingNames(decl.name, names)
     } else if (ts.isImportDeclaration(stmt) && stmt.importClause) {
       const ic = stmt.importClause
       if (ic.name) names.add(ic.name.text)
@@ -340,7 +450,9 @@ function collectModuleScopeNames(sourceFile: ts.SourceFile): Set<string> {
  * Build the synthesized component declaration source. Preserves the
  * arrow's original parameter syntax (including type annotations) and
  * its body verbatim — relying on the host file's TypeScript context
- * for any imported types referenced in the annotations.
+ * for any imported types referenced in the annotations. Nested inline
+ * JSX-returning arrows in the body are rewritten on the next fixpoint
+ * iteration once the synthesized component reaches module scope.
  */
 function buildSyntheticDeclaration(
   name: string,

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -4,14 +4,13 @@
  * Renders the JSX-native `<Flow>` graph editor with the four overlays
  * (`<Background>` / `<Controls>` / `<MiniMap>`).
  *
- * Why no `renderNode` callbacks live in this file: the barefoot
- * compiler does not transform JSX nested inside arrow-function
- * callbacks, so `renderNode={(n) => <div>…</div>}` ends up as raw JSX
- * in the emitted client bundle and the whole module fails to parse in
- * the browser. To keep the bundle hydratable we lean on Flow's default
- * node body (target=Top / source=Bottom + `data.label`) for every demo
- * here. Custom-body / custom-handle examples on the docs pages stay
- * code-sample-only.
+ * The custom-body / custom-handle demos below still return HTML strings
+ * from `renderNode` rather than inline JSX. This file predates the
+ * compiler fix in #1211 (which now hoists inline `(n) => <div/>`
+ * arrows into synthesized client components); the string-returning
+ * helpers are kept as-is to preserve the existing visual snapshots
+ * until a follow-up rewrites them in inline JSX with end-to-end
+ * verification.
  */
 
 "use client"
@@ -50,17 +49,12 @@ function escapeHtml(s: string): string {
 
 // Custom-body / custom-handle previews.
 //
-// These demos return an HTML *string* from `renderNode`. The barefoot
-// compiler does not transform JSX nested inside arrow-function
-// callbacks, so the conventional `renderNode={(n) => <div/>}` shape
-// emits raw JSX into the client bundle and parsing fails, taking down
-// every other demo in the same bundle. A function-call shape
-// (`(n) => MyNode(n)`) compiles cleanly but the generated
-// `insert(...)` branch template embeds the result into a template
-// literal — a live HTMLElement stringifies to
-// `[object HTMLDivElement]` and breaks hydration. A string slots in
-// safely on both sides; the trade-off is that the node body loses
-// signal-driven reactivity, which is fine for static docs previews.
+// These demos return an HTML *string* from `renderNode` (the
+// `pillBodyHTML` / `fanBodyHTML` helpers below). The compiler fix in
+// #1211 makes the conventional `renderNode={(n) => <div/>}` shape
+// compile cleanly, but the string-return shape is kept here to preserve
+// the existing visual snapshots; a follow-up will migrate these demos
+// to inline JSX once the new path has bake-in time.
 const customBodyNodes = [
   { id: 'src', position: { x:  80, y: 100 }, data: { label: 'Source' } },
   { id: 'mid', position: { x: 320, y:  80 }, data: { label: 'Pipeline' } },

--- a/site/ui/components/xyflow-intro-demo.tsx
+++ b/site/ui/components/xyflow-intro-demo.tsx
@@ -2,10 +2,11 @@
 /**
  * xyflow Introduction Demos
  *
- * Standalone demos for the xyflow Introduction page. Kept in a dedicated
- * file so the Introduction's bundle stays isolated from xyflow-demo.tsx
- * (whose XyflowCustomNodeDemo carries `renderNode` callback JSX the
- * compiler does not transform).
+ * Standalone demos for the xyflow Introduction page. Originally kept in
+ * a dedicated file so the Introduction's bundle was isolated from the
+ * `renderNode` callback JSX in xyflow-demo.tsx that the compiler used
+ * to leave untransformed. The compiler fix in #1211 has eliminated that
+ * crash mode, but the file split is retained for clarity.
  *
  * The demos rely on Flow's default node renderer (DefaultNodeBody),
  * which mounts target=Top / source=Bottom handles so edges flow


### PR DESCRIPTION
## Summary

- JSX nested in arrow-function callbacks (e.g. `renderNode={(n) => <div>{n.data.label}</div>}`) used to survive compilation as raw JSX in the emitted client bundle, throwing `SyntaxError: Unexpected token '<'` at parse time and killing hydration for every other component in the same bundle.
- Add a source-rewriting pre-pass in `compileJSX` that hoists each inline JSX-returning arrow into a freshly synthesized PascalCase `'use client'` component appended to the source; the call site is rewritten to reference the synthesized name so the existing `init${Name}` + `hydrate(...)` + `createComponent` shim machinery (the same path that makes `<Flow renderNode={Bridge}>` work today) takes over with full reactivity.
- Closure capture of non-module identifiers is rejected with a new `BF080` error that points the user at the named-component escape hatch; arrow params and module-scope bindings are accepted as-is.

## Mapping to the issue

| Issue requirement | Where addressed |
|---|---|
| Recursively walk callback bodies and compile JSX the same way as top-level returns | `packages/jsx/src/preprocess-inline-jsx-callbacks.ts` (new) |
| Wire into the JSX→IR pass | `packages/jsx/src/compiler.ts` — `preprocessInlineJsxCallbacks` runs before `listComponentFunctions` |
| Keep parse-safe client bundles | New unit tests assert no `=> <tag` / `return <tag` survives the pass |
| Preserve the documented `<Flow renderNode={Bridge}>` callable-shim contract | The synthesized component reuses the unchanged shim path |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/inline-jsx-callback.test.ts` — 8/8 pass (parse-safety, shim emission, naming for multiple inline arrows, block-body arrows, BF080 closure-capture, module-scope identifiers, non-`'use client'` files)
- [x] `bun test packages/jsx/src/__tests__/` — same pass/fail counts as `main` (4 pre-existing alias-resolver failures unrelated to this change; reproduced on `main` via `git stash`)
- [ ] CI: full repository `bun test` green
- [ ] Manual: load `/docs/ui/xyflow` after this change to confirm hydration succeeds (string-returning workaround in `xyflow-demo.tsx` is unaffected — its arrow body is not JSX, so the preprocessor doesn't touch it)

## Known v1 limitation

Inline arrows that capture variables from the surrounding closure (e.g. a signal declared in the parent component) are rejected with `BF080`. Workaround: extract the callback into a top-level `'use client'` component and pass captures via props. Full closure-capture support can land in a follow-up.

## Cleanup deferred

The string-returning workarounds in `site/ui/components/xyflow-demo.tsx` (`pillBodyHTML` / `fanBodyHTML`) still work because their arrow bodies return strings, not JSX, so the preprocessor leaves them alone. Migrating those demos to inline JSX is left to a follow-up that includes visual verification — only the file-level explanatory comments are updated here to reflect the fix.

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)