### PR TITLE
fix(xyflow): accept JSX-component shim entries in nodeTypes map (#1236)

### DIFF
--- a/packages/adapter-hono/src/__tests__/build.test.ts
+++ b/packages/adapter-hono/src/__tests__/build.test.ts
@@ -53,6 +53,70 @@ export function Counter() {
     expect(result).toContain('/assets/js/Counter.client.js')
   })
 
+  test('ignores `function PascalCase(` text inside JSDoc / inline comments (#1236)', () => {
+    // A docstring example previously triggered a bogus insertion when
+    // the function-pattern regex matched inside the comment, after
+    // which the paren counter walked into the wrong `{` and corrupted
+    // a real function further down.
+    const input = `import { jsx } from 'hono/jsx'
+
+export interface MyProps {
+  /**
+   * Example imperative signature for the docs:
+   *   function MyNode(this: HTMLElement, props): void
+   */
+  nodeTypes?: Record<string, unknown>
+}
+
+// also: function FakeFromLineComment(this: any) {} should not match
+
+export function Counter(props: MyProps) {
+  return (<div>hello</div>)
+}`
+
+    const result = addScriptCollection(input, 'Counter', 'Counter.client.js')
+
+    // The real Counter must be wrapped exactly once.
+    const collectorCount = (result.match(/let __bfInlineScripts/g) || []).length
+    expect(collectorCount).toBe(1)
+
+    // And the collector must land inside Counter's body, immediately after
+    // its opening brace — the same shape the destructured-params test
+    // above verifies. If the comment matches had fired, the collector
+    // would be misplaced inside the interface or the JSDoc.
+    const counterBodyMatch = result.match(/function Counter\(props: MyProps\)\s*\{/)
+    expect(counterBodyMatch).not.toBeNull()
+    if (counterBodyMatch) {
+      const after = result.slice(result.indexOf(counterBodyMatch[0]) + counterBodyMatch[0].length)
+      expect(after.trimStart().startsWith('let __bfInlineScripts')).toBe(true)
+    }
+  })
+
+  test('still finds function declarations after JSX text with apostrophes (#1236)', () => {
+    // Defensive: an unbalanced `'` inside JSX text content (e.g.
+    // `How's it going`) used to cause an over-aggressive string-mask
+    // to blank everything until the next stray `'`, hiding later
+    // function declarations from the regex. Keep apostrophe-containing
+    // JSX text unmasked so subsequent functions still get instrumented.
+    const input = `import { jsx } from 'hono/jsx'
+
+export function Greeting() {
+  return (<div>Hey! How's it going?</div>)
+}
+
+export function Footer() {
+  return (<div>Bye</div>)
+}`
+
+    const result = addScriptCollection(input, 'page', 'page-abc.js')
+
+    // BOTH functions must be wrapped.
+    const collectorCount = (result.match(/let __bfInlineScripts/g) || []).length
+    expect(collectorCount).toBe(2)
+    expect(result).toMatch(/function Greeting\(\)\s*\{\s*\n?\s*let __bfInlineScripts/)
+    expect(result).toMatch(/function Footer\(\)\s*\{\s*\n?\s*let __bfInlineScripts/)
+  })
+
   test('handles destructured params with arrow function defaults', () => {
     const input = `import { jsx } from 'hono/jsx'
 

--- a/packages/adapter-hono/src/__tests__/build.test.ts
+++ b/packages/adapter-hono/src/__tests__/build.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { addScriptCollection, createConfig } from '../build'
+import { addScriptCollection, createConfig, maskComments } from '../build'
 
 // ── addScriptCollection ──────────────────────────────────────────────
 
@@ -212,5 +212,78 @@ export function Counter() {
     const config = createConfig()
     expect(config.externals).toBeUndefined()
     expect(config.externalsBasePath).toBeUndefined()
+  })
+})
+
+// ── maskComments ────────────────────────────────────────────────────
+
+describe('maskComments', () => {
+  test('preserves length and newlines so indices stay valid in the original', () => {
+    const src = '/* foo */ x // bar\ny\n/* multi\nline */ z'
+    const masked = maskComments(src)
+    expect(masked).toHaveLength(src.length)
+    // Every newline position in the original is preserved in the masked
+    // copy, so line counts (and therefore line:column error reporting
+    // from downstream tools) line up.
+    const newlinePositions = (s: string) => [...s].flatMap((c, i) => c === '\n' ? [i] : [])
+    expect(newlinePositions(masked)).toEqual(newlinePositions(src))
+  })
+
+  test('blanks JSDoc / block comments including any quotes inside', () => {
+    const comment = "/** has 'apostrophe' inside */"
+    const tail = ' const x = 1'
+    const src = comment + tail
+    const masked = maskComments(src)
+    // The whole `/** ... */` is replaced with spaces; the apostrophes
+    // inside cannot re-open as strings later.
+    expect(masked).toBe(' '.repeat(comment.length) + tail)
+  })
+
+  test('blanks `//` line comments up to (but not including) the newline', () => {
+    const comment = '// ignored'
+    const tail = '\nconst x = 1'
+    const src = comment + tail
+    const masked = maskComments(src)
+    expect(masked).toBe(' '.repeat(comment.length) + tail)
+  })
+
+  test('handles unclosed block comment by masking through end of input', () => {
+    const src = 'a /* never closed\nfunction Real() {}'
+    const masked = maskComments(src)
+    // Without `*/`, the masker blanks to EOF. `function Real()` is
+    // hidden — this matches the JS lexer's behaviour for unterminated
+    // comments and is the conservative thing to do for the
+    // function-pattern regex.
+    expect(masked.startsWith('a ')).toBe(true)
+    expect(masked).not.toContain('function Real')
+    expect(masked).toHaveLength(src.length)
+  })
+
+  test('leaves comment-free code untouched (no false positives on JSX text)', () => {
+    // Plain code with no comment delimiters round-trips identically.
+    // JSX text with apostrophes (`How's`) is the hot path: a
+    // string-aware masker would treat the `'` as an open quote and
+    // blank the rest of the file, hiding later function declarations
+    // (#1236 follow-up).
+    const src = `export function Greeting() {\n  return (<div>Hey! How's it going?</div>)\n}\nexport function Footer() {}`
+    expect(maskComments(src)).toBe(src)
+  })
+
+  test('KNOWN LIMITATION: `//` inside a string is still treated as a line comment', () => {
+    // Documented in `maskComments` jsdoc: this helper does not track
+    // string boundaries, so a `//` appearing inside a string literal
+    // is still treated as a comment delimiter. SSR template output
+    // (the only current caller) does not produce such cases, so the
+    // simpler implementation is acceptable. If a future caller can
+    // produce them, swap in a real lexer — this test will start to
+    // fail and force the conversation.
+    const prefix = `const u = "https:`
+    const blanked = `//example.com" ; const x = 1`
+    const src = prefix + blanked
+    const masked = maskComments(src)
+    // The `//` in `https://` is treated as a line-comment delimiter
+    // and the rest of the line gets blanked.
+    expect(masked).toBe(prefix + ' '.repeat(blanked.length))
+    expect(masked).toHaveLength(src.length)
   })
 })

--- a/packages/adapter-hono/src/build.ts
+++ b/packages/adapter-hono/src/build.ts
@@ -96,11 +96,19 @@ function __bfWrap(jsx: any, scripts: string[]) {
   // Matches both exported and non-exported PascalCase components (#786).
   // Uses paren counting instead of regex to correctly handle nested
   // delimiters in destructured params (e.g. `onInput = () => {}`).
+  //
+  // The regex matches against a comment-masked copy so a docstring
+  // example like `function MyNode(this: HTMLElement, props)` is NOT
+  // misread as a real function declaration (#1236). The paren counter
+  // still walks the ORIGINAL `restOfFile` and keeps the quote-skip
+  // logic — TS parameter type annotations contain balanced strings
+  // (e.g. `"data-key"?: string`) that the skip handles correctly.
   let modifiedRest = restOfFile
+  const maskedRest = maskComments(restOfFile)
   const exportFuncPattern = /(?:export )?function ([A-Z]\w*)\s*\(/g
   const insertions: Array<{ index: number; text: string }> = []
   let efMatch: RegExpExecArray | null
-  while ((efMatch = exportFuncPattern.exec(restOfFile)) !== null) {
+  while ((efMatch = exportFuncPattern.exec(maskedRest)) !== null) {
     const openParenPos = efMatch.index + efMatch[0].length - 1
     // Count parens to find matching ')'
     let depth = 1
@@ -132,8 +140,15 @@ function __bfWrap(jsx: any, scripts: string[]) {
     modifiedRest = modifiedRest.slice(0, ins.index) + ins.text + modifiedRest.slice(ins.index)
   }
 
-  // Wrap each return (...) with __bfWrap((...), __bfInlineScripts)
-  // Process from back to front to preserve offsets
+  // Wrap each return (...) with __bfWrap((...), __bfInlineScripts).
+  //
+  // Intentionally NO comment/string masking here. JSX bodies routinely
+  // contain unbalanced apostrophes in text content (`Hey! How's it
+  // going`) which a string-aware scanner misreads as an open quote and
+  // ends up blanking everything until the next stray `'`, breaking
+  // paren counting. Plain `(` / `)` counting works for JSX returns
+  // because JSX text cannot contain literal parens — those only appear
+  // inside `{expr}` slots, which are balanced JS.
   const returnPattern = /return\s*\(/g
   const returnMatches: Array<{ index: number; length: number }> = []
   let m: RegExpExecArray | null
@@ -158,4 +173,47 @@ function __bfWrap(jsx: any, scripts: string[]) {
   }
 
   return beforeImports + existingImports + importStatement + helperFn + modifiedRest
+}
+
+/**
+ * Replace comment contents with spaces (preserving length and newlines
+ * so indices computed against the masked text are valid in the
+ * original). Used by `addScriptCollection` so its `function Foo(`
+ * regex ignores JSDoc / inline comments — a docstring example like
+ * `function MyNode(this: HTMLElement, props)` previously masqueraded
+ * as a real function declaration (#1236).
+ *
+ * Handles `//` line comments and `/* ... *\/` block comments (incl.
+ * JSDoc). String literals are intentionally NOT masked: JSX text
+ * content routinely contains unbalanced apostrophes (`How's`) that a
+ * string-aware masker would misread as an open quote, blanking the
+ * rest of the file and hiding later function declarations.
+ *
+ * Strings inside comments are handled implicitly: the whole comment
+ * (including any quotes it contains) is blanked.
+ */
+export function maskComments(s: string): string {
+  let out = ''
+  let i = 0
+  while (i < s.length) {
+    const ch = s[i]
+    const next = s[i + 1]
+    if (ch === '/' && next === '*') {
+      const end = s.indexOf('*/', i + 2)
+      const stop = end === -1 ? s.length : end + 2
+      for (let j = i; j < stop; j++) out += s[j] === '\n' ? '\n' : ' '
+      i = stop
+      continue
+    }
+    if (ch === '/' && next === '/') {
+      const end = s.indexOf('\n', i + 2)
+      const stop = end === -1 ? s.length : end
+      for (let j = i; j < stop; j++) out += ' '
+      i = stop
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
 }

--- a/packages/adapter-hono/src/build.ts
+++ b/packages/adapter-hono/src/build.ts
@@ -191,6 +191,16 @@ function __bfWrap(jsx: any, scripts: string[]) {
  *
  * Strings inside comments are handled implicitly: the whole comment
  * (including any quotes it contains) is blanked.
+ *
+ * **Known limitation**: this function does NOT track string
+ * boundaries, so a `//` or `/*` appearing INSIDE a string literal is
+ * still treated as a comment delimiter. Example: in
+ * `const u = "https://x.y" ; export function Foo() {}` the `//` in
+ * `https://` is misread as a line comment and the rest of the line is
+ * blanked — a `function Foo()` on that same line would be hidden from
+ * the regex. SSR template output (the only caller) does not embed
+ * such cases in practice. If a future caller can produce them, swap
+ * in a real lexer rather than extending this helper.
  */
 export function maskComments(s: string): string {
   let out = ''

--- a/packages/xyflow/src/__tests__/node-type-dispatch.test.ts
+++ b/packages/xyflow/src/__tests__/node-type-dispatch.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Boundary contract tests for `dispatchNodeType` — the helper that
+ * `FlowNodeTypeBridge` funnels imperative and JSX-component shim
+ * `nodeTypes` entries through. Without these tests, the IR test in
+ * `ui/components/ui/xyflow/index.test.tsx` only verifies the bridge's
+ * structural shape (signals, memos, effect count) — the `instanceof Node`
+ * branch lives inside the effect body where IR analysis can't see it.
+ *
+ * Regression guard for piconic-ai/barefootjs#1236 (xyflow: nodeTypes
+ * map can't accept 'use client' JSX components).
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register()
+})
+
+describe('dispatchNodeType', () => {
+  test('imperative entry: mutates the host via `this`, returns void', async () => {
+    const { dispatchNodeType } = await import('../node-type-dispatch')
+
+    const host = document.createElement('div')
+
+    const imperative: (this: HTMLElement, props: { id: string }) => void = function (props) {
+      const child = document.createElement('span')
+      child.textContent = `imperative:${props.id}`
+      this.appendChild(child)
+    }
+
+    dispatchNodeType(host, imperative as never, { id: 'a' } as never)
+
+    expect(host.children).toHaveLength(1)
+    expect(host.firstChild?.textContent).toBe('imperative:a')
+  })
+
+  test("JSX-component shim entry: returned Node is appended to the host (the #1236 contract)", async () => {
+    const { dispatchNodeType } = await import('../node-type-dispatch')
+
+    const host = document.createElement('div')
+
+    // Mirrors the bundler-emitted shim shape for a `'use client'` `.tsx`
+    // component: ignores `this`, returns a DOM `Node`.
+    const jsxShim: (this: HTMLElement, props: { id: string }) => Node = (props) => {
+      const node = document.createElement('div')
+      node.textContent = `jsx:${props.id}`
+      return node
+    }
+
+    dispatchNodeType(host, jsxShim as never, { id: 'b' } as never)
+
+    expect(host.children).toHaveLength(1)
+    expect(host.firstChild?.textContent).toBe('jsx:b')
+  })
+
+  test('JSX-component shim returning a DocumentFragment unwraps into the host', async () => {
+    const { dispatchNodeType } = await import('../node-type-dispatch')
+
+    const host = document.createElement('div')
+
+    // `createComponent` shims that produce multiple top-level nodes
+    // wrap them in a DocumentFragment. `appendChild` of a fragment
+    // unwraps its children into the host — this exercise pins that
+    // behaviour so a future "only HTMLElement" tightening of the
+    // guard is caught.
+    const fragmentShim: () => Node = () => {
+      const frag = document.createDocumentFragment()
+      const a = document.createElement('span')
+      a.textContent = 'one'
+      const b = document.createElement('span')
+      b.textContent = 'two'
+      frag.appendChild(a)
+      frag.appendChild(b)
+      return frag
+    }
+
+    dispatchNodeType(host, fragmentShim as never, {} as never)
+
+    expect(host.children).toHaveLength(2)
+    expect(host.children[0]?.textContent).toBe('one')
+    expect(host.children[1]?.textContent).toBe('two')
+  })
+
+  test('non-Node return value is ignored (imperative entries that accidentally return a primitive)', async () => {
+    const { dispatchNodeType } = await import('../node-type-dispatch')
+
+    const host = document.createElement('div')
+
+    // Defensive: an imperative entry that accidentally returns a
+    // non-Node value (e.g. a number from a `.forEach` chain) MUST NOT
+    // trigger an `appendChild` — the `instanceof Node` guard is the
+    // only thing keeping the imperative path safe.
+    const stray: (this: HTMLElement) => unknown = function () {
+      this.dataset.touched = '1'
+      return 42
+    }
+
+    dispatchNodeType(host, stray as never, {} as never)
+
+    expect(host.dataset.touched).toBe('1')
+    expect(host.children).toHaveLength(0)
+  })
+})

--- a/packages/xyflow/src/index.ts
+++ b/packages/xyflow/src/index.ts
@@ -32,6 +32,8 @@ export type { EdgePathTuple } from './edge-path'
 // node resizer needs raw dimension math.
 export { attachFlowSubsystems, clampDragPositionToParent } from './flow-subsystems'
 export { attachConnectionHandler, attachReconnectionHandler } from './connection'
+export { dispatchNodeType } from './node-type-dispatch'
+export type { NodeInitFn } from './node-type-dispatch'
 export { initNodeResizer, ResizeControlVariant } from './node-resizer'
 export type {
   NodeResizerOptions,

--- a/packages/xyflow/src/node-type-dispatch.ts
+++ b/packages/xyflow/src/node-type-dispatch.ts
@@ -1,0 +1,46 @@
+/**
+ * Node-type dispatch — the helper that funnels `<Flow nodeTypes={...}>`
+ * entries into the host `<div>` produced by `FlowNodeTypeBridge`.
+ *
+ * `nodeTypes` accepts two entry shapes through the same map so projects
+ * can migrate custom nodes from imperative to JSX one file at a time
+ * without touching every `<Flow>` call site:
+ *
+ *   1. Imperative: `function MyNode(this: HTMLElement, props): void`
+ *      — mutates `this` (the host element) and returns nothing.
+ *   2. JSX-component shim: post-`'use client'` `.tsx` compile output
+ *      — ignores `this` and returns a real DOM `Node`. The bridge
+ *      appends that returned node into the host so subsequent
+ *      wipe+rebuild cycles see it.
+ *
+ * See piconic-ai/barefootjs#1236 for the migration motivation.
+ */
+
+import type { NodeBase } from './types'
+import type { NodeComponentProps } from './types'
+
+/**
+ * Cross-shape `nodeTypes` entry. The return type covers both supported
+ * shapes — imperative entries return `void`, JSX-component shim
+ * entries return a `Node`.
+ */
+export type NodeInitFn<NodeType extends NodeBase = NodeBase> = (
+  this: HTMLElement,
+  props: NodeComponentProps<NodeType>,
+) => void | Node | undefined
+
+/**
+ * Dispatch a `nodeTypes` entry into the host element. Invokes `initFn`
+ * with `el` bound as `this` (imperative path) and appends its return
+ * value when it is a `Node` (JSX-component shim path). The
+ * `instanceof Node` guard is harmless on the imperative path: `void`
+ * is not an instance of `Node`, so the branch is skipped.
+ */
+export function dispatchNodeType<NT extends NodeBase>(
+  el: HTMLElement,
+  initFn: NodeInitFn<NT>,
+  props: NodeComponentProps<NT>,
+): void {
+  const result = initFn.call(el, props)
+  if (result instanceof Node) el.appendChild(result)
+}

--- a/ui/components/ui/xyflow/index.tsx
+++ b/ui/components/ui/xyflow/index.tsx
@@ -64,6 +64,7 @@ import {
   BF_FLOW_VIEWPORT,
   computeEdgePosition,
   createFlowStore,
+  dispatchNodeType,
   FlowContext,
   getEdgePath,
   Position,
@@ -76,7 +77,7 @@ import type {
   HandleType,
   InternalFlowStore,
   NodeBase,
-  NodeComponentProps,
+  NodeInitFn,
 } from '@barefootjs/xyflow'
 
 type Child = JSX.Element | string | number | boolean | null | undefined | Child[]
@@ -804,16 +805,6 @@ export function MiniMap(props: MiniMapComponentProps) {
 // Flow — top-level container.
 // ============================================================================
 
-/**
- * Imperative node init signature: `function MyNode(this: HTMLElement, props)`.
- * Each entry in `nodeTypes` is one of these — Flow's default renderer mounts
- * the matching one for each node based on `node.type`.
- */
-type NodeInitFn<NodeType extends NodeBase = NodeBase> = (
-  this: HTMLElement,
-  props: NodeComponentProps<NodeType>,
-) => void
-
 export interface FlowComponentProps<
   NodeType extends NodeBase = NodeBase,
   EdgeType extends EdgeBase = EdgeBase,
@@ -830,13 +821,23 @@ export interface FlowComponentProps<
    */
   renderNode?: (node: NodeType) => Child
   /**
-   * Map of `node.type` → imperative init function (`NodeInitFn`). When
-   * `renderNode` is unset, Flow synthesises a per-node bridge that picks
-   * the right init from this map and mounts it into a host `<div>`.
+   * Map of `node.type` → `NodeInitFn`. When `renderNode` is unset,
+   * Flow synthesises a per-node bridge that picks the right entry
+   * from this map and mounts it into a host `<div>`.
    *
-   * The runtime fills in the imperative `NodeComponentProps` shape from
-   * the live store entry — including the reactive `selected` getter —
-   * so individual nodes don't need to re-walk the store themselves.
+   * Each entry can be either:
+   *   1. **Imperative** — `function MyNode(this: HTMLElement, props)`
+   *      that mutates `this` and returns `void`.
+   *   2. **JSX-component shim** — a `'use client'` `.tsx` component
+   *      that ignores `this` and returns a DOM `Node`. The bridge
+   *      appends that node into the host so projects can migrate
+   *      custom nodes from imperative to JSX one file at a time
+   *      without flipping every `<Flow>` site to `renderNode`.
+   *
+   * The runtime fills in the `NodeComponentProps` shape from the live
+   * store entry — including the reactive `selected` getter — so
+   * individual nodes don't need to re-walk the store themselves. See
+   * `dispatchNodeType` in `@barefootjs/xyflow` and #1236.
    */
   nodeTypes?: Record<string, NodeInitFn<NodeType>>
 }
@@ -885,7 +886,7 @@ interface FlowNodeTypeBridgeProps {
   // biome-ignore lint/suspicious/noExplicitAny: nodes can be any narrowed shape
   forNode: any
   // biome-ignore lint/suspicious/noExplicitAny: per-type init signatures vary
-  nodeTypes: Record<string, (this: HTMLElement, props: any) => void>
+  nodeTypes: Record<string, (this: HTMLElement, props: any) => void | Node | undefined>
 }
 
 // Prop names are deliberately not `node` (which would collide with the
@@ -974,8 +975,13 @@ export function FlowNodeTypeBridge(props: FlowNodeTypeBridgeProps) {
     // registers is still rooted at this effect and tears down on the
     // next bridge re-run, preserving the wipe + rebuild semantics
     // documented above.
+    //
+    // `dispatchNodeType` (from `@barefootjs/xyflow`) handles both
+    // `initFn` shapes: imperative entries that mutate `this`, and
+    // JSX-component shim entries that return a `Node`. See its jsdoc
+    // and piconic-ai/barefootjs#1236.
     untrack(() =>
-      initFn.call(el, {
+      dispatchNodeType(el, initFn, {
         id,
         data,
         // The `selected` getter has to subscribe consumers (the user


### PR DESCRIPTION
## Summary

- `FlowNodeTypeBridge` invoked each `nodeTypes` entry as `initFn.call(el, props)` and discarded the return value, so JSX-component shim entries (post-`'use client'` `.tsx` compile) — which compile to `createComponent(...)` and return a DOM `Node` — left the host empty. Imperative entries that mutate `this` were fine because they don't rely on the return value.
- Extracted `dispatchNodeType` into `@barefootjs/xyflow` so the helper captures `initFn`'s return value and appends it to the host when it is a `Node`. Imperative entries (`void` return) are unaffected — the `instanceof Node` guard skips them.
- Both shapes now coexist in the same `nodeTypes` map, unblocking incremental imperative → JSX migration of custom nodes file-by-file without flipping every `<Flow>` site to `renderNode`.

Closes #1236.

## Reproduction

A `nodeTypes` map mixing the two `NodeInitFn` shapes:

```ts
// CardNode.ts — imperative entry (mutates `this`, returns void)
export function CardNode(this: HTMLElement, props: { id: string }) {
  const card = document.createElement('div')
  card.textContent = props.id
  this.appendChild(card)
}
```

Convert the same file to a `'use client'` JSX component (returns a Node, ignores `this`):

```tsx
// CardNode.tsx
'use client'
export function CardNode(props: { id: string }) {
  return <div>{props.id}</div>
}
```

Parent:

```tsx
'use client'
import { CardNode } from './CardNode'

export function MyFlow() {
  return <Flow nodeTypes={{ card: CardNode }}>…</Flow>
}
```

**Before this PR**: the `.tsx` variant renders an empty node host because `FlowNodeTypeBridge` calls `initFn.call(el, props)` and discards the returned JSX element.

**After this PR**: both variants render correctly through the same `nodeTypes` map, so a project can migrate its custom node types one file at a time.

## Why a separate helper

The fix is one line, but the boundary it guards is the contract between `FlowNodeTypeBridge` and the user-supplied entry. The existing IR test layer (`ui/components/ui/xyflow/index.test.tsx`) cannot see the `instanceof Node` branch — it lives inside the effect body. Extracting `dispatchNodeType` lets `packages/xyflow/src/__tests__/node-type-dispatch.test.ts` pin the contract directly under happy-dom, so a future edit that drops the `Node` branch is caught at the test boundary instead of at runtime in a downstream project.

## CI fix bundled in (commits 2 & 3)

The first push broke `e2e-site-ui`: the JSDoc I added to `nodeTypes` contained a literal docstring example `function MyNode(this: HTMLElement, props)`, which `addScriptCollection`'s function-pattern regex in `@barefootjs/adapter-hono` misread as a real function declaration. The paren counter then walked into the wrong `{` and inserted the script collector inside the parameter type of the next real component, corrupting the dist `.tsx`.

Rather than work around it in the docstring, the root cause is fixed in `addScriptCollection`:

- New `maskComments` helper blanks `/* … */` and `//` content while preserving positions, so the function-pattern regex only sees real code.
- Comments are masked; **string literals are intentionally left alone** because JSX text routinely carries unbalanced apostrophes (`Hey! How's`) that a string-aware masker would treat as an open quote and blank everything until the next stray `'`, hiding later function declarations. A regression test pins both cases (`build.test.ts`).
- The `return (` wrapping loop is left untouched — plain `(` / `)` counting works on JSX bodies because JSX text cannot contain literal parens (only `{expr}` slots, which are balanced JS).
- `maskComments` has a documented limitation: a `//` or `/*` appearing INSIDE a string literal is still treated as a comment delimiter. SSR template output (the only current caller) does not produce such inputs in practice. Direct unit test `maskComments > KNOWN LIMITATION` pins this so a future caller hitting it forces a re-evaluation.

## Backwards compatibility

Type widening only: `NodeInitFn` return changed from `void` to `void | Node | undefined`. All existing imperative entries continue to compile and run unchanged. The runtime change is additive (extra `if (result instanceof Node) el.appendChild(result)`) and harmless on the imperative path.

## Test plan

- [x] `bun test packages/xyflow/src/__tests__/node-type-dispatch.test.ts` — 4/4 boundary cases pass (imperative, JSX shim, DocumentFragment, non-Node guard)
- [x] `bun test packages/xyflow/src/__tests__/` — 43/43 pass (existing + new)
- [x] `bun test ui/components/ui/xyflow/` — 27/27 pass (existing IR tests, including `FlowNodeTypeBridge` structure guards)
- [x] `bun test packages/adapter-hono/src/__tests__/build.test.ts` — 21/21 pass (existing + 2 `#1236` regression + 5 direct `maskComments` cases)
- [x] CI green (test, test-ui, e2e-hono, e2e-site-ui ×4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)