### PR TITLE
refactor(jsx): unify four loop plan types into single LoopPlan union (#1253)

### DIFF
--- a/packages/jsx/src/__tests__/loop-plan-classification.test.ts
+++ b/packages/jsx/src/__tests__/loop-plan-classification.test.ts
@@ -1,0 +1,170 @@
+/**
+ * BarefootJS Compiler — `buildLoopPlan` decision tree classification (#1253).
+ *
+ * Exercises every predicate branch of the single `buildLoopPlan` entry with
+ * minimal `TopLevelLoop` fixtures so a future predicate change shows up as a
+ * single-test failure with an obvious diagnostic, rather than as a subtle
+ * stringifier regression caught only by adapter conformance.
+ *
+ * Predicate order under test (matches the implementation in
+ * `control-flow/plan/build-loop.ts`):
+ *
+ *   1. `isStaticArray`                                              → 'static'
+ *   2. `useElementReconciliation` AND (nestedComps OR innerLoops)   → 'composite'
+ *   3. `childComponent`                                             → 'component'
+ *   4. fallthrough                                                  → 'plain'
+ *
+ * Boundary cases verified inline:
+ *   - composite predicate requires BOTH `useElementReconciliation` and a
+ *     non-empty `nestedComponents`/`innerLoops` — either alone falls through.
+ *   - `childComponent` is checked AFTER composite, so a loop carrying both
+ *     `childComponent` and `useElementReconciliation` still routes to
+ *     composite (the per-issue refactor target shape).
+ *   - `isStaticArray` wins over every dynamic predicate.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { buildLoopPlan } from '../ir-to-client-js/control-flow/plan/build-loop'
+import type { TopLevelLoop } from '../ir-to-client-js/types'
+import type { IRLoopChildComponent } from '../types'
+
+function makeLoop(overrides: Partial<TopLevelLoop> = {}): TopLevelLoop {
+  return {
+    kind: 'top-level',
+    slotId: 's1',
+    index: null,
+    template: '<li bf="s2"></li>',
+    array: 'items',
+    param: 'item',
+    key: null,
+    markerId: 'm0',
+    childEventHandlers: [],
+    childEvents: [],
+    childReactiveAttrs: [],
+    childReactiveTexts: [],
+    isStaticArray: false,
+    ...overrides,
+  }
+}
+
+function makeChildComponent(name = 'Card'): IRLoopChildComponent {
+  return { name, slotId: 's3', props: [], children: [] }
+}
+
+const NO_UNSAFE = new Set<string>()
+
+describe('buildLoopPlan decision tree (#1253)', () => {
+  test('isStaticArray → static (wins over every dynamic predicate)', () => {
+    const plan = buildLoopPlan(
+      makeLoop({
+        isStaticArray: true,
+        useElementReconciliation: true,
+        nestedComponents: [makeChildComponent()],
+        childComponent: makeChildComponent('Outer'),
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    expect(plan.kind).toBe('static')
+  })
+
+  test('dynamic + useElementReconciliation + nestedComponents → composite', () => {
+    const plan = buildLoopPlan(
+      makeLoop({
+        useElementReconciliation: true,
+        nestedComponents: [makeChildComponent()],
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    expect(plan.kind).toBe('composite')
+  })
+
+  test('dynamic + useElementReconciliation + innerLoops → composite', () => {
+    const plan = buildLoopPlan(
+      makeLoop({
+        useElementReconciliation: true,
+        nestedComponents: [],
+        innerLoops: [
+          {
+            kind: 'nested',
+            array: 'item.subs',
+            param: 'sub',
+            key: null,
+            markerId: 'inner-m1',
+            template: '<span></span>',
+            depth: 1,
+            containerSlotId: null,
+          },
+        ],
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    expect(plan.kind).toBe('composite')
+  })
+
+  test('boundary: useElementReconciliation true but NO nestedComps/innerLoops → falls through (not composite)', () => {
+    const plan = buildLoopPlan(
+      makeLoop({ useElementReconciliation: true }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    // Falls through to 'plain' — the composite predicate is `AND`, not `OR`.
+    expect(plan.kind).toBe('plain')
+  })
+
+  test('boundary: nestedComponents present but useElementReconciliation false → not composite', () => {
+    const plan = buildLoopPlan(
+      makeLoop({
+        useElementReconciliation: false,
+        nestedComponents: [makeChildComponent()],
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    // Without `useElementReconciliation`, the IR collector decided this is
+    // not a reconcile-driven shape, so the plan stays plain even though
+    // nestedComponents data is present.
+    expect(plan.kind).toBe('plain')
+  })
+
+  test('childComponent without composite indicators → component', () => {
+    const plan = buildLoopPlan(
+      makeLoop({
+        template: '',
+        childComponent: makeChildComponent('Card'),
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    expect(plan.kind).toBe('component')
+  })
+
+  test('boundary: childComponent + composite predicate → composite wins (single-component-body inner loops)', () => {
+    // A loop whose body is a single component but ALSO has inner loops at
+    // the component's children level still routes through composite — the
+    // composite predicate is checked first by design so the inner loops
+    // get their own mapArray reconciliation.
+    const plan = buildLoopPlan(
+      makeLoop({
+        useElementReconciliation: true,
+        childComponent: makeChildComponent('Card'),
+        nestedComponents: [],
+        innerLoops: [
+          {
+            kind: 'nested',
+            array: 'item.subs',
+            param: 'sub',
+            key: null,
+            markerId: 'inner-m1',
+            template: '<span></span>',
+            depth: 1,
+            containerSlotId: null,
+          },
+        ],
+      }),
+      { unsafeLocalNames: NO_UNSAFE },
+    )
+    expect(plan.kind).toBe('composite')
+  })
+
+  test('plain element body, no child components, no inner loops → plain', () => {
+    const plan = buildLoopPlan(makeLoop(), { unsafeLocalNames: NO_UNSAFE })
+    expect(plan.kind).toBe('plain')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -85,7 +85,20 @@ function emitLoopEventDelegation(
     return
   }
   // Dynamic plain-element body: keyed delegation by data-key/bf-i marker.
-  if (kind === 'plain' && elem.childEvents.length > 0) {
+  //
+  // `!elem.useElementReconciliation` is preserved here even though the
+  // decision tree only routes to `'plain'` when `useElementReconciliation`
+  // is false OR `hasInnerStructure` is false. The hand-constructed boundary
+  // shape (`useElementReconciliation=true` AND empty nestedComponents /
+  // innerLoops) is unreachable from real IR — the collector sets
+  // `useElementReconciliation` only when it has at least one of those —
+  // but the explicit guard keeps the legacy behaviour byte-equal even if a
+  // future collector change makes that combination valid.
+  if (
+    kind === 'plain'
+    && !elem.useElementReconciliation
+    && elem.childEvents.length > 0
+  ) {
     stringifyEventDelegation(lines, buildDynamicLoopDelegationPlan(elem))
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -23,12 +23,8 @@
 import type { ClientJsContext, TopLevelLoop } from './types'
 import { buildInsertPlan } from './control-flow/plan/build-insert'
 import { stringifyInsert } from './control-flow/stringify/insert'
-import { buildPlainLoopPlan, buildStaticLoopPlan } from './control-flow/plan/build-loop'
-import { stringifyPlainLoop, stringifyStaticLoop } from './control-flow/stringify/loop'
-import { buildComponentLoopPlan } from './control-flow/plan/build-component-loop'
-import { stringifyComponentLoop } from './control-flow/stringify/component-loop'
-import { buildTopLevelCompositePlan } from './control-flow/plan/build-composite-loop'
-import { stringifyCompositeLoop } from './control-flow/stringify/composite-loop'
+import { buildLoopPlan } from './control-flow/plan/build-loop'
+import { stringifyLoop } from './control-flow/stringify/loop'
 import {
   buildDynamicLoopDelegationPlan,
   buildStaticArrayDelegationPlan,
@@ -54,53 +50,42 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
   }
 }
 
-/** Emit loop updates: dispatches to static or dynamic handlers per element. */
+/**
+ * Emit loop updates: builds a unified `LoopPlan` via the single
+ * `buildLoopPlan` entry, stringifies via `stringifyLoop`, and attaches
+ * event delegation per-variant.
+ *
+ * Event-delegation predicates (kept here because they consult the IR's
+ * `childEvents` and `childComponent`, not the Plan):
+ *   - `'static'`  → plain-element static array with events
+ *   - `'plain'`   → dynamic plain-element body with events
+ *   - `'component' / 'composite'` → events ride on the component's own
+ *     event surface, no delegation pass needed
+ */
 export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLocalNames: Set<string>): void {
   for (const elem of ctx.loopElements) {
-    if (elem.isStaticArray) {
-      emitStaticArrayUpdates(lines, elem, unsafeLocalNames)
-    } else {
-      emitDynamicLoopUpdates(lines, elem)
+    const plan = buildLoopPlan(elem, { unsafeLocalNames })
+    stringifyLoop(lines, plan)
+    emitLoopEventDelegation(lines, elem, plan.kind)
+  }
+}
+
+function emitLoopEventDelegation(
+  lines: string[],
+  elem: TopLevelLoop,
+  kind: 'plain' | 'component' | 'composite' | 'static',
+): void {
+  if (kind === 'static') {
+    // Event delegation for plain elements in static arrays (#537). Static
+    // arrays have no data-key/bf-i markers, so walk up from target to the
+    // container's direct child and use indexOf for index lookup.
+    if (!elem.childComponent && elem.childEvents.length > 0) {
+      stringifyEventDelegation(lines, buildStaticArrayDelegationPlan(elem))
     }
+    return
   }
-}
-
-/**
- * Emit reactive attribute effects and event delegation for static arrays.
- * Static arrays are server-rendered once; only signal-dependent attributes
- * and event handlers need client-side setup. (initChild calls are deferred to
- * the `static-array-child-inits` phase so parent context providers run first.)
- */
-function emitStaticArrayUpdates(lines: string[], elem: TopLevelLoop, unsafeLocalNames: Set<string>): void {
-  stringifyStaticLoop(lines, buildStaticLoopPlan(elem, unsafeLocalNames))
-
-  // Event delegation for plain elements in static arrays (#537).
-  // Static arrays have no data-key/bf-i markers, so walk up from target to
-  // the container's direct child and use indexOf for index lookup.
-  if (!elem.childComponent && elem.childEvents.length > 0) {
-    stringifyEventDelegation(lines, buildStaticArrayDelegationPlan(elem))
-  }
-}
-
-/**
- * Emit reconcileElements for a dynamic loop element. Three sub-cases:
- *   - Composite (native element body containing nested comps or inner loops)
- *   - Single-component body
- *   - Plain element body
- * Plus event delegation for plain element loops (component loops handle
- * events differently — through the component's own event surface).
- */
-function emitDynamicLoopUpdates(lines: string[], elem: TopLevelLoop): void {
-  if (elem.useElementReconciliation && (elem.nestedComponents?.length || elem.innerLoops?.length)) {
-    stringifyCompositeLoop(lines, buildTopLevelCompositePlan(elem))
-  } else if (elem.childComponent) {
-    stringifyComponentLoop(lines, buildComponentLoopPlan(elem))
-  } else {
-    stringifyPlainLoop(lines, buildPlainLoopPlan(elem))
-  }
-  lines.push('')
-
-  if (!elem.childComponent && !elem.useElementReconciliation && elem.childEvents.length > 0) {
+  // Dynamic plain-element body: keyed delegation by data-key/bf-i marker.
+  if (kind === 'plain' && elem.childEvents.length > 0) {
     stringifyEventDelegation(lines, buildDynamicLoopDelegationPlan(elem))
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -29,6 +29,7 @@ import { irChildrenToJsExpr } from '../../html-template'
 import { buildReactiveEffectsPlan } from './build-reactive-effects'
 import type { ComponentLoopPlan, NestedComponentInit } from './types'
 
+/** @internal — prefer `buildLoopPlan`. */
 export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
   const { name } = elem.childComponent!
   const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
@@ -56,7 +57,7 @@ export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
   const hasChildConds = (elem.childConditionals?.length ?? 0) > 0
 
   return {
-    kind: 'component-loop',
+    kind: 'component',
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
     arrayExpr: buildChainedArrayExpr(elem),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
@@ -24,6 +24,7 @@ import { buildReactiveEffectsPlan } from './build-reactive-effects'
 import { buildInnerLoopsPlan } from './build-inner-loop'
 import type { CompositeLoopPlan } from './types'
 
+/** @internal — prefer `buildLoopPlan`. */
 export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPlan {
   const nestedComps = elem.nestedComponents!
   const depthLevels = buildDepthLevels(elem.innerLoops ?? [], nestedComps, elem.childEvents)
@@ -33,7 +34,7 @@ export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPla
   const outerCompsByDepth = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
 
   return {
-    kind: 'composite-loop',
+    kind: 'composite',
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
     arrayExpr: buildChainedArrayExpr(elem),
@@ -80,7 +81,7 @@ export function buildBranchCompositePlan(loop: BranchLoop, cv: string): Composit
   const outerCompsByDepth = nestedComps.filter(c => !c.loopDepth || c.loopDepth === 0)
 
   return {
-    kind: 'composite-loop',
+    kind: 'composite',
     containerVar: `__loop_${cv}`,
     markerId: loop.markerId,
     // Branch-scoped loops use the raw array expression (no filter/sort chaining

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -1,11 +1,22 @@
 /**
- * Build LoopPlan variants from a `TopLevelLoop` IR node.
+ * Build `LoopPlan` from a `TopLevelLoop` IR node (#1253).
  *
- * Coverage (PR 2-a):
- *   - PlainLoopPlan  ← plain element body, no child components, no inner loops
- *   - StaticLoopPlan ← static array (literal) with reactive attrs / texts
+ * `buildLoopPlan` is the single entry point. It dispatches to a private
+ * per-variant builder via the decision tree documented inline. Per-variant
+ * builders are exported with `@internal` JSDoc — only the unified entry
+ * should be consumed by emit code.
  *
- * PR 2-b will add `SingleComponentLoopPlan`; PR 2-c adds `CompositeLoopPlan`.
+ * Classification predicates (in evaluation order):
+ *
+ *   1. `isStaticArray` → `'static'`
+ *   2. dynamic + (`nestedComponents` or `innerLoops`) under
+ *      `useElementReconciliation` → `'composite'`
+ *   3. dynamic + `childComponent` → `'component'`
+ *   4. fallthrough → `'plain'`
+ *
+ * The branch composite plan (built by `buildBranchCompositePlan`) intentionally
+ * lives in `build-composite-loop.ts` — it takes `BranchLoop`, not
+ * `TopLevelLoop`, and is reused by the branch-loop wrapper plan.
  */
 
 import type {
@@ -23,8 +34,41 @@ import {
   destructureLoopParam,
 } from '../shared'
 import { buildLoopReactiveEffectsPlan } from './build-reactive-effects'
-import type { PlainLoopPlan, StaticLoopMaterializePlan, StaticLoopPlan } from './types'
+import { buildComponentLoopPlan } from './build-component-loop'
+import { buildTopLevelCompositePlan } from './build-composite-loop'
+import type {
+  LoopPlan,
+  PlainLoopPlan,
+  StaticLoopMaterializePlan,
+  StaticLoopPlan,
+} from './types'
 
+/** Inputs only the static-array variant consumes. */
+export interface BuildLoopPlanOptions {
+  /** Local names whose CSR-time substitution forces the static-array self-heal path (#1247). */
+  unsafeLocalNames: Set<string>
+}
+
+/**
+ * The single public builder. Selects the variant via the decision tree
+ * described above and returns the discriminated `LoopPlan`.
+ */
+export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): LoopPlan {
+  if (elem.isStaticArray) {
+    return buildStaticLoopPlan(elem, opts.unsafeLocalNames)
+  }
+  const hasInnerStructure = (elem.nestedComponents?.length ?? 0) > 0
+    || (elem.innerLoops?.length ?? 0) > 0
+  if (elem.useElementReconciliation && hasInnerStructure) {
+    return buildTopLevelCompositePlan(elem)
+  }
+  if (elem.childComponent) {
+    return buildComponentLoopPlan(elem)
+  }
+  return buildPlainLoopPlan(elem)
+}
+
+/** @internal — prefer `buildLoopPlan`. Exported for the branch-loop wrapper only. */
 export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
   const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
@@ -33,7 +77,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
     || (elem.childConditionals?.length ?? 0) > 0
 
   return {
-    kind: 'plain-loop',
+    kind: 'plain',
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
     arrayExpr: buildChainedArrayExpr(elem),
@@ -48,6 +92,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
   }
 }
 
+/** @internal — prefer `buildLoopPlan`. */
 export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<string>): StaticLoopPlan {
   // Group reactive attrs by their child slot id, preserving the legacy
   // declaration-order Map-iteration semantics.
@@ -67,7 +112,7 @@ export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<st
   const childIndexExpr = elem.siblingOffset ? `${indexParam} + ${elem.siblingOffset}` : indexParam
 
   return {
-    kind: 'static-loop',
+    kind: 'static',
     containerVar: `_${varSlotId(elem.slotId)}`,
     arrayExpr: elem.array,
     param: elem.param,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -1,12 +1,19 @@
 /**
- * Plan types for the four loop emission shapes.
+ * The unified Plan type for every loop emission shape (#1253).
  *
- * - `PlainLoopPlan`     — body is a plain element (no comp, no inner loop)
- * - `ComponentLoopPlan` — body is a single child component (with optional nested comps)
- * - `CompositeLoopPlan` — body is a plain element containing comps and/or inner loops
- * - `StaticLoopPlan`    — array is a constant literal; only reactive attrs/texts need setup
+ * `LoopPlan` is a single discriminated union keyed by `kind`. The four
+ * legacy interfaces (`PlainLoopPlan`, `ComponentLoopPlan`,
+ * `CompositeLoopPlan`, `StaticLoopPlan`) have been collapsed into the
+ * `'plain'` / `'component'` / `'composite'` / `'static'` variants below.
  *
- * The classification is documented in spec/compiler.md "Loop emission shapes".
+ * Per-item reactive concepts (attrs, texts, conditionals, multi-root
+ * cloning, `qsa` vs `qsaItem` slot lookup) live in shared fields on the
+ * dynamic-loop base. Variant-specific fields stay under the discriminator
+ * so dispatch in stringifiers narrows correctly.
+ *
+ * Classification semantics are documented in spec/compiler.md
+ * "Loop emission shapes" and validated by the decision-tree fixtures in
+ * `__tests__/loop-plan-classification.test.ts`.
  */
 
 import type {
@@ -19,40 +26,40 @@ import type { IRLoopChildComponent } from '../../../types'
 import type { ReactiveEffectsPlan } from './reactive-effects'
 import type { InnerLoopsPlan } from './inner-loop'
 
-/**
- * Plan for a top-level dynamic loop with a plain element body (no child
- * components, no inner loops). Covers `emitPlainElementLoopReconciliation`.
- *
- * The "single-line vs multi-line renderItem" split in the legacy emitter is
- * a stringifier concern, not a Plan concern — the Plan just records
- * whether reactive effects exist and the stringifier picks the layout.
- */
-export interface PlainLoopPlan {
-  kind: 'plain-loop'
-  /** The container element variable, e.g. `_s1`. */
+/** Fields shared by every `LoopPlan` variant. */
+interface LoopPlanCommon {
+  /** Container element variable (e.g. `_s1` for top-level, `__loop_<cv>` for branch). */
   containerVar: string
+  /** Array expression to drive iteration. Pre-chained (filter/sort) for top-level dynamic loops. */
+  arrayExpr: string
+  /** Index parameter identifier, e.g. `__idx` or user-supplied. */
+  indexParam: string
+}
+
+/** Fields shared by every dynamic (`mapArray`-driven) loop variant. */
+interface DynamicLoopCommon extends LoopPlanCommon {
   /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
   markerId: string
-  /** Array expression to drive `mapArray(() => ARR, ...)`. Already chained (filter/sort). */
-  arrayExpr: string
   /** Key function source — `null` when the loop has no explicit key. */
   keyFn: string
   /** renderItem param identifier (after destructure unwrap rename). */
   paramHead: string
-  /** Index parameter identifier, e.g. `__idx` or user-supplied. */
-  indexParam: string
   /** Statement to unwrap a destructured param at body entry. Empty when not needed. */
   paramUnwrap: string
+}
+
+/**
+ * Plain element body, no child components, no inner loops. Covers the
+ * single-line and multi-line renderItem shapes — the stringifier picks
+ * the layout based on `reactiveEffects` and `bodyIsMultiRoot`.
+ */
+interface PlainLoopVariant extends DynamicLoopCommon {
+  kind: 'plain'
   /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
   mapPreambleWrapped: string
   /** HTML template string for one item. */
   template: string
-  /**
-   * Fully-resolved reactive-effects plan (attrs / texts / conditionals). When
-   * `null`, the stringifier emits the single-line renderItem. The Plan is
-   * built by `buildReactiveEffectsPlan` — every wrap and partition decision
-   * is already made.
-   */
+  /** Resolved reactive-effects plan — null forces the single-line renderItem shape. */
   reactiveEffects: ReactiveEffectsPlan | null
   /**
    * True when the loop body is a multi-root JSX Fragment. Forces the
@@ -63,29 +70,19 @@ export interface PlainLoopPlan {
 }
 
 /**
- * Plan for a top-level dynamic loop whose body is a single child component
- * (with or without nested child components inside it). Covers
- * `emitComponentLoopReconciliation`.
+ * Loop body is a single child component (with or without nested child
+ * components inside it).
  *
- * `nestedComps.length === 0`  → emit the simple two-line renderItem
- *                               (initChild on existing, createComponent on new).
- * `nestedComps.length > 0`    → emit the SSR/CSR split that initialises both
- *                               the outer component and each nested child.
+ * `nestedComps.length === 0`  → simple two-line renderItem.
+ * `nestedComps.length > 0`    → SSR/CSR split that initialises both the
+ *                               outer component and each nested child.
  *
- * Reactive-effects construction inside `childConditionals` is now a fully
- * resolved `ReactiveEffectsPlan` — same shape as `PlainLoopPlan.reactiveEffects`.
+ * `childConditionalEffects` is non-null when the body contains reactive
+ * conditionals; same plan shape as plain/composite `reactiveEffects`.
  */
-export interface ComponentLoopPlan {
-  kind: 'component-loop'
-  containerVar: string
-  /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
-  markerId: string
-  arrayExpr: string
-  keyFn: string
-  paramHead: string
-  paramUnwrap: string
-  indexParam: string
-  /** The outer (loop body) component's name, e.g. `'Card'`. */
+interface ComponentLoopVariant extends DynamicLoopCommon {
+  kind: 'component'
+  /** The outer (loop body) component's name. */
   componentName: string
   /** Pre-built props object expression for the outer component. */
   componentPropsExpr: string
@@ -93,59 +90,19 @@ export interface ComponentLoopPlan {
   keyExpr: string
   /** Nested child component initialisers; empty for the simple case. */
   nestedComps: NestedComponentInit[]
-  /**
-   * Reactive-effects plan for `childConditionals` inside the loop body. Only
-   * populated when conditionals exist (attrs / texts in this shape go through
-   * the per-component nested-init effect, not this plan).
-   */
+  /** Reactive-effects plan for `childConditionals` inside the loop body. */
   childConditionalEffects: ReactiveEffectsPlan | null
 }
 
 /**
- * One nested child component to initialise inside a renderItem body.
- * `childrenTextEffect` is non-null when the component's children are
- * text-equivalent AND reference the outer loop param — in that case the
- * stringifier emits a `createEffect` that updates the child's `textContent`.
+ * Composite — body is a plain element that contains nested child components
+ * (`outerComps`) and/or inner loops (`innerLoops`). Used for both top-level
+ * emission and branch-scoped emission. The two contexts differ only in
+ * container variable name, array expression chaining, indentation, and
+ * whether `branchClearChildren` is set.
  */
-export interface NestedComponentInit {
-  componentName: string
-  /** CSS selector used by `qsa(...)` to find the SSR-rendered placeholder. */
-  selector: string
-  /** Pre-built props object expression for the nested component. */
-  propsExpr: string
-  /** When non-null, emit a reactive textContent effect alongside `initChild`. */
-  childrenTextEffect: { wrappedChildren: string } | null
-}
-
-/**
- * Plan for a composite loop — body is a plain element that contains either
- * nested child components (`outerComps`) and/or inner loops
- * (`depthLevels`). Used for both top-level emission
- * (`emitCompositeElementReconciliation`) and branch-scoped emission
- * (`emitCompositeBranchLoop`).
- *
- * The two contexts differ only in:
- *   - container variable name (`_sN` vs `__loop_cv`)
- *   - `arrayExpr` (top: chained filter/sort/map; branch: raw `loop.array`)
- *   - leading/body indent
- *   - `branchClearChildren`: when true, prepends a `getLoopChildren(...)
- *     .forEach(__el => __el.remove())` line so the branch swap starts from
- *     a clean slate (legacy parity).
- *
- * Inner-loop emission and component-and-event setup remain on the legacy
- * `emitInnerLoopSetup` / `emitComponentAndEventSetup` helpers, invoked from
- * the stringifier as a passthrough.
- */
-export interface CompositeLoopPlan {
-  kind: 'composite-loop'
-  containerVar: string
-  /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
-  markerId: string
-  arrayExpr: string
-  keyFn: string
-  paramHead: string
-  paramUnwrap: string
-  indexParam: string
+interface CompositeLoopVariant extends DynamicLoopCommon {
+  kind: 'composite'
   /** Wrapped mapPreamble line, hoisted before the SSR/CSR split. Empty when none. */
   mapPreambleWrapped: string
   /** Inner template HTML for the loop body (single item). */
@@ -173,51 +130,70 @@ export interface CompositeLoopPlan {
   /** Indent of the lines inside the renderItem body. */
   bodyIndent: string
   /**
-   * True when the loop body is a multi-root JSX Fragment. Forces the
-   * multi-root template clone path and per-item `<!--bf-loop-i-->` marker
-   * emission, and switches reactive-attr / event / insert lookups from
-   * `qsa(__el, ...)` to `qsaItem(__el, ...)` so they walk past `__el`'s
-   * siblings within the same item (#1212).
+   * True when the loop body is a multi-root JSX Fragment — drives the
+   * multi-root template clone, per-item marker emission, and
+   * `qsa(__el, ...)` → `qsaItem(__el, ...)` for reactive lookups (#1212).
    */
   bodyIsMultiRoot: boolean
 }
 
 /**
- * Plan for a top-level static array loop. A single `forEach` pass handles
- * both reactive attrs and reactive texts — mirrors the legacy
- * `emitStaticArrayUpdates` shape after the O-4 merge.
+ * Top-level static array. A single `forEach` pass handles both reactive
+ * attrs and reactive texts — mirrors the legacy `emitStaticArrayUpdates`
+ * shape after the O-4 merge.
  */
-export interface StaticLoopPlan {
-  kind: 'static-loop'
-  containerVar: string
-  /** Source array expression as written in user code (no signal accessor wrap). */
-  arrayExpr: string
-  /** Loop param name. */
+interface StaticLoopVariant extends LoopPlanCommon {
+  kind: 'static'
+  /** Loop param name (the forEach callback's first arg). */
   param: string
-  /** Index parameter identifier. */
-  indexParam: string
   /** Children-index offset expression — index when no offset, `${idx} + N` otherwise. */
   childIndexExpr: string
-  /**
-   * Reactive attrs grouped by child slot id (preserves emission order).
-   * Empty list means no attrs to emit.
-   */
+  /** Reactive attrs grouped by child slot id (preserves emission order). */
   attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
   /** Reactive texts in declaration order. */
   texts: readonly LoopChildReactiveText[]
   /**
    * CSR self-heal payload (#1247). Set when the loop's array expression
    * references an init-scope local that the CSR template substitutes with
-   * `[]` — without these, the container is empty on a CSR-only mount
-   * (`createComponent`) because SSR never ran. When non-null, the
-   * stringifier emits a clone-and-insert branch inside the per-item forEach
-   * that materialises missing children before binding reactive effects.
-   *
-   * `null` for the SSR-then-hydrate-only common case: the forEach finds
-   * each `__iterEl` already present and never enters the materialize
-   * branch, so the cost is purely the additional `if (!__iterEl)` check.
+   * `[]` — without these, the container is empty on a CSR-only mount.
+   * Null for the SSR-then-hydrate-only common case.
    */
   csrMaterialize: StaticLoopMaterializePlan | null
+}
+
+/**
+ * The unified Plan for every loop emission shape. Stringifiers narrow on
+ * `kind`; builders return this type from a single entry point.
+ */
+export type LoopPlan =
+  | PlainLoopVariant
+  | ComponentLoopVariant
+  | CompositeLoopVariant
+  | StaticLoopVariant
+
+/**
+ * Helpers for callers that need a specific variant. Prefer these over
+ * hand-rolled `Extract<LoopPlan, ...>` so the kind keys stay in one place.
+ */
+export type PlainLoopPlan = Extract<LoopPlan, { kind: 'plain' }>
+export type ComponentLoopPlan = Extract<LoopPlan, { kind: 'component' }>
+export type CompositeLoopPlan = Extract<LoopPlan, { kind: 'composite' }>
+export type StaticLoopPlan = Extract<LoopPlan, { kind: 'static' }>
+
+/**
+ * One nested child component to initialise inside a renderItem body.
+ * `childrenTextEffect` is non-null when the component's children are
+ * text-equivalent AND reference the outer loop param — in that case the
+ * stringifier emits a `createEffect` that updates the child's `textContent`.
+ */
+export interface NestedComponentInit {
+  componentName: string
+  /** CSS selector used by `qsa(...)` to find the SSR-rendered placeholder. */
+  selector: string
+  /** Pre-built props object expression for the nested component. */
+  propsExpr: string
+  /** When non-null, emit a reactive textContent effect alongside `initChild`. */
+  childrenTextEffect: { wrappedChildren: string } | null
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -9,8 +9,9 @@
  *                          `ReactiveAttrEffect`, `ReactiveTextEffect`,
  *                          `NestedConditionalPlan`
  *   insert.ts            — `InsertPlan` family (arms, bindings)
- *   loop.ts              — `PlainLoopPlan`, `ComponentLoopPlan`,
- *                          `CompositeLoopPlan`, `StaticLoopPlan`,
+ *   loop.ts              — `LoopPlan` (discriminated union), variant
+ *                          aliases (`PlainLoopPlan`, `ComponentLoopPlan`,
+ *                          `CompositeLoopPlan`, `StaticLoopPlan`),
  *                          `NestedComponentInit`
  *   event-delegation.ts  — `EventDelegationPlan`, `ItemLookup` family
  *
@@ -37,6 +38,7 @@ export type {
   ArmTextEffect,
 } from './insert'
 export type {
+  LoopPlan,
   PlainLoopPlan,
   ComponentLoopPlan,
   CompositeLoopPlan,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
@@ -13,7 +13,7 @@
 import { stringifyCompositeLoop } from './composite-loop'
 import { stringifyEventDelegation } from './event-delegation'
 import { stringifyReactiveEffects } from './reactive-effects'
-import { emitTemplateCloneInline, emitMultiRootTemplateCloneLines } from './template-parse'
+import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse'
 import type {
   BranchLoopPlan,
   BranchPlainLoopPlan,
@@ -82,18 +82,12 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     if (mapPreambleWrapped) {
       lines.push(`          ${mapPreambleWrapped}`)
     }
-    if (bodyIsMultiRoot) {
-      lines.push(`          let __el, __extras`)
-      lines.push(`          if (__existing) {`)
-      lines.push(`            __el = __existing`)
-      lines.push(`          } else {`)
-      for (const ln of emitMultiRootTemplateCloneLines(template, '            ', '__el', '__extras')) lines.push(ln)
-      lines.push(`            __el.__bfExtras = __extras`)
-      lines.push(`          }`)
-    } else {
-      const cloneExpr = emitTemplateCloneInline(template)
-      lines.push(`          const __el = __existing ?? (() => { ${cloneExpr} })()`)
-    }
+    emitLoopItemElementSetup(lines, {
+      template,
+      bodyIsMultiRoot,
+      indent: '          ',
+      singleRootLayout: 'inline',
+    })
     if (reactiveEffects !== null) {
       stringifyReactiveEffects(lines, reactiveEffects, { indent: '          ', elVar: '__el', bodyIsMultiRoot })
     }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -33,7 +33,7 @@
 import { emitComponentAndEventSetup } from '../shared'
 import { stringifyInnerLoops } from './inner-loop'
 import { stringifyReactiveEffects } from './reactive-effects'
-import { emitTemplateCloneLines, emitMultiRootTemplateCloneLines } from './template-parse'
+import { emitLoopItemElementSetup } from './template-parse'
 import type { CompositeLoopPlan } from '../plan/types'
 
 export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan): void {
@@ -102,30 +102,20 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   // emitted after the if/else block.
   if (mapPreambleWrapped) lines.push(`${bodyIndent}${mapPreambleWrapped}`)
 
-  const innerIndent = bodyIndent + '  '
   const compsArr = [...outerComps]
   const eventsArr = [...outerEvents]
 
   // __el is either the existing SSR-rendered element or a fresh clone of
   // the template — both shapes accept the same mode-independent setup
   // (upsertChild resolves SSR vs CSR per-component at runtime, inner-loop
-  // mapArrays are mode-independent by definition).
-  if (bodyIsMultiRoot) {
-    // Multi-root Fragment item: clone the primary root + collect each
-    // sibling root into `__extras`, then stash on `__el.__bfExtras` so
-    // mapArray pairs all of them with the item's key (#1212).
-    lines.push(`${bodyIndent}let __el, __extras`)
-    lines.push(`${bodyIndent}if (__existing) {`)
-    lines.push(`${innerIndent}__el = __existing`)
-    lines.push(`${bodyIndent}} else {`)
-    for (const ln of emitMultiRootTemplateCloneLines(template, innerIndent, '__el', '__extras')) lines.push(ln)
-    lines.push(`${innerIndent}__el.__bfExtras = __extras`)
-    lines.push(`${bodyIndent}}`)
-  } else {
-    lines.push(`${bodyIndent}const __el = __existing ?? (() => {`)
-    for (const ln of emitTemplateCloneLines(template, innerIndent)) lines.push(ln)
-    lines.push(`${bodyIndent}})()`)
-  }
+  // mapArrays are mode-independent by definition). Multi-root Fragment
+  // items also stash their sibling roots on `__el.__bfExtras` (#1212).
+  emitLoopItemElementSetup(lines, {
+    template,
+    bodyIsMultiRoot,
+    indent: bodyIndent,
+    singleRootLayout: 'multiline',
+  })
   emitComponentAndEventSetup(lines, bodyIndent, '__el', compsArr, eventsArr, loopParam, loopParamBindings, bodyIsMultiRoot)
   if (innerLoops.length > 0) {
     stringifyInnerLoops(lines, innerLoops, bodyIndent)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -60,7 +60,19 @@ export function stringifyLoop(lines: string[], plan: LoopPlan): void {
       stringifyPlainLoop(lines, plan)
       lines.push('')
       return
+    default:
+      return assertNever(plan)
   }
+}
+
+/**
+ * Exhaustiveness guard. Adding a new `LoopPlan` variant without a matching
+ * `case` in `stringifyLoop` becomes a compile-time error (the parameter
+ * stops narrowing to `never`) instead of a silent no-op at runtime.
+ */
+function assertNever(plan: never): never {
+  const kind = (plan as { kind?: string } | null)?.kind
+  throw new Error(`stringifyLoop: unhandled LoopPlan kind ${JSON.stringify(kind)}`)
 }
 
 export function stringifyPlainLoop(

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -27,8 +27,41 @@
 import { varSlotId } from '../../utils'
 import { emitAttrUpdate } from '../../emit-reactive'
 import { stringifyReactiveEffects } from './reactive-effects'
-import { emitTemplateCloneInline, emitMultiRootTemplateCloneLines } from './template-parse'
-import type { PlainLoopPlan, StaticLoopPlan } from '../plan/types'
+import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse'
+import { stringifyComponentLoop } from './component-loop'
+import { stringifyCompositeLoop } from './composite-loop'
+import type { LoopPlan, PlainLoopPlan, StaticLoopPlan } from '../plan/types'
+
+/**
+ * Single dispatch over `LoopPlan` (#1253). Narrows on `plan.kind` and
+ * delegates to the per-variant stringifier. Callers should consume this
+ * rather than the per-variant functions so future shared-helper extraction
+ * happens in one place.
+ *
+ * Trailing-newline policy: every variant ends its emission with a single
+ * blank line so downstream code blocks (event delegation, child-init) are
+ * separated from the loop body. `stringifyStaticLoop` already pushes its
+ * trailing `''` internally; the dynamic variants push one here.
+ */
+export function stringifyLoop(lines: string[], plan: LoopPlan): void {
+  switch (plan.kind) {
+    case 'static':
+      stringifyStaticLoop(lines, plan)
+      return
+    case 'composite':
+      stringifyCompositeLoop(lines, plan)
+      lines.push('')
+      return
+    case 'component':
+      stringifyComponentLoop(lines, plan)
+      lines.push('')
+      return
+    case 'plain':
+      stringifyPlainLoop(lines, plan)
+      lines.push('')
+      return
+  }
+}
 
 export function stringifyPlainLoop(
   lines: string[],
@@ -65,19 +98,12 @@ export function stringifyPlainLoop(
   const bodyIndent = topIndent + '  '
   if (paramUnwrap) lines.push(`${bodyIndent}${paramUnwrap}`)
   if (mapPreambleWrapped) lines.push(`${bodyIndent}${mapPreambleWrapped}`)
-  if (bodyIsMultiRoot) {
-    const innerIndent = bodyIndent + '  '
-    lines.push(`${bodyIndent}let __el, __extras`)
-    lines.push(`${bodyIndent}if (__existing) {`)
-    lines.push(`${innerIndent}__el = __existing`)
-    lines.push(`${bodyIndent}} else {`)
-    for (const ln of emitMultiRootTemplateCloneLines(template, innerIndent, '__el', '__extras')) lines.push(ln)
-    lines.push(`${innerIndent}__el.__bfExtras = __extras`)
-    lines.push(`${bodyIndent}}`)
-  } else {
-    const cloneExpr = emitTemplateCloneInline(template)
-    lines.push(`${bodyIndent}const __el = __existing ?? (() => { ${cloneExpr} })()`)
-  }
+  emitLoopItemElementSetup(lines, {
+    template,
+    bodyIsMultiRoot,
+    indent: bodyIndent,
+    singleRootLayout: 'inline',
+  })
   if (reactiveEffects !== null) {
     stringifyReactiveEffects(lines, reactiveEffects, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot })
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -264,6 +264,65 @@ export function emitTemplateCloneLines(template: string, indent: string): string
 }
 
 /**
+ * Emit the renderItem-body element-setup block for one dynamic loop item
+ * (#1253). Shared by `stringifyPlainLoop`, `stringifyCompositeLoop`, and
+ * `stringifyBranchLoop`'s plain arm — every byte of the multi-root path is
+ * identical across them and the single-root path varies only on layout.
+ *
+ * Output:
+ *
+ *   bodyIsMultiRoot = true
+ *     <indent>let __el, __extras
+ *     <indent>if (__existing) {
+ *     <indent+2>__el = __existing
+ *     <indent>} else {
+ *     <emitMultiRootTemplateCloneLines (indent+2)>
+ *     <indent+2>__el.__bfExtras = __extras
+ *     <indent>}
+ *
+ *   bodyIsMultiRoot = false, singleRootLayout = 'inline'  (plain / branch-plain)
+ *     <indent>const __el = __existing ?? (() => { <emitTemplateCloneInline> })()
+ *
+ *   bodyIsMultiRoot = false, singleRootLayout = 'multiline'  (composite)
+ *     <indent>const __el = __existing ?? (() => {
+ *     <emitTemplateCloneLines (indent+2)>
+ *     <indent>})()
+ */
+export function emitLoopItemElementSetup(
+  lines: string[],
+  opts: {
+    template: string
+    bodyIsMultiRoot: boolean
+    indent: string
+    /** Single-root layout: 'inline' (plain / branch-plain) or 'multiline' (composite). */
+    singleRootLayout: 'inline' | 'multiline'
+  },
+): void {
+  const { template, bodyIsMultiRoot, indent, singleRootLayout } = opts
+  const innerIndent = indent + '  '
+  if (bodyIsMultiRoot) {
+    lines.push(`${indent}let __el, __extras`)
+    lines.push(`${indent}if (__existing) {`)
+    lines.push(`${innerIndent}__el = __existing`)
+    lines.push(`${indent}} else {`)
+    for (const ln of emitMultiRootTemplateCloneLines(template, innerIndent, '__el', '__extras')) {
+      lines.push(ln)
+    }
+    lines.push(`${innerIndent}__el.__bfExtras = __extras`)
+    lines.push(`${indent}}`)
+    return
+  }
+  if (singleRootLayout === 'inline') {
+    const cloneExpr = emitTemplateCloneInline(template)
+    lines.push(`${indent}const __el = __existing ?? (() => { ${cloneExpr} })()`)
+    return
+  }
+  lines.push(`${indent}const __el = __existing ?? (() => {`)
+  for (const ln of emitTemplateCloneLines(template, innerIndent)) lines.push(ln)
+  lines.push(`${indent}})()`)
+}
+
+/**
  * Multi-root template clone for loop bodies that emit a JSX Fragment with
  * two or more sibling elements (#1212). Initialises both `varEl` (the
  * primary, first root) and `varExtras` (an array of cloned sibling roots).

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -282,16 +282,23 @@ Adapters should render the filter as a conditional wrapper inside the loop (e.g.
 
 ### Loop emission shapes (client JS)
 
-The client JS emitter classifies each `IRLoop` into one of four shapes for code generation. The category is captured by the corresponding `*LoopPlan` type in `packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts`:
+The client JS emitter classifies each `IRLoop` into one of four shapes for code generation. All four are variants of a single `LoopPlan` discriminated union (`packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts`), keyed by `kind`. The unified `buildLoopPlan(ir, opts)` entry in `control-flow/plan/build-loop.ts` is the only public builder — per-variant builders are `@internal` (#1253).
 
-| Shape | Body | Plan type | Client emission |
+| Shape | Body | `kind` | Client emission |
 |---|---|---|---|
-| **Static** | array is a constant literal (no signal) | `StaticLoopPlan` | `arr.forEach(...)` for reactive attrs / texts only |
-| **Plain** | dynamic array, body is a plain element with no child components and no inner loops | `PlainLoopPlan` | `mapArray(() => arr, container, keyFn, renderItem)` returning a clone of the template |
-| **Component** | dynamic array, body is a single child component (with optional nested child components) | `ComponentLoopPlan` | `mapArray(...)` whose `renderItem` calls `initChild` (SSR) or `createComponent` (CSR) |
-| **Composite** | dynamic array, body is a plain element that **contains** at least one child component or inner loop | `CompositeLoopPlan` | `mapArray(...)` whose `renderItem` rebuilds the body element and dispatches both component init and inner-loop setup |
+| **Static** | array is a constant literal (no signal) | `'static'` | `arr.forEach(...)` for reactive attrs / texts only |
+| **Plain** | dynamic array, body is a plain element with no child components and no inner loops | `'plain'` | `mapArray(() => arr, container, keyFn, renderItem)` returning a clone of the template |
+| **Component** | dynamic array, body is a single child component (with optional nested child components) | `'component'` | `mapArray(...)` whose `renderItem` calls `initChild` (SSR) or `createComponent` (CSR) |
+| **Composite** | dynamic array, body is a plain element that **contains** at least one child component or inner loop | `'composite'` | `mapArray(...)` whose `renderItem` rebuilds the body element and dispatches both component init and inner-loop setup |
 
 "Composite" specifically denotes the *plain-element-with-children* case. A loop whose body is a bare component is **Component**, not Composite — keeping the two separate avoids the historical "composite means two different things" confusion.
+
+Classification predicates are evaluated in this order (mirrors the decision tree in `buildLoopPlan`, validated by `__tests__/loop-plan-classification.test.ts`):
+
+1. `isStaticArray` → `'static'` (wins over every dynamic predicate)
+2. `useElementReconciliation` AND (`nestedComponents` OR `innerLoops`) → `'composite'`
+3. `childComponent` → `'component'`
+4. fallthrough → `'plain'`
 
 ### Loop param evaluation contexts
 


### PR DESCRIPTION
Closes #1253.

## Summary

Collapse the four loop plan interfaces (`PlainLoopPlan`, `ComponentLoopPlan`, `CompositeLoopPlan`, `StaticLoopPlan`) into a single `LoopPlan` discriminated union keyed by `kind: 'plain' | 'component' | 'composite' | 'static'`. A new `buildLoopPlan(elem, opts)` entry replaces the four per-variant builders and routes via an explicit decision tree. A shared `emitLoopItemElementSetup` helper replaces the multi-root / single-root template-clone block previously duplicated across plain / composite / branch-plain stringifiers.

Per-item reactive concepts (attrs, texts, conditionals, multi-root cloning) now live on a shared dynamic-loop base. Future additions land in one place instead of being re-implemented across four parallel plans — which is exactly the failure mode #1253 was filed against.

## Acceptance criteria coverage

| AC | Status |
|---|---|
| Single `LoopPlan` discriminated union; four interfaces deleted | done — `Extract<LoopPlan, { kind: ... }>` aliases retained for ergonomic callers |
| Single `buildLoopPlan(ir)` entry; per-variant builders private | done — per-variant builders marked `@internal` |
| Shared `stringifyReactiveEffects` / multi-root template / attr-lookup helpers | done — `stringifyReactiveEffects` already shared; new `emitLoopItemElementSetup` consolidates the multi-root + single-root setup block; `qsa` vs `qsaItem` selection already centralized inside `stringifyReactiveEffects` |
| `decideLoopRendering` replaced by tested decision tree with boundary fixtures | done — predicate ordering inlined in `buildLoopPlan` with documentation; 8 unit tests cover every branch + 3 explicit boundary cases |
| Snapshot tests prove byte-equal output | done — verified by existing adapter conformance / CSR conformance / IR-level fixtures |

## Files changed

- `packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts` — unified union
- `packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts` — single entry + decision tree
- `packages/jsx/src/ir-to-client-js/control-flow/plan/{build-component-loop,build-composite-loop}.ts` — `@internal` markers
- `packages/jsx/src/ir-to-client-js/control-flow.ts` — emit path uses unified plan
- `packages/jsx/src/ir-to-client-js/control-flow/stringify/{loop,composite-loop,branch-loop,template-parse}.ts` — shared helper + dispatcher
- `packages/jsx/src/__tests__/loop-plan-classification.test.ts` — new decision-tree tests
- `spec/compiler.md` — updated docs

## Test plan

- [x] `bun test packages/` — 2373 pass / 0 fail
- [x] `bun x tsgo --noEmit -p __tests__/tsconfig.json` (jsx package) — clean
- [x] Loop-related test files (`branch-loop-plain`, `composite-branch-loop`, `multi-root-loop-body`, `static-loop-csr-materialize`, `nested-loop-plain`, `loop-plan-classification`) — 42 pass
- [ ] Wait for CI to confirm adapter + e2e suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)