### PR TITLE
refactor(jsx): unify reactivity classification across phases (#1248 + #1251)

### DIFF
--- a/packages/jsx/src/__tests__/free-refs.test.ts
+++ b/packages/jsx/src/__tests__/free-refs.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for resolveFreeRefs — the single classification entry point for
+ * `OriginInfo.freeRefs` (issue #1248 + #1251). These tests pin down the
+ * resolver in isolation; analyzer-integration coverage lives in
+ * reactivity-classification/.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import { resolveFreeRefs, type BindingEnvironment } from '../free-refs'
+import type { SignalInfo, MemoInfo, ParamInfo, ConstantInfo, FunctionInfo, ImportInfo } from '../types'
+
+const dummyLoc = { file: 'test.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } }
+
+function parseExpression(text: string): ts.Expression {
+  const sf = ts.createSourceFile(
+    'test.ts',
+    `const __probe = (${text});`,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const stmt = sf.statements[0] as ts.VariableStatement
+  const decl = stmt.declarationList.declarations[0]
+  // Unwrap the parenthesized expression we added so consumers see the bare expr.
+  const init = decl.initializer as ts.ParenthesizedExpression
+  return init.expression
+}
+
+function emptyEnv(): BindingEnvironment {
+  return {
+    signals: [] as readonly SignalInfo[],
+    memos: [] as readonly MemoInfo[],
+    propsParams: [] as readonly ParamInfo[],
+    propsObjectName: null,
+    restPropsName: null,
+    localConstants: [] as readonly ConstantInfo[],
+    localFunctions: [] as readonly FunctionInfo[],
+    imports: [] as readonly ImportInfo[],
+    ambientGlobals: new Set<string>(),
+    checker: null,
+  }
+}
+
+function mkSignal(getter: string, setter: string | null = null): SignalInfo {
+  return {
+    getter,
+    setter,
+    initialValue: '0',
+    type: { kind: 'unknown', raw: 'number' },
+    loc: dummyLoc,
+  } as SignalInfo
+}
+
+function mkMemo(name: string): MemoInfo {
+  return {
+    name,
+    computation: '0',
+    type: { kind: 'unknown', raw: 'number' },
+    deps: [],
+    loc: dummyLoc,
+  } as MemoInfo
+}
+
+function mkProp(name: string): ParamInfo {
+  return { name, type: { kind: 'unknown', raw: 'unknown' }, optional: false } as ParamInfo
+}
+
+function mkConst(name: string): ConstantInfo {
+  return { name } as ConstantInfo
+}
+
+describe('resolveFreeRefs — kind resolution', () => {
+  test('signal getter is classified as signal-getter', () => {
+    const node = parseExpression('count()')
+    const env = { ...emptyEnv(), signals: [mkSignal('count', 'setCount')] }
+    const refs = resolveFreeRefs(node, env)
+    const count = refs.find(r => r.name === 'count')
+    expect(count?.kind).toBe('signal-getter')
+  })
+
+  test('memo reference is classified as memo-getter (whether called or bare)', () => {
+    // Case 2 from #1248: bare memo reference must still classify as memo-getter
+    const env = { ...emptyEnv(), memos: [mkMemo('doubled')] }
+    const called = resolveFreeRefs(parseExpression('doubled()'), env)
+    const bare = resolveFreeRefs(parseExpression('doubled'), env)
+    expect(called.find(r => r.name === 'doubled')?.kind).toBe('memo-getter')
+    expect(bare.find(r => r.name === 'doubled')?.kind).toBe('memo-getter')
+  })
+
+  test('destructured prop name is classified as prop, even when renamed', () => {
+    // Case 3 from #1248: `({ value: renamed })` registers `renamed` in propsParams
+    const env = { ...emptyEnv(), propsParams: [mkProp('renamed')] }
+    const refs = resolveFreeRefs(parseExpression('renamed'), env)
+    expect(refs.find(r => r.name === 'renamed')?.kind).toBe('prop')
+  })
+
+  test('props object reference is classified as prop', () => {
+    const env = { ...emptyEnv(), propsObjectName: 'props' }
+    const refs = resolveFreeRefs(parseExpression('props.label'), env)
+    expect(refs.find(r => r.name === 'props')?.kind).toBe('prop')
+  })
+
+  test('local constant is classified as init-local', () => {
+    const env = { ...emptyEnv(), localConstants: [mkConst('x')] }
+    const refs = resolveFreeRefs(parseExpression('x'), env)
+    expect(refs.find(r => r.name === 'x')?.kind).toBe('init-local')
+  })
+
+  test('loop param is classified as render-item (overrides outer init-local)', () => {
+    const env = {
+      ...emptyEnv(),
+      localConstants: [mkConst('item')],
+      loopParams: new Set(['item']),
+    }
+    const refs = resolveFreeRefs(parseExpression('item'), env)
+    expect(refs.find(r => r.name === 'item')?.kind).toBe('render-item')
+  })
+
+  test('unrecognised identifier without ambient global hit is classified as global', () => {
+    const refs = resolveFreeRefs(parseExpression('unknownThing'), emptyEnv())
+    expect(refs.find(r => r.name === 'unknownThing')?.kind).toBe('global')
+  })
+
+  test('identifier in ambientGlobals is excluded entirely', () => {
+    const env = { ...emptyEnv(), ambientGlobals: new Set(['window']) }
+    const refs = resolveFreeRefs(parseExpression('window.foo'), env)
+    expect(refs.find(r => r.name === 'window')).toBeUndefined()
+  })
+})
+
+describe('resolveFreeRefs — skip rules', () => {
+  test('property name on member access is not a free ref', () => {
+    const env = { ...emptyEnv(), propsObjectName: 'props' }
+    const refs = resolveFreeRefs(parseExpression('props.label'), env)
+    // `label` is a property name; only `props` should appear
+    expect(refs.find(r => r.name === 'label')).toBeUndefined()
+    expect(refs.find(r => r.name === 'props')).toBeDefined()
+  })
+
+  test('object literal key is not a free ref', () => {
+    const refs = resolveFreeRefs(parseExpression('{ foo: 1 }'), emptyEnv())
+    expect(refs.find(r => r.name === 'foo')).toBeUndefined()
+  })
+})
+
+describe('resolveFreeRefs — dedup', () => {
+  test('same name resolved to same kind appears once', () => {
+    const env = { ...emptyEnv(), signals: [mkSignal('count', 'setCount')] }
+    const refs = resolveFreeRefs(parseExpression('count() + count()'), env)
+    const matches = refs.filter(r => r.name === 'count')
+    expect(matches.length).toBe(1)
+  })
+})

--- a/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared helpers for reactivity-classification tests.
+ *
+ * These tests pin down the *post-refactor* contract for issue #1248 + #1251:
+ * a single classification pipeline backed by `OriginInfo.freeRefs` with no
+ * silent regex fallback. They are expected to fail until the refactor lands.
+ */
+
+import ts from 'typescript'
+import path from 'path'
+import { analyzeComponent } from '../../analyzer'
+import { jsxToIR } from '../../jsx-to-ir'
+import { generateClientJs } from '../../ir-to-client-js'
+import { buildMetadata } from '../../compiler'
+import type {
+  ComponentIR,
+  IRExpression,
+  IRConditional,
+  IRNode,
+  FreeReference,
+} from '../../types'
+
+/**
+ * Future BindingKind values are referenced as plain strings to keep these
+ * tests type-stable before the type literal is widened. Cast at the call site.
+ */
+export type FutureBindingKind = FreeReference['kind'] | 'reactive-brand'
+
+/**
+ * Build a ts.Program from in-memory sources. Use this when the test exercises
+ * the TypeChecker (e.g. library-getter brand detection).
+ */
+export function createInMemoryProgram(
+  files: Record<string, string>,
+  entryFile: string
+): { program: ts.Program; entryPath: string } {
+  const baseDir = path.resolve(__dirname)
+  const resolvedFiles = new Map<string, string>()
+  for (const [name, content] of Object.entries(files)) {
+    resolvedFiles.set(path.join(baseDir, name), content)
+  }
+
+  const entryPath = path.join(baseDir, entryFile)
+
+  const opts: ts.CompilerOptions = {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx: ts.JsxEmit.ReactJSX,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  }
+  const defaultHost = ts.createCompilerHost(opts)
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    getSourceFile(name, lang) {
+      const resolved = path.resolve(name)
+      const text = resolvedFiles.get(resolved)
+      if (text !== undefined) return ts.createSourceFile(name, text, lang, true, ts.ScriptKind.TSX)
+      return defaultHost.getSourceFile(name, lang)
+    },
+    fileExists(name) {
+      return resolvedFiles.has(path.resolve(name)) || defaultHost.fileExists(name)
+    },
+    readFile(name) {
+      const text = resolvedFiles.get(path.resolve(name))
+      return text !== undefined ? text : defaultHost.readFile(name)
+    },
+  }
+
+  return { program: ts.createProgram([entryPath], opts, host), entryPath }
+}
+
+/**
+ * Run Phase 1 (analyzer + jsxToIR) on a source and return a ComponentIR.
+ * `program` is optional for cases that intentionally exercise the
+ * "no shared Program" failure mode.
+ */
+export function compileToComponentIR(
+  source: string,
+  filePath: string,
+  program?: ts.Program
+): { componentIR: ComponentIR | null; analyzerErrors: ReturnType<typeof analyzeComponent>['errors'] } {
+  const ctx = analyzeComponent(source, filePath, undefined, program)
+  if (!ctx.jsxReturn) {
+    return { componentIR: null, analyzerErrors: ctx.errors }
+  }
+  const root = jsxToIR(ctx)
+  if (!root) {
+    return { componentIR: null, analyzerErrors: ctx.errors }
+  }
+  const componentIR: ComponentIR = {
+    version: '0.1',
+    metadata: buildMetadata(ctx, ''),
+    root,
+    errors: [],
+  }
+  return { componentIR, analyzerErrors: ctx.errors }
+}
+
+/**
+ * Run Phase 2 on a ComponentIR and return the generated client JS string.
+ */
+export function compileToClientJs(componentIR: ComponentIR): string {
+  return generateClientJs(componentIR)
+}
+
+/**
+ * Walk an IR tree and collect every `IRExpression` node.
+ */
+export function collectExpressions(root: IRNode | null): IRExpression[] {
+  if (!root) return []
+  const out: IRExpression[] = []
+  const walk = (n: any) => {
+    if (!n) return
+    if (n.type === 'expression') out.push(n)
+    if (n.type === 'conditional') {
+      walk(n.whenTrue)
+      walk(n.whenFalse)
+    }
+    if (Array.isArray(n.children)) n.children.forEach(walk)
+  }
+  walk(root as any)
+  return out
+}
+
+/**
+ * Walk an IR tree and collect every `IRConditional` node.
+ */
+export function collectConditionals(root: IRNode | null): IRConditional[] {
+  if (!root) return []
+  const out: IRConditional[] = []
+  const walk = (n: any) => {
+    if (!n) return
+    if (n.type === 'conditional') {
+      out.push(n)
+      walk(n.whenTrue)
+      walk(n.whenFalse)
+    }
+    if (Array.isArray(n.children)) n.children.forEach(walk)
+  }
+  walk(root as any)
+  return out
+}
+
+/**
+ * True when `freeRefs` carries at least one entry whose `kind` matches
+ * any of the supplied names. Accepts post-refactor kinds as strings.
+ */
+export function hasFreeRefKind(
+  freeRefs: FreeReference[] | undefined,
+  ...kinds: FutureBindingKind[]
+): boolean {
+  if (!freeRefs) return false
+  const set = new Set<string>(kinds)
+  return freeRefs.some(r => set.has(r.kind as string))
+}
+
+/**
+ * Match an effect/createEffect wrap in emitted client JS.
+ */
+export const EFFECT_WRAP_RE = /createEffect\s*\(|__bf\.effect\s*\(|\beffect\s*\(/

--- a/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
@@ -21,10 +21,11 @@ import type {
 } from '../../types'
 
 /**
- * Alias kept for readability; once the `BindingKind` widening lands the
- * cast at hasFreeRefKind call sites becomes a no-op.
+ * Convenience alias so the `kinds` rest parameter type in
+ * `hasFreeRefKind` reads at call sites as a domain-level "binding kind"
+ * rather than indexing through `FreeReference['kind']`.
  */
-export type FutureBindingKind = FreeReference['kind']
+type FreeRefKind = FreeReference['kind']
 
 /**
  * Build a ts.Program from in-memory sources. Use this when the test exercises
@@ -150,7 +151,7 @@ export function collectConditionals(root: IRNode | null): IRConditional[] {
  */
 export function hasFreeRefKind(
   freeRefs: FreeReference[] | undefined,
-  ...kinds: FutureBindingKind[]
+  ...kinds: FreeRefKind[]
 ): boolean {
   if (!freeRefs) return false
   const set = new Set<string>(kinds)

--- a/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
@@ -21,10 +21,10 @@ import type {
 } from '../../types'
 
 /**
- * Future BindingKind values are referenced as plain strings to keep these
- * tests type-stable before the type literal is widened. Cast at the call site.
+ * Alias kept for readability; once the `BindingKind` widening lands the
+ * cast at hasFreeRefKind call sites becomes a no-op.
  */
-export type FutureBindingKind = FreeReference['kind'] | 'reactive-brand'
+export type FutureBindingKind = FreeReference['kind']
 
 /**
  * Build a ts.Program from in-memory sources. Use this when the test exercises

--- a/packages/jsx/src/__tests__/reactivity-classification/cross-phase-consistency.test.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/cross-phase-consistency.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Reactivity Classification — Cross-Phase Consistency (issue #1248 AC)
+ *
+ * Invariant: for any expression-bearing IR node, the Phase 1 reactivity
+ * judgement (derived from `origin.freeRefs`) and the Phase 2 emit shape
+ * (effect wrap vs bare emit) must agree. Today the two channels can
+ * silently diverge; this test pins the invariant.
+ *
+ * The check is structural — every expression node carries `origin` and
+ * (when `reactive` is true) the emitted client JS wraps SOME expression.
+ * We deliberately keep the assertion shape coarse so the test survives
+ * minor emit changes; the point is "they don't disagree", not the exact
+ * emission detail.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  compileToComponentIR,
+  compileToClientJs,
+  collectExpressions,
+  EFFECT_WRAP_RE,
+} from './_helpers'
+
+const FIXTURES: Array<{ label: string; source: string }> = [
+  {
+    label: 'signal getter call',
+    source: `
+      import { createSignal } from '@barefootjs/client'
+      export const A = () => {
+        const [count, setCount] = createSignal(0)
+        return <div>{count()}</div>
+      }
+    `,
+  },
+  {
+    label: 'memo call',
+    source: `
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export const B = () => {
+        const [count, setCount] = createSignal(0)
+        const doubled = createMemo(() => count() * 2)
+        return <div>{doubled()}</div>
+      }
+    `,
+  },
+  {
+    label: 'prop reference',
+    source: `
+      export const C = (props: { label: string }) => {
+        return <div>{props.label}</div>
+      }
+    `,
+  },
+  {
+    label: 'renamed destructured prop',
+    source: `
+      export const D = ({ label: renamed }: { label: string }) => {
+        return <div>{renamed}</div>
+      }
+    `,
+  },
+  {
+    label: 'static literal expression (not reactive)',
+    source: `
+      export const E = () => {
+        const x = 'hello'
+        return <div>{x}</div>
+      }
+    `,
+  },
+]
+
+describe('cross-phase consistency invariant', () => {
+  for (const { label, source } of FIXTURES) {
+    test(`${label}: every expression has origin populated`, () => {
+      const { componentIR } = compileToComponentIR(source, `/virtual/${label}.tsx`)
+      expect(componentIR).not.toBeNull()
+      const exprs = collectExpressions(componentIR!.root)
+      expect(exprs.length).toBeGreaterThan(0)
+      for (const e of exprs) {
+        expect(e.origin).toBeDefined()
+        // freeRefs is mandatory post-refactor
+        expect(Array.isArray(e.origin!.freeRefs)).toBe(true)
+      }
+    })
+
+    test(`${label}: Phase 1 reactive flag ⇔ Phase 2 effect wrap`, () => {
+      const { componentIR } = compileToComponentIR(source, `/virtual/${label}.tsx`)
+      expect(componentIR).not.toBeNull()
+      const exprs = collectExpressions(componentIR!.root)
+      const anyReactive = exprs.some(e => e.reactive)
+      const clientJs = compileToClientJs(componentIR!)
+      const hasEffectWrap = EFFECT_WRAP_RE.test(clientJs)
+      // Two-way implication: if Phase 1 says reactive, Phase 2 must wrap;
+      // if Phase 1 says nothing reactive, Phase 2 must not introduce a
+      // spurious effect either.
+      expect(hasEffectWrap).toBe(anyReactive)
+    })
+  }
+})

--- a/packages/jsx/src/__tests__/reactivity-classification/destructured-renamed-prop.test.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/destructured-renamed-prop.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Reactivity Classification — Destructured / Renamed Prop (issue #1248 Case 3)
+ *
+ *   const Comp = ({ value: renamed }: { value: string }) => {
+ *     const x = renamed
+ *     return <div>{x}</div>   // reactive because `renamed` is a prop
+ *   }
+ *
+ * Today:
+ *   - Phase 1 wraps via prop-name match heuristic (the analyzer knows
+ *     `renamed` came from prop `value`).
+ *   - Phase 2 regex looks for `props.renamed` in the expanded text and
+ *     never finds it — the rename hides the prop identity at the string level.
+ *
+ * After unification the IR's `origin.freeRefs` for the `<div>{x}</div>`
+ * expression must contain a `prop` reference pointing at the source prop
+ * (or the renamed local that resolves to it through taint), and Phase 2
+ * must agree.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  compileToComponentIR,
+  compileToClientJs,
+  collectExpressions,
+  hasFreeRefKind,
+  EFFECT_WRAP_RE,
+} from './_helpers'
+
+const SOURCE = `
+  export const Comp = ({ value: renamed }: { value: string }) => {
+    const x = renamed
+    return <div>{x}</div>
+  }
+`
+
+describe('destructured / renamed prop', () => {
+  test('IR marks expression reactive via prop reference in origin.freeRefs', () => {
+    const { componentIR } = compileToComponentIR(SOURCE, '/virtual/Comp.tsx')
+    expect(componentIR).not.toBeNull()
+    const target = collectExpressions(componentIR!.root).find(
+      e => e.expr.trim() === 'x'
+    )
+    expect(target).toBeDefined()
+    expect(target!.reactive).toBe(true)
+
+    expect(target!.origin).toBeDefined()
+    expect(
+      hasFreeRefKind(target!.origin!.freeRefs, 'prop', 'init-local')
+    ).toBe(true)
+  })
+
+  test('cross-phase consistency: Phase 2 wraps the expression too', () => {
+    const { componentIR } = compileToComponentIR(SOURCE, '/virtual/Comp.tsx')
+    expect(componentIR).not.toBeNull()
+    const clientJs = compileToClientJs(componentIR!)
+    expect(clientJs).toMatch(EFFECT_WRAP_RE)
+  })
+})

--- a/packages/jsx/src/__tests__/reactivity-classification/library-getter-unresolved-type.test.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/library-getter-unresolved-type.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Reactivity Classification — Library Getter (issue #1248 Case 1)
+ *
+ * A `Reactive<T>`-branded library getter (`form.isSubmitting()`,
+ * `username.error()`, etc.) carries reactivity via the TypeChecker.
+ * After unification (#1248 + #1251), classification must:
+ *
+ * 1. Recognise the library getter when a shared `ts.Program` is supplied,
+ *    and tag the corresponding `FreeReference.kind` as `'reactive-brand'`.
+ * 2. Refuse to compile (BFxxx) when no `ts.Program` is supplied — silent
+ *    regex fallback is no longer allowed.
+ *
+ * Both phases (analyzer-derived IR flag and emit-time effect wrapping)
+ * must agree, derived from the same `origin.freeRefs`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  createInMemoryProgram,
+  compileToComponentIR,
+  compileToClientJs,
+  collectExpressions,
+  hasFreeRefKind,
+  EFFECT_WRAP_RE,
+} from './_helpers'
+
+const REACTIVE_DEFS = `
+  export type Reactive<T> = T & { readonly __reactive: true };
+  export interface FormReturn {
+    isSubmitting: Reactive<() => boolean>;
+  }
+  export declare function createForm(): FormReturn;
+`
+
+const COMPONENT_SOURCE = `
+  import { createForm, type FormReturn } from './_reactive-defs';
+  export const Indicator = (props: { form: FormReturn }) => {
+    return <div>{props.form.isSubmitting()}</div>
+  }
+`
+
+describe('library getter — Reactive<T> brand', () => {
+  test('with shared Program: IR marks expression as reactive via origin.freeRefs', () => {
+    const { program, entryPath } = createInMemoryProgram(
+      { '_reactive-defs.ts': REACTIVE_DEFS, '_indicator.tsx': COMPONENT_SOURCE },
+      '_indicator.tsx'
+    )
+    const { componentIR } = compileToComponentIR(COMPONENT_SOURCE, entryPath, program)
+    expect(componentIR).not.toBeNull()
+
+    const exprs = collectExpressions(componentIR!.root)
+    const target = exprs.find(e => e.expr.includes('isSubmitting'))
+    expect(target).toBeDefined()
+
+    // Phase 1 — `reactive` flag set
+    expect(target!.reactive).toBe(true)
+
+    // Post-refactor — `origin.freeRefs` carries a brand-derived kind
+    expect(target!.origin).toBeDefined()
+    expect(hasFreeRefKind(target!.origin!.freeRefs, 'reactive-brand')).toBe(true)
+  })
+
+  test('with shared Program: Phase 2 emits effect wrapping for library getter', () => {
+    const { program, entryPath } = createInMemoryProgram(
+      { '_reactive-defs.ts': REACTIVE_DEFS, '_indicator.tsx': COMPONENT_SOURCE },
+      '_indicator.tsx'
+    )
+    const { componentIR } = compileToComponentIR(COMPONENT_SOURCE, entryPath, program)
+    expect(componentIR).not.toBeNull()
+    const clientJs = compileToClientJs(componentIR!)
+    expect(clientJs).toMatch(EFFECT_WRAP_RE)
+  })
+
+  test('without shared Program: compile fails with BFxxx (no silent regex fallback)', () => {
+    // Post-refactor behavior: analyzer must refuse to classify reactivity
+    // by regex alone when a library getter is in play. Today this falls
+    // through silently — that is the bug.
+    const source = `
+      export const Indicator = (props: { form: any }) => {
+        return <div>{props.form.isSubmitting()}</div>
+      }
+    `
+    const { componentIR, analyzerErrors } = compileToComponentIR(
+      source,
+      '/virtual/Indicator.tsx'
+      // intentionally no `program`
+    )
+    const allErrors = [
+      ...(analyzerErrors ?? []),
+      ...(componentIR?.errors ?? []),
+    ]
+    const hasProgramRequiredError = allErrors.some(e =>
+      typeof e.message === 'string' && /program required|shared program/i.test(e.message)
+    )
+    expect(hasProgramRequiredError).toBe(true)
+  })
+})

--- a/packages/jsx/src/__tests__/reactivity-classification/library-getter-unresolved-type.test.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/library-getter-unresolved-type.test.ts
@@ -72,11 +72,14 @@ describe('library getter — Reactive<T> brand', () => {
   })
 
   test('without shared Program: compile fails with BFxxx (no silent regex fallback)', () => {
-    // Post-refactor behavior: analyzer must refuse to classify reactivity
-    // by regex alone when a library getter is in play. Today this falls
-    // through silently — that is the bug.
+    // Post-refactor behavior: when the source imports from a known brand
+    // package (`@barefootjs/form`) we cannot classify reactivity from
+    // regex alone — the analyzer must refuse to proceed without a shared
+    // ts.Program. Today this falls through silently via the per-file
+    // program fallback, which is the bug.
     const source = `
-      export const Indicator = (props: { form: any }) => {
+      import type { FormReturn } from '@barefootjs/form'
+      export const Indicator = (props: { form: FormReturn }) => {
         return <div>{props.form.isSubmitting()}</div>
       }
     `

--- a/packages/jsx/src/__tests__/reactivity-classification/memo-as-value.test.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/memo-as-value.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Reactivity Classification — Memo as Value (issue #1248 Case 2)
+ *
+ * When a memo is passed as a *value* rather than called (`const x = memo`),
+ * the bare reference still carries the `Reactive<T>` brand on the TypeChecker.
+ *
+ *   const memo = createMemo(() => count() + 1)
+ *   const x = memo            // brand sits on `memo`
+ *   return <div>{x()}</div>   // `x` is reactive transitively
+ *
+ * Today the channels disagree:
+ *   - TypeChecker brand walk picks up the reactivity on `memo`.
+ *   - Phase 1 regex requires `memo\s*\(` and misses bare `memo`.
+ *   - Phase 2 sees only the local `x` and never `memo`.
+ *
+ * After unification, the IR's `origin.freeRefs` must trace
+ * `x → memo` (taint through the local constant) and mark the
+ * expression reactive.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  compileToComponentIR,
+  compileToClientJs,
+  collectExpressions,
+  hasFreeRefKind,
+  EFFECT_WRAP_RE,
+} from './_helpers'
+
+const SOURCE = `
+  import { createSignal, createMemo } from '@barefootjs/client'
+  export const Counter = () => {
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    const x = doubled
+    return <div>{x()}</div>
+  }
+`
+
+describe('memo as value (not called)', () => {
+  test('bare memo reference through local constant is reactive', () => {
+    const { componentIR } = compileToComponentIR(SOURCE, '/virtual/Counter.tsx')
+    expect(componentIR).not.toBeNull()
+    const target = collectExpressions(componentIR!.root).find(
+      e => e.expr.trim() === 'x()'
+    )
+    expect(target).toBeDefined()
+    expect(target!.reactive).toBe(true)
+
+    expect(target!.origin).toBeDefined()
+    // Should resolve via taint through the local constant `x` → `doubled`
+    expect(
+      hasFreeRefKind(target!.origin!.freeRefs, 'memo-getter', 'init-local')
+    ).toBe(true)
+  })
+
+  test('cross-phase consistency: Phase 2 wraps the expression too', () => {
+    const { componentIR } = compileToComponentIR(SOURCE, '/virtual/Counter.tsx')
+    expect(componentIR).not.toBeNull()
+    const clientJs = compileToClientJs(componentIR!)
+    expect(clientJs).toMatch(EFFECT_WRAP_RE)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -49,6 +49,34 @@ export function needsTypeBasedDetection(source: string): boolean {
 }
 
 /**
+ * Locate the first `import ... from '<brand-package>'` statement in
+ * `sourceFile`. Used by BF050 so the diagnostic points at the offending
+ * import line rather than a synthetic (1, 0) position.
+ *
+ * The scan is structural (`ts.ImportDeclaration` + `StringLiteral`
+ * specifier) rather than substring-based so it doesn't false-match on
+ * the package name appearing inside a string literal or comment.
+ */
+function findBrandPackageImportLoc(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+): { file: string; start: { line: number; column: number }; end: { line: number; column: number } } | null {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!REACTIVE_BRAND_PACKAGES.includes(stmt.moduleSpecifier.text)) continue
+    const start = sourceFile.getLineAndCharacterOfPosition(stmt.getStart(sourceFile))
+    const end = sourceFile.getLineAndCharacterOfPosition(stmt.getEnd())
+    return {
+      file: filePath,
+      start: { line: start.line + 1, column: start.character },
+      end: { line: end.line + 1, column: end.character },
+    }
+  }
+  return null
+}
+
+/**
  * Create a TypeScript program for a single file to enable type-based reactivity detection.
  * Uses a virtual CompilerHost that injects the source string as a virtual file
  * and delegates to the real file system for node_modules resolution.
@@ -201,15 +229,11 @@ export function analyzeComponent(
   // broader `needsTypeBasedDetection` predicate also fires for `.map()`
   // (BF023/BF024 nullable-key check), which is unrelated to reactivity
   // and must NOT trigger BF050.
-  const usesReactiveBrandPackage = REACTIVE_BRAND_PACKAGES.some(pkg => source.includes(pkg))
-  if (!hadSharedProgram && usesReactiveBrandPackage) {
+  const brandImportLoc = findBrandPackageImportLoc(sourceFile, filePath)
+  if (!hadSharedProgram && brandImportLoc !== null) {
     ctx.errors.push(createError(
       ErrorCodes.SHARED_PROGRAM_REQUIRED,
-      {
-        file: filePath,
-        start: { line: 1, column: 0 },
-        end: { line: 1, column: 0 },
-      },
+      brandImportLoc,
     ))
   }
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -121,6 +121,12 @@ export function analyzeComponent(
   program?: ts.Program
 ): AnalyzerContext {
   incrementCounter('filesAnalyzed')
+  // Track whether the caller supplied a shared ts.Program. Used downstream
+  // to decide whether the silent per-file fallback should also emit a
+  // BF050 diagnostic (issue #1248): when the source needs type-based
+  // detection but no shared Program is in scope, the regex fallback may
+  // misclassify library-getter reactivity.
+  const hadSharedProgram = program !== undefined
   // Pre-pass: inline calls to same-file reactive factory helpers so the
   // downstream analyzer sees ordinary `createSignal(...)` declarations
   // instead of `const [a, b] = customFactory(...)` (#931). Skipped when
@@ -185,6 +191,27 @@ export function analyzeComponent(
 
   const ctx = createAnalyzerContext(sourceFile, filePath)
   ctx.checker = checker
+
+  // BF050 — surface "no shared Program supplied for type-based reactivity
+  // classification" as a diagnostic so callers can fail strict builds
+  // rather than silently depending on the per-file Program fallback
+  // (issue #1248). Restricted to sources that import a known
+  // Reactive<T>-branded library: regex alone cannot classify those
+  // getters, so the per-file fallback may misclassify reactivity. The
+  // broader `needsTypeBasedDetection` predicate also fires for `.map()`
+  // (BF023/BF024 nullable-key check), which is unrelated to reactivity
+  // and must NOT trigger BF050.
+  const usesReactiveBrandPackage = REACTIVE_BRAND_PACKAGES.some(pkg => source.includes(pkg))
+  if (!hadSharedProgram && usesReactiveBrandPackage) {
+    ctx.errors.push(createError(
+      ErrorCodes.SHARED_PROGRAM_REQUIRED,
+      {
+        file: filePath,
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 0 },
+      },
+    ))
+  }
 
   // If no target specified, prioritize the default exported component
   if (!targetComponentName) {

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -46,6 +46,7 @@ export const ErrorCodes = {
   COMPONENT_REQUIRED_PROP_MISSING: 'BF046',
 
   // Import errors (BF050-BF059)
+  SHARED_PROGRAM_REQUIRED: 'BF050',
   WRONG_PACKAGE_IMPORT: 'BF051',
 
   // Init statement errors (BF052)
@@ -129,6 +130,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.COMPONENT_REQUIRED_PROP_MISSING]:
     'Built-in component is missing a required prop.',
+
+  [ErrorCodes.SHARED_PROGRAM_REQUIRED]:
+    'Shared ts.Program required for type-based reactivity classification. This source imports a Reactive<T>-branded library (e.g. @barefootjs/form) whose getters cannot be classified by regex alone. Pass `options.program` (built via `createProgramForCorpus`) so the analyzer can resolve the brand through the TypeChecker.',
 
   [ErrorCodes.WRONG_PACKAGE_IMPORT]:
     'Import from wrong package.',

--- a/packages/jsx/src/free-refs.ts
+++ b/packages/jsx/src/free-refs.ts
@@ -1,0 +1,380 @@
+/**
+ * Free-reference resolution for `OriginInfo.freeRefs` (issue #1248 + #1251).
+ *
+ * Walks an expression AST, collects bare identifier references, and resolves
+ * each one to a `BindingKind` using the analyzer's binding environment.
+ * Phase 2 (relocate, emit) reads the resulting `FreeReference[]` to decide
+ * rewrite shape per identifier without re-walking the AST or running regex.
+ *
+ * This is the single classification entry point that future passes consume;
+ * the legacy `isReactiveExpression` / regex / TypeChecker fan-out collapses
+ * onto this once `origin` is populated uniformly.
+ */
+
+import ts from 'typescript'
+import type {
+  BindingKind,
+  FreeReference,
+  Scope,
+  ImportInfo,
+  SignalInfo,
+  MemoInfo,
+  ParamInfo,
+  ConstantInfo,
+  FunctionInfo,
+} from './types'
+import { isReactiveType } from './reactivity-checker'
+
+/**
+ * Subset of `AnalyzerContext` / `TransformContext` that this resolver reads.
+ * Kept as a structural type so the same helper works from either side without
+ * dragging in the full context shape (and the circular imports that would bring).
+ */
+export interface BindingEnvironment {
+  signals: readonly SignalInfo[]
+  memos: readonly MemoInfo[]
+  propsParams: readonly ParamInfo[]
+  propsObjectName: string | null
+  restPropsName: string | null
+  localConstants: readonly ConstantInfo[]
+  localFunctions: readonly FunctionInfo[]
+  imports: readonly ImportInfo[]
+  ambientGlobals: ReadonlySet<string>
+  /** Active `.map()` callback parameter names — present inside loop bodies. */
+  loopParams?: ReadonlySet<string>
+  /** Names declared inside nested arrow / function bodies — passed by caller. */
+  subInitLocals?: ReadonlySet<string>
+  checker: ts.TypeChecker | null
+}
+
+/**
+ * Build a name → BindingKind table from the binding environment.
+ *
+ * Order of precedence matters: a loop callback parameter shadows an outer
+ * `init-local`; an `init-local` shadows a `module-import`. The table is
+ * keyed by name only — the resolver does not track lexical scopes per
+ * identifier site, which is fine for the analyzer's current usage but
+ * misses true shadowing inside nested arrows. That is the next refinement
+ * (issue #1251 shadowing tests).
+ */
+function buildBindingMap(env: BindingEnvironment): Map<string, BindingKind> {
+  const map = new Map<string, BindingKind>()
+
+  // Lowest precedence first — later writes override.
+  for (const imp of env.imports) {
+    for (const spec of imp.specifiers) {
+      const visibleName = spec.alias ?? spec.name
+      map.set(visibleName, 'module-import')
+    }
+  }
+  for (const fn of env.localFunctions) {
+    map.set(fn.name, 'init-local')
+  }
+  for (const c of env.localConstants) {
+    map.set(c.name, 'init-local')
+  }
+  for (const p of env.propsParams) {
+    // `children` from destructured props is server-rendered into the
+    // outer HTML, not a reactive value — treat it the same as the
+    // `props.children` skip below. Matches the legacy
+    // `isPropsReference` filter (`.filter(p => p.name !== 'children')`).
+    // Without this skip, `<div>{children}</div>` in a destructuring
+    // component (e.g. SelectGroup) classifies `children` as `prop` and
+    // the OR-combined `reactive` flag promotes it to a text slot,
+    // breaking SSR hydration on every UI component that forwards
+    // children.
+    if (p.name === 'children') continue
+    map.set(p.name, 'prop')
+  }
+  if (env.propsObjectName !== null) {
+    map.set(env.propsObjectName, 'prop')
+  }
+  if (env.restPropsName !== null) {
+    map.set(env.restPropsName, 'prop')
+  }
+  for (const s of env.signals) {
+    map.set(s.getter, 'signal-getter')
+    if (s.setter !== null) map.set(s.setter, 'signal-setter')
+  }
+  for (const m of env.memos) {
+    map.set(m.name, 'memo-getter')
+  }
+  // Highest precedence — innermost scope.
+  if (env.subInitLocals) {
+    for (const name of env.subInitLocals) map.set(name, 'sub-init-local')
+  }
+  if (env.loopParams) {
+    for (const name of env.loopParams) map.set(name, 'render-item')
+  }
+
+  return map
+}
+
+/**
+ * Default `bindingScope` assignment for a given `BindingKind`. Mirrors the
+ * authoring scope in the canonical SCOPE_FORBIDDEN table — `prop`-kind refs
+ * are introduced in `init` scope (component body), `render-item` in
+ * `render-item` scope, and so on.
+ */
+function defaultBindingScope(kind: BindingKind): Scope {
+  switch (kind) {
+    case 'render-item':
+      return 'render-item'
+    case 'sub-init-local':
+      return 'sub-init'
+    case 'module-import':
+    case 'module-local':
+    case 'global':
+      return 'module'
+    // signal/memo/prop/init-local are all introduced in the component body
+    case 'prop':
+    case 'signal-getter':
+    case 'signal-setter':
+    case 'memo-getter':
+    case 'reactive-brand':
+    case 'init-local':
+    default:
+      return 'init'
+  }
+}
+
+/**
+ * Collect every bare identifier reference inside `node`. Skips positions
+ * that are not references (property names, key names, JSX tag names).
+ *
+ * This is intentionally an over-collection — we keep duplicate names so
+ * the resolver can dedupe after kind resolution (a name resolved to two
+ * different kinds in different positions is rare but possible with future
+ * shadowing support, and dedup-by-name+kind handles that).
+ */
+function collectIdentifiers(node: ts.Node): ts.Identifier[] {
+  const out: ts.Identifier[] = []
+  const visit = (n: ts.Node, parent?: ts.Node): void => {
+    if (ts.isIdentifier(n)) {
+      // foo.X — X is a property name
+      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === n) return
+      // { X: ... } — X is a key
+      if (parent && ts.isPropertyAssignment(parent) && parent.name === n) return
+      // { X } — shorthand key (the value side IS a ref, but in TS AST the
+      // single identifier node serves both roles; treat it as a ref)
+      // JSX <Tag .../> — Tag identifier
+      if (parent && (ts.isJsxOpeningElement(parent) || ts.isJsxClosingElement(parent) || ts.isJsxSelfClosingElement(parent)) && (parent as any).tagName === n) {
+        // JSX intrinsic tags (lowercase) are not free refs; component refs are.
+        // We still skip — the tagName is handled separately by the IR builder.
+        return
+      }
+      // JSX attribute name — not a free ref
+      if (parent && ts.isJsxAttribute(parent) && parent.name === n) return
+      out.push(n)
+      return
+    }
+    ts.forEachChild(n, child => visit(child, n))
+  }
+  visit(node)
+  return out
+}
+
+/**
+ * Walk the AST and collect every PropertyAccessExpression whose static
+ * type carries the Reactive<T> brand. Library getters such as
+ * `form.isSubmitting` and `username.error` enter the IR through this path
+ * — the leaf identifier (`isSubmitting`) is a property name and so is
+ * skipped by `collectIdentifiers`; the reactivity lives on the access
+ * expression as a whole.
+ *
+ * Each match contributes one FreeReference whose `name` is the full
+ * access text (e.g. `props.form.isSubmitting`) so it remains uniquely
+ * identifiable in downstream emit. The root identifier of the access
+ * (e.g. `props`) is reported separately by the identifier walk under its
+ * own kind.
+ */
+function collectReactiveBrandRefs(
+  node: ts.Node,
+  checker: ts.TypeChecker
+): FreeReference[] {
+  const out: FreeReference[] = []
+  const seen = new Set<string>()
+  const visit = (n: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(n)) {
+      try {
+        const type = checker.getTypeAtLocation(n)
+        if (isReactiveType(type)) {
+          const accessText = n.getText()
+          if (!seen.has(accessText)) {
+            seen.add(accessText)
+            out.push({
+              name: accessText,
+              bindingScope: 'init',
+              kind: 'reactive-brand',
+            })
+          }
+        }
+      } catch {
+        // Type resolution can fail for some nodes; ignore.
+      }
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
+  return out
+}
+
+/**
+ * Re-parse a constant's initializer text (stored as a string in
+ * `ConstantInfo.value`) and resolve its own freeRefs. Used by transitive
+ * taint propagation: `const x = doubled` should surface `doubled`'s
+ * `memo-getter` kind when something reads `x` later.
+ *
+ * Returns an empty array on parse failure or when the constant has no
+ * recorded `value`.
+ */
+function resolveConstantInitializerRefs(
+  c: import('./types').ConstantInfo,
+  env: BindingEnvironment,
+  visited: Set<string>
+): FreeReference[] {
+  if (c.value === undefined) return []
+  // Skip locals whose initializer is an arrow / function expression. The
+  // references inside the function body do not run at the consuming
+  // expression's read site — they run when (and if) the function is
+  // invoked, and the invocation gets its own reactivity classification
+  // from the consumer's expression. Recursing into the body here
+  // over-classifies (e.g. `const numMonths = () => props.numberOfMonths
+  // ?? 1` would taint any `numMonths()` call site with a `prop` ref even
+  // though the props read is gated by the call). Matches the legacy
+  // `isReactiveExpression` semantics, which never walked into function
+  // bodies during constant taint analysis.
+  if (c.containsArrow) return []
+  // Wrap in parens so any expression form parses as a single expression.
+  const sf = ts.createSourceFile(
+    '__const_init.ts',
+    `const __probe = (${c.value});`,
+    ts.ScriptTarget.Latest,
+    true
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return []
+  const decl = stmt.declarationList.declarations[0]
+  if (!decl || !decl.initializer) return []
+  const expr = ts.isParenthesizedExpression(decl.initializer)
+    ? decl.initializer.expression
+    : decl.initializer
+  return resolveFreeRefsInternal(expr, env, visited)
+}
+
+/**
+ * Inner resolver shared between the top-level `resolveFreeRefs` call and
+ * the transitive-taint expansion path. `visited` tracks identifier names
+ * already expanded to break cycles like `const a = b; const b = a`.
+ */
+function resolveFreeRefsInternal(
+  node: ts.Node,
+  env: BindingEnvironment,
+  visited: Set<string>
+): FreeReference[] {
+  const bindingMap = buildBindingMap(env)
+  const idents = collectIdentifiers(node)
+
+  const seen = new Set<string>()
+  const out: FreeReference[] = []
+
+  for (const ident of idents) {
+    const name = ident.text
+
+    // `props.children` is rendered into the server-side HTML (it is the
+    // child slot, not a reactive value). Treat the `props` identifier as
+    // a non-reactive reference *only* in this position so consumers don't
+    // wrap the surrounding expression in createEffect just because it
+    // touches `props`. Matches the legacy `isPropsReference` semantics.
+    if (env.propsObjectName === name) {
+      const parent = ident.parent
+      if (
+        parent &&
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === ident &&
+        parent.name.text === 'children'
+      ) {
+        continue
+      }
+    }
+
+    let kind: BindingKind | undefined = bindingMap.get(name)
+
+    // Reactive<T> brand check on the bare identifier (memo as value).
+    if (env.checker) {
+      try {
+        const type = env.checker.getTypeAtLocation(ident)
+        if (isReactiveType(type)) {
+          if (
+            kind === undefined ||
+            kind === 'module-import' ||
+            kind === 'module-local' ||
+            kind === 'global'
+          ) {
+            kind = 'reactive-brand'
+          }
+        }
+      } catch {
+        // Ignore.
+      }
+    }
+
+    if (kind === undefined) {
+      if (env.ambientGlobals.has(name)) continue
+      kind = 'global'
+    }
+
+    const dedupKey = `${name}::${kind}`
+    if (!seen.has(dedupKey)) {
+      seen.add(dedupKey)
+      out.push({
+        name,
+        bindingScope: defaultBindingScope(kind),
+        kind,
+      })
+    }
+
+    // Transitive taint: when a referenced identifier is a local constant,
+    // recurse into its initializer so the consumer sees the *kinds* the
+    // constant captures. `const x = doubled` → reading `x` surfaces a
+    // `memo-getter` for `doubled` here, which is what makes `<div>{x()}</div>`
+    // wrap correctly without the regex Phase-2 rescan.
+    if (kind === 'init-local' && !visited.has(name)) {
+      visited.add(name)
+      const constInfo = env.localConstants.find(c => c.name === name)
+      if (constInfo !== undefined) {
+        for (const transitive of resolveConstantInitializerRefs(constInfo, env, visited)) {
+          const tk = `${transitive.name}::${transitive.kind}`
+          if (seen.has(tk)) continue
+          seen.add(tk)
+          out.push(transitive)
+        }
+      }
+    }
+  }
+
+  // Property-access brand walk — catches `form.isSubmitting` etc.
+  if (env.checker) {
+    for (const brandRef of collectReactiveBrandRefs(node, env.checker)) {
+      const dedupKey = `${brandRef.name}::${brandRef.kind}`
+      if (seen.has(dedupKey)) continue
+      seen.add(dedupKey)
+      out.push(brandRef)
+    }
+  }
+
+  return out
+}
+
+/**
+ * Resolve `node`'s free-identifier references against `env` and return one
+ * `FreeReference` per (name, kind) pair encountered. References that flow
+ * through a local constant are recursively expanded so the consumer sees
+ * the constant's *kind composition*, not just the local name.
+ */
+export function resolveFreeRefs(
+  node: ts.Node,
+  env: BindingEnvironment
+): FreeReference[] {
+  return resolveFreeRefsInternal(node, env, new Set<string>())
+}

--- a/packages/jsx/src/free-refs.ts
+++ b/packages/jsx/src/free-refs.ts
@@ -24,6 +24,7 @@ import type {
   FunctionInfo,
 } from './types'
 import { isReactiveType } from './reactivity-checker'
+import { incrementCounter } from './instrumentation'
 
 /**
  * Subset of `AnalyzerContext` / `TransformContext` that this resolver reads.
@@ -42,10 +43,18 @@ export interface BindingEnvironment {
   ambientGlobals: ReadonlySet<string>
   /** Active `.map()` callback parameter names — present inside loop bodies. */
   loopParams?: ReadonlySet<string>
-  /** Names declared inside nested arrow / function bodies — passed by caller. */
-  subInitLocals?: ReadonlySet<string>
   checker: ts.TypeChecker | null
 }
+
+/**
+ * Per-environment cache for the binding map. `BindingEnvironment` identity
+ * is stable per (analyzer, loopParams snapshot) — `jsx-to-ir.ts` memoizes
+ * `makeBindingEnv` so the same object is reused across every
+ * `resolveFreeRefs` call within a loop scope. With N expressions per
+ * component and M bindings per env, this drops binding-table construction
+ * from O(N*M) to O(N + M).
+ */
+const _bindingMapCache: WeakMap<BindingEnvironment, Map<string, BindingKind>> = new WeakMap()
 
 /**
  * Build a name → BindingKind table from the binding environment.
@@ -56,8 +65,13 @@ export interface BindingEnvironment {
  * identifier site, which is fine for the analyzer's current usage but
  * misses true shadowing inside nested arrows. That is the next refinement
  * (issue #1251 shadowing tests).
+ *
+ * Memoized via `_bindingMapCache` so repeated `resolveFreeRefs` calls
+ * against the same env reuse one table.
  */
 function buildBindingMap(env: BindingEnvironment): Map<string, BindingKind> {
+  const cached = _bindingMapCache.get(env)
+  if (cached) return cached
   const map = new Map<string, BindingKind>()
 
   // Lowest precedence first — later writes override.
@@ -100,13 +114,11 @@ function buildBindingMap(env: BindingEnvironment): Map<string, BindingKind> {
     map.set(m.name, 'memo-getter')
   }
   // Highest precedence — innermost scope.
-  if (env.subInitLocals) {
-    for (const name of env.subInitLocals) map.set(name, 'sub-init-local')
-  }
   if (env.loopParams) {
     for (const name of env.loopParams) map.set(name, 'render-item')
   }
 
+  _bindingMapCache.set(env, map)
   return map
 }
 
@@ -157,10 +169,15 @@ function collectIdentifiers(node: ts.Node): ts.Identifier[] {
       if (parent && ts.isPropertyAssignment(parent) && parent.name === n) return
       // { X } — shorthand key (the value side IS a ref, but in TS AST the
       // single identifier node serves both roles; treat it as a ref)
-      // JSX <Tag .../> — Tag identifier
-      if (parent && (ts.isJsxOpeningElement(parent) || ts.isJsxClosingElement(parent) || ts.isJsxSelfClosingElement(parent)) && (parent as any).tagName === n) {
-        // JSX intrinsic tags (lowercase) are not free refs; component refs are.
-        // We still skip — the tagName is handled separately by the IR builder.
+      // JSX <Tag .../> — Tag identifier. Intrinsic tags (lowercase) are
+      // never free refs; component refs are, but the IR builder collects
+      // them separately so we skip to avoid double counting. All three
+      // JSX element kinds expose a `tagName` field with the same shape.
+      if (
+        parent &&
+        (ts.isJsxOpeningElement(parent) || ts.isJsxClosingElement(parent) || ts.isJsxSelfClosingElement(parent)) &&
+        parent.tagName === n
+      ) {
         return
       }
       // JSX attribute name — not a free ref
@@ -210,7 +227,12 @@ function collectReactiveBrandRefs(
           }
         }
       } catch {
-        // Type resolution can fail for some nodes; ignore.
+        // Type resolution can fail when the AST node was parsed in a
+        // synthetic SourceFile (transitive-taint recursion path) but the
+        // checker is rooted in a different Program. Surface the count via
+        // instrumentation so the bench harness can flag the divergence
+        // instead of letting it accumulate as silent misclassification.
+        incrementCounter('freeRefsTypeLookupFailures')
       }
     }
     ts.forEachChild(n, visit)
@@ -315,7 +337,10 @@ function resolveFreeRefsInternal(
           }
         }
       } catch {
-        // Ignore.
+        // See the equivalent catch in `collectReactiveBrandRefs`: ignored
+        // here so the resolver still produces a useful (if conservative)
+        // result, surfaced via instrumentation for the bench harness.
+        incrementCounter('freeRefsTypeLookupFailures')
       }
     }
 

--- a/packages/jsx/src/instrumentation.ts
+++ b/packages/jsx/src/instrumentation.ts
@@ -21,6 +21,15 @@ export interface CompilerCounters {
   reactivityChecks: number
   /** Number of analyzeComponent() invocations (one per file per target). */
   filesAnalyzed: number
+  /**
+   * Number of TypeChecker lookups that threw or otherwise failed inside
+   * free-refs resolution. Always silently swallowed at the site (the
+   * resolver falls back to whatever the binding map produced), but a
+   * climb here in the bench harness flags a real bug — most often
+   * passing AST nodes from a synthetic SourceFile to a checker rooted
+   * in a different Program.
+   */
+  freeRefsTypeLookupFailures: number
 }
 
 let _enabled = false
@@ -32,6 +41,7 @@ function freshCounters(): CompilerCounters {
     typeCheckerQueries: 0,
     reactivityChecks: 0,
     filesAnalyzed: 0,
+    freeRefsTypeLookupFailures: 0,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -57,9 +57,18 @@ export type WrapReason =
  * IRConditional nodes. Consults `origin.freeRefs` (the unified Phase 1
  * classification) first when available — this collapses the historic
  * `reactive || callsReactiveGetters || hasFunctionCalls` fan-out onto a
- * single source of truth. Legacy flags remain as fallbacks during the
- * migration: nodes whose origin has not been populated yet (e.g. attr
- * values, future IR kinds) still wrap correctly under the old gates.
+ * single source of truth.
+ *
+ * `node.reactive` is checked separately even though `jsx-to-ir.ts` already
+ * OR-combines it with `isReactiveOrigin(origin)` at every populate site:
+ * the legacy flag still covers shapes the origin-side classifier hasn't
+ * been wired through (e.g. IRConditional nodes synthesized by deeper
+ * dispatchers that haven't been migrated), and the duplication is cheap.
+ * `callsReactiveGetters` / `hasFunctionCalls` remain as Solid-style
+ * wrap-by-default fallbacks (#937, #941); they are NOT redundant with
+ * origin because they capture call-shape information that `freeRefs`
+ * doesn't carry.
+ *
  * Pure literals and bare identifiers (no calls) stay un-wrapped because
  * their SSR value is already in the DOM.
  */
@@ -83,6 +92,10 @@ export function decideWrapFromAstFlags(node: {
  * string-level `needsEffectWrapper` check (recognises signal getters / memos /
  * prop names inside expanded local-const references) with the AST flags from
  * the source attribute expression.
+ *
+ * TODO(#1255): once `IRAttribute` carries `origin.freeRefs`, switch this to
+ * `isReactiveOrigin(attr.origin)` so the attr path joins the unified
+ * classification — `needsEffectWrapper` should then be deletable.
  */
 export function decideWrapForAttr(
   expandedValue: string,

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -2,7 +2,7 @@
  * Reactivity detection: reactive expression checking, event/ref collection.
  */
 
-import { type IRNode, type IRElement, type IRProp, type LoopParamBinding, pickAttrMeta } from '../types'
+import { type IRNode, type IRElement, type IRProp, type LoopParamBinding, type OriginInfo, pickAttrMeta, isReactiveOrigin } from '../types'
 import type {
   ClientJsContext,
   ConditionalBranchEvent,
@@ -54,16 +54,24 @@ export type WrapReason =
 
 /**
  * AST-flag based wrap decision for IRExpression / IRConditional / nested
- * IRConditional nodes. Replaces the duplicated
- * `node.reactive || node.callsReactiveGetters || node.hasFunctionCalls`
- * predicate (#937 / #941). Pure literals and bare identifiers (no calls)
- * stay un-wrapped because their SSR value is already in the DOM.
+ * IRConditional nodes. Consults `origin.freeRefs` (the unified Phase 1
+ * classification) first when available — this collapses the historic
+ * `reactive || callsReactiveGetters || hasFunctionCalls` fan-out onto a
+ * single source of truth. Legacy flags remain as fallbacks during the
+ * migration: nodes whose origin has not been populated yet (e.g. attr
+ * values, future IR kinds) still wrap correctly under the old gates.
+ * Pure literals and bare identifiers (no calls) stay un-wrapped because
+ * their SSR value is already in the DOM.
  */
 export function decideWrapFromAstFlags(node: {
   reactive?: boolean
   callsReactiveGetters?: boolean
   hasFunctionCalls?: boolean
+  origin?: OriginInfo
 }): WrapDecision {
+  if (node.origin && isReactiveOrigin(node.origin)) {
+    return { wrap: true, reason: 'proven-reactive' }
+  }
   if (node.reactive) return { wrap: true, reason: 'proven-reactive' }
   if (node.callsReactiveGetters) return { wrap: true, reason: 'fallback-getter-calls' }
   if (node.hasFunctionCalls) return { wrap: true, reason: 'fallback-function-calls' }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -25,13 +25,16 @@ import {
   type LoopParamBinding,
   type SourceLocation,
   type TypeInfo,
+  type OriginInfo,
   pickAttrMeta,
+  isReactiveOrigin,
 } from './types'
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
 import { createError, ErrorCodes } from './errors'
 import { containsReactiveExpression } from './reactivity-checker'
 import { rewriteBarePropRefs as rewriteBarePropRefsCore } from './prop-rewrite'
+import { resolveFreeRefs, type BindingEnvironment } from './free-refs'
 
 // =============================================================================
 // Transform Context
@@ -242,6 +245,30 @@ function generateSlotId(ctx: TransformContext, forComponent: boolean = false): s
   // passed as children into a child component's scope.
   if (forComponent) return id
   return ctx.insideComponentChildren ? `^${id}` : id
+}
+
+/**
+ * Build the binding environment for `resolveFreeRefs` from the current
+ * transform context. The analyzer's collected bindings (signals, memos,
+ * props, locals, imports) plus the active loop params form the resolution
+ * frame; the TypeChecker, when available, is forwarded so library getters
+ * carrying the Reactive<T> brand are recognised.
+ */
+function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
+  const a = ctx.analyzer
+  return {
+    signals: a.signals,
+    memos: a.memos,
+    propsParams: a.propsParams,
+    propsObjectName: a.propsObjectName,
+    restPropsName: a.restPropsName,
+    localConstants: a.localConstants,
+    localFunctions: a.localFunctions,
+    imports: a.imports,
+    ambientGlobals: a.ambientGlobals,
+    loopParams: ctx.loopParams,
+    checker: a.checker,
+  }
 }
 
 // =============================================================================
@@ -988,7 +1015,18 @@ function transformExpression(
 
   // Scalar fallback — unchanged from pre-refactor.
   const exprText = ctx.getJS(expr)
-  const reactive = isReactiveExpression(exprText, ctx, expr)
+  const freeRefs = resolveFreeRefs(expr, makeBindingEnv(ctx))
+  const origin: OriginInfo = {
+    phase: 'tick',
+    scope: 'template',
+    effect: 'pure',
+    freeRefs,
+  }
+  // Combine the legacy regex/checker classifier with the new origin-based
+  // result so memo-as-value (Case 2) and renamed-prop (Case 3) cases —
+  // which the regex path misses — light up the reactive flag during the
+  // migration period.
+  const reactive = isReactiveExpression(exprText, ctx, expr) || isReactiveOrigin(origin)
   // @client expressions always need slotId and are treated as reactive for client-side evaluation
   // Expressions inside loops that reference the loop parameter need slotId
   // so fine-grained effects can target them for per-item signal updates
@@ -1019,6 +1057,7 @@ function transformExpression(
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin,
   }
 }
 
@@ -1075,6 +1114,12 @@ function transformJsxFunctionCall(
       reactive: false,
       slotId: null,
       loc: getSourceLocation(callExpr, ctx.sourceFile, ctx.filePath),
+      origin: {
+        phase: 'tick',
+        scope: 'template',
+        effect: 'pure',
+        freeRefs: [],
+      },
     }
   } finally {
     ctx.getJS = originalCtxGetJS
@@ -1087,7 +1132,13 @@ function transformConditional(
   ctx: TransformContext
 ): IRConditional {
   const condition = ctx.getJS(node.condition)
-  const reactive = isReactiveExpression(condition, ctx, node.condition)
+  const conditionOrigin: OriginInfo = {
+    phase: 'tick',
+    scope: 'template',
+    effect: 'pure',
+    freeRefs: resolveFreeRefs(node.condition, makeBindingEnv(ctx)),
+  }
+  const reactive = isReactiveExpression(condition, ctx, node.condition) || isReactiveOrigin(conditionOrigin)
   const loopParamReactive = !reactive && referencesLoopParam(condition, ctx)
   // Solid-style wrap-by-default fallback (#941, follow-up to #937/#939).
   // A condition the analyzer can't prove reactive but that contains a
@@ -1115,6 +1166,7 @@ function transformConditional(
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin: conditionOrigin,
   }
 }
 
@@ -1123,7 +1175,13 @@ function transformLogicalAnd(
   ctx: TransformContext
 ): IRConditional {
   const condition = ctx.getJS(node.left)
-  const reactive = isReactiveExpression(condition, ctx, node.left)
+  const leftOrigin: OriginInfo = {
+    phase: 'tick',
+    scope: 'template',
+    effect: 'pure',
+    freeRefs: resolveFreeRefs(node.left, makeBindingEnv(ctx)),
+  }
+  const reactive = isReactiveExpression(condition, ctx, node.left) || isReactiveOrigin(leftOrigin)
   const loopParamReactive = !reactive && referencesLoopParam(condition, ctx)
   // Wrap-by-default fallback (#941) — see transformConditional.
   const callsReactive = exprCallsReactiveGetters(node.left, ctx)
@@ -1139,6 +1197,12 @@ function transformLogicalAnd(
     reactive: false,
     slotId: null,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin: {
+      phase: 'tick',
+      scope: 'template',
+      effect: 'pure',
+      freeRefs: [],
+    },
   }
 
   return {
@@ -1153,6 +1217,7 @@ function transformLogicalAnd(
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin: leftOrigin,
   }
 }
 
@@ -1183,7 +1248,13 @@ function transformNullishCoalescing(
   const leftText = ctx.getJS(node.left)
   const isNullish = node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
   const condition = isNullish ? `${leftText} != null` : leftText
-  const reactive = isReactiveExpression(leftText, ctx, node.left)
+  const leftOrigin: OriginInfo = {
+    phase: 'tick',
+    scope: 'template',
+    effect: 'pure',
+    freeRefs: resolveFreeRefs(node.left, makeBindingEnv(ctx)),
+  }
+  const reactive = isReactiveExpression(leftText, ctx, node.left) || isReactiveOrigin(leftOrigin)
   const loopParamReactive = !reactive && referencesLoopParam(leftText, ctx)
   // Wrap-by-default fallback (#941) — see transformConditional. The call
   // flags are computed from node.left (the operand that stands in for the
@@ -1206,6 +1277,7 @@ function transformNullishCoalescing(
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node.left, ctx.sourceFile, ctx.filePath),
+    origin: leftOrigin,
   }
 
   // whenFalse: recursively transform the right-hand side (may contain JSX)
@@ -1227,6 +1299,7 @@ function transformNullishCoalescing(
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin: leftOrigin,
   }
 }
 
@@ -1446,16 +1519,23 @@ function transformConditionalBranch(
   // value. `null` specifically renders as empty via the adapter's scalar
   // pathway.
   const exprText = ctx.getJS(node)
+  const branchOrigin: OriginInfo = {
+    phase: 'tick',
+    scope: 'template',
+    effect: 'pure',
+    freeRefs: resolveFreeRefs(node, makeBindingEnv(ctx)),
+  }
   return {
     type: 'expression',
     expr: exprText,
     templateExpr: rewriteBarePropRefs(exprText, node, ctx),
     typeInfo: inferExpressionType(node, ctx),
-    reactive: isReactiveExpression(exprText, ctx, node),
+    reactive: isReactiveExpression(exprText, ctx, node) || isReactiveOrigin(branchOrigin),
     slotId: null,
     callsReactiveGetters: exprCallsReactiveGetters(node, ctx) || undefined,
     hasFunctionCalls: exprHasFunctionCalls(node) || undefined,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    origin: branchOrigin,
   }
 }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -70,6 +70,14 @@ interface TransformContext {
   asyncIdCounter: number
   /** Counter for loop marker IDs (l0, l1, ...) — separate from slot IDs so element bf="sN" numbering stays stable across versions (#1087). */
   loopMarkerCounter: number
+  /**
+   * Memoized free-refs binding environment. Built lazily by
+   * `makeBindingEnv` and reused across every `resolveFreeRefs` call as
+   * long as `loopParams` content is unchanged. Invalidated by serializing
+   * `loopParams` into `_bindingEnvLoopKey` and comparing on read.
+   */
+  _bindingEnv?: BindingEnvironment
+  _bindingEnvLoopKey?: string
 }
 
 /**
@@ -253,10 +261,23 @@ function generateSlotId(ctx: TransformContext, forComponent: boolean = false): s
  * props, locals, imports) plus the active loop params form the resolution
  * frame; the TypeChecker, when available, is forwarded so library getters
  * carrying the Reactive<T> brand are recognised.
+ *
+ * Memoized on `ctx`: the returned env is identity-stable as long as
+ * `loopParams` content is unchanged, which keeps the `WeakMap`-keyed
+ * binding-table cache in `free-refs.ts` warm across every expression in
+ * the same loop scope. `loopParams` is `.add`/`.delete`-mutated as the
+ * visitor enters / leaves `.map()` callbacks, so we serialize its
+ * contents into a key rather than relying on Set identity.
  */
 function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
+  const loopKey = ctx.loopParams.size === 0
+    ? ''
+    : Array.from(ctx.loopParams).sort().join('\0')
+  if (ctx._bindingEnv && ctx._bindingEnvLoopKey === loopKey) {
+    return ctx._bindingEnv
+  }
   const a = ctx.analyzer
-  return {
+  const env: BindingEnvironment = {
     signals: a.signals,
     memos: a.memos,
     propsParams: a.propsParams,
@@ -266,9 +287,14 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
     localFunctions: a.localFunctions,
     imports: a.imports,
     ambientGlobals: a.ambientGlobals,
-    loopParams: ctx.loopParams,
+    // Snapshot — the env must observe a stable view even if `ctx.loopParams`
+    // is later mutated by an enclosing visitor frame.
+    loopParams: new Set(ctx.loopParams),
     checker: a.checker,
   }
+  ctx._bindingEnv = env
+  ctx._bindingEnvLoopKey = loopKey
+  return env
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -161,7 +161,17 @@ export interface OriginInfo {
  * authoring scope's binding environment.
  */
 export interface FreeReference {
-  /** The identifier as written in source. */
+  /**
+   * Identifier text. For every kind except `'reactive-brand'` this is a
+   * bare identifier (`count`, `props`, …) and downstream rewriters can
+   * treat it as a word-boundary token. For `'reactive-brand'` it is the
+   * full property-access expression text (e.g. `props.form.isSubmitting`)
+   * because the brand lives on the access expression as a whole — the
+   * root identifier of that access is reported separately under its own
+   * kind. `relocate()` rewrites identifier refs by name, so consumers
+   * that touch `reactive-brand` entries must consult `kind` before
+   * matching.
+   */
   name: string
   /** Where the binding for this name lives. */
   bindingScope: Scope

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -174,16 +174,19 @@ export interface FreeReference {
 }
 
 export type BindingKind =
-  | 'prop'           // destructured-from-props or props.X
-  | 'signal-getter'  // [count, setCount] = createSignal(...) → count
-  | 'signal-setter'  // → setCount
-  | 'memo-getter'    // createMemo(...)
-  | 'init-local'     // const x = ... in init body (not a memo/signal)
-  | 'sub-init-local' // declared inside a nested arrow / function
-  | 'render-item'    // .map() callback param
-  | 'module-import'  // from an import declaration
-  | 'module-local'   // module-level const/function (not imported)
-  | 'global'         // not declared anywhere we tracked → assume global
+  | 'prop'            // destructured-from-props or props.X
+  | 'signal-getter'   // [count, setCount] = createSignal(...) → count
+  | 'signal-setter'   // → setCount
+  | 'memo-getter'     // createMemo(...)
+  | 'reactive-brand'  // identifier carrying Reactive<T> brand from a library
+                      // (e.g. form.isSubmitting, username.error) — reactivity
+                      // comes from the type, not from a local declaration
+  | 'init-local'      // const x = ... in init body (not a memo/signal)
+  | 'sub-init-local'  // declared inside a nested arrow / function
+  | 'render-item'     // .map() callback param
+  | 'module-import'   // from an import declaration
+  | 'module-local'    // module-level const/function (not imported)
+  | 'global'          // not declared anywhere we tracked → assume global
 
 /**
  * Static visibility table — kinds NOT directly emittable as a bare
@@ -198,6 +201,7 @@ const SCOPE_FORBIDDEN: Record<Scope, ReadonlySet<BindingKind>> = {
     'signal-getter',
     'signal-setter',
     'memo-getter',
+    'reactive-brand',
     'init-local',
     'sub-init-local',
     'render-item',
@@ -209,6 +213,9 @@ const SCOPE_FORBIDDEN: Record<Scope, ReadonlySet<BindingKind>> = {
     'signal-getter',
     'signal-setter',
     'memo-getter',
+    // A library getter (`form.isSubmitting()`) must be re-evaluated inside
+    // an effect to subscribe — not bare-emittable in template scope.
+    'reactive-brand',
     'init-local',
     'sub-init-local',
     'render-item',
@@ -225,6 +232,36 @@ const SCOPE_FORBIDDEN: Record<Scope, ReadonlySet<BindingKind>> = {
  */
 export function isVisibleIn(scope: Scope, kind: BindingKind): boolean {
   return !SCOPE_FORBIDDEN[scope].has(kind)
+}
+
+/**
+ * BindingKinds that contribute reactivity to an enclosing expression.
+ * Used by `isReactiveOrigin()` and any future single-channel classifier
+ * derived from `OriginInfo.freeRefs`.
+ *
+ * `init-local` is intentionally excluded here — a local constant is only
+ * reactive if its initializer itself contains a reactive reference, and
+ * that taint should already be flattened into the consuming expression's
+ * `freeRefs` by the analyzer (transitive resolution). Listing it here
+ * would over-wrap any expression that references any local.
+ */
+export const REACTIVE_BINDING_KINDS: ReadonlySet<BindingKind> = new Set<BindingKind>([
+  'prop',
+  'signal-getter',
+  'memo-getter',
+  'reactive-brand',
+])
+
+/**
+ * Single source of truth for "is this expression reactive?" once
+ * `OriginInfo.freeRefs` is populated uniformly (issue #1248 + #1251).
+ *
+ * Until that migration is complete, callers must handle the absence of
+ * `origin` themselves — this helper deliberately requires a non-optional
+ * `OriginInfo` so the type system flags un-migrated sites.
+ */
+export function isReactiveOrigin(origin: OriginInfo): boolean {
+  return origin.freeRefs?.some(r => REACTIVE_BINDING_KINDS.has(r.kind)) ?? false
 }
 
 // =============================================================================
@@ -278,12 +315,12 @@ export interface IRExpression {
   /** When true, expression contains function call(s) — any `identifier()` pattern (computed from AST). */
   hasFunctionCalls?: boolean
   /**
-   * Staged-IR origin info (#1138). When present, supersedes the implicit
-   * "always init scope at tick phase" assumption used by today's
-   * templateExpr precomputation. relocate() consults this when
-   * deriving the template-side form.
+   * Staged-IR origin info (#1138). Mandatory as of #1248: every
+   * expression-bearing IR node carries `origin` and downstream emit
+   * passes (relocate, decideWrapFromAstFlags) read it as the single
+   * source of truth for free-reference / reactivity classification.
    */
-  origin?: OriginInfo
+  origin: OriginInfo
 }
 
 export interface IRConditional {
@@ -303,6 +340,14 @@ export interface IRConditional {
   callsReactiveGetters?: boolean
   /** When true, condition contains function call(s) — any `identifier()` pattern (computed from AST). */
   hasFunctionCalls?: boolean
+  /**
+   * Staged-IR origin info — same semantics as `IRExpression.origin`,
+   * mandatory as of #1248. The condition expression's classification
+   * and free-reference resolution live here; consumers
+   * (`isReactiveOrigin`, relocate) read from here instead of running
+   * their own walks.
+   */
+  origin: OriginInfo
 }
 
 /**


### PR DESCRIPTION
## Summary

Unifies the four parallel reactivity-classification channels described in #1248 into a single \`OriginInfo.freeRefs\`-backed pipeline, completing the staged-IR migration from #1251 along the way.

Driven by a red-baseline test suite under \`packages/jsx/src/__tests__/reactivity-classification/\`. Built incrementally; final state collapses the regex + TypeChecker fan-out and adds a strict-mode diagnostic (BF050) for missing shared \`ts.Program\` when the source uses a Reactive<T>-branded library.

## Steps (all complete)

- [x] **Step 1** — red baseline test suite (issue cases 1–3 + cross-phase invariant)
- [x] **Step 2a** — extend \`BindingKind\` with \`'reactive-brand'\`; add \`isReactiveOrigin\` helper
- [x] **Step 2b** — \`resolveFreeRefs\` + populate \`origin\` at the main IRExpression site
- [x] **Step 3** — populate \`origin\` at remaining expression-bearing IR sites; init-local transitive taint
- [x] **Step 4** — Phase 2 \`decideWrapFromAstFlags\` consults \`origin.freeRefs\`; \`props.children\` excluded in \`resolveFreeRefs\`
- [x] **Step 5** — \`IRExpression.origin\` and \`IRConditional.origin\` made mandatory
- [x] **Step 6** — \`reactive\` flag OR-combined with \`isReactiveOrigin(origin)\` at every IRConditional / IRExpression site
- [x] **Step 7** — BF050 \"shared Program required\" diagnostic for brand-package sources
- [x] **Step 8** — destructured \`children\` excluded from prop kind resolution
- [x] **Step 9** — transitive taint stops at arrow-function locals (don't walk function bodies)

## Test results

- \`packages/jsx\`: 1077 pass / 0 fail
- \`packages/adapter-hono\`: 109 pass / 0 fail (3 pre-existing module-resolution failures unrelated)
- \`packages/adapter-go-template\`: 87 pass / 0 fail
- \`packages/adapter-mojolicious\`: 68 pass / 0 fail
- \`reactivity-classification\` suite: 28 / 28

## E2E status (CI — Core / e2e-site-ui)

⚠️ All 4 shards of \`e2e-site-ui\` fail on this PR — **but the same failures reproduce on a clean main HEAD when CI-Core is triggered** (verified via diagnostic PR #1257, closed). The regression was introduced upstream by [\`133a69a9\`](../commit/133a69a9) (#1240 — \"fix(cli): rewrite stripped 'use client' .tsx imports as runtime stubs\"), not by this refactor. Local \`site/ui\` dist output is byte-identical to main (functionally; only FNV-1a path-scope hashes differ).

This PR does not regress e2e relative to main. Once #1240's e2e fallout is fixed on main, this PR should land green.

## Deferred to follow-up work

- Strict \`options.program\` requirement for all sources (broader-than-brand deletion of the per-file fallback)
- Delete \`scanRefsByName\` and the legacy \`templateValue\` / \`templateExpr\` paths once the staged-IR migration (#1251) sweeps the remaining consumers
- Delete the derived \`IRExpression.reactive\` / \`callsReactiveGetters\` / \`hasFunctionCalls\` fields once Phase 2 consumers move to \`isReactiveOrigin(origin)\` exclusively

## Related

- Closes #1248
- Closes #1251 (partial — see deferred items)
- Spinoff: #1255 (Hono adapter \`isJsExpression\` → \`IRProp.isLiteral\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)