### PR TITLE
feat(blocks): #135 Concrete additions — CSS-var × rAF demos + 4 compiler fixes

### DIFF
--- a/packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts
+++ b/packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Hono adapter: string-literal props containing JS-shaped values (#135).
+ *
+ * A JSX string attribute like `fill="var(--area-fill)"` is an SVG
+ * presentation attribute whose value happens to look like a JS function
+ * call. The old adapter used a regex (`isJsExpression`) to disambiguate
+ * string literals from arrow / call expressions and tripped on values
+ * shaped like `var(...)`, `url(...)`, or `calc(...)`, emitting them as
+ * `fill={var(--area-fill)}` — `var` is then parsed as a JS identifier
+ * and the build fails with "Unexpected var".
+ *
+ * The IR's `isLiteral` flag is the authoritative source of truth here,
+ * so the adapter now short-circuits on it before falling back to the
+ * regex.
+ *
+ * Surfaced by the area chart palette demo (#135 Concrete Additions).
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '../adapter'
+
+const adapter = new HonoAdapter()
+
+describe('string-literal component prop containing CSS function-shape (#135)', () => {
+  test('fill="var(--x)" survives as a string literal in the marked template', () => {
+    const source = `
+      function Area(props: { fill: string }) {
+        return <path d="M0 0" fill={props.fill} />
+      }
+
+      export function Demo() {
+        return <Area fill="var(--area-fill)" />
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const template = result.files.find((f) => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    const content = template!.content
+
+    // Must emit the string literal verbatim — NOT as a JS expression
+    expect(content).toContain('fill="var(--area-fill)"')
+    expect(content).not.toContain('fill={var(--area-fill)}')
+  })
+
+  test('stroke="url(#grad)" survives as a string literal', () => {
+    const source = `
+      function S(props: { stroke: string }) {
+        return <line x1="0" y1="0" x2="10" y2="10" stroke={props.stroke} />
+      }
+
+      export function Demo() {
+        return <S stroke="url(#grad)" />
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'markedTemplate')!.content
+
+    expect(content).toContain('stroke="url(#grad)"')
+    expect(content).not.toContain('stroke={url(#grad)}')
+  })
+
+  test('arrow-function expression prop is still emitted as a JS expression', () => {
+    // Regression guard — the JS-expression branch must remain reachable
+    // for non-literal values (the case `isJsExpression` was added for).
+    const source = `
+      function B(props: { onClick: (e: Event) => void }) {
+        return <button onClick={props.onClick} />
+      }
+
+      export function Demo() {
+        return <B onClick={() => 1} />
+      }
+    `
+    const result = compileJSX(source, 'Demo.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'markedTemplate')!.content
+
+    expect(content).toContain('onClick={() => 1}')
+  })
+})

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -869,6 +869,17 @@ export class HonoAdapter extends JsxAdapter {
         keyValue = prop.value
       } else if (prop.dynamic) {
         parts.push(`${prop.name}={${prop.value}}`)
+      } else if (prop.isLiteral) {
+        // `isLiteral` is the IR's authoritative signal that this value
+        // came from a JSX string-attribute (`fill="var(--c)"`). Emit it
+        // verbatim as a string attribute — falling back to
+        // `isJsExpression()` here misidentifies legitimate CSS values
+        // like `var(--area-fill)` (parses as a JS function call) and
+        // strips the quotes, producing `fill={var(--area-fill)}`. The
+        // regex stays below as a defensive net for non-literal
+        // string-shaped props that the IR couldn't tag, but the literal
+        // case must short-circuit first.
+        parts.push(`${prop.name}="${prop.value}"`)
       } else if (prop.value === 'true') {
         // Boolean true: <Component disabled />
         parts.push(prop.name)
@@ -881,7 +892,7 @@ export class HonoAdapter extends JsxAdapter {
         // JavaScript expressions (arrow functions, etc.)
         parts.push(`${prop.name}={${prop.value}}`)
       } else {
-        // String literals
+        // String literals (without isLiteral flag — pre-IR fixture path)
         parts.push(`${prop.name}="${prop.value}"`)
       }
     }

--- a/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
+++ b/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * applyRestAttrs / spreadAttrs runtime contract (#135).
+ *
+ * When a user-defined component spreads `...props` onto its underlying
+ * element, the `style` prop may arrive as a JS object literal
+ * (`<Card style={{'--stat-c': 'red'}}>`). Both the reactive DOM helper
+ * (`applyRestAttrs`) and the SSR-string helper (`spreadAttrs`) must
+ * route the object through `styleToCss` instead of falling back to
+ * `String(value)` — otherwise the DOM ends up with the literal
+ * `style="[object Object]"`. Surfaced by the analytics demo's
+ * per-source stat cards (#135 Concrete Additions), which set
+ * `style={{'--stat-c': sourceColors[s]}}` inside a `.map()` body and
+ * pass it through Card's `{...props}` spread.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { applyRestAttrs } from '../../src/runtime/apply-rest-attrs'
+import { spreadAttrs } from '../../src/runtime/spread-attrs'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('applyRestAttrs', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('object-valued `style` prop is rendered as a CSS string', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(el, { style: { '--stat-c': 'hsl(142 71% 45%)' } }, [])
+
+    const attr = el.getAttribute('style') ?? ''
+    expect(attr).toContain('--stat-c')
+    expect(attr).toContain('hsl(142 71% 45%)')
+    expect(attr).not.toContain('[object Object]')
+  })
+
+  test('multi-property style object is serialized with kebab-case keys', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(
+      el,
+      { style: { backgroundColor: 'red', '--err': '210' } },
+      [],
+    )
+
+    const attr = el.getAttribute('style') ?? ''
+    expect(attr).toContain('background-color:red')
+    expect(attr).toContain('--err:210')
+  })
+
+  test('string `style` prop is preserved verbatim', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(el, { style: 'color:red;font-size:12px' }, [])
+    expect(el.getAttribute('style')).toBe('color:red;font-size:12px')
+  })
+
+  test('null style removes the attribute', () => {
+    const el = document.createElement('div')
+    el.setAttribute('style', 'color:red')
+    document.body.appendChild(el)
+
+    applyRestAttrs(el, { style: null }, [])
+    expect(el.hasAttribute('style')).toBe(false)
+  })
+
+  test('`children` is never written as a DOM attribute', () => {
+    // Without this exclusion, parent components that pass `children`
+    // through `{...props}` end up with `children="<p>...</p>"` on the
+    // wrapper element — surfaced by the admin analytics demo's
+    // per-source Stat cards where CardContent was getting fresh children
+    // strings from a reactive `.map()` but the DOM kept the SSR text.
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(el, { children: '<p>hi</p>', 'data-x': 'y' }, [])
+
+    expect(el.hasAttribute('children')).toBe(false)
+    expect(el.getAttribute('data-x')).toBe('y')
+  })
+
+  test('keys in excludeKeys are not applied', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(
+      el,
+      { style: { color: 'red' }, 'data-x': 'y' },
+      ['style'],
+    )
+
+    expect(el.hasAttribute('style')).toBe(false)
+    expect(el.getAttribute('data-x')).toBe('y')
+  })
+})
+
+describe('spreadAttrs', () => {
+  test('object-valued `style` becomes a CSS string attribute', () => {
+    const out = spreadAttrs({ style: { '--stat-c': 'hsl(142 71% 45%)' } })
+    expect(out).toContain('style="--stat-c:hsl(142 71% 45%)"')
+    expect(out).not.toContain('[object Object]')
+  })
+
+  test('string `style` is passed through unchanged', () => {
+    const out = spreadAttrs({ style: 'color:red' })
+    expect(out).toBe('style="color:red"')
+  })
+})

--- a/packages/client/__tests__/runtime/upsert-child-multi-same-name.test.ts
+++ b/packages/client/__tests__/runtime/upsert-child-multi-same-name.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: multiple `<SameNameComponent>` children inside a single
+ * parent's renderItem body get correctly upserted at distinct slot ids
+ * (#135 board demo).
+ *
+ * When a `mapArray` body holds two or more child components of the same
+ * name (e.g. three `<Button>`s on a Kanban task card — delete, move-left,
+ * move-right), the per-item renderItem emits one `upsertChild` call per
+ * slot. For a freshly inserted item (`__existing` undefined → cloned
+ * template, no SSR scopes yet) the calls must each find their CSR
+ * `[data-bf-ph="<slotId>"]` placeholder and replace it independently.
+ *
+ * Before the fix, `findSsrScopeBySlotIn`'s name-prefix last-resort
+ * fallback (`[bf-s^="~Button_"], [bf-s^="Button_"]`) over-matched. After
+ * the first upsertChild stamped `<button bf-s="~Button_xxx" bf-mount="s10">`
+ * into the parent, subsequent calls for `s13` / `s14` returned the
+ * already-mounted `s10` element and ran `initChild` on it — leaving the
+ * actual `data-bf-ph="s13"` / `s14` placeholders orphaned. The Kanban
+ * card lost its arrow buttons after a task moved between columns.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { upsertChild } from '../../src/runtime/registry'
+import { hydrate, flushHydration } from '../../src/runtime/hydrate'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('upsertChild — multiple same-name children at distinct slots', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('three Buttons at slots s10/s13/s14 each replace their own placeholder', () => {
+    // Minimal SmallButton component — a single-root `<button>` with bf="s0"
+    // and a children text slot. Modelled on the real Button's emit shape.
+    hydrate('SmallButton', {
+      init: () => {},
+      template: (props) => {
+        const children = props.children as unknown as string
+        return `<button bf="s0">${children}</button>`
+      },
+    })
+    flushHydration()
+
+    // Simulate the inner-loop's freshly-cloned template clone — three
+    // placeholders, all pointing at the same component name, at three
+    // distinct slot ids. The parent (loop body root) carries a
+    // `bf-s="ProductivityBoardDemo_xxx"`-shaped scope so `parentScopeOf`
+    // can derive a non-empty `parentBfs` and the primary
+    // `[bf-parent][bf-mount]` lookup is exercised first.
+    const anchor = document.createElement('div')
+    anchor.setAttribute('bf-s', 'ProductivityBoardDemo_test')
+    document.body.appendChild(anchor)
+
+    const card = document.createElement('div')
+    card.innerHTML =
+      '<button class="delete" data-bf-ph="s10"></button>' +
+      '<button class="left" data-bf-ph="s13"></button>' +
+      '<button class="right" data-bf-ph="s14"></button>'
+    // Convert children to divs (placeholders) — the compiler emits
+    // `<div data-bf-ph="…">` in real output, but the placeholder lookup
+    // is by attribute, not tag.
+    card.innerHTML =
+      '<div data-bf-ph="s10"></div>' +
+      '<div data-bf-ph="s13"></div>' +
+      '<div data-bf-ph="s14"></div>'
+    anchor.appendChild(card)
+
+    // First call — the s10 placeholder.
+    const e1 = upsertChild(card, 'SmallButton', 's10', { children: 'X' }, undefined, anchor)
+    expect(e1).not.toBeNull()
+    expect(e1!.tagName).toBe('BUTTON')
+    expect(e1!.textContent).toBe('X')
+    expect(e1!.getAttribute('bf-mount')).toBe('s10')
+
+    // Second call — the s13 placeholder must still be present and must
+    // be replaced, NOT the already-mounted s10 element. This is the
+    // critical regression assertion.
+    const phS13Before = card.querySelector('[data-bf-ph="s13"]')
+    expect(phS13Before).not.toBeNull()
+    const e2 = upsertChild(card, 'SmallButton', 's13', { children: 'L' }, undefined, anchor)
+    expect(e2).not.toBeNull()
+    expect(e2!.getAttribute('bf-mount')).toBe('s13')
+    expect(e2!.textContent).toBe('L')
+    // Critically: s10 keeps its content, s13 placeholder is gone, both
+    // buttons exist side-by-side.
+    expect(card.querySelector('[data-bf-ph="s13"]')).toBeNull()
+    expect(e1!.textContent).toBe('X')
+    expect(e1!.getAttribute('bf-mount')).toBe('s10')
+
+    // Third call — same again for s14.
+    const e3 = upsertChild(card, 'SmallButton', 's14', { children: 'R' }, undefined, anchor)
+    expect(e3).not.toBeNull()
+    expect(e3!.getAttribute('bf-mount')).toBe('s14')
+    expect(e3!.textContent).toBe('R')
+    expect(card.querySelector('[data-bf-ph="s14"]')).toBeNull()
+
+    // All three buttons coexist with distinct content.
+    const buttons = card.querySelectorAll('button')
+    expect(buttons.length).toBe(3)
+    expect(buttons[0].textContent).toBe('X')
+    expect(buttons[1].textContent).toBe('L')
+    expect(buttons[2].textContent).toBe('R')
+  })
+
+  test('legacy SSR with two same-name children (bf-s suffixes only) — each slot resolves correctly', () => {
+    // Predates the bf-parent/bf-mount markers — only bf-s suffix info
+    // survives. Two same-name children at distinct slot ids must each
+    // resolve to their OWN suffix-matched SSR scope. The suffix selector
+    // (`[bf-s$="_<slotId>"]`) is unique enough to disambiguate; the fix
+    // adds belt-and-braces filtering via `bf-mount` which is irrelevant
+    // here (no bf-mount in legacy markup), so resolution still works.
+    hydrate('Item', {
+      init: () => {},
+      template: () => '<i bf="s0"></i>',
+    })
+    flushHydration()
+
+    const anchor = document.createElement('div')
+    anchor.setAttribute('bf-s', 'Parent_test')
+    document.body.appendChild(anchor)
+
+    const host = document.createElement('div')
+    // Two SSR scopes already in tree (legacy shape, no bf-mount).
+    host.innerHTML =
+      '<i class="a" bf-s="~Item_legacy_s10"></i>' +
+      '<i class="b" bf-s="~Item_legacy_s11"></i>'
+    anchor.appendChild(host)
+
+    const a = upsertChild(host, 'Item', 's10', {}, undefined, anchor)
+    expect(a).not.toBeNull()
+    expect(a!.classList.contains('a')).toBe(true)
+
+    const b = upsertChild(host, 'Item', 's11', {}, undefined, anchor)
+    expect(b).not.toBeNull()
+    expect(b!.classList.contains('b')).toBe(true)
+  })
+})

--- a/packages/client/src/runtime/apply-rest-attrs.ts
+++ b/packages/client/src/runtime/apply-rest-attrs.ts
@@ -6,6 +6,7 @@
  */
 
 import { createEffect } from '@barefootjs/client/reactive'
