### PR TITLE
fix(cli): rewrite stripped 'use client' .tsx imports as runtime stubs (#1240)

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -49,7 +49,7 @@ console.log(highlight('hello'))
     expect(result).toContain("from '@barefootjs/client'")
   })
 
-  test('strips .tsx client component import when binding is unused', async () => {
+  test('replaces a named .tsx client-component import with a runtime-resolving stub (#1240)', async () => {
     writeFileSync(resolve(COMPONENTS_DIR, 'ClientComp.tsx'), `'use client'
 export function ClientComp() {
   return <div>client only</div>
@@ -68,21 +68,33 @@ console.log('client code')
     const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
     const result = await Bun.file(resolve(COMPONENTS_DIR, 'Parent-abc123.js')).text()
-    expect(result).not.toContain('ClientComp')
+    // The original `import` statement is gone — replaced with a stub that
+    // delegates to `createComponent` so the local binding works in any
+    // call shape (JSX, Record literal, .call(el, props), …).
+    expect(result).not.toContain("from './ClientComp'")
+    // The stub must keep the original local binding name.
+    expect(result).toContain('const ClientComp =')
+    expect(result).toContain("createComponent(\"ClientComp\", props, key)")
+    // The stub relies on the host bundle already importing `createComponent`
+    // from the umbrella `barefoot.js` runtime (every JSX-emitted client
+    // bundle does, since `<X />` compiles to `createComponent(...)`). We
+    // deliberately do NOT hoist a `from '@barefootjs/client/runtime'` line
+    // — that bare specifier isn't on the page's importmap and would 404 in
+    // the browser. See the comment on the stub branch in resolve-imports.ts.
+    // Pre-existing imports + body lines stay intact.
     expect(result).toContain("from '@barefootjs/client'")
     expect(result).toContain("console.log('client code')")
-    // No dangling reference → no diagnostic.
+    // The binding has a working definition → no dangling reference, no diagnostic.
     expect(errors).toHaveLength(0)
   })
 
-  // Regression: bf#1227 — a `.ts` helper (no `'use client'`) inlined into a
-  // client bundle imports a sibling `'use client'` `.tsx` AND calls it. The
-  // strip used to be silent (`console.log` only, build exit 0), so the
-  // bundle shipped with a dangling identifier and crashed at runtime with
-  // `ReferenceError: DraftTitleEditor is not defined`. After the fix the
-  // strip is detected via a post-assembly identifier scan and surfaced as
-  // BF053, so the build exits non-zero.
-  test('errors when stripped .tsx binding is still referenced (bf#1227)', async () => {
+  // Regression: bf#1227 used to surface BF053 when a stripped `'use client'`
+  // import left a dangling reference. bf#1240 turns the strip into a
+  // runtime-resolving stub instead, so the same call site that previously
+  // crashed at runtime (the original `884173f` ReferenceError) now works.
+  // BF053 still fires for non-stubbable shapes — see the default + namespace
+  // tests below.
+  test('replaces .tsx binding called from an inlined .ts helper with a runtime stub instead of stripping (#1240, supersedes #1227 dangling case)', async () => {
     writeFileSync(resolve(COMPONENTS_DIR, 'DraftTitleEditor.tsx'), `'use client'
 export function DraftTitleEditor() { return <textarea /> }
 `)
@@ -105,15 +117,60 @@ IssueCardNode()
 
     const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
 
+    // No diagnostic — the binding now has a definition (the stub).
+    expect(errors).toHaveLength(0)
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'DeskCanvas-aaa.js')).text()
+    // The `.ts` helper got inlined; the stripped `.tsx` import inside it
+    // becomes the runtime stub, so calling `DraftTitleEditor({…})` from
+    // the helper resolves to `createComponent('DraftTitleEditor', …)` at
+    // runtime instead of the previous ReferenceError.
+    expect(result).toContain('const DraftTitleEditor =')
+    expect(result).toContain("createComponent(\"DraftTitleEditor\", props, key)")
+  })
+
+  // BF053 still fires for the shapes the stub can't faithfully recreate —
+  // namespace and default imports of a `'use client'` `.tsx` don't have a
+  // single registry name to delegate to (default exports compile without a
+  // stable JSX-registration name; namespace imports would need every export
+  // enumerated against the registry). Per #1240 those fall back to the
+  // pre-#1240 strip + BF053 path.
+  test('still fires BF053 for namespace .tsx imports (no single registry name to stub)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'NsClient.tsx'), `'use client'
+export function NsClient() { return <div /> }
+`)
+    const clientJs = `import * as Ns from './NsClient'
+console.log(Ns.NsClient)
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'NsParent-aaa.js'), clientJs)
+    const manifest = {
+      NsParent: { clientJs: 'components/NsParent-aaa.js', markedTemplate: 'components/NsParent.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
     expect(errors).toHaveLength(1)
     expect(errors[0].code).toBe('BF053')
-    expect(errors[0].severity).toBe('error')
-    // The error must name the binding so the developer can find the call.
-    expect(errors[0].message).toContain('DraftTitleEditor')
-    // And the import path so they can find the source file.
-    expect(errors[0].message).toContain('./DraftTitleEditor')
-    // And the bundle so they know which entry to investigate.
-    expect(errors[0].loc.file).toBe('components/DeskCanvas-aaa.js')
+    expect(errors[0].message).toContain('Ns')
+  })
+
+  test('still fires BF053 for default .tsx imports (no single registry name to stub)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'DefClient.tsx'), `'use client'
+export default function DefClient() { return <div /> }
+`)
+    const clientJs = `import Def from './DefClient'
+Def()
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'DefParent-aaa.js'), clientJs)
+    const manifest = {
+      DefParent: { clientJs: 'components/DefParent-aaa.js', markedTemplate: 'components/DefParent.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].code).toBe('BF053')
+    expect(errors[0].message).toContain('Def')
   })
 
   // Sanity: stripping is fine when the import was for types-only or

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -685,10 +685,65 @@ async function walkAndCollect(
 
     if (result.path.endsWith('.tsx')) {
       // A sibling `.tsx` reaching this path is, in practice, a `'use client'`
-      // component: it has its own compiled `.client.js` and is not callable
-      // as a plain function from a client bundle. Drop the import line and
-      // record the bindings so a later post-assembly scan can flag any
-      // call sites that survived the strip. piconic-ai/barefootjs#1227.
+      // component. Its own compiled `.client.js` exports a JSX-shim function
+      // (`function X(props, key) { return createComponent('X', props, key) }`)
+      // that delegates to the runtime registry. The shim isn't reachable
+      // from another bundle as a plain import, so we replace the parent's
+      // import with local stubs that perform the same `createComponent`
+      // delegation in scope. That keeps every reference shape working — JSX
+      // (`<X />`, where the JSX compiler also rewrites to `createComponent`
+      // and never reads the local binding), passing the value through a
+      // Record (`<Flow nodeTypes={{ kind: X }}>`), or any of the other
+      // non-JSX usages piconic-ai/barefootjs#1238 made supported at the
+      // runtime side. Closes piconic-ai/barefootjs#1240.
+      //
+      // Default and namespace imports of a `'use client'` `.tsx` are NOT
+      // stubbed — the registered runtime name for those isn't trivially
+      // recoverable from the import statement alone (default exports
+      // compile without a stable JSX-registration name; namespace imports
+      // would need every export of the target file enumerated against the
+      // registry). They fall back to the pre-existing strip + BF053 path so
+      // any actual usage still surfaces a build error rather than a silent
+      // ReferenceError. The named-import path covers the practical case
+      // (`nodeTypes={{ kind: Component }}`) that drove both #1236 and #1240.
+      const shape = parseImportShape(fullMatch)
+      const namedBindings = shape?.named ?? []
+      const fallbackBindings: string[] = []
+      if (shape?.namespace) fallbackBindings.push(shape.namespace)
+      if (shape?.default) fallbackBindings.push(shape.default)
+
+      if (namedBindings.length > 0) {
+        const stubBody = namedBindings
+          .map(({ local, imported }) => `const ${local} = (props, key) => createComponent(${JSON.stringify(imported)}, props, key);`)
+          .join('\n')
+        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), `${stubBody}\n`)
+        // The stub references the runtime `createComponent` symbol. Every
+        // JSX-emitted client bundle already imports it as part of the
+        // umbrella `barefoot.js` runtime (any `<X />` use compiles to a
+        // `createComponent(...)` call), so the binding is in scope at the
+        // top of the parent file. We deliberately do NOT hoist a separate
+        // `import { createComponent } from '@barefootjs/client/runtime'`
+        // here: the page's importmap only exposes the umbrella `barefoot.js`
+        // module, so the bare runtime path would 404 in the browser.
+        // Bundles that genuinely don't have `createComponent` in scope are
+        // not realistic for this strip path (you only reach it from a
+        // `'use client'` parent, which always emits JSX → always imports
+        // `createComponent`), and a "createComponent is not defined" error
+        // there would point at the stub line anyway.
+        if (fallbackBindings.length === 0) {
+          // Every binding is now a working stub — nothing to strip, no
+          // dangling references possible.
+          continue
+        }
+        // Default + namespace siblings still need to be stripped; keep them
+        // recorded so BF053 fires only for those specific names.
+        stripped.push({ kind: 'tsx', importPath, bindings: fallbackBindings, loggingPath })
+        continue
+      }
+
+      // No named bindings (only default / namespace, or unparseable / side-
+      // effect-only). Preserve the pre-#1240 behaviour: drop the import and
+      // let BF053 fire on dangling references.
       content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), '')
       console.log(`Stripped client component import: ${importPath} from ${loggingPath}`)
       recordStrippedImport(fullMatch, importPath, loggingPath, 'tsx', stripped)


### PR DESCRIPTION
Closes #1240. Pairs with #1227 (silent strip → BF053) and #1238 (`FlowNodeTypeBridge` accepts JSX-shim entries) to make `'use client'` `.tsx` components actually usable through `<Flow nodeTypes={…}>` end to end.

## Problem

After #1238 the runtime bridge does the right thing with a JSX-component shim entry in `nodeTypes`, but the bundler half stayed in the original strip-and-leave-dangling shape: passing a JSX-component reference into a Record literal counts as "non-JSX usage" and triggers BF053. The two layers disagreed about what's valid, so the runtime fix wasn't actually reachable from app code that registers JSX components in a `nodeTypes` map — the only path forward was rewriting every `<Flow nodeTypes={…}>` site to `<Flow renderNode={…}>`, a much larger refactor than the JSX migration itself.

## Fix

Replace the strip behaviour for **named** `.tsx` imports with a local runtime stub that delegates to `createComponent`:

```js
import { X } from './X'           // before
const X = (props, key) => createComponent('X', props, key)  // after
```

The stub works in every reference shape — JSX (`<X />`, where the JSX compiler also rewrites to `createComponent` and never touches the binding), Record literal (`<Flow nodeTypes={{ kind: X }}>`), plain function call from an inlined `.ts` helper. The runtime resolves the binding via the existing hydrate registry, the same path JSX usage already takes.

`createComponent` is in scope on every JSX-emitted client bundle (it lands as part of the umbrella `barefoot.js` import that every `<X />` needs), so the stub doesn't add a new module dependency. We deliberately do NOT hoist a separate `import { createComponent } from '@barefootjs/client/runtime'` — the page's importmap only exposes the umbrella `barefoot.js` module, so the bare runtime path would 404 in the browser. The realistic case of "consumer doesn't have `createComponent` in scope" — a non-JSX bundle accidentally importing a `'use client'` component — already wouldn't have worked under the old strip path either, and now produces a clearer "createComponent is not defined" error pointing at the stub line.

Default and namespace imports of `.tsx` fall back to the pre-#1240 strip + BF053 path. The registered runtime name for those isn't trivially recoverable from the import statement alone — default exports compile without a stable JSX-registration name, namespace imports would need every export of the target file enumerated against the registry. The named-import path covers the practical case (`nodeTypes={{ kind: Component }}`) that drove this issue.

## Test plan

- [x] `bun test packages/cli/src/__tests__/resolve-imports.test.ts` — 16 pass / 0 fail. New cases:
  - "replaces a named .tsx client-component import with a runtime-resolving stub" — happy path
  - "replaces .tsx binding called from an inlined .ts helper with a runtime stub instead of stripping" — closes the #1227 dangling-reference case for named imports (the binding now has a definition, so no BF053)
  - "still fires BF053 for namespace .tsx imports"
  - "still fires BF053 for default .tsx imports"
- [x] Existing cli tests (12) updated where the previous behaviour expected a strip-only outcome
- [x] `bun test packages/cli/` — 396 pass / 1 pre-existing fail unrelated (mojo adapter `runtimes.generated` missing)