### PR TITLE
fix(site/core): update playground type-bundle path after hono .d.ts merge

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -443,8 +443,12 @@ const HONO_JSX_RUNTIME_SHIM = `declare module 'hono/jsx/jsx-runtime' {
 `
 
 const typeBundle: Record<string, string> = {
+  // Source of truth for @barefootjs/hono JSX types is `index.ts` (ambient
+  // declarations via `export declare namespace`); a sibling `.d.ts` no
+  // longer exists. Monaco parses the file based on the virtual `.d.ts`
+  // key, and the source's syntax is valid as a `.d.ts` body.
   'file:///node_modules/@barefootjs/hono/jsx/jsx-runtime/index.d.ts':
-    await Bun.file(resolve(PKG_DIR, 'adapter-hono/src/jsx/jsx-runtime/index.d.ts')).text(),
+    await Bun.file(resolve(PKG_DIR, 'adapter-hono/src/jsx/jsx-runtime/index.ts')).text(),
   'file:///node_modules/@barefootjs/jsx/jsx-runtime/index.d.ts':
     await Bun.file(resolve(PKG_DIR, 'jsx/src/jsx-runtime/index.d.ts')).text(),
   'file:///node_modules/@barefootjs/jsx/html-types.d.ts':


### PR DESCRIPTION
## Summary

- Fixes a `deploy-core / Build site` job failure caused by `ENOENT: …/adapter-hono/src/jsx/jsx-runtime/index.d.ts` ([failing run](https://github.com/piconic-ai/barefootjs/actions/runs/25653717444/job/75297264717))
- The preceding commit c6277b76 merged that `index.d.ts` into its sibling `index.ts` as ambient declarations (`export declare namespace` / `export declare function`), which caused the Monaco type-bundle builder in `site/core/build.ts` to reference a src path that no longer existed
- Switches the reference to the `.ts` source instead. Its contents — re-exports, `import type`, and `export declare` — are valid `.d.ts` syntax, so Monaco parses it fine under the virtual key `…/index.d.ts`

## Test plan

- [x] `cd site/core && bun run build` completes with `Build complete!` (reproduced locally, confirmed fixed after the change)
- [x] Verified via `grep` that no remaining references to the deleted `adapter-hono/src/jsx/**/*.d.ts` exist in the repository
- [ ] Confirm that CI `deploy-core / Build site` turns green