### PR TITLE
refactor(shared): trim noise from integration test components

### DIFF
--- a/integrations/shared/components/AIChatInteractive.tsx
+++ b/integrations/shared/components/AIChatInteractive.tsx
@@ -1,11 +1,6 @@
-"use client"
+'use client'
 
-/**
- * AI Chat Interactive Component
- *
- * Client-side chat with SSE streaming responses.
- * Each user message triggers a streaming AI response via /api/ai-chat.
- */
+// Client-side chat with SSE streaming responses via /api/ai-chat.
 
 import { createSignal, createEffect } from '@barefootjs/client'
 
@@ -29,7 +24,7 @@ export function AIChatInteractive() {
     const trimmed = text.trim()
     if (!trimmed || isStreaming()) return
 
-    setMessages((prev: Message[]) => [...prev, { id: Date.now(), role: 'user', content: trimmed }])
+    setMessages(prev => [...prev, { id: Date.now(), role: 'user', content: trimmed }])
     setInput('')
     setIsStreaming(true)
     setStreamingText('')
@@ -39,13 +34,13 @@ export function AIChatInteractive() {
     es.onmessage = (e) => {
       if (e.data === '[DONE]') {
         const final = streamingText()
-        setMessages((prev: Message[]) => [...prev, { id: Date.now(), role: 'assistant', content: final }])
+        setMessages(prev => [...prev, { id: Date.now(), role: 'assistant', content: final }])
         setStreamingText('')
         setIsStreaming(false)
         es.close()
       } else {
         const token = JSON.parse(e.data) as string
-        setStreamingText((prev: string) => prev + token)
+        setStreamingText(prev => prev + token)
       }
     }
 
@@ -62,7 +57,7 @@ export function AIChatInteractive() {
   return (
     <div className="chat-container">
       <div className="chat-messages" id="chat-messages">
-        {messages().map((msg: Message) => (
+        {messages().map(msg => (
           <div key={msg.id} className={`chat-msg chat-${msg.role}`}>
             <div className="chat-bubble">
               <p>{msg.content}</p>
@@ -84,7 +79,7 @@ export function AIChatInteractive() {
           className="chat-input"
           placeholder="Type a message..."
           value={input()}
-          onInput={(e) => setInput((e.target as HTMLInputElement).value)}
+          onInput={e => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={isStreaming()}
         />

--- a/integrations/shared/components/ConditionalReturn.tsx
+++ b/integrations/shared/components/ConditionalReturn.tsx
@@ -1,12 +1,7 @@
 'use client'
 
-/**
- * ConditionalReturn Component (Shared)
- *
- * Exercises if/else conditional JSX returns (IRIfStatement).
- * Renders a <button> by default or an <a> when variant="link".
- * Both branches have reactive state to verify client-side hydration.
- */
+// Test fixture: exercises if/else conditional JSX returns (IRIfStatement).
+// Renders a <button> by default or an <a> when variant="link".
 
 import { createSignal } from '@barefootjs/client'
 
@@ -23,7 +18,7 @@ function ConditionalReturn(props: ConditionalReturnProps) {
         href="#"
         className="conditional-link"
         data-active={count() > 0}
-        onClick={(e: Event) => {
+        onClick={(e) => {
           e.preventDefault()
           setCount(n => n + 1)
         }}

--- a/integrations/shared/components/Counter.tsx
+++ b/integrations/shared/components/Counter.tsx
@@ -1,12 +1,5 @@
 'use client'
 
-/**
- * Counter Component (Shared)
- *
- * This component is shared across all adapter integrations.
- * Used to verify consistent behavior across different backends.
- */
-
 import { createSignal, createMemo } from '@barefootjs/client'
 
 interface CounterProps {
@@ -29,5 +22,3 @@ export function Counter(props: CounterProps) {
     </div>
   )
 }
-
-export default Counter

--- a/integrations/shared/components/Form.tsx
+++ b/integrations/shared/components/Form.tsx
@@ -1,16 +1,5 @@
 'use client'
 
-/**
- * Form Component (Shared)
- *
- * A practical form demonstrating checkbox + button interaction.
- * When the checkbox is checked, the submit button becomes enabled.
- * This component tests:
- * - Checkbox state toggle
- * - Conditional button disabled attribute
- * - Null branch rendering (SVG checkmark appears/disappears)
- */
-
 import { createSignal } from '@barefootjs/client'
 
 export function Form() {
@@ -66,5 +55,3 @@ export function Form() {
     </div>
   )
 }
-
-export default Form

--- a/integrations/shared/components/PortalExample.tsx
+++ b/integrations/shared/components/PortalExample.tsx
@@ -1,13 +1,8 @@
 'use client'
-/**
- * PortalExample - Simple Portal Component
- *
- * Demonstrates Portal usage for SSR.
- * Uses the same pattern as DialogOverlay/DialogContent:
- * - Elements are always rendered (not conditionally)
- * - On mount (via ref callback), elements are moved to document.body
- * - Visibility is controlled via inline style (hidden attribute)
- */
+
+// Portal test fixture. Uses the same pattern as DialogOverlay/DialogContent:
+// elements are always rendered (not conditionally) and moved to document.body
+// on mount via ref callback, with visibility controlled by `hidden`.
 
 import { createSignal, createPortal, isSSRPortal } from '@barefootjs/client'
 
@@ -17,8 +12,6 @@ export function PortalExample() {
   const handleOpen = () => setOpen(true)
   const handleClose = () => setOpen(false)
 
-  // Move element to document.body on mount (portal behavior)
-  // Skip if element is already in an SSR portal (content already at body)
   const moveToBody = (el: HTMLElement) => {
     if (el && el.parentNode !== document.body && !isSSRPortal(el)) {
       const ownerScope = el.closest('[bf-s]') ?? undefined
@@ -68,5 +61,3 @@ export function PortalExample() {
     </div>
   )
 }
-
-export default PortalExample

--- a/integrations/shared/components/ReactiveProps.tsx
+++ b/integrations/shared/components/ReactiveProps.tsx
@@ -1,18 +1,12 @@
 'use client'
 
-/**
- * ReactiveProps Component
- *
- * Tests reactivity model documented in spec/compiler.md:
- * 1. Signal access via getter calls: count()
- * 2. Parent-to-child reactive props propagation
- * 3. Callback props from child to parent
- */
+// Test fixture for the reactivity model in spec/compiler.md:
+// - signal getter calls (count())
+// - parent-to-child reactive prop propagation
+// - callback props from child to parent
 
 import { createSignal, createMemo } from '@barefootjs/client'
 
-// Child component that receives reactive props
-// Uses SolidJS-style props (props.xxx) to maintain reactivity
 type ChildProps = {
   value: number
   label: string
@@ -31,14 +25,12 @@ function ReactiveChild(props: ChildProps) {
   )
 }
 
-// Parent component with signal
 export function ReactiveProps() {
   const [count, setCount] = createSignal(0)
   const doubled = createMemo(() => count() * 2)
 
   return (
     <div className="reactive-props-container">
-      {/* Signal basic: count() getter call */}
       <div className="parent-section">
         <p className="parent-count">Parent count: {count()}</p>
         <p className="parent-doubled">Doubled: {doubled()}</p>
@@ -47,14 +39,12 @@ export function ReactiveProps() {
         </button>
       </div>
 
-      {/* Parent-to-child reactive props */}
       <ReactiveChild
         value={count()}
         label="Child A"
         onIncrement={() => setCount(n => n + 1)}
       />
 
-      {/* Multiple children with same reactive prop */}
       <ReactiveChild
         value={doubled()}
         label="Child B (doubled)"
@@ -64,22 +54,14 @@ export function ReactiveProps() {
   )
 }
 
-// =============================================================================
-// Props Reactivity Comparison Tests
-// =============================================================================
-
-/**
- * SolidJS-style: function Component(props: Props)
- * Props accessed via props.xxx maintain reactivity
- */
+// Demonstrates that `props.xxx` access preserves reactivity while
+// destructured props capture the initial value. See spec/compiler.md.
 type PropsStyleChildProps = {
   value: number
   label: string
 }
 
 function PropsStyleChild(props: PropsStyleChildProps) {
-  // This createMemo will react to props.value changes
-  // because we access props.value directly
   const displayValue = createMemo(() => props.value * 10)
 
   return (
@@ -91,14 +73,8 @@ function PropsStyleChild(props: PropsStyleChildProps) {
   )
 }
 
-/**
- * Destructured style: function Component({ value, label }: Props)
- * Destructured props lose reactivity - value is captured at initial render
- */
 // @bf-ignore props-destructuring
 function DestructuredStyleChild({ value, label }: PropsStyleChildProps) {
-  // This createMemo captures the initial value of 'value'
-  // and will NOT react to changes from the parent
   const displayValue = createMemo(() => value * 10)
 
   return (
@@ -110,13 +86,6 @@ function DestructuredStyleChild({ value, label }: PropsStyleChildProps) {
   )
 }
 
-/**
- * PropsReactivityComparison Component
- *
- * Demonstrates the difference between:
- * 1. SolidJS-style props (props.xxx) - maintains reactivity
- * 2. Destructured props - loses reactivity
- */
 export function PropsReactivityComparison() {
   const [count, setCount] = createSignal(1)
 
@@ -139,5 +108,3 @@ export function PropsReactivityComparison() {
     </div>
   )
 }
-
-export default ReactiveProps

--- a/integrations/shared/components/TodoApp.tsx
+++ b/integrations/shared/components/TodoApp.tsx
@@ -1,11 +1,7 @@
-"use client"
+'use client'
 
-/**
- * BarefootJS TodoApp with SSR
- *
- * Main component - renders initial todos from server, then uses API for updates
- * Follows TodoMVC HTML structure and styling conventions
- */
+// SSR variant. Initial todos come from the server, updates go through /api/todos.
+// Follows TodoMVC HTML structure and styling conventions.
 
 import { createSignal, onMount } from '@barefootjs/client'
 import TodoItem from './TodoItem'
@@ -166,7 +162,7 @@ function TodoApp(props: Props) {
           className="new-todo"
           placeholder="What needs to be done?"
           value={newText()}
-          onInput={(e) => setNewText((e.target as HTMLInputElement).value)}
+          onInput={e => setNewText(e.target.value)}
           onKeyDown={handleKeyDown}
           autofocus
         />

--- a/integrations/shared/components/TodoAppSSR.tsx
+++ b/integrations/shared/components/TodoAppSSR.tsx
@@ -1,11 +1,7 @@
-"use client"
+'use client'
 
-/**
- * BarefootJS TodoApp without @client markers
- *
- * This version tests rendering without @client comment markers.
- * Used to verify higher-order function handling.
- */
+// Twin of TodoApp.tsx but without `/* @client */` markers.
+// Exists to verify the compiler handles higher-order functions without them.
 
 import { createSignal, onMount } from '@barefootjs/client'
 import TodoItem from './TodoItem'
@@ -166,7 +162,7 @@ function TodoAppSSR(props: Props) {
           className="new-todo"
           placeholder="What needs to be done?"
           value={newText()}
-          onInput={(e) => setNewText((e.target as HTMLInputElement).value)}
+          onInput={e => setNewText(e.target.value)}
           onKeyDown={handleKeyDown}
           autofocus
         />

--- a/integrations/shared/components/TodoItem.tsx
+++ b/integrations/shared/components/TodoItem.tsx
@@ -1,9 +1,6 @@
-"use client"
-/**
- * TodoItem Component
- * Displays and edits individual todo items
- * Follows TodoMVC HTML structure and styling conventions
- */
+'use client'
+
+// Single row of the TodoMVC list — view / edit / toggle / destroy.
 
 type Todo = {
   id: number


### PR DESCRIPTION
## Summary

- `(e.target as HTMLInputElement).value` → `e.target.value` and `(e: Event)` / `(prev: T)` overrides removed. Hono's `TargetedInputEvent<HTMLInputElement>` already narrows `e.target` correctly; the casts were silencing inference, not adding safety.
- Redundant `export default Component` removed where the file already had `export function Component`. The compiler registers components by function name, so the default export was dead code (consumers reference these as registry strings, not via `import X from`). Files that export only via default were left alone.
- JSDoc preambles that restated the file name or listed test intents were dropped per CLAUDE.md guidance. Block comments that explain *why* a fixture exists (the `TodoAppSSR` twin, `PortalExample`'s DialogOverlay parallel) are kept, condensed.

Compiled `.client.js` for these components is byte-identical to `main` or differs only cosmetically (`(prev)` vs `prev`). No runtime behavior change.

## Test plan

- [x] `bun run build` succeeds in `integrations/csr` (10 components compiled, 0 errors)
- [x] `bun run build` succeeds in `integrations/hono` (10 components compiled, 1 cached, 0 errors)
- [x] Diff of compiled output vs `main` shows only cosmetic differences
- [ ] CI / shared E2E suite (counter, todo-app, ai-chat, form, portal, conditional-return, reactive-props, toggle) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)