### PR TITLE
fix(jsx): resolve src/ for bun consumers so workspace tests don't depend on stale dist

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./jsx-runtime": {


### PR DESCRIPTION
## Summary

Four tests in `packages/cli` ([BF053 cases](https://github.com/piconic-ai/barefootjs/blob/main/packages/cli/src/__tests__/resolve-imports.test.ts#L85)) were failing locally. The cause: `@barefootjs/jsx` was resolved through `./dist/index.js`, so when `src/errors.ts` added BF053 but `dist` had not been rebuilt, **`ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED` evaluated to `undefined`**. CI (`ci-cli.yml`) masked this by running `bun run --filter '@barefootjs/jsx' build` as an explicit step before the CLI tests, but running `bun test packages/cli/...` directly on a fresh checkout (or against a stale dist) surfaced it.

## Fix

Add `"bun": "./src/index.ts"` to `@barefootjs/jsx`'s `exports`. Bun matches the `bun` condition before the generic `import`, so every workspace consumer running on Bun (tests, runtime, site build) now loads the source directly. This matches the source-resolution pattern `@barefootjs/hono` already uses.

- Published Node consumers still resolve `import` → `./dist/index.js`
- `types` still points at `./dist/index.d.ts` for IDE / `tsc`

## Test plan

- [x] With `packages/jsx/dist` **fully deleted**, `bun test packages/cli/src/__tests__/resolve-imports.test.ts` → 14/14 pass
- [x] Even after overwriting `dist/index.js` with `throw new Error('STALE DIST')`, the same 14/14 pass — direct evidence that Bun is resolving `src/` instead of `dist/`
- [x] After restoring `dist`, `bun test __tests__` (entire repo) → 2270 pass / 4 skip / 0 fail (the four pre-existing BF053 failures are gone)
- [x] All PR CI checks green (publish skipped as expected for non-main branches)