### PR TITLE
fix(jsx): static-loop CSR self-heal for childComponent body (#1268)

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -41,9 +41,10 @@ runAdapterConformanceTests({
     // `Object.entries(props.x).filter(...)` is JS-only — the Go
     // renderer would need a dedicated `bf_entries` primitive plus
     // multi-binding range support to materialise the loop at SSR
-    // time. The CSR self-heal (#1247) is unrelated to the Go path,
-    // so the JS-only fixture stays Hono/CSR-only for now.
+    // time. The CSR self-heal (#1247, #1268) is unrelated to the Go
+    // path, so the JS-only fixtures stay Hono/CSR-only for now.
     'static-array-from-props',
+    'static-array-from-props-with-component',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -41,10 +41,11 @@ runAdapterConformanceTests({
     'return-nullish-coalescing',
     'return-map',
     // Same JS-only `Object.entries(...).filter(...)` shape the Go
-    // adapter skips. The CSR self-heal (#1247) covers the bug on the
-    // JS side; the Perl SSR side would need bespoke helpers to
-    // materialise the loop at request time.
+    // adapter skips. The CSR self-heal (#1247, #1268) covers the bug
+    // on the JS side; the Perl SSR side would need bespoke helpers
+    // to materialise the loop at request time.
     'static-array-from-props',
+    'static-array-from-props-with-component',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -56,6 +56,7 @@ import { fixture as componentWithJsxChildren } from './component-with-jsx-childr
 import { fixture as multipleInstances } from './multiple-instances'
 import { fixture as staticArrayChildren } from './static-array-children'
 import { fixture as staticArrayFromProps } from './static-array-from-props'
+import { fixture as staticArrayFromPropsWithComponent } from './static-array-from-props-with-component'
 // Priority 8: CSR conformance
 import { fixture as booleanDynamicAttr } from './boolean-dynamic-attr'
 import { fixture as childComponentInit } from './child-component-init'
@@ -122,6 +123,7 @@ export const jsxFixtures: JSXFixture[] = [
   multipleInstances,
   staticArrayChildren,
   staticArrayFromProps,
+  staticArrayFromPropsWithComponent,
   // Priority 8: CSR conformance
   booleanDynamicAttr,
   childComponentInit,

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
@@ -1,0 +1,63 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Static-array loop whose body is a single child component, where the
+ * array is built from props at component-init time (#1268). The
+ * expression `Object.entries(props.tags).filter(...)` cannot be inlined
+ * into the CSR template (function call + component-scope dependency),
+ * so the loop array becomes `[]` in the template substitution.
+ *
+ * Before #1268 the materialize gate excluded childComponent bodies, so
+ * `createComponent` mounts of `TagList` rendered an empty `<ul>`. The
+ * fix builds a `staticItemTemplate` for childComponent loops (a single
+ * `${renderChild('Tag', ..., key)}` expression) and removes the
+ * exclusion, letting the existing clone-and-insert branch handle the
+ * rendered child HTML.
+ *
+ * This fixture pins the SSR-then-hydrate path: the Hono adapter
+ * evaluates the JSX at request time with real prop values and emits the
+ * fully rendered HTML directly. CSR conformance for this fixture is
+ * covered by the runtime regression test in
+ * `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`
+ * since the harness here only evaluates the `template:` lambda.
+ */
+export const fixture = createFixture({
+  id: 'static-array-from-props-with-component',
+  description: 'Static-array loop with childComponent body materialises rendered children on CSR (#1268)',
+  source: `
+'use client'
+import { Tag } from './tag'
+
+type Props = {
+  tags: Record<string, { variant: 'on' | 'off' }>
+}
+
+export function TagList(props: Props) {
+  const entries = Object.entries(props.tags).filter(([, t]) => t.variant === 'on')
+  return (
+    <ul>
+      {entries.map(([id, t]) => (
+        <Tag key={id} id={id} variant={t.variant} />
+      ))}
+    </ul>
+  )
+}
+`,
+  components: {
+    './tag.tsx': `
+'use client'
+export function Tag(props: { id: string; variant: 'on' | 'off' }) {
+  return <span class={'tag-' + props.variant}>{props.id}</span>
+}
+`,
+  },
+  props: {
+    tags: { a: { variant: 'on' }, b: { variant: 'off' }, c: { variant: 'on' } },
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <span class="tag-on" bf-s="Tag_*" data-key="a" bf="s1"><!--bf:s0-->a<!--/--></span>
+      <span class="tag-on" bf-s="Tag_*" data-key="c" bf="s1"><!--bf:s0-->c<!--/--></span>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -32,6 +32,11 @@ describe('CSR Conformance Tests', () => {
     // lambda, so the post-init DOM shape is verified by the runtime regression
     // in `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`.
     'static-array-from-props',
+    // #1268: same reason as `static-array-from-props` — the childComponent
+    // variant also materialises children at init time via the clone-and-
+    // insert fallback, not at template-eval time. CSR coverage lives in
+    // `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`.
+    'static-array-from-props-with-component',
     // Static style object is converted at compile time — no runtime needed.
     // Attribute ordering differs between SSR (style first) and CSR injection (bf-s first).
     'style-object-static',

--- a/packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts
+++ b/packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts
@@ -36,12 +36,12 @@ async function compileAndEvalClientJs(source: string, filename: string): Promise
 
   // Rewrite the runtime imports to absolute paths so dynamic `import()`
   // resolves them from a temp directory without needing a workspace
-  // resolver. Drop `export` so the file can be loaded as ESM.
+  // resolver. Strip `@bf-child` registry placeholder imports so the
+  // generated module loads under `import()` without a workspace bundler.
   const runtimePath = join(__dirname, '../../src/runtime/index.ts')
-  const rewritten = clientJs.replace(
-    /from\s+['"]@barefootjs\/client\/runtime['"]/g,
-    `from '${runtimePath}'`,
-  )
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
 
   const dir = mkdtempSync(join(tmpdir(), 'bf-1247-'))
   const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
@@ -93,6 +93,102 @@ describe('#1247 — createComponent on static-loop with prop-derived array', () 
     expect(buttons[0].textContent).toContain('2')
     expect(buttons[1].textContent).toContain('🎉')
     expect(buttons[1].textContent).toContain('1')
+  })
+
+  test('#1268 — childComponent body materialises rendered children', async () => {
+    // Loop body is a single child component reading a prop-derived
+    // `entries`. Before #1268 the materialize gate excluded
+    // childComponent loops, so `createComponent` mounts rendered an
+    // empty `<ul>`. The fix builds a per-iteration template that
+    // evaluates `${renderChild('Tag', ..., key)}`; the resulting child
+    // HTML lands inside the container and `static-array-child-inits`
+    // wires it via `initChild`.
+    const tagSource = `
+      'use client'
+      export function Tag(props: { id: string; variant: 'on' | 'off' }) {
+        return <span class={'tag-' + props.variant}>{props.id}</span>
+      }
+    `
+    await compileAndEvalClientJs(tagSource, 'Tag.tsx')
+    const listSource = `
+      'use client'
+      type Props = { tags: Record<string, { variant: 'on' | 'off' }> }
+      export function TagList(props: Props) {
+        const entries = Object.entries(props.tags).filter(([, t]) => t.variant === 'on')
+        return (
+          <ul>
+            {entries.map(([id, t]) => (
+              <Tag key={id} id={id} variant={t.variant} />
+            ))}
+          </ul>
+        )
+      }
+    `
+    await compileAndEvalClientJs(listSource, 'TagList.tsx')
+
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('TagList', {
+      tags: { a: { variant: 'on' }, b: { variant: 'on' }, c: { variant: 'off' } },
+    }) as Element
+    document.body.appendChild(el)
+
+    // Two `on` entries become two rendered children; the `off` entry is
+    // filtered out before the loop.
+    const tags = el.querySelectorAll('span.tag-on')
+    expect(tags.length).toBe(2)
+    expect(tags[0].textContent).toBe('a')
+    expect(tags[1].textContent).toBe('b')
+    // bf-s carries the child-prefix marker (`~Tag_...`) so hydrate skips
+    // it on a re-walk — parent-driven init owns this scope.
+    expect(tags[0].getAttribute('bf-s') || '').toMatch(/^~Tag_/)
+  })
+
+  test('#1268 — composite element body with nested component materialises', async () => {
+    // Loop body is `<li><Cell /></li>` — a plain element wrapping a
+    // nested child component. The materialize template inlines
+    // `${renderChild('Cell', ...)}` inside the `<li>`; the resulting
+    // `<li>` lands in the container with the `Cell` already rendered as
+    // a real child element (not a `data-bf-ph` placeholder).
+    const cellSource = `
+      'use client'
+      export function Cell(props: { label: string }) {
+        return <span>{props.label}</span>
+      }
+    `
+    await compileAndEvalClientJs(cellSource, 'Cell.tsx')
+    const tableSource = `
+      'use client'
+      type Props = { rows: Record<string, { label: string }> }
+      export function Table(props: Props) {
+        const entries = Object.entries(props.rows)
+        return (
+          <ul>
+            {entries.map(([id, row]) => (
+              <li key={id}>
+                <Cell label={row.label} />
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    await compileAndEvalClientJs(tableSource, 'Table.tsx')
+
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent('Table', {
+      rows: { a: { label: 'A' }, b: { label: 'B' } },
+    }) as Element
+    document.body.appendChild(el)
+
+    const items = el.querySelectorAll('li')
+    expect(items.length).toBe(2)
+    expect(items[0].getAttribute('data-key')).toBe('a')
+    expect(items[1].getAttribute('data-key')).toBe('b')
+    // No placeholder slipped through into the rendered output.
+    expect(el.querySelectorAll('[data-bf-ph]').length).toBe(0)
+    // Each `<li>` contains a `Cell` rendered with the prop label.
+    expect(items[0].textContent).toContain('A')
+    expect(items[1].textContent).toContain('B')
   })
 
   test('empty prop produces empty container (no spurious children)', async () => {

--- a/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
+++ b/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
@@ -206,6 +206,92 @@ describe('#1247 — static-loop CSR self-heal', () => {
     expect(clientJs).not.toMatch(/__bfItem\(\)/)
   })
 
+  test('#1268 — childComponent body emits renderChild materialize template', () => {
+    // Loop body is a single child component reading from a prop-derived
+    // const (`entries`). Before #1268 the materialize gate excluded
+    // childComponent loops, so `createComponent` mounts of `TagList`
+    // rendered an empty `<ul>`. Now the per-iteration template is the
+    // `${renderChild('Tag', ..., key)}` expression — evaluating that
+    // template literal produces the rendered child HTML, which the
+    // existing `static-array-child-inits` phase wires via `initChild`.
+    const source = `
+      'use client'
+      type Props = { tags: Record<string, { variant: 'on' | 'off' }> }
+      export function TagList(props: Props) {
+        const entries = Object.entries(props.tags).filter(([, t]) => t.variant === 'on')
+        return (
+          <ul>
+            {entries.map(([id, t]) => (
+              <Tag key={id} id={id} variant={t.variant} />
+            ))}
+          </ul>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'TagList.tsx')
+    // Materialize branch present.
+    expect(clientJs).toMatch(/if \(!__iterEl\)/)
+    // The cloned template body is a single `renderChild('Tag', ...)`
+    // expression — props read from the destructured forEach param.
+    const matMatch = clientJs.match(/__tpl\.innerHTML = `([^`]*)`/)
+    expect(matMatch).toBeTruthy()
+    const inner = matMatch![1]
+    expect(inner).toMatch(/\$\{renderChild\('Tag', \{[^}]*id: id[^}]*variant: t\.variant[^}]*\}, id/)
+    // No `__bfItem()` accessor (forEach destructures the param directly).
+    expect(clientJs).not.toMatch(/__bfItem\(\)/)
+    // The `static-array-child-inits` phase still emits its `initChild`
+    // pass — it runs after materialize, finds the cloned children via
+    // `qsaChildScopes`, and wires them with the same prop getters as
+    // before. Pinning this here is a guard against an accidental
+    // double-init by emitting renderChild AND createComponent.
+    expect(clientJs).toMatch(/qsaChildScopes\(/)
+    expect(clientJs).toMatch(/initChild\('Tag',/)
+  })
+
+  test('#1268 — composite element body with nested component materializes via renderChild', () => {
+    // Loop body is `<li><Cell /></li>` — a plain element wrapping a
+    // nested child component, with the array still prop-derived.
+    // `useElementReconciliation` is forced false for static arrays in
+    // `decideLoopRendering`, so the per-iteration template comes from
+    // `irToHtmlTemplate` (not `irToPlaceholderTemplate`), inlining a
+    // `${renderChild('Cell', ...)}` expression inside the `<li>`. The
+    // existing materialize plan from #1265 covers this — this test
+    // documents the contract so a later refactor doesn't accidentally
+    // route this shape through the placeholder path.
+    const source = `
+      'use client'
+      type Props = { rows: Record<string, { label: string }> }
+      export function Table(props: Props) {
+        const entries = Object.entries(props.rows)
+        return (
+          <ul>
+            {entries.map(([id, row]) => (
+              <li key={id}>
+                <Cell label={row.label} />
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const clientJs = getClientJs(source, 'Table.tsx')
+    // Materialize branch present.
+    expect(clientJs).toMatch(/if \(!__iterEl\)/)
+    // Per-iteration template is `<li ...>...renderChild('Cell', ...)...</li>`.
+    const matMatch = clientJs.match(/__tpl\.innerHTML = `([^`]*)`/)
+    expect(matMatch).toBeTruthy()
+    const inner = matMatch![1]
+    expect(inner).toMatch(/^<li\b/)
+    expect(inner).toMatch(/\$\{renderChild\('Cell', \{[^}]*label: row\.label[^}]*\}/)
+    // The materialize must NOT emit a `data-bf-ph` placeholder for
+    // composite-with-nested-component static loops — that's the
+    // useElementReconciliation shape, which the classifier forbids for
+    // static arrays.
+    expect(inner).not.toMatch(/data-bf-ph=/)
+    // Nested-comp init still runs after materialize.
+    expect(clientJs).toMatch(/initChild\('Cell',/)
+  })
+
   test('block-body .map emits mapPreamble at forEach top, visible to both branches', () => {
     // When the arrow body is a block (`{ const count = ...; return ... }`),
     // the const declaration lands in `csrMaterialize.mapPreamble`. The

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -497,6 +497,21 @@ export function collectElements(
       let staticItemTemplate: string | undefined
       if (l.childComponent) {
         template = '' // childComponent path uses createComponent directly
+        // CSR materialize fallback (#1268): when the loop array references an
+        // init-scope local the CSR template substitutes `[]`, so the
+        // container is empty on a `createComponent` mount. The materialize
+        // forEach in `stringifyStaticLoop` evaluates this per-iteration
+        // template (a single `${renderChild('Name', ...)}` expression) so the
+        // rendered child HTML lands inside the container; the
+        // `static-array-child-inits` phase then wires it via `initChild`.
+        // Loop-param refs use the raw destructured binding (no loopParams
+        // passed), matching the plain-element path's `staticItemTemplate`.
+        if (l.isStaticArray && l.children[0]) {
+          // `insideLoop=true` so the component-emit drops the parent's slot
+          // suffix — each iteration owns a distinct scope identified by
+          // `data-key`, mirroring the SSR template's renderChild emit.
+          staticItemTemplate = irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0, undefined, undefined, /* insideLoop */ true)
+        }
       } else if (l.children[0]) {
         // Pass loopParams so expressions are wrapped at generation time,
         // avoiding post-hoc regex wrapping that corrupts literal attribute values.
@@ -512,6 +527,15 @@ export function collectElements(
         // accessor wrap so the CSR materialize fallback (#1247) can clone
         // items inside the forEach body without rewriting the template.
         if (l.isStaticArray) {
+          // Plain-element body: leave `insideLoop=false` so any nested
+          // component nodes keep their parent-slot suffix in the per-iteration
+          // renderChild call. The `outer-nested` static-array-child-init plan
+          // uses a strict `'[bf-s$="_${slotId}"]'` selector with no `~Name_`
+          // fallback, so the materialized children must end in `_${slotId}`
+          // for `initChild` to find them. SSR's parent-anchored shape
+          // (`test_${slotId}`) and CSR's random-anchored shape
+          // (`~${name}_<rand>_${slotId}`) both end in `_${slotId}` — keeping
+          // them aligned is what makes the dual SSR/CSR lookup work.
           staticItemTemplate = useElementReconciliation
             ? irToPlaceholderTemplate(l.children[0], buildRestSpreadNames(ctx), 0)
             : irToHtmlTemplate(l.children[0], buildRestSpreadNames(ctx), 0)

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -83,16 +83,25 @@ export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<st
  * Decide whether the CSR template will substitute the loop's array with `[]`
  * (the unsafe-name fallback in `html-template.ts`) and, if so, package the
  * inputs the stringifier needs to clone per-iteration children into the
- * container at hydrate time (#1247).
+ * container at hydrate time (#1247, #1268).
  *
  * Skipped when:
+ *   - there are no init-scope locals (the CSR template never substitutes),
+ *   - the per-iteration template wasn't built (cannot reproduce content), or
  *   - the array is safe in template scope (the CSR template already emits
- *     items via `.map(...)`, no fallback needed),
- *   - the loop body is a child component or composite/element-reconciled
- *     shape (the SSR-then-CSR mismatch in that case is handled by the
- *     dynamic-loop path; the static branch here only materialises plain
- *     element bodies), or
- *   - the loop's per-iteration template wasn't built (childComponent path).
+ *     items via `.map(...)`, no fallback needed).
+ *
+ * Body shape handling: the per-iteration template carries `${renderChild(...)}`
+ * expressions for component bodies (plain element, single-child-component, and
+ * composite-with-nested-components paths alike). The clone-and-insert branch
+ * in `stringifyStaticLoop` evaluates them when constructing the template's
+ * `innerHTML`, so the cloned children land with the SSR `bf-s` shape and
+ * `static-array-child-inits` can wire them via `initChild` unchanged.
+ *
+ * Note: `useElementReconciliation` is forced to `false` for static arrays in
+ * `decideLoopRendering`, so no explicit exclusion is needed for that flag —
+ * the composite-with-nested-components case takes the plain-element template
+ * path with renderChild expressions inlined.
  */
 function buildStaticLoopMaterialize(
   elem: TopLevelLoop,
@@ -100,8 +109,6 @@ function buildStaticLoopMaterialize(
 ): StaticLoopMaterializePlan | null {
   if (unsafeLocalNames.size === 0) return null
   if (!elem.staticItemTemplate) return null
-  if (elem.childComponent) return null
-  if (elem.useElementReconciliation) return null
   if (!exprReferencesAny(elem.array, unsafeLocalNames)) return null
   return {
     itemTemplate: elem.staticItemTemplate,

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -88,9 +88,15 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
  *    are wrapped with `__bfSlot(EXPR, <branchSlotsVar>)` so the runtime can
  *    splice live `Node` returns into the parsed fragment instead of
  *    stringifying them via the template literal (#1213).
+ *  @param insideLoop - When true, component nodes omit their `slotId` from the
+ *    `renderChild` call. Each loop iteration produces its own scope (identified
+ *    by `data-key`), so the parent-slot suffix would create scopes that don't
+ *    match the SSR shape — see #1268 and the matching `insideLoop` guard in
+ *    `generateCsrTemplate` (case `'component'`). Set to `true` when generating
+ *    the per-iteration `staticItemTemplate` for static loops.
  */
-export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string): string {
-  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar)
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string, insideLoop = false): string {
+  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
   const wrapInterpolation = (expr: string): string => branchSlotsVar
     ? `__bfSlot(${expr}, ${branchSlotsVar})`
@@ -186,8 +192,11 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
       const keyArg = keyProp ? `, ${keyProp.value}` : ''
-      // Pass slotId as suffix so $c() can find the child component by slot after branch swap
-      const slotArg = node.slotId ? `, '${node.slotId}'` : ''
+      // Pass slotId as suffix so $c() can find the child component by slot after branch swap.
+      // Inside a loop body each iteration owns a separate scope (identified by
+      // `data-key`), so the parent-slot suffix is dropped — matching the
+      // SSR template's loop component emit in `generateCsrTemplate` (#1268).
+      const slotArg = (!insideLoop && node.slotId) ? `, '${node.slotId}'` : ''
       return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
     }
 
@@ -196,7 +205,9 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // Increment loopDepth so inner key attrs become data-key-N
       // Forward loopParams so expressions referencing outer/inner loop params
       // get wrapped as signal accessors (e.g., task.title → task().title).
-      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar)
+      // `insideLoop` is forced to true for the recursive walk so nested
+      // component renderChild calls drop their slot suffix.
+      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar, true)
       const childTemplate = node.children.map(innerRecurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
       const wrappedArray = wrapExpr(node.array)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -205,9 +205,13 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // Increment loopDepth so inner key attrs become data-key-N
       // Forward loopParams so expressions referencing outer/inner loop params
       // get wrapped as signal accessors (e.g., task.title → task().title).
-      // `insideLoop` is forced to true for the recursive walk so nested
-      // component renderChild calls drop their slot suffix.
-      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar, true)
+      // `insideLoop` is preserved (not forced to `true`): downstream branch /
+      // inner-loop templates depend on the legacy slot-suffix-keeping shape
+      // to find scopes via `findSsrScopeBySlotIn`. The opt-in at the entry
+      // call site is the only place that wants the suffix dropped (#1268
+      // Case 1 — childComponent body materialize); propagating it through
+      // every nested loop regressed form-builder's inner-loop Select wiring.
+      const innerRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth + 1, loopParams, branchSlotsVar, insideLoop)
       const childTemplate = node.children.map(innerRecurse).join('')
       const indexParam = node.index ? `, ${node.index}` : ''
       const wrappedArray = wrapExpr(node.array)


### PR DESCRIPTION
Closes #1268.

## Summary

PR #1265 introduced a CSR self-heal for static-array loops whose array references an init-scope local — but it only covered **plain-element bodies**. The gate in `build-loop.ts` excluded the `childComponent` shape (`entries.map(([id, t]) => <Tag .../>)`), so `createComponent` mounts of such components rendered an empty container.

This extends the materialize to the childComponent shape and clarifies the remaining (already-working) composite case.

## What broke and what fixed it

**Case 1 — childComponent body (real bug).** `static-array-child-inits` scans for child scopes via `qsaChildScopes(...)` and finds nothing, because the CSR template substituted the unsafe array with `[]`. Before the fix:
```
<ul bf="s1" bf-s="TagList_..."><!--bf-loop:l0--><!--bf-/loop:l0--></ul>
```
After:
```
<ul ...><span bf-s="~Tag_..." data-key="a" class="tag-on">a</span><span bf-s="~Tag_..." data-key="b" ...>b</span></ul>
```

**Case 2 — composite element body with nested components (already working).** The issue describes this as `useElementReconciliation`, but `decideLoopRendering` forces `useElementReconciliation = false` for static arrays. The `staticItemTemplate` from #1265 already inlines `${renderChild('Cell', ...)}` inside the `<li>` via `irToHtmlTemplate`, so the existing materialize handles it. The `useElementReconciliation` exclusion in `buildStaticLoopMaterialize` was dead code for static arrays — removed for clarity, and a regression-pin test added.

## Implementation notes

- **`collect-elements.ts`** — builds `staticItemTemplate` for the `l.childComponent` path by running the IRComponent through `irToHtmlTemplate(..., insideLoop=true)`. The result is a single `${renderChild('Name', ..., key)}` expression.
- **`build-loop.ts`** — `buildStaticLoopMaterialize` drops both exclusions (`childComponent` and `useElementReconciliation`). The remaining gates (unsafeLocalNames non-empty, `staticItemTemplate` set, array references an unsafe name) are sufficient.
- **`html-template.ts`** — `irToHtmlTemplate` grows an optional `insideLoop` flag that drops the parent's slot suffix on component nodes (matching `generateCsrTemplate`). Used only by the **childComponent** materialize path, where the `single-comp` selector has a `~Name_` fallback. The composite path keeps the slot suffix because its `outer-nested` selector is strict (`'[bf-s$="_${slotId}"]'`, no fallback) and depends on the materialized children ending in `_${slotId}`.
- **`stringifyStaticLoop`** — no changes needed; the existing clone-and-insert branch handles both shapes uniformly. Template literal evaluation of `${renderChild(...)}` produces the rendered child HTML, and the static-array-child-inits phase wires it via `initChild`.

## Tests

| Layer | File | Pins |
|-------|------|------|
| IR unit | `packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts` | Case 1 + Case 2 emit shape (9 tests total, the existing 7 stay green) |
| Runtime DOM | `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts` | `createComponent` mount renders children for both shapes (4 tests) |
| Adapter conformance | `packages/adapter-tests/fixtures/static-array-from-props-with-component.ts` | Hono SSR output; skipped in CSR conformance (template-only harness) and Go/Mojo (JS-only `Object.entries`) |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts` — 9/9
- [x] `bun test packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts` — 4/4
- [x] `bun test packages/adapter-tests/` — 237/237 (CSR + SSR-hydration contract + JSX conformance)
- [x] `bun test packages/adapter-hono/` — 111/111
- [x] `bun test packages/jsx/` — 1086/1086
- [x] `bun test packages/client/` — 498/498
- [x] `bun test packages/` — 2365 pass / 0 fail / 4 skip
- [ ] `site/ui/e2e/` — verified in CI (requires docker-compose; the change is scoped to a specific CSR-only path that does not overlap with E2E playgrounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)