### PR TITLE
refactor(adapter-hono): trust IRProp.isLiteral; delete isJsExpression regex (#1255)

### DIFF
--- a/packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts
+++ b/packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts
@@ -1,17 +1,19 @@
 /**
- * Hono adapter: string-literal props containing JS-shaped values (#135).
+ * Hono adapter: string-literal props containing JS-shaped values (#135, #1255).
  *
  * A JSX string attribute like `fill="var(--area-fill)"` is an SVG
  * presentation attribute whose value happens to look like a JS function
- * call. The old adapter used a regex (`isJsExpression`) to disambiguate
- * string literals from arrow / call expressions and tripped on values
- * shaped like `var(...)`, `url(...)`, or `calc(...)`, emitting them as
- * `fill={var(--area-fill)}` — `var` is then parsed as a JS identifier
- * and the build fails with "Unexpected var".
+ * call. An older adapter implementation used a regex (`isJsExpression`)
+ * to disambiguate string literals from arrow / call expressions, and
+ * tripped on values shaped like `var(...)`, `url(...)`, or `calc(...)`,
+ * emitting them as `fill={var(--area-fill)}` — `var` was then parsed as
+ * a JS identifier and the build failed with "Unexpected var".
  *
- * The IR's `isLiteral` flag is the authoritative source of truth here,
- * so the adapter now short-circuits on it before falling back to the
- * regex.
+ * The IR's `isLiteral` flag is the authoritative source of truth here.
+ * #1255 deleted the regex fallback: every prop emitted by Phase 1
+ * already carries `dynamic | isLiteral | boolean-shorthand`, so the
+ * decision is made from IR alone, not by re-classifying the value
+ * string at emit time.
  *
  * Surfaced by the area chart palette demo (#135 Concrete Additions).
  */

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -868,31 +868,22 @@ export class HonoAdapter extends JsxAdapter {
         // data-key which the BarefootJS client runtime uses for reconciliation.
         keyValue = prop.value
       } else if (prop.dynamic) {
+        // JSX expression container: <X onClick={() => 1} />, <X foo={false} />
         parts.push(`${prop.name}={${prop.value}}`)
       } else if (prop.isLiteral) {
-        // `isLiteral` is the IR's authoritative signal that this value
-        // came from a JSX string-attribute (`fill="var(--c)"`). Emit it
-        // verbatim as a string attribute — falling back to
-        // `isJsExpression()` here misidentifies legitimate CSS values
-        // like `var(--area-fill)` (parses as a JS function call) and
-        // strips the quotes, producing `fill={var(--area-fill)}`. The
-        // regex stays below as a defensive net for non-literal
-        // string-shaped props that the IR couldn't tag, but the literal
-        // case must short-circuit first.
+        // IR-authoritative string literal: <X fill="var(--c)" />. Emitting
+        // this verbatim is what distinguishes a CSS-shaped value (`var(...)`,
+        // `url(...)`, `calc(...)`) from a JS expression — both look alike
+        // after the IR collapses to `string + flags`, but `isLiteral` carries
+        // the parser's original answer.
         parts.push(`${prop.name}="${prop.value}"`)
       } else if (prop.value === 'true') {
-        // Boolean true: <Component disabled />
+        // Boolean shorthand: <X disabled /> (no initializer → propValue 'true')
         parts.push(prop.name)
-      } else if (prop.value === 'false') {
-        // Boolean false: <Component disabled={false} />
-        // Note: we output this explicitly rather than omitting it
-        // because the child component may need the explicit false value
-        parts.push(`${prop.name}={false}`)
-      } else if (this.isJsExpression(prop.value)) {
-        // JavaScript expressions (arrow functions, etc.)
-        parts.push(`${prop.name}={${prop.value}}`)
       } else {
-        // String literals (without isLiteral flag — pre-IR fixture path)
+        // Unreachable from the JSX → IR pipeline: Phase 1 always emits one of
+        // (dynamic | isLiteral | boolean-shorthand) for every prop. Defensive
+        // string fallback for hand-built IRs from external producers.
         parts.push(`${prop.name}="${prop.value}"`)
       }
     }
@@ -917,23 +908,6 @@ export class HonoAdapter extends JsxAdapter {
     }
     output += '`'
     return output
-  }
-
-  private isJsExpression(value: string): boolean {
-    // Arrow function: () => ..., (x) => ..., x => ...
-    if (/^(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>/.test(value)) {
-      return true
-    }
-    // Function call with parentheses: foo(), bar(x)
-    if (/^[a-zA-Z_$][a-zA-Z0-9_$.]*\s*\(/.test(value)) {
-      return true
-    }
-    // Function/setter reference: setFoo, handleClick (common naming patterns)
-    // These are likely function references, not string values
-    if (/^(set[A-Z]|handle[A-Z]|on[A-Z])[a-zA-Z0-9_$]*$/.test(value)) {
-      return true
-    }
-    return false
   }
 
 }


### PR DESCRIPTION
## Summary

Closes #1255.

`HonoAdapter.renderComponentProps` used to consult a regex (`isJsExpression`) to decide whether a non-dynamic prop value was a string literal or a JS expression. The regex misclassified CSS-shaped values like `var(--x)`, `url(#g)`, and `calc(...)` as function calls and stripped the quotes, emitting `fill={var(--x)}` for a JSX source of `fill="var(--x)"`. #135 added an `isLiteral` short-circuit ahead of the regex to paper over that case.

This PR completes the fix by removing the regex entirely. `IRProp.isLiteral` is required (not optional), and Phase 1 (`jsx-to-ir.ts`) emits exactly one of (`dynamic` | `isLiteral` | `value === 'true'` boolean shorthand) for every prop it produces. The remaining `else` is unreachable from the JSX → IR pipeline and is kept as a documented defensive fallback for hand-built IRs from external producers.

Concretely:

- Deleted the `isJsExpression` method (47 lines, three regexes for arrow-function shape / call shape / `set*|handle*|on*` naming).
- Collapsed the `prop.value === 'false'` branch — `<X foo={false} />` produces `dynamic: true`, so the `dynamic` branch already emits `foo={false}` with the same output and same explicit-false semantics.
- Updated the `string-literal-css-var-prop.test.ts` header comment to point at this PR rather than the previous "fallback to regex" wording.

Sibling adapter `adapter-go-template` already reads only `prop.isLiteral` (see `go-template-adapter.ts:727`), so this PR brings `adapter-hono` to the same contract.

The long-term direction in the issue (lift `string + flags` to a discriminated `AttrValue` union) is out of scope here; it is a cross-cutting refactor that touches IR producers, both adapters, and many internal consumers.

## Test plan

- [x] `bun test packages/adapter-hono/src/__tests__/string-literal-css-var-prop.test.ts` — 3 pass (covers `var(--x)`, `url(#g)`, and an arrow-function regression guard).
- [x] `bun test packages/adapter-hono` — 106 pass; 3 unrelated `ssr-context-bridge` failures are pre-existing in this worktree only (workspace symlink quirk; main passes).
- [x] `bun test packages/adapter-tests` — 229 pass.

## References

- Split from #1248 (reactivity classification unification).
- Sub-issue of #1244 §F "IR fields exist but aren't trusted downstream".
- The `isLiteral` short-circuit landed in #135 (area-chart palette signal via CSS variable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)