### PR TITLE
fix(xyflow): FlowStore emits per-node + coarse signals on every change (#1270)

### DIFF
--- a/packages/xyflow/src/__tests__/store.test.ts
+++ b/packages/xyflow/src/__tests__/store.test.ts
@@ -167,6 +167,108 @@ describe('createFlowStore', () => {
     })
   })
 
+  test('nodeLookup emits a fresh Map on setNodes-driven update (#1270)', () => {
+    // Regression for #1270: `adoptUserNodes` mutates the underlying
+    // Map in place, and the old code re-emitted the same reference.
+    // barefoot's Object.is dedupe swallowed the notification so per-
+    // node consumers stayed stuck on the initial value.
+    createRoot(() => {
+      const store = createFlowStore({
+        nodes: [
+          { id: '1', position: { x: 0, y: 0 }, data: { count: 0 } },
+          { id: '2', position: { x: 10, y: 0 }, data: {} },
+        ],
+      })
+      // Touch `nodesInitialized` so the memo evaluates and the lookup
+      // is populated before the assertions below.
+      store.nodesInitialized()
+
+      let fires = 0
+      let lastSeen: unknown
+      createEffect(() => {
+        const lookup = store.nodeLookup()
+        const entry = lookup.get('1')
+        lastSeen = (entry?.internals.userNode.data as { count?: number } | undefined)?.count
+        fires++
+      })
+      expect(fires).toBe(1)
+      expect(lastSeen).toBe(0)
+
+      store.setNodes((nds) =>
+        nds.map((n) => (n.id === '1' ? { ...n, data: { count: 1 } } : n)) as typeof nds,
+      )
+
+      expect(fires).toBe(2)
+      expect(lastSeen).toBe(1)
+    })
+  })
+
+  test('nodeSignal(id) fires only for the changed id (#1270 acceptance)', () => {
+    // Acceptance criterion from #1270: a single-node setNodes update
+    // must NOT wake up every per-node consumer. `nodeSignal(id)`
+    // delivers the fine-grained subscription that satisfies this.
+    createRoot(() => {
+      const store = createFlowStore({
+        nodes: [
+          { id: '1', position: { x: 0, y: 0 }, data: { count: 0 } },
+          { id: '2', position: { x: 10, y: 0 }, data: { count: 0 } },
+        ],
+      })
+      store.nodesInitialized()
+
+      let firesForOne = 0
+      let firesForTwo = 0
+      createEffect(() => {
+        store.nodeSignal('1')
+        firesForOne++
+      })
+      createEffect(() => {
+        store.nodeSignal('2')
+        firesForTwo++
+      })
+      expect([firesForOne, firesForTwo]).toEqual([1, 1])
+
+      // Mutate only node '1' — node '2's subscriber must NOT wake up.
+      store.setNodes((nds) =>
+        nds.map((n) => (n.id === '1' ? { ...n, data: { count: 1 } } : n)) as typeof nds,
+      )
+      expect([firesForOne, firesForTwo]).toEqual([2, 1])
+
+      // Mutate only node '2' via `selected` — node '1's subscriber stays asleep.
+      store.setNodes((nds) =>
+        nds.map((n) => (n.id === '2' ? { ...n, selected: true } : n)) as typeof nds,
+      )
+      expect([firesForOne, firesForTwo]).toEqual([2, 2])
+    })
+  })
+
+  test('nodeSignal(id) survives remove and re-add of the same id (#1270)', () => {
+    // Slots are retained across structural changes so a consumer that
+    // subscribed before the node was removed (or before it existed)
+    // resumes receiving updates when the node reappears.
+    createRoot(() => {
+      const store = createFlowStore({
+        nodes: [
+          { id: '1', position: { x: 0, y: 0 }, data: { count: 7 } },
+        ],
+      })
+      store.nodesInitialized()
+
+      const seen: Array<number | undefined> = []
+      createEffect(() => {
+        const entry = store.nodeSignal('1')
+        seen.push((entry?.internals.userNode.data as { count?: number } | undefined)?.count)
+      })
+      expect(seen).toEqual([7])
+
+      store.setNodes([])
+      expect(seen).toEqual([7, undefined])
+
+      store.setNodes([{ id: '1', position: { x: 0, y: 0 }, data: { count: 99 } }])
+      expect(seen).toEqual([7, undefined, 99])
+    })
+  })
+
   test('edgeLookup is derived from edges', () => {
     createRoot(() => {
       const edges = [

--- a/packages/xyflow/src/flow-subsystems.ts
+++ b/packages/xyflow/src/flow-subsystems.ts
@@ -357,7 +357,9 @@ export function attachFlowSubsystems<
   createEffect(() => {
     store.positionEpoch()
     const currentEdges = store.edges()
-    store.nodes()
+    // `nodeLookup()` now emits a fresh `Map` reference on every
+    // setNodes-driven change (see #1270), so the previous
+    // `store.nodes()` wake-up call is no longer needed here.
     const lookup = store.nodeLookup()
     const edgesSvg = el.querySelector('.bf-flow__edges')
     if (!edgesSvg) return

--- a/packages/xyflow/src/store.ts
+++ b/packages/xyflow/src/store.ts
@@ -63,7 +63,18 @@ export function createFlowStore<
   const [panZoom, setPanZoom] = createSignal<PanZoomInstance | null>(null)
   const [domNode, setDomNode] = createSignal<HTMLElement | null>(null)
 
-  // --- Lookups (mutable maps, tracked via signals for change notification) ---
+  // --- Lookups ---
+  //
+  // The outer signals hold the lookup `Map` for iteration-style
+  // consumers (edge-path effect, adapters that walk every node). They
+  // emit a fresh `Map` reference on each change so barefoot's
+  // identity-based dedupe does not suppress notification.
+  //
+  // The internal map of per-node signals (`nodeSignals`) is what
+  // delivers the fine-grained channel: per-node consumers subscribe
+  // through `nodeSignal(id)` and only wake up when *that* node's entry
+  // changes. This removes the recurring "read `nodes()` first to wake
+  // up the lookup" workaround at its source (#1270).
   const [nodeLookup, setNodeLookup] = createSignal<NodeLookup<InternalNodeBase<NodeType>>>(
     new Map()
   )
@@ -72,6 +83,35 @@ export function createFlowStore<
   )
   const [edgeLookup, setEdgeLookup] = createSignal<EdgeLookup<EdgeType>>(new Map())
   const [connectionLookup, setConnectionLookup] = createSignal<ConnectionLookup>(new Map())
+
+  type NodeSignalSlot = {
+    get: () => InternalNodeBase<NodeType> | undefined
+    set: (
+      value:
+        | InternalNodeBase<NodeType>
+        | undefined
+        | ((prev: InternalNodeBase<NodeType> | undefined) => InternalNodeBase<NodeType> | undefined),
+    ) => void
+  }
+  const nodeSignals = new Map<string, NodeSignalSlot>()
+
+  // Slots are retained across remove → re-add so a consumer that
+  // called `nodeSignal(id)` before the node was added (or after it was
+  // removed) keeps subscribing to the same slot and is notified when
+  // the node appears.
+  function getOrCreateNodeSlot(id: string): NodeSignalSlot {
+    let slot = nodeSignals.get(id)
+    if (!slot) {
+      const [get, set] = createSignal<InternalNodeBase<NodeType> | undefined>(undefined)
+      slot = { get, set: set as NodeSignalSlot['set'] }
+      nodeSignals.set(id, slot)
+    }
+    return slot
+  }
+
+  function nodeSignal(id: string): InternalNodeBase<NodeType> | undefined {
+    return getOrCreateNodeSlot(id).get()
+  }
 
   // Lightweight counter for notifying position-dependent subscribers (edges,
   // per-node position effects) without triggering the full adoptUserNodes
@@ -87,8 +127,8 @@ export function createFlowStore<
    */
   const nodesInitialized = createMemo(() => {
     const currentNodes = nodes()
-    const lookup = nodeLookup()
-    const parents = parentLookup()
+    const lookup = untrack(nodeLookup)
+    const parents = untrack(parentLookup)
 
     // Preserve measured dimensions from existing internal nodes.
     // adoptUserNodes reads userNode.measured but setNodes callers
@@ -115,9 +155,34 @@ export function createFlowStore<
       nodeExtent,
     })
 
-    // Trigger signal update so dependents know lookups changed
-    setNodeLookup(() => lookup)
-    setParentLookup(() => parents)
+    // Reconcile the per-node signal cache with the freshly-rebuilt
+    // lookup. `adoptUserNodes(..., checkEquality: false)` constructs
+    // a new InternalNode wrapper for every entry on every call, so
+    // entry identity is **not** a reliable change signal. The
+    // underlying `internals.userNode` reference, however, only flips
+    // when `setNodes` actually produced a new node identity (callers
+    // use `prev.map(n => n.id === target ? { ...n, ... } : n)`), so
+    // we gate on that — sibling ids whose user node is unchanged stay
+    // silent. Removed ids see `undefined`.
+    for (const [id, entry] of lookup) {
+      const slot = getOrCreateNodeSlot(id)
+      const current = untrack(slot.get)
+      if (current?.internals.userNode !== entry.internals.userNode) {
+        slot.set(entry)
+      }
+    }
+    for (const [id, slot] of nodeSignals) {
+      if (!lookup.has(id) && untrack(slot.get) !== undefined) {
+        slot.set(undefined)
+      }
+    }
+
+    // Emit fresh outer Map references so coarse consumers (iterators
+    // that walk every node) re-run. `adoptUserNodes` mutates the
+    // existing `Map` in place, so re-emitting the same reference
+    // would be a no-op under barefoot's Object.is dedupe (#1270).
+    setNodeLookup(() => new Map(lookup))
+    setParentLookup(() => new Map(parents))
 
     return result.nodesInitialized
   })
@@ -133,7 +198,9 @@ export function createFlowStore<
 
     const connLookup = untrack(connectionLookup)
     updateConnectionLookup(connLookup, eLookup, currentEdges)
-    setConnectionLookup(() => connLookup)
+    // `updateConnectionLookup` mutates `connLookup` in place; emit a
+    // fresh `Map` reference so subscribers actually see the change.
+    setConnectionLookup(() => new Map(connLookup))
   })
 
   // --- Selection state ---
@@ -211,6 +278,7 @@ export function createFlowStore<
     isDragging = true,
   ) {
     const lookup = untrack(nodeLookup)
+    let mutated = false
 
     for (const [id, item] of dragItems) {
       const internalNode = lookup.get(id)
@@ -222,9 +290,27 @@ export function createFlowStore<
 
       internalNode.internals.userNode.position = item.position
       internalNode.internals.userNode.dragging = isDragging
+
+      // Per-node fine-grained emit: shallow-clone so the entry identity
+      // flips (barefoot's Object.is dedupe would otherwise swallow the
+      // notification — the mutations above don't change the entry
+      // reference). The inner `internals` object stays shared, so
+      // consumers reading `.internals.positionAbsolute` still see the
+      // updated position.
+      const fresh = { ...internalNode } as InternalNodeBase<NodeType>
+      lookup.set(id, fresh)
+      getOrCreateNodeSlot(id).set(fresh)
+      mutated = true
     }
 
-    // Notify position-dependent subscribers via lightweight epoch bump
+    if (mutated) {
+      // Coarse emit so iteration-style consumers re-run too. Per-node
+      // bridges that switched to `nodeSignal(id)` only wake up for
+      // their own id and skip this channel.
+      setNodeLookup(() => new Map(lookup))
+    }
+    // Keep positionEpoch as the dedicated drag-rate channel for
+    // existing subscribers (edge-path effect).
     triggerPositionUpdate()
   }
 
@@ -349,6 +435,7 @@ export function createFlowStore<
     parentLookup,
     edgeLookup,
     connectionLookup,
+    nodeSignal,
 
     // Internal refs
     panZoom,

--- a/packages/xyflow/src/types.ts
+++ b/packages/xyflow/src/types.ts
@@ -141,6 +141,19 @@ export type FlowStore<
   edgeLookup: Signal<EdgeLookup<EdgeType>>[0]
   connectionLookup: Signal<ConnectionLookup>[0]
 
+  /**
+   * Fine-grained per-node subscription. Returns the current internal
+   * entry for the given id, and tracks it for reactivity — the
+   * surrounding effect / memo will re-run only when **this** node's
+   * entry changes (data, selected, position via setNodes, or in-place
+   * drag updates), not on changes to sibling nodes.
+   *
+   * Use this in per-node consumers (data / selected / position
+   * observers). For iteration-style consumers that walk all nodes,
+   * keep using `nodeLookup()`.
+   */
+  nodeSignal: (id: string) => InternalNodeBase<NodeType> | undefined
+
   // Lightweight position change counter — subscribers re-run without
   // triggering the full adoptUserNodes pipeline.
   positionEpoch: Signal<number>[0]

--- a/ui/components/ui/xyflow/index.tsx
+++ b/ui/components/ui/xyflow/index.tsx
@@ -101,15 +101,14 @@ export function SimpleEdge(props: SimpleEdgeProps) {
   const selected = createMemo(() => !!store?.edgeLookup().get(props.edgeId)?.selected)
   const animated = createMemo(() => !!store?.edgeLookup().get(props.edgeId)?.animated)
 
-  // Path memo. BOTH `positionEpoch` and `nodes()` reads are required —
-  // positionEpoch covers in-flight drag updates, nodes() covers the
-  // post-drag commit where setNodes mutates nodeLookup in place.
+  // Path memo. `positionEpoch` covers in-flight drag updates;
+  // `nodeLookup()` now emits a fresh Map reference on setNodes (#1270)
+  // so the previous `store.nodes()` wake-up is no longer needed.
   const pathD = createMemo(() => {
     if (!store) return ''
     const edge = store.edgeLookup().get(props.edgeId)
     if (!edge) return ''
     store.positionEpoch()
-    store.nodes()
     const nodeLookup = store.nodeLookup()
     const sourceNode = nodeLookup.get(edge.source)
     const targetNode = nodeLookup.get(edge.target)
@@ -195,11 +194,10 @@ export function NodeWrapper(props: NodeWrapperProps) {
 
   const node = createMemo(() => {
     if (!store) return null
-    // Reading `nodes()` AND `nodeLookup()` mirrors the imperative wrapper
-    // effect — `positionEpoch` covers in-flight drag updates, `nodes()`
-    // covers structural commits.
+    // `positionEpoch` covers in-flight drag updates; `nodeLookup()`
+    // now emits a fresh Map reference on setNodes (#1270) so the
+    // previous `store.nodes()` wake-up is no longer needed.
     store.positionEpoch()
-    store.nodes()
     return store.nodeLookup().get(props.nodeId) ?? null
   })
 
@@ -730,7 +728,8 @@ export function MiniMap(props: MiniMapComponentProps) {
 
   const nodeRects = createMemo<NodeRect[]>(() => {
     if (!store) return []
-    store.nodes()
+    // `nodeLookup()` now emits on setNodes (#1270); `positionEpoch`
+    // still covers drag updates that mutate internals in place.
     store.positionEpoch()
     const nodeLookup = store.nodeLookup()
     const colorProp = nodeColor()
@@ -984,21 +983,10 @@ export function FlowNodeTypeBridge(props: FlowNodeTypeBridgeProps) {
       dispatchNodeType(el, initFn, {
         id,
         data,
-        // The `selected` getter has to subscribe consumers (the user
-        // component's effects that read it) to the `nodes()` signal,
-        // not just `nodeLookup()`. `nodesInitialized` mutates the
-        // lookup map in place and re-fires `setNodeLookup(() => lookup)`
-        // with the same reference, which createSignal dedupes — so
-        // `nodeLookup()` reads alone never wake up downstream effects
-        // on selection changes. Reading `nodes()` first guarantees
-        // the consumer's effect re-runs on every setNodes; the
-        // `nodeLookup().get(id)?.selected` read after still returns
-        // the latest selected state because the lookup is mutated in
-        // place. (Mirrors `NodeWrapper`'s `node` memo.)
-        selected: () => {
-          store.nodes()
-          return !!store.nodeLookup().get(id)?.selected
-        },
+        // Fine-grained per-node subscription. `nodeSignal(id)` only
+        // wakes consumers when this specific node's entry changes;
+        // sibling-node updates stay silent (#1270).
+        selected: () => !!store.nodeSignal(id)?.selected,
         dragging: false,
         positionAbsoluteX: 0,
         positionAbsoluteY: 0,


### PR DESCRIPTION
## Summary

Fixes #1270 — `FlowStore.nodeLookup` (and its sibling `Map`-valued
signals) never emitted when their underlying `Map` was mutated in
place. barefoot's `createSignal` dedupes via hard-coded `Object.is`,
so re-emitting the same `Map` reference is a no-op. Every per-node
consumer worked around it by reading `store.nodes()` first, paying
O(N) wake-up cost on every change.

This PR fixes three layers:

1. **Outer Map signals emit fresh references.** `nodeLookup`,
   `parentLookup`, and `connectionLookup` now clone the `Map` on
   emit so iteration-style consumers (edge-path effect, minimap,
   adapters) wake up reliably without the `store.nodes()` workaround.

2. **New `store.nodeSignal(id)` for fine-grained per-node
   subscription.** Per-node bridges subscribe only to their id's
   slot; sibling-node updates stay silent. The gate compares
   `internals.userNode` identity (the user-provided reference)
   since `adoptUserNodes(..., checkEquality: false)` rebuilds the
   `InternalNode` wrapper on every call. This is the acceptance
   criterion's "no N-times re-evaluation" path.

3. **Drag emits per-node + coarse signals.** `updateNodePositions`
   shallow-clones each dragged entry so identity flips and per-node
   consumers see drag updates through the lookup channel.
   `positionEpoch` is preserved as the dedicated drag-rate channel
   for the imperative edge-path effect.

In-tree consumers migrated:
- `FlowNodeTypeBridge.selected` getter → `nodeSignal(id)`
- `SimpleEdge.pathD`, `NodeWrapper.node`, `MiniMap.nodeRects`, and
  the imperative `flow-subsystems` edge-path effect → drop the
  redundant `store.nodes()` line (kept `positionEpoch` for drag).

## Test plan

- [x] `bun test packages/xyflow` (46/46 pass, includes 3 new regression tests)
- [x] `bun run --filter '*' test` workspace-wide (cli 412, client
  261, hono 111, mojolicious 66, go-template 85, jsx 1094, xyflow
  46 — all green)
- [x] `bun test ui/components/ui/xyflow` (27/27 pass)
- [x] `bun test packages/adapter-tests` (237/237 pass)
- [x] xyflow typecheck (`tsgo --noEmit -p src/__tests__/tsconfig.json`)
- [ ] Spot-check the graph-editor demo (`site/ui/components/graph-editor-demo.tsx`)
      in dev — drag + edge rendering.

## Acceptance against #1270

- ✅ Outer `nodeLookup()` emits on per-node `data` / `selected` updates.
- ✅ `nodeSignal('2')` does NOT fire when `setNodes` touches only
  node `'1'` — directly asserted in
  `nodeSignal(id) fires only for the changed id (#1270 acceptance)`.
- ✅ Existing `nodeLookup` entry shape preserved — iteration-style
  consumers (edge-path effect, minimap, etc.) keep using `nodeLookup()`
  with no API change.
- 🟡 Downstream desk PR (piconic-ai/desk#106) can now drop its
  vendored `dataMemo` + `selected` `store.nodes()` workarounds —
  that change lives in the desk repo, verified there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)