### PR TITLE
fix(runtime): untrack branch template() reads in insert()

### DIFF
--- a/packages/client/__tests__/runtime/insert.test.ts
+++ b/packages/client/__tests__/runtime/insert.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { insert } from '../../src/runtime/insert'
 import { __bfSlot } from '../../src/runtime/branch-slot'
-import { createSignal } from '../../src/reactive'
+import { createSignal, createEffect } from '../../src/reactive'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
 beforeAll(() => {
@@ -373,6 +373,121 @@ describe('insert', () => {
       // Set back to false → element removed
       setShow(false)
       expect(scope.querySelector('p')).toBeNull()
+    })
+  })
+
+  describe('template purity contract (#1224 follow-up)', () => {
+    // The contract: signal reads inside a branch template MUST NOT be
+    // attributed to whatever effect is the active Listener when
+    // `insert()` runs. Otherwise a `createDisposableEffect` that wraps
+    // an `insert()` call would re-run on every signal change inside the
+    // template, re-invoke `insert()`, and spawn duplicate inner
+    // constructs (e.g. duplicate mapArray instances).
+    //
+    // These tests verify the contract directly — they exercise the
+    // private `evalBranchTemplate` chokepoint through `insert()`'s
+    // public API.
+
+    test('isFragmentCond probe does not leak signal reads to a surrounding effect', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <span bf-c="c1">Initial</span>
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const [show] = createSignal(true)
+      const [count, setCount] = createSignal(0)
+
+      let outerRuns = 0
+      createEffect(() => {
+        outerRuns++
+        insert(
+          scope,
+          'c1',
+          show,
+          {
+            // Template intentionally reads `count` — this models the
+            // compiler-emitted `_p.item.replies.map(...)` pattern.
+            // The probe walks both branches on insert() entry, so the
+            // read happens regardless of `show`.
+            template: () => `<span bf-c="c1">${count()}</span>`,
+            bindEvents: () => {},
+          },
+          { template: () => '<span bf-c="c1">Hidden</span>', bindEvents: () => {} }
+        )
+      })
+
+      expect(outerRuns).toBe(1)
+      // Mutate the signal the template reads. If insert() were leaking
+      // the read into the surrounding createEffect, outerRuns would tick.
+      setCount(5)
+      expect(outerRuns).toBe(1)
+      setCount(6)
+      expect(outerRuns).toBe(1)
+    })
+
+    test('first-run template evaluation inside insert\'s own effect does not leak', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <span bf-c="c1">Initial</span>
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const [show] = createSignal(true)
+      const [count, setCount] = createSignal(0)
+
+      let outerRuns = 0
+      createEffect(() => {
+        outerRuns++
+        insert(
+          scope,
+          'c1',
+          show,
+          // Only the active branch reads the signal — exercises the
+          // first-run template-evaluation path inside insert's internal
+          // createEffect (distinct from the entry-time probe above).
+          { template: () => `<span bf-c="c1">${count()}</span>`, bindEvents: () => {} },
+          { template: () => '<span bf-c="c1">Hidden</span>', bindEvents: () => {} }
+        )
+      })
+
+      expect(outerRuns).toBe(1)
+      setCount(42)
+      expect(outerRuns).toBe(1)
+    })
+
+    test('branch-swap template evaluation does not leak', () => {
+      document.body.innerHTML = `
+        <div bf-s="Test_1">
+          <span bf-c="c1">Initial</span>
+        </div>
+      `
+      const scope = document.querySelector('[bf-s]')!
+      const [show, setShow] = createSignal(false)
+      const [count, setCount] = createSignal(0)
+
+      let outerRuns = 0
+      createEffect(() => {
+        outerRuns++
+        insert(
+          scope,
+          'c1',
+          show,
+          { template: () => `<span bf-c="c1">on:${count()}</span>`, bindEvents: () => {} },
+          { template: () => `<span bf-c="c1">off:${count()}</span>`, bindEvents: () => {} }
+        )
+      })
+
+      expect(outerRuns).toBe(1)
+      // Trigger a branch swap — this calls the branch.template() path
+      // inside insert's internal createEffect at the swap site.
+      setShow(true)
+      // The branch-swap path itself does not re-run the outer effect.
+      expect(outerRuns).toBe(1)
+      // And subsequent signal mutations whose reads happened inside the
+      // template still do not leak.
+      setCount(99)
+      expect(outerRuns).toBe(1)
     })
   })
 })

--- a/packages/client/__tests__/runtime/insert.test.ts
+++ b/packages/client/__tests__/runtime/insert.test.ts
@@ -376,18 +376,8 @@ describe('insert', () => {
     })
   })
 
-  describe('template purity contract (#1224 follow-up)', () => {
-    // The contract: signal reads inside a branch template MUST NOT be
-    // attributed to whatever effect is the active Listener when
-    // `insert()` runs. Otherwise a `createDisposableEffect` that wraps
-    // an `insert()` call would re-run on every signal change inside the
-    // template, re-invoke `insert()`, and spawn duplicate inner
-    // constructs (e.g. duplicate mapArray instances).
-    //
-    // These tests verify the contract directly — they exercise the
-    // private `evalBranchTemplate` chokepoint through `insert()`'s
-    // public API.
-
+  // Contract documented on `BranchConfig.template` in insert.ts.
+  describe('template purity contract', () => {
     test('isFragmentCond probe does not leak signal reads to a surrounding effect', () => {
       document.body.innerHTML = `
         <div bf-s="Test_1">
@@ -405,23 +395,16 @@ describe('insert', () => {
           scope,
           'c1',
           show,
-          {
-            // Template intentionally reads `count` — this models the
-            // compiler-emitted `_p.item.replies.map(...)` pattern.
-            // The probe walks both branches on insert() entry, so the
-            // read happens regardless of `show`.
-            template: () => `<span bf-c="c1">${count()}</span>`,
-            bindEvents: () => {},
-          },
-          { template: () => '<span bf-c="c1">Hidden</span>', bindEvents: () => {} }
+          // The probe walks BOTH branches on insert() entry, so a read in
+          // either template would leak — putting it in the inactive
+          // branch isolates the probe path from the first-run path below.
+          { template: () => '<span bf-c="c1">Visible</span>', bindEvents: () => {} },
+          { template: () => `<span bf-c="c1">${count()}</span>`, bindEvents: () => {} }
         )
       })
 
       expect(outerRuns).toBe(1)
-      // Mutate the signal the template reads. If insert() were leaking
-      // the read into the surrounding createEffect, outerRuns would tick.
       setCount(5)
-      expect(outerRuns).toBe(1)
       setCount(6)
       expect(outerRuns).toBe(1)
     })
@@ -443,9 +426,6 @@ describe('insert', () => {
           scope,
           'c1',
           show,
-          // Only the active branch reads the signal — exercises the
-          // first-run template-evaluation path inside insert's internal
-          // createEffect (distinct from the entry-time probe above).
           { template: () => `<span bf-c="c1">${count()}</span>`, bindEvents: () => {} },
           { template: () => '<span bf-c="c1">Hidden</span>', bindEvents: () => {} }
         )
@@ -479,13 +459,7 @@ describe('insert', () => {
       })
 
       expect(outerRuns).toBe(1)
-      // Trigger a branch swap — this calls the branch.template() path
-      // inside insert's internal createEffect at the swap site.
       setShow(true)
-      // The branch-swap path itself does not re-run the outer effect.
-      expect(outerRuns).toBe(1)
-      // And subsequent signal mutations whose reads happened inside the
-      // template still do not leak.
       setCount(99)
       expect(outerRuns).toBe(1)
     })

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -6,7 +6,7 @@
  * handles event binding for both branches.
  */
 
-import { createEffect } from '@barefootjs/client/reactive'
+import { createEffect, untrack } from '@barefootjs/client/reactive'
 import { find } from './query'
 import { setParentScopeId, parseHTML } from './component'
 import { BF_COND, BF_SCOPE, BF_CHILD_PREFIX } from '@barefootjs/shared'
@@ -85,9 +85,18 @@ export function insert(
   // Both branches need to be checked because SSR may render either branch.
   // Use try/catch because template evaluation may access nullable expressions
   // (e.g., selectedMail().subject when the branch is for the non-null case).
+  //
+  // The template() calls are wrapped in untrack() because a branch template
+  // may read signals (e.g. `_p.item.replies` when expanding a list) while
+  // `insert()` itself may be invoked from inside a surrounding effect
+  // (e.g. a `createDisposableEffect` set up by a parent branch's
+  // bindEvents). Without untrack, those reads would be attributed to the
+  // outer effect, causing it to re-run on every list update and spawn
+  // duplicate `mapArray` instances inside this conditional — the recursive
+  // CommentNode duplication observed in #1224 follow-up.
   let isFragmentCond = false
   try {
-    const sampleTrue = normalizeTemplate(whenTrue.template())
+    const sampleTrue = untrack(() => normalizeTemplate(whenTrue.template()))
     isFragmentCond = sampleTrue.html.includes(`<!--bf-cond-start:${id}-->`)
   } catch (err) {
     // Template may throw TypeError for nullable access (e.g., selectedMail().subject)
@@ -95,7 +104,7 @@ export function insert(
   }
   if (!isFragmentCond) {
     try {
-      const sampleFalse = normalizeTemplate(whenFalse.template())
+      const sampleFalse = untrack(() => normalizeTemplate(whenFalse.template()))
       isFragmentCond = sampleFalse.html.includes(`<!--bf-cond-start:${id}-->`)
     } catch (err) {
       if (!(err instanceof TypeError)) throw err
@@ -130,9 +139,12 @@ export function insert(
       // Hydration mode: check if existing DOM matches expected branch
       // If the existing element doesn't match the expected branch,
       // we need to swap the DOM first (e.g., SSR rendered whenFalse but now we need whenTrue)
+      // untrack the template() call: signal reads inside the template should
+      // not leak into this createEffect's dependency set — only conditionFn()
+      // governs when we re-run.
       setParentScopeId(parentScopeId)
       let result: BranchTemplateResult
-      try { result = normalizeTemplate(branch.template()) } finally { setParentScopeId(null) }
+      try { result = untrack(() => normalizeTemplate(branch.template())) } finally { setParentScopeId(null) }
       const existingEl = find(scope, `[${BF_COND}="${id}"]`)
       if (existingEl) {
         // Compare full opening tag signatures to detect branch mismatch.
@@ -191,10 +203,11 @@ export function insert(
       branchCleanup = null
     }
 
-    // Branch changed: swap DOM and bind events
+    // Branch changed: swap DOM and bind events.
+    // untrack the template() call (see isFirstRun branch above for rationale).
     setParentScopeId(parentScopeId)
     let result: BranchTemplateResult
-    try { result = normalizeTemplate(branch.template()) } finally { setParentScopeId(null) }
+    try { result = untrack(() => normalizeTemplate(branch.template())) } finally { setParentScopeId(null) }
     if (isFragmentCond) {
       updateFragmentConditional(scope, id, result)
     } else {

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -31,6 +31,35 @@ export interface BranchConfig {
    * HTML template function for this branch. Returns either a plain HTML
    * string (legacy) or a `{ html, slots }` pair for templates that
    * captured live `Node` values via `__bfSlot` (#1213).
+   *
+   * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   *  INVARIANT — TEMPLATES RUN WITH REACTIVITY UNTRACKED.
+   * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   *
+   * Every call site goes through `evalBranchTemplate()` in this file,
+   * which wraps the invocation in `untrack()`. Signal reads inside
+   * the template are therefore NOT registered as effect dependencies.
+   *
+   * Consequences for authors of new branch shapes:
+   *
+   *  - `template()` must produce a function of state-at-call-time only.
+   *    Any reactive portion of the rendered fragment is wired up
+   *    afterwards by `bindEvents()` (events + per-binding effects) and
+   *    `__bfSlot` (live-Node splicing for slot-captured signals).
+   *
+   *  - A template such as `() => signalA() ? '<a>' : '<b>'` is a BUG:
+   *    later changes to `signalA` will not re-evaluate the template,
+   *    because the read was performed without tracking. Branch
+   *    selection belongs in the `conditionFn` argument of `insert()`,
+   *    not inside the template body.
+   *
+   *  - This is not a per-site choice. Bypassing `evalBranchTemplate`
+   *    re-introduces the failure mode it was added to prevent: signal
+   *    reads inside the template leak into whatever effect is the
+   *    active Listener when `insert()` runs, which (when the compiler
+   *    nests `insert()` calls through `createDisposableEffect`) spawns
+   *    duplicate inner constructs on every signal change — observed
+   *    as item duplication in `mapArray` (#1224 follow-up).
    */
   template: () => string | BranchTemplateResult
 
@@ -48,6 +77,44 @@ const EMPTY_SLOTS: Node[] = []
 
 function normalizeTemplate(value: string | BranchTemplateResult): BranchTemplateResult {
   return typeof value === 'string' ? { html: value, slots: EMPTY_SLOTS } : value
+}
+
+/**
+ * Evaluate a branch template with reactivity tracking SUPPRESSED.
+ *
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *  PURITY CONTRACT — the single chokepoint for every `branch.template()`
+ *  invocation in this module. All four template-evaluation sites inside
+ *  `insert()` (isFragmentCond detection × 2, then first-run and
+ *  branch-swap inside the internal `createEffect`) flow through here so
+ *  the contract cannot be locally bypassed.
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
+ * Compiler-emitted branch templates routinely read reactive signals
+ * while building their HTML string — e.g. a list branch expanding
+ * `${_p.item.replies.map(...)}`. Those reads must NOT register as
+ * dependencies of whatever effect happens to be the active Listener
+ * when `insert()` is invoked.
+ *
+ * The compiler often nests `insert()` calls inside a
+ * `createDisposableEffect` set up by a parent branch's `bindEvents`.
+ * Without `untrack`, signal reads inside the template would be
+ * attributed to that outer effect — so any later mutation of those
+ * signals would re-run the outer effect, re-invoke `insert()`, and
+ * set up duplicate inner constructs. The observable symptom is a
+ * fresh `mapArray` instance per re-run, which then double-creates
+ * every newly-added item (#1224 follow-up).
+ *
+ * Reactivity inside branches still flows correctly because it does
+ * NOT depend on template-time tracking. It is wired up afterwards by
+ * `bindEvents()` (which sets up per-binding effects) and the
+ * `__bfSlot` slot-splice pipeline (which preserves live `Node`s).
+ *
+ * If you introduce a new `template()` call site, route it through
+ * this helper. Do not call `branch.template()` directly.
+ */
+function evalBranchTemplate(branch: BranchConfig): BranchTemplateResult {
+  return untrack(() => normalizeTemplate(branch.template()))
 }
 
 
@@ -85,18 +152,10 @@ export function insert(
   // Both branches need to be checked because SSR may render either branch.
   // Use try/catch because template evaluation may access nullable expressions
   // (e.g., selectedMail().subject when the branch is for the non-null case).
-  //
-  // The template() calls are wrapped in untrack() because a branch template
-  // may read signals (e.g. `_p.item.replies` when expanding a list) while
-  // `insert()` itself may be invoked from inside a surrounding effect
-  // (e.g. a `createDisposableEffect` set up by a parent branch's
-  // bindEvents). Without untrack, those reads would be attributed to the
-  // outer effect, causing it to re-run on every list update and spawn
-  // duplicate `mapArray` instances inside this conditional — the recursive
-  // CommentNode duplication observed in #1224 follow-up.
+  // See `evalBranchTemplate` for the reactivity-untracked contract.
   let isFragmentCond = false
   try {
-    const sampleTrue = untrack(() => normalizeTemplate(whenTrue.template()))
+    const sampleTrue = evalBranchTemplate(whenTrue)
     isFragmentCond = sampleTrue.html.includes(`<!--bf-cond-start:${id}-->`)
   } catch (err) {
     // Template may throw TypeError for nullable access (e.g., selectedMail().subject)
@@ -104,7 +163,7 @@ export function insert(
   }
   if (!isFragmentCond) {
     try {
-      const sampleFalse = untrack(() => normalizeTemplate(whenFalse.template()))
+      const sampleFalse = evalBranchTemplate(whenFalse)
       isFragmentCond = sampleFalse.html.includes(`<!--bf-cond-start:${id}-->`)
     } catch (err) {
       if (!(err instanceof TypeError)) throw err
@@ -139,12 +198,11 @@ export function insert(
       // Hydration mode: check if existing DOM matches expected branch
       // If the existing element doesn't match the expected branch,
       // we need to swap the DOM first (e.g., SSR rendered whenFalse but now we need whenTrue)
-      // untrack the template() call: signal reads inside the template should
-      // not leak into this createEffect's dependency set — only conditionFn()
-      // governs when we re-run.
+      // The template runs untracked via evalBranchTemplate so that only
+      // conditionFn() drives this createEffect's re-runs.
       setParentScopeId(parentScopeId)
       let result: BranchTemplateResult
-      try { result = untrack(() => normalizeTemplate(branch.template())) } finally { setParentScopeId(null) }
+      try { result = evalBranchTemplate(branch) } finally { setParentScopeId(null) }
       const existingEl = find(scope, `[${BF_COND}="${id}"]`)
       if (existingEl) {
         // Compare full opening tag signatures to detect branch mismatch.
@@ -204,10 +262,10 @@ export function insert(
     }
 
     // Branch changed: swap DOM and bind events.
-    // untrack the template() call (see isFirstRun branch above for rationale).
+    // Template runs untracked via evalBranchTemplate (see helper).
     setParentScopeId(parentScopeId)
     let result: BranchTemplateResult
-    try { result = untrack(() => normalizeTemplate(branch.template())) } finally { setParentScopeId(null) }
+    try { result = evalBranchTemplate(branch) } finally { setParentScopeId(null) }
     if (isFragmentCond) {
       updateFragmentConditional(scope, id, result)
     } else {

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -30,7 +30,7 @@ export interface BranchConfig {
   /**
    * HTML template function for this branch. Returns either a plain HTML
    * string (legacy) or a `{ html, slots }` pair for templates that
-   * captured live `Node` values via `__bfSlot` (#1213).
+   * captured live `Node` values via `__bfSlot`.
    *
    * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    *  INVARIANT — TEMPLATES RUN WITH REACTIVITY UNTRACKED.
@@ -52,14 +52,6 @@ export interface BranchConfig {
    *    because the read was performed without tracking. Branch
    *    selection belongs in the `conditionFn` argument of `insert()`,
    *    not inside the template body.
-   *
-   *  - This is not a per-site choice. Bypassing `evalBranchTemplate`
-   *    re-introduces the failure mode it was added to prevent: signal
-   *    reads inside the template leak into whatever effect is the
-   *    active Listener when `insert()` runs, which (when the compiler
-   *    nests `insert()` calls through `createDisposableEffect`) spawns
-   *    duplicate inner constructs on every signal change — observed
-   *    as item duplication in `mapArray` (#1224 follow-up).
    */
   template: () => string | BranchTemplateResult
 
@@ -80,38 +72,16 @@ function normalizeTemplate(value: string | BranchTemplateResult): BranchTemplate
 }
 
 /**
- * Evaluate a branch template with reactivity tracking SUPPRESSED.
+ * Single chokepoint for every `branch.template()` call in this module —
+ * routes the invocation through `untrack()` so the contract on
+ * `BranchConfig.template` cannot be locally bypassed.
  *
- * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- *  PURITY CONTRACT — the single chokepoint for every `branch.template()`
- *  invocation in this module. All four template-evaluation sites inside
- *  `insert()` (isFragmentCond detection × 2, then first-run and
- *  branch-swap inside the internal `createEffect`) flow through here so
- *  the contract cannot be locally bypassed.
- * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * Reads inside the template would otherwise be attributed to whatever
+ * effect is the active Listener when `insert()` runs, causing duplicate
+ * inner constructs (notably duplicate `mapArray` instances) when an
+ * outer effect re-runs and re-invokes `insert()`.
  *
- * Compiler-emitted branch templates routinely read reactive signals
- * while building their HTML string — e.g. a list branch expanding
- * `${_p.item.replies.map(...)}`. Those reads must NOT register as
- * dependencies of whatever effect happens to be the active Listener
- * when `insert()` is invoked.
- *
- * The compiler often nests `insert()` calls inside a
- * `createDisposableEffect` set up by a parent branch's `bindEvents`.
- * Without `untrack`, signal reads inside the template would be
- * attributed to that outer effect — so any later mutation of those
- * signals would re-run the outer effect, re-invoke `insert()`, and
- * set up duplicate inner constructs. The observable symptom is a
- * fresh `mapArray` instance per re-run, which then double-creates
- * every newly-added item (#1224 follow-up).
- *
- * Reactivity inside branches still flows correctly because it does
- * NOT depend on template-time tracking. It is wired up afterwards by
- * `bindEvents()` (which sets up per-binding effects) and the
- * `__bfSlot` slot-splice pipeline (which preserves live `Node`s).
- *
- * If you introduce a new `template()` call site, route it through
- * this helper. Do not call `branch.template()` directly.
+ * New `template()` call sites: route through here, never call directly.
  */
 function evalBranchTemplate(branch: BranchConfig): BranchTemplateResult {
   return untrack(() => normalizeTemplate(branch.template()))
@@ -150,9 +120,8 @@ export function insert(
 
   // Check if either branch uses fragment conditional (comment markers).
   // Both branches need to be checked because SSR may render either branch.
-  // Use try/catch because template evaluation may access nullable expressions
-  // (e.g., selectedMail().subject when the branch is for the non-null case).
-  // See `evalBranchTemplate` for the reactivity-untracked contract.
+  // try/catch absorbs TypeError from nullable access during the probe
+  // (e.g. `selectedMail().subject` when the branch is for the non-null case).
   let isFragmentCond = false
   try {
     const sampleTrue = evalBranchTemplate(whenTrue)
@@ -195,11 +164,8 @@ export function insert(
     const branch = currCond ? whenTrue : whenFalse
 
     if (isFirstRun) {
-      // Hydration mode: check if existing DOM matches expected branch
-      // If the existing element doesn't match the expected branch,
-      // we need to swap the DOM first (e.g., SSR rendered whenFalse but now we need whenTrue)
-      // The template runs untracked via evalBranchTemplate so that only
-      // conditionFn() drives this createEffect's re-runs.
+      // Hydration mode: check if existing DOM matches expected branch.
+      // If not, swap first (e.g., SSR rendered whenFalse but now we need whenTrue).
       setParentScopeId(parentScopeId)
       let result: BranchTemplateResult
       try { result = evalBranchTemplate(branch) } finally { setParentScopeId(null) }
@@ -262,7 +228,6 @@ export function insert(
     }
 
     // Branch changed: swap DOM and bind events.
-    // Template runs untracked via evalBranchTemplate (see helper).
     setParentScopeId(parentScopeId)
     let result: BranchTemplateResult
     try { result = evalBranchTemplate(branch) } finally { setParentScopeId(null) }

--- a/site/ui/e2e/recursive-comments.spec.ts
+++ b/site/ui/e2e/recursive-comments.spec.ts
@@ -133,31 +133,53 @@ test.describe('Recursive Comments Block', () => {
     })
 
     test('replying twice to a CSR-created top-level comment does not duplicate the second reply', async ({ page }) => {
-      // Regression for the post-#1224 follow-up bug: posting test1 (CSR root),
-      // replying test2, then replying test3 produced two test3 nodes because
-      // `insert()` was leaking its template() reads into the surrounding
-      // createDisposableEffect, spawning a duplicate inner mapArray instance
-      // on every parent-signal change.
+      // Regression for the post-#1224 follow-up bug: posting test1 (CSR
+      // root), replying test2, then replying test3 produced two test3
+      // nodes because `insert()` was leaking branch-template signal reads
+      // into the surrounding createDisposableEffect, spawning a duplicate
+      // inner mapArray instance on every parent-signal change.
       const s = section(page)
+
+      // Post test1 as a new root comment, then anchor it by the auto-
+      // assigned data-comment-id so subsequent locators don't depend on
+      // DOM ordering as the tree grows.
       await s.locator('.recursive-comments-input').fill('test1')
       await s.locator('.recursive-comments-post').click()
-      const test1 = s.locator('.recursive-comments-roots > li').first()
-      await expect(test1.locator('[data-depth="0"] .comment-text').first()).toHaveText('test1')
+      const firstRoot = s.locator('.recursive-comments-roots > li').first()
+      const test1Id = await firstRoot.locator('[data-comment-id]').first().getAttribute('data-comment-id')
+      expect(test1Id).toBeTruthy()
+      const test1 = s.locator(`[data-comment-id="${test1Id}"]`)
+      await expect(test1).toHaveCount(1)
 
-      await test1.locator('.comment-toggle-form').first().click()
-      await test1.locator('.comment-reply-textarea').first().fill('test2')
-      await test1.locator('.comment-post-reply-btn').first().click()
-      await expect(test1.locator('.comment-text', { hasText: 'test2' })).toHaveCount(1)
+      // Within a CommentNode subtree, the node's own controls render in
+      // document order BEFORE its `.comment-children` block (where any
+      // descendant CommentNode lives with its own controls). `.first()`
+      // therefore consistently picks the *self* control of `subject`.
+      const replyTo = async (subject: ReturnType<typeof s.locator>, text: string) => {
+        await subject.locator('.comment-toggle-form').first().click()
+        const ta = subject.locator('.comment-reply-textarea').first()
+        await expect(ta).toBeVisible()
+        await ta.fill(text)
+        await subject.locator('.comment-post-reply-btn').first().click()
+        // Verify the new comment landed exactly once before the next step,
+        // so we never measure the increment against partial DOM state.
+        await expect(
+          s.locator('.comment-text').filter({ hasText: new RegExp(`^${text}$`) }),
+        ).toHaveCount(1)
+      }
 
-      await test1.locator('.comment-toggle-form').first().click()
-      await test1.locator('.comment-reply-textarea').first().fill('test3')
-      await test1.locator('.comment-post-reply-btn').first().click()
+      await replyTo(test1, 'test2')
+      await replyTo(test1, 'test3')
 
-      // The bug rendered test3 twice; the rest of the tree must also remain
-      // singular so we don't regress in a way the count check would miss.
-      await expect(test1.locator('.comment-text', { hasText: 'test3' })).toHaveCount(1)
-      await expect(test1.locator('.comment-text', { hasText: 'test2' })).toHaveCount(1)
-      await expect(test1.locator('.comment-text', { hasText: 'test1' })).toHaveCount(1)
+      // Final assertions are scoped to the entire section and use exact
+      // text matches on individual `.comment-text` elements — so a
+      // duplicate-node regression cannot hide behind ancestor `hasText`
+      // (which matches any subtree containing the string).
+      await expect(s.locator('.comment-text').filter({ hasText: /^test3$/ })).toHaveCount(1)
+      await expect(s.locator('.comment-text').filter({ hasText: /^test2$/ })).toHaveCount(1)
+      await expect(s.locator('.comment-text').filter({ hasText: /^test1$/ })).toHaveCount(1)
+      // Stat strip should reflect 8 seeded + 3 new comments.
+      await expect(s.locator('.recursive-comments-total')).toHaveText('11')
     })
   })
 })

--- a/site/ui/e2e/recursive-comments.spec.ts
+++ b/site/ui/e2e/recursive-comments.spec.ts
@@ -133,36 +133,31 @@ test.describe('Recursive Comments Block', () => {
     })
 
     test('replying twice to a CSR-created top-level comment does not duplicate the second reply', async ({ page }) => {
-      // Regression for the post-#1224 follow-up bug: posting test1 (CSR
-      // root), replying test2, then replying test3 produced two test3
-      // nodes because `insert()` was leaking branch-template signal reads
-      // into the surrounding createDisposableEffect, spawning a duplicate
-      // inner mapArray instance on every parent-signal change.
+      // Regression: replying twice to a freshly-posted root comment used
+      // to duplicate the second reply because branch-template signal
+      // reads in insert() leaked into the surrounding effect, spawning
+      // a duplicate inner mapArray instance per signal change.
       const s = section(page)
 
-      // Post test1 as a new root comment, then anchor it by the auto-
-      // assigned data-comment-id so subsequent locators don't depend on
-      // DOM ordering as the tree grows.
       await s.locator('.recursive-comments-input').fill('test1')
       await s.locator('.recursive-comments-post').click()
+      // Anchor test1 by its auto-assigned id; locator must not depend
+      // on DOM ordering once the tree grows.
       const firstRoot = s.locator('.recursive-comments-roots > li').first()
       const test1Id = await firstRoot.locator('[data-comment-id]').first().getAttribute('data-comment-id')
       expect(test1Id).toBeTruthy()
       const test1 = s.locator(`[data-comment-id="${test1Id}"]`)
       await expect(test1).toHaveCount(1)
 
-      // Within a CommentNode subtree, the node's own controls render in
-      // document order BEFORE its `.comment-children` block (where any
-      // descendant CommentNode lives with its own controls). `.first()`
-      // therefore consistently picks the *self* control of `subject`.
+      // `.first()` inside `subject`: a CommentNode's own controls render
+      // before its `.comment-children` block, so document order picks
+      // the self control even after descendants exist.
       const replyTo = async (subject: ReturnType<typeof s.locator>, text: string) => {
         await subject.locator('.comment-toggle-form').first().click()
         const ta = subject.locator('.comment-reply-textarea').first()
         await expect(ta).toBeVisible()
         await ta.fill(text)
         await subject.locator('.comment-post-reply-btn').first().click()
-        // Verify the new comment landed exactly once before the next step,
-        // so we never measure the increment against partial DOM state.
         await expect(
           s.locator('.comment-text').filter({ hasText: new RegExp(`^${text}$`) }),
         ).toHaveCount(1)
@@ -171,14 +166,11 @@ test.describe('Recursive Comments Block', () => {
       await replyTo(test1, 'test2')
       await replyTo(test1, 'test3')
 
-      // Final assertions are scoped to the entire section and use exact
-      // text matches on individual `.comment-text` elements — so a
-      // duplicate-node regression cannot hide behind ancestor `hasText`
-      // (which matches any subtree containing the string).
+      // Exact-match on individual `.comment-text` so a duplicate cannot
+      // hide behind ancestor `hasText` (which matches any subtree).
       await expect(s.locator('.comment-text').filter({ hasText: /^test3$/ })).toHaveCount(1)
       await expect(s.locator('.comment-text').filter({ hasText: /^test2$/ })).toHaveCount(1)
       await expect(s.locator('.comment-text').filter({ hasText: /^test1$/ })).toHaveCount(1)
-      // Stat strip should reflect 8 seeded + 3 new comments.
       await expect(s.locator('.recursive-comments-total')).toHaveText('11')
     })
   })

--- a/site/ui/e2e/recursive-comments.spec.ts
+++ b/site/ui/e2e/recursive-comments.spec.ts
@@ -131,5 +131,33 @@ test.describe('Recursive Comments Block', () => {
       const firstRoot = s.locator('.recursive-comments-roots > li').first()
       await expect(firstRoot.locator('[data-depth="0"] .comment-text').first()).toHaveText('A brand-new thread')
     })
+
+    test('replying twice to a CSR-created top-level comment does not duplicate the second reply', async ({ page }) => {
+      // Regression for the post-#1224 follow-up bug: posting test1 (CSR root),
+      // replying test2, then replying test3 produced two test3 nodes because
+      // `insert()` was leaking its template() reads into the surrounding
+      // createDisposableEffect, spawning a duplicate inner mapArray instance
+      // on every parent-signal change.
+      const s = section(page)
+      await s.locator('.recursive-comments-input').fill('test1')
+      await s.locator('.recursive-comments-post').click()
+      const test1 = s.locator('.recursive-comments-roots > li').first()
+      await expect(test1.locator('[data-depth="0"] .comment-text').first()).toHaveText('test1')
+
+      await test1.locator('.comment-toggle-form').first().click()
+      await test1.locator('.comment-reply-textarea').first().fill('test2')
+      await test1.locator('.comment-post-reply-btn').first().click()
+      await expect(test1.locator('.comment-text', { hasText: 'test2' })).toHaveCount(1)
+
+      await test1.locator('.comment-toggle-form').first().click()
+      await test1.locator('.comment-reply-textarea').first().fill('test3')
+      await test1.locator('.comment-post-reply-btn').first().click()
+
+      // The bug rendered test3 twice; the rest of the tree must also remain
+      // singular so we don't regress in a way the count check would miss.
+      await expect(test1.locator('.comment-text', { hasText: 'test3' })).toHaveCount(1)
+      await expect(test1.locator('.comment-text', { hasText: 'test2' })).toHaveCount(1)
+      await expect(test1.locator('.comment-text', { hasText: 'test1' })).toHaveCount(1)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Post-merge follow-up to #1224. Replying twice in a row to a CSR-created
top-level comment in the Recursive Comments block produced a duplicate
second reply in the DOM.

### Root cause

`insert()` evaluates `branch.template()` in two places:
1. On entry, to detect whether either branch is a fragment-conditional
   (comment-marker-bounded).
2. Inside its `createEffect`, on first run and on every subsequent
   branch swap.

A branch template may read signals — e.g. a list branch expanding
`_p.item.replies` while building its HTML. When `insert()` is itself
invoked from inside an enclosing effect (a parent branch's
`createDisposableEffect` setting up nested conditionals via `insert()`),
those signal reads were being attributed to the **outer** effect.

The result: every mutation of `_p.item.replies` re-ran the outer
`createDisposableEffect`, which called `insert()` again, which set up
another `createDisposableEffect`, which spawned a fresh `mapArray`
instance for the same loop slot. The duplicate mapArrays then both
reconciled against the same data with empty scope maps, so each
newly-added item was created twice — visible as the second reply
appearing twice in the rendered tree.

### Fix

Wrap every `branch.template()` call in `untrack()`. The tracked
dependencies of `insert()`'s internal `createEffect` are now reduced to
just `conditionFn()`, which is the only thing the effect is supposed
to react to. Template-internal signal-driven reactivity continues to
flow through the bindings set up by `bindEvents` and `__bfSlot`, not
through the template string itself.

## Test plan

- [x] `recursive-comments` E2E (11 tests including new regression for
      the reply-twice scenario)
- [x] Compiler unit tests (`packages/jsx`, 1027 pass)
- [x] Client runtime unit tests (`packages/client`, 244 pass)
- [x] Adapter conformance (`packages/adapter-tests`, 229 pass)
- [x] Adapter unit tests (`hono` + `go-template`, 183 pass)
- [x] Site E2E sample: form-builder, dialog, accordion, collapsible,
      field-arrays, data-table (145 pass)
- [x] Site E2E sample: graph-editor, dashboard-builder, catalog, kanban,
      mail, todo-list (47 pass)
- [x] Site E2E: tabs, dialog, alert, switch, theme-switcher (100 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)