### PR TITLE
ci(core): gate CI — Core on packages/cli changes (#1258 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,8 @@ on:
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
-      # The CLI bundles site/ui (resolve-imports, JSX → IR → client JS), so a
-      # cli change can break the playground bundles e2e-site-ui exercises even
-      # when no gated source file moves. #1258 was a regression in cli/resolve-
-      # imports that all 4 e2e-site-ui shards caught locally but CI Core missed
-      # because cli wasn't gated here.
+      # The CLI compiles site/ui, so cli changes can break the e2e-site-ui
+      # job without touching any other gated path.
       - 'packages/cli/**'
       - 'ui/**'
       - 'site/ui/**'
@@ -35,11 +32,8 @@ on:
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
-      # The CLI bundles site/ui (resolve-imports, JSX → IR → client JS), so a
-      # cli change can break the playground bundles e2e-site-ui exercises even
-      # when no gated source file moves. #1258 was a regression in cli/resolve-
-      # imports that all 4 e2e-site-ui shards caught locally but CI Core missed
-      # because cli wasn't gated here.
+      # The CLI compiles site/ui, so cli changes can break the e2e-site-ui
+      # job without touching any other gated path.
       - 'packages/cli/**'
       - 'ui/**'
       - 'site/ui/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ on:
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
+      # The CLI bundles site/ui (resolve-imports, JSX → IR → client JS), so a
+      # cli change can break the playground bundles e2e-site-ui exercises even
+      # when no gated source file moves. #1258 was a regression in cli/resolve-
+      # imports that all 4 e2e-site-ui shards caught locally but CI Core missed
+      # because cli wasn't gated here.
+      - 'packages/cli/**'
       - 'ui/**'
       - 'site/ui/**'
       - '.github/workflows/ci.yml'
@@ -29,6 +35,12 @@ on:
       # site/ui is the Hono adapter's end-to-end target, so Hono changes must
       # re-run this workflow's e2e-site-ui job (ci-hono.yml no longer duplicates it).
       - 'packages/adapter-hono/**'
+      # The CLI bundles site/ui (resolve-imports, JSX → IR → client JS), so a
+      # cli change can break the playground bundles e2e-site-ui exercises even
+      # when no gated source file moves. #1258 was a regression in cli/resolve-
+      # imports that all 4 e2e-site-ui shards caught locally but CI Core missed
+      # because cli wasn't gated here.
+      - 'packages/cli/**'
       - 'ui/**'
       - 'site/ui/**'
       - '.github/workflows/ci.yml'


### PR DESCRIPTION
## Summary

- Follow-up to #1259. Add `packages/cli/**` to the CI — Core path filter so a cli regression that breaks `site/ui` e2e is caught in CI, not by hand-bisecting on `main`.
- #1240 was the canonical case: a cli-only change broke every `e2e-site-ui` shard but CI Core never ran because `packages/cli/**` wasn't gated. The regression sat on `main` from `ee8524ea` → `e7ded56d` until #1258 was filed.

## Rationale

The CLI compiles `site/ui`. `resolve-imports.ts` (the file that regressed in #1240) and the JSX → IR → client JS pipeline both feed the playground bundles `e2e-site-ui` exercises. So a cli change can degrade the runtime even when no source file in the currently-gated set moves — exactly the masking shape that hid #1240.

A separate `CI — CLI` workflow already runs cli unit tests; this PR only adds the *e2e-side* gate, not a duplicate unit-test run.

## Test plan

- [x] This PR touches `.github/workflows/ci.yml`, which is itself gated, so CI Core will run on this PR and verify the e2e-site-ui suite stays green with the path-filter change applied (the change is path-filter-only — no test or build logic changes).
- [ ] After merge, the next cli-only PR should auto-trigger CI Core on the `packages/cli/**` path.

Refs #1258, #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)