### PR TITLE
fix(runtime): splice live Node returns into branch templates via __bfSlot (#1213)

### DIFF
--- a/packages/client/__tests__/runtime/insert.test.ts
+++ b/packages/client/__tests__/runtime/insert.test.ts
@@ -200,6 +200,98 @@ describe('insert', () => {
       expect(scope.textContent).not.toContain('placeholder')
     })
 
+    test('preserves identity for slot nodes nested inside an element wrapper (#1213)', () => {
+      // Catches a regression where the runtime would `cloneNode(true)` the
+      // parsed wrapper element, cloning the slot Node along with it and
+      // dropping its event listeners / signal effects. The fix moves
+      // parsed nodes by reference instead of cloning.
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <!--bf-cond-start:c1--><span>placeholder</span><!--bf-cond-end:c1-->
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const live = document.createElement('button')
+      live.id = 'nested-live'
+      live.textContent = 'click'
+      let clicks = 0
+      live.addEventListener('click', () => { clicks++ })
+      const [show] = createSignal(true)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        {
+          template: () => {
+            const slots: Node[] = []
+            return {
+              html: `<!--bf-cond-start:c1--><div class="wrapper">${__bfSlot(live, slots)}</div><!--bf-cond-end:c1-->`,
+              slots,
+            }
+          },
+          bindEvents: () => {},
+        },
+        {
+          template: () => `<!--bf-cond-start:c1--><!--bf-cond-end:c1-->`,
+          bindEvents: () => {},
+        },
+      )
+
+      const found = scope.querySelector('#nested-live')
+      expect(found).toBe(live)
+      expect((found as HTMLElement | null)?.parentElement?.className).toBe('wrapper')
+
+      // Identity preservation should keep the original event listener
+      // attached. Cloning would have detached it.
+      ;(found as HTMLElement).click()
+      expect(clicks).toBe(1)
+    })
+
+    test('preserves identity for slot nodes inside element conditional root (#1213)', () => {
+      // First-run hydration with `slots.length > 0` forces a swap via
+      // `updateElementConditional`. The replaced element has the slot
+      // node nested inside it; identity must survive.
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <div bf-c="c1">stale</div>
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const live = document.createElement('button')
+      live.id = 'el-cond-live'
+      live.textContent = 'live'
+      let clicks = 0
+      live.addEventListener('click', () => { clicks++ })
+      const [show] = createSignal(true)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        {
+          template: () => {
+            const slots: Node[] = []
+            return {
+              html: `<div bf-c="c1" class="root">${__bfSlot(live, slots)}</div>`,
+              slots,
+            }
+          },
+          bindEvents: () => {},
+        },
+        {
+          template: () => `<div bf-c="c1"></div>`,
+          bindEvents: () => {},
+        },
+      )
+
+      const found = scope.querySelector('#el-cond-live')
+      expect(found).toBe(live)
+      expect((found as HTMLElement | null)?.parentElement?.className).toBe('root')
+      ;(found as HTMLElement).click()
+      expect(clicks).toBe(1)
+    })
+
     test('swaps live element on branch toggle via slots (#1213)', () => {
       document.body.innerHTML = `
         <div bf-s="Test_1">

--- a/packages/client/__tests__/runtime/insert.test.ts
+++ b/packages/client/__tests__/runtime/insert.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { insert } from '../../src/runtime/insert'
+import { __bfSlot } from '../../src/runtime/branch-slot'
 import { createSignal } from '../../src/reactive'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
@@ -153,6 +154,102 @@ describe('insert', () => {
       // Toggle back to false → "Verify"
       setShow(false)
       expect(button.textContent).toBe('Verify')
+    })
+
+    test('inserts live HTMLElement returned via template slots (#1213)', () => {
+      // Reproduces the bug from #1213: a `renderNode={(n) => SomeComp(n)}`
+      // callback returns a live HTMLElement. The branch template captures
+      // it via __bfSlot; insert() must splice the actual node by identity
+      // rather than letting the template literal stringify it.
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <!--bf-cond-start:c1--><span>placeholder</span><!--bf-cond-end:c1-->
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const live = document.createElement('div')
+      live.id = 'live-marker'
+      live.textContent = 'live content'
+      const [show] = createSignal(true)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        {
+          template: () => {
+            const slots: Node[] = []
+            return {
+              html: `<!--bf-cond-start:c1-->${__bfSlot(live, slots)}<!--bf-cond-end:c1-->`,
+              slots,
+            }
+          },
+          bindEvents: () => {},
+        },
+        {
+          template: () => `<!--bf-cond-start:c1--><!--bf-cond-end:c1-->`,
+          bindEvents: () => {},
+        },
+      )
+
+      // The live node should be in the DOM by identity (not cloned, not
+      // stringified to "[object HTMLDivElement]").
+      const found = scope.querySelector('#live-marker')
+      expect(found).toBe(live)
+      expect(scope.textContent).not.toContain('[object')
+      expect(scope.textContent).not.toContain('placeholder')
+    })
+
+    test('swaps live element on branch toggle via slots (#1213)', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <!--bf-cond-start:c1--><!--bf-cond-end:c1-->
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const liveTrue = document.createElement('div')
+      liveTrue.id = 'true-marker'
+      liveTrue.textContent = 'TRUE'
+      const liveFalse = document.createElement('div')
+      liveFalse.id = 'false-marker'
+      liveFalse.textContent = 'FALSE'
+      const [show, setShow] = createSignal(true)
+
+      insert(
+        scope,
+        'c1',
+        show,
+        {
+          template: () => {
+            const slots: Node[] = []
+            return {
+              html: `<!--bf-cond-start:c1-->${__bfSlot(liveTrue, slots)}<!--bf-cond-end:c1-->`,
+              slots,
+            }
+          },
+          bindEvents: () => {},
+        },
+        {
+          template: () => {
+            const slots: Node[] = []
+            return {
+              html: `<!--bf-cond-start:c1-->${__bfSlot(liveFalse, slots)}<!--bf-cond-end:c1-->`,
+              slots,
+            }
+          },
+          bindEvents: () => {},
+        },
+      )
+
+      expect(scope.querySelector('#true-marker')).toBe(liveTrue)
+      expect(scope.querySelector('#false-marker')).toBeNull()
+
+      setShow(false)
+      expect(scope.querySelector('#false-marker')).toBe(liveFalse)
+      expect(scope.querySelector('#true-marker')).toBeNull()
+
+      setShow(true)
+      expect(scope.querySelector('#true-marker')).toBe(liveTrue)
     })
 
     test('null-to-element branch switch via comment markers', () => {

--- a/packages/client/src/runtime/branch-slot.ts
+++ b/packages/client/src/runtime/branch-slot.ts
@@ -1,0 +1,32 @@
+/**
+ * Branch-template slot helper (#1213).
+ *
+ * Conditional `template()` arrows interpolate Child-position expressions
+ * via `${expr}`. When `expr` evaluates to a live `Node` (e.g. the result
+ * of `_p.renderNode(node())` returning an `HTMLElement` from
+ * `createComponent`), the surrounding template literal coerces it via
+ * `Object.prototype.toString`, producing `"[object HTMLDivElement]"` and
+ * destroying the live node identity on hydration.
+ *
+ * `__bfSlot` intercepts the value before stringification: if it's a
+ * `Node`, it stashes the node into the closure-scoped `slots` array and
+ * returns a unique marker comment. The `insert()` runtime then walks the
+ * parsed fragment for those markers and splices the original node back
+ * in by identity (no `cloneNode`), preserving event listeners and signal
+ * bindings.
+ *
+ * Non-node values fall through to `String(value)` for the existing
+ * inline-string path.
+ */
+export function __bfSlot(value: unknown, slots: Node[]): string {
+  if (value == null || value === false || value === true) return ''
+  if (typeof Node !== 'undefined' && value instanceof Node) {
+    const idx = slots.length
+    slots.push(value)
+    return `<!--bf-slot:${idx}-->`
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => __bfSlot(v, slots)).join('')
+  }
+  return String(value)
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -79,7 +79,8 @@ export { styleToCss } from './style'
 export { findScope, find, $, $c, $t, qsa } from './query'
 export { hydrate, rehydrateAll, flushHydration } from './hydrate'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry'
-export { insert, type BranchConfig } from './insert'
+export { insert, type BranchConfig, type BranchTemplateResult } from './insert'
+export { __bfSlot } from './branch-slot'
 export { updateClientMarker } from './client-marker'
 
 // Hydration state

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -301,20 +301,19 @@ function updateFragmentConditional(scope: Element, id: string, result: BranchTem
       ? startComment.parentNode
       : null
     const fragment = spliceSlots(parseHTML(html, insertParent), slots)
-    // Live slot nodes were installed by identity in `spliceSlots`. Move
-    // them out of the fragment by reference rather than cloning so event
-    // listeners and reactive bindings survive the splice.
-    const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
-    const newNodes: Node[] = []
+    // Move parsed nodes by identity rather than cloning. A slot Node
+    // nested inside an element wrapper (e.g. `<div>${__bfSlot(...)}</div>`)
+    // would otherwise be cloned along with its parent, dropping event
+    // listeners and reactive effects (#1213). The parsed fragment is
+    // freshly built per call, so consuming it by reference is safe.
     let child = fragment.firstChild
     while (child) {
       const next: ChildNode | null = child.nextSibling
       if (!(child.nodeType === 8 && child.nodeValue?.startsWith('bf-cond-'))) {
-        newNodes.push(slotSet?.has(child) ? child : child.cloneNode(true))
+        startComment!.parentNode?.insertBefore(child, endComment)
       }
       child = next
     }
-    newNodes.forEach(n => startComment!.parentNode?.insertBefore(n, endComment))
   } else if (condEl) {
     // Single element: replace with new content. The replacement's
     // namespace is determined by the parent of the element being
@@ -326,21 +325,22 @@ function updateFragmentConditional(scope: Element, id: string, result: BranchTem
     const firstChild = parsed.firstChild
 
     if (firstChild?.nodeType === 8 && firstChild?.nodeValue === `bf-cond-start:${id}`) {
-      // Switching from element to fragment
+      // Switching from element to fragment. Move parsed nodes by
+      // identity (see fragment branch above) so nested slot nodes keep
+      // their event/effect bindings (#1213).
       const parent = condEl.parentNode
-      const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
-      const nodes: Node[] = []
       let n: ChildNode | null = parsed.firstChild
       while (n) {
         const next: ChildNode | null = n.nextSibling
-        nodes.push(slotSet?.has(n) ? n : n.cloneNode(true))
+        parent?.insertBefore(n, condEl)
         n = next
       }
-      nodes.forEach(node => parent?.insertBefore(node, condEl))
       condEl.remove()
     } else if (firstChild) {
-      const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
-      condEl.replaceWith(slotSet?.has(firstChild) ? firstChild : firstChild.cloneNode(true))
+      // Replace the existing conditional element with the parsed root
+      // by reference; cloning would re-clone any slot nodes nested
+      // inside `firstChild` and break identity preservation (#1213).
+      condEl.replaceWith(firstChild)
     }
   }
 }
@@ -359,7 +359,9 @@ function updateElementConditional(scope: Element, id: string, result: BranchTemp
   const fragment = spliceSlots(parseHTML(html, insertParent), slots)
   const newEl = fragment.firstChild
   if (newEl) {
-    const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
-    condEl.replaceWith(slotSet?.has(newEl) ? newEl : newEl.cloneNode(true))
+    // Move `newEl` into the DOM by identity. The fragment is discarded
+    // after this call, so cloning would only serve to break identity
+    // for any slot nodes nested inside `newEl` (#1213).
+    condEl.replaceWith(newEl)
   }
 }

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -12,12 +12,27 @@ import { setParentScopeId, parseHTML } from './component'
 import { BF_COND, BF_SCOPE, BF_CHILD_PREFIX } from '@barefootjs/shared'
 
 /**
+ * Result returned by a branch's `template()` when the template captures
+ * live DOM nodes via `__bfSlot` (#1213). `html` carries the marker-bearing
+ * HTML string; `slots[N]` is the actual `Node` referenced by the
+ * `<!--bf-slot:N-->` placeholder at the same index.
+ */
+export interface BranchTemplateResult {
+  html: string
+  slots: Node[]
+}
+
+/**
  * Branch configuration for conditional rendering.
  * Contains template and event binding functions for each branch.
  */
 export interface BranchConfig {
-  /** HTML template function for this branch */
-  template: () => string
+  /**
+   * HTML template function for this branch. Returns either a plain HTML
+   * string (legacy) or a `{ html, slots }` pair for templates that
+   * captured live `Node` values via `__bfSlot` (#1213).
+   */
+  template: () => string | BranchTemplateResult
 
   /**
    * Bind events and reactive effects to elements within the branch.
@@ -27,6 +42,12 @@ export interface BranchConfig {
    *          Used to dispose reactive effects scoped to this branch.
    */
   bindEvents: (scope: Element) => (() => void) | void
+}
+
+const EMPTY_SLOTS: Node[] = []
+
+function normalizeTemplate(value: string | BranchTemplateResult): BranchTemplateResult {
+  return typeof value === 'string' ? { html: value, slots: EMPTY_SLOTS } : value
 }
 
 
@@ -66,16 +87,16 @@ export function insert(
   // (e.g., selectedMail().subject when the branch is for the non-null case).
   let isFragmentCond = false
   try {
-    const sampleTrue = whenTrue.template()
-    isFragmentCond = sampleTrue.includes(`<!--bf-cond-start:${id}-->`)
+    const sampleTrue = normalizeTemplate(whenTrue.template())
+    isFragmentCond = sampleTrue.html.includes(`<!--bf-cond-start:${id}-->`)
   } catch (err) {
     // Template may throw TypeError for nullable access (e.g., selectedMail().subject)
     if (!(err instanceof TypeError)) throw err
   }
   if (!isFragmentCond) {
     try {
-      const sampleFalse = whenFalse.template()
-      isFragmentCond = sampleFalse.includes(`<!--bf-cond-start:${id}-->`)
+      const sampleFalse = normalizeTemplate(whenFalse.template())
+      isFragmentCond = sampleFalse.html.includes(`<!--bf-cond-start:${id}-->`)
     } catch (err) {
       if (!(err instanceof TypeError)) throw err
     }
@@ -110,13 +131,13 @@ export function insert(
       // If the existing element doesn't match the expected branch,
       // we need to swap the DOM first (e.g., SSR rendered whenFalse but now we need whenTrue)
       setParentScopeId(parentScopeId)
-      let html: string
-      try { html = branch.template() } finally { setParentScopeId(null) }
+      let result: BranchTemplateResult
+      try { result = normalizeTemplate(branch.template()) } finally { setParentScopeId(null) }
       const existingEl = find(scope, `[${BF_COND}="${id}"]`)
       if (existingEl) {
         // Compare full opening tag signatures to detect branch mismatch.
         // Tag-name-only comparison fails when both branches use the same tag (e.g., <div>).
-        const expectedSig = getTemplateRootSignature(html)
+        const expectedSig = getTemplateRootSignature(result.html)
         const existingSig = existingEl.outerHTML.match(/^<[^>]+>/)?.[0] ?? null
 
         if (isFragmentCond) {
@@ -124,20 +145,26 @@ export function insert(
           // CSR composite loops inline-evaluate conditionals into bf-c elements,
           // but insert() manages them as fragment conditionals (comment markers).
           // Replace the bf-c element with the fragment template content.
-          updateFragmentConditional(scope, id, html)
+          updateFragmentConditional(scope, id, result)
         } else if (expectedSig && existingSig && expectedSig !== existingSig) {
           // DOM doesn't match expected branch - need to swap
-          updateElementConditional(scope, id, html)
+          updateElementConditional(scope, id, result)
+        } else if (result.slots.length > 0) {
+          // Branch template captured live nodes via __bfSlot (#1213). The
+          // SSR DOM rendered Hono-stringified HTML, but the client now needs
+          // the live signal-bound nodes installed. Force a swap so the
+          // existing element is replaced with the slot-spliced template.
+          updateElementConditional(scope, id, result)
         }
       } else if (isFragmentCond) {
         // For @client fragment conditionals, SSR renders only comment markers.
         // We need to insert the actual content on first run.
-        updateFragmentConditional(scope, id, html)
+        updateFragmentConditional(scope, id, result)
       }
 
       // Bind events to the (possibly updated) SSR element
-      const result = branch.bindEvents(scope)
-      branchCleanup = typeof result === 'function' ? result : null
+      const cleanup = branch.bindEvents(scope)
+      branchCleanup = typeof cleanup === 'function' ? cleanup : null
 
       // Auto-focus on first run too (for components created via createComponent with editing=true)
       autoFocusConditionalElement(scope, id)
@@ -159,17 +186,17 @@ export function insert(
 
     // Branch changed: swap DOM and bind events
     setParentScopeId(parentScopeId)
-    let html: string
-    try { html = branch.template() } finally { setParentScopeId(null) }
+    let result: BranchTemplateResult
+    try { result = normalizeTemplate(branch.template()) } finally { setParentScopeId(null) }
     if (isFragmentCond) {
-      updateFragmentConditional(scope, id, html)
+      updateFragmentConditional(scope, id, result)
     } else {
-      updateElementConditional(scope, id, html)
+      updateElementConditional(scope, id, result)
     }
 
     // Bind events to the newly inserted element
-    const result = branch.bindEvents(scope)
-      branchCleanup = typeof result === 'function' ? result : null
+    const cleanup = branch.bindEvents(scope)
+    branchCleanup = typeof cleanup === 'function' ? cleanup : null
 
     // Auto-focus elements with autofocus attribute (for dynamically created elements)
     autoFocusConditionalElement(scope, id)
@@ -211,9 +238,37 @@ function getTemplateRootSignature(template: string): string | null {
 }
 
 /**
+ * Replace `<!--bf-slot:N-->` placeholder comments inside a parsed fragment
+ * with the live `Node` from `slots[N]` (#1213). Walks every comment in
+ * the fragment and substitutes by identity (no clone) so event bindings
+ * and signal effects on the slot node remain intact.
+ *
+ * Returns the same fragment for chaining.
+ */
+function spliceSlots(fragment: DocumentFragment, slots: Node[]): DocumentFragment {
+  if (slots.length === 0) return fragment
+  const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_COMMENT)
+  const replacements: Array<[Comment, Node]> = []
+  while (walker.nextNode()) {
+    const c = walker.currentNode as Comment
+    const m = c.nodeValue?.match(/^bf-slot:(\d+)$/)
+    if (m) {
+      const idx = Number(m[1])
+      const node = slots[idx]
+      if (node) replacements.push([c, node])
+    }
+  }
+  for (const [marker, node] of replacements) {
+    marker.parentNode?.replaceChild(node, marker)
+  }
+  return fragment
+}
+
+/**
  * Update fragment conditional (content between comment markers)
  */
-function updateFragmentConditional(scope: Element, id: string, html: string): void {
+function updateFragmentConditional(scope: Element, id: string, result: BranchTemplateResult): void {
+  const { html, slots } = result
   // Find start comment marker
   const startMarker = `bf-cond-start:${id}`
   let startComment: Comment | null = null
@@ -245,14 +300,19 @@ function updateFragmentConditional(scope: Element, id: string, html: string): vo
     const insertParent = (startComment.parentNode instanceof Element)
       ? startComment.parentNode
       : null
-    const fragment = parseHTML(html, insertParent)
+    const fragment = spliceSlots(parseHTML(html, insertParent), slots)
+    // Live slot nodes were installed by identity in `spliceSlots`. Move
+    // them out of the fragment by reference rather than cloning so event
+    // listeners and reactive bindings survive the splice.
+    const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
     const newNodes: Node[] = []
     let child = fragment.firstChild
     while (child) {
+      const next: ChildNode | null = child.nextSibling
       if (!(child.nodeType === 8 && child.nodeValue?.startsWith('bf-cond-'))) {
-        newNodes.push(child.cloneNode(true))
+        newNodes.push(slotSet?.has(child) ? child : child.cloneNode(true))
       }
-      child = child.nextSibling
+      child = next
     }
     newNodes.forEach(n => startComment!.parentNode?.insertBefore(n, endComment))
   } else if (condEl) {
@@ -262,17 +322,25 @@ function updateFragmentConditional(scope: Element, id: string, html: string): vo
     const insertParent = (condEl.parentNode instanceof Element)
       ? condEl.parentNode
       : null
-    const parsed = parseHTML(html, insertParent)
+    const parsed = spliceSlots(parseHTML(html, insertParent), slots)
     const firstChild = parsed.firstChild
 
     if (firstChild?.nodeType === 8 && firstChild?.nodeValue === `bf-cond-start:${id}`) {
       // Switching from element to fragment
       const parent = condEl.parentNode
-      const nodes = Array.from(parsed.childNodes).map(n => n.cloneNode(true))
-      nodes.forEach(n => parent?.insertBefore(n, condEl))
+      const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
+      const nodes: Node[] = []
+      let n: ChildNode | null = parsed.firstChild
+      while (n) {
+        const next: ChildNode | null = n.nextSibling
+        nodes.push(slotSet?.has(n) ? n : n.cloneNode(true))
+        n = next
+      }
+      nodes.forEach(node => parent?.insertBefore(node, condEl))
       condEl.remove()
     } else if (firstChild) {
-      condEl.replaceWith(firstChild.cloneNode(true))
+      const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
+      condEl.replaceWith(slotSet?.has(firstChild) ? firstChild : firstChild.cloneNode(true))
     }
   }
 }
@@ -280,15 +348,18 @@ function updateFragmentConditional(scope: Element, id: string, html: string): vo
 /**
  * Update element conditional (single element with bf-c)
  */
-function updateElementConditional(scope: Element, id: string, html: string): void {
+function updateElementConditional(scope: Element, id: string, result: BranchTemplateResult): void {
   const condEl = scope.querySelector(`[${BF_COND}="${id}"]`)
   if (!condEl) return
 
+  const { html, slots } = result
   const insertParent = (condEl.parentNode instanceof Element)
     ? condEl.parentNode
     : null
-  const newEl = parseHTML(html, insertParent).firstChild
+  const fragment = spliceSlots(parseHTML(html, insertParent), slots)
+  const newEl = fragment.firstChild
   if (newEl) {
-    condEl.replaceWith(newEl.cloneNode(true))
+    const slotSet = slots.length > 0 ? new Set<Node>(slots) : null
+    condEl.replaceWith(slotSet?.has(newEl) ? newEl : newEl.cloneNode(true))
   }
 }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -850,11 +850,16 @@ function buildConditionalMetadata(
   // Use loopDepth=-1 so the first loop encountered inside the branch emits
   // data-key (depth 0) for its items, matching the mapArray item template
   // and event dispatcher convention. Matches irToComponentTemplate/generateCsrTemplate.
+  // `__slots` is the closure-scoped accumulator emitted by
+  // `stringifyInsert` for each branch's `template()` body (#1213).
+  // Forwarding it here makes Child-position expression interpolations
+  // route Element/Node returns through `__bfSlot` instead of being
+  // stringified by the surrounding template literal.
   return {
     slotId: node.slotId!,
     condition: node.condition,
-    whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames, -1),
-    whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames, -1),
+    whenTrueHtml: irToHtmlTemplate(node.whenTrue, restNames, -1, undefined, '__slots'),
+    whenFalseHtml: irToHtmlTemplate(node.whenFalse, restNames, -1, undefined, '__slots'),
     whenTrue: summarizeBranch(node.whenTrue, ctx, siblingOffsets),
     whenFalse: summarizeBranch(node.whenFalse, ctx, siblingOffsets),
   }
@@ -962,8 +967,12 @@ export function collectLoopChildConditionals(
       const loopParamsForCond = loopParam
         ? [{ param: loopParam, bindings: loopParamBindings }]
         : undefined
-      const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond)
-      const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond)
+      // `__slots` matches the closure variable emitted by
+      // `stringifyLoopChildConditional` — Child-position interpolations
+      // get wrapped in `__bfSlot(EXPR, __slots)` so live `Node` returns
+      // survive the splice (#1213).
+      const whenTrueHtml = irToHtmlTemplate(n.whenTrue, undefined, 0, loopParamsForCond, '__slots')
+      const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond, '__slots')
       conditionals.push({
         slotId: n.slotId,
         condition: expanded,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -65,7 +65,12 @@ function emitArm(
   armIndent: string,
   bodyIndent: string,
 ): void {
-  lines.push(`${armIndent}template: () => \`${arm.templateHtml}\`,`)
+  // `__slots` accumulates live `Node` returns captured by `__bfSlot` so
+  // the `insert()` runtime can splice them into the parsed fragment
+  // instead of letting the template literal stringify them (#1213).
+  // The collector in `collect-elements.ts` injects `__bfSlot(EXPR, __slots)`
+  // wrappers around Child-position interpolations under this var name.
+  lines.push(`${armIndent}template: () => { const __slots = []; return { html: \`${arm.templateHtml}\`, slots: __slots } },`)
   lines.push(`${armIndent}bindEvents: (__branchScope) => {`)
   emitArmBody(lines, arm.body, mode, bodyIndent)
   lines.push(`${armIndent}}`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -150,13 +150,17 @@ function stringifyLoopChildConditional(
   indent: string,
 ): void {
   const armIndent = `${indent}    `
+  // Body-form arrows wire `__bfSlot` captures into the runtime so live
+  // `Node` returns from Child-position interpolations are spliced into
+  // the parsed fragment instead of being stringified by the surrounding
+  // template literal (#1213).
   lines.push(`${indent}insert(${cond.scopeVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
-  lines.push(`${indent}  template: () => \`${cond.whenTrueTemplateHtml}\`,`)
+  lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope) => {`)
   stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
-  lines.push(`${indent}  template: () => \`${cond.whenFalseTemplateHtml}\`,`)
+  lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope) => {`)
   stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent)
   lines.push(`${indent}  }`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -96,13 +96,15 @@ function emitOuterConditional(
 ): void {
   const armIndent = `${indent}    `
 
+  // Body-form arrows so live `Node` returns from Child-position
+  // interpolations route through `__bfSlot` and survive the splice (#1213).
   lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
-  lines.push(`${indent}  template: () => \`${cond.whenTrueTemplateHtml}\`,`)
+  lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope) => {`)
   emitArmBody(lines, cond.whenTrueArm, armIndent)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
-  lines.push(`${indent}  template: () => \`${cond.whenFalseTemplateHtml}\`,`)
+  lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope) => {`)
   emitArmBody(lines, cond.whenFalseArm, armIndent)
   lines.push(`${indent}  }`)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -84,10 +84,17 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
 /** Convert an IR node tree to an HTML template string (for conditionals/loops).
  *  @param loopDepth - Current nesting depth inside inner loops. 0 = outer loop level.
  *    When > 0, `key` attributes are converted to `data-key-{depth}` instead of `data-key`.
+ *  @param branchSlotsVar - When set, Child-position expression interpolations
+ *    are wrapped with `__bfSlot(EXPR, <branchSlotsVar>)` so the runtime can
+ *    splice live `Node` returns into the parsed fragment instead of
+ *    stringifying them via the template literal (#1213).
  */
-export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>): string {
-  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams)
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string): string {
+  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
+  const wrapInterpolation = (expr: string): string => branchSlotsVar
+    ? `__bfSlot(${expr}, ${branchSlotsVar})`
+    : expr
 
   switch (node.type) {
     case 'element': {
@@ -134,9 +141,9 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
       if (node.slotId) {
-        return `<!--bf:${node.slotId}-->\${${wrapExpr(node.expr)}}<!--/-->`
+        return `<!--bf:${node.slotId}-->\${${wrapInterpolation(wrapExpr(node.expr))}}<!--/-->`
       }
-      return `\${${wrapExpr(node.expr)}}`
+      return `\${${wrapInterpolation(wrapExpr(node.expr))}}`
 
     case 'conditional': {
       const trueBranch = recurse(node.whenTrue)
@@ -189,7 +196,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // Increment loopDepth so inner key attrs become data-key-N
       // Forward loopParams so expressions referencing outer/inner loop params
       // get wrapped as signal accessors (e.g., task.title → task().title).
-      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams)
+      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar)
       const childTemplate = node.children.map(innerRecurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
       const wrappedArray = wrapExpr(node.array)

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -12,7 +12,7 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   'createPortal',
   'provideContext', 'createContext', 'useContext',
   'forwardProps', 'applyRestAttrs', 'splitProps', 'spreadAttrs', 'styleToCss',
-  'qsa', 'qsaItem', 'upsertChildItem', '__slot',
+  'qsa', 'qsaItem', 'upsertChildItem', '__slot', '__bfSlot',
 ] as const
 
 /** @deprecated Use RUNTIME_IMPORT_CANDIDATES */

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -4,13 +4,12 @@
  * Renders the JSX-native `<Flow>` graph editor with the four overlays
  * (`<Background>` / `<Controls>` / `<MiniMap>`).
  *
- * The custom-body / custom-handle demos below still return HTML strings
- * from `renderNode` rather than inline JSX. This file predates the
- * compiler fix in #1211 (which now hoists inline `(n) => <div/>`
- * arrows into synthesized client components); the string-returning
- * helpers are kept as-is to preserve the existing visual snapshots
- * until a follow-up rewrites them in inline JSX with end-to-end
- * verification.
+ * The custom-body / custom-handle demos below return live JSX from
+ * `renderNode`. This relies on the compiler fix in #1211 (inline
+ * `(n) => <div/>` arrows hoisted into synthesized client components)
+ * and the runtime fix in #1213 (live `Node` returns spliced into
+ * branch templates via `__bfSlot` instead of being stringified by
+ * the surrounding template literal).
  */
 
 "use client"
@@ -19,42 +18,11 @@ import {
   Background,
   Controls,
   Flow,
+  Handle,
   MiniMap,
 } from '@/components/ui/xyflow'
 import { Position } from '@barefootjs/xyflow'
 
-// Static-handle markup helper: produces the same DOM signature as the
-// JSX `<Handle>` (class names + data-* attributes) so static node
-// previews still register handle bounds for the connection layer.
-function handleHTML(opts: {
-  type: 'source' | 'target'
-  position: Position
-  nodeId: string
-  id?: string
-}): string {
-  const modifier = opts.type === 'source' ? 'bf-flow__handle--source' : 'bf-flow__handle--target'
-  const idAttr = opts.id ? ` data-handleid="${opts.id}"` : ''
-  return (
-    `<div class="bf-flow__handle ${modifier} ${opts.type}"` +
-    ` data-handle-type="${opts.type}"` +
-    ` data-handlepos="${opts.position}"` +
-    ` data-handle-position="${opts.position}"` +
-    ` data-node-id="${opts.nodeId}"${idAttr}></div>`
-  )
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
-// Custom-body / custom-handle previews.
-//
-// These demos return an HTML *string* from `renderNode` (the
-// `pillBodyHTML` / `fanBodyHTML` helpers below). The compiler fix in
-// #1211 makes the conventional `renderNode={(n) => <div/>}` shape
-// compile cleanly, but the string-return shape is kept here to preserve
-// the existing visual snapshots; a follow-up will migrate these demos
-// to inline JSX once the new path has bake-in time.
 const customBodyNodes = [
   { id: 'src', position: { x:  80, y: 100 }, data: { label: 'Source' } },
   { id: 'mid', position: { x: 320, y:  80 }, data: { label: 'Pipeline' } },
@@ -73,14 +41,16 @@ const customBodyTone: Record<string, string> = {
   dst: 'bg-sky-500    text-white border-sky-600',
 }
 
-function pillBodyHTML(n: { id: string; data: { label?: string } }): string {
-  const tone = customBodyTone[n.id] ?? 'bg-card text-foreground border'
+function PillNode(props: { id: string }) {
+  const node = customBodyNodes.find((n) => n.id === props.id)
+  const label = node?.data?.label ?? props.id
+  const tone = customBodyTone[props.id] ?? 'bg-card text-foreground border'
   return (
-    `<div class="rounded-full border-2 px-5 py-2 text-sm font-semibold shadow-md ${tone}">` +
-    handleHTML({ type: 'target', position: Position.Left, nodeId: n.id }) +
-    escapeHtml(n.data.label ?? n.id) +
-    handleHTML({ type: 'source', position: Position.Right, nodeId: n.id }) +
-    `</div>`
+    <div className={`rounded-full border-2 px-5 py-2 text-sm font-semibold shadow-md ${tone}`}>
+      <Handle type="target" position={Position.Left} nodeId={props.id} />
+      {label}
+      <Handle type="source" position={Position.Right} nodeId={props.id} />
+    </div>
   )
 }
 
@@ -90,8 +60,7 @@ export function XyflowCustomBodyDemo() {
       <Flow
         nodes={customBodyNodes}
         edges={customBodyEdges}
-        // biome-ignore lint/suspicious/noExplicitAny: returning a string (not Child) so the SSR + hydrate template-literal embedding stays clean.
-        renderNode={((n: { id: string; data: { label?: string } }) => pillBodyHTML(n)) as any}
+        renderNode={(n) => <PillNode id={n.id} />}
       >
         <Background variant="dots" gap={30} />
       </Flow>
@@ -111,22 +80,24 @@ const fanEdges = [
   { id: 'fan-c', source: 'fan', sourceHandle: 'bottom', target: 'c' },
 ]
 
-function fanBodyHTML(n: { id: string; data: { label?: string } }): string {
-  if (n.id === 'fan') {
+function FanNode(props: { id: string }) {
+  const node = fanNodes.find((n) => n.id === props.id)
+  const label = node?.data?.label ?? props.id
+  if (props.id === 'fan') {
     return (
-      `<div class="rounded-full border-2 border-violet-600 bg-violet-500 text-white px-5 py-2 text-sm font-semibold shadow-md">` +
-      handleHTML({ type: 'source', position: Position.Top,    nodeId: n.id, id: 'top' }) +
-      handleHTML({ type: 'source', position: Position.Right,  nodeId: n.id, id: 'right' }) +
-      handleHTML({ type: 'source', position: Position.Bottom, nodeId: n.id, id: 'bottom' }) +
-      escapeHtml(n.data.label ?? n.id) +
-      `</div>`
+      <div className="rounded-full border-2 border-violet-600 bg-violet-500 text-white px-5 py-2 text-sm font-semibold shadow-md">
+        <Handle type="source" position={Position.Top} nodeId={props.id} id="top" />
+        <Handle type="source" position={Position.Right} nodeId={props.id} id="right" />
+        <Handle type="source" position={Position.Bottom} nodeId={props.id} id="bottom" />
+        {label}
+      </div>
     )
   }
   return (
-    `<div class="rounded-full border-2 border-slate-400 bg-white text-slate-800 px-4 py-1.5 text-sm font-medium shadow-sm">` +
-    handleHTML({ type: 'target', position: Position.Left, nodeId: n.id }) +
-    escapeHtml(n.data.label ?? n.id) +
-    `</div>`
+    <div className="rounded-full border-2 border-slate-400 bg-white text-slate-800 px-4 py-1.5 text-sm font-medium shadow-sm">
+      <Handle type="target" position={Position.Left} nodeId={props.id} />
+      {label}
+    </div>
   )
 }
 
@@ -136,8 +107,7 @@ export function XyflowCustomHandlesDemo() {
       <Flow
         nodes={fanNodes}
         edges={fanEdges}
-        // biome-ignore lint/suspicious/noExplicitAny: see XyflowCustomBodyDemo above for the rationale.
-        renderNode={((n: { id: string; data: { label?: string } }) => fanBodyHTML(n)) as any}
+        renderNode={(n) => <FanNode id={n.id} />}
       >
         <Background variant="dots" gap={30} />
       </Flow>

--- a/site/ui/e2e/xyflow.spec.ts
+++ b/site/ui/e2e/xyflow.spec.ts
@@ -147,11 +147,39 @@ test.describe('xyflow Reference Page', () => {
   })
 
   // ------------------------------------------------------------
-  // Custom-node-body coverage (renderNode / nodeTypes) is intentionally
-  // absent: the docs page only ships code samples for that path because
-  // the barefoot compiler does not transform JSX nested inside
-  // arrow-function callbacks, so a `renderNode={(n) => <div/>}` demo
-  // would emit raw JSX into the client bundle and crash the parser.
+  // Custom-node-body coverage. The compiler (#1211) hoists inline
+  // JSX-returning arrows like `renderNode={(n) => <PillNode .../>}`
+  // into synthesized client components, and the runtime (#1213) splices
+  // the live HTMLElement returns into the branch template via
+  // `__bfSlot` instead of stringifying them to "[object HTMLDivElement]".
+  // ------------------------------------------------------------
+  test.describe('renderNode JSX-callback (#1213)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/xyflow/nodes')
+    })
+
+    test('pill bodies hydrate without [object HTMLDivElement]', async ({ page }) => {
+      const container = firstScope(page, '[bf-s^="XyflowCustomBodyDemo_"]:not([data-slot])')
+      await expect(container).toBeAttached()
+      const text = await container.innerText()
+      expect(text).not.toContain('[object')
+    })
+
+    test('pill nodes carry both source and target handles', async ({ page }) => {
+      const container = firstScope(page, '[bf-s^="XyflowCustomBodyDemo_"]:not([data-slot])')
+      await expect(container.locator('.bf-flow__node')).toHaveCount(3)
+      await expect(container.locator('.bf-flow__handle--source')).toHaveCount(3)
+      await expect(container.locator('.bf-flow__handle--target')).toHaveCount(3)
+    })
+
+    test('fan router exposes top/right/bottom handles', async ({ page }) => {
+      const container = firstScope(page, '[bf-s^="XyflowCustomHandlesDemo_"]:not([data-slot])')
+      await expect(container.locator('[data-handleid="top"]')).toBeAttached()
+      await expect(container.locator('[data-handleid="right"]')).toBeAttached()
+      await expect(container.locator('[data-handleid="bottom"]')).toBeAttached()
+    })
+  })
+
   // ------------------------------------------------------------
   // Pan / zoom / drag / connection-drag interactivity is gated on the
   // pointer-paced subsystem attach implemented in cutover step C4.


### PR DESCRIPTION
## Summary

- `<Flow renderNode>` callbacks returning a live `HTMLElement` (the natural shape after #1211 hoisting) had their values stringified to `"[object HTMLDivElement]"` by the client-side branch template literal. SSR worked via Hono's `toString`, but hydration replaced the SSR DOM with literal text. This PR fixes the root cause at the runtime/codegen boundary.
- Added a new runtime helper `__bfSlot(value, slots)` that captures `Node` values into a closure-scoped slots array and emits `<!--bf-slot:N-->` markers. The compiler now wraps every Child-position interpolation in branch templates with `__bfSlot` and emits a body-form `template()` returning `{ html, slots }`. The `insert()` runtime parses the html, walks the fragment for slot markers, and `replaceChild`s them with `slots[N]` by identity (no `cloneNode`) so event listeners and signal bindings survive.
- Forces a DOM swap on first-run hydration when `slots.length > 0` so the SSR-rendered Hono-stringified HTML is replaced by the live signal-bound nodes returned by the client.
- Migrated the xyflow custom-body and custom-handles demos from HTML-string workarounds to live JSX (`PillNode`, `FanNode`), and removed the `as any` coercions / escape-html helpers. The `(n) => <PillNode .../>` shape now compiles via #1211 and hydrates via #1213.

## Closes

Closes #1213

## Test plan

- [x] Added two unit tests in `packages/client/__tests__/runtime/insert.test.ts` exercising `template()` returning `{html, slots}` — verifies the live element is in the DOM by identity and that no `[object` text appears, including a branch-toggle case.
- [x] All 240 client runtime tests pass.
- [x] All 1022 jsx compiler tests pass (no regressions vs main).
- [x] All 412 adapter conformance tests pass.
- [x] Total `bun run test`: 2245 pass, 0 fail across 166 files.
- [x] Added 3 E2E specs in `site/ui/e2e/xyflow.spec.ts` (`renderNode JSX-callback (#1213)`) covering pill body hydration, source/target handles, and the fan router top/right/bottom handles.
- [x] Full Playwright suite: 1078 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)