### PR TITLE
fix(jsx): static-loop dispatch picks empty SSR template, leaving DOM children unrendered when array is init-body-only (#1245)

### DIFF
--- a/packages/jsx/src/__tests__/init-scope-loop-routing.test.ts
+++ b/packages/jsx/src/__tests__/init-scope-loop-routing.test.ts
@@ -1,0 +1,46 @@
+'use client'
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('init-scope loop array routes through mapArray (#1245)', () => {
+  test('component-local const array derived from props uses mapArray', () => {
+    const source = `
+      'use client'
+      export function Bar(props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div>
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button" onClick={() => props.onClick(emoji)}>
+                <span>{emoji}</span>
+                <span>{String(users.length)}</span>
+              </button>
+            ))}
+          </div>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'Bar.tsx')
+    // Before #1245 this loop hit the static-array path: `forEach` over the
+    // array in init scope, attaching reactive effects to pre-existing
+    // `containerVar.children[idx]` — but the template emitted `${[].map(...)}`
+    // for the unsafe array, so SSR rendered zero children and init's loop
+    // silently skipped every iteration. After #1245 the dispatch detects
+    // the unsafe array and routes through `mapArray`, which materialises
+    // children at init time.
+    expect(clientJs).toContain('mapArray(')
+    // Negative assertion: the broken static-loop signature should NOT appear.
+    expect(clientJs).not.toMatch(/entries\.forEach\(/)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1701,8 +1701,12 @@ function extractValueBranches(node: ts.Expression, ctx: AnalyzerContext): string
 /**
  * Extract free identifier references from an AST node by walking the tree.
  * Skips property keys, member access properties, and bound parameter names.
+ *
+ * Exported so other compiler stages (e.g. `jsx-to-ir.ts` for loop arrays)
+ * can record the same canonical free-identifier set on their IR nodes
+ * instead of re-deriving it from the printed expression string.
  */
-function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
+export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
   const ids = new Set<string>()
   const boundNames = new Set<string>()
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -526,6 +526,7 @@ export function collectElements(
         childComponent: l.childComponent,
         nestedComponents: l.nestedComponents,
         isStaticArray: l.isStaticArray,
+        arrayFreeIdentifiers: l.arrayFreeIdentifiers,
         useElementReconciliation,
         innerLoops: (useElementReconciliation || (l.isStaticArray && innerLoops?.length)) ? innerLoops : undefined,
         siblingOffset: siblingOffsets.get(l) || undefined,

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -61,7 +61,7 @@ export function emitLoopUpdates(
   unsafeLocalNames: Set<string>,
 ): void {
   for (const elem of ctx.loopElements) {
-    if (elem.isStaticArray && !arrayReferencesUnsafeName(elem.array, unsafeLocalNames)) {
+    if (elem.isStaticArray && !arrayReferencesUnsafeName(elem, unsafeLocalNames)) {
       emitStaticArrayUpdates(lines, elem)
     } else {
       emitDynamicLoopUpdates(lines, elem)
@@ -73,8 +73,8 @@ export function emitLoopUpdates(
  * Static-array dispatch (`emitStaticArrayUpdates`) emits a `forEach` that
  * binds reactive effects on `containerVar.children[idx]` — which assumes
  * the SSR template has already rendered one DOM child per array entry. But
- * when the array expression is an init-body-only local (a `const` whose
- * value can't be relocated to template scope; see #1128 + the
+ * when the array expression resolves to an init-body-only local (a `const`
+ * whose value can't be relocated to template scope; see #1128 + the
  * `UNSAFE_TEMPLATE_EXPR` substitution at html-template.ts), the template
  * emits `${[].map(…)}` and SSR produces zero children. The static loop
  * then iterates a non-empty array but finds `__iterEl === undefined` for
@@ -85,18 +85,21 @@ export function emitLoopUpdates(
  * body's per-iteration template. The `TopLevelLoop` element already
  * carries the same `template` clone source the dynamic path needs, so
  * no IR-level rewrite is required.
+ *
+ * Detection uses the precomputed `arrayFreeIdentifiers` set on the IR
+ * loop — populated in `jsx-to-ir.ts` via the same
+ * `extractFreeIdentifiersFromNode` walker that fills
+ * `localConstants.freeIdentifiers`. Property access RHS / property keys /
+ * arrow-bound params are excluded, so for `state.items` the set contains
+ * `state` (and we correctly flag the loop as unsafe when `state` is an
+ * init-body-only local).
  */
-function arrayReferencesUnsafeName(arrayExpr: string, unsafeLocalNames: Set<string>): boolean {
+function arrayReferencesUnsafeName(elem: TopLevelLoop, unsafeLocalNames: Set<string>): boolean {
   if (unsafeLocalNames.size === 0) return false
-  // Conservative-but-cheap check: the array expression on a TopLevelLoop is
-  // typically a bare identifier (`{items.map(...)}` → `items`) or a short
-  // member chain (`{state.items.map(...)}` → `state.items`). A whole-word
-  // scan over the identifier set covers both without paying for an AST
-  // parse on every loop. Names come from a Set of valid JS identifiers, so
-  // no regex escaping is needed.
-  for (const name of unsafeLocalNames) {
-    const re = new RegExp(`(^|[^\\w$])${name}([^\\w$]|$)`)
-    if (re.test(arrayExpr)) return true
+  const freeIds = elem.arrayFreeIdentifiers
+  if (!freeIds || freeIds.size === 0) return false
+  for (const id of freeIds) {
+    if (unsafeLocalNames.has(id)) return true
   }
   return false
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -55,14 +55,50 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
 }
 
 /** Emit loop updates: dispatches to static or dynamic handlers per element. */
-export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
+export function emitLoopUpdates(
+  lines: string[],
+  ctx: ClientJsContext,
+  unsafeLocalNames: Set<string>,
+): void {
   for (const elem of ctx.loopElements) {
-    if (elem.isStaticArray) {
+    if (elem.isStaticArray && !arrayReferencesUnsafeName(elem.array, unsafeLocalNames)) {
       emitStaticArrayUpdates(lines, elem)
     } else {
       emitDynamicLoopUpdates(lines, elem)
     }
   }
+}
+
+/**
+ * Static-array dispatch (`emitStaticArrayUpdates`) emits a `forEach` that
+ * binds reactive effects on `containerVar.children[idx]` — which assumes
+ * the SSR template has already rendered one DOM child per array entry. But
+ * when the array expression is an init-body-only local (a `const` whose
+ * value can't be relocated to template scope; see #1128 + the
+ * `UNSAFE_TEMPLATE_EXPR` substitution at html-template.ts), the template
+ * emits `${[].map(…)}` and SSR produces zero children. The static loop
+ * then iterates a non-empty array but finds `__iterEl === undefined` for
+ * every index, leaving the DOM permanently empty.
+ *
+ * Re-route those loops through the dynamic emitter (`stringifyPlainLoop`
+ * + `mapArray`), which materialises children at init time from the loop
+ * body's per-iteration template. The `TopLevelLoop` element already
+ * carries the same `template` clone source the dynamic path needs, so
+ * no IR-level rewrite is required.
+ */
+function arrayReferencesUnsafeName(arrayExpr: string, unsafeLocalNames: Set<string>): boolean {
+  if (unsafeLocalNames.size === 0) return false
+  // Conservative-but-cheap check: the array expression on a TopLevelLoop is
+  // typically a bare identifier (`{items.map(...)}` → `items`) or a short
+  // member chain (`{state.items.map(...)}` → `state.items`). A whole-word
+  // scan over the identifier set covers both without paying for an AST
+  // parse on every loop. Names come from a Set of valid JS identifiers, so
+  // no regex escaping is needed.
+  for (const name of unsafeLocalNames) {
+    const re = new RegExp(`(^|[^\\w$])${name}([^\\w$]|$)`)
+    if (re.test(arrayExpr)) return true
+  }
+  return false
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -14,7 +14,7 @@ import { PROPS_PARAM } from './utils'
 import { buildReferencesGraph } from './build-references'
 import { computePropUsage } from './compute-prop-usage'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports'
-import { emitRegistrationAndHydration } from './emit-registration'
+import { buildInlinableConstants, emitRegistrationAndHydration } from './emit-registration'
 import { emitChildComponentImports } from './child-components'
 import { classifyLocalDeclarations } from './init-declarations'
 import { emitModuleLevelDeclarations, resolveFinalImports } from './emit-module-level'
@@ -43,6 +43,14 @@ export function generateInitFunction(
   const graph = buildReferencesGraph(ctx, ir.root)
   const classification = classifyLocalDeclarations(ctx, graph)
   const propUsage = computePropUsage(ctx, classification.neededConstants)
+  // Pre-compute `unsafeLocalNames` once. The result is consumed by
+  // `loop-updates` (to re-route static-array loops with unsafe arrays
+  // into the dynamic `mapArray` path; see `emitLoopUpdates`) and again
+  // by `emitRegistrationAndHydration` (to drive template substitution).
+  // Sharing avoids double work and guarantees both stages agree on the
+  // unsafe set — a divergence here would mean the loop dispatch and the
+  // template emitter could disagree about whether a name is safe.
+  const { unsafeLocalNames } = buildInlinableConstants(ctx, graph, ir.root)
 
   // --- Emission: declarative phase pipeline. Each entry in `PHASES`
   //     declares its inputs (dependsOn) and emission action (run); the
@@ -54,6 +62,7 @@ export function generateInitFunction(
     graph,
     classification,
     propUsage,
+    unsafeLocalNames,
   })
   runPhases(lines, phaseCtx, PHASES)
 

--- a/packages/jsx/src/ir-to-client-js/phases.ts
+++ b/packages/jsx/src/ir-to-client-js/phases.ts
@@ -51,6 +51,15 @@ export interface PhaseCtx {
   /** Slots that live inside a conditional branch (handled via `insert()`).
    *  Cached so `event-handlers` and `ref-callbacks` don't recompute. */
   conditionalSlotIds: Set<string>
+  /**
+   * Constants that can't be relocated to template scope (init-body-only).
+   * Threaded into `loop-updates` so static-array loops whose array refs
+   * an unsafe name fall back to the dynamic `mapArray` path — the static
+   * path assumes SSR-rendered children but the template emits `${[].map(…)}`
+   * for unsafe arrays, leaving zero children to bind. See `emitLoopUpdates`
+   * for the dispatch override.
+   */
+  unsafeLocalNames: Set<string>
 }
 
 /** Build the read-only carrier that every phase consumes. */
@@ -250,7 +259,7 @@ export const PHASES: readonly EmitPhase[] = [
     // contract is enforceable at registry-validation time.
     id: 'loop-updates',
     dependsOn: ['provider-and-child-inits'],
-    run: (lines, p) => emitLoopUpdates(lines, p.ctx),
+    run: (lines, p) => emitLoopUpdates(lines, p.ctx, p.unsafeLocalNames),
   },
   {
     id: 'static-array-child-inits',

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -358,6 +358,16 @@ export interface TopLevelLoop extends LoopCore {
   childComponent?: IRLoopChildComponent // For createComponent-based rendering
   nestedComponents?: IRLoopChildComponent[] // For nested components in loop bodies
   isStaticArray: boolean // True if array is a static prop (not a signal)
+  /**
+   * Free identifiers referenced by `array`, copied from `IRLoop.arrayFreeIdentifiers`.
+   * `emitLoopUpdates` intersects this with the component's `unsafeLocalNames` set
+   * to detect arrays that resolve to init-body-only locals. Such loops can't
+   * use the static `forEach` + `children[idx]` path (the SSR template emits
+   * `${[].map(…)}` for unsafe identifiers — zero children to bind), so they
+   * must be re-routed through the dynamic `mapArray` emitter, which
+   * materialises children at init time.
+   */
+  arrayFreeIdentifiers?: Set<string>
   useElementReconciliation?: boolean // True: reconcileElements + composite rendering (native root with child components)
   /** Inner loop metadata for composite element reconciliation (array, param, key, container) */
   innerLoops?: NestedLoop[]

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -27,6 +27,7 @@ import {
   type TypeInfo,
   pickAttrMeta,
 } from './types'
+import { extractFreeIdentifiersFromNode } from './analyzer'
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
 import { createError, ErrorCodes } from './errors'
@@ -2353,6 +2354,7 @@ function transformMapCall(
     isStaticArray,
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
+    arrayFreeIdentifiers: extractFreeIdentifiersFromNode(arrayExpr),
     bodyIsMultiRoot: bodyIsMultiRoot || undefined,
     childComponent,
     nestedComponents,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -372,6 +372,22 @@ export interface IRLoop {
   hasFunctionCalls?: boolean
 
   /**
+   * Free identifiers referenced by the array expression, computed via
+   * `extractFreeIdentifiersFromNode` against the source AST. Used by the
+   * client-JS dispatch in `control-flow.ts` to detect loops whose array
+   * resolves to an init-body-only local — those loops are forced through
+   * the dynamic `mapArray` path because the static path's child-binding
+   * forEach assumes SSR rendered children, but the template substitutes
+   * `${[].map(…)}` for unsafe identifiers.
+   *
+   * Property access RHS, property keys, and arrow-function-bound params
+   * are excluded by the walker — so for `state.items` the set contains
+   * `state`, not `items`. That mirrors how `unsafeLocalNames` indexes
+   * roots (chained access through an unsafe root is itself unsafe).
+   */
+  arrayFreeIdentifiers?: Set<string>
+
+  /**
    * When the loop body is a single component, store its info here
    * for createComponent-based rendering instead of template strings.
    * This enables proper parent-to-child prop passing (including event handlers).


### PR DESCRIPTION
Closes #1245.

## Summary

When a `'use client'` component renders `.map()` over a component-local `const` whose initializer cannot be relocated to template scope (e.g. `Object.entries(props.x ?? {}).filter(...)`), the rendered DOM contains the outer container but **no children** — the loop silently produces nothing.

Two compiler stages disagreed about whether the array was reachable from template scope:

1. `html-template.ts` substituted `${[].map(...)}` for the unsafe identifier — SSR template with zero children
2. `jsx-to-ir.ts:2324` classified the loop as `isStaticArray = true` (the array expression itself is just a bare identifier — no signal call, no function calls)
3. `control-flow.ts` dispatched to the static path, which `forEach`s over the array and tries to attach reactive effects to `containerVar.children[idx]` — but the SSR template emitted nothing, so every iteration silently `if (__iterEl) { ... }` skipped

The static path has no codegen branch that creates children when the SSR shape is empty. Only `mapArray` does.

## Fix

Re-route in `emitLoopUpdates`: when the array references a name in `unsafeLocalNames`, dispatch to `emitDynamicLoopUpdates` instead. The dynamic path uses `mapArray`, which materialises children at init time from the per-iteration template clone source the `TopLevelLoop` element already carries on `elem.template` (consumed by `buildPlainLoopPlan`).

The static path's performance edge only matters when SSR rendered children — for unsafe arrays SSR rendered nothing, so the comparison is moot.

## Wiring

- Add `unsafeLocalNames: Set<string>` to `PhaseCtx` and thread the pre-computed value (`buildInlinableConstants`) through `generate-init.ts` once. The `loop-updates` phase and the later `emitRegistrationAndHydration` template stage now consume the same set, so they can't disagree about whether a given identifier is unsafe.
- `emitLoopUpdates` accepts the set and consults a small `arrayReferencesUnsafeName` whole-word scan. Loop arrays in practice are bare identifiers or short member chains (`items`, `state.items`), so a tiny regex is cheaper than an AST parse, and identifier names need no escaping.

## Test plan

- [x] New test `packages/jsx/src/__tests__/init-scope-loop-routing.test.ts` — verifies `clientJs` contains `mapArray(` and does NOT contain the broken `entries.forEach(` static-loop signature for the repro case. Confirmed red without the fix (the `forEach` + `children[__idx]` pattern produces empty DOM at runtime), green with it.
- [x] `bun test packages/jsx` — 1046 pass / 4 pre-existing fail (alias resolver tests, unrelated to this PR)
- [x] `bun test packages/adapter-tests` — 39 / 39 CSR conformance pass (no regression)
- [x] **Real-world end-to-end**: piconic-ai/desk's `IssueCardCatalog` now renders three `<ReactionBar>` chip buttons (`👍2`, `🎉1`, `❤️2`) for a card with `data.deskReactions = { '👍': ['alice','bob'], '🎉': ['alice'], '❤️': ['carol','alice'] }` and `data.currentUser = 'alice'`. Before this fix the same component rendered an empty `<div data-reaction-bar="true">`. Verified via Chrome DevTools / playwright MCP.