### PR TITLE
refactor(csr): move createConfig to @barefootjs/client/build

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
 
       - name: Embed adapter runtime sources
         run: bun run --filter '@barefootjs/cli' embed-runtimes

--- a/.github/workflows/ci-form.yml
+++ b/.github/workflows/ci-form.yml
@@ -29,7 +29,9 @@ jobs:
         run: bun install
 
       - name: Build dependencies
-        run: bun run --filter '@barefootjs/client' build
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
 
       - name: Type check
         run: cd packages/form && npx tsc --noEmit

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
       - name: Pre-warm Go build cache
@@ -75,8 +75,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
       - name: Build integrations/echo

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
       - name: Run unit tests
@@ -70,8 +70,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
       - name: Build integrations/hono

--- a/.github/workflows/ci-mojolicious.yml
+++ b/.github/workflows/ci-mojolicious.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/mojolicious' build
 
       - name: Run Perl unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
         run: bun test packages/client packages/jsx packages/test packages/adapter-tests
@@ -72,8 +72,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
 
       - name: Run UI component IR tests
         run: bun test ui/components/
@@ -99,8 +99,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build
           bun run --filter '@barefootjs/xyflow' build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
 
       - name: Build site
         run: cd site/core && bun run build
@@ -95,8 +95,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build
@@ -141,8 +141,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
       - name: Build integration
@@ -179,8 +179,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/go-template' build
 
       - name: Build integration
@@ -220,8 +220,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/mojolicious' build
 
       - name: Build integration

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -38,8 +38,8 @@ jobs:
       # consumed by the others, so build them first.
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/form' build
           bun run --filter '@barefootjs/chart' build
           bun run --filter '@barefootjs/xyflow' build

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Build packages
         run: |
-          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
           bun run --filter '@barefootjs/hono' build
 
       - name: Generate expectedHtml

--- a/integrations/csr/barefoot.config.ts
+++ b/integrations/csr/barefoot.config.ts
@@ -1,9 +1,7 @@
-import { createConfig } from '@barefootjs/hono/build'
+import { createConfig } from '@barefootjs/client/build'
 
 export default createConfig({
   components: ['../shared/components'],
   outDir: 'dist',
-  clientOnly: true,
-  scriptCollection: false,
   minify: true,
 })

--- a/packages/adapter-go-template/src/build.ts
+++ b/packages/adapter-go-template/src/build.ts
@@ -244,7 +244,6 @@ export function createConfig(options: GoTemplateBuildOptions = {}) {
     outDir: options.outDir,
     minify: options.minify,
     contentHash: options.contentHash,
-    clientOnly: options.clientOnly,
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,

--- a/packages/adapter-hono/src/__tests__/build.test.ts
+++ b/packages/adapter-hono/src/__tests__/build.test.ts
@@ -127,13 +127,11 @@ export function Counter() {
       outDir: 'build',
       minify: true,
       contentHash: true,
-      clientOnly: true,
     })
     expect(config.components).toEqual(['src'])
     expect(config.outDir).toBe('build')
     expect(config.minify).toBe(true)
     expect(config.contentHash).toBe(true)
-    expect(config.clientOnly).toBe(true)
   })
 
   test('passes through externals and externalsBasePath', () => {

--- a/packages/adapter-hono/src/build.ts
+++ b/packages/adapter-hono/src/build.ts
@@ -29,7 +29,6 @@ export function createConfig(options: HonoBuildOptions = {}) {
     outDir: options.outDir,
     minify: options.minify,
     contentHash: options.contentHash,
-    clientOnly: options.clientOnly,
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,

--- a/packages/adapter-mojolicious/src/build.ts
+++ b/packages/adapter-mojolicious/src/build.ts
@@ -23,7 +23,6 @@ export function createConfig(options: MojoBuildOptions = {}) {
     outDir: options.outDir,
     minify: options.minify,
     contentHash: options.contentHash,
-    clientOnly: options.clientOnly,
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -51,7 +51,7 @@ describe('adapter registry', () => {
     expect(csr.files['server.ts']).toMatch(/Bun\.serve/)
     expect(csr.files['pages/index.html']).toMatch(/<div id="app">/)
     expect(csr.files['pages/index.html']).toMatch(/@barefootjs\/client\/runtime/)
-    expect(csr.files['barefoot.config.ts']).toMatch(/clientOnly: true/)
+    expect(csr.files['barefoot.config.ts']).toMatch(/@barefootjs\/client\/build/)
   })
 })
 

--- a/packages/cli/src/lib/adapters/csr.ts
+++ b/packages/cli/src/lib/adapters/csr.ts
@@ -2,8 +2,9 @@
 //
 // Ships a static HTML page with an empty mount point and a tiny Bun
 // server that serves the page + the compiled client bundles produced
-// by `barefoot build` (with `clientOnly: true`). No SSR — everything
-// renders in the browser via @barefootjs/client/runtime.
+// by `barefoot build`. The `createConfig` from `@barefootjs/client/build`
+// switches the compiler into CSR mode — no SSR — everything renders in
+// the browser via @barefootjs/client/runtime.
 
 import { execSync } from 'node:child_process'
 import type { AdapterTemplate } from '../templates'
@@ -16,7 +17,7 @@ import {
   unoConfigTs,
 } from './shared'
 
-const CSR_BAREFOOT_CONFIG_TS = `import { createConfig } from '@barefootjs/hono/build'
+const CSR_BAREFOOT_CONFIG_TS = `import { createConfig } from '@barefootjs/client/build'
 
 export default createConfig({
   paths: {
@@ -26,12 +27,6 @@ export default createConfig({
   },
   components: ['components'],
   outDir: 'dist',
-  // CSR mode: skip the server-render path and only emit client bundles.
-  // \`scriptCollection: false\` disables the collector (no SSR layout to
-  // splice scripts into).
-  clientOnly: true,
-  scriptCollection: false,
-  scriptBasePath: '/static/components/',
   adapterOptions: {
     clientJsBasePath: '/static/components/',
     barefootJsPath: '/static/components/barefoot.js',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,10 @@
     "./runtime/standalone": {
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/standalone.js"
+    },
+    "./build": {
+      "types": "./dist/build.d.ts",
+      "import": "./dist/build.js"
     }
   },
   "files": [
@@ -29,7 +33,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm",
+    "build:js": "bun build ./src/reactive.ts --outdir ./dist --format esm && bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outdir ./dist/runtime --format esm --external '@barefootjs/client/reactive' && bun build ./src/runtime/index.ts --outfile ./dist/runtime/standalone.js --format esm && bun build ./src/build.ts --outdir ./dist --format esm --external '@barefootjs/jsx' --external '@barefootjs/hono/adapter'",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"
@@ -51,7 +55,21 @@
   "dependencies": {
     "@barefootjs/shared": "workspace:*"
   },
+  "peerDependencies": {
+    "@barefootjs/hono": "workspace:*",
+    "@barefootjs/jsx": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@barefootjs/hono": {
+      "optional": true
+    },
+    "@barefootjs/jsx": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@barefootjs/hono": "workspace:*",
+    "@barefootjs/jsx": "workspace:*",
     "@happy-dom/global-registrator": "^20.0.11",
     "typescript": "^5.0.0"
   }

--- a/packages/client/src/build.ts
+++ b/packages/client/src/build.ts
@@ -1,0 +1,76 @@
+// CSR build config factory for `barefoot.config.ts`.
+//
+// CSR (client-side rendering) projects emit client JS only — no marked
+// templates, no SSR. Pair this config with `render()` from
+// `@barefootjs/client/runtime` on the page.
+//
+// The compiler still needs a `TemplateAdapter` to drive IR→client-JS
+// codegen (template primitives, client-shim resolution, etc.). The marked
+// templates the adapter would produce are simply not written to disk.
+// `HonoAdapter` is used by default since it accepts the broadest JS surface
+// at template scope, matching what the browser can execute.
+
+import type {
+  BarefootPaths,
+  BundleEntry,
+  ExternalSpec,
+  OutputLayout,
+  PostBuildContext,
+  TemplateAdapter,
+} from '@barefootjs/jsx'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import type { HonoAdapterOptions } from '@barefootjs/hono/adapter'
+
+export interface CSRBuildOptions {
+  /** Project layout paths consumed by registry tooling. */
+  paths?: BarefootPaths
+  /** Source component directories relative to the config file. */
+  components?: string[]
+  /** Output directory relative to the config file. */
+  outDir?: string
+  /** Minify client JS output. */
+  minify?: boolean
+  /** Add content hash to client JS filenames. */
+  contentHash?: boolean
+  /** Custom output directory layout. */
+  outputLayout?: OutputLayout
+  /** Post-build hook called after minification, before manifest write. */
+  postBuild?: (ctx: PostBuildContext) => Promise<void> | void
+  /** Vendor packages to split out as separately-cached browser chunks. */
+  externals?: Record<string, ExternalSpec>
+  /** URL base path for vendor chunks in the emitted importmap. */
+  externalsBasePath?: string
+  /** Additional entry points to bundle with esbuild directly. */
+  bundleEntries?: BundleEntry[]
+  /**
+   * Override the compiler adapter. The marked templates this adapter
+   * generates are discarded in CSR mode — set this only if the default
+   * `HonoAdapter` clashes with something else in your build.
+   */
+  adapter?: TemplateAdapter
+  /** Options forwarded to the default `HonoAdapter`. Ignored when `adapter` is set. */
+  adapterOptions?: HonoAdapterOptions
+}
+
+/**
+ * Create a BarefootBuildConfig for CSR projects.
+ *
+ * Uses structural typing — does not import `BarefootBuildConfig` to avoid
+ * a circular dependency between `@barefootjs/client` and `@barefootjs/cli`.
+ */
+export function createConfig(options: CSRBuildOptions = {}) {
+  return {
+    adapter: options.adapter ?? new HonoAdapter(options.adapterOptions),
+    paths: options.paths,
+    components: options.components,
+    outDir: options.outDir,
+    minify: options.minify,
+    contentHash: options.contentHash,
+    clientOnly: true,
+    externals: options.externals,
+    externalsBasePath: options.externalsBasePath,
+    bundleEntries: options.bundleEntries,
+    outputLayout: options.outputLayout,
+    postBuild: options.postBuild,
+  }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -164,8 +164,6 @@ export interface BuildOptions {
   minify?: boolean
   /** Add content hash to client JS filenames */
   contentHash?: boolean
-  /** Output only client JS, skip marked templates and manifest */
-  clientOnly?: boolean
   /** Custom output directory layout */
   outputLayout?: OutputLayout
   /** Post-build hook called after minification, before manifest write */


### PR DESCRIPTION
## Summary

- Move CSR build config factory from `@barefootjs/hono/build` to `@barefootjs/client/build`, the same package that ships `render()`.
- Set `clientOnly: true` internally — CSR users no longer pass it explicitly, and SSR adapters (Hono/Go/Mojolicious) no longer surface this option in their public `BuildOptions`.
- `HonoAdapter` is still used under the hood (added as optional peer dependency of `@barefootjs/client`), so CSR users do not import or reference Hono in their config.

### Motivation

Previously, even pure CSR projects had to import `createConfig` from `@barefootjs/hono/build`, which leaked Hono semantics into a non-SSR setup. `clientOnly: true` was also exposed on every SSR adapter's options object despite being meaningful only for CSR.

### Before / After

```diff
-import { createConfig } from '@barefootjs/hono/build'
+import { createConfig } from '@barefootjs/client/build'

 export default createConfig({
   components: ['../shared/components'],
   outDir: 'dist',
-  clientOnly: true,
-  scriptCollection: false,
   minify: true,
 })
```

## Test plan

- [x] `bun run --filter '*' build` — all packages build clean
- [x] `bun test packages/{adapter-hono,adapter-go-template,adapter-mojolicious,client,cli}` — 900 pass / 4 skip / 0 fail
- [x] `integrations/csr` build emits only `*.client.js` + `barefoot.js` (no marked templates), confirming `clientOnly: true` is being applied internally
- [ ] Manual smoke test of `integrations/csr` server in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)