### PR TITLE
fix(adapters): emit `${MAP[KEY]}` lookups in hono + mojo SSR (#1272)

### DIFF
--- a/packages/adapter-hono/__tests__/hono-adapter.test.ts
+++ b/packages/adapter-hono/__tests__/hono-adapter.test.ts
@@ -15,15 +15,5 @@ runAdapterConformanceTests({
   factory: () => new HonoAdapter(),
   render: renderHonoComponent,
   // Hono's SSR runtime is JS — broad `acceptsTemplateCall` covers
-  // every conformance case. Only one outlier:
-  skipJsx: [
-    // `Record<K, V>` + `obj[key]` index lookup (Button's variantClasses
-    // pattern) — tracked in #1272 (sub-issue of #1244). SSR drops the
-    // substitution: `class="base "` instead of `class="base class-a"`.
-    // Browser-side hydration overwrites the class on first paint so
-    // site/ui works in practice, but server-rendered HTML is wrong on
-    // the wire. The go-template adapter renders the same case
-    // correctly — Hono's SSR expression path is the gap.
-    'record-index-lookup',
-  ],
+  // every conformance case.
 })

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -904,6 +904,17 @@ export class HonoAdapter extends JsxAdapter {
         output += part.value
       } else if (part.type === 'ternary') {
         output += `\${${part.condition} ? '${part.whenTrue}' : '${part.whenFalse}'}`
+      } else if (part.type === 'lookup') {
+        // Hono runs JS at SSR time, so a `${MAP[KEY]}` lookup can be
+        // re-materialised as a runtime indexed access against the
+        // resolved cases — byte-identical to the client emit path in
+        // `ir-to-client-js/utils.ts`. Use `part.key` (raw JS source)
+        // because this output runs inside the destructured-prop scope
+        // of the component, mirroring the `'ternary'` branch above.
+        const obj = '{' + Object.entries(part.cases).map(
+          ([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`
+        ).join(', ') + '}'
+        output += `\${(${obj})[${part.key}]}`
       }
     }
     output += '`'

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -46,14 +46,6 @@ runAdapterConformanceTests({
     // to materialise the loop at request time.
     'static-array-from-props',
     'static-array-from-props-with-component',
-    // `Record<K, V>` + `obj[key]` index lookup (Button's variantClasses
-    // pattern) — tracked in #1272 (sub-issue of #1244). Mojo's
-    // regex-based `convertExpressionToPerl` doesn't materialise the
-    // object literal as a Perl hash, and the SSR template ends up
-    // with verbatim JS `({...})[key]` syntax that Perl rejects.
-    // Pin the failing fixture as a skip so a future fix removes the
-    // entry rather than landing the regression silently.
-    'record-index-lookup',
   ],
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -730,6 +730,19 @@ export class MojoAdapter extends BaseAdapter {
       } else if (part.type === 'ternary') {
         const cond = this.convertExpressionToPerl(part.condition)
         parts.push(`(${cond} ? '${part.whenTrue}' : '${part.whenFalse}')`)
+      } else if (part.type === 'lookup') {
+        // `${MAP[KEY]}` against a Record<T, string> literal — emit a
+        // Perl anonymous hash with an immediate `->{ $key } // ''`
+        // lookup. The `//''` guard turns a miss into an empty string,
+        // matching the go-template adapter's "empty when no case
+        // matches" semantics. Pass `key` through `convertExpressionToPerl`
+        // so its top-level-identifier tail (`variant` → `$variant`) and
+        // existing `props.x` rule apply uniformly.
+        const keyExpr = this.convertExpressionToPerl(part.key)
+        const entries = Object.entries(part.cases)
+          .map(([k, v]) => `'${k}' => '${v}'`)
+          .join(', ')
+        parts.push(`({ ${entries} }->{${keyExpr}} // '')`)
       }
     }
     // Join with Perl string concatenation

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -22,13 +22,7 @@ const FIXTURES_DIR = resolve(import.meta.dir, '../fixtures')
 // fixture exists specifically to pin that gap). Auto-update would
 // overwrite the intentional value with the bug's output, so we skip
 // regeneration here.
-const SKIP_AUTO_UPDATE = new Set<string>([
-  // HonoAdapter currently emits an empty substitution for the
-  // `classes[variant]` lookup — pinning Hono's broken output as the
-  // expected value would mask the bug from the go-template adapter
-  // (which renders this case correctly).
-  'record-index-lookup',
-])
+const SKIP_AUTO_UPDATE = new Set<string>([])
 
 async function main() {
   let updated = 0


### PR DESCRIPTION
## Summary

The IR already represents `${classes[variant]}` against a const
`Record<T, string>` as a first-class `lookup` template part. The
go-template adapter, the client-JS emit path, and the Hono
component-prop forwarding path each handle it — but the two SSR
template-literal emitters had no case for it and silently dropped the
substitution:

- **Hono**: emitted `class="base "` (browser hydration overwrote the
  class on first paint, hiding the bug from user-facing checks).
- **Mojo**: leaked the JS `({...})[key]` expression into the `*.html.ep`
  template verbatim, producing a Perl parse error.

This PR adds the missing `'lookup'` branch to both adapters' template
literal emitters and removes the `skipJsx` / `SKIP_AUTO_UPDATE` pins
introduced by #1237.

- `packages/adapter-hono/src/adapter/hono-adapter.ts` — mirror the
  client-side handler in `ir-to-client-js/utils.ts`:
  `${({"a":"class-a","b":"class-b"})[variant]}`. Hono runs JS at SSR,
  so client and server emit are byte-equal.
- `packages/adapter-mojolicious/src/adapter/mojo-adapter.ts` — emit a
  Perl anonymous hash with `->{ $key } // ''` so the new branch composes
  cleanly with the existing `parts.join(' . ')` Perl-string-concat chain.
  The key passes through `convertExpressionToPerl` for the existing
  bare-ident → `$ident` rewrite, so `variant` becomes `$variant` and
  `props.variant` becomes `$variant` uniformly. The expression never
  touches the regex pipeline that prompted the original leak.
- `'record-index-lookup'` dropped from `skipJsx` in both adapter test
  suites and from `SKIP_AUTO_UPDATE` in
  `packages/adapter-tests/scripts/generate-expected-html.ts`.

The fixture (`packages/adapter-tests/fixtures/record-index-lookup.ts`,
landed in #1237) is now green for all three adapters — the acceptance
contract from the issue.

## Test plan

- [x] `bun run -F @barefootjs/adapter-tests test` — 242 / 242 pass.
- [x] `bun run -F @barefootjs/adapter-hono test` — 110 / 110 pass.
- [x] `bun run -F @barefootjs/adapter-mojolicious test` — 67 / 67 pass
      (2 unrelated `static-array-from-props` skips remain).
- [x] `bun run -F @barefootjs/adapter-go-template test` — 86 / 86 pass
      (2 unrelated skips remain). No regression on the reference adapter.
- [x] `bun run -F @barefootjs/jsx test` — 1094 / 1094 pass. No compiler
      change; existing `ir-const-resolution.test.ts` coverage for the
      `'lookup'` part is unchanged.
- [ ] CI green.

Closes #1272