### PR TITLE
fix(jsx): use src as single source of truth and fail loud on unknown ErrorCode

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.1",
   "description": "JSX compiler for BarefootJS - transforms JSX to server HTML + client JS",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     },
     "./jsx-runtime": {
       "types": "./src/jsx-runtime/index.d.ts"

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * BarefootJS Compiler - Single-Pass Analyzer
  *

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -168,6 +168,21 @@ export function createError(
     suggestion?: ErrorSuggestion
   }
 ): CompilerError {
+  // Guard against silent failure when a stale build of this package is
+  // loaded by a consumer: if `code` is `undefined` (typically because a
+  // newer source-level ErrorCodes entry isn't present in the compiled
+  // artifact), every error this consumer creates would otherwise carry
+  // `code: undefined` and pass through downstream `errors[i].code ===
+  // 'BFxxx'` checks as `undefined` — a runtime ReferenceError waiting to
+  // happen. Fail loud at the construction site instead.
+  if (code === undefined || !(code in errorMessages)) {
+    throw new Error(
+      `createError: unknown error code ${JSON.stringify(code)}. ` +
+        `This usually means a consumer is loading a stale build of @barefootjs/jsx ` +
+        `that predates the ErrorCodes entry, or the code was renamed without ` +
+        `updating callers.`,
+    )
+  }
   return {
     code,
     severity: options?.severity ?? 'error',

--- a/packages/jsx/src/shared-program.ts
+++ b/packages/jsx/src/shared-program.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * Shared ts.Program construction for whole-corpus builds.
  *


### PR DESCRIPTION
## Summary

Two layered root-cause fixes that together eliminate the silent-failure mode behind the four BF053 test failures (replaces the workaround in #1233).

### 1. `src` as the single source of truth

`packages/jsx/package.json` previously routed `main` / `types` / `exports` through the bundled `./dist/index.js`. The bundle is rebuilt manually, so any time `src/errors.ts` added an entry (e.g. BF053) and `bun run build` had not been re-run, workspace consumers loaded a **stale `ErrorCodes`** — `ErrorCodes.STRIPPED_CLIENT_IMPORT_REFERENCED` evaluated to `undefined`. `ci-cli.yml` masked it by rebuilding jsx as an explicit step; local `bun test packages/cli/...` did not.

Point the main entry at `./src/index.ts`, matching the `@barefootjs/hono` pattern already used elsewhere. The `build` script and `files: ["dist", "src"]` stay so the publish tarball still ships a bundled artifact for downstream Node consumers — **only the workspace resolution path changes**.

### 2. `createError` rejects unknown codes

Even if some other consumer somewhere loads a stale build, the previous `createError` happily returned `{ code: undefined, message: undefined, ... }`, and downstream `errors[i].code === 'BFxxx'` checks read `undefined` without throwing — a runtime `ReferenceError` waiting to happen.

Throw at the construction site, with a message that names the offending code and points at the likely cause. Type-correct callers (the only callers inside this repo) never trip this guard — it fires only on the silent-failure paths that hid the original BF053 bug.

## Test plan

- [x] `rm -rf packages/jsx/dist && bun test __tests__` → 2270 pass / 4 skip / 0 fail (the four previously-failing BF053 cases now green even with no dist on disk)
- [x] `bun test` inside `packages/jsx` → 1027/1027 pass (no regression in the package's own suite)
- [x] `bun run --filter '@barefootjs/jsx' build` still emits a valid bundle + `.d.ts` to `dist/` for the publish path
- [x] Guard fires loudly for `undefined` and for unknown string codes (e.g. `'BF999'`) in a direct-call repro
- [ ] CI green