+import { styleToCss } from './style'
 
 /** Map of JSX prop names to HTML attribute names */
 function toAttrName(key: string): string {
@@ -64,6 +65,13 @@ export function applyRestAttrs(
 
       // Event handlers and ref are wired up above, not as attributes
       if (key === 'ref') continue
+      // `children` is a JSX construct rendered inside the element, never
+      // a DOM attribute. Without this exclusion, parent components that
+      // pass `children` through `{...props}` end up with
+      // `children="<p ...>...</p>"` written as a literal attribute on
+      // the wrapper div. The matching `spreadAttrs` (SSR-string) path
+      // already skips `children` for the same reason.
+      if (key === 'children') continue
       if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) continue
 
       const value = source[key]
@@ -76,6 +84,16 @@ export function applyRestAttrs(
           if ((el as HTMLInputElement).value !== strVal) (el as HTMLInputElement).value = strVal
         } else if (attr === 'checked' && 'checked' in el) {
           (el as HTMLInputElement).checked = !!value
+        } else if (attr === 'style') {
+          // Route the `style` prop through `styleToCss` so object literals
+          // (`{'--err': errorHue()}`) and inline strings (`'color:red'`)
+          // both reach the DOM as a real CSS string instead of
+          // `[object Object]`. Mirrors the compiler's
+          // `setAttribute('style', styleToCss(...))` path used when the
+          // attribute is bound directly on a JSX element.
+          const css = styleToCss(value)
+          if (css == null) el.removeAttribute('style')
+          else el.setAttribute('style', css)
         } else {
           el.setAttribute(attr, String(value))
         }

--- a/packages/client/src/runtime/slot-resolver.ts
+++ b/packages/client/src/runtime/slot-resolver.ts
@@ -21,6 +21,22 @@ import { BF_SCOPE, BF_CHILD_PREFIX, BF_PARENT, BF_MOUNT } from '@barefootjs/shar
  *  wrong `initChild` never fires (#1220). */
 const NESTED_SLOT_SUFFIX = /_s\d+_s\d+$/
 
+/** A candidate element is "claimed for a different slot" when it already
+ *  carries a `bf-mount` attribute that doesn't match the slot we're
+ *  looking for. That can only happen when a previous `upsertChild` in
+ *  the SAME parent has CSR-replaced a sibling placeholder and stamped
+ *  the new component's metadata onto it. Without this filter the
+ *  legacy fallbacks (suffix + name-prefix) happily return the
+ *  already-mounted sibling and `initChild` fires on the wrong element,
+ *  leaving the actual `data-bf-ph` placeholder for `slotId` orphaned.
+ *  Surfaces when a `.map()` inserts a fresh item whose body holds
+ *  multiple child components of the same name (#135 board demo:
+ *  delete-task + move-left + move-right Buttons inside one task card). */
+function isClaimedForOtherSlot(candidate: Element, slotId: string): boolean {
+  const mount = candidate.getAttribute(BF_MOUNT)
+  return mount !== null && mount !== slotId
+}
+
 /** Resolve the parent component scope id (without the `~` child prefix)
  *  for a slot lookup. Prefers the explicit `anchorScope` because the
  *  immediate `parent` element may be a freshly-created detached fragment
@@ -96,13 +112,19 @@ export function findSsrScopeBySlotIn(
   for (const candidate of candidates) {
     const bfs = candidate.getAttribute(BF_SCOPE) || ''
     if (NESTED_SLOT_SUFFIX.test(bfs)) continue
+    if (isClaimedForOtherSlot(candidate, slotId)) continue
     return candidate as HTMLElement
   }
 
   // Last-resort fallback: component-name prefix search.
   const namePrefixSelector = `[${BF_SCOPE}^="~${name}_"], [${BF_SCOPE}^="${name}_"]`
-  if (selfMatch && parent.matches(namePrefixSelector)) {
+  if (selfMatch && parent.matches(namePrefixSelector) && !isClaimedForOtherSlot(parent, slotId)) {
     return parent as HTMLElement
   }
-  return parent.querySelector(namePrefixSelector) as HTMLElement | null
+  const prefixMatches = Array.from(parent.querySelectorAll(namePrefixSelector))
+  for (const candidate of prefixMatches) {
+    if (isClaimedForOtherSlot(candidate, slotId)) continue
+    return candidate as HTMLElement
+  }
+  return null
 }

--- a/packages/client/src/runtime/spread-attrs.ts
+++ b/packages/client/src/runtime/spread-attrs.ts
@@ -6,10 +6,14 @@
  * a static string for server/template rendering of computed local spreads.
  */
 
+import { styleToCss } from './style'
+
 /**
  * Convert an object to an HTML attribute string.
  * Aligned with applyRestAttrs conventions: skips null/undefined/false,
- * event handlers, maps className→class and htmlFor→for.
+ * event handlers, maps className→class and htmlFor→for. The `style`
+ * prop is routed through `styleToCss` so object literals serialize to
+ * a real CSS string (matching the reactive `applyRestAttrs` path).
  */
 export function spreadAttrs(obj: Record<string, unknown>): string {
   if (!obj || typeof obj !== 'object') return ''
@@ -20,6 +24,11 @@ export function spreadAttrs(obj: Record<string, unknown>): string {
     if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) continue
     // Skip children prop
     if (key === 'children') continue
+    if (key === 'style') {
+      const css = styleToCss(value)
+      if (css != null) parts.push(`style="${css}"`)
+      continue
+    }
     // Map JSX prop names to HTML attribute names
     const attr = key === 'className' ? 'class' : key === 'htmlFor' ? 'for'
       : key.replace(/([A-Z])/g, '-$1').toLowerCase()

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -101,6 +101,51 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     expect(content).toContain('active()')
   })
 
+  test('`attr={expr || undefined}` uses truthy check, not `!= null`', () => {
+    // Regression for the calendar break: `data-outside={day.isOutside ||
+    // undefined}` is normalised by jsx-to-ir to bare `day.isOutside` +
+    // `presenceOrUndefined: true`. Without the dedicated emit shape,
+    // the generic `__v != null` branch fires for `false` and writes
+    // `data-outside="false"`, which then trips Playwright selectors
+    // like `:not([data-outside])`.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number; isOff: boolean; label: string }
+      type Row = { id: string; cells: Cell[] }
+
+      export function Grid() {
+        const [hover, setHover] = createSignal<number | null>(null)
+        const [rows] = createSignal<Row[]>([])
+        return (
+          <div>
+            {rows().map(r => (
+              <div key={r.id}>
+                {r.cells.map(c => (
+                  <button
+                    key={c.id}
+                    data-off={c.isOff || undefined}
+                    aria-pressed={hover() === c.id || undefined}
+                  >{c.label}</button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Grid.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+
+    // `data-off` uses the truthy-check shape (no `__v != null` for this
+    // attribute) so a concrete `false` removes the attribute.
+    expect(content).toMatch(/createEffect\(\(\) => \{ if \([^)]*c\(\)\.isOff[^)]*\)\s*[^.]+\.setAttribute\('data-off',\s*''\)/)
+    // aria-* keeps the explicit "true" value per WAI-ARIA.
+    expect(content).toContain("setAttribute('aria-pressed', 'true')")
+  })
+
   test('inner-loop event handler keeps working alongside reactive attrs', () => {
     // Regression guard — make sure adding the reactive-attr emission
     // didn't break the existing inner-loop event-handler emission path.

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -1,0 +1,139 @@
+/**
+ * BarefootJS Compiler — Reactive attributes on a NESTED `.map()` body (#135).
+ *
+ * Background: top-level `.map()` already wires `createEffect` for
+ * signal-driven attributes on the loop body's root element (covered by
+ * `reactive-attrs-in-map.test.ts`). Until #135 the same plumbing was
+ * missing for INNER loops — `collectInnerLoops` collected reactive
+ * texts but no reactive attrs, the per-item renderItem only emitted
+ * `__rt.textContent = …` effects, and `style` / `data-*` / `className`
+ * bindings stayed frozen at the SSR value.
+ *
+ * Surfaced by the board demo's drag preview (#135 Concrete Additions)
+ * where `style={{'--drag-opacity': draggingTaskId() === task.id ? '0.4'
+ * : '1'}}` on a nested `tasks.map()` root never updated.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('reactive attributes inside a nested .map() body (#135)', () => {
+  test('object-style binding on a nested .map() root emits per-item createEffect', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Col { id: string; tasks: { id: number; title: string }[] }
+
+      export function Board() {
+        const [draggingId, setDraggingId] = createSignal<number | null>(null)
+        const [cols, setCols] = createSignal<Col[]>([])
+        return (
+          <div>
+            {cols().map(col => (
+              <div key={col.id}>
+                {col.tasks.map(task => (
+                  <div
+                    key={task.id}
+                    style={{ '--drag-opacity': draggingId() === task.id ? '0.4' : '1' }}
+                    data-dragging={draggingId() === task.id ? 'true' : 'false'}
+                    onPointerDown={() => setDraggingId(task.id)}
+                  >{task.title}</div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Board.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // The per-item renderItem callback for the inner `tasks.map(...)`
+    // must emit `createEffect` blocks that re-evaluate the reactive
+    // `style` and `data-dragging` bindings on the inner-loop root.
+    expect(content).toContain("setAttribute('style'")
+    expect(content).toContain("setAttribute('data-dragging'")
+    expect(content).toContain('styleToCss')
+    // Both effects must run inside the inner mapArray's renderItem (so
+    // they capture `task` as the inner-loop accessor — `task()` rather
+    // than the module-level closure).
+    expect(content).toMatch(/createEffect\(\(\) => \{\s*const __v = styleToCss\([\s\S]*?task\(\)\.id/)
+  })
+
+  test('non-style reactive attribute (className) wires up too', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Row = { id: number; label: string }
+      type Group = { id: string; rows: Row[] }
+
+      export function Tbl() {
+        const [active, setActive] = createSignal<number | null>(null)
+        const [groups] = createSignal<Group[]>([])
+        return (
+          <div>
+            {groups().map(g => (
+              <div key={g.id}>
+                {g.rows.map(r => (
+                  <span key={r.id} className={active() === r.id ? 'on' : 'off'}>{r.label}</span>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Tbl.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+
+    // className uses the kebab `class` attribute name once routed
+    // through `toHtmlAttrName`.
+    expect(content).toContain("setAttribute('class'")
+    expect(content).toContain('active()')
+  })
+
+  test('inner-loop event handler keeps working alongside reactive attrs', () => {
+    // Regression guard — make sure adding the reactive-attr emission
+    // didn't break the existing inner-loop event-handler emission path.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Item = { id: number; label: string }
+
+      export function L() {
+        const [sel, setSel] = createSignal<number | null>(null)
+        const [groups] = createSignal<{ id: string; items: Item[] }[]>([])
+        return (
+          <div>
+            {groups().map(g => (
+              <div key={g.id}>
+                {g.items.map(it => (
+                  <button
+                    key={it.id}
+                    className={sel() === it.id ? 'sel' : ''}
+                    onClick={() => setSel(it.id)}
+                  >{it.label}</button>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'L.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+    expect(content).toContain("addEventListener('click'")
+    expect(content).toContain("setAttribute('class'")
+  })
+})

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -181,4 +181,117 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     expect(content).toContain("addEventListener('click'")
     expect(content).toContain("setAttribute('class'")
   })
+
+  test('JS comment with apostrophe inside an inner-loop style object does not swallow loop-param refs', () => {
+    // Regression for the silently-dropped `task()` wrap (#135 board demo
+    // drag preview). The compiler routes reactive-attr expressions
+    // through `wrapLoopParamAsAccessor`, whose string-context-aware
+    // replacement walked `'`, `"`, `` ` `` — but ignored JS comments. An
+    // apostrophe in an inline `//` comment inside the `style={{…}}`
+    // object literal (e.g. `they're "holding"`) was interpreted as the
+    // start of a string literal; the scanner then read up to the next
+    // `'` (the next CSS-var key) and skipped every loop-param reference
+    // in between. Result: `task.id` stayed unwrapped, the effect closed
+    // over the loop-callback's parameter at first iteration, and the
+    // style attribute never reacted.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: number }
+      type Col = { id: string; tasks: Task[] }
+
+      export function B() {
+        const [dragId, setDragId] = createSignal<number | null>(null)
+        const [cols] = createSignal<Col[]>([])
+        return (
+          <div>
+            {cols().map(col => (
+              <div key={col.id}>
+                {col.tasks.map(task => (
+                  <div
+                    key={task.id}
+                    style={{
+                      // user can tell at a glance which card they're "holding"
+                      '--drag-opacity': dragId() === task.id ? '0.4' : '1',
+                      '--drag-scale': dragId() === task.id ? '1.03' : '1',
+                    }}
+                  >{task.id}</div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'B.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+
+    // The compiler emits the style object literally in TWO places: the
+    // outer-loop SSR template (raw `task.id`, no per-item wrap needed)
+    // and the inner-loop reactive `createEffect` (must be `task().id`
+    // to subscribe to the per-item accessor). The bug we're locking
+    // down is purely in the createEffect emission, so scope to that.
+    const effectMatch = content.match(
+      /createEffect\(\(\) => \{ const __v = styleToCss\(\{[\s\S]*?\}\); if \(__v != null\) __ta_s\d+\.setAttribute\('style'/,
+    )
+    expect(effectMatch).not.toBeNull()
+    const effectBody = effectMatch![0]
+    // Inside the createEffect, every loop-param ref to `task.id` MUST
+    // be wrapped — otherwise the closure pins to the first iteration's
+    // `task` argument and the effect never re-runs per-item.
+    expect(effectBody).not.toMatch(/\btask\.id\b/)
+    expect(effectBody.match(/task\(\)\.id/g)?.length ?? 0).toBeGreaterThanOrEqual(2)
+  })
+
+  test('block comment with quotes inside an inner-loop style object is also skipped', () => {
+    // Mirror of the line-comment regression for `/* … */` form. The same
+    // string-walker that confused `//` comments would also have missed
+    // block comments. The fix skips both forms; this test pins the
+    // block-comment branch in place.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Cell = { id: number }
+      type Row = { id: string; cells: Cell[] }
+
+      export function G() {
+        const [hover, setHover] = createSignal<number | null>(null)
+        const [rows] = createSignal<Row[]>([])
+        return (
+          <div>
+            {rows().map(r => (
+              <div key={r.id}>
+                {r.cells.map(c => (
+                  <div
+                    key={c.id}
+                    style={{
+                      /* note: c.id is the cell's "stable" key */
+                      '--w': hover() === c.id ? '8' : '4',
+                    }}
+                  >{c.id}</div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'G.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+    const effectMatch = content.match(
+      /createEffect\(\(\) => \{ const __v = styleToCss\(\{[\s\S]*?\}\); if \(__v != null\) __ta_s\d+\.setAttribute\('style'/,
+    )
+    expect(effectMatch).not.toBeNull()
+    const effectBody = effectMatch![0]
+    // After the fix, `c.id` in the active expression IS wrapped to
+    // `c().id`. The `c.id` reference inside the block comment is left
+    // intact because the walker skips it — that's a side-effect of
+    // the comment-aware scan, but the strict assertion is just that
+    // the live conditional sees the wrapped accessor.
+    expect(effectBody).toContain('c().id')
+  })
 })

--- a/packages/jsx/src/__tests__/style-css-var-reactive.test.ts
+++ b/packages/jsx/src/__tests__/style-css-var-reactive.test.ts
@@ -1,0 +1,119 @@
+/**
+ * BarefootJS Compiler - Reactive CSS custom properties via `style={{}}` (#135).
+ *
+ * The Concrete Additions section of the Phase 9 issue calls for landing
+ * `style={{'--foo': signalOrMemo()}}` patterns across the gallery. The
+ * runtime path goes through `styleToCss` so the inline object literal is
+ * converted to a CSS string at both SSR and hydration time, and the
+ * compiler must keep the two outputs aligned even when the property value
+ * references a signal or memo.
+ *
+ * Two related guarantees this file locks down:
+ *
+ *   1. A dynamic CSS custom property fires a `createEffect` that calls
+ *      `setAttribute('style', styleToCss({...}))`. The custom property
+ *      name (`--foo`) survives the camelCase → kebab-case pass.
+ *
+ *   2. The SSR template substitutes a `createMemo`'s computation for the
+ *      property value so the initial paint matches hydration. Plain
+ *      arrow constants (`const f = () => sig()`) are NOT substituted by
+ *      design — this test pins the canonical `createMemo` path that
+ *      validation-demo's async demo relies on.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('reactive CSS custom properties (#135)', () => {
+  test('signal-driven CSS var fires setAttribute("style", styleToCss(...))', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Bar() {
+        const [pct, setPct] = createSignal('25%')
+        return <div style={{ '--w': pct() }}>x</div>
+      }
+    `
+    const result = compileJSX(source, 'Bar.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Reactive update path uses styleToCss + setAttribute('style', ...).
+    expect(content).toContain('createEffect')
+    expect(content).toContain("setAttribute('style'")
+    expect(content).toContain('styleToCss({')
+    expect(content).toContain("'--w'")
+    // The custom property name must NOT be converted to camelCase.
+    expect(content).not.toContain('"--W"')
+    expect(content).not.toContain("'--W'")
+  })
+
+  test('createMemo body is inlined into the SSR style template', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      export function H() {
+        const [level, setLevel] = createSignal(0)
+        const hue = createMemo(() => {
+          const lvl = level()
+          if (lvl === 1) return '140'
+          if (lvl === 2) return '40'
+          if (lvl === 3) return '0'
+          return '210'
+        })
+        return <p style={{ '--err': hue() }}>msg</p>
+      }
+    `
+    const result = compileJSX(source, 'H.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // SSR template inlines the memo as an IIFE with the signal's initial
+    // value substituted so the server-rendered `style` attribute is
+    // identical to what hydration would write.
+    expect(content).toContain("template: (_p) => `<p")
+    expect(content).toContain("styleToCss({ '--err': ((() => {")
+    expect(content).toContain('const lvl = (0)')
+    expect(content).toContain("return '210'")
+  })
+
+  test('reactive `aria-busy` and `disabled` on the same component re-emit independently', () => {
+    // Locks the Async demo's three-signal-flips-together pattern at the
+    // compiler level: both attribute bindings must be emitted as
+    // independent reactive updates that respond to the shared
+    // `validating()` setter.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function W() {
+        const [busy, setBusy] = createSignal(false)
+        return (
+          <button
+            disabled={busy()}
+            aria-busy={busy() ? 'true' : 'false'}
+          >ok</button>
+        )
+      }
+    `
+    const result = compileJSX(source, 'W.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find((f) => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Both reactive sinks live in the init body — one assigning the DOM
+    // `disabled` property, the other writing the `aria-busy` attribute.
+    expect(content).toMatch(/\.disabled\s*=\s*!!\(busy\(\)\)/)
+    expect(content).toContain("setAttribute('aria-busy'")
+  })
+})

--- a/packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts
+++ b/packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts
@@ -83,6 +83,53 @@ describe('SVG attribute kebab-case emission (#135)', () => {
     expect(content).not.toContain('className=')
   })
 
+  test('reactive SVG attributes inside .map() use kebab-case for setAttribute', () => {
+    // Regression: Pie chart "Animated" demo (#135 Concrete Additions). The
+    // path lives inside a `.map()` body, and the reactive update on
+    // `stroke-dashoffset` is driven by a high-frequency `progress()` signal
+    // fed by `requestAnimationFrame`. If the per-item reactive
+    // `setAttribute` did not match the SSR kebab spelling, both attributes
+    // would coexist on the DOM and the rAF tick would write the wrong one.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Slice = { name: string; d: string; fill: string }
+
+      export function Wheel() {
+        const [progress] = createSignal(1)
+        const slices: Slice[] = []
+        return (
+          <svg viewBox="0 0 100 100">
+            <g>
+              {slices.map((s) => (
+                <path
+                  key={s.name}
+                  d={s.d}
+                  fill={s.fill}
+                  strokeDasharray={String(800)}
+                  strokeDashoffset={String(800 * (1 - progress()))}
+                />
+              ))}
+            </g>
+          </svg>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Wheel.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    const content = clientJs!.content
+
+    // Reactive update goes through setAttribute with the kebab spelling.
+    expect(content).toContain("'stroke-dashoffset'")
+    expect(content).not.toContain("'strokeDashoffset'")
+    // SSR template literal uses the kebab spelling as well.
+    expect(content).toContain('stroke-dashoffset=')
+    expect(content).not.toContain('strokeDashoffset=')
+  })
+
   test('non-SVG camelCase attributes are NOT converted', () => {
     // tabIndex, autoFocus, etc. are HTML attributes that stay camelCase
     // in the JSX → DOM property pipeline (or get specific handling

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -163,6 +163,21 @@ export function collectInnerLoops(
           }
         }
 
+        // Collect reactive attribute bindings inside inner loop items.
+        // Mirrors the text collector above so signal-driven attributes on
+        // the inner-loop body root (and any descendant) wire up a
+        // per-item createEffect that updates the DOM when the dependent
+        // signal changes. Without this, the SSR template renders the
+        // initial value and the attribute stays frozen forever — see
+        // the board demo's drag-preview `--drag-opacity` regression
+        // (#135 Concrete Additions).
+        const innerReactiveAttrs: import('./types').LoopChildReactiveAttr[] = []
+        if (ctx) {
+          for (const child of n.children) {
+            innerReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, n.param, n.paramBindings))
+          }
+        }
+
         // Per-item bindings for branch-mode callers (child components,
         // events, nested conditionals) — matches the pre-Phase 2
         // `collectBranchInnerLoops` behaviour.
@@ -225,6 +240,7 @@ export function collectInnerLoops(
           mapPreamble: n.mapPreamble,
           refsOuterParam: refsOuter,
           childReactiveTexts: innerReactiveTexts.length > 0 ? innerReactiveTexts : undefined,
+          childReactiveAttrs: innerReactiveAttrs.length > 0 ? innerReactiveAttrs : undefined,
           childComponents,
           childEvents,
           childConditionals,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -179,6 +179,7 @@ function buildReactiveEmit(
       wrappedExpression: wrapped,
       isStyleObject,
       isBoolean: isBooleanAttr(attr.attrName),
+      presenceOrUndefined: !!attr.presenceOrUndefined,
     }
   })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -33,11 +33,14 @@ import {
 } from '../shared'
 import type {
   InnerLoopPlan,
+  InnerLoopReactiveAttr,
   InnerLoopReactiveEmit,
   InnerLoopStaticEmit,
   InnerLoopText,
   InnerLoopsPlan,
 } from './inner-loop'
+import { toHtmlAttrName } from '../../utils'
+import { isBooleanAttr } from '../../../html-constants'
 
 export interface BuildInnerLoopsArgs {
   levels: readonly DepthLevel[]
@@ -167,6 +170,18 @@ function buildReactiveEmit(
     insideConditional: !!text.insideConditional,
   }))
 
+  const reactiveAttrs: InnerLoopReactiveAttr[] = (inner.childReactiveAttrs ?? []).map(attr => {
+    const wrapped = wrapLoopParamAsAccessor(wrapOuter(attr.expression), inner.param, inner.paramBindings)
+    const isStyleObject = attr.attrName === 'style' && /^\s*\{/.test(attr.expression)
+    return {
+      slotId: attr.childSlotId,
+      attrName: toHtmlAttrName(attr.attrName),
+      wrappedExpression: wrapped,
+      isStyleObject,
+      isBoolean: isBooleanAttr(attr.attrName),
+    }
+  })
+
   // The inner `.map()` callback's block-body locals (e.g.
   // `const derivedClass = cell.flag ? 'on' : 'off'`) are baked into
   // `inner.template` at the outer-loop SSR level, but the `mapArray`
@@ -192,6 +207,7 @@ function buildReactiveEmit(
     components,
     events,
     reactiveTexts,
+    reactiveAttrs,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -61,6 +61,15 @@ export interface InnerLoopReactiveAttr {
   isStyleObject: boolean
   /** True for boolean DOM attributes (`disabled`, `checked`, ...). */
   isBoolean: boolean
+  /**
+   * True for `attr={expr || undefined}` patterns where the compiler
+   * stripped the `|| undefined` and now stores the bare expression.
+   * The emitter must use a truthy check (not `!= null`) — otherwise a
+   * concrete `false` value writes `data-attr="false"` instead of
+   * removing the attribute. Surfaced by the calendar demo's
+   * `data-outside={day.isOutside || undefined}` on a nested map root.
+   */
+  presenceOrUndefined: boolean
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -42,6 +42,28 @@ export interface InnerLoopText {
 }
 
 /**
+ * A reactive attribute effect inside a reactive inner loop's renderItem
+ * body. Mirrors `InnerLoopText` for `style`, `data-*`, `className`,
+ * etc. — every element in the loop body whose attribute reads a signal
+ * (or the loop param) gets its own per-item `createEffect`.
+ *
+ * `attrName` is already in DOM-spelling (kebab for SVG presentation
+ * attrs, `class` for `className`) so the stringifier can emit
+ * `setAttribute(attrName, ...)` directly.
+ */
+export interface InnerLoopReactiveAttr {
+  slotId: string
+  /** DOM attribute name (already mapped via `toHtmlAttrName`). */
+  attrName: string
+  /** Already wrapped via inner+outer loop param accessor. */
+  wrappedExpression: string
+  /** True for `style={{...}}` object literals — routed through `styleToCss`. */
+  isStyleObject: boolean
+  /** True for boolean DOM attributes (`disabled`, `checked`, ...). */
+  isBoolean: boolean
+}
+
+/**
  * One inner loop level inside a composite renderItem.
  *
  * The `mode` discriminator selects the emission shape:
@@ -118,6 +140,8 @@ export interface InnerLoopReactiveEmit {
   events: readonly LoopChildEvent[]
   /** Pre-wrapped reactive text effects for the inner-item body. */
   reactiveTexts: readonly InnerLoopText[]
+  /** Pre-wrapped reactive attribute effects for the inner-item body. */
+  reactiveAttrs: readonly InnerLoopReactiveAttr[]
 }
 
 export interface InnerLoopStaticEmit {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -119,6 +119,15 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
       lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = styleToCss(${attr.wrappedExpression}); if (__v != null) ${targetVar}.setAttribute('style', __v); else ${targetVar}.removeAttribute('style') }) }`)
     } else if (attr.isBoolean) {
       lines.push(`${indent}  if (${targetVar}) createEffect(() => { if (${attr.wrappedExpression}) ${targetVar}.setAttribute('${attr.attrName}', ''); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
+    } else if (attr.presenceOrUndefined) {
+      // `attr={expr || undefined}` was normalised by jsx-to-ir to the
+      // bare expression + presenceOrUndefined=true. Use a truthy check
+      // so a concrete `false` value removes the attribute instead of
+      // writing `data-foo="false"`. aria-* attributes must keep an
+      // explicit "true" value per WAI-ARIA. Surfaced by calendar's
+      // `data-outside={day.isOutside || undefined}` (#135 follow-up).
+      const ariaVal = attr.attrName.startsWith('aria-') ? "'true'" : "''"
+      lines.push(`${indent}  if (${targetVar}) createEffect(() => { if (${attr.wrappedExpression}) ${targetVar}.setAttribute('${attr.attrName}', ${ariaVal}); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
     } else {
       lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = ${attr.wrappedExpression}; if (__v != null) ${targetVar}.setAttribute('${attr.attrName}', String(__v)); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
     }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -108,6 +108,21 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
       lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }) }`)
     }
   }
+  // Reactive attribute effects: emit one `createEffect` per attribute
+  // binding so a signal change updates the inner-loop element's DOM
+  // attribute in place (mirrors `collectLoopChildReactiveAttrs` for
+  // top-level loops).
+  for (const attr of emit.reactiveAttrs) {
+    const targetVar = `__ta_${attr.slotId.replace(/[^a-zA-Z0-9]/g, '_')}`
+    lines.push(`${indent}  { const ${targetVar} = qsa(__innerEl${uid}, '[bf="${attr.slotId}"]')`)
+    if (attr.isStyleObject) {
+      lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = styleToCss(${attr.wrappedExpression}); if (__v != null) ${targetVar}.setAttribute('style', __v); else ${targetVar}.removeAttribute('style') }) }`)
+    } else if (attr.isBoolean) {
+      lines.push(`${indent}  if (${targetVar}) createEffect(() => { if (${attr.wrappedExpression}) ${targetVar}.setAttribute('${attr.attrName}', ''); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
+    } else {
+      lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = ${attr.wrappedExpression}; if (__v != null) ${targetVar}.setAttribute('${attr.attrName}', String(__v)); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
+    }
+  }
   lines.push(`${indent}  return __innerEl${uid}`)
   lines.push(`${indent}}, '${inner.markerId}') }`)
 }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -260,6 +260,18 @@ export interface NestedLoop extends LoopCore {
   refsOuterParam?: boolean
   /** Reactive text expressions inside inner loop items (slotId → expression) */
   childReactiveTexts?: LoopChildReactiveText[]
+  /**
+   * Reactive attribute bindings inside inner loop items. Mirrors
+   * `childReactiveTexts` for attributes like `style`, `data-*`,
+   * `className`, etc., on the loop body's root or any descendant. Without
+   * this field, inner-loop bodies that bind a signal-driven attribute on
+   * the root element get no per-item `createEffect` and the attribute
+   * stays frozen at the SSR value. Surfaced by the board demo's drag
+   * preview (#135 Concrete Additions) where the `style={{'--drag-opacity':
+   * draggingTaskId() === task.id ? '0.4' : '1'}}` binding on a nested
+   * `tasks.map()` root never updated.
+   */
+  childReactiveAttrs?: LoopChildReactiveAttr[]
   /** Child components inside inner loop items (for initChild/createComponent) */
   childComponents?: import('../types').IRLoopChildComponent[]
   /** Event handlers inside inner loop items */

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -325,7 +325,17 @@ export function substituteLoopBindings(
 // offsets have heterogeneous types; narrow them at the callback instead.
 type Replacement = string | ((substring: string, ...args: any[]) => string)
 
-/** Replace `re` with `replacement` only in expression contexts (not in string literals). */
+/** Replace `re` with `replacement` only in expression contexts (not in
+ *  string literals or JS comments).
+ *
+ *  Comment-skipping is required for prop values that survive into the
+ *  emitted client JS verbatim (e.g. object-literal `style={{…}}` props
+ *  with a `// ...` inline note). Apostrophes in such a comment (e.g.
+ *  `// they're "holding"`) would otherwise be mistaken for a string
+ *  start, swallowing the rest of the expression up to the next single
+ *  quote and skipping every loop-param reference in between — the
+ *  symptom of #135 board demo's silent failure to wrap `task.id` to
+ *  `task().id` inside the inner-loop reactive style effect. */
 function _replaceInExprContexts(code: string, re: RegExp, replacement: Replacement): string {
   let result = ''
   let i = 0
@@ -355,12 +365,37 @@ function _replaceInExprContexts(code: string, re: RegExp, replacement: Replaceme
       result += tplResult
       i = nextI
       exprStart = i
+    } else if (ch === '/' && code[i + 1] === '/') {
+      flushExpr(i)
+      i = _skipLineComment(code, i)
+      result += code.slice(exprStart, i)
+      exprStart = i
+    } else if (ch === '/' && code[i + 1] === '*') {
+      flushExpr(i)
+      i = _skipBlockComment(code, i)
+      result += code.slice(exprStart, i)
+      exprStart = i
     } else {
       i++
     }
   }
   flushExpr(i)
   return result
+}
+
+function _skipLineComment(code: string, start: number): number {
+  let i = start + 2
+  while (i < code.length && code[i] !== '\n') i++
+  return i
+}
+
+function _skipBlockComment(code: string, start: number): number {
+  let i = start + 2
+  while (i < code.length - 1) {
+    if (code[i] === '*' && code[i + 1] === '/') return i + 2
+    i++
+  }
+  return code.length
 }
 
 function _skipQuotedString(code: string, start: number): number {
@@ -431,6 +466,16 @@ function _processInterpolation(code: string, start: number, re: RegExp, replacem
       const [tplResult, nextI] = _processTemplateLiteral(code, i, re, replacement)
       result += tplResult
       i = nextI
+      exprStart = i
+    } else if (ch === '/' && code[i + 1] === '/') {
+      flushExpr(i)
+      i = _skipLineComment(code, i)
+      result += code.slice(exprStart, i)
+      exprStart = i
+    } else if (ch === '/' && code[i + 1] === '*') {
+      flushExpr(i)
+      i = _skipBlockComment(code, i)
+      result += code.slice(exprStart, i)
       exprStart = i
     } else if (ch === '{') {
       depth++

--- a/site/ui/components/area-chart-demo.tsx
+++ b/site/ui/components/area-chart-demo.tsx
@@ -146,3 +146,73 @@ export function AreaChartInteractiveDemo() {
     </div>
   )
 }
+
+/**
+ * Palette demo — CSS custom property reactive on a chart wrapper.
+ *
+ * A `palette()` signal picks a named colour. Instead of binding the
+ * SVG `fill` / `stroke` attributes directly to the colour value, the
+ * demo writes `style={{'--area-fill': palette()}}` on the wrapper div,
+ * and the `<Area>` reads it back via `fill="var(--area-fill)"`. This
+ * exercises the path where:
+ *
+ *   - A reactive `style` object literal is bound on an HTML element
+ *     (not a passed-through `...props` spread).
+ *   - CSS cascade carries the value into an SVG presentation attribute
+ *     in a descendant rendered by another component.
+ *
+ * The CSS variable is the only thing that flips on palette change —
+ * the chart subtree is otherwise structurally identical.
+ */
+const PALETTES = {
+  ocean: 'hsl(199 89% 48%)',
+  sunset: 'hsl(20 90% 55%)',
+  forest: 'hsl(142 71% 35%)',
+} as const
+type PaletteName = keyof typeof PALETTES
+
+export function AreaChartPaletteDemo() {
+  const [palette, setPalette] = createSignal<PaletteName>('ocean')
+
+  return (
+    <div
+      className="w-full space-y-4"
+      style={{ '--area-fill': PALETTES[palette()] }}
+      data-area-palette-demo
+      data-palette={palette()}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Palette:</span>
+        {(Object.keys(PALETTES) as PaletteName[]).map((p) => (
+          <button
+            key={p}
+            type="button"
+            data-palette-option={p}
+            className={`inline-flex items-center justify-center rounded-md text-sm font-medium h-8 px-3 capitalize ${
+              palette() === p
+                ? 'bg-primary text-primary-foreground'
+                : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+            }`}
+            onClick={() => setPalette(p)}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <AreaChart data={chartData}>
+          <AreaCartesianGrid vertical={false} />
+          <AreaXAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <AreaYAxis />
+          <AreaChartTooltip />
+          <Area
+            dataKey="desktop"
+            fill="var(--area-fill)"
+            stroke="var(--area-fill)"
+            fillOpacity={0.35}
+          />
+        </AreaChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/site/ui/components/gallery/admin/analytics-demo.tsx
+++ b/site/ui/components/gallery/admin/analytics-demo.tsx
@@ -227,6 +227,31 @@ export function AdminAnalyticsDemo() {
     return [...bySource.values()]
   })
 
+  // Per-source performance aggregate that feeds the Source Stat cards
+  // below. Each entry's `accent` is consumed as a CSS custom property
+  // (`--stat-c`) on the card so the visual variant is driven by data,
+  // not by a swap of static utility classes (`bg-blue-500` vs
+  // `bg-green-500`). Tests the CSS-var × .map() × per-item reactive
+  // path — the only attribute that changes when `sourceFilter` flips
+  // the visible rows is the inline `style`.
+  const sourceStatsByKey = createMemo(() => {
+    const sources: TrafficSource[] = ['organic', 'direct', 'referral', 'social', 'paid']
+    return sources.map((s) => {
+      const rows = filteredData().filter((r) => r.source === s)
+      const visitors = rows.reduce((acc, r) => acc + r.visitors, 0)
+      const revenue = rows.reduce((acc, r) => acc + r.revenue, 0)
+      const totalVisitors = aggregateStats().totalVisitors
+      const share = totalVisitors > 0 ? Math.round((visitors / totalVisitors) * 100) : 0
+      return {
+        source: s,
+        accent: sourceColors[s],
+        visitors,
+        revenue,
+        share,
+      }
+    })
+  })
+
   const handleSort = (key: 'page' | 'views' | 'visitors' | 'bounceRate' | 'revenue') => {
     if (sortKey() === key) {
       setSortDir(sortDir() === 'asc' ? 'desc' : 'asc')
@@ -341,6 +366,31 @@ export function AdminAnalyticsDemo() {
             <p className="text-sm text-muted-foreground">across {filteredData().length} pages</p>
           </CardContent>
         </Card>
+      </div>
+
+      <div
+        className="source-stat-grid grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-5"
+        data-source-stat-grid
+      >
+        {sourceStatsByKey().map((s) => (
+          <Card
+            key={s.source}
+            className="source-stat-card"
+            style={{ '--stat-c': s.accent }}
+            data-source-stat={s.source}
+          >
+            <CardHeader className="pb-2">
+              <CardDescription className="capitalize">{s.source}</CardDescription>
+              <CardTitle className="text-xl">{s.visitors.toLocaleString()}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-xs text-muted-foreground">
+                <span data-source-share>{s.share}</span>% of visitors
+              </p>
+              <p className="text-xs text-muted-foreground">{formatCurrency(s.revenue)}</p>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">

--- a/site/ui/components/gallery/productivity/board-demo.tsx
+++ b/site/ui/components/gallery/productivity/board-demo.tsx
@@ -80,8 +80,17 @@ export function ProductivityBoardDemo() {
   // on a `.map()` root, the compiler path adjacent to the outstanding
   // Dashboard Builder reactive-className-on-.map()-root bug.
   const [draggingTaskId, setDraggingTaskId] = createSignal<number | null>(null)
+  // Column currently under the dragged card (HTML5 DnD hover target).
+  // Drives a per-column reactive `style={{'--drop-active': …}}` binding
+  // on the OUTER `.map()` body root, so the column wrapper exercises
+  // the same nested-reactive-attr path as the inner task card — but
+  // one level up the loop nesting.
+  const [dragOverColId, setDragOverColId] = createSignal<string | null>(null)
   const startDragPreview = (taskId: number) => setDraggingTaskId(taskId)
-  const endDragPreview = () => setDraggingTaskId(null)
+  const endDragPreview = () => {
+    setDraggingTaskId(null)
+    setDragOverColId(null)
+  }
 
   const showToast = (message: string) => {
     setToastMessage(message)
@@ -89,20 +98,84 @@ export function ProductivityBoardDemo() {
     setTimeout(() => setToastOpen(false), 3000)
   }
 
-  const moveTask = (taskId: number, fromColId: string, direction: 'left' | 'right') => {
+  // Move a task to an absolute target column (by id). Same-column drops
+  // are a no-op. Used both by drag-and-drop and the ←/→ buttons (the
+  // arrows resolve to the neighbour column and delegate here).
+  const moveTaskTo = (taskId: number, fromColId: string, toColId: string) => {
+    if (fromColId === toColId) return false
+    let didMove = false
     setColumns(prev => {
       const fromIdx = prev.findIndex(c => c.id === fromColId)
-      const toIdx = direction === 'left' ? fromIdx - 1 : fromIdx + 1
-      if (toIdx < 0 || toIdx >= prev.length) return prev
+      const toIdx = prev.findIndex(c => c.id === toColId)
+      if (fromIdx === -1 || toIdx === -1) return prev
       const task = prev[fromIdx].tasks.find(t => t.id === taskId)
       if (!task) return prev
+      didMove = true
       return prev.map((col, i) => {
         if (i === fromIdx) return { ...col, tasks: col.tasks.filter(t => t.id !== taskId) }
         if (i === toIdx) return { ...col, tasks: [...col.tasks, task] }
         return col
       })
     })
-    showToast('Task moved')
+    if (didMove) showToast('Task moved')
+    return didMove
+  }
+
+  const moveTask = (taskId: number, fromColId: string, direction: 'left' | 'right') => {
+    const cols = columns()
+    const fromIdx = cols.findIndex(c => c.id === fromColId)
+    const toIdx = direction === 'left' ? fromIdx - 1 : fromIdx + 1
+    if (toIdx < 0 || toIdx >= cols.length) return
+    moveTaskTo(taskId, fromColId, cols[toIdx].id)
+  }
+
+  // --- HTML5 drag-and-drop handlers ---
+  // The card publishes its task id + source column id via DataTransfer
+  // on dragstart; the column reads it back on drop. We also flip the
+  // shared drag-preview signal so the dragged card keeps its lifted
+  // visual treatment for the duration of the gesture (HTML5 DnD does
+  // NOT emit pointerdown/up, so the pointer-based handlers don't fire).
+  const handleDragStart = (taskId: number, fromColId: string) => (e: DragEvent) => {
+    if (e.dataTransfer) {
+      e.dataTransfer.setData('application/task', JSON.stringify({ taskId, fromColId }))
+      e.dataTransfer.effectAllowed = 'move'
+    }
+    startDragPreview(taskId)
+  }
+
+  const handleDragEnd = () => {
+    endDragPreview()
+  }
+
+  const handleColDragOver = (colId: string) => (e: DragEvent) => {
+    // preventDefault is required for the element to count as a drop
+    // target — without it `drop` never fires.
+    e.preventDefault()
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+    if (dragOverColId() !== colId) setDragOverColId(colId)
+  }
+
+  const handleColDragLeave = (colId: string) => (e: DragEvent) => {
+    // dragleave fires on every child boundary; only clear when leaving
+    // the column root (best-effort: relatedTarget outside this column).
+    const rel = e.relatedTarget as Node | null
+    const cur = e.currentTarget as Node | null
+    if (cur && rel && cur.contains(rel)) return
+    if (dragOverColId() === colId) setDragOverColId(null)
+  }
+
+  const handleColDrop = (toColId: string) => (e: DragEvent) => {
+    e.preventDefault()
+    const raw = e.dataTransfer?.getData('application/task')
+    setDragOverColId(null)
+    setDraggingTaskId(null)
+    if (!raw) return
+    try {
+      const { taskId, fromColId } = JSON.parse(raw) as { taskId: number; fromColId: string }
+      moveTaskTo(taskId, fromColId, toColId)
+    } catch {
+      // Malformed payload — ignore.
+    }
   }
 
   const addTask = (colId: string) => {
@@ -136,8 +209,33 @@ export function ProductivityBoardDemo() {
 
       <div className="kanban-columns flex gap-4 overflow-x-auto pb-4">
         {columns().map(col => (
-          <div key={col.id} className="kanban-column flex-1 min-w-[250px]">
-            <div className="flex items-center justify-between mb-3">
+          <div
+            key={col.id}
+            className="kanban-column flex-1 min-w-[250px] rounded-lg transition-colors duration-100"
+            // Per-column drop-target highlight, published as a CSS
+            // variable on the OUTER `.map()` body root. The boolean is
+            // also fanned out to concrete `background-color` / `outline`
+            // CSS properties so the highlight is visible without any
+            // additional class plumbing — and exercises the nested
+            // reactive-style path at the OUTER nesting level (cf. the
+            // inner task-card `--drag-*` vars one nesting level deeper).
+            style={{
+              '--drop-active': dragOverColId() === col.id ? '1' : '0',
+              backgroundColor: dragOverColId() === col.id
+                ? 'var(--color-accent, oklch(0.97 0 0))'
+                : 'transparent',
+              outline: dragOverColId() === col.id
+                ? '2px dashed var(--color-primary, oklch(0.205 0 0))'
+                : '2px dashed transparent',
+              outlineOffset: '-2px',
+            }}
+            data-col-id={col.id}
+            data-col-drop-active={dragOverColId() === col.id ? 'true' : 'false'}
+            onDragOver={handleColDragOver(col.id)}
+            onDragLeave={handleColDragLeave(col.id)}
+            onDrop={handleColDrop(col.id)}
+          >
+            <div className="flex items-center justify-between mb-3 px-1 pt-1">
               <div className="flex items-center gap-2">
                 <h3 className="column-title text-sm font-semibold">{col.title}</h3>
                 <Badge variant="secondary" className="task-count">{col.tasks.length}</Badge>
@@ -197,9 +295,12 @@ export function ProductivityBoardDemo() {
                   }}
                   data-task-id={String(task.id)}
                   data-task-dragging={draggingTaskId() === task.id ? 'true' : 'false'}
+                  draggable={true}
                   onPointerDown={() => startDragPreview(task.id)}
                   onPointerUp={endDragPreview}
                   onPointerLeave={endDragPreview}
+                  onDragStart={handleDragStart(task.id, col.id)}
+                  onDragEnd={handleDragEnd}
                 >
                   <div className="flex items-start justify-between gap-2">
                     <p className="task-title text-sm font-medium">{task.title}</p>

--- a/site/ui/components/gallery/productivity/board-demo.tsx
+++ b/site/ui/components/gallery/productivity/board-demo.tsx
@@ -72,6 +72,17 @@ export function ProductivityBoardDemo() {
     columns().reduce((sum, col) => sum + col.tasks.length, 0)
   )
 
+  // Drag-preview state — the id of the task currently being held down
+  // (pointerdown without a release yet). Drives a single reactive
+  // `style` attribute on each task card root so the active card fades
+  // via the `--drag-opacity` CSS variable without re-keying or
+  // re-mounting. Exercises a single-attribute reactive `style` binding
+  // on a `.map()` root, the compiler path adjacent to the outstanding
+  // Dashboard Builder reactive-className-on-.map()-root bug.
+  const [draggingTaskId, setDraggingTaskId] = createSignal<number | null>(null)
+  const startDragPreview = (taskId: number) => setDraggingTaskId(taskId)
+  const endDragPreview = () => setDraggingTaskId(null)
+
   const showToast = (message: string) => {
     setToastMessage(message)
     setToastOpen(true)
@@ -158,7 +169,19 @@ export function ProductivityBoardDemo() {
 
             <div className="space-y-2">
               {col.tasks.map(task => (
-                <div key={task.id} className="task-card rounded-xl border bg-card p-3 space-y-2 shadow-sm">
+                <div
+                  key={task.id}
+                  className="task-card rounded-xl border bg-card p-3 space-y-2 shadow-sm transition-opacity"
+                  style={{
+                    '--drag-opacity': draggingTaskId() === task.id ? '0.4' : '1',
+                    opacity: 'var(--drag-opacity)',
+                  }}
+                  data-task-id={String(task.id)}
+                  data-task-dragging={draggingTaskId() === task.id ? 'true' : 'false'}
+                  onPointerDown={() => startDragPreview(task.id)}
+                  onPointerUp={endDragPreview}
+                  onPointerLeave={endDragPreview}
+                >
                   <div className="flex items-start justify-between gap-2">
                     <p className="task-title text-sm font-medium">{task.title}</p>
                     <Button

--- a/site/ui/components/gallery/productivity/board-demo.tsx
+++ b/site/ui/components/gallery/productivity/board-demo.tsx
@@ -171,10 +171,29 @@ export function ProductivityBoardDemo() {
               {col.tasks.map(task => (
                 <div
                   key={task.id}
-                  className="task-card rounded-xl border bg-card p-3 space-y-2 shadow-sm transition-opacity"
+                  className="task-card rounded-xl border bg-card p-3 space-y-2 shadow-sm transition-all duration-150 cursor-grab active:cursor-grabbing"
                   style={{
-                    '--drag-opacity': draggingTaskId() === task.id ? '0.4' : '1',
+                    // Drag-preview visual: card fades, lifts (scale + shadow),
+                    // and gains a primary-coloured outline so the user can
+                    // tell at a glance which card they're "holding". Each
+                    // visual fact is published as a CSS variable so the
+                    // single `style` attribute on the inner-loop root carries
+                    // them all — exercising the nested-loop reactive style
+                    // path on a richer object literal (multiple custom-prop
+                    // members + a non-custom property).
+                    '--drag-opacity': draggingTaskId() === task.id ? '0.55' : '1',
+                    '--drag-scale': draggingTaskId() === task.id ? '1.03' : '1',
+                    '--drag-shadow': draggingTaskId() === task.id
+                      ? '0 12px 24px -8px rgba(0,0,0,0.25)'
+                      : '0 1px 2px 0 rgba(0,0,0,0.05)',
+                    '--drag-ring': draggingTaskId() === task.id
+                      ? '2px solid var(--color-primary, oklch(0.205 0 0))'
+                      : '2px solid transparent',
                     opacity: 'var(--drag-opacity)',
+                    transform: 'scale(var(--drag-scale))',
+                    boxShadow: 'var(--drag-shadow)',
+                    outline: 'var(--drag-ring)',
+                    outlineOffset: '2px',
                   }}
                   data-task-id={String(task.id)}
                   data-task-dragging={draggingTaskId() === task.id ? 'true' : 'false'}

--- a/site/ui/components/gallery/saas/pricing-demo.tsx
+++ b/site/ui/components/gallery/saas/pricing-demo.tsx
@@ -146,6 +146,21 @@ export function SaasPricingDemo() {
             <Badge variant="default" className="savings-badge">Save {savingsPercent()}%</Badge>
           ) : null}
         </div>
+
+        {/* Savings progress bar — width is a CSS custom property derived
+            from the savingsPercent() memo. Replaces what would otherwise
+            be a class-swap variant ('w-0' vs 'w-1/5'). */}
+        <div
+          className="saas-savings-progress mx-auto h-1.5 w-48 rounded-full bg-muted overflow-hidden"
+          data-savings-progress
+          aria-label="Annual savings progress"
+        >
+          <div
+            className="saas-savings-progress-bar h-full bg-primary transition-[width] duration-300"
+            style={{ '--w': savingsPercent() + '%', width: 'var(--w)' }}
+            data-savings-bar
+          />
+        </div>
       </div>
 
       {/* Plan cards */}

--- a/site/ui/components/gallery/social/profile-demo.tsx
+++ b/site/ui/components/gallery/social/profile-demo.tsx
@@ -197,6 +197,16 @@ export function SocialProfileDemo() {
     setEditingField(null)
   }
 
+  // Activity-feed scroll progress — drives an inline CSS variable on the
+  // progress bar above the activity list. Tests high-frequency scroll
+  // event → CSS-var update without re-rendering the surrounding tree.
+  const [scrollPct, setScrollPct] = createSignal(0)
+  const handleActivityScroll = (e: Event) => {
+    const el = e.currentTarget as HTMLDivElement
+    const max = el.scrollHeight - el.clientHeight
+    setScrollPct(max > 0 ? Math.round((el.scrollTop / max) * 100) : 0)
+  }
+
   return (
     <div className="mx-auto max-w-4xl space-y-6">
 
@@ -429,7 +439,22 @@ export function SocialProfileDemo() {
         </TabsContent>
 
         <TabsContent value="activity" selected={isActivityTab()}>
-          <div className="space-y-1">
+          <div
+            className="activity-progress h-1 w-full bg-muted rounded-full overflow-hidden mb-3"
+            data-activity-progress
+            aria-label="Activity feed scroll progress"
+          >
+            <div
+              className="h-full bg-primary transition-[width] duration-75"
+              style={{ '--p': scrollPct() + '%', width: 'var(--p)' }}
+              data-activity-progress-bar
+            />
+          </div>
+          <div
+            className="space-y-1 max-h-72 overflow-y-auto pr-2"
+            onScroll={handleActivityScroll}
+            data-activity-scroll
+          >
             {profile().activities.map(activity => (
               <div key={activity.id} className="activity-item flex items-start gap-3 py-3">
                 <Badge variant={activityBadgeVariant[activity.type]} className="activity-badge shrink-0 mt-0.5">

--- a/site/ui/components/line-chart-demo.tsx
+++ b/site/ui/components/line-chart-demo.tsx
@@ -6,7 +6,7 @@
  * Uses JSX component API with @barefootjs/chart.
  */
 
-import { createSignal } from '@barefootjs/client'
+import { createSignal, createMemo } from '@barefootjs/client'
 import type { ChartConfig } from '@barefootjs/chart'
 import {
   ChartContainer,
@@ -141,6 +141,99 @@ export function LineChartInteractiveDemo() {
           <YAxis />
           <ChartTooltip />
           <Line dataKey={category()} stroke={`var(--color-${category()})`} type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Zoom demo — signal-driven X-axis windowing.
+ *
+ * Two range inputs slice the underlying 12-point dataset into a window
+ * via a `createMemo`. Every reactive read in the chart subtree
+ * (`viewBox`, point spacing, the SVG path's `d` string, axis tick
+ * positions) cascades from that one memo, so a slider tick triggers a
+ * full memo chain re-evaluation without re-keying the chart.
+ */
+const yearlyData = [
+  { month: 'January', desktop: 186, mobile: 80 },
+  { month: 'February', desktop: 305, mobile: 200 },
+  { month: 'March', desktop: 237, mobile: 120 },
+  { month: 'April', desktop: 73, mobile: 190 },
+  { month: 'May', desktop: 209, mobile: 130 },
+  { month: 'June', desktop: 214, mobile: 140 },
+  { month: 'July', desktop: 278, mobile: 168 },
+  { month: 'August', desktop: 312, mobile: 220 },
+  { month: 'September', desktop: 251, mobile: 175 },
+  { month: 'October', desktop: 198, mobile: 145 },
+  { month: 'November', desktop: 264, mobile: 210 },
+  { month: 'December', desktop: 343, mobile: 290 },
+]
+
+export function LineChartZoomDemo() {
+  const [start, setStart] = createSignal(0)
+  const [end, setEnd] = createSignal(yearlyData.length - 1)
+
+  const visibleData = createMemo(() => {
+    const a = Math.min(start(), end())
+    const b = Math.max(start(), end())
+    return yearlyData.slice(a, b + 1)
+  })
+
+  const visibleLabel = createMemo(() => {
+    const data = visibleData()
+    if (data.length === 0) return '—'
+    return `${data[0].month.slice(0, 3)} – ${data[data.length - 1].month.slice(0, 3)}`
+  })
+
+  return (
+    <div className="w-full space-y-4" data-line-zoom-demo>
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <span className="text-muted-foreground">Window:</span>
+          <span className="font-medium" data-zoom-window>
+            {visibleLabel()}
+          </span>
+          <span className="text-xs text-muted-foreground" data-zoom-count>
+            ({visibleData().length} of {yearlyData.length} months)
+          </span>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="w-10">From</span>
+            <input
+              type="range"
+              min="0"
+              max={String(yearlyData.length - 1)}
+              value={String(start())}
+              onInput={(e: Event) => setStart(Number((e.target as HTMLInputElement).value))}
+              data-zoom-from
+              className="flex-1 accent-primary"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="w-10">To</span>
+            <input
+              type="range"
+              min="0"
+              max={String(yearlyData.length - 1)}
+              value={String(end())}
+              onInput={(e: Event) => setEnd(Number((e.target as HTMLInputElement).value))}
+              data-zoom-to
+              className="flex-1 accent-primary"
+            />
+          </label>
+        </div>
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={visibleData()}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v: string) => v.slice(0, 3)} />
+          <YAxis />
+          <ChartTooltip />
+          <Line dataKey="desktop" stroke={'var(--color-desktop)'} type="monotone" />
+          <Line dataKey="mobile" stroke={'var(--color-mobile)'} type="monotone" />
         </LineChart>
       </ChartContainer>
     </div>

--- a/site/ui/components/pie-chart-demo.tsx
+++ b/site/ui/components/pie-chart-demo.tsx
@@ -6,8 +6,9 @@
  * Uses JSX component API with @barefootjs/chart.
  */
 
-import { createSignal } from '@barefootjs/client'
+import { createSignal, createEffect, onCleanup } from '@barefootjs/client'
 import type { ChartConfig } from '@barefootjs/chart'
+import { buildPieSlices } from '@barefootjs/chart'
 import {
   ChartContainer,
   PieChart,
@@ -132,6 +133,101 @@ export function PieChartInteractiveDemo() {
           <Pie dataKey={metric()} nameKey="status" innerRadius={0.3} paddingAngle={2} />
         </PieChart>
       </ChartContainer>
+    </div>
+  )
+}
+
+/**
+ * Animated demo — rAF-driven reactive SVG attributes.
+ *
+ * Each `<path>` slice has reactive `stroke-dasharray` / `stroke-dashoffset`
+ * driven by a progress signal that climbs 0 → 1 via requestAnimationFrame
+ * each time the "Animate" toggle is enabled. Exercises three compiler
+ * paths in one demo:
+ *
+ *   1. SVG presentation attribute reactive binding (`stroke-dasharray` /
+ *      `stroke-dashoffset`) inside a `.map()` body.
+ *   2. `requestAnimationFrame` loop owned by a `createEffect`, with
+ *      `cancelAnimationFrame` in `onCleanup` so toggling off mid-flight
+ *      releases the frame handle.
+ *   3. High-frequency signal updates (one tick per animation frame) driving
+ *      DOM attribute writes without intervening user input.
+ */
+const ANIMATED_DURATION_MS = 1200
+const ANIMATED_DASH_LENGTH = 800
+
+export function PieChartAnimatedDemo() {
+  const [animating, setAnimating] = createSignal(false)
+  const [progress, setProgress] = createSignal(1)
+
+  const slices = buildPieSlices(
+    chartData,
+    'tasks',
+    'status',
+    chartConfig,
+    400,
+    400,
+    0.3,
+    0.85,
+    2,
+  )
+
+  createEffect(() => {
+    if (!animating()) return
+
+    setProgress(0)
+    const start = performance.now()
+    let frame = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / ANIMATED_DURATION_MS)
+      setProgress(t)
+      if (t < 1) {
+        frame = requestAnimationFrame(tick)
+      } else {
+        setAnimating(false)
+      }
+    }
+    frame = requestAnimationFrame(tick)
+    onCleanup(() => cancelAnimationFrame(frame))
+  })
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-anim-toggle
+          className="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground text-sm font-medium h-8 px-3 hover:bg-primary/90"
+          onClick={() => setAnimating(true)}
+          disabled={animating()}
+        >
+          {animating() ? 'Animating…' : 'Animate'}
+        </button>
+        <span className="text-xs text-muted-foreground">
+          stroke-dashoffset is driven by requestAnimationFrame
+        </span>
+      </div>
+      <svg
+        viewBox="0 0 400 400"
+        style="width:100%;max-width:400px;height:auto;display:block;margin:0 auto"
+      >
+        <g transform="translate(200,200)">
+          {slices.map((s) => (
+            <path
+              key={s.name}
+              d={s.d}
+              fill={s.fill}
+              stroke="hsl(0 0% 100% / 0.85)"
+              stroke-width="2"
+              stroke-dasharray={String(ANIMATED_DASH_LENGTH)}
+              stroke-dashoffset={String(ANIMATED_DASH_LENGTH * (1 - progress()))}
+              data-name={s.name}
+              data-value={String(s.value)}
+              data-anim-path
+            />
+          ))}
+        </g>
+      </svg>
     </div>
   )
 }

--- a/site/ui/components/pie-chart-demo.tsx
+++ b/site/ui/components/pie-chart-demo.tsx
@@ -141,20 +141,31 @@ export function PieChartInteractiveDemo() {
  * Animated demo — rAF-driven reactive SVG attributes.
  *
  * Each `<path>` slice has reactive `stroke-dasharray` / `stroke-dashoffset`
- * driven by a progress signal that climbs 0 → 1 via requestAnimationFrame
- * each time the "Animate" toggle is enabled. Exercises three compiler
- * paths in one demo:
+ * AND reactive `fill-opacity` driven by a progress signal that climbs 0 → 1
+ * via requestAnimationFrame each time the "Animate" toggle is enabled. The
+ * combination is what makes the animation visible: stroke-dashoffset alone
+ * only animates the thin separator stroke (which is barely perceptible
+ * against the solid fill), so we also fade the fill in. Exercises four
+ * compiler paths in one demo:
  *
  *   1. SVG presentation attribute reactive binding (`stroke-dasharray` /
  *      `stroke-dashoffset`) inside a `.map()` body.
- *   2. `requestAnimationFrame` loop owned by a `createEffect`, with
+ *   2. Reactive numeric SVG attribute (`fill-opacity`) inside the same
+ *      `.map()` body, driving the visible reveal.
+ *   3. `requestAnimationFrame` loop owned by a `createEffect`, with
  *      `cancelAnimationFrame` in `onCleanup` so toggling off mid-flight
  *      releases the frame handle.
- *   3. High-frequency signal updates (one tick per animation frame) driving
+ *   4. High-frequency signal updates (one tick per animation frame) driving
  *      DOM attribute writes without intervening user input.
+ *
+ * Why `pathLength="1"`: SVG `pathLength` normalises the path's length for
+ * stroke-dash math so the offset arithmetic is independent of the actual
+ * geometric length. Without it the dash math depended on `~809px` (the real
+ * path length for these slices) being close to a hard-coded `800` constant,
+ * which left only `~9px` of visual travel and made the stroke animation
+ * effectively invisible (the underlying bug behind #135 reports).
  */
 const ANIMATED_DURATION_MS = 1200
-const ANIMATED_DASH_LENGTH = 800
 
 export function PieChartAnimatedDemo() {
   const [animating, setAnimating] = createSignal(false)
@@ -204,7 +215,7 @@ export function PieChartAnimatedDemo() {
           {animating() ? 'Animating…' : 'Animate'}
         </button>
         <span className="text-xs text-muted-foreground">
-          stroke-dashoffset is driven by requestAnimationFrame
+          fill-opacity & stroke-dashoffset are driven by requestAnimationFrame
         </span>
       </div>
       <svg
@@ -217,10 +228,12 @@ export function PieChartAnimatedDemo() {
               key={s.name}
               d={s.d}
               fill={s.fill}
+              fill-opacity={String(progress())}
               stroke="hsl(0 0% 100% / 0.85)"
               stroke-width="2"
-              stroke-dasharray={String(ANIMATED_DASH_LENGTH)}
-              stroke-dashoffset={String(ANIMATED_DASH_LENGTH * (1 - progress()))}
+              pathLength="1"
+              stroke-dasharray="1"
+              stroke-dashoffset={String(1 - progress())}
               data-name={s.name}
               data-value={String(s.value)}
               data-anim-path

--- a/site/ui/components/validation-demo.tsx
+++ b/site/ui/components/validation-demo.tsx
@@ -7,9 +7,10 @@
  */
 
 import { createForm } from '@barefootjs/form'
-import { createSignal } from '@barefootjs/client'
+import { createSignal, createMemo, onCleanup } from '@barefootjs/client'
 import { Input } from '@ui/components/ui/input'
 import { Button } from '@ui/components/ui/button'
+import { Spinner } from '@ui/components/ui/spinner'
 import { z } from 'zod'
 
 /**
@@ -136,6 +137,125 @@ export function PasswordConfirmationDemo() {
       {matched() ? (
         <p className="match-indicator text-sm text-success">Passwords match!</p>
       ) : null}
+    </form>
+  )
+}
+
+/**
+ * Async availability validation — three UI surfaces flip together while
+ * the in-flight async check is pending:
+ *
+ *   1. `<Spinner>` mounts conditionally inside the input row.
+ *   2. The submit `<Button>` is `disabled`.
+ *   3. The `<Input>` carries `aria-busy="true"` so assistive tech reports
+ *      the field as busy.
+ *
+ * All three are driven by the same `validating()` signal — the compiler
+ * has to emit three independent reactive bindings that fire on a single
+ * setter call without one masking the others.
+ *
+ * In addition, the error/status text uses `style={{'--err': errorHue()}}`
+ * — a CSS custom property whose value comes from a signal — so the color
+ * computed via `hsl(var(--err) …)` in `globals.css` tracks the validation
+ * outcome (red error, amber warning, green success) without re-mounting
+ * the paragraph.
+ */
+const TAKEN_USERNAMES = new Set(['admin', 'root', 'test', 'guest'])
+
+export function AsyncFieldValidationDemo() {
+  const [username, setUsername] = createSignal('')
+  const [validating, setValidating] = createSignal(false)
+  // 0 = neutral/empty, 1 = success (green), 2 = warning (amber), 3 = error (red)
+  const [errorLevel, setErrorLevel] = createSignal(0)
+  const [errorMessage, setErrorMessage] = createSignal('')
+
+  // `createMemo` (not a plain arrow `const`) so the compiler can inline the
+  // derived hue into the SSR template's initial `style` attribute — the
+  // memo-substitution path in `buildSignalAndMemoMaps()` wraps a block-body
+  // memo in an IIFE and resolves `errorLevel()` to its initial value at
+  // hydrate time, keeping SSR and hydration in agreement.
+  const errorHue = createMemo(() => {
+    const lvl = errorLevel()
+    if (lvl === 1) return '140' // green
+    if (lvl === 2) return '40' // amber
+    if (lvl === 3) return '0' // red
+    return '210' // neutral slate
+  })
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const handleInput = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value
+    setUsername(value)
+    if (timer) clearTimeout(timer)
+
+    if (value.length === 0) {
+      setValidating(false)
+      setErrorLevel(0)
+      setErrorMessage('')
+      return
+    }
+
+    setValidating(true)
+    setErrorMessage('Checking availability…')
+    setErrorLevel(0)
+
+    timer = setTimeout(() => {
+      setTimeout(() => {
+        const trimmed = value.trim().toLowerCase()
+        if (trimmed.length < 3) {
+          setErrorLevel(3)
+          setErrorMessage('Username must be at least 3 characters')
+        } else if (TAKEN_USERNAMES.has(trimmed)) {
+          setErrorLevel(3)
+          setErrorMessage(`"${value}" is already taken`)
+        } else if (/[^a-z0-9_-]/i.test(trimmed)) {
+          setErrorLevel(2)
+          setErrorMessage('Only letters, digits, _ and - are allowed')
+        } else {
+          setErrorLevel(1)
+          setErrorMessage(`"${value}" is available`)
+        }
+        setValidating(false)
+      }, 400)
+    }, 200)
+  }
+
+  onCleanup(() => {
+    if (timer) clearTimeout(timer)
+  })
+
+  return (
+    <form className="space-y-3" data-async-validation>
+      <div className="space-y-2">
+        <label className="text-sm text-muted-foreground">Username *</label>
+        <div className="flex items-center gap-2">
+          <Input
+            value={username()}
+            onInput={handleInput}
+            aria-busy={validating() ? 'true' : 'false'}
+            placeholder="Pick a username (e.g. admin is taken)"
+            data-async-input
+          />
+          {validating() ? (
+            <Spinner className="size-4 text-muted-foreground" data-async-spinner />
+          ) : null}
+        </div>
+        <p
+          className="async-validation-msg text-sm min-h-5"
+          style={{ '--err': errorHue() }}
+          data-async-msg
+          data-async-level={String(errorLevel())}
+        >
+          {errorMessage()}
+        </p>
+      </div>
+      <Button
+        type="submit"
+        disabled={validating() || errorLevel() === 3}
+        data-async-submit
+      >
+        Create account
+      </Button>
     </form>
   )
 }

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -14,6 +14,7 @@
 
 "use client"
 
+import { createSignal, createEffect, onCleanup } from '@barefootjs/client'
 import {
   Background,
   Controls,
@@ -213,6 +214,71 @@ export function XyflowAnimatedEdgesDemo() {
       <Flow nodes={animatedEdgesNodes} edges={animatedEdgesEdges}>
         <Background variant="dots" gap={30} />
       </Flow>
+    </div>
+  )
+}
+
+/**
+ * Flow Animation demo — rAF-driven reactive `stroke-dashoffset` on a
+ * standalone `<path>` element.
+ *
+ * Pairs with the pie-chart "Animated" demo (#135 Concrete Additions)
+ * but exercises a CONTINUOUS rAF loop (the dashoffset keeps decreasing
+ * every frame for the duration of the toggle) instead of a one-shot
+ * easing. Toggling off stops the loop via `cancelAnimationFrame` in
+ * `onCleanup`, leaving the dashoffset at its last value.
+ */
+const FLOW_PATH = 'M 40 60 C 140 60 160 120 280 120 S 380 60 480 60'
+
+export function XyflowFlowAnimateDemo() {
+  const [animating, setAnimating] = createSignal(false)
+  const [offset, setOffset] = createSignal(0)
+
+  createEffect(() => {
+    if (!animating()) return
+    let frame = 0
+    let last = performance.now()
+    const tick = (now: number) => {
+      const dt = now - last
+      last = now
+      setOffset((prev: number) => (prev - dt * 0.04) % 16)
+      frame = requestAnimationFrame(tick)
+    }
+    frame = requestAnimationFrame(tick)
+    onCleanup(() => cancelAnimationFrame(frame))
+  })
+
+  return (
+    <div className="w-full space-y-3" data-flow-animate>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-flow-animate-toggle
+          className="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground text-sm font-medium h-8 px-3 hover:bg-primary/90"
+          onClick={() => setAnimating(!animating())}
+        >
+          {animating() ? 'Stop' : 'Animate flow'}
+        </button>
+        <span className="text-xs text-muted-foreground">
+          stroke-dashoffset is driven by requestAnimationFrame
+        </span>
+      </div>
+      <div className="w-full h-[180px] rounded-lg border bg-background overflow-hidden">
+        <svg viewBox="0 0 520 180" style="width:100%;height:100%;display:block">
+          <path
+            d={FLOW_PATH}
+            fill="none"
+            stroke="var(--primary)"
+            stroke-width="3"
+            stroke-dasharray="8 8"
+            stroke-dashoffset={String(offset())}
+            stroke-linecap="round"
+            data-flow-path
+          />
+          <circle cx="40" cy="60" r="6" fill="var(--primary)" />
+          <circle cx="480" cy="60" r="6" fill="var(--primary)" />
+        </svg>
+      </div>
     </div>
   )
 }

--- a/site/ui/components/xyflow-demo.tsx
+++ b/site/ui/components/xyflow-demo.tsx
@@ -14,7 +14,7 @@
 
 "use client"
 
-import { createSignal, createEffect, onCleanup } from '@barefootjs/client'
+import { createSignal, createEffect, onCleanup, createContext, useContext } from '@barefootjs/client'
 import {
   Background,
   Controls,
@@ -215,6 +215,115 @@ export function XyflowAnimatedEdgesDemo() {
         <Background variant="dots" gap={30} />
       </Flow>
     </div>
+  )
+}
+
+/**
+ * Highlight Depth demo — per-node `--node-glow` CSS custom property
+ * driven by a depth signal.
+ *
+ * A slider controls a `depthLimit` signal (0..4). Each node has a
+ * pre-configured `nodeDepth` (its distance from the root). When the
+ * slider's value is at or above the node's depth, the node gets a
+ * visible glow whose intensity is `style={{'--node-glow': intensity}}`.
+ * Otherwise the node fades.
+ *
+ * Exercises the CSS-var × `.map()` × per-node binding path inside a
+ * `renderNode` callback that's invoked once per node by `<Flow>`.
+ */
+const highlightDepthNodes = [
+  { id: 'root', position: { x:  80, y: 130 }, data: { label: 'Root', depth: 0 } },
+  { id: 'l1',   position: { x: 280, y:  60 }, data: { label: 'Tier 1', depth: 1 } },
+  { id: 'l1b',  position: { x: 280, y: 200 }, data: { label: 'Tier 1', depth: 1 } },
+  { id: 'l2',   position: { x: 480, y:  30 }, data: { label: 'Tier 2', depth: 2 } },
+  { id: 'l2b',  position: { x: 480, y: 130 }, data: { label: 'Tier 2', depth: 2 } },
+  { id: 'l2c',  position: { x: 480, y: 230 }, data: { label: 'Tier 2', depth: 2 } },
+]
+const highlightDepthEdges = [
+  { id: 'root-l1',  source: 'root', target: 'l1' },
+  { id: 'root-l1b', source: 'root', target: 'l1b' },
+  { id: 'l1-l2',    source: 'l1',   target: 'l2' },
+  { id: 'l1-l2b',   source: 'l1',   target: 'l2b' },
+  { id: 'l1b-l2c',  source: 'l1b',  target: 'l2c' },
+]
+
+// Module-scope lookup so the inline `renderNode` callback can read each
+// node's depth inside the template lambda — BF052 forbids referencing
+// init-body locals from the template position, so the Record stays at
+// module scope and the callback only reads `props.id`.
+const highlightDepthMap: Record<string, { label: string; depth: number }> = {
+  root: { label: 'Root',   depth: 0 },
+  l1:   { label: 'Tier 1', depth: 1 },
+  l1b:  { label: 'Tier 1', depth: 1 },
+  l2:   { label: 'Tier 2', depth: 2 },
+  l2b:  { label: 'Tier 2', depth: 2 },
+  l2c:  { label: 'Tier 2', depth: 2 },
+}
+
+// Context bridges the depth signal across the renderNode boundary.
+// `<Flow renderNode>` callbacks can't capture init-body locals (the
+// callback's body is lifted to a synthesized module-level component),
+// so we publish the value via a Context the wrapper sets up.
+const HighlightDepthContext = createContext<{ depth: () => number }>({ depth: () => 0 })
+
+function HighlightDepthNodeBody(props: { id: string }) {
+  const ctx = useContext(HighlightDepthContext)
+  const intensity = () => {
+    const nodeDepth = highlightDepthMap[props.id]?.depth ?? 0
+    return ctx.depth() >= nodeDepth
+      ? Math.max(0, 1 - (ctx.depth() - nodeDepth) * 0.25).toFixed(2)
+      : '0'
+  }
+  return (
+    <div
+      className="xyflow-depth-node rounded-md border-2 border-primary bg-card px-4 py-2 text-sm font-medium shadow-sm transition-[opacity,box-shadow]"
+      style={{
+        '--node-glow': intensity(),
+        opacity: 'calc(0.3 + 0.7 * var(--node-glow))',
+        boxShadow: '0 0 calc(12px * var(--node-glow)) hsl(var(--primary, 0deg) / var(--node-glow))',
+      }}
+      data-depth-node={props.id}
+      data-node-depth={String(highlightDepthMap[props.id]?.depth ?? 0)}
+    >
+      <Handle type="target" position={Position.Left} nodeId={props.id} />
+      {highlightDepthMap[props.id]?.label ?? props.id}
+      <Handle type="source" position={Position.Right} nodeId={props.id} />
+    </div>
+  )
+}
+
+export function XyflowHighlightDepthDemo() {
+  const [depth, setDepth] = createSignal(2)
+
+  return (
+    <HighlightDepthContext.Provider value={{ depth }}>
+      <div className="w-full space-y-3" data-highlight-depth-demo>
+        <label className="flex items-center gap-3 text-sm">
+          <span className="text-muted-foreground w-32">Highlight depth</span>
+          <input
+            type="range"
+            min="0"
+            max="4"
+            value={String(depth())}
+            onInput={(e: Event) => setDepth(Number((e.target as HTMLInputElement).value))}
+            data-highlight-depth-slider
+            className="flex-1 accent-primary"
+          />
+          <span className="w-8 text-right font-mono" data-highlight-depth-value>
+            {depth()}
+          </span>
+        </label>
+        <div className="w-full h-[280px] rounded-lg border bg-background overflow-hidden">
+          <Flow
+            nodes={highlightDepthNodes}
+            edges={highlightDepthEdges}
+            renderNode={(n) => <HighlightDepthNodeBody id={n.id} />}
+          >
+            <Background variant="dots" gap={30} />
+          </Flow>
+        </div>
+      </div>
+    </HighlightDepthContext.Provider>
   )
 }
 

--- a/site/ui/e2e/admin-gallery.spec.ts
+++ b/site/ui/e2e/admin-gallery.spec.ts
@@ -121,6 +121,57 @@ test.describe('Gallery: Admin app', () => {
       expect(insideShell).toBe(0)
     })
 
+    test('source-stat cards carry inline `--stat-c` CSS variable per item', async ({ page }) => {
+      // CSS-var × .map() × per-item reactive coverage. Each source's
+      // accent comes from the per-item `s.accent` value, not a class
+      // swap, so the only attribute that varies across cards is the
+      // inline `style="--stat-c: ..."`.
+      await page.goto('/gallery/admin/analytics')
+
+      const grid = page.locator('[data-source-stat-grid]')
+      await expect(grid).toBeVisible()
+      await expect(grid.locator('[data-source-stat]')).toHaveCount(5)
+
+      const organic = grid.locator('[data-source-stat="organic"]')
+      const direct = grid.locator('[data-source-stat="direct"]')
+      const paid = grid.locator('[data-source-stat="paid"]')
+
+      // Inline style carries the per-source colour as a CSS custom property.
+      await expect(organic).toHaveAttribute('style', /--stat-c\s*:\s*hsl\(142/)
+      await expect(direct).toHaveAttribute('style', /--stat-c\s*:\s*hsl\(221/)
+      await expect(paid).toHaveAttribute('style', /--stat-c\s*:\s*hsl\(38/)
+
+      // Resolved `color` on the share badge picks up the same variable.
+      const share = organic.locator('[data-source-share]')
+      await expect(share).toBeVisible()
+      const color = await share.evaluate((el) => getComputedStyle(el).color)
+      // hsl(142 71% 45%) → close to rgb(33, 197, 94). Just assert green-ish.
+      expect(color).toMatch(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)/)
+    })
+
+    test('each .map() item carries its own `--stat-c` value (no shared style)', async ({ page }) => {
+      // Locks the per-item CSS variable contract: five sibling cards
+      // produced by a single `.map()` must end up with five DIFFERENT
+      // inline `--stat-c` values, proving that the compiler emits a
+      // per-item style binding rather than collapsing the spread into a
+      // module-level constant.
+      await page.goto('/gallery/admin/analytics')
+
+      const cards = page.locator('[data-source-stat-grid] [data-source-stat]')
+      await expect(cards).toHaveCount(5)
+
+      const styles = await cards.evaluateAll((nodes) =>
+        nodes.map((el) => el.getAttribute('style') ?? ''),
+      )
+      // All five inline styles must be unique — no two cards share an accent.
+      expect(new Set(styles).size).toBe(5)
+      // Each style is a real CSS string, not the legacy `[object Object]`
+      // fallback from applyRestAttrs' pre-#135 path.
+      for (const s of styles) {
+        expect(s).toMatch(/^--stat-c\s*:\s*hsl\(/)
+      }
+    })
+
     test('unread notification count reflects on other pages after navigation', async ({ page }) => {
       await page.goto('/gallery/admin/notifications')
 

--- a/site/ui/e2e/area-chart.spec.ts
+++ b/site/ui/e2e/area-chart.spec.ts
@@ -149,4 +149,38 @@ test.describe('Area Chart Reference Page', () => {
       await expect(tooltip).toHaveCSS('opacity', '1')
     })
   })
+
+  test.describe('Palette', () => {
+    const scope = '[data-area-palette-demo]'
+
+    test('inline `--area-fill` CSS variable is emitted on the wrapper', async ({ page }) => {
+      const demo = page.locator(scope)
+      await expect(demo).toBeVisible()
+      await expect(demo).toHaveAttribute('data-palette', 'ocean')
+      await expect(demo).toHaveAttribute('style', /--area-fill\s*:\s*hsl\(199/)
+    })
+
+    test('switching palette flips the CSS variable; the Area inherits it', async ({ page }) => {
+      const demo = page.locator(scope)
+      const areaPath = demo.locator('path[data-key="desktop"]').first()
+
+      // Initial fill is the CSS variable reference; resolves via cascade.
+      await expect(areaPath).toHaveAttribute('fill', 'var(--area-fill)')
+      const oceanFill = await areaPath.evaluate(
+        (el) => getComputedStyle(el).fill,
+      )
+
+      // Switch to "sunset".
+      await demo.locator('[data-palette-option="sunset"]').click()
+      await expect(demo).toHaveAttribute('data-palette', 'sunset')
+      await expect(demo).toHaveAttribute('style', /--area-fill\s*:\s*hsl\(20/)
+
+      // Resolved fill changes — the cascaded `--area-fill` flipped, the
+      // chart subtree was not re-rendered.
+      const sunsetFill = await areaPath.evaluate(
+        (el) => getComputedStyle(el).fill,
+      )
+      expect(sunsetFill).not.toBe(oceanFill)
+    })
+  })
 })

--- a/site/ui/e2e/line-chart.spec.ts
+++ b/site/ui/e2e/line-chart.spec.ts
@@ -153,4 +153,61 @@ test.describe('Line Chart Reference Page', () => {
       await expect(tooltip).toHaveCSS('opacity', '1')
     })
   })
+
+  test.describe('Zoom', () => {
+    const scope = '[bf-s^="LineChartZoomDemo_"]:not([data-slot])'
+
+    test('renders the full 12-month window on first paint', async ({ page }) => {
+      const container = page.locator(scope)
+      await expect(container.locator('[data-zoom-count]')).toHaveText(
+        '(12 of 12 months)',
+      )
+      await expect(container.locator('[data-zoom-window]')).toContainText('Jan')
+      await expect(container.locator('[data-zoom-window]')).toContainText('Dec')
+    })
+
+    test('"From" slider shrinks the window and the line path reflows', async ({ page }) => {
+      const container = page.locator(scope)
+      const fromInput = container.locator('[data-zoom-from]')
+      const path = container.locator('path[data-key="desktop"]').first()
+
+      const originalD = await path.getAttribute('d')
+      expect(originalD).not.toBeNull()
+
+      // Move the "From" slider 5 ticks to the right.
+      await fromInput.evaluate((el) => {
+        const input = el as HTMLInputElement
+        input.value = '5'
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+
+      await expect(container.locator('[data-zoom-count]')).toHaveText(
+        '(7 of 12 months)',
+      )
+      await expect(container.locator('[data-zoom-window]')).toContainText('Jun')
+
+      // The line path `d` string is recomputed from the sliced dataset,
+      // so the SVG attribute MUST change.
+      await expect
+        .poll(async () => await path.getAttribute('d'), { timeout: 2000 })
+        .not.toBe(originalD)
+    })
+
+    test('"To" slider also drives the memo chain', async ({ page }) => {
+      const container = page.locator(scope)
+      const toInput = container.locator('[data-zoom-to]')
+
+      await toInput.evaluate((el) => {
+        const input = el as HTMLInputElement
+        input.value = '2'
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+
+      await expect(container.locator('[data-zoom-count]')).toHaveText(
+        '(3 of 12 months)',
+      )
+      await expect(container.locator('[data-zoom-window]')).toContainText('Jan')
+      await expect(container.locator('[data-zoom-window]')).toContainText('Mar')
+    })
+  })
 })

--- a/site/ui/e2e/pie-chart.spec.ts
+++ b/site/ui/e2e/pie-chart.spec.ts
@@ -91,6 +91,49 @@ test.describe('Pie Chart Reference Page', () => {
     })
   })
 
+  test.describe('Animated', () => {
+    const scope = '[bf-s^="PieChartAnimatedDemo_"]:not([data-slot])'
+
+    test('renders 4 slices with reactive stroke attributes', async ({ page }) => {
+      const container = page.locator(scope)
+      const paths = container.locator('path[data-anim-path]')
+      await expect(paths).toHaveCount(4)
+      // Initial progress is 1, so dashoffset starts at 0 (fully drawn).
+      await expect(paths.first()).toHaveAttribute('stroke-dashoffset', '0')
+      await expect(paths.first()).toHaveAttribute('stroke-dasharray', '800')
+    })
+
+    test('rAF loop drives stroke-dashoffset 800 → 0 on toggle', async ({ page }) => {
+      const container = page.locator(scope)
+      const toggle = container.locator('[data-anim-toggle]')
+      const firstPath = container.locator('path[data-anim-path]').first()
+
+      // Sanity: starts fully drawn.
+      await expect(firstPath).toHaveAttribute('stroke-dashoffset', '0')
+
+      await toggle.click()
+
+      // The rAF tick should have pushed dashoffset away from 0 by the time
+      // the next frame paints. Poll briefly to catch the mid-animation value.
+      await expect
+        .poll(
+          async () => Number(await firstPath.getAttribute('stroke-dashoffset')),
+          { timeout: 1000 },
+        )
+        .toBeGreaterThan(0)
+
+      // After the animation duration completes, it returns to 0 and the
+      // toggle becomes available again (effect cleanup released the frame).
+      await expect
+        .poll(
+          async () => Number(await firstPath.getAttribute('stroke-dashoffset')),
+          { timeout: 3000 },
+        )
+        .toBe(0)
+      await expect(toggle).toBeEnabled()
+    })
+  })
+
   test.describe('Tooltip', () => {
     test('tooltip appears on slice hover', async ({ page }) => {
       const container = page.locator('[bf-s^="PieChartPreviewDemo_"]:not([data-slot])')

--- a/site/ui/e2e/pie-chart.spec.ts
+++ b/site/ui/e2e/pie-chart.spec.ts
@@ -94,16 +94,20 @@ test.describe('Pie Chart Reference Page', () => {
   test.describe('Animated', () => {
     const scope = '[bf-s^="PieChartAnimatedDemo_"]:not([data-slot])'
 
-    test('renders 4 slices with reactive stroke attributes', async ({ page }) => {
+    test('renders 4 slices with reactive stroke + fill-opacity attributes', async ({ page }) => {
       const container = page.locator(scope)
       const paths = container.locator('path[data-anim-path]')
       await expect(paths).toHaveCount(4)
-      // Initial progress is 1, so dashoffset starts at 0 (fully drawn).
+      // Initial progress is 1, so dashoffset starts at 0 (fully drawn) and
+      // fill-opacity starts at 1 (fully visible). Math is normalised against
+      // pathLength="1" so dasharray is "1", independent of geometric length.
       await expect(paths.first()).toHaveAttribute('stroke-dashoffset', '0')
-      await expect(paths.first()).toHaveAttribute('stroke-dasharray', '800')
+      await expect(paths.first()).toHaveAttribute('stroke-dasharray', '1')
+      await expect(paths.first()).toHaveAttribute('pathLength', '1')
+      await expect(paths.first()).toHaveAttribute('fill-opacity', '1')
     })
 
-    test('rAF loop drives stroke-dashoffset 800 → 0 on toggle', async ({ page }) => {
+    test('rAF loop drives stroke-dashoffset 1 → 0 on toggle', async ({ page }) => {
       const container = page.locator(scope)
       const toggle = container.locator('[data-anim-toggle]')
       const firstPath = container.locator('path[data-anim-path]').first()
@@ -131,6 +135,38 @@ test.describe('Pie Chart Reference Page', () => {
         )
         .toBe(0)
       await expect(toggle).toBeEnabled()
+    })
+
+    test('rAF loop fades fill-opacity 0 → 1 so the slices visibly draw in', async ({ page }) => {
+      // Regression guard for the original report ("animation not working
+      // visually"): the previous implementation only animated the thin white
+      // stroke separator between slices, which was imperceptible against the
+      // solid fill. We now also animate `fill-opacity`, so the slices fade in
+      // — that fade is what makes the animation visible.
+      const container = page.locator(scope)
+      const toggle = container.locator('[data-anim-toggle]')
+      const firstPath = container.locator('path[data-anim-path]').first()
+
+      await expect(firstPath).toHaveAttribute('fill-opacity', '1')
+
+      await toggle.click()
+
+      // Mid-animation, fill-opacity must drop strictly below 1 (slice is
+      // partially transparent) and reach > 0 (animation has started).
+      await expect
+        .poll(
+          async () => Number(await firstPath.getAttribute('fill-opacity')),
+          { timeout: 1000 },
+        )
+        .toBeLessThan(1)
+
+      // After the animation duration completes, fill-opacity is back to 1.
+      await expect
+        .poll(
+          async () => Number(await firstPath.getAttribute('fill-opacity')),
+          { timeout: 3000 },
+        )
+        .toBe(1)
     })
   })
 

--- a/site/ui/e2e/productivity-gallery.spec.ts
+++ b/site/ui/e2e/productivity-gallery.spec.ts
@@ -142,6 +142,100 @@ test.describe('Gallery: Productivity app', () => {
       await expect(card).toHaveAttribute('style', /--drag-ring\s*:\s*2px\s+solid\s+transparent/)
     })
 
+    test('board: drag-and-drop moves a task between columns and highlights the drop target', async ({ page }) => {
+      // Trello/Notion-style cross-column drag. The card publishes
+      // {taskId, fromColId} on `dragstart`, the column reads it on
+      // `drop` and calls `moveTaskTo`. While the dragged card is
+      // over a column, the column root's `--drop-active` CSS var
+      // (bound on the OUTER `.map()` body root) flips to '1' and a
+      // dashed outline appears — exercising a reactive-style binding
+      // at the outer loop nesting level (one above the existing
+      // inner-loop task-card `--drag-*` test).
+      await page.goto('/gallery/productivity/board')
+
+      const card = page.locator('[data-task-id="1"]')
+      await expect(card).toBeVisible()
+
+      const todoCol = page.locator('[data-col-id="todo"]')
+      const doneCol = page.locator('[data-col-id="done"]')
+
+      // Task 1 starts in To Do — sanity check.
+      await expect(todoCol.locator('[data-task-id="1"]')).toHaveCount(1)
+      await expect(doneCol.locator('[data-task-id="1"]')).toHaveCount(0)
+
+      // Idle: outline is transparent (no drop-active highlight).
+      await expect(doneCol).toHaveAttribute('data-col-drop-active', 'false')
+      await expect(doneCol).toHaveAttribute('style', /--drop-active\s*:\s*0/)
+
+      // Drive dragstart + dragover from inside the page so the same
+      // DataTransfer instance is shared across events (Playwright's
+      // dispatchEvent serializes its eventInit, which would lose the
+      // DataTransfer payload otherwise).
+      await page.evaluate(() => {
+        const dt = new DataTransfer()
+        const src = document.querySelector('[data-task-id="1"]') as HTMLElement
+        const dst = document.querySelector('[data-col-id="done"]') as HTMLElement
+        src.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer: dt }))
+        dst.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      })
+
+      // Drop target column is now highlighted.
+      await expect(doneCol).toHaveAttribute('data-col-drop-active', 'true')
+      await expect(doneCol).toHaveAttribute('style', /--drop-active\s*:\s*1/)
+      await expect(doneCol).toHaveAttribute('style', /outline\s*:\s*2px\s+dashed\s+var\(--color-primary/)
+
+      // Complete the gesture: drop on Done, dragend on the source.
+      await page.evaluate(() => {
+        const dt = new DataTransfer()
+        dt.setData('application/task', JSON.stringify({ taskId: 1, fromColId: 'todo' }))
+        const dst = document.querySelector('[data-col-id="done"]') as HTMLElement
+        const src = document.querySelector('[data-task-id="1"]') as HTMLElement
+        dst.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }))
+        src.dispatchEvent(new DragEvent('dragend', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      })
+
+      // Task 1 has moved out of To Do and into Done.
+      await expect(todoCol.locator('[data-task-id="1"]')).toHaveCount(0)
+      await expect(doneCol.locator('[data-task-id="1"]')).toHaveCount(1)
+
+      // And the drop-active highlight has cleared.
+      await expect(doneCol).toHaveAttribute('data-col-drop-active', 'false')
+      await expect(doneCol).toHaveAttribute('style', /--drop-active\s*:\s*0/)
+
+      // Arrow buttons on the moved card still work — the moved card
+      // can travel back via ← (Done → In Progress).
+      const movedCard = page.locator('[data-task-id="1"]')
+      await expect(movedCard.locator('.move-left')).toHaveCount(1)
+      await movedCard.locator('.move-left').click()
+      await expect(page.locator('[data-col-id="progress"] [data-task-id="1"]')).toHaveCount(1)
+    })
+
+    test('board: dropping a task onto its own column is a no-op', async ({ page }) => {
+      // Same-column drop must not duplicate / lose the task, and the
+      // drop-target highlight must clear afterwards.
+      await page.goto('/gallery/productivity/board')
+
+      const todoCol = page.locator('[data-col-id="todo"]')
+      const initialCount = await todoCol.locator('[data-task-id]').count()
+
+      await page.evaluate(() => {
+        const dt = new DataTransfer()
+        const src = document.querySelector('[data-task-id="1"]') as HTMLElement
+        const dst = document.querySelector('[data-col-id="todo"]') as HTMLElement
+        src.dispatchEvent(new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer: dt }))
+        dst.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }))
+        // Payload is already on `dt` (set by dragstart), so drop reads
+        // the SAME values back out — exactly the production path.
+        dst.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }))
+        src.dispatchEvent(new DragEvent('dragend', { bubbles: true, cancelable: true, dataTransfer: dt }))
+      })
+
+      // Same number of cards, same column.
+      await expect(todoCol.locator('[data-task-id]')).toHaveCount(initialCount)
+      await expect(todoCol.locator('[data-task-id="1"]')).toHaveCount(1)
+      await expect(todoCol).toHaveAttribute('data-col-drop-active', 'false')
+    })
+
     test('board: arrow buttons survive moving a task between columns', async ({ page }) => {
       // Regression for the slot-resolver name-prefix over-match (#135):
       // a freshly-inserted inner-loop item carries three same-name

--- a/site/ui/e2e/productivity-gallery.spec.ts
+++ b/site/ui/e2e/productivity-gallery.spec.ts
@@ -103,6 +103,31 @@ test.describe('Gallery: Productivity app', () => {
       await expect(page.locator('[data-productivity-sidebar] .productivity-unread-count')).toHaveText(String(initialUnread))
     })
 
+    test('board drag-preview CSS var flips on pointerdown of a nested task card', async ({ page }) => {
+      // Locks down the per-item reactive `style={{'--drag-opacity':
+      // draggingTaskId() === task.id ? '0.4' : '1'}}` binding on the
+      // root element of a NESTED `tasks.map()` body. Before #135 the
+      // inner-loop renderItem never emitted a `createEffect` for the
+      // root's `style` attribute, so the variable stayed at the SSR
+      // value and the card never faded.
+      await page.goto('/gallery/productivity/board')
+
+      const card = page.locator('[data-task-id="1"]')
+      await expect(card).toBeVisible()
+      await expect(card).toHaveAttribute('data-task-dragging', 'false')
+      await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*1/)
+
+      // pointerdown — same card flips to dragging state.
+      await card.dispatchEvent('pointerdown')
+      await expect(card).toHaveAttribute('data-task-dragging', 'true')
+      await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*0\.4/)
+
+      // Releasing the pointer brings the card back to the idle state.
+      await card.dispatchEvent('pointerup')
+      await expect(card).toHaveAttribute('data-task-dragging', 'false')
+      await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*1/)
+    })
+
     test('reading a mail reduces the unread badge count', async ({ page }) => {
       await page.goto('/gallery/productivity/mail')
 

--- a/site/ui/e2e/productivity-gallery.spec.ts
+++ b/site/ui/e2e/productivity-gallery.spec.ts
@@ -103,29 +103,84 @@ test.describe('Gallery: Productivity app', () => {
       await expect(page.locator('[data-productivity-sidebar] .productivity-unread-count')).toHaveText(String(initialUnread))
     })
 
-    test('board drag-preview CSS var flips on pointerdown of a nested task card', async ({ page }) => {
-      // Locks down the per-item reactive `style={{'--drag-opacity':
-      // draggingTaskId() === task.id ? '0.4' : '1'}}` binding on the
-      // root element of a NESTED `tasks.map()` body. Before #135 the
-      // inner-loop renderItem never emitted a `createEffect` for the
-      // root's `style` attribute, so the variable stayed at the SSR
-      // value and the card never faded.
+    test('board drag-preview CSS vars flip on pointerdown of a nested task card', async ({ page }) => {
+      // Locks down the per-item reactive `style={{'--drag-opacity': …,
+      // '--drag-scale': …, '--drag-shadow': …, '--drag-ring': …}}`
+      // binding on the root element of a NESTED `tasks.map()` body.
+      // Before #135 the inner-loop renderItem never emitted a
+      // `createEffect` for the root's `style` attribute, so the
+      // variables stayed at the SSR value and the card never reacted.
+      //
+      // The visual story (opacity fade + lift via scale/shadow +
+      // primary-coloured outline) is encoded across multiple CSS
+      // variables on the same `style` literal — exercising a richer
+      // object-style binding than the original single-var shape.
       await page.goto('/gallery/productivity/board')
 
       const card = page.locator('[data-task-id="1"]')
       await expect(card).toBeVisible()
       await expect(card).toHaveAttribute('data-task-dragging', 'false')
       await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*1/)
+      await expect(card).toHaveAttribute('style', /--drag-scale\s*:\s*1/)
+      // Idle outline is transparent — no visible ring.
+      await expect(card).toHaveAttribute('style', /--drag-ring\s*:\s*2px\s+solid\s+transparent/)
 
-      // pointerdown — same card flips to dragging state.
+      // pointerdown — same card flips to dragging state on every
+      // tracked variable.
       await card.dispatchEvent('pointerdown')
       await expect(card).toHaveAttribute('data-task-dragging', 'true')
-      await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*0\.4/)
+      await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*0\.55/)
+      await expect(card).toHaveAttribute('style', /--drag-scale\s*:\s*1\.03/)
+      await expect(card).toHaveAttribute('style', /--drag-shadow\s*:\s*0\s+12px\s+24px/)
+      await expect(card).toHaveAttribute('style', /--drag-ring\s*:\s*2px\s+solid\s+var\(--color-primary/)
 
       // Releasing the pointer brings the card back to the idle state.
       await card.dispatchEvent('pointerup')
       await expect(card).toHaveAttribute('data-task-dragging', 'false')
       await expect(card).toHaveAttribute('style', /--drag-opacity\s*:\s*1/)
+      await expect(card).toHaveAttribute('style', /--drag-scale\s*:\s*1/)
+      await expect(card).toHaveAttribute('style', /--drag-ring\s*:\s*2px\s+solid\s+transparent/)
+    })
+
+    test('board: arrow buttons survive moving a task between columns', async ({ page }) => {
+      // Regression for the slot-resolver name-prefix over-match (#135):
+      // a freshly-inserted inner-loop item carries three same-name
+      // <Button> children (delete-task + move-left + move-right). After
+      // the first `upsertChild` mounted the delete button, the second
+      // and third found that already-mounted Button via the legacy
+      // name-prefix selector and `initChild`-ed it again — leaving the
+      // arrow placeholders orphaned. The visible symptom: clicking ←
+      // or → moved the task into a different column but the arrow
+      // buttons disappeared from the moved card, breaking subsequent
+      // moves.
+      await page.goto('/gallery/productivity/board')
+
+      // Task 1 starts in "To Do" with three buttons on the card
+      // (delete + left + right). The To Do column has no neighbour to
+      // the left, so move-left is a no-op there — we move right.
+      const card = page.locator('[data-task-id="1"]')
+      await expect(card).toBeVisible()
+      await expect(card.locator('.delete-task')).toHaveCount(1)
+      await expect(card.locator('.move-left')).toHaveCount(1)
+      await expect(card.locator('.move-right')).toHaveCount(1)
+
+      // Move task 1 from To Do → In Progress.
+      await card.locator('.move-right').click()
+
+      const movedCard = page.locator('[data-task-id="1"]')
+      // The data-task-id locator now resolves to the SAME id, but in
+      // the new column. The three buttons must still exist on the
+      // freshly-inserted card.
+      await expect(movedCard.locator('.delete-task')).toHaveCount(1)
+      await expect(movedCard.locator('.move-left')).toHaveCount(1)
+      await expect(movedCard.locator('.move-right')).toHaveCount(1)
+
+      // And the buttons must be wired — moving once more lands the
+      // task in "Done".
+      await movedCard.locator('.move-right').click()
+      const doneCard = page.locator('[data-task-id="1"]')
+      await expect(doneCard.locator('.move-left')).toHaveCount(1)
+      await expect(doneCard.locator('.move-right')).toHaveCount(1)
     })
 
     test('reading a mail reduces the unread badge count', async ({ page }) => {

--- a/site/ui/e2e/saas-gallery.spec.ts
+++ b/site/ui/e2e/saas-gallery.spec.ts
@@ -99,6 +99,37 @@ test.describe('Gallery: SaaS Marketing app', () => {
       await expect(page.locator('.saas-original-price')).toHaveCount(2) // pro + enterprise
     })
 
+    test('savings progress CSS variable tracks the billing toggle', async ({ page }) => {
+      // CSS custom property derived from `savingsPercent()` memo.
+      // Width is driven by the inline `--w` variable, NOT by a class
+      // swap — locks down the derived-memo → CSS-var → width path.
+      await page.goto('/gallery/saas/pricing')
+
+      const bar = page.locator('[data-savings-bar]')
+      // At 0% width the element is not technically "visible" — assert
+      // presence via count + the inline style instead.
+      await expect(bar).toHaveCount(1)
+      // Monthly: --w resolves to 0%
+      await expect(bar).toHaveAttribute('style', /--w\s*:\s*0%/)
+
+      // Toggle annual
+      await page.locator('.saas-billing-toggle [role="switch"]').click()
+      // Annual: --w resolves to 20%
+      await expect(bar).toHaveAttribute('style', /--w\s*:\s*20%/)
+
+      // The computed `width` resolves through `var(--w)`, so the bar
+      // actually grows beyond zero once the CSS variable updates. Poll
+      // for the layout-resolved width to settle past 0 since the
+      // transition is async.
+      await expect
+        .poll(
+          async () =>
+            bar.evaluate((el) => el.getBoundingClientRect().width),
+          { timeout: 1500 },
+        )
+        .toBeGreaterThan(0)
+    })
+
     test('selecting a plan navigates to login', async ({ page }) => {
       await page.goto('/gallery/saas/pricing')
 

--- a/site/ui/e2e/social-gallery.spec.ts
+++ b/site/ui/e2e/social-gallery.spec.ts
@@ -133,6 +133,36 @@ test.describe('Gallery: Social app', () => {
       await page.locator('[role="tab"]', { hasText: 'Activity' }).click()
       await expect(page.locator('.activity-item').first()).toBeVisible()
     })
+
+    test('activity scroll updates the `--p` CSS variable on the progress bar', async ({ page }) => {
+      // High-frequency scroll event → signal → inline CSS variable
+      // → resolved width. Locks down the CSS-var × scroll path.
+      await page.goto('/gallery/social/profile')
+      await page.locator('[role="tab"]', { hasText: 'Activity' }).click()
+
+      const bar = page.locator('[data-activity-progress-bar]')
+      const scroller = page.locator('[data-activity-scroll]')
+
+      // Initial — bar sits at 0%.
+      await expect(bar).toHaveAttribute('style', /--p\s*:\s*0%/)
+
+      // Scroll the activity feed half-way and verify --p moves off 0.
+      await scroller.evaluate((el) => {
+        const div = el as HTMLDivElement
+        div.scrollTop = div.scrollHeight
+        div.dispatchEvent(new Event('scroll', { bubbles: true }))
+      })
+
+      await expect
+        .poll(
+          async () =>
+            Number(
+              (await bar.getAttribute('style'))?.match(/--p\s*:\s*(\d+)%/)?.[1] ?? '0',
+            ),
+          { timeout: 1500 },
+        )
+        .toBeGreaterThan(0)
+    })
   })
 
   test.describe('Messages page', () => {

--- a/site/ui/e2e/validation.spec.ts
+++ b/site/ui/e2e/validation.spec.ts
@@ -206,4 +206,59 @@ test.describe('Form Validation Documentation Page', () => {
       await expect(emailError).toHaveText('')
     })
   })
+
+  test.describe('Async Availability Demo', () => {
+    const scope = '[bf-s^="AsyncFieldValidationDemo_"]:not([data-slot])'
+
+    test('renders inline `--err` CSS variable on initial paint', async ({ page }) => {
+      const demo = page.locator(scope)
+      const msg = demo.locator('[data-async-msg]')
+      // SSR should emit the neutral hue (210) so the post-hydration paint
+      // matches the server-rendered colour. This locks the
+      // `createMemo`-driven SSR substitution path so the inline style
+      // attribute is never empty.
+      await expect(msg).toHaveAttribute('style', /--err\s*:\s*210/)
+    })
+
+    test('Spinner, aria-busy and disabled flip together on async check', async ({ page }) => {
+      const demo = page.locator(scope)
+      const input = demo.locator('[data-async-input]')
+      const spinner = demo.locator('[data-async-spinner]')
+      const submit = demo.locator('[data-async-submit]')
+
+      // Pre-validation: no spinner, no busy state, submit enabled.
+      await expect(spinner).toHaveCount(0)
+      await expect(input).toHaveAttribute('aria-busy', 'false')
+      await expect(submit).toBeEnabled()
+
+      await input.fill('newuser')
+
+      // During the in-flight check all three signals fire together.
+      await expect(spinner).toBeVisible()
+      await expect(input).toHaveAttribute('aria-busy', 'true')
+      await expect(submit).toBeDisabled()
+
+      // After it resolves: success state, all three return to idle.
+      await expect(spinner).toHaveCount(0, { timeout: 2000 })
+      await expect(input).toHaveAttribute('aria-busy', 'false')
+      await expect(submit).toBeEnabled()
+    })
+
+    test('CSS `--err` hue tracks the validation outcome', async ({ page }) => {
+      const demo = page.locator(scope)
+      const input = demo.locator('[data-async-input]')
+      const msg = demo.locator('[data-async-msg]')
+
+      // Available username → success hue (140 → green)
+      await input.fill('newuser')
+      await expect(msg).toHaveAttribute('data-async-level', '1', { timeout: 2000 })
+      await expect(msg).toHaveAttribute('style', /--err\s*:\s*140/)
+
+      // Reserved username → error hue (0 → red) and submit stays disabled
+      await input.fill('admin')
+      await expect(msg).toHaveAttribute('data-async-level', '3', { timeout: 2000 })
+      await expect(msg).toHaveAttribute('style', /--err\s*:\s*0(?:[^\d]|$)/)
+      await expect(demo.locator('[data-async-submit]')).toBeDisabled()
+    })
+  })
 })

--- a/site/ui/e2e/xyflow.spec.ts
+++ b/site/ui/e2e/xyflow.spec.ts
@@ -202,6 +202,42 @@ test.describe('xyflow Reference Page', () => {
     })
   })
 
+  test.describe('rAF Flow Animation (#135)', () => {
+    test('toggling on advances `stroke-dashoffset` via requestAnimationFrame', async ({ page }) => {
+      // The pair: animate toggle + reactive `stroke-dashoffset`. Until
+      // the user clicks, the path is static; clicking starts a
+      // `createEffect`-owned rAF loop that re-evaluates the offset every
+      // frame. Toggling off must drop it back to a stable value (the
+      // cleanup callback releases the frame handle).
+      await page.goto('/xyflow/edges')
+      const demo = page.locator('[data-flow-animate]')
+      const path = demo.locator('[data-flow-path]')
+      const toggle = demo.locator('[data-flow-animate-toggle]')
+
+      await expect(path).toHaveAttribute('stroke-dashoffset', '0')
+
+      await toggle.click()
+
+      // The rAF loop should produce a stream of distinct dashoffset
+      // values. Polling for "moved off zero" is enough to prove the
+      // effect is firing.
+      await expect
+        .poll(
+          async () => Number(await path.getAttribute('stroke-dashoffset')),
+          { timeout: 1500 },
+        )
+        .not.toBe(0)
+
+      // Stop the animation — the offset should freeze (cleanup
+      // released the frame handle, so no more rAF tick fires).
+      await toggle.click()
+      const stopped = await path.getAttribute('stroke-dashoffset')
+      await page.waitForTimeout(120)
+      const after = await path.getAttribute('stroke-dashoffset')
+      expect(after).toBe(stopped)
+    })
+  })
+
   test.describe.skip('Edge Reconnection (re-enable in cutover step C4)', () => {
     test('reconnect handles update edge endpoints', async () => {
       // Filled in once the reconnect overlay wiring ships from

--- a/site/ui/e2e/xyflow.spec.ts
+++ b/site/ui/e2e/xyflow.spec.ts
@@ -202,6 +202,49 @@ test.describe('xyflow Reference Page', () => {
     })
   })
 
+  test.describe('Highlight Depth (#135 stretch)', () => {
+    test('slider moves through depth values; each node carries its own `--node-glow`', async ({ page }) => {
+      // CSS-var × .map() × per-node binding inside a `renderNode`
+      // callback that's invoked once per node. Each rendered node
+      // publishes its own `--node-glow` inline style and the slider
+      // signal flows through a Context so the callback doesn't
+      // capture an init-scope local (which the JSX compiler forbids).
+      await page.goto('/xyflow/nodes')
+
+      const demo = page.locator('[data-highlight-depth-demo]')
+      const slider = demo.locator('[data-highlight-depth-slider]')
+      const root = demo.locator('[data-depth-node="root"]')
+      const l2 = demo.locator('[data-depth-node="l2"]')
+
+      await expect(demo).toBeVisible()
+      // Initial slider = 2. Intensity = max(0, 1 - (slider - nodeDepth) * 0.25).
+      // root (nodeDepth=0) → 1 - 2*0.25 = 0.50.
+      // l2   (nodeDepth=2) → 1 - 0*0.25 = 1.00.
+      await expect(root).toHaveAttribute('style', /--node-glow\s*:\s*0\.50/)
+      await expect(l2).toHaveAttribute('style', /--node-glow\s*:\s*1\.00/)
+
+      // Slide to 0 — root climbs to full glow, tier-2 fades to 0.
+      await slider.evaluate((el) => {
+        const input = el as HTMLInputElement
+        input.value = '0'
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+      await expect(root).toHaveAttribute('style', /--node-glow\s*:\s*1\.00/)
+      await expect(l2).toHaveAttribute('style', /--node-glow\s*:\s*0(?:\.00)?(?:[;\s]|$)/)
+
+      // Slide to 4 — every node is past its depth, intensity decays.
+      await slider.evaluate((el) => {
+        const input = el as HTMLInputElement
+        input.value = '4'
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+      // root: 1 - 4*0.25 = 0
+      // l2:   1 - 2*0.25 = 0.50
+      await expect(root).toHaveAttribute('style', /--node-glow\s*:\s*0(?:\.00)?(?:[;\s]|$)/)
+      await expect(l2).toHaveAttribute('style', /--node-glow\s*:\s*0\.50/)
+    })
+  })
+
   test.describe('rAF Flow Animation (#135)', () => {
     test('toggling on advances `stroke-dashoffset` via requestAnimationFrame', async ({ page }) => {
       // The pair: animate toggle + reactive `stroke-dashoffset`. Until

--- a/site/ui/pages/charts/area-chart.tsx
+++ b/site/ui/pages/charts/area-chart.tsx
@@ -7,6 +7,7 @@ import {
   AreaChartBasicDemo,
   AreaChartMultipleDemo,
   AreaChartInteractiveDemo,
+  AreaChartPaletteDemo,
 } from '@/components/area-chart-demo'
 import { AreaChartPlayground } from '@/components/area-chart-playground'
 import {
@@ -28,7 +29,8 @@ const tocItems: TocItem[] = [
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'multiple', title: 'Multiple', branch: 'child' },
-  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'interactive', title: 'Interactive', branch: 'child' },
+  { id: 'palette', title: 'Palette', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
@@ -193,6 +195,44 @@ export function AreaChartInteractiveDemo() {
   )
 }`
 
+const paletteCode = `"use client"
+
+import { createSignal } from "@barefootjs/client"
+
+const PALETTES = {
+  ocean: "hsl(199 89% 48%)",
+  sunset: "hsl(20 90% 55%)",
+  forest: "hsl(142 71% 35%)",
+}
+
+export function AreaChartPaletteDemo() {
+  const [palette, setPalette] = createSignal("ocean")
+
+  return (
+    // CSS variable on the wrapper cascades into the SVG attribute below.
+    <div style={{ "--area-fill": PALETTES[palette()] }}>
+      <div className="flex gap-2">
+        {Object.keys(PALETTES).map((p) => (
+          <button onClick={() => setPalette(p)}>{p}</button>
+        ))}
+      </div>
+      <ChartContainer config={chartConfig} className="w-full">
+        <AreaChart data={chartData}>
+          <AreaCartesianGrid vertical={false} />
+          <AreaXAxis dataKey="month" tickFormatter={(v) => v.slice(0, 3)} />
+          <AreaYAxis />
+          <Area
+            dataKey="desktop"
+            fill="var(--area-fill)"
+            stroke="var(--area-fill)"
+            fillOpacity={0.35}
+          />
+        </AreaChart>
+      </ChartContainer>
+    </div>
+  )
+}`
+
 const areaChartProps: PropDefinition[] = [
   {
     name: 'data',
@@ -331,6 +371,10 @@ export function AreaChartRefPage() {
 
             <Example title="Interactive" code={interactiveCode}>
               <AreaChartInteractiveDemo />
+            </Example>
+
+            <Example title="Palette" code={paletteCode}>
+              <AreaChartPaletteDemo />
             </Example>
           </div>
         </Section>

--- a/site/ui/pages/charts/line-chart.tsx
+++ b/site/ui/pages/charts/line-chart.tsx
@@ -7,6 +7,7 @@ import {
   LineChartBasicDemo,
   LineChartMultipleDemo,
   LineChartInteractiveDemo,
+  LineChartZoomDemo,
 } from '@/components/line-chart-demo'
 import { LineChartPlayground } from '@/components/line-chart-playground'
 import {
@@ -28,7 +29,8 @@ const tocItems: TocItem[] = [
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'multiple', title: 'Multiple', branch: 'child' },
-  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'interactive', title: 'Interactive', branch: 'child' },
+  { id: 'zoom', title: 'Zoom', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
@@ -193,6 +195,53 @@ export function LineChartInteractiveDemo() {
   )
 }`
 
+const zoomCode = `"use client"
+
+import { createSignal, createMemo } from "@barefootjs/client"
+
+const yearlyData = [/* 12 months */]
+
+export function LineChartZoomDemo() {
+  const [start, setStart] = createSignal(0)
+  const [end,   setEnd  ] = createSignal(yearlyData.length - 1)
+
+  // Memo cascade: slider → window indices → sliced data → chart
+  // viewBox, axis ticks, line path \`d\` strings.
+  const visibleData = createMemo(() => {
+    const a = Math.min(start(), end())
+    const b = Math.max(start(), end())
+    return yearlyData.slice(a, b + 1)
+  })
+
+  return (
+    <div>
+      <input
+        type="range"
+        min="0"
+        max={String(yearlyData.length - 1)}
+        value={String(start())}
+        onInput={(e) => setStart(Number(e.target.value))}
+      />
+      <input
+        type="range"
+        min="0"
+        max={String(yearlyData.length - 1)}
+        value={String(end())}
+        onInput={(e) => setEnd(Number(e.target.value))}
+      />
+      <ChartContainer config={chartConfig} className="w-full">
+        <LineChart data={visibleData()}>
+          <CartesianGrid vertical={false} />
+          <XAxis dataKey="month" tickFormatter={(v) => v.slice(0, 3)} />
+          <YAxis />
+          <Line dataKey="desktop" stroke="var(--color-desktop)" type="monotone" />
+          <Line dataKey="mobile"  stroke="var(--color-mobile)"  type="monotone" />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}`
+
 const lineChartProps: PropDefinition[] = [
   {
     name: 'data',
@@ -337,6 +386,10 @@ export function LineChartRefPage() {
 
             <Example title="Interactive" code={interactiveCode}>
               <LineChartInteractiveDemo />
+            </Example>
+
+            <Example title="Zoom" code={zoomCode}>
+              <LineChartZoomDemo />
             </Example>
           </div>
         </Section>

--- a/site/ui/pages/charts/pie-chart.tsx
+++ b/site/ui/pages/charts/pie-chart.tsx
@@ -7,6 +7,7 @@ import {
   PieChartBasicDemo,
   PieChartDonutDemo,
   PieChartInteractiveDemo,
+  PieChartAnimatedDemo,
 } from '@/components/pie-chart-demo'
 import { PieChartPlayground } from '@/components/pie-chart-playground'
 import {
@@ -28,7 +29,8 @@ const tocItems: TocItem[] = [
   { id: 'examples', title: 'Examples' },
   { id: 'basic', title: 'Basic', branch: 'start' },
   { id: 'donut', title: 'Donut', branch: 'child' },
-  { id: 'interactive', title: 'Interactive', branch: 'end' },
+  { id: 'interactive', title: 'Interactive', branch: 'child' },
+  { id: 'animated', title: 'Animated', branch: 'end' },
   { id: 'api-reference', title: 'API Reference' },
 ]
 
@@ -166,6 +168,63 @@ export function PieChartInteractiveDemo() {
   )
 }`
 
+const animatedCode = `"use client"
+
+import { createSignal, createEffect, onCleanup } from "@barefootjs/client"
+import { buildPieSlices } from "@barefootjs/chart"
+
+const DURATION = 1200
+const DASH = 800
+
+export function PieChartAnimatedDemo() {
+  const [animating, setAnimating] = createSignal(false)
+  const [progress, setProgress] = createSignal(1)
+
+  const slices = buildPieSlices(
+    chartData, "tasks", "status", chartConfig,
+    400, 400, 0.3, 0.85, 2,
+  )
+
+  createEffect(() => {
+    if (!animating()) return
+    setProgress(0)
+    const start = performance.now()
+    let frame = 0
+    const tick = (now) => {
+      const t = Math.min(1, (now - start) / DURATION)
+      setProgress(t)
+      if (t < 1) frame = requestAnimationFrame(tick)
+      else setAnimating(false)
+    }
+    frame = requestAnimationFrame(tick)
+    onCleanup(() => cancelAnimationFrame(frame))
+  })
+
+  return (
+    <div>
+      <button
+        onClick={() => setAnimating(true)}
+        disabled={animating()}
+      >
+        {animating() ? "Animating…" : "Animate"}
+      </button>
+      <svg viewBox="0 0 400 400">
+        <g transform="translate(200,200)">
+          {slices.map((s) => (
+            <path
+              key={s.name}
+              d={s.d}
+              fill={s.fill}
+              stroke-dasharray={String(DASH)}
+              stroke-dashoffset={String(DASH * (1 - progress()))}
+            />
+          ))}
+        </g>
+      </svg>
+    </div>
+  )
+}`
+
 const pieChartProps: PropDefinition[] = [
   {
     name: 'data',
@@ -262,6 +321,10 @@ export function PieChartRefPage() {
 
             <Example title="Interactive" code={interactiveCode}>
               <PieChartInteractiveDemo />
+            </Example>
+
+            <Example title="Animated" code={animatedCode}>
+              <PieChartAnimatedDemo />
             </Example>
           </div>
         </Section>

--- a/site/ui/pages/forms/validation.tsx
+++ b/site/ui/pages/forms/validation.tsx
@@ -9,6 +9,7 @@ import {
   RequiredFieldDemo,
   EmailValidationDemo,
   PasswordConfirmationDemo,
+  AsyncFieldValidationDemo,
   MultiFieldFormDemo,
 } from '@/components/validation-demo'
 import {
@@ -25,6 +26,7 @@ const tocItems: TocItem[] = [
   { id: 'required-field', title: 'Required Field', branch: 'start' },
   { id: 'email-format', title: 'Email Format', branch: 'child' },
   { id: 'cross-field', title: 'Cross-Field', branch: 'child' },
+  { id: 'async-availability', title: 'Async Availability', branch: 'child' },
   { id: 'multi-field', title: 'Multi-Field', branch: 'end' },
 ]
 
@@ -80,6 +82,64 @@ const form = createForm({
   validateOn: 'blur',
   revalidateOn: 'input',
 })`
+
+const asyncValidationCode = `import { createSignal, onCleanup } from '@barefootjs/client'
+import { Spinner } from '@/components/ui/spinner'
+
+const TAKEN = new Set(['admin', 'root', 'test', 'guest'])
+
+export function AsyncFieldValidationDemo() {
+  const [username, setUsername] = createSignal('')
+  const [validating, setValidating] = createSignal(false)
+  // 0 neutral · 1 success · 2 warning · 3 error
+  const [errorLevel, setErrorLevel] = createSignal(0)
+  const [message, setMessage] = createSignal('')
+
+  // Hue drives \`color: hsl(var(--err) 70% 45%)\` defined in globals.css.
+  const errorHue = () =>
+    errorLevel() === 1 ? '140' :
+    errorLevel() === 2 ? '40' :
+    errorLevel() === 3 ? '0' : '210'
+
+  let timer = null
+  const onInput = (e) => {
+    const value = e.target.value
+    setUsername(value)
+    if (timer) clearTimeout(timer)
+    if (!value) { setValidating(false); setErrorLevel(0); setMessage(''); return }
+
+    setValidating(true)
+    setMessage('Checking availability…')
+    timer = setTimeout(() => {
+      const lower = value.toLowerCase()
+      if (TAKEN.has(lower)) { setErrorLevel(3); setMessage(\`"\${value}" is taken\`) }
+      else                  { setErrorLevel(1); setMessage(\`"\${value}" is available\`) }
+      setValidating(false)
+    }, 600)
+  }
+  onCleanup(() => timer && clearTimeout(timer))
+
+  return (
+    <form className="space-y-3">
+      <label>Username</label>
+      <div className="flex items-center gap-2">
+        <Input
+          value={username()}
+          onInput={onInput}
+          aria-busy={validating() ? 'true' : 'false'}
+        />
+        {validating() ? <Spinner className="size-4" /> : null}
+      </div>
+      <p
+        className="async-validation-msg text-sm"
+        style={{ '--err': errorHue() }}
+      >{message()}</p>
+      <Button type="submit" disabled={validating() || errorLevel() === 3}>
+        Create account
+      </Button>
+    </form>
+  )
+}`
 
 const multiFieldFormCode = `const form = createForm({
   schema: z
@@ -162,6 +222,17 @@ export function ValidationPage() {
               <Example title="Cross-Field (Password Confirmation)" code={passwordConfirmCode}>
                 <div className="max-w-sm">
                   <PasswordConfirmationDemo />
+                </div>
+              </Example>
+            </div>
+
+            <div id="async-availability">
+              <Example
+                title="Async Availability (Spinner + disabled + aria-busy synced)"
+                code={asyncValidationCode}
+              >
+                <div className="max-w-sm">
+                  <AsyncFieldValidationDemo />
                 </div>
               </Example>
             </div>

--- a/site/ui/pages/xyflow/edges.tsx
+++ b/site/ui/pages/xyflow/edges.tsx
@@ -6,7 +6,11 @@
  */
 
 import { XyflowEdgesDemo } from '@/components/xyflow-intro-demo'
-import { XyflowEdgeVariantsDemo, XyflowAnimatedEdgesDemo } from '@/components/xyflow-demo'
+import {
+  XyflowEdgeVariantsDemo,
+  XyflowAnimatedEdgesDemo,
+  XyflowFlowAnimateDemo,
+} from '@/components/xyflow-demo'
 import {
   PageHeader,
   Section,
@@ -22,6 +26,7 @@ const tocItems: TocItem[] = [
   { id: 'default-routing', title: 'Default Routing' },
   { id: 'variants', title: 'Edge Variants' },
   { id: 'animated', title: 'Animated Edges' },
+  { id: 'flow-animate', title: 'rAF Flow Animation' },
 ]
 
 const edgeShapeCode = `// An edge is a plain object connecting two node ids.
@@ -72,6 +77,47 @@ const edges = [
 <Flow nodes={nodes} edges={edges}>
   <Background variant="dots" gap={30} />
 </Flow>`
+
+const flowAnimateCode = `"use client"
+
+import { createSignal, createEffect, onCleanup } from "@barefootjs/client"
+
+export function XyflowFlowAnimateDemo() {
+  const [animating, setAnimating] = createSignal(false)
+  const [offset, setOffset]       = createSignal(0)
+
+  createEffect(() => {
+    if (!animating()) return
+    let frame = 0
+    let last  = performance.now()
+    const tick = (now) => {
+      const dt = now - last
+      last = now
+      setOffset((prev) => (prev - dt * 0.04) % 16)
+      frame = requestAnimationFrame(tick)
+    }
+    frame = requestAnimationFrame(tick)
+    onCleanup(() => cancelAnimationFrame(frame))
+  })
+
+  return (
+    <div>
+      <button onClick={() => setAnimating(!animating())}>
+        {animating() ? "Stop" : "Animate flow"}
+      </button>
+      <svg viewBox="0 0 520 180">
+        <path
+          d="M 40 60 C 140 60 160 120 280 120 S 380 60 480 60"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="3"
+          stroke-dasharray="8 8"
+          stroke-dashoffset={String(offset())}
+        />
+      </svg>
+    </div>
+  )
+}`
 
 export function XyflowEdgesPage() {
   return (
@@ -140,6 +186,24 @@ export function XyflowEdgesPage() {
 
           <Example title="Animated stroke" code={animatedEdgesCode}>
             <XyflowAnimatedEdgesDemo />
+          </Example>
+        </Section>
+
+        <Section id="flow-animate" title="rAF Flow Animation">
+          <div className="prose prose-invert max-w-none">
+            <p className="text-muted-foreground">
+              The CSS keyframe animation above happens entirely inside the browser. When you need the
+              path direction or speed to be reactive — to track a signal — drive the
+              {' '}<code className="text-foreground">stroke-dashoffset</code> attribute from a
+              {' '}<code className="text-foreground">requestAnimationFrame</code> loop owned by a
+              {' '}<code className="text-foreground">createEffect</code>. Toggling the effect off
+              calls <code className="text-foreground">cancelAnimationFrame</code> in{' '}
+              <code className="text-foreground">onCleanup</code>, so the loop never leaks past unmount.
+            </p>
+          </div>
+
+          <Example title="rAF-driven dashoffset" code={flowAnimateCode}>
+            <XyflowFlowAnimateDemo />
           </Example>
         </Section>
       </div>

--- a/site/ui/pages/xyflow/nodes.tsx
+++ b/site/ui/pages/xyflow/nodes.tsx
@@ -6,7 +6,11 @@
  */
 
 import { XyflowNodesDemo } from '@/components/xyflow-intro-demo'
-import { XyflowCustomBodyDemo, XyflowCustomHandlesDemo } from '@/components/xyflow-demo'
+import {
+  XyflowCustomBodyDemo,
+  XyflowCustomHandlesDemo,
+  XyflowHighlightDepthDemo,
+} from '@/components/xyflow-demo'
 import {
   PageHeader,
   Section,
@@ -22,6 +26,7 @@ const tocItems: TocItem[] = [
   { id: 'default-body', title: 'Default Body' },
   { id: 'custom-bodies', title: 'Custom Bodies' },
   { id: 'custom-handles', title: 'Custom Handles' },
+  { id: 'highlight-depth', title: 'Highlight Depth' },
 ]
 
 const nodeShapeCode = `// A node is a plain object: id, position, data.
@@ -129,6 +134,50 @@ const edges = [
   <Background variant="dots" gap={30} />
 </Flow>`
 
+const highlightDepthCode = `"use client"
+
+import { createSignal } from "@barefootjs/client"
+import { Flow, Handle, Background } from "@/components/ui/xyflow"
+import { Position } from "@barefootjs/xyflow"
+
+const [depth, setDepth] = createSignal(2)
+
+const nodes = [
+  { id: "root", position: { x:  80, y: 130 }, data: { label: "Root",   depth: 0 } },
+  { id: "l1",   position: { x: 280, y:  60 }, data: { label: "Tier 1", depth: 1 } },
+  // ...
+]
+
+function HighlightDepthNode({ id }) {
+  const node = nodes.find((n) => n.id === id)
+  const nodeDepth = node.data.depth
+  const intensity = () =>
+    depth() >= nodeDepth
+      ? Math.max(0, 1 - (depth() - nodeDepth) * 0.25).toFixed(2)
+      : "0"
+  return (
+    <div
+      style={{
+        "--node-glow": intensity(),
+        opacity: "calc(0.3 + 0.7 * var(--node-glow))",
+        boxShadow: "0 0 calc(12px * var(--node-glow)) currentColor",
+      }}
+    >
+      <Handle type="target" position={Position.Left}  nodeId={id} />
+      {node.data.label}
+      <Handle type="source" position={Position.Right} nodeId={id} />
+    </div>
+  )
+}
+
+<input type="range" min="0" max="4"
+       value={String(depth())}
+       onInput={(e) => setDepth(Number(e.target.value))} />
+<Flow nodes={nodes} edges={edges}
+      renderNode={(n) => <HighlightDepthNode id={n.id} />}>
+  <Background variant="dots" gap={30} />
+</Flow>`
+
 export function XyflowNodesPage() {
   return (
     <div className="flex gap-10">
@@ -202,6 +251,21 @@ export function XyflowNodesPage() {
 
           <Example title="Three-way fan-out" code={customHandlesCode}>
             <XyflowCustomHandlesDemo />
+          </Example>
+        </Section>
+
+        <Section id="highlight-depth" title="Highlight Depth">
+          <div className="prose prose-invert max-w-none">
+            <p className="text-muted-foreground">
+              A slider drives a <code className="text-foreground">depth()</code> signal that's read by
+              every node inside <code className="text-foreground">renderNode</code>. Each rendered node
+              writes its own inline <code className="text-foreground">style={'{{'}'--node-glow': intensity{'}}'}</code>
+              CSS variable so the glow can fade per-node without a chart-level re-render.
+            </p>
+          </div>
+
+          <Example title="Per-node CSS variable" code={highlightDepthCode}>
+            <XyflowHighlightDepthDemo />
           </Example>
         </Section>
       </div>

--- a/site/ui/styles/globals.css
+++ b/site/ui/styles/globals.css
@@ -150,3 +150,11 @@ html.theme-transition *::after {
 [data-slot="card"]:hover [data-card-hover-action] {
   opacity: 1;
 }
+
+/* Async validation status text — color is driven by the `--err` CSS
+   variable set inline from `errorLevel()` in the validation demo. The
+   variable holds the hue (0..360); the rest is fixed. */
+.async-validation-msg {
+  color: hsl(var(--err, 210) 70% 45%);
+  transition: color 150ms ease;
+}

--- a/site/ui/styles/globals.css
+++ b/site/ui/styles/globals.css
@@ -158,3 +158,16 @@ html.theme-transition *::after {
   color: hsl(var(--err, 210) 70% 45%);
   transition: color 150ms ease;
 }
+
+/* Per-source stat card accent — color is driven by the `--stat-c` CSS
+   variable set inline from `sourceColors[source]` in the admin
+   analytics demo. Replaces the previous class swap variant so the
+   visual treatment is data-driven (one inline style attribute per
+   card) instead of branching on a static utility-class lookup. */
+.source-stat-card {
+  border-left: 3px solid var(--stat-c, var(--border));
+}
+.source-stat-card [data-source-share] {
+  color: var(--stat-c, var(--muted-foreground));
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary

Implements all 10 items in the **Concrete additions** TODO of #135 — small in-place edits to existing demos that exercise compiler paths with previously zero coverage (CSS custom properties, rAF loops, reactive SVG attrs on nested `.map()` roots).

Along the way found and **root-cause fixed 4 compiler / runtime bugs**, each landed with unit + E2E regression tests.

## Concrete additions (10/10)

| # | Block | Path it covers |
|---|---|---|
| 1 | `pie-chart.tsx` Animated demo | rAF loop + reactive `stroke-dasharray`/`stroke-dashoffset` inside `.map()` |
| 2 | `forms/validation.tsx` Async availability | `<Spinner>` + `disabled` + `aria-busy` synced; `style={{'--err': hue()}}` |
| 3 | `gallery/admin/analytics-demo.tsx` Source-stat cards | CSS-var × `.map()` × per-item via Card `{...props}` spread |
| 4 | `line-chart.tsx` Zoom slider | Slider → window memo → `viewBox`/`d`/tick cascade |
| 5 | `area-chart.tsx` Palette demo | `style={{'--area-fill': palette()}}` cascading into SVG `fill` |
| 6 | `gallery/saas/pricing-demo.tsx` Savings progress | Derived memo → `--w` → resolved width |
| 7 | `board-demo.tsx` Drag preview | Single-attr `style` reactive on a **nested** `.map()` root |
| 8 | `xyflow/edges.tsx` Flow animate | Continuous rAF + `cancelAnimationFrame` cleanup |
| 9 | `xyflow/nodes.tsx` Highlight depth (stretch) | Per-node `--node-glow` via Context bridge |
| 10 | `social/profile-demo.tsx` Activity scroll (stretch) | Scroll event → signal → `--p` width |

## Compiler / runtime fixes surfaced by the new coverage

1. **`applyRestAttrs` serialized `style` objects as `[object Object]`.**
   `<Card style={{'--stat-c': 'hsl(…)'}}>` reached the DOM literally because `setAttribute('style', String(value))` ignored object shapes. Routed through `styleToCss`. (analytics source-stat cards.)
2. **`applyRestAttrs` wrote `children` as a DOM attribute.**
   `children="<p>…</p>"` leaked onto wrapper divs. Excluded `children` from the rest-attr loop. (board demo follow-up.)
3. **Hono adapter `isJsExpression` regex misclassified CSS function values.**
   `fill="var(--area-fill)"` got emitted as `fill={var(--area-fill)}` and Bun's parser failed with `Unexpected var`. Switched the disambiguator to the IR `isLiteral` flag with the regex as fallback. (area-chart palette demo.)
4. **Reactive attributes on nested `.map()` body roots were not wired.**
   Outstanding Dashboard Builder bug, generalised: `collectInnerLoops` collected reactive *texts* but no reactive *attrs*. The board drag preview's `style={{'--drag-opacity': draggingTaskId() === task.id ? '0.4' : '1'}}` stayed frozen at the SSR value. Added `LoopChildReactiveAttr` collection + `InnerLoopReactiveAttr` plan emit + stringifier path (`style` / boolean / generic shapes). (board drag preview demo.)

## Test plan

- [x] `bun test packages/jsx/src/__tests__/ packages/client/__tests__/ packages/adapter-hono/` — 1402 pass / 0 fail
- [x] `bunx playwright test` (site/ui) — 1089 pass / 3 skip (pre-existing) / 0 fail
- [x] Each fix ships with a focused unit test:
  - `packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts` (extended)
  - `packages/jsx/src/__tests__/style-css-var-reactive.test.ts` (new)
  - `packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts` (new)
  - `packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts` (new)
  - `packages/client/__tests__/runtime/apply-rest-attrs.test.ts` (new)
- [x] Each new demo ships with E2E coverage in its page's spec file.
- [x] `bun run build` succeeds; no new TS errors in source (pre-existing `dist/` and `logo.tsx` errors unchanged).

## Paths these additions land

Matches the table in #135:

| Path | Before | After |
|------|--------|-------|
| `style={{'--var': signal()}}` | ❌ zero | ✓ pie-chart, validation, analytics, area-chart, pricing, board, xyflow-edges, xyflow-nodes, profile |
| `requestAnimationFrame` loop + cleanup | ❌ zero | ✓ pie-chart, xyflow-edges |
| SVG `stroke-dashoffset` reactive | ❌ static | ✓ pie-chart, xyflow-edges |
| Async multi-attribute simultaneous reactive | ⚠️ partial | ✓ validation |
| `style` single-attribute reactive on `.map()` root | ⚠️ partial | ✓ board (and compiler fix lifts the cap) |

Refs #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)