### PR TITLE
fix(cli): scope 'use client' .tsx import stub to safe call sites (#1258)

### DIFF
--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -88,6 +88,107 @@ console.log('client code')
     expect(errors).toHaveLength(0)
   })
 
+  // Regression: bf#1258 — a sibling `.tsx` without the `'use client'`
+  // directive is a plain server-side module (e.g. data + utility helpers
+  // that happen to live in a `.tsx` file because they shape SSR JSX). The
+  // runtime registry has no entry for `getPost`/`BLOG_POSTS`, so
+  // `createComponent('getPost', slug, undefined)` is a wrong-shaped
+  // descriptor, not a `BlogPost` — the consumer crashes, hydration aborts,
+  // and the SSR DOM never animates back to its rendered state. Treat
+  // non-`'use client'` `.tsx` the same as the pre-#1240 strip path: drop
+  // the import, let the SSR template's server-side resolution carry the
+  // value (the client bundle just doesn't get it).
+  test('does not stub a sibling .tsx import that is NOT a use-client component (#1258)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'blog-data.tsx'), `// Static blog post data — SSR-only, no 'use client' directive.
+export interface BlogPost { slug: string; title: string }
+export const BLOG_POSTS: BlogPost[] = [{ slug: 'a', title: 'A' }]
+export function getPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((p) => p.slug === slug)
+}
+`)
+    const clientJs = `import { BLOG_POSTS, getPost } from './blog-data'
+import { createComponent } from '@barefootjs/client/runtime'
+export function initBlogDemo(_p) {
+  const post = getPost(_p.slug)
+  return post?.title ?? BLOG_POSTS[0].title
+}
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'BlogDemo-abc.js'), clientJs)
+    const manifest = {
+      BlogDemo: { clientJs: 'components/BlogDemo-abc.js', markedTemplate: 'components/BlogDemo.tsx' },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'BlogDemo-abc.js')).text()
+    // The import line is gone …
+    expect(result).not.toContain("from './blog-data'")
+    // … and crucially NO stub is emitted: a `createComponent('getPost', …)`
+    // stub would silently return a malformed descriptor and break every
+    // consumer that reads the value.
+    expect(result).not.toContain('const getPost =')
+    expect(result).not.toContain('const BLOG_POSTS =')
+    // The original references stay as dangling identifiers — matching the
+    // pre-#1240 behaviour. The SSR template (server-side) has the real
+    // values; this client bundle's hydration may silently no-op, which is
+    // the documented contract for non-stateful SSR-only modules.
+    expect(result).toContain('getPost(_p.slug)')
+    expect(result).toContain('BLOG_POSTS[0].title')
+  })
+
+  // Regression: bf#1258 — the playground client bundles take two paths to
+  // the same sibling `'use client'` target:
+  //   (1) the parent `.tsx` has `import { Foo } from './foo'`, which reaches
+  //       `walkAndCollect` and (post-#1240) emits `const Foo = (props, key)
+  //       => createComponent('Foo', ...)` at the top of the bundle;
+  //   (2) esbuild bundled `./foo`'s compiled `.js` whole upstream, so the
+  //       bundle already contains `export function Foo(_p, __bfKey) { ... }`.
+  // Emitting (1) on top of (2) produces a duplicate top-level identifier and
+  // the whole script fails to parse — every hydration in the bundle dies
+  // silently, leaving SSR HTML with unsubstituted variant/signal slots.
+  // Fix: skip stub emission for any name esbuild has already declared at
+  // top level; for those, just strip the redundant import.
+  test('does not emit a duplicate-binding stub when the bundle already declares the named import at top level (#1258)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'CopyButton.tsx'), `'use client'
+export function CopyButton() {
+  return <button>copy</button>
+}
+`)
+    // Simulates esbuild having already inlined CopyButton's compiled JS into
+    // the parent bundle (real-world case: relative `./copy-button` import in
+    // the source survives JSX compilation as a still-relative import in the
+    // emitted client JS *and* esbuild's bundling pass inlines the target's
+    // compiled output whole, so the same name appears twice).
+    const clientJs = `import { CopyButton } from './CopyButton'
+import { createComponent, hydrate } from '@barefootjs/client/runtime'
+export function initCopyButton(__scope, _p = {}) { /* ... */ }
+hydrate('CopyButton', { init: initCopyButton, template: (_p) => '<button>copy</button>' })
+export function CopyButton(_p, __bfKey) { return createComponent('CopyButton', _p, __bfKey) }
+console.log('parent bundle body')
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Playground-abc123.js'), clientJs)
+
+    const manifest = {
+      Playground: { clientJs: 'components/Playground-abc123.js', markedTemplate: 'components/Playground.tsx' },
+    }
+
+    const { errors } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'Playground-abc123.js')).text()
+    // The redundant import is gone …
+    expect(result).not.toContain("from './CopyButton'")
+    // … but the stub MUST NOT be emitted — the bundle already declares
+    // `function CopyButton(...)` lower down, and a second `const CopyButton`
+    // at the top would make the whole script unparseable.
+    expect(result).not.toContain('const CopyButton =')
+    // The pre-existing inlined definition stays intact (this is the binding
+    // that the runtime registry looks up via `createComponent('CopyButton', …)`).
+    expect(result).toContain('export function CopyButton(_p, __bfKey)')
+    expect(result).toContain("hydrate('CopyButton'")
+    // No BF053 — the binding has a real definition, so no dangling reference.
+    expect(errors).toHaveLength(0)
+  })
+
   // Regression: bf#1227 used to surface BF053 when a stripped `'use client'`
   // import left a dangling reference. bf#1240 turns the strip into a
   // runtime-resolving stub instead, so the same call site that previously

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -145,6 +145,92 @@ function collectExportedNames(source: string): string[] {
 }
 
 /**
+ * Detect whether a `.tsx` source file declares the `'use client'` directive
+ * as its first executable statement (per the JSX analyzer, which is the
+ * canonical check). Used to gate stub emission: only `'use client'`
+ * components have a runtime registry entry that the stub's
+ * `createComponent(...)` delegation can reach. A `.tsx` source without the
+ * directive is a plain server-side module (e.g. `blog-data.tsx` exporting
+ * data + utility functions), and stubbing its named imports as component
+ * factories breaks any consumer that actually reads the value — calling
+ * `getPost(slug)` returns a `createComponent('getPost', slug, undefined)`
+ * descriptor instead of a `BlogPost`, then `post.title` is undefined and
+ * the rendered DOM ends up empty/corrupt. piconic-ai/barefootjs#1258.
+ */
+function hasUseClientDirective(source: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    'check.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    /*setParents*/ false,
+    ts.ScriptKind.TSX,
+  )
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isExpressionStatement(stmt) || !ts.isStringLiteral(stmt.expression)) {
+      return false
+    }
+    if (stmt.expression.text === 'use client') return true
+  }
+  return false
+}
+
+/**
+ * Collect every top-level value-binding name introduced by a declaration
+ * (`function`, `const`/`let`/`var`, `class`) in a JS/TS module body.
+ *
+ * The stub-emission path uses this to detect when a sibling `'use client'`
+ * `.tsx`'s named binding is already provided by an earlier inlined module
+ * inside the assembled bundle (e.g. esbuild bundled the target's compiled
+ * `.js` whole), so re-declaring it as `const X = …` would produce a
+ * SyntaxError on parse and take the whole hydration script down with it.
+ * piconic-ai/barefootjs#1258.
+ *
+ * `import` declarations are intentionally excluded: the import we're about
+ * to process is itself an import declaration that would otherwise count
+ * itself as an existing binding and short-circuit the stub. Whether other
+ * pending imports collide with the stub is moot — they'll be stripped or
+ * stubbed in their own pass through `walkAndCollect` and any same-name
+ * collision becomes a real top-level declaration only via inlining.
+ *
+ * Type-only declarations (`type`, `interface`) are ignored because
+ * they're erased at runtime and can't collide with a value stub.
+ */
+function collectTopLevelBindings(source: string): Set<string> {
+  const names = new Set<string>()
+  const sourceFile = ts.createSourceFile(
+    'bundle.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /*setParents*/ false,
+    ts.ScriptKind.TS,
+  )
+
+  function collectFromBindingName(name: ts.BindingName): void {
+    if (ts.isIdentifier(name)) {
+      names.add(name.text)
+      return
+    }
+    for (const el of name.elements) {
+      if (ts.isBindingElement(el)) collectFromBindingName(el.name)
+    }
+  }
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const d of stmt.declarationList.declarations) {
+        collectFromBindingName(d.name)
+      }
+    } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      names.add(stmt.name.text)
+    } else if (ts.isClassDeclaration(stmt) && stmt.name) {
+      names.add(stmt.name.text)
+    }
+  }
+
+  return names
+}
+
+/**
  * Strip top-level `import` declarations and `export` modifiers/keywords
  * from a module body so it's valid as the inside of an IIFE.
  *
@@ -684,7 +770,7 @@ async function walkAndCollect(
     }
 
     if (result.path.endsWith('.tsx')) {
-      // A sibling `.tsx` reaching this path is, in practice, a `'use client'`
+      // A sibling `.tsx` that declares `'use client'` is a separately-compiled
       // component. Its own compiled `.client.js` exports a JSX-shim function
       // (`function X(props, key) { return createComponent('X', props, key) }`)
       // that delegates to the runtime registry. The shim isn't reachable
@@ -697,6 +783,17 @@ async function walkAndCollect(
       // non-JSX usages piconic-ai/barefootjs#1238 made supported at the
       // runtime side. Closes piconic-ai/barefootjs#1240.
       //
+      // A `.tsx` without the directive is a plain server-side module that
+      // happens to use JSX syntax (e.g. `blog-data.tsx` exporting BLOG_POSTS
+      // + getPost helpers, or any non-stateful render helper that bundles
+      // for SSR only). Those have no runtime registry entry, so a
+      // `createComponent(...)` stub returns a wrong-shaped descriptor and
+      // breaks every consumer that actually reads the value. Fall back to
+      // the pre-#1240 strip path for non-`'use client'` `.tsx` siblings —
+      // the SSR template imports them at the server-rendered layer where
+      // they resolve normally; the client bundle just doesn't get them.
+      // piconic-ai/barefootjs#1258.
+      //
       // Default and namespace imports of a `'use client'` `.tsx` are NOT
       // stubbed — the registered runtime name for those isn't trivially
       // recoverable from the import statement alone (default exports
@@ -706,17 +803,28 @@ async function walkAndCollect(
       // any actual usage still surfaces a build error rather than a silent
       // ReferenceError. The named-import path covers the practical case
       // (`nodeTypes={{ kind: Component }}`) that drove both #1236 and #1240.
+      const targetSource = await readText(result.path)
+      const isUseClientTarget = hasUseClientDirective(targetSource)
       const shape = parseImportShape(fullMatch)
       const namedBindings = shape?.named ?? []
       const fallbackBindings: string[] = []
       if (shape?.namespace) fallbackBindings.push(shape.namespace)
       if (shape?.default) fallbackBindings.push(shape.default)
 
-      if (namedBindings.length > 0) {
-        const stubBody = namedBindings
+      if (isUseClientTarget && namedBindings.length > 0) {
+        // Skip stubs for names esbuild has already inlined as real top-level
+        // bindings (typically the target's whole compiled JS got bundled in
+        // upstream, so `function X(_p, __bfKey) { return createComponent(…) }`
+        // is already present). Re-declaring those as `const X = …` produces
+        // a SyntaxError on parse and silently kills every hydration in the
+        // bundle. piconic-ai/barefootjs#1258.
+        const existingTopLevel = collectTopLevelBindings(content)
+        const stubsToEmit = namedBindings.filter(({ local }) => !existingTopLevel.has(local))
+        const stubBody = stubsToEmit
           .map(({ local, imported }) => `const ${local} = (props, key) => createComponent(${JSON.stringify(imported)}, props, key);`)
           .join('\n')
-        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), `${stubBody}\n`)
+        const replacement = stubBody.length > 0 ? `${stubBody}\n` : ''
+        content = content.replace(new RegExp(escapeRegExp(fullMatch) + '\\n?'), replacement)
         // The stub references the runtime `createComponent` symbol. Every
         // JSX-emitted client bundle already imports it as part of the
         // umbrella `barefoot.js` runtime (any `<X />` use compiles to a
@@ -731,8 +839,8 @@ async function walkAndCollect(
         // `createComponent`), and a "createComponent is not defined" error
         // there would point at the stub line anyway.
         if (fallbackBindings.length === 0) {
-          // Every binding is now a working stub — nothing to strip, no
-          // dangling references possible.
+          // Every named binding is either already in scope or now stubbed —
+          // nothing to strip, no dangling references possible.
           continue
         }
         // Default + namespace siblings still need to be stripped; keep them


### PR DESCRIPTION
## Summary

- #1240's unconditional stub of every named `.tsx` sibling import broke all 4 `e2e-site-ui` shards on `main`. Two distinct mechanisms — duplicate top-level binding (`const CopyButton =` colliding with `function CopyButton`) and non-`'use client'` `.tsx` data modules (`BLOG_POSTS`, `getPost` from `blog-data.tsx`) — were silently corrupting the bundle.
- Fix gates stub emission on two checks: (a) the target `.tsx` actually declares `'use client'` (otherwise fall back to pre-#1240 strip), and (b) no existing top-level binding of the local name already lives in the bundle (otherwise skip the stub and just drop the import).
- The original #1240 `<Flow nodeTypes={{ kind: X }}>` Record case is unchanged — that path has neither an inlined definition nor a non-`'use client'` target, so it continues to get the stub.

## Root cause

The `alert-playground-4d5a4a3c.js` bundle diff against `ee8524ea` (last known-good) was 2 lines: a `const CopyButton = (props, key) => createComponent(...)` stub at the top, sibling to the bundle's pre-existing `export function CopyButton(_p, __bfKey) { return createComponent('CopyButton', _p, __bfKey) }` further down (esbuild had inlined CopyButton's compiled JS through the `@ui/...` alias). Duplicate top-level identifier → `SyntaxError` on parse → every `hydrate('…', …)` call after that point never runs → SSR-rendered HTML stays static with `${variantClasses[variant]}` collapsed to the empty-slot two-trailing-spaces shape from the issue body.

The blog-post-demo failure is a different leak from the same source: `blog-data.tsx` has no `'use client'` directive, so `getPost(slug)` was stubbed as `createComponent('getPost', slug, undefined)` — returns a JSX descriptor, breaks `post.title`.

## Test plan

- [x] `bun test src/__tests__/resolve-imports.test.ts` in `packages/cli` — 18 pass (16 existing + 2 new regression cases)
- [x] `bunx playwright test --shard=1/4` (site/ui) — 279 passed
- [x] `bunx playwright test --shard=2/4` — 278 passed
- [x] `bunx playwright test --shard=3/4` — 278 passed (incl. saas-gallery blog navigation)
- [x] `bunx playwright test --shard=4/4` — 275 passed, 3 skipped (pre-existing xyflow drag/zoom/reconnect)
- [x] Confirmed alert-playground bundle now diffs from `ee8524ea` by exactly one line (the `const PlaygroundControl = …` stub for the uninlined sibling)
- [ ] CI Core to confirm green on remote

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)