### PR TITLE
fix(runtime): preserve inner scope for comment-wrapper createComponent (#1222)

### DIFF
--- a/packages/client/__tests__/runtime/comment-wrapper-create-component.test.ts
+++ b/packages/client/__tests__/runtime/comment-wrapper-create-component.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for #1222.
+ *
+ * `comment: true` components are transparent wrappers — their template
+ * body is `${renderChild('Inner', ...)}` with no enclosing element of
+ * their own, so the parsed `firstChild` IS the Inner component's root
+ * (with its `~Inner_..._s0` scope marker). The CSR `createComponent`
+ * string-path used to overwrite that `bf-s` with the wrapper's own
+ * scope, stranding `$c(__scope, 's0')` lookups in the wrapper's init
+ * — `_s0` resolved to null, the wrapper's `initChild('Inner', _s0,
+ * ...)` bailed, and the Inner's body never ran.
+ *
+ * Surfaced through #1211 (synthesized inline-JSX-callback wrappers
+ * are emitted with `comment: true`): `<Flow renderNode={(n) =>
+ * <PillNode id={n.id} />}>` mounted PillNode but its initFn never
+ * ran, so the JSX text-child slot stayed empty and `<Handle>` props
+ * were never wired.
+ *
+ * Fix: when the registered def has `comment: true`, leave the inner
+ * element's `bf-s` in place. `$cSingle`'s self-match fallback then
+ * returns the scope element itself for the wrapper's slot lookup,
+ * letting the wrapper's `initChild('Inner', _s0, ...)` mount the
+ * Inner component correctly.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('createComponent + comment: true wrapper (#1222)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('preserves inner component scope when wrapper is registered with comment: true', async () => {
+    // Re-import inside the test so the previous test's module mutations
+    // (component registry) don't leak across tests; bun-test runs in
+    // isolation but the static module-level Map persists across files.
+    const {
+      hydrate,
+      createComponent,
+      $c,
+      initChild,
+    } = await import('../../src/runtime')
+
+    const innerInitCalls: Array<{ id: unknown; sawScope: boolean }> = []
+
+    // Inner: a regular component with one prop and a single slot.
+    hydrate('Inner_test1222', {
+      init: (scope, p: any) => {
+        innerInitCalls.push({ id: p?.id, sawScope: !!scope })
+      },
+      template: (p: any) =>
+        `<div bf-s="~Inner_test1222_${Math.random().toString(36).slice(2, 8)}_s0" data-id="${p.id}"></div>`,
+    })
+
+    // Wrapper: comment-mode (transparent). Its body is just the inner.
+    hydrate('Wrapper_test1222', {
+      init: (scope, p: any) => {
+        const [_s0] = $c(scope, 's0')
+        // The wrapper's slot lookup MUST resolve to the inner element.
+        // Pre-fix this returned null because createComponent had
+        // overwritten the inner's `bf-s` with the wrapper's scope.
+        initChild('Inner_test1222', _s0, { id: p?.id })
+      },
+      template: (p: any) => {
+        // Mirror the compiler's "comment: true" template shape:
+        // pure renderChild interpolation with no enclosing element.
+        const innerScope = `Inner_test1222_${Math.random().toString(36).slice(2, 8)}`
+        return `<div bf-s="~${innerScope}_s0" data-id="${p.id}"></div>`
+      },
+      comment: true,
+    })
+
+    const el = createComponent('Wrapper_test1222', { id: 'src' })
+    document.body.appendChild(el)
+
+    expect(innerInitCalls).toHaveLength(1)
+    expect(innerInitCalls[0]).toEqual({ id: 'src', sawScope: true })
+    // The element's bf-s should still be the inner's child-prefixed scope,
+    // not the wrapper's. This is what lets `$c(scope, 's0')` self-match.
+    const bfs = el.getAttribute('bf-s')
+    expect(bfs).toMatch(/^~Inner_test1222_/)
+  })
+
+  test('regular (non-comment) wrappers still get their bf-s overwritten as before', async () => {
+    const {
+      hydrate,
+      createComponent,
+    } = await import('../../src/runtime')
+
+    hydrate('Normal_test1222', {
+      init: () => {},
+      template: () => `<div data-marker="payload"></div>`,
+    })
+
+    const el = createComponent('Normal_test1222', {})
+    expect(el.getAttribute('bf-s')).toMatch(/^Normal_test1222_/)
+    expect(el.getAttribute('data-marker')).toBe('payload')
+  })
+})

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -7,6 +7,7 @@
 
 import { getTemplate } from './template'
 import { getComponentInit } from './registry'
+import { getRegisteredDef } from './hydrate'
 import { hydratedScopes } from './hydration-state'
 import { untrack } from '@barefootjs/client/reactive'
 import { setCurrentScope } from './context'
@@ -120,9 +121,29 @@ export function createComponent(
     return createPlaceholder(name, key)
   }
 
-  // 6. Set scope ID and key attributes
-  const scopeId = `${name}_${generateId()}`
-  element.setAttribute(BF_SCOPE, scopeId)
+  // 6. Set scope ID and key attributes.
+  //
+  // `comment: true` components (synthesized inline-JSX-callback wrappers
+  // from #1211, etc.) render as transparent shells: the template body
+  // is `${renderChild('Inner', ...)}` with no enclosing element of
+  // their own, so the parsed `firstChild` is actually the Inner
+  // component's root with its `~Inner_..._s0` scope marker. Overwriting
+  // that `bf-s` here strands `$c(__scope, 's0')` lookups in the
+  // wrapper's init — `_s0` resolves to null, the Inner's `initChild`
+  // call bails, and the Inner's body never runs.
+  //
+  // For comment-mode components we leave the original child-prefixed
+  // `bf-s` in place; `$cSingle`'s self-match fallback
+  // (`scope.matches('[bf-s$="_s0"]')`) then returns the scope element
+  // itself, so the wrapper's `initChild('Inner', _s0, ...)` mounts the
+  // Inner correctly. The `key` attribute still goes on for list
+  // reconciliation.
+  const def = getRegisteredDef(name)
+  const isCommentWrapper = def?.comment === true
+  if (!isCommentWrapper) {
+    const scopeId = `${name}_${generateId()}`
+    element.setAttribute(BF_SCOPE, scopeId)
+  }
   if (key !== undefined) {
     element.setAttribute(BF_KEY, String(key))
   }

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -52,6 +52,17 @@ import type { ComponentDef } from './types'
  */
 const registeredDefs = new Map<string, ComponentDef>()
 
+/**
+ * Look up a registered component definition by name. Used by the CSR
+ * `createComponent` path to honour `comment: true` (transparent
+ * wrapper) components — without the def lookup, those components
+ * overwrite the inner element's `bf-s` and break child-scope
+ * resolution at hydration.
+ */
+export function getRegisteredDef(name: string): ComponentDef | undefined {
+  return registeredDefs.get(name)
+}
+
 let microtaskScheduled = false
 let rafScheduled = false
 

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -77,7 +77,7 @@ export { styleToCss } from './style'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa, qsaChildScope, qsaChildScopes } from './query'
-export { hydrate, rehydrateAll, flushHydration } from './hydrate'
+export { hydrate, rehydrateAll, flushHydration, getRegisteredDef } from './hydrate'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry'
 export { insert, type BranchConfig, type BranchTemplateResult } from './insert'
 export { __bfSlot } from './branch-slot'


### PR DESCRIPTION
Closes #1222.

## Symptom

Recapping the original bug:

- `'use client'` JSX component reads a prop and renders it in a JSX text-child slot.
- SSR markup is correct (`<!--bf:s1-->Source<!--/-->`).
- Post-hydration the slot is empty (`<!--bf:s1--><!--/-->`), even though sibling expressions on the same element resolve fine (the className driven by `props.id` paints the right colour).

Visible on `site/ui`'s `/xyflow/nodes` Custom Bodies / Custom Handles previews. Filed in #1222 with a docs-page workaround: pass `label` as an explicit prop instead of deriving it from a const.

## Root cause

Surfaced through #1211 (synthesized inline-JSX-callback wrappers are emitted with `comment: true`):

```ts
hydrate('BFInlineJsxCallback1__bdcff84c', {
  init: initBFInlineJsxCallback1,
  template: (_p) => `${renderChild('PillNode__bdcff84c', { id: _p.id }, undefined, 's0')}`,
  comment: true,
})
export function BFInlineJsxCallback1(_p, __bfKey) {
  return createComponent('BFInlineJsxCallback1__bdcff84c', _p, __bfKey)
}
```

The wrapper's template is pure `renderChild` interpolation — no enclosing element of its own. The parsed `firstChild` IS the Inner (`PillNode`) component's root, carrying its own `~PillNode_..._s0` scope marker.

`createComponent` then unconditionally overwrites that `bf-s` with the wrapper's scope. Inside `initBFInlineJsxCallback1`:

```js
const [_s0] = $c(__scope, 's0')   // returns null after the overwrite
initChild('PillNode__bdcff84c', _s0, { get id() { return _p.id } })  // bails on !childScope
```

`initPillNode` never runs. The JSX text-child createEffect that should set `_s1.nodeValue = label` never fires either, so the SSR-rendered text gets clobbered when the runtime re-renders the slot during `insert()`'s diff pass.

(Confirmed by adding a side-effect probe to `PillNode`'s body — `window.__pillCalls` stays `undefined` while the `renderNode` arrow body runs 6 times. Init runs on `BFInlineJsxCallback1`, never on `PillNode`.)

## Fix

When the registered def has `comment: true`, leave the inner element's `bf-s` in place. `$cSingle`'s existing self-match fallback (`scope.matches('[bf-s$="_s0"]')`) then returns the scope element itself for the wrapper's slot lookup, and the wrapper's `initChild('Inner', _s0, ...)` mounts the Inner correctly. The `key` attribute still goes on so list reconciliation works.

Tests:

- `packages/client/__tests__/runtime/comment-wrapper-create-component.test.ts` — TDD-style. Mounts a `comment: true` wrapper around an Inner with a single slot, asserts the Inner's init runs once with the wrapper's prop, and asserts the resulting `bf-s` is the inner's `~Inner_…` scope.
- A no-regression test pins the regular (non-comment) path — fresh `Wrapper_…` scope id is still applied.

## Test plan

- [x] `bun test packages/client/__tests__/runtime/comment-wrapper-create-component.test.ts` — 2 pass
- [x] `bun test packages/client packages/jsx ui/components/ui/xyflow/index.test.tsx` — 1294 pass / 1 unrelated flake (`compiler-runtime-contract.test.ts > nested loop uses data-key-N`, hits 5s timeout under load, passes in isolation)
- [x] Browser smoke: `/xyflow/nodes` Custom Bodies shows Source / Pipeline / Sink labels, Custom Handles shows Router / A / B / C, console error count 0
- [x] `/xyflow/components` Overview, Background variants, Handle section all render with their expected node + edge counts and label text

## Follow-up

When this lands, the docs preview workaround in `fix/xyflow-custom-body-label-prop` (passing `label` as an explicit prop) becomes unnecessary — `(n) => <PillNode id={n.id} />` with the local-const-derived label will work directly. Up to the maintainers whether to keep the explicit-prop shape (more idiomatic) or revert to the simpler form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)