### PR TITLE
fix(cli): surface stripped client-import dangling reference as BF053 (#1227)

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -49,13 +49,13 @@ console.log(highlight('hello'))
     expect(result).toContain("from '@barefootjs/client'")
   })
 
-  test('strips .tsx server component import', async () => {
-    writeFileSync(resolve(COMPONENTS_DIR, 'ServerComp.tsx'), `
-export function ServerComp() {
-  return <div>server only</div>
+  test('strips .tsx client component import when binding is unused', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'ClientComp.tsx'), `'use client'
+export function ClientComp() {
+  return <div>client only</div>
 }
 `)
-    const clientJs = `import { ServerComp } from './ServerComp'
+    const clientJs = `import { ClientComp } from './ClientComp'
 import { createSignal } from '@barefootjs/client'
 console.log('client code')
 `
@@ -65,12 +65,75 @@ console.log('client code')
       Parent: { clientJs: 'components/Parent-abc123.js', markedTemplate: 'components/Parent.tsx' },
     }
 
-    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Parent-abc123.js')).text()
-    expect(result).not.toContain('ServerComp')
+    expect(result).not.toContain('ClientComp')
     expect(result).toContain("from '@barefootjs/client'")
     expect(result).toContain("console.log('client code')")
+    // No dangling reference → no diagnostic.
+    expect(errors).toHaveLength(0)
+  })
+
+  // Regression: bf#1227 — a `.ts` helper (no `'use client'`) inlined into a
+  // client bundle imports a sibling `'use client'` `.tsx` AND calls it. The
+  // strip used to be silent (`console.log` only, build exit 0), so the
+  // bundle shipped with a dangling identifier and crashed at runtime with
+  // `ReferenceError: DraftTitleEditor is not defined`. After the fix the
+  // strip is detected via a post-assembly identifier scan and surfaced as
+  // BF053, so the build exits non-zero.
+  test('errors when stripped .tsx binding is still referenced (bf#1227)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'DraftTitleEditor.tsx'), `'use client'
+export function DraftTitleEditor() { return <textarea /> }
+`)
+    writeFileSync(resolve(COMPONENTS_DIR, 'IssueCardNode.ts'), `
+import { DraftTitleEditor } from './DraftTitleEditor'
+export function IssueCardNode() {
+  return DraftTitleEditor({ initialTitle: '' })
+}
+`)
+    const clientJs = `import { IssueCardNode } from './IssueCardNode'
+IssueCardNode()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DeskCanvas-aaa.js'), clientJs)
+    const manifest = {
+      DeskCanvas: {
+        clientJs: 'components/DeskCanvas-aaa.js',
+        markedTemplate: 'components/DeskCanvas.tsx',
+      },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF053')
+    expect(errors[0].severity).toBe('error')
+    // The error must name the binding so the developer can find the call.
+    expect(errors[0].message).toContain('DraftTitleEditor')
+    // And the import path so they can find the source file.
+    expect(errors[0].message).toContain('./DraftTitleEditor')
+    // And the bundle so they know which entry to investigate.
+    expect(errors[0].loc.file).toBe('components/DeskCanvas-aaa.js')
+  })
+
+  // Sanity: stripping is fine when the import was for types-only or
+  // side-effects and no value reference survives. Locks the fix to the
+  // dangling-reference case so we don't over-trigger BF053.
+  test('does not error when stripped .tsx binding is unused at the call site', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'TypesOnly.tsx'), `'use client'
+export function TypesOnly() { return <div /> }
+`)
+    const clientJs = `import { TypesOnly } from './TypesOnly'
+console.log('client code')
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Quiet-bbb.js'), clientJs)
+    const manifest = {
+      Quiet: { clientJs: 'components/Quiet-bbb.js', markedTemplate: 'components/Quiet.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(0)
   })
 
   test('deduplicates same module imported by two client JS files', async () => {

--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -210,11 +210,90 @@ console.log('still works')
       Broken: { clientJs: 'components/Broken-111.js', markedTemplate: 'components/Broken.tsx' },
     }
 
-    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Broken-111.js')).text()
     expect(result).not.toContain('nonexistent')
     expect(result).toContain("console.log('still works')")
+    // Dropped binding is unused — no BF053 expected.
+    expect(errors).toHaveLength(0)
+  })
+
+  // Coverage: namespace import (`import * as ns from '.tsx'`) gets stripped,
+  // and `ns.foo()` survives → BF053 must fire on the namespace binding.
+  // The reference is placed deliberately on line 3 of the input so we can
+  // assert that `loc` reports a non-placeholder position in the
+  // post-strip bundle (line 2 after the single import line is removed).
+  test('errors when stripped namespace binding is referenced', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'NsClient.tsx'), `'use client'
+export function Foo() { return <div /> }
+`)
+    const clientJs = `import * as ns from './NsClient'
+const greeting = 'hi'
+ns.Foo()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'NsParent-aaa.js'), clientJs)
+    const manifest = {
+      NsParent: { clientJs: 'components/NsParent-aaa.js', markedTemplate: 'components/NsParent.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF053')
+    expect(errors[0].message).toContain('ns')
+    expect(errors[0].message).toContain('./NsClient')
+    // Position points at the post-strip bundle: the import line is gone,
+    // `const greeting = 'hi'` is now line 1, and `ns.Foo()` lands on
+    // line 2. That's the dev-facing location the error should navigate to.
+    expect(errors[0].loc.start.line).toBe(2)
+    expect(errors[0].loc.start.column).toBe(0)
+  })
+
+  // Coverage: default import (`import D from '.tsx'`) gets stripped,
+  // and `D()` survives → BF053 must fire on the default binding.
+  test('errors when stripped default binding is referenced', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'DefClient.tsx'), `'use client'
+export default function DefClient() { return <div /> }
+`)
+    const clientJs = `import DefClient from './DefClient'
+DefClient()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DefParent-aaa.js'), clientJs)
+    const manifest = {
+      DefParent: { clientJs: 'components/DefParent-aaa.js', markedTemplate: 'components/DefParent.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF053')
+    expect(errors[0].message).toContain('DefClient')
+  })
+
+  // Coverage: a `missing`-strip whose binding survives reference. Distinct
+  // message from the `.tsx` case — the remediation is "fix the path", not
+  // "render as JSX from 'use client' parent". Locks the per-kind wording
+  // added for #1227 review feedback #1.
+  test('errors with missing-path-specific wording when unresolved binding is referenced', async () => {
+    const clientJs = `import { stillUsed } from './nonexistent'
+stillUsed()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Dangling-aaa.js'), clientJs)
+    const manifest = {
+      Dangling: { clientJs: 'components/Dangling-aaa.js', markedTemplate: 'components/Dangling.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF053')
+    expect(errors[0].message).toContain('stillUsed')
+    expect(errors[0].message).toContain('./nonexistent')
+    // Per-kind diagnostic — missing strip is about path resolution,
+    // not 'use client' boundary.
+    expect(errors[0].message).toContain('could not be resolved')
+    expect(errors[0].message).not.toContain('use client')
   })
 
   test('recursively inlines transitive .ts imports', async () => {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,6 +1,6 @@
 // Core build module: shared pipeline for `barefoot build`.
 
-import { compileJSX, combineParentChildClientJs, createProgramForCorpus } from '@barefootjs/jsx'
+import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError } from '@barefootjs/jsx'
 import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry } from '@barefootjs/jsx'
 import type ts from 'typescript'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
@@ -631,11 +631,18 @@ export async function build(
       sourceDirsByManifestKey[entry.manifestKey] = [dirname(sourcePath)]
     }
   }
-  await resolveRelativeImports({
+  const { errors: resolveErrors } = await resolveRelativeImports({
     distDir: config.outDir,
     manifest,
     sourceDirsByManifestKey,
   })
+  // Surface stripped-import diagnostics (BF053) as build errors so they
+  // turn into a non-zero exit at `commands/build.ts` instead of silently
+  // shipping a bundle that will `ReferenceError` at runtime. See #1227.
+  for (const err of resolveErrors) {
+    console.error(formatError(err))
+    errorCount++
+  }
 
   // 6c. Normalize @barefootjs/client* specifiers to the relative barefoot.js
   //     path so the per-source dedup below can collapse multiple specifiers

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -2,6 +2,7 @@
 
 import { dirname, resolve } from 'node:path'
 import ts from 'typescript'
+import { createError, ErrorCodes, type CompilerError } from '@barefootjs/jsx'
 import { RELATIVE_IMPORT_RE } from './patterns'
 import { fileExists, readText, transpile, writeText } from './runtime'
 
@@ -358,8 +359,11 @@ export interface ResolveRelativeImportsOptions {
  *     would duplicate code; stripping the import would break runtime
  *     references. Leave the line alone.
  *   - `inline`   — `.ts` source found; transpile and splice in.
- *     `.tsx` is treated as a server component (already rendered at
- *     SSR time) and the import line is stripped instead.
+ *     `.tsx` is treated as a separately-compiled `'use client'`
+ *     component (it has its own `.client.js`) and the import line is
+ *     stripped instead — the binding can't be a plain function call in
+ *     the consumer bundle. Any residual reference is caught by
+ *     `detectStrippedReferences` after IIFE assembly.
  *   - `missing`  — nothing matched. Strip the import line.
  */
 type ResolveResult =
@@ -406,6 +410,162 @@ interface InlinedModule {
 }
 
 /**
+ * One stripped import recorded during the graph walk. Surfaces in the final
+ * post-assembly bundle scan: if any of the local binding names below still
+ * appears as a value reference, that is a build-time error (BF053). See
+ * `detectStrippedReferences` and piconic-ai/barefootjs#1227.
+ */
+interface StrippedImport {
+  /** The original import specifier, e.g. `./DraftTitleEditor`. */
+  importPath: string
+  /** Every local name the parent bound (named, namespace, default). */
+  bindings: string[]
+  /** The bundle path passed in for logging — used for the error location. */
+  loggingPath: string
+}
+
+/**
+ * Record an `import` statement that was just stripped (because the target
+ * was a sibling `.tsx`, an unresolved path, or a circular relative dep) so
+ * a later pass can verify none of its locals are still referenced.
+ */
+function recordStrippedImport(
+  fullMatch: string,
+  importPath: string,
+  loggingPath: string,
+  stripped: StrippedImport[],
+): void {
+  const shape = parseImportShape(fullMatch)
+  if (!shape) return // side-effect import (`import './x'`) — no bound names.
+  const bindings: string[] = []
+  for (const { local } of shape.named) bindings.push(local)
+  if (shape.namespace) bindings.push(shape.namespace)
+  if (shape.default) bindings.push(shape.default)
+  if (bindings.length === 0) return
+  stripped.push({ importPath, bindings, loggingPath })
+}
+
+/**
+ * Identifier-position classifier: returns `true` when `id` is being USED
+ * as a value (and could therefore be the dangling reference to a stripped
+ * import), `false` when it's a declaration name, property key, member-
+ * access name, or other non-reference slot.
+ *
+ * Caveat: this is a syntactic test, not a scope analysis. If a local
+ * function parameter happens to share a name with a stripped import,
+ * references inside that function's body will count as references to
+ * the stripped import (false positive). Acceptable per #1227: a loud
+ * build error is a strict improvement over a silent runtime
+ * ReferenceError, and shadowing genuine import binding names is rare in
+ * practice.
+ */
+function isValueReference(id: ts.Identifier): boolean {
+  const parent = id.parent
+  if (!parent) return false
+  if (ts.isPropertyAccessExpression(parent) && parent.name === id) return false
+  if (ts.isPropertyAssignment(parent) && parent.name === id) return false
+  if (
+    (ts.isMethodDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent)) &&
+    parent.name === id
+  ) {
+    return false
+  }
+  if (ts.isVariableDeclaration(parent) && parent.name === id) return false
+  if (ts.isFunctionDeclaration(parent) && parent.name === id) return false
+  if (ts.isFunctionExpression(parent) && parent.name === id) return false
+  if (ts.isClassDeclaration(parent) && parent.name === id) return false
+  if (ts.isClassExpression(parent) && parent.name === id) return false
+  if (ts.isParameter(parent) && parent.name === id) return false
+  if (ts.isBindingElement(parent) && (parent.name === id || parent.propertyName === id)) return false
+  if (ts.isLabeledStatement(parent) && parent.label === id) return false
+  if (ts.isBreakOrContinueStatement(parent) && parent.label === id) return false
+  if (ts.isImportSpecifier(parent)) return false
+  if (ts.isExportSpecifier(parent)) return false
+  if (ts.isImportClause(parent) && parent.name === id) return false
+  if (ts.isNamespaceImport(parent) && parent.name === id) return false
+  if (ts.isQualifiedName(parent) && parent.right === id) return false
+  return true
+}
+
+/**
+ * Scan the assembled bundle source for value references to any binding
+ * name we removed during the walk. Returns one CompilerError per
+ * (stripped import × dangling binding) pair. Uses the TypeScript parser
+ * so member-access property names, declaration names, etc. are
+ * correctly excluded.
+ *
+ * Closes piconic-ai/barefootjs#1227: the previous strip flow logged at
+ * info level and continued, so a `.ts` helper inlined into a client
+ * bundle that called into a sibling `'use client'` component left a
+ * dangling identifier and a `ReferenceError` only visible at runtime.
+ */
+function detectStrippedReferences(
+  bundleSource: string,
+  stripped: StrippedImport[],
+): CompilerError[] {
+  if (stripped.length === 0) return []
+  // The bundle is already transpiled JS at this point — parse as JS so
+  // residual TS-only syntax isn't mistakenly required.
+  let sf: ts.SourceFile
+  try {
+    sf = ts.createSourceFile(
+      'bundle.js',
+      bundleSource,
+      ts.ScriptTarget.Latest,
+      /*setParents*/ true,
+      ts.ScriptKind.JS,
+    )
+  } catch {
+    // If the bundle can't be parsed for any reason, fall back silently:
+    // the strip itself is the bug we care about; a parse failure here is
+    // a separate problem that will surface elsewhere.
+    return []
+  }
+  const referenced = new Set<string>()
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node) && isValueReference(node)) {
+      referenced.add(node.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+
+  const errors: CompilerError[] = []
+  for (const s of stripped) {
+    for (const b of s.bindings) {
+      if (!referenced.has(b)) continue
+      const message =
+        `Import \`${b}\` from '${s.importPath}' was stripped from the client bundle \`${s.loggingPath}\`, ` +
+        `but \`${b}\` is still referenced in the assembled JS. ` +
+        `Client components ('use client' .tsx) are not callable as plain functions from imperative .ts ` +
+        `modules — render them as JSX from a 'use client' parent instead. ` +
+        `(If \`${b}\` is a local shadow rather than the stripped import, please file an issue.)`
+      errors.push(
+        createError(
+          ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED,
+          {
+            file: s.loggingPath,
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 0 },
+          },
+          {
+            message,
+            suggestion: {
+              message:
+                `Move the call site into a 'use client' .tsx parent and render \`${b}\` as JSX, ` +
+                `or restructure so the imperative .ts module no longer needs to call \`${b}\` directly.`,
+            },
+          },
+        ),
+      )
+    }
+  }
+  return errors
+}
+
+/**
  * Walk relative imports in `content` and collect every transitively-reachable
  * `.ts` module. Replaces each direct relative import line in `content` with
  * a destructure pulling from a per-module top-level identifier — the IIFE
@@ -422,6 +582,12 @@ interface InlinedModule {
  * bare-package imports stripped from any inlined module body bubble up
  * here so the outer entry point can prepend them, deduped, to the parent
  * bundle's top level. piconic-ai/barefootjs#1148.
+ *
+ * `stripped` is the other mutable accumulator: any import line dropped
+ * because the target is a sibling `.tsx`, missing, or a circular `.ts`
+ * dep is recorded here so `inlineRelativeImports` can verify, after IIFE
+ * assembly, that none of the dropped bindings are still referenced in
+ * the final bundle. piconic-ai/barefootjs#1227.
  */
 async function walkAndCollect(
   content: string,
@@ -429,6 +595,7 @@ async function walkAndCollect(
   modules: Map<string, InlinedModule>,
   visiting: Set<string>,
   loggingPath: string,
+  stripped: StrippedImport[],
 ): Promise<string> {
   const re = new RegExp(RELATIVE_IMPORT_RE.source, RELATIVE_IMPORT_RE.flags)
   const matches = [...content.matchAll(re)]
@@ -448,12 +615,19 @@ async function walkAndCollect(
       // Surface unresolved imports — silent strips made #1151 hard to spot.
       console.warn(`Stripped unresolved import: ${importPath} from ${loggingPath}`)
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+      recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
       continue
     }
 
     if (result.path.endsWith('.tsx')) {
+      // A sibling `.tsx` reaching this path is, in practice, a `'use client'`
+      // component: it has its own compiled `.client.js` and is not callable
+      // as a plain function from a client bundle. Drop the import line and
+      // record the bindings so a later post-assembly scan can flag any
+      // call sites that survived the strip. piconic-ai/barefootjs#1227.
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-      console.log(`Stripped server component import: ${importPath} from ${loggingPath}`)
+      console.log(`Stripped client component import: ${importPath} from ${loggingPath}`)
+      recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
       continue
     }
 
@@ -465,6 +639,7 @@ async function walkAndCollect(
       if (visiting.has(result.path)) {
         console.warn(`Skipping circular relative import: ${importPath} from ${loggingPath}`)
         content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
+        recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
         continue
       }
       visiting.add(result.path)
@@ -488,6 +663,7 @@ async function walkAndCollect(
         modules,
         visiting,
         loggingPath,
+        stripped,
       )
       mod.transpiledBody = replacedBody
       visiting.delete(result.path)
@@ -551,12 +727,19 @@ async function inlineRelativeImports(
   searchDirs: string[],
   loggingPath: string,
   hoistedAcc: string[],
+  errorAcc: CompilerError[],
 ): Promise<string> {
   const modules = new Map<string, InlinedModule>()
   const visiting = new Set<string>()
-  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath)
+  const stripped: StrippedImport[] = []
+  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath, stripped)
 
-  if (modules.size === 0) return parentContent
+  if (modules.size === 0) {
+    // No IIFEs to prepend — the parent content already reflects every
+    // strip. Run the dangling-reference scan on it directly.
+    for (const err of detectStrippedReferences(parentContent, stripped)) errorAcc.push(err)
+    return parentContent
+  }
 
   // Now resolve each module's transitive import edges — the body has
   // already been rewritten with destructures, so the only paths left to
@@ -595,7 +778,13 @@ async function inlineRelativeImports(
     for (const h of hoistedImports) hoistedAcc.push(h)
   }
 
-  return iifes.join('\n') + '\n' + parentContent
+  const finalContent = iifes.join('\n') + '\n' + parentContent
+  // Run the dangling-reference scan AFTER IIFE assembly so any binding
+  // that escaped a strip (whether at the parent level or inside an
+  // inlined module's body) gets caught — that body now lives inside an
+  // IIFE arrow in `finalContent`.
+  for (const err of detectStrippedReferences(finalContent, stripped)) errorAcc.push(err)
+  return finalContent
 }
 
 /**
@@ -603,11 +792,19 @@ async function inlineRelativeImports(
  *
  * For each client JS file in the manifest:
  * - `.ts` imports: transpile and inline the code (recursively for transitive `.ts` deps)
- * - `.tsx` imports: strip (server component, already rendered at SSR time)
- * - Not found / already inlined: strip
+ * - `.tsx` imports: strip (separately-compiled `'use client'` component)
+ * - Not found / circular: strip
+ *
+ * Returns the set of diagnostics emitted during resolution. The only
+ * error currently produced here is `BF053` — a stripped import whose
+ * binding is still referenced in the assembled bundle. See
+ * `detectStrippedReferences` and piconic-ai/barefootjs#1227.
  */
-export async function resolveRelativeImports(options: ResolveRelativeImportsOptions): Promise<void> {
+export async function resolveRelativeImports(
+  options: ResolveRelativeImportsOptions,
+): Promise<{ errors: CompilerError[] }> {
   const { distDir, manifest, sourceDirs = [], sourceDirsByManifestKey = {} } = options
+  const errors: CompilerError[] = []
 
   for (const [name, entry] of Object.entries(manifest)) {
     if (!entry.clientJs) continue
@@ -626,6 +823,7 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       [dirname(filePath), ...perEntryDirs, ...sourceDirs],
       entry.clientJs,
       hoistedAcc,
+      errors,
     )
 
     // Prepend bare-package imports that bubbled up from inlined modules,
@@ -648,4 +846,6 @@ export async function resolveRelativeImports(options: ResolveRelativeImportsOpti
       await writeText(filePath, next)
     }
   }
+
+  return { errors }
 }

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -410,12 +410,25 @@ interface InlinedModule {
 }
 
 /**
+ * Why an import line was dropped during the graph walk. Drives the
+ * diagnostic wording when a dangling reference is later discovered —
+ * each reason has a different remediation, so a single generic message
+ * would mislead the developer.
+ */
+type StripKind =
+  | 'tsx'      // sibling .tsx, separately-compiled 'use client' component
+  | 'missing'  // import path could not be resolved on disk
+  | 'circular' // circular relative dependency; the IIFE topo-sort can't safely emit it
+
+/**
  * One stripped import recorded during the graph walk. Surfaces in the final
  * post-assembly bundle scan: if any of the local binding names below still
  * appears as a value reference, that is a build-time error (BF053). See
  * `detectStrippedReferences` and piconic-ai/barefootjs#1227.
  */
 interface StrippedImport {
+  /** Reason the import was dropped — controls the diagnostic message. */
+  kind: StripKind
   /** The original import specifier, e.g. `./DraftTitleEditor`. */
   importPath: string
   /** Every local name the parent bound (named, namespace, default). */
@@ -433,6 +446,7 @@ function recordStrippedImport(
   fullMatch: string,
   importPath: string,
   loggingPath: string,
+  kind: StripKind,
   stripped: StrippedImport[],
 ): void {
   const shape = parseImportShape(fullMatch)
@@ -442,7 +456,54 @@ function recordStrippedImport(
   if (shape.namespace) bindings.push(shape.namespace)
   if (shape.default) bindings.push(shape.default)
   if (bindings.length === 0) return
-  stripped.push({ importPath, bindings, loggingPath })
+  stripped.push({ kind, importPath, bindings, loggingPath })
+}
+
+/**
+ * Build the per-kind diagnostic body for a dangling stripped reference.
+ * Each strip reason has its own remediation; a one-size message would
+ * mislead developers (a missing-path strip is NOT a 'use client'
+ * boundary problem).
+ */
+function buildDanglingReferenceMessage(
+  binding: string,
+  s: StrippedImport,
+): { message: string; suggestion: string } {
+  const head =
+    `Import \`${binding}\` from '${s.importPath}' was stripped from the client bundle ` +
+    `\`${s.loggingPath}\`, but \`${binding}\` is still referenced in the assembled JS.`
+  const shadowNote =
+    `(If \`${binding}\` is a local shadow rather than the stripped import, please file an issue.)`
+  switch (s.kind) {
+    case 'tsx':
+      return {
+        message:
+          `${head} Client components ('use client' .tsx) are not callable as plain functions ` +
+          `from imperative .ts modules — render them as JSX from a 'use client' parent ` +
+          `instead. ${shadowNote}`,
+        suggestion:
+          `Move the call site into a 'use client' .tsx parent and render \`${binding}\` ` +
+          `as JSX, or restructure so the imperative .ts module no longer needs to call ` +
+          `\`${binding}\` directly.`,
+      }
+    case 'missing':
+      return {
+        message:
+          `${head} The import path could not be resolved on disk. ${shadowNote}`,
+        suggestion:
+          `Check the path '${s.importPath}' — either fix the typo, restore the deleted ` +
+          `file, or remove the dead import.`,
+      }
+    case 'circular':
+      return {
+        message:
+          `${head} The import was dropped because the IIFE topological sort cannot safely ` +
+          `emit a circular relative dependency. ${shadowNote}`,
+        suggestion:
+          `Break the cycle: extract the shared bindings into a third module that both ` +
+          `sides can depend on without re-entry.`,
+      }
+  }
 }
 
 /**
@@ -481,8 +542,12 @@ function isValueReference(id: ts.Identifier): boolean {
   if (ts.isBindingElement(parent) && (parent.name === id || parent.propertyName === id)) return false
   if (ts.isLabeledStatement(parent) && parent.label === id) return false
   if (ts.isBreakOrContinueStatement(parent) && parent.label === id) return false
-  if (ts.isImportSpecifier(parent)) return false
-  if (ts.isExportSpecifier(parent)) return false
+  // ImportSpecifier (`{ X }` or `{ X as Y }`) and ExportSpecifier have
+  // only `name`/`propertyName` as Identifier children — written as an
+  // explicit slot check for stylistic consistency with the other
+  // branches above.
+  if (ts.isImportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
+  if (ts.isExportSpecifier(parent) && (parent.name === id || parent.propertyName === id)) return false
   if (ts.isImportClause(parent) && parent.name === id) return false
   if (ts.isNamespaceImport(parent) && parent.name === id) return false
   if (ts.isQualifiedName(parent) && parent.right === id) return false
@@ -523,10 +588,13 @@ function detectStrippedReferences(
     // a separate problem that will surface elsewhere.
     return []
   }
-  const referenced = new Set<string>()
+  // For each value-referenced identifier name, capture the FIRST node we
+  // see — that's the call/use site we'll point the developer at. Walking
+  // top-down gives source-order positions naturally.
+  const firstReference = new Map<string, ts.Identifier>()
   function visit(node: ts.Node): void {
     if (ts.isIdentifier(node) && isValueReference(node)) {
-      referenced.add(node.text)
+      if (!firstReference.has(node.text)) firstReference.set(node.text, node)
     }
     ts.forEachChild(node, visit)
   }
@@ -535,28 +603,24 @@ function detectStrippedReferences(
   const errors: CompilerError[] = []
   for (const s of stripped) {
     for (const b of s.bindings) {
-      if (!referenced.has(b)) continue
-      const message =
-        `Import \`${b}\` from '${s.importPath}' was stripped from the client bundle \`${s.loggingPath}\`, ` +
-        `but \`${b}\` is still referenced in the assembled JS. ` +
-        `Client components ('use client' .tsx) are not callable as plain functions from imperative .ts ` +
-        `modules — render them as JSX from a 'use client' parent instead. ` +
-        `(If \`${b}\` is a local shadow rather than the stripped import, please file an issue.)`
+      const refNode = firstReference.get(b)
+      if (!refNode) continue
+      // 1-indexed line, 0-indexed column — matches `SourceLocation` per
+      // packages/jsx/src/types.ts.
+      const start = sf.getLineAndCharacterOfPosition(refNode.getStart(sf))
+      const end = sf.getLineAndCharacterOfPosition(refNode.getEnd())
+      const { message, suggestion } = buildDanglingReferenceMessage(b, s)
       errors.push(
         createError(
           ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED,
           {
             file: s.loggingPath,
-            start: { line: 1, column: 0 },
-            end: { line: 1, column: 0 },
+            start: { line: start.line + 1, column: start.character },
+            end: { line: end.line + 1, column: end.character },
           },
           {
             message,
-            suggestion: {
-              message:
-                `Move the call site into a 'use client' .tsx parent and render \`${b}\` as JSX, ` +
-                `or restructure so the imperative .ts module no longer needs to call \`${b}\` directly.`,
-            },
+            suggestion: { message: suggestion },
           },
         ),
       )
@@ -615,7 +679,7 @@ async function walkAndCollect(
       // Surface unresolved imports — silent strips made #1151 hard to spot.
       console.warn(`Stripped unresolved import: ${importPath} from ${loggingPath}`)
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-      recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
+      recordStrippedImport(fullMatch, importPath, loggingPath, 'missing', stripped)
       continue
     }
 
@@ -627,7 +691,7 @@ async function walkAndCollect(
       // call sites that survived the strip. piconic-ai/barefootjs#1227.
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
       console.log(`Stripped client component import: ${importPath} from ${loggingPath}`)
-      recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
+      recordStrippedImport(fullMatch, importPath, loggingPath, 'tsx', stripped)
       continue
     }
 
@@ -639,7 +703,7 @@ async function walkAndCollect(
       if (visiting.has(result.path)) {
         console.warn(`Skipping circular relative import: ${importPath} from ${loggingPath}`)
         content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
-        recordStrippedImport(fullMatch, importPath, loggingPath, stripped)
+        recordStrippedImport(fullMatch, importPath, loggingPath, 'circular', stripped)
         continue
       }
       visiting.add(result.path)
@@ -826,6 +890,13 @@ export async function resolveRelativeImports(
       errors,
     )
 
+    // Note: `inlineRelativeImports` runs `detectStrippedReferences` BEFORE
+    // the hoisted bare-package imports below are prepended. A stripped
+    // relative-import binding name colliding with a hoisted bare-package
+    // binding name is not possible inside a single source file (TS
+    // forbids same-name imports), so detection sees the complete set of
+    // identifiers it needs to classify references against. See #1227.
+    //
     // Prepend bare-package imports that bubbled up from inlined modules,
     // deduped by exact statement text after whitespace normalization.
     // ES modules hoist all `import` statements anyway, so placement is

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -51,6 +51,14 @@ export const ErrorCodes = {
   // Init statement errors (BF052)
   UNDECLARED_INIT_STATEMENT_REFERENCE: 'BF052',
 
+  // Stripped-import diagnostics (BF053) — a relative import was removed
+  // from a compiled client bundle (e.g. a sibling '.tsx' deferred to its
+  // own client JS, an unresolved path, or a circular relative dep) but
+  // the binding name still appears as a value reference in the bundle.
+  // Silent strips here surface as runtime `ReferenceError`; making the
+  // strip a build-time error closes the gap. See piconic-ai/barefootjs#1227.
+  STRIPPED_CLIENT_IMPORT_REFERENCED: 'BF053',
+
   // Stage-violation errors (BF060-BF069) — cross-scope references the
   // staged-IR refactor (#1138) surfaces structurally rather than
   // hiding behind silent fallbacks. All three are hard errors: at
@@ -127,6 +135,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.UNDECLARED_INIT_STATEMENT_REFERENCE]:
     'Init statement references an undeclared identifier. Declare it at module scope, inside the component, or import it — otherwise ESM strict mode throws ReferenceError at runtime.',
+
+  [ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED]:
+    "Import was stripped from the client bundle but its binding is still referenced. Client components ('use client' .tsx) are not callable as plain functions from imperative .ts modules — render them as JSX from a 'use client' parent instead. If the flagged name is a local shadow rather than the stripped import, please file an issue.",
 
   [ErrorCodes.STAGE_REACTIVE_IN_TEMPLATE]:
     'Reactive binding (signal getter or memo) referenced from template scope. The template lambda runs at module scope without the reactive context, so the value cannot be evaluated at SSR. Wrap the JSX expression in /* @client */ to defer it to hydrate, or restructure so the template uses a prop or static value.',

--- a/packages/preview/src/compile.ts
+++ b/packages/preview/src/compile.ts
@@ -5,7 +5,7 @@
  * Follows site/ui/build.ts patterns but minimal — only what previews need.
  */
 
-import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
+import { compileJSX, combineParentChildClientJs, formatError } from '@barefootjs/jsx'
 import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { addScriptCollection } from '@barefootjs/hono/build'
 import { mkdir, readdir, symlink, lstat } from 'node:fs/promises'
@@ -182,8 +182,12 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     console.log(`Combined: ${entry.clientJs}`)
   }
 
-  // 5b. Resolve relative imports
-  await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+  // 5b. Resolve relative imports. Surface BF053 diagnostics — preview
+  // generation hits the same strip path as the main build, so a
+  // dangling stripped binding would crash the previewed component at
+  // hydrate time with no clue at compile time. See #1227.
+  const { errors: resolveErrors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+  for (const err of resolveErrors) console.error(formatError(err))
 
   // 6. Rewrite imports and add JSX pragma in compiled .tsx files
   const HONO_UTILS_PATH = resolve(ROOT_DIR, 'packages/adapter-hono/src/utils')


### PR DESCRIPTION
## Summary

Closes #1227.

Compiled client bundles silently dropped relative `import` lines whose target was a sibling `'.tsx'` (treated as a separately-compiled `'use client'` component), an unresolved path, or a circular `'.ts'` dep. The strip was a one-way transformation with no verification that the bound name became orphaned, so a `.ts` helper inlined into a client bundle that still called the stripped binding shipped a dangling identifier and crashed at runtime with `ReferenceError: X is not defined`. `barefoot build` reported `0 errors` and exit code 0.

### Root cause

`packages/cli/src/lib/resolve-imports.ts` `walkAndCollect()` had three strip sites (`.tsx`, missing path, circular dep). Each removed the import line, logged at `info`/`warn`, and continued. Nothing checked the post-strip bundle for residual references.

### Fix

`resolveRelativeImports` now records every dropped binding (named, namespace, default) and, after IIFE assembly, parses the final bundle via the TypeScript compiler API. It walks every `Identifier` node, excluding property names, declaration positions, and import/export specifiers, and reports any dropped binding still appearing as a value reference as a build error with the new code `BF053: STRIPPED_CLIENT_IMPORT_REFERENCED`. `build.ts` and `preview/compile.ts` consume the diagnostics via `formatError`, and the existing `errorCount > 0` exit in `commands/build.ts` makes the build non-zero.

The misleading log message `Stripped server component import:` is renamed to `Stripped client component import:` (sibling `.tsx` files reaching that strip path are in practice `'use client'` components — server components don't emit `.client.js`).

### Why detection rather than auto-promotion or runtime stubs

The issue suggested three remedies: auto-promote `.ts` → `'use client'`, build-time error, or `console.warn` runtime stub. Auto-promotion is incorrect — `'use client'` `.tsx` files compile to a separate `markedTemplate + clientJs` pair and are not callable as plain JS functions from imperative `.ts`. Even if the import were preserved, the runtime call site would never resolve. The only correct user remedy is to render the client component as JSX from a `'use client'` parent, which a build error can communicate clearly. Runtime stubs only move the surprise to a later phase.

### Caveat (documented in the error text)

The scan is syntactic, not scope-aware. A local function parameter that happens to share a name with a stripped import will register as a reference (loud false positive). This is a strict improvement over the silent strip — the previous failure mode was a runtime ReferenceError at hydrate.

## Test plan

- [x] New regression test `errors when stripped .tsx binding is still referenced (bf#1227)` in `packages/cli/src/__tests__/resolve-imports.test.ts` asserts the BF053 error, severity, message contents (binding + import path), and `loc.file` (the bundle).
- [x] Sanity test `does not error when stripped .tsx binding is unused at the call site` locks the fix to the dangling-reference case so BF053 doesn't over-trigger.
- [x] Existing `strips .tsx server component import` renamed and updated to assert `errors` is empty.
- [x] `bun test` in `packages/cli`: 405 pass / 0 fail.
- [x] `bun test` in `packages/jsx`: pre-existing 4 failures (primitive-resolver-alias) confirmed unrelated by stashing changes; all other tests pass.
- [x] `bun test` in `packages/adapter-tests`: 229 pass / 0 fail.
- [x] `bun test` in `packages/client`: 247 pass / 0 fail.
- [x] CLI build (`bun run build` in `packages/cli`) succeeds.

## Files changed

- `packages/jsx/src/errors.ts` — new `BF053` code + message.
- `packages/cli/src/lib/resolve-imports.ts` — `StrippedImport` tracking at all three strip sites, `isValueReference` AST classifier, `detectStrippedReferences` post-assembly scan, `resolveRelativeImports` now returns `{ errors }`. Misleading log rename.
- `packages/cli/src/lib/build.ts` — consume `resolveErrors` and add to `errorCount`.
- `packages/preview/src/compile.ts` — surface the same diagnostics through `formatError`.
- `packages/cli/src/__tests__/resolve-imports.test.ts` — regression + sanity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)