### PR TITLE
fix(compiler): re-parse rewritten source when shared ts.Program is supplied (#1217)

### DIFF
--- a/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
+++ b/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { $ } from 'bun'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { TestAdapter } from '../adapters/test-adapter'
@@ -299,14 +299,14 @@ describe('inline JSX in arrow callback with options.program (#1217)', () => {
   let tmpDir: string
 
   beforeAll(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'bfjs-1217-'))
+    tmpDir = join(tmpdir(), `bfjs-1217-${crypto.randomUUID()}`)
   })
 
-  afterAll(() => {
-    rmSync(tmpDir, { recursive: true, force: true })
+  afterAll(async () => {
+    await $`rm -rf ${tmpDir}`.quiet()
   })
 
-  test('preserves the BFInlineJsxCallback rewrite when a shared program is supplied', () => {
+  test('preserves the BFInlineJsxCallback rewrite when a shared program is supplied', async () => {
     const source = `'use client'
 import { Flow } from '@/components/ui/xyflow'
 
@@ -321,7 +321,7 @@ export function Demo() {
 }
 `
     const filePath = join(tmpDir, 'demo-single.tsx')
-    writeFileSync(filePath, source, 'utf8')
+    await Bun.write(filePath, source)
     const program = createProgramForCorpus([filePath])
     const js = clientJsWithProgram(source, filePath, program)
 
@@ -334,7 +334,7 @@ export function Demo() {
     expect(js).toContain('BFInlineJsxCallback1')
   })
 
-  test('multi-component file rewrites the inline arrow with and without a shared program', () => {
+  test('multi-component file rewrites the inline arrow with and without a shared program', async () => {
     const source = `'use client'
 import { Flow } from '@/components/ui/xyflow'
 
@@ -353,7 +353,7 @@ export function Demo() {
 }
 `
     const filePath = join(tmpDir, 'demo-multi.tsx')
-    writeFileSync(filePath, source, 'utf8')
+    await Bun.write(filePath, source)
 
     // Path A — no shared program (compileMultipleComponents builds its own).
     const noProgramJs = clientJs(source, filePath)

--- a/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
+++ b/packages/jsx/src/__tests__/inline-jsx-callback.test.ts
@@ -8,14 +8,27 @@
  * regular pipeline compiles into init + hydrate + a callable shim.
  */
 
-import { describe, expect, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { TestAdapter } from '../adapters/test-adapter'
 import { compileJSX } from '../compiler'
+import { createProgramForCorpus } from '../shared-program'
+import type ts from 'typescript'
 
 const adapter = new TestAdapter()
 
 function clientJs(source: string, fileName = 'Demo.tsx'): string {
   const result = compileJSX(source, fileName, { adapter })
+  expect(result.errors).toEqual([])
+  const file = result.files.find(f => f.type === 'clientJs')
+  expect(file).toBeDefined()
+  return file!.content
+}
+
+function clientJsWithProgram(source: string, filePath: string, program: ts.Program): string {
+  const result = compileJSX(source, filePath, { adapter, program })
   expect(result.errors).toEqual([])
   const file = result.files.find(f => f.type === 'clientJs')
   expect(file).toBeDefined()
@@ -271,5 +284,86 @@ describe('inline JSX in arrow callback (#1211)', () => {
     // No BF080 — but no synthesis either; the file just doesn't ship a
     // client bundle and its arrow stays inert in the SSR template.
     expect(result.errors.filter(e => e.code === 'BF080')).toEqual([])
+  })
+})
+
+/**
+ * #1217 — inline-JSX-callback rewrite must survive the shared `ts.Program`
+ * path. The single-call `compileJSX` flow always re-parses `compileSource`,
+ * but production builds (`site/ui/build.ts`) pass an `options.program`
+ * built from the on-disk corpus. Without the analyzer's source-vs-program
+ * guard, the cached SourceFile masks the preprocess output and raw JSX
+ * leaks into the client bundle, crashing the parser at module load.
+ */
+describe('inline JSX in arrow callback with options.program (#1217)', () => {
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bfjs-1217-'))
+  })
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('preserves the BFInlineJsxCallback rewrite when a shared program is supplied', () => {
+    const source = `'use client'
+import { Flow } from '@/components/ui/xyflow'
+
+export function Demo() {
+  return (
+    <Flow
+      nodes={[]}
+      edges={[]}
+      renderNode={(n) => <div>{n.data.label}</div>}
+    />
+  )
+}
+`
+    const filePath = join(tmpDir, 'demo-single.tsx')
+    writeFileSync(filePath, source, 'utf8')
+    const program = createProgramForCorpus([filePath])
+    const js = clientJsWithProgram(source, filePath, program)
+
+    // Without the analyzer guard, the program's cached SourceFile would
+    // mask the preprocess output and the original arrow JSX would survive.
+    expect(js).not.toMatch(/=>\s*<div\b/)
+    expect(js).not.toMatch(/=>\s*\(\s*<div\b/)
+    expect(js).not.toMatch(/return\s*<div\b/)
+    expect(js).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+    expect(js).toContain('BFInlineJsxCallback1')
+  })
+
+  test('multi-component file rewrites the inline arrow with and without a shared program', () => {
+    const source = `'use client'
+import { Flow } from '@/components/ui/xyflow'
+
+export function Sibling() {
+  return <p>sibling</p>
+}
+
+export function Demo() {
+  return (
+    <Flow
+      nodes={[]}
+      edges={[]}
+      renderNode={(n) => <span>{n.data.label}</span>}
+    />
+  )
+}
+`
+    const filePath = join(tmpDir, 'demo-multi.tsx')
+    writeFileSync(filePath, source, 'utf8')
+
+    // Path A — no shared program (compileMultipleComponents builds its own).
+    const noProgramJs = clientJs(source, filePath)
+    expect(noProgramJs).not.toMatch(/=>\s*<span\b/)
+    expect(noProgramJs).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
+
+    // Path B — shared program (the production case that #1217 reports).
+    const program = createProgramForCorpus([filePath])
+    const sharedJs = clientJsWithProgram(source, filePath, program)
+    expect(sharedJs).not.toMatch(/=>\s*<span\b/)
+    expect(sharedJs).toMatch(/hydrate\(\s*['"]BFInlineJsxCallback1(?:__|['"])/)
   })
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -140,6 +140,19 @@ export function analyzeComponent(
   let sourceFile: ts.SourceFile | undefined
   let checker: ts.TypeChecker | null = null
 
+  // If the caller passed a shared program but `source` was rewritten
+  // upstream (e.g. by preprocessInlineJsxCallbacks in compiler.ts), the
+  // program's cached SourceFile still reflects the on-disk text and would
+  // mask the rewrite. Discard the program so the parse below uses the
+  // rewritten source. needsTypeBasedDetection() further down rebuilds a
+  // per-file program when type-based detection is required (#1217).
+  if (program) {
+    const cachedSourceFile = program.getSourceFile(filePath)
+    if (cachedSourceFile && cachedSourceFile.text !== source) {
+      program = undefined
+    }
+  }
+
   if (program) {
     // Use the pre-built program's source file and checker
     sourceFile = program.getSourceFile(filePath)


### PR DESCRIPTION
## Summary

- The #1211 inline-JSX-callback preprocess output was silently discarded whenever `compileJSX` was called with `options.program`. `site/ui/build.ts` always passes a shared corpus program for performance, so the regression was invisible to the existing tests but trips on every production build.
- `analyzer.ts` was reading the cached `SourceFile` from the program (built from the on-disk text), masking the rewrite. Raw `renderNode={(n) => <PillNode/>}` arrows then survived into the client bundle and crashed the parser at module load (`SyntaxError: Unexpected token '<'`).
- This PR adds a guard in `analyzeComponent`: if the caller passed a shared program but the program's cached `SourceFile.text` no longer matches the (rewritten) `source`, the program is dropped so the analyzer parses the rewritten source via `ts.createSourceFile`. The same pattern already exists for `prescanReactiveFactoriesInSource` (analyzer.ts:128-138). The downstream `needsTypeBasedDetection` fallback rebuilds a per-file program when checker-based detection is required, so type-based reactivity detection still works.

## Changes

| File | Change |
|------|--------|
| `packages/jsx/src/analyzer.ts` | Add guard before the `if (program)` block to discard the shared program when its cached `SourceFile.text !== source`. |
| `packages/jsx/src/__tests__/inline-jsx-callback.test.ts` | Close the test gap called out in the issue: add `options.program` and multi-component cases that exercise both `compileJSX` and `compileMultipleComponents` paths. |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/inline-jsx-callback.test.ts` — both new tests pass; the `options.program` case fails on `main` without the analyzer guard.
- [x] `bun test packages/jsx` — pre-existing `pass / fail / errors` counts unchanged (+2 pass from the new tests).
- [x] `bun test packages/adapter-tests` — pre-existing counts unchanged.
- [x] `bun run build` (root) — `site/ui` builds cleanly. `site/ui/dist/components/xyflow-demo-*.js` contains 10 `BFInlineJsxCallback` references and zero raw `=> <PillNode|FanNode` arrows.
- [x] `bun build site/ui/dist/components/xyflow-demo-*.js` — bundle parses successfully (was the original repro of the `Unexpected token '<'` failure).

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)