### PR TITLE
fix(jsx): static-loop CSR self-heal for prop-derived arrays (#1247)

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -38,6 +38,12 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
+    // `Object.entries(props.x).filter(...)` is JS-only — the Go
+    // renderer would need a dedicated `bf_entries` primitive plus
+    // multi-binding range support to materialise the loop at SSR
+    // time. The CSR self-heal (#1247) is unrelated to the Go path,
+    // so the JS-only fixture stays Hono/CSR-only for now.
+    'static-array-from-props',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -40,6 +40,11 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
+    // Same JS-only `Object.entries(...).filter(...)` shape the Go
+    // adapter skips. The CSR self-heal (#1247) covers the bug on the
+    // JS side; the Perl SSR side would need bespoke helpers to
+    // materialise the loop at request time.
+    'static-array-from-props',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -55,6 +55,7 @@ import { fixture as childComponent } from './child-component'
 import { fixture as componentWithJsxChildren } from './component-with-jsx-children'
 import { fixture as multipleInstances } from './multiple-instances'
 import { fixture as staticArrayChildren } from './static-array-children'
+import { fixture as staticArrayFromProps } from './static-array-from-props'
 // Priority 8: CSR conformance
 import { fixture as booleanDynamicAttr } from './boolean-dynamic-attr'
 import { fixture as childComponentInit } from './child-component-init'
@@ -120,6 +121,7 @@ export const jsxFixtures: JSXFixture[] = [
   componentWithJsxChildren,
   multipleInstances,
   staticArrayChildren,
+  staticArrayFromProps,
   // Priority 8: CSR conformance
   booleanDynamicAttr,
   childComponentInit,

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Static array loop whose array is built from props at component-init time
+ * (#1247). The expression `Object.entries(props.reactions ?? {})` cannot be
+ * inlined into the CSR template (function call + component-scope dependency),
+ * so the loop array becomes `[]` in the template substitution. Before the
+ * fix, the static-loop emitter assumed SSR had materialised the children
+ * and produced no fallback path — leaving the `<div>` empty on CSR mount.
+ *
+ * The fix routes the static-loop emitter through a clone-and-append fallback
+ * when the per-iteration child element is missing from the container.
+ */
+export const fixture = createFixture({
+  id: 'static-array-from-props',
+  description: 'Static-array loop with prop-derived array materialises children on CSR (#1247)',
+  source: `
+'use client'
+
+type Props = {
+  reactions: Record<string, string[]>
+}
+
+export function ReactionBar(props: Props) {
+  const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+  return (
+    <div data-reaction-bar="true">
+      {entries.map(([emoji, users]) => (
+        <button key={emoji} type="button">
+          <span>{emoji}</span>
+          <span>{String(users.length)}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+`,
+  props: {
+    reactions: { '👍': ['alice', 'bob'] },
+  },
+  expectedHtml: `
+    <div data-reaction-bar="true" bf-s="test" bf="s2">
+      <button type="button" data-key="👍">
+        <span><!--bf:s0-->👍<!--/--></span>
+        <span><!--bf:s1-->2<!--/--></span>
+      </button>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -39,11 +39,6 @@ export function ReactionBar(props: Props) {
     reactions: { '👍': ['alice', 'bob'] },
   },
   expectedHtml: `
-    <div data-reaction-bar="true" bf-s="test" bf="s2">
-      <button type="button" data-key="👍">
-        <span><!--bf:s0-->👍<!--/--></span>
-        <span><!--bf:s1-->2<!--/--></span>
-      </button>
-    </div>
+    <div data-reaction-bar="true" bf-s="test" bf="s2"><button type="button" data-key="👍"><span><!--bf:s0-->👍<!--/--></span><span><!--bf:s1-->2<!--/--></span></button></div>
   `,
 })

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -26,6 +26,12 @@ describe('CSR Conformance Tests', () => {
     // Local array variable (items) is not available at CSR template module scope.
     // CSR templates only have access to props and signals, not file-scope constants.
     'static-array-children',
+    // #1247: prop-derived static-array loops materialize their children at init
+    // time (via the clone-and-insert fallback in the static-loop emitter), not
+    // at template-eval time. This test harness runs only the `template:`
+    // lambda, so the post-init DOM shape is verified by the runtime regression
+    // in `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`.
+    'static-array-from-props',
     // Static style object is converted at compile time — no runtime needed.
     // Attribute ordering differs between SSR (style first) and CSR injection (bf-s first).
     'style-object-static',

--- a/packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts
+++ b/packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Runtime regression test for #1247.
+ *
+ * Verifies the end-to-end behaviour of the static-loop CSR self-heal:
+ * compile a component whose static-array loop reads from props, register
+ * its `template:` + `init:` via the real runtime's `hydrate`, mount via
+ * `createComponent`, and assert the resulting DOM contains the per-item
+ * elements. Without the fix, `createComponent` returns an empty container
+ * because the CSR template substitutes `[].map(...)`.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+const adapter = new TestAdapter()
+
+async function compileAndEvalClientJs(source: string, filename: string): Promise<void> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compilation errors in ${filename}:\n${errors.map(e => e.message).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+
+  // Rewrite the runtime imports to absolute paths so dynamic `import()`
+  // resolves them from a temp directory without needing a workspace
+  // resolver. Drop `export` so the file can be loaded as ESM.
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs.replace(
+    /from\s+['"]@barefootjs\/client\/runtime['"]/g,
+    `from '${runtimePath}'`,
+  )
+
+  const dir = mkdtempSync(join(tmpdir(), 'bf-1247-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
+  writeFileSync(file, rewritten)
+  try {
+    await import(file)
+  } finally {
+    try { unlinkSync(file) } catch {}
+  }
+}
+
+describe('#1247 — createComponent on static-loop with prop-derived array', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('materialises children when CSR template substitutes the array with []', async () => {
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function ReactionBar(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div data-reaction-bar="true">
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button">
+                <span>{emoji}</span>
+                <span>{String(users.length)}</span>
+              </button>
+            ))}
+          </div>
+        )
+      }
+    `
+    await compileAndEvalClientJs(source, 'ReactionBar.tsx')
+
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('ReactionBar', {
+      reactions: { '👍': ['alice', 'bob'], '🎉': ['alice'] },
+    }) as Element
+    document.body.appendChild(el)
+
+    expect(el.getAttribute('data-reaction-bar')).toBe('true')
+    const buttons = el.querySelectorAll('button')
+    expect(buttons.length).toBe(2)
+    // Each button has two `<span>` children for emoji + count.
+    expect(buttons[0].querySelectorAll('span').length).toBe(2)
+    expect(buttons[0].textContent).toContain('👍')
+    expect(buttons[0].textContent).toContain('2')
+    expect(buttons[1].textContent).toContain('🎉')
+    expect(buttons[1].textContent).toContain('1')
+  })
+
+  test('empty prop produces empty container (no spurious children)', async () => {
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function ReactionBar2(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div data-reaction-bar="true">
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button">
+                <span>{emoji}</span>
+                <span>{String(users.length)}</span>
+              </button>
+            ))}
+          </div>
+        )
+      }
+    `
+    await compileAndEvalClientJs(source, 'ReactionBar2.tsx')
+
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('ReactionBar2', { reactions: {} }) as Element
+    document.body.appendChild(el)
+
+    expect(el.querySelectorAll('button').length).toBe(0)
+  })
+})

--- a/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
+++ b/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
@@ -128,4 +128,126 @@ describe('#1247 — static-loop CSR self-heal', () => {
     // inside `mapArray` renderItems, not inside a plain forEach.
     expect(block).not.toMatch(/__bfItem\(\)/)
   })
+
+  test('multi-root (Fragment) body emits multi-sibling clone-and-insert', () => {
+    // When the per-item body is a JSX Fragment with multiple top-level
+    // siblings, `csrMaterialize.bodyIsMultiRoot` is true and the emitter
+    // must clone every sibling of the template content, tracking the first
+    // one as `__iterEl` so reactive bindings still anchor correctly.
+    // This pins the `bodyIsMultiRoot === true` branch in `loop.ts:122-138`.
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function MultiRootBar(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div>
+            {entries.map(([emoji, users]) => (
+              <>
+                <span data-emoji>{emoji}</span>
+                <span data-count>{String(users.length)}</span>
+              </>
+            ))}
+          </div>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'MultiRootBar.tsx')
+    // `__mtpl` is the multi-root template var — distinct from the
+    // single-root `__tpl` to make the branch easy to grep.
+    expect(clientJs).toMatch(/const __mtpl = document\.createElement\('template'\)/)
+    // The sibling-walk loop:
+    expect(clientJs).toMatch(/let __sib = __mtpl\.content\.firstElementChild/)
+    expect(clientJs).toMatch(/while \(__sib\) \{/)
+    // First-sibling tracking — initialised to null and assigned to
+    // `__iterEl` after the walk so reactive bindings attach to the first
+    // root.
+    expect(clientJs).toMatch(/let __first = null/)
+    expect(clientJs).toMatch(/__iterEl = __first/)
+    // No `__bfItem()` accessor (this is a plain forEach with destructured
+    // params, not a mapArray renderItems).
+    expect(clientJs).not.toMatch(/__bfItem\(\)/)
+  })
+
+  test('static loop containing inner .map still compiles cleanly', () => {
+    // `collect-elements.ts` builds `staticItemTemplate` with
+    // `loopParams=undefined` so item-body templates render in caller scope.
+    // This test pins that change does NOT break a nested-map case: the
+    // outer static loop's materialize branch must include the inner
+    // `items.map(...)` expression inside the cloned template, and the
+    // compile must produce zero errors.
+    const source = `
+      'use client'
+      type Props = { groups: Record<string, string[]> }
+      export function NestedList(props: Props) {
+        const entries = Object.entries(props.groups ?? {})
+        return (
+          <div>
+            {entries.map(([name, items]) => (
+              <ul key={name}>
+                {items.map((it, i) => <li key={i}>{it}</li>)}
+              </ul>
+            ))}
+          </div>
+        )
+      }
+    `
+    // `getClientJs` already asserts zero errors.
+    const clientJs = getClientJs(source, 'NestedList.tsx')
+    // Outer materialize branch present.
+    expect(clientJs).toMatch(/if \(!__iterEl\)/)
+    // Inner `items.map(...)` is inlined into the cloned template literal
+    // — its expression survives intact (no mangled accessor, no loss of
+    // the inner `it` param).
+    expect(clientJs).toMatch(/items\.map\(\(it, i\) =>/)
+    // The inner per-item HTML references the inner destructured param
+    // directly (`${it}` in the template), not via a `__bfItem` accessor.
+    expect(clientJs).toMatch(/\$\{it\}/)
+    expect(clientJs).not.toMatch(/__bfItem\(\)/)
+  })
+
+  test('block-body .map emits mapPreamble at forEach top, visible to both branches', () => {
+    // When the arrow body is a block (`{ const count = ...; return ... }`),
+    // the const declaration lands in `csrMaterialize.mapPreamble`. The
+    // emitter places it at the forEach body's top — BEFORE the
+    // `let __iterEl` lookup — so the declared local is in scope for BOTH
+    // the materialize-clone template literal AND any reactive bind that
+    // happens to reference it. Pinning the preamble inside
+    // `if (!__iterEl) { ... }` only would leave reactive bindings
+    // depending on `expandConstantForReactivity` rescuing every reference,
+    // a brittle hidden dependency.
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]>; currentUser?: string }
+      export function ReactionWithPreamble(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div>
+            {entries.map(([emoji, users]) => {
+              const count = users.length
+              return <button key={emoji}>{emoji}: {String(count)}</button>
+            })}
+          </div>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'ReactionWithPreamble.tsx')
+
+    // Preamble appears at the forEach body's top — directly after the
+    // arrow opener, before the `let __iterEl` lookup. The preamble
+    // emit preserves the source-level statement (which may include a
+    // trailing semicolon).
+    expect(clientJs).toMatch(
+      /forEach\(\(\[emoji, users\], __idx\) => \{\s*\n\s+const count = users\.length;?\s*\n\s+let __iterEl/,
+    )
+    // Split into the two halves of the forEach body.
+    const matMatch = clientJs.match(/if \(!__iterEl\) \{([\s\S]*?)\n {6}\}\n {6}if \(__iterEl\)/)
+    expect(matMatch).toBeTruthy()
+    const materializeBlock = matMatch![1]
+    // Preamble is NOT duplicated inside the materialize branch.
+    expect(materializeBlock).not.toMatch(/const count = users\.length/)
+    // The cloned template still references `count` — now resolved by the
+    // forEach-scope `const` introduced just above.
+    expect(materializeBlock).toMatch(/\$\{String\(count\)\}/)
+  })
 })

--- a/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
+++ b/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #1247 — static-array loops whose array references an init-scope local
+ * (e.g. `Object.entries(props.x).filter(...)`) substitute `[]` in the
+ * CSR template, so a `createComponent`-only mount renders an empty
+ * container. The fix emits a clone-and-insert fallback inside the
+ * static-loop's per-item forEach so the init function materialises
+ * missing children at hydrate time.
+ *
+ * These tests pin the emit shape:
+ *   - materialize branch present when the array is unsafe
+ *   - materialize branch absent when the array is safe (no regression)
+ *   - SSR path unaffected — when `__iterEl` already exists, the branch is
+ *     a dead `if (!__iterEl)` and reactive bindings run as before
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('#1247 — static-loop CSR self-heal', () => {
+  test('prop-derived static array emits clone-and-insert fallback', () => {
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function ReactionBar(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div data-reaction-bar="true">
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button">
+                <span>{emoji}</span>
+                <span>{String(users.length)}</span>
+              </button>
+            ))}
+          </div>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'ReactionBar.tsx')
+    // The forEach must use `let __iterEl` (not `const`) so the materialize
+    // branch can reassign after cloning.
+    expect(clientJs).toMatch(/let __iterEl = /)
+    // Clone-and-insert branch must be present.
+    expect(clientJs).toMatch(/if \(!__iterEl\)/)
+    expect(clientJs).toMatch(/document\.createElement\('template'\)/)
+    expect(clientJs).toMatch(/insertBefore\(/)
+  })
+
+  test('inline literal static array does NOT emit the materialize branch', () => {
+    // `[1, 2, 3]` is template-safe — the CSR template emits the array
+    // inline, so children always exist on the CSR-only mount and no
+    // self-heal is needed. Adding the branch here would be dead code on
+    // every static loop, undoing the size discipline this path enforces.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function NumberList() {
+        const [n] = createSignal(0)
+        return (
+          <ul data-n={n()}>
+            {[1, 2, 3].map(x => <li key={x}>{x}</li>)}
+          </ul>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'NumberList.tsx')
+    expect(clientJs).not.toMatch(/if \(!__iterEl\)/)
+  })
+
+  test('safe-prop array (no init-scope local) does NOT emit the branch', () => {
+    // `props.items` is directly usable in the CSR template — no fallback
+    // needed.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Props = { items: number[] }
+      export function PropList(props: Props) {
+        const [n] = createSignal(0)
+        return (
+          <ul data-n={n()}>
+            {props.items.map(x => <li key={x}>{x}</li>)}
+          </ul>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'PropList.tsx')
+    expect(clientJs).not.toMatch(/if \(!__iterEl\)/)
+  })
+
+  test('materialize branch uses raw destructured param refs (no __bfItem())', () => {
+    // The static forEach destructures the param directly; the cloned
+    // template literal must reference `emoji` not `__bfItem().emoji` —
+    // otherwise the IIFE throws because `__bfItem` is not in scope.
+    const source = `
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function ReactionBar(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div>
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button">
+                <span>{emoji}</span>
+              </button>
+            ))}
+          </div>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'ReactionBar.tsx')
+    // Find the materialize block.
+    const m = clientJs.match(/if \(!__iterEl\) \{[\s\S]*?\n\s+\}\n\s+if \(__iterEl\)/)
+    expect(m).toBeTruthy()
+    const block = m![0]
+    // The cloned template must reference `emoji` directly.
+    expect(block).toMatch(/\$\{emoji\}/)
+    // It must NOT reference `__bfItem()` — that accessor only exists
+    // inside `mapArray` renderItems, not inside a plain forEach.
+    expect(block).not.toMatch(/__bfItem\(\)/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -494,6 +494,7 @@ export function collectElements(
       const { useElementReconciliation, innerLoops } = decideLoopRendering(l, siblingOffsets, ctx)
 
       let template = ''
+      let staticItemTemplate: string | undefined
       if (l.childComponent) {
         template = '' // childComponent path uses createComponent directly
       } else if (l.children[0]) {
@@ -505,6 +506,16 @@ export function collectElements(
         template = useElementReconciliation
           ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0, loopParamSpec)
           : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0, loopParamSpec)
+        // Static-array loops emit a `forEach((param, idx) => ...)` whose body
+        // references the destructured param directly — `__bfItem()` is not in
+        // scope there. Build a second template that skips the loop-param
+        // accessor wrap so the CSR materialize fallback (#1247) can clone
+        // items inside the forEach body without rewriting the template.
+        if (l.isStaticArray) {
+          staticItemTemplate = useElementReconciliation
+            ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0)
+            : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0)
+        }
       }
 
       ctx.loopElements.push({
@@ -518,6 +529,7 @@ export function collectElements(
         markerId: l.markerId,
         bodyIsMultiRoot: l.bodyIsMultiRoot,
         template,
+        staticItemTemplate,
         childEventHandlers: childHandlers,
         childEvents,
         childReactiveAttrs,

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -55,10 +55,10 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
 }
 
 /** Emit loop updates: dispatches to static or dynamic handlers per element. */
-export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
+export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLocalNames: Set<string>): void {
   for (const elem of ctx.loopElements) {
     if (elem.isStaticArray) {
-      emitStaticArrayUpdates(lines, elem)
+      emitStaticArrayUpdates(lines, elem, unsafeLocalNames)
     } else {
       emitDynamicLoopUpdates(lines, elem)
     }
@@ -71,8 +71,8 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext): void {
  * and event handlers need client-side setup. (initChild calls are deferred to
  * the `static-array-child-inits` phase so parent context providers run first.)
  */
-function emitStaticArrayUpdates(lines: string[], elem: TopLevelLoop): void {
-  stringifyStaticLoop(lines, buildStaticLoopPlan(elem))
+function emitStaticArrayUpdates(lines: string[], elem: TopLevelLoop, unsafeLocalNames: Set<string>): void {
+  stringifyStaticLoop(lines, buildStaticLoopPlan(elem, unsafeLocalNames))
 
   // Event delegation for plain elements in static arrays (#537).
   // Static arrays have no data-key/bf-i markers, so walk up from target to

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../types'
 import {
   buildChainedArrayExpr,
-  exprReferencesIdent,
+  exprReferencesAny,
   varSlotId,
   wrapLoopParamAsAccessor,
 } from '../../utils'
@@ -102,17 +102,10 @@ function buildStaticLoopMaterialize(
   if (!elem.staticItemTemplate) return null
   if (elem.childComponent) return null
   if (elem.useElementReconciliation) return null
-  if (!arrayReferencesAny(elem.array, unsafeLocalNames)) return null
+  if (!exprReferencesAny(elem.array, unsafeLocalNames)) return null
   return {
     itemTemplate: elem.staticItemTemplate,
     mapPreamble: elem.mapPreamble ?? '',
     bodyIsMultiRoot: elem.bodyIsMultiRoot ?? false,
   }
-}
-
-function arrayReferencesAny(expr: string, names: Set<string>): boolean {
-  for (const name of names) {
-    if (exprReferencesIdent(expr, name)) return true
-  }
-  return false
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../types'
 import {
   buildChainedArrayExpr,
+  exprReferencesIdent,
   varSlotId,
   wrapLoopParamAsAccessor,
 } from '../../utils'
@@ -22,7 +23,7 @@ import {
   destructureLoopParam,
 } from '../shared'
 import { buildLoopReactiveEffectsPlan } from './build-reactive-effects'
-import type { PlainLoopPlan, StaticLoopPlan } from './types'
+import type { PlainLoopPlan, StaticLoopMaterializePlan, StaticLoopPlan } from './types'
 
 export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
   const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
@@ -47,7 +48,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
   }
 }
 
-export function buildStaticLoopPlan(elem: TopLevelLoop): StaticLoopPlan {
+export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<string>): StaticLoopPlan {
   // Group reactive attrs by their child slot id, preserving the legacy
   // declaration-order Map-iteration semantics.
   const attrsBySlotMap = new Map<string, LoopChildReactiveAttr[]>()
@@ -74,5 +75,44 @@ export function buildStaticLoopPlan(elem: TopLevelLoop): StaticLoopPlan {
     childIndexExpr,
     attrsBySlot: [...attrsBySlotMap].map(([slotId, attrs]) => [slotId, attrs] as const),
     texts: elem.childReactiveTexts,
+    csrMaterialize: buildStaticLoopMaterialize(elem, unsafeLocalNames),
   }
+}
+
+/**
+ * Decide whether the CSR template will substitute the loop's array with `[]`
+ * (the unsafe-name fallback in `html-template.ts`) and, if so, package the
+ * inputs the stringifier needs to clone per-iteration children into the
+ * container at hydrate time (#1247).
+ *
+ * Skipped when:
+ *   - the array is safe in template scope (the CSR template already emits
+ *     items via `.map(...)`, no fallback needed),
+ *   - the loop body is a child component or composite/element-reconciled
+ *     shape (the SSR-then-CSR mismatch in that case is handled by the
+ *     dynamic-loop path; the static branch here only materialises plain
+ *     element bodies), or
+ *   - the loop's per-iteration template wasn't built (childComponent path).
+ */
+function buildStaticLoopMaterialize(
+  elem: TopLevelLoop,
+  unsafeLocalNames: Set<string>,
+): StaticLoopMaterializePlan | null {
+  if (unsafeLocalNames.size === 0) return null
+  if (!elem.staticItemTemplate) return null
+  if (elem.childComponent) return null
+  if (elem.useElementReconciliation) return null
+  if (!arrayReferencesAny(elem.array, unsafeLocalNames)) return null
+  return {
+    itemTemplate: elem.staticItemTemplate,
+    mapPreamble: elem.mapPreamble ?? '',
+    bodyIsMultiRoot: elem.bodyIsMultiRoot ?? false,
+  }
+}
+
+function arrayReferencesAny(expr: string, names: Set<string>): boolean {
+  for (const name of names) {
+    if (exprReferencesIdent(expr, name)) return true
+  }
+  return false
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -205,4 +205,39 @@ export interface StaticLoopPlan {
   attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
   /** Reactive texts in declaration order. */
   texts: readonly LoopChildReactiveText[]
+  /**
+   * CSR self-heal payload (#1247). Set when the loop's array expression
+   * references an init-scope local that the CSR template substitutes with
+   * `[]` — without these, the container is empty on a CSR-only mount
+   * (`createComponent`) because SSR never ran. When non-null, the
+   * stringifier emits a clone-and-insert branch inside the per-item forEach
+   * that materialises missing children before binding reactive effects.
+   *
+   * `null` for the SSR-then-hydrate-only common case: the forEach finds
+   * each `__iterEl` already present and never enters the materialize
+   * branch, so the cost is purely the additional `if (!__iterEl)` check.
+   */
+  csrMaterialize: StaticLoopMaterializePlan | null
+}
+
+/**
+ * Inputs the stringifier needs to clone one per-iteration element on the
+ * CSR fallback path. Stored as a sub-plan so the SSR-then-hydrate static
+ * loop emission doesn't pay the bytes for it.
+ */
+export interface StaticLoopMaterializePlan {
+  /** Per-iteration HTML template with raw param references (no `__bfItem()` wrap). */
+  itemTemplate: string
+  /**
+   * Pre-template statements that must run inside the forEach body (e.g. the
+   * `const reacted = ...` preamble from a `.map(item => { ... return <jsx/> })`
+   * block form). Empty when the loop callback was an expression-bodied arrow.
+   */
+  mapPreamble: string
+  /**
+   * True when the loop body is a multi-root JSX Fragment; the stringifier
+   * uses `emitMultiRootTemplateCloneLines` so every per-iteration sibling
+   * lands in the right place.
+   */
+  bodyIsMultiRoot: boolean
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -41,6 +41,7 @@ export type {
   ComponentLoopPlan,
   CompositeLoopPlan,
   StaticLoopPlan,
+  StaticLoopMaterializePlan,
   NestedComponentInit,
 } from './loop'
 export type {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -112,13 +112,21 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
   lines.push(`  // ${parts.join(' / ')} in static array children`)
   lines.push(`  if (${containerVar}) {`)
   lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
+  // `mapPreamble` (the user's pre-return statements inside the .map callback's
+  // block body, e.g. `const reacted = ...`) is emitted at the forEach body's
+  // top so its bindings are visible BOTH to the materialize-clone branch (which
+  // may interpolate them into the per-item template) AND to the reactive
+  // bind branch below. Pinning it inside `if (!__iterEl)` only would leave
+  // any preamble-declared local invisible to reactive-text / reactive-attr
+  // expressions — a silent hidden dependency on `expandConstantForReactivity`
+  // rescuing every such reference (#1247 follow-up).
+  if (csrMaterialize?.mapPreamble) {
+    lines.push(`      ${csrMaterialize.mapPreamble}`)
+  }
   // `let` (not `const`) so the materialize branch can reassign after cloning.
   lines.push(`      let __iterEl = ${containerVar}.children[${childIndexExpr}]`)
   if (csrMaterialize) {
     lines.push(`      if (!__iterEl) {`)
-    if (csrMaterialize.mapPreamble) {
-      lines.push(`        ${csrMaterialize.mapPreamble}`)
-    }
     if (csrMaterialize.bodyIsMultiRoot) {
       // Multi-root: clone every top-level sibling of the per-item template and
       // insert them in order. `__iterEl` is the first root (the one reactive

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -86,10 +86,10 @@ export function stringifyPlainLoop(
 }
 
 export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {
-  const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts } = plan
+  const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts, csrMaterialize } = plan
   const hasAttrs = attrsBySlot.length > 0
   const hasTexts = texts.length > 0
-  if (!hasAttrs && !hasTexts) return
+  if (!hasAttrs && !hasTexts && !csrMaterialize) return
 
   // Single forEach pass that handles both reactive attrs and reactive texts.
   // Pre-O-4 the legacy emitter wrote two parallel forEach blocks (one per
@@ -98,15 +98,56 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
   // contract identical (`createEffect`s subscribe to the same signals;
   // attrs run before texts within each iteration) while halving the
   // setup cost.
-  const heading = hasAttrs && hasTexts
-    ? '// Reactive attributes and texts in static array children'
-    : hasAttrs
-      ? '// Reactive attributes in static array children'
-      : '// Reactive texts in static array children'
-  lines.push(`  ${heading}`)
+  //
+  // When `csrMaterialize` is set, the same forEach also self-heals an
+  // empty container by cloning the per-iteration template — the CSR path
+  // for a static loop whose array references an init-scope local (#1247).
+  const parts: string[] = []
+  if (hasAttrs) parts.push('Reactive attributes')
+  if (hasTexts) parts.push('reactive texts')
+  if (csrMaterialize) parts.push('CSR materialize')
+  // Capitalise the first segment regardless of position so the comment reads
+  // naturally when only `csrMaterialize` is set.
+  if (parts.length > 0) parts[0] = parts[0][0].toUpperCase() + parts[0].slice(1)
+  lines.push(`  // ${parts.join(' / ')} in static array children`)
   lines.push(`  if (${containerVar}) {`)
   lines.push(`    ${arrayExpr}.forEach((${param}, ${indexParam}) => {`)
-  lines.push(`      const __iterEl = ${containerVar}.children[${childIndexExpr}]`)
+  // `let` (not `const`) so the materialize branch can reassign after cloning.
+  lines.push(`      let __iterEl = ${containerVar}.children[${childIndexExpr}]`)
+  if (csrMaterialize) {
+    lines.push(`      if (!__iterEl) {`)
+    if (csrMaterialize.mapPreamble) {
+      lines.push(`        ${csrMaterialize.mapPreamble}`)
+    }
+    if (csrMaterialize.bodyIsMultiRoot) {
+      // Multi-root: clone every top-level sibling of the per-item template and
+      // insert them in order. `__iterEl` is the first root (the one reactive
+      // bindings attach to); the rest land alongside it via insertBefore.
+      lines.push(`        const __mtpl = document.createElement('template')`)
+      lines.push(`        __mtpl.innerHTML = \`${csrMaterialize.itemTemplate}\``)
+      lines.push(`        const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
+      lines.push(`        let __first = null`)
+      lines.push(`        let __sib = __mtpl.content.firstElementChild`)
+      lines.push(`        while (__sib) {`)
+      lines.push(`          const __next = __sib.nextElementSibling`)
+      lines.push(`          const __cloned = __sib.cloneNode(true)`)
+      lines.push(`          ${containerVar}.insertBefore(__cloned, __anchor)`)
+      lines.push(`          if (!__first) __first = __cloned`)
+      lines.push(`          __sib = __next`)
+      lines.push(`        }`)
+      lines.push(`        __iterEl = __first`)
+    } else {
+      lines.push(`        const __tpl = document.createElement('template')`)
+      lines.push(`        __tpl.innerHTML = \`${csrMaterialize.itemTemplate}\``)
+      lines.push(`        const __cloned = __tpl.content.firstElementChild`)
+      lines.push(`        if (__cloned) {`)
+      lines.push(`          const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
+      lines.push(`          ${containerVar}.insertBefore(__cloned, __anchor)`)
+      lines.push(`          __iterEl = __cloned`)
+      lines.push(`        }`)
+    }
+    lines.push(`      }`)
+  }
   lines.push(`      if (__iterEl) {`)
   for (const [slotId, attrs] of attrsBySlot) {
     const varName = `__t_${varSlotId(slotId)}`

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -242,6 +242,14 @@ export function emitRegistrationAndHydration(
   ctx: ClientJsContext,
   _ir: ComponentIR,
   graph: ReferencesGraph,
+  /**
+   * Precomputed inlinability. `buildInlinableConstants` is side-effectful
+   * (pushes BF060/BF061 diagnostics into `ctx.warnings`); the caller in
+   * `generate-init.ts` runs it once and forwards it here so phases that
+   * also need `unsafeLocalNames` can share the result without surfacing
+   * duplicate warnings (#1247).
+   */
+  inlinability?: { inlinableConstants: Map<string, string>; unsafeLocalNames: Set<string> },
 ): string {
   const name = ctx.componentName
 
@@ -249,7 +257,7 @@ export function emitRegistrationAndHydration(
   lines.push('')
 
   const propNamesForStaticCheck = new Set(ctx.propsParams.map((p) => p.name))
-  const { inlinableConstants, unsafeLocalNames } = buildInlinableConstants(ctx, graph, _ir.root)
+  const { inlinableConstants, unsafeLocalNames } = inlinability ?? buildInlinableConstants(ctx, graph, _ir.root)
 
   // Build rest spread names: these are rest/props spreads handled by applyRestAttrs, not spreadAttrs
   const restSpreadNames = new Set<string>()

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -20,6 +20,7 @@ import { classifyLocalDeclarations } from './init-declarations'
 import { emitModuleLevelDeclarations, resolveFinalImports } from './emit-module-level'
 import { buildPhaseCtx, PHASES, runPhases } from './phases'
 import { rewritePropsObjectRef } from './rewrite-props-object'
+import { buildInlinableConstants } from './emit-registration'
 
 export function generateInitFunction(
   ir: ComponentIR,
@@ -43,6 +44,11 @@ export function generateInitFunction(
   const graph = buildReferencesGraph(ctx, ir.root)
   const classification = classifyLocalDeclarations(ctx, graph)
   const propUsage = computePropUsage(ctx, classification.neededConstants)
+  // Compute once and thread through PhaseCtx + emitRegistrationAndHydration —
+  // `buildInlinableConstants` walks the graph and pushes BF060/BF061
+  // diagnostics into `ctx.warnings`, so calling it twice would surface
+  // duplicate warnings (#1247).
+  const inlinability = buildInlinableConstants(ctx, graph, ir.root)
 
   // --- Emission: declarative phase pipeline. Each entry in `PHASES`
   //     declares its inputs (dependsOn) and emission action (run); the
@@ -54,10 +60,11 @@ export function generateInitFunction(
     graph,
     classification,
     propUsage,
+    unsafeLocalNames: inlinability.unsafeLocalNames,
   })
   runPhases(lines, phaseCtx, PHASES)
 
-  const hydrateLine = emitRegistrationAndHydration(lines, ctx, ir, graph)
+  const hydrateLine = emitRegistrationAndHydration(lines, ctx, ir, graph, inlinability)
 
   // --- Finalisation: props rename → hydrate line → import / module-level
   //     placeholder replacement.

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, exprReferencesIdent, wrapExprWithLoopParams } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, exprReferencesAny, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
 
@@ -614,19 +614,6 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
 }
 
 /**
- * Check if an expression references any identifier from the given set.
- * Used to detect unsafe local variable references in template expressions (#343).
- */
-function expressionReferencesAny(expr: string, names: Set<string>): boolean {
-  for (const name of names) {
-    if (exprReferencesIdent(expr, name)) {
-      return true
-    }
-  }
-  return false
-}
-
-/**
  * Check if a component can have a simple static template generated.
  * Returns false if the component has:
  * - Loops (which use dynamic signal arrays)
@@ -649,7 +636,7 @@ export function canGenerateStaticTemplate(
   unsafeLocalNames?: Set<string>
 ): boolean {
   const hasUnsafeRef = (expr: string): boolean => {
-    return !!(unsafeLocalNames && unsafeLocalNames.size > 0 && expressionReferencesAny(expr, unsafeLocalNames))
+    return !!(unsafeLocalNames && unsafeLocalNames.size > 0 && exprReferencesAny(expr, unsafeLocalNames))
   }
 
   switch (node.type) {
@@ -806,7 +793,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     // call sites (loop array, text expression, child component prop) decide
     // how to render that placeholder. The init function's createEffect /
     // initChild bindings repaint the real value once init runs.
-    if (unsafeLocalNames && unsafeLocalNames.size > 0 && expressionReferencesAny(finalResult, unsafeLocalNames)) {
+    if (unsafeLocalNames && unsafeLocalNames.size > 0 && exprReferencesAny(finalResult, unsafeLocalNames)) {
       return UNSAFE_TEMPLATE_EXPR
     }
 

--- a/packages/jsx/src/ir-to-client-js/phases.ts
+++ b/packages/jsx/src/ir-to-client-js/phases.ts
@@ -51,6 +51,12 @@ export interface PhaseCtx {
   /** Slots that live inside a conditional branch (handled via `insert()`).
    *  Cached so `event-handlers` and `ref-callbacks` don't recompute. */
   conditionalSlotIds: Set<string>
+  /** Local names that resolve to component-scope expressions and therefore
+   *  become `[]` / `undefined` when referenced from the CSR template (the
+   *  same set the registration emitter feeds `generateCsrTemplate`).
+   *  Phases consult this to decide whether a static-array loop's CSR
+   *  template substitution leaves the container empty (#1247). */
+  unsafeLocalNames: Set<string>
 }
 
 /** Build the read-only carrier that every phase consumes. */
@@ -250,7 +256,7 @@ export const PHASES: readonly EmitPhase[] = [
     // contract is enforceable at registry-validation time.
     id: 'loop-updates',
     dependsOn: ['provider-and-child-inits'],
-    run: (lines, p) => emitLoopUpdates(lines, p.ctx),
+    run: (lines, p) => emitLoopUpdates(lines, p.ctx, p.unsafeLocalNames),
   },
   {
     id: 'static-array-child-inits',

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -350,6 +350,16 @@ export interface TopLevelLoop extends LoopCore {
   slotId: string
   index: string | null
   template: string
+  /**
+   * Per-iteration HTML template for static-array loops that need to
+   * self-heal on CSR mount (#1247). Unlike `template`, this variant skips
+   * the `__bfItem()` / `param()` loop-param accessor wrapping so the
+   * destructured `forEach((param, idx) => ...)` body can clone items
+   * directly. Populated only when `isStaticArray` is true and the array
+   * expression references an init-scope local (i.e. `Object.entries(props.x).filter(...)`)
+   * that becomes `[]` in the CSR template substitution.
+   */
+  staticItemTemplate?: string
   childEventHandlers: string[] // Event handlers from child elements (for identifier extraction)
   childEvents: LoopChildEvent[] // Detailed event info for delegation
   childReactiveAttrs: LoopChildReactiveAttr[] // Reactive attributes in loop children

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -264,6 +264,24 @@ export function exprReferencesIdent(expr: string, ident: string): boolean {
   return new RegExp(`\\b${escapeRegExp(ident)}\\b`).test(expr)
 }
 
+/**
+ * Check if `expr` references any identifier in `names`. Short-circuits on
+ * the first hit.
+ *
+ * Canonical helper for the "does this expression depend on any of the
+ * <unsafe / signal / prop / loop-param> names we're tracking" question.
+ * Multiple callers used to inline this loop or define a private clone
+ * (`expressionReferencesAny` in html-template.ts, `arrayReferencesAny`
+ * in control-flow/plan/build-loop.ts) — having a single shared helper
+ * keeps the semantic identical across the codebase.
+ */
+export function exprReferencesAny(expr: string, names: Iterable<string>): boolean {
+  for (const name of names) {
+    if (exprReferencesIdent(expr, name)) return true
+  }
+  return false
+}
+
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -259,6 +259,19 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
 /**
  * Check if a JS expression string references a given identifier.
  * Uses word-boundary matching with proper regex escaping.
+ *
+ * **Known limitation (#1267)**: regex `\b...\b` over-matches —
+ *   - string literals (`'foo-className'` falsely matches `className`)
+ *   - member-access property names (`a.className` falsely matches `className`)
+ *   - comment contents
+ *
+ * All 12 callers in this directory want "is `ident` referenced as an
+ * identifier?" (strict). The over-match is tolerated, not intended.
+ * Single-shot AST replacement would re-parse per call and break the
+ * project-wide "AST is parsed once" invariant — see #1267 for the
+ * proper fix (extend `freeIdentifiers` to every expression-carrying
+ * IR node so each caller looks up `node.freeIdentifiers.has(name)`
+ * instead of running this regex).
  */
 export function exprReferencesIdent(expr: string, ident: string): boolean {
   return new RegExp(`\\b${escapeRegExp(ident)}\\b`).test(expr)
@@ -274,6 +287,9 @@ export function exprReferencesIdent(expr: string, ident: string): boolean {
  * (`expressionReferencesAny` in html-template.ts, `arrayReferencesAny`
  * in control-flow/plan/build-loop.ts) — having a single shared helper
  * keeps the semantic identical across the codebase.
+ *
+ * Inherits `exprReferencesIdent`'s regex over-match limitation; the
+ * AST-driven follow-up is tracked in #1267.
  */
 export function exprReferencesAny(expr: string, names: Iterable<string>): boolean {
   for (const name of names) {


### PR DESCRIPTION
Closes #1247.

## Summary

A `'use client'` component whose JSX maps over a component-local `const` that depends on props (`Object.entries(props.x ?? {}).filter(...)`) rendered **zero children** when mounted via `createComponent` (CSR-only path). The outer container appeared with `<!--bf-loop:l0-->` markers but the body between them was empty. SSR-then-hydrate worked because the Hono adapter executes the JSX at request time with real values.

This implements **Option 1** from the issue: extend the static-loop emitter to self-heal an empty container by cloning the per-iteration template — only when the array expression references an init-scope local that the CSR template substitutes with `[]`.

## What changed

- **`unsafeLocalNames` is now computed once** in `generate-init.ts` and threaded through `PhaseCtx`. Previously it was re-derived inside `emit-registration.ts`; calling it twice would duplicate BF060/BF061 diagnostics, so the registration emitter accepts the precomputed result.
- **`buildStaticLoopPlan(elem, unsafeLocalNames)`** decides whether the loop's array expression references any unsafe name. If yes, it attaches a `csrMaterialize` sub-plan carrying the per-iteration template, `mapPreamble`, and `bodyIsMultiRoot` flag. Skipped for child-component / element-reconciled loops (handled by the dynamic path).
- **`stringifyStaticLoop`** emits a `let __iterEl = container.children[idx]; if (!__iterEl) { …clone+insertBefore… }` branch before the existing reactive-effect bindings. SSR-then-hydrate stays a single `if (!__iterEl)` dead check; CSR-only mount enters the clone path.
- **`collect-elements.ts`** builds a second per-iteration template (`staticItemTemplate`) for static loops with `loopParams` left undefined. The regular `elem.template` rewrites destructured bindings to `__bfItem().path` for the `mapArray` accessor — that pattern would `ReferenceError` inside the static `forEach((param, idx) => ...)` body where `__bfItem` is not in scope.

## Why not just always emit the materialize branch?

The narrow gate (array references an unsafe name) keeps the byte cost off static loops whose CSR template already emits items correctly — inline literal arrays, prop arrays, signal arrays. Those paths stay byte-identical.

## Tests

- **`packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts`** — IR-level pins for the new emit shape: branch present for unsafe arrays, absent for inline literals + safe-prop arrays, and the cloned template uses raw destructured refs (no `__bfItem()`).
- **`packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`** — end-to-end runtime test: compile the issue's repro, register via real `hydrate`, mount via `createComponent` against happy-dom, and assert the resulting `<button>` chips contain the per-item content.
- **`packages/adapter-tests/fixtures/static-array-from-props.ts`** — new conformance fixture covering the Hono SSR path; skipped in `csr-conformance.test.ts` (template-only harness can't run init), Go and Perl adapters (JS-only shape).

## Test plan

- [x] `bun test packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts` — pins new emit shape
- [x] `bun test packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts` — runtime DOM materialisation works
- [x] `bun test packages/adapter-tests/` — 233/233 conformance tests pass
- [x] `bun test packages/adapter-hono/` — static-array-from-props fixture renders correctly via Hono SSR
- [x] `bun test packages/` — no new regressions (8 pre-existing failures verified against main are all environment / workspace-resolution issues in the worktree, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)