### PR TITLE
feat(xyflow): clamp child node drag with extent: 'parent'

### DIFF
--- a/packages/xyflow/src/__tests__/clamp-drag-position.test.ts
+++ b/packages/xyflow/src/__tests__/clamp-drag-position.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import type { InternalNodeBase, NodeLookup } from '@xyflow/system'
+import { clampDragPositionToParent } from '../flow-subsystems'
+import type { NodeBase } from '../types'
+
+// Build a minimal NodeLookup that satisfies the bits clampDragPositionToParent
+// reads (`internal.measured.width/height`, `internal.internals.userNode`).
+// adoptUserNodes-produced internals carry many more fields, but the clamp
+// helper is intentionally narrow: anything outside its read set goes
+// untouched at runtime.
+function makeLookup(
+  nodes: Array<Partial<NodeBase> & { id: string; measured?: { width: number; height: number } }>,
+): NodeLookup<InternalNodeBase<NodeBase>> {
+  const m = new Map<string, InternalNodeBase<NodeBase>>()
+  for (const n of nodes) {
+    const userNode = { position: { x: 0, y: 0 }, data: {}, ...n } as NodeBase
+    const internal = {
+      ...userNode,
+      measured: n.measured,
+      internals: {
+        positionAbsolute: { x: 0, y: 0 },
+        z: 0,
+        userNode,
+      },
+    } as unknown as InternalNodeBase<NodeBase>
+    m.set(n.id, internal)
+  }
+  return m as NodeLookup<InternalNodeBase<NodeBase>>
+}
+
+describe("clampDragPositionToParent — extent: 'parent'", () => {
+  const parent = {
+    id: 'p',
+    position: { x: 0, y: 0 },
+    measured: { width: 200, height: 100 },
+  }
+
+  test('clamps a child whose proposed relative position would overflow on +x', () => {
+    const lookup = makeLookup([
+      parent,
+      { id: 'c', parentId: 'p', extent: 'parent', measured: { width: 40, height: 30 } },
+    ])
+    // parent 200×100, child 40×30 → max relative x = 160, max y = 70
+    const clamped = clampDragPositionToParent({ x: 500, y: 500 }, 'c', lookup)
+    expect(clamped).toEqual({ x: 160, y: 70 })
+  })
+
+  test('clamps to 0 on the negative side', () => {
+    const lookup = makeLookup([
+      parent,
+      { id: 'c', parentId: 'p', extent: 'parent', measured: { width: 40, height: 30 } },
+    ])
+    const clamped = clampDragPositionToParent({ x: -50, y: -10 }, 'c', lookup)
+    expect(clamped).toEqual({ x: 0, y: 0 })
+  })
+
+  test('passes through when child fits and is inside the rect', () => {
+    const lookup = makeLookup([
+      parent,
+      { id: 'c', parentId: 'p', extent: 'parent', measured: { width: 40, height: 30 } },
+    ])
+    const clamped = clampDragPositionToParent({ x: 80, y: 40 }, 'c', lookup)
+    expect(clamped).toEqual({ x: 80, y: 40 })
+  })
+
+  test('returns the input unchanged for nodes without parentId', () => {
+    const lookup = makeLookup([{ id: 'c', measured: { width: 40, height: 30 } }])
+    const proposed = { x: 1234, y: -5 }
+    expect(clampDragPositionToParent(proposed, 'c', lookup)).toEqual(proposed)
+  })
+
+  test('returns the input unchanged when the node has parentId but extent is not "parent"', () => {
+    const lookup = makeLookup([
+      parent,
+      // No extent set → drag should NOT be clamped (xyflow contract).
+      { id: 'c', parentId: 'p', measured: { width: 40, height: 30 } },
+    ])
+    const proposed = { x: 999, y: 999 }
+    expect(clampDragPositionToParent(proposed, 'c', lookup)).toEqual(proposed)
+  })
+
+  test('returns the input unchanged when the parent is missing from the lookup', () => {
+    const lookup = makeLookup([
+      // Parent intentionally absent — drag handler must not throw.
+      { id: 'c', parentId: 'missing', extent: 'parent', measured: { width: 40, height: 30 } },
+    ])
+    const proposed = { x: 999, y: 999 }
+    expect(clampDragPositionToParent(proposed, 'c', lookup)).toEqual(proposed)
+  })
+
+  test('returns the input unchanged when measurements are still pending', () => {
+    const lookup = makeLookup([
+      // No `measured` on the parent. Drag begins before ResizeObserver
+      // has fired — clamp would otherwise pin to 0/0 and prevent any
+      // drag motion.
+      { id: 'p', position: { x: 0, y: 0 } },
+      { id: 'c', parentId: 'p', extent: 'parent', measured: { width: 40, height: 30 } },
+    ])
+    const proposed = { x: 999, y: 999 }
+    expect(clampDragPositionToParent(proposed, 'c', lookup)).toEqual(proposed)
+  })
+
+  test('clamps to 0 on each axis when the child is bigger than the parent', () => {
+    const lookup = makeLookup([
+      parent,
+      { id: 'c', parentId: 'p', extent: 'parent', measured: { width: 999, height: 999 } },
+    ])
+    // pw - myW < 0 → max{0, …} = 0; same for y.
+    expect(clampDragPositionToParent({ x: 50, y: 50 }, 'c', lookup)).toEqual({ x: 0, y: 0 })
+  })
+})

--- a/packages/xyflow/src/flow-subsystems.ts
+++ b/packages/xyflow/src/flow-subsystems.ts
@@ -18,11 +18,53 @@
 
 import { createEffect, onCleanup, untrack } from '@barefootjs/client'
 import { PanOnScrollMode, XYPanZoom } from '@xyflow/system'
-import type { Transform, Viewport } from '@xyflow/system'
+import type { InternalNodeBase, NodeLookup, Transform, Viewport, XYPosition } from '@xyflow/system'
 import { INFINITE_EXTENT } from './constants'
 import { computeEdgePosition, getEdgePath } from './edge-path'
 import { setupKeyboardHandlers, setupSelectionRectangle } from './selection'
 import type { FlowProps, InternalFlowStore, NodeBase, EdgeBase } from './types'
+
+/**
+ * Clamp a child node's drag position so the node's rect stays inside
+ * its parent's rect — implements xyflow's `extent: 'parent'` contract
+ * for the pointer-paced single-node drag handler.
+ *
+ * Operates on the **relative** coordinate the parent-relative model
+ * stores in `userNode.position`: the constraint per axis is
+ * `0 ≤ pos ≤ parentSize − childSize`. Returns the input unchanged when
+ * the node has no `parentId`, isn't `extent: 'parent'`, the parent is
+ * missing, or either node is unmeasured.
+ *
+ * Exposed (non-default-export) so the same primitive can be reused if
+ * the C4 XYDrag integration replaces the inline drag handler — the
+ * extent contract remains the same.
+ */
+export function clampDragPositionToParent(
+  position: XYPosition,
+  nodeId: string,
+  lookup: NodeLookup<InternalNodeBase<NodeBase>>,
+): XYPosition {
+  const internal = lookup.get(nodeId)
+  if (!internal) return position
+  const userNode = internal.internals.userNode as NodeBase & {
+    parentId?: string
+    extent?: 'parent' | unknown
+  }
+  if (!userNode.parentId || userNode.extent !== 'parent') return position
+  const parent = lookup.get(userNode.parentId)
+  if (!parent) return position
+  const myW = internal.measured?.width
+  const myH = internal.measured?.height
+  const pw = parent.measured?.width
+  const ph = parent.measured?.height
+  if (myW == null || myH == null || pw == null || ph == null) return position
+  const maxX = Math.max(0, pw - myW)
+  const maxY = Math.max(0, ph - myH)
+  return {
+    x: Math.min(Math.max(position.x, 0), maxX),
+    y: Math.min(Math.max(position.y, 0), maxY),
+  }
+}
 
 /**
  * Attach all pointer-paced + ResizeObserver-based subsystems to the
@@ -263,9 +305,16 @@ export function attachFlowSubsystems<
     const zoom = untrack(store.viewport).zoom || 1
     const dx = (event.clientX - dragState.startClientX) / zoom
     const dy = (event.clientY - dragState.startClientY) / zoom
-    const nextX = dragState.startNodeX + dx
-    const nextY = dragState.startNodeY + dy
-    writeDragPosition(dragState.nodeId, nextX, nextY, true)
+    // Clamp child nodes that opt in via `extent: 'parent'`. Done in the
+    // relative coordinate the drag handler already manipulates, so the
+    // commit shape (`writeDragPosition` → `setNodes` → `adoptUserNodes`)
+    // stays unchanged.
+    const clamped = clampDragPositionToParent(
+      { x: dragState.startNodeX + dx, y: dragState.startNodeY + dy },
+      dragState.nodeId,
+      untrack(store.nodeLookup),
+    )
+    writeDragPosition(dragState.nodeId, clamped.x, clamped.y, true)
   }
   const onNodePointerUp = (event: PointerEvent) => {
     if (!dragState || event.pointerId !== dragState.pointerId) return

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -30,7 +30,7 @@ export type { EdgePathTuple } from './edge-path'
 // `XYPanZoom` (D3-zoom-derived), the selection rectangle owns global
 // pointer capture, connection drag uses `elementFromPoint`, and the
 // node resizer needs raw dimension math.
-export { attachFlowSubsystems } from './flow-subsystems'
+export { attachFlowSubsystems, clampDragPositionToParent } from './flow-subsystems'
 export { attachConnectionHandler, attachReconnectionHandler } from './connection'
 export { initNodeResizer, ResizeControlVariant } from './node-resizer'
 export type {


### PR DESCRIPTION
## Summary
- The single-node drag handler in `flow-subsystems.ts` already updates the relative `position` of a child node, but did not honor xyflow's `extent: 'parent'` contract — a child could be dragged outside its parent's rect, leaving its relative coordinate larger than the parent size.
- Adds `clampDragPositionToParent`, a small pure helper that clamps a proposed relative position to `[0, parentSize − childSize]` per axis when the dragged node has `parentId` and `extent === 'parent'`. Wired into `onNodePointerMove` before `writeDragPosition`.

## Why a pure helper

The drag handler comment at line 198 already calls out:
> The cutover-step C4 XYDrag integration will eventually replace this with multi-select / snap / extent support, but a Flow that does not let users move nodes is a poor default — wire a minimal pointer-paced handler so the JSX renderer is interactive out of the box.

Keeping the `extent: 'parent'` contract in a small exported function lets that future swap reuse it verbatim — XYDrag can call `clampDragPositionToParent` from its `onNodeDrag` hook and produce the same behavior. The helper is also unit-testable without spinning up the full DOM/event harness.

## Behavior

The clamp is applied in the **relative** coordinate the drag handler already manipulates (the `n.position` xyflow stores for child nodes) so the commit shape — `writeDragPosition` → `setNodes` → `adoptUserNodes` — stays exactly the same. No-op for unparented nodes, for nodes whose `extent` is anything other than `'parent'`, when the parent has been removed from the lookup, or when measurements haven't arrived yet (preserves the pre-resize-observer drag-from-start UX).

## Test plan
- [x] `bun test` in `packages/xyflow/` — 39 pass (8 new in `clamp-drag-position.test.ts` covering: clamp on +x overflow, clamp on negative side, pass-through inside rect, no-parent / non-extent / missing-parent / unmeasured no-ops, child-bigger-than-parent zero-clamp).
- [x] `bun run typecheck:tests` — clean.
- [x] `bun run build` — clean.
- [x] `bunx biome check` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)