### PR TITLE
refactor(jsx): replace regex-based exprReferencesIdent with AST-driven freeIdentifiers (#1267)

### DIFF
--- a/packages/jsx/src/__tests__/over-match-regression.test.ts
+++ b/packages/jsx/src/__tests__/over-match-regression.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration regression tests for #1267 — `exprReferencesIdent` /
+ * `exprReferencesAny` over-match fixes.
+ *
+ * Each test compiles a piece of JSX whose source contains an identifier-
+ * shaped substring inside a position where it is NOT a real reference
+ * (string literal, member-access tail). Pre-#1267 the regex helpers
+ * would over-match and the compiler would either:
+ *   - mark a constant as depending on an unsafe local (sentinel template
+ *     substitution at site 14)
+ *   - treat a loop child as reactive when it isn't (site 6)
+ *
+ * Post-#1267, the AST-driven `freeIdentifiers` lookup respects the
+ * string-literal / member-access boundary, so the false positives are
+ * gone.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('#1267 — over-match regressions', () => {
+  test('string-literal lookalike does not trigger sentinel substitution', () => {
+    // `props.size` is an init-scope local resolution; a constant whose
+    // value contains the literal text `size-4` (inside a string literal
+    // within a Record lookup) must NOT be downgraded just because the
+    // characters `size` appear in the template. Pre-#1267 the regex
+    // helper would mis-classify and substitute the sentinel.
+    const source = `
+      type Props = { size: 'sm' | 'md' }
+      const SIZES: Record<string, string> = { sm: 'size-2', md: 'size-4' }
+      export function Icon({ size }: Props) {
+        const klass = SIZES[size]
+        return <span className={klass}>x</span>
+      }
+    `
+    const result = compileJSX(source, 'Icon.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+
+  test('loop-param-shaped substring inside string literal is not a loop-param reference', () => {
+    // Conditional whose `condition` string contains `item` only inside a
+    // string literal: the conditional should NOT be classified as a
+    // loop-param conditional. Without #1267 the regex would over-match.
+    const source = `
+      type Item = { id: string; label: string }
+      type Props = { items: Item[]; mode: string }
+      export function List(props: Props) {
+        return (
+          <ul>
+            {props.items.map(item => (
+              <li key={item.id}>
+                {props.mode === 'item-row' ? <strong>{item.label}</strong> : <em>{item.label}</em>}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSX(source, 'List.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // Sanity check: compile succeeded — the conditional was still routed
+    // correctly through the static + reactive paths.
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+  })
+
+  test('member-access tail name is not a free identifier', () => {
+    // `const x = props.className` — the constant references the prop
+    // `props`, not a bare identifier `className`. With strict semantics,
+    // a prop named `className` should still be detected because the
+    // `propsObjectName.<tail>` regex path catches it separately.
+    const source = `
+      type Props = { className: string }
+      export function Box(props: Props) {
+        const x = props.className
+        return <div className={x} />
+      }
+    `
+    const result = compileJSX(source, 'Box.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // Sanity check: the compile produced a client JS bundle.
+    expect(result.files.find(f => f.type === 'clientJs')).toBeDefined()
+  })
+})

--- a/packages/jsx/src/__tests__/token-contains-ident.test.ts
+++ b/packages/jsx/src/__tests__/token-contains-ident.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for `tokenContainsIdent` / `tokenContainsAny` — the lexer-aware
+ * fallback for the call sites that operate on **synthesised** expression
+ * strings with no originating AST node (post-substitution CSR templates,
+ * post-chain-resolve constant values).
+ *
+ * AST-bearing call sites read `node.freeIdentifiers` instead — see #1267.
+ *
+ * These tests pin down the over-match classes that motivated #1267:
+ * string literals, member-access tail names, comments, template literals.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { tokenContainsIdent, tokenContainsAny } from '../ir-to-client-js/utils'
+
+describe('tokenContainsIdent', () => {
+  describe('positive controls', () => {
+    test('bare identifier match', () => {
+      expect(tokenContainsIdent('className', 'className')).toBe(true)
+    })
+
+    test('identifier inside a function call argument', () => {
+      expect(tokenContainsIdent('foo(className)', 'className')).toBe(true)
+    })
+
+    test('identifier inside a binary expression', () => {
+      expect(tokenContainsIdent('x + className', 'className')).toBe(true)
+    })
+
+    test('identifier inside a bracket subscript is still a reference', () => {
+      expect(tokenContainsIdent('a[className]', 'className')).toBe(true)
+    })
+
+    test('identifier inside template-literal expression substitution', () => {
+      expect(tokenContainsIdent('`${className}`', 'className')).toBe(true)
+    })
+
+    test('identifier with non-target match nearby', () => {
+      expect(tokenContainsIdent('className2 + className', 'className')).toBe(true)
+    })
+  })
+
+  describe('string literal over-match (the #1267 motivation)', () => {
+    test('single-quoted string literal', () => {
+      expect(tokenContainsIdent("'className'", 'className')).toBe(false)
+    })
+
+    test('double-quoted string literal with hyphen', () => {
+      expect(tokenContainsIdent('"prefix-className"', 'className')).toBe(false)
+    })
+
+    test('escaped quote inside string literal does not break scanning', () => {
+      expect(tokenContainsIdent("'\\'className\\''", 'className')).toBe(false)
+    })
+
+    test('mixed: string literal then identifier reference', () => {
+      expect(tokenContainsIdent("'className' + className", 'className')).toBe(true)
+    })
+
+    test('template literal text part (between backticks, outside ${})', () => {
+      expect(tokenContainsIdent('`pre-className`', 'className')).toBe(false)
+    })
+
+    test('template literal with text-part match and expression hit', () => {
+      expect(tokenContainsIdent('`label-${className}`', 'className')).toBe(true)
+    })
+
+    test('template literal with text-part match but no expression hit', () => {
+      expect(tokenContainsIdent('`pre-${other}-className`', 'className')).toBe(false)
+    })
+
+    test('nested template literal inside template expression', () => {
+      // Outer template literal expression contains another template literal
+      // text part; the inner text part should not match.
+      expect(tokenContainsIdent('`${`inner-className`}`', 'className')).toBe(false)
+    })
+
+    test('nested template literal where inner expr references the ident', () => {
+      expect(tokenContainsIdent('`${`${className}`}`', 'className')).toBe(true)
+    })
+  })
+
+  describe('member-access over-match', () => {
+    test('property name on dot-access does not count', () => {
+      expect(tokenContainsIdent('a.className', 'className')).toBe(false)
+    })
+
+    test('property name on dot-access via whitespace does not count', () => {
+      expect(tokenContainsIdent('a . className', 'className')).toBe(false)
+    })
+
+    test('left-hand side of member access is still a reference', () => {
+      expect(tokenContainsIdent('className.foo', 'className')).toBe(true)
+    })
+
+    test('chained member-access does not match middle names', () => {
+      expect(tokenContainsIdent('a.b.className', 'className')).toBe(false)
+    })
+
+    test('optional chaining member-access tail does not count', () => {
+      // `?.className` — preceding non-whitespace is `.`, so member-tail rule
+      // skips this identifier.
+      expect(tokenContainsIdent('a?.className', 'className')).toBe(false)
+    })
+
+    test('spread operator should not be confused with member access', () => {
+      // `...className` — preceding non-whitespace is `.` of `...`, but the
+      // char before that is also `.`, so this is the spread operator. The
+      // identifier following `...` IS a reference, not a property tail.
+      expect(tokenContainsIdent('foo(...className)', 'className')).toBe(true)
+    })
+  })
+
+  describe('comment over-match', () => {
+    test('line comment content', () => {
+      expect(tokenContainsIdent('x // className', 'className')).toBe(false)
+    })
+
+    test('block comment content', () => {
+      expect(tokenContainsIdent('/* className */ x', 'className')).toBe(false)
+    })
+
+    test('multi-line block comment', () => {
+      expect(tokenContainsIdent('/*\n * className\n */ x', 'className')).toBe(false)
+    })
+
+    test('line comment then real reference on next line', () => {
+      expect(tokenContainsIdent('x // not\nclassName', 'className')).toBe(true)
+    })
+  })
+
+  describe('non-matches', () => {
+    test('substring is not a match (word boundary)', () => {
+      expect(tokenContainsIdent('myClassName', 'className')).toBe(false)
+    })
+
+    test('superstring is not a match', () => {
+      expect(tokenContainsIdent('class', 'className')).toBe(false)
+    })
+
+    test('empty expression', () => {
+      expect(tokenContainsIdent('', 'className')).toBe(false)
+    })
+  })
+})
+
+describe('tokenContainsAny', () => {
+  test('returns true if any name matches', () => {
+    expect(tokenContainsAny('foo + bar', ['baz', 'bar'])).toBe(true)
+  })
+
+  test('returns false if no name matches', () => {
+    expect(tokenContainsAny('foo + bar', ['baz', 'qux'])).toBe(false)
+  })
+
+  test('respects string literal boundaries for all candidates', () => {
+    expect(tokenContainsAny("'foo bar'", ['foo', 'bar'])).toBe(false)
+  })
+
+  test('respects member-access tail for all candidates', () => {
+    expect(tokenContainsAny('a.foo + b.bar', ['foo', 'bar'])).toBe(false)
+  })
+
+  test('accepts a Set<string>', () => {
+    expect(tokenContainsAny('foo + bar', new Set(['bar']))).toBe(true)
+  })
+
+  test('empty name set returns false', () => {
+    expect(tokenContainsAny('foo', [])).toBe(false)
+  })
+
+  test('short-circuits at first hit', () => {
+    // Cannot directly observe short-circuit without instrumentation; the
+    // semantic check is sufficient and consistent with the API contract.
+    expect(tokenContainsAny('x', ['x', 'y'])).toBe(true)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1753,7 +1753,7 @@ function extractValueBranches(node: ts.Expression, ctx: AnalyzerContext): string
  * Extract free identifier references from an AST node by walking the tree.
  * Skips property keys, member access properties, and bound parameter names.
  */
-function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
+export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
   const ids = new Set<string>()
   const boundNames = new Set<string>()
 

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -4,7 +4,7 @@
 
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
-import { attrValueToString, exprReferencesIdent, quotePropName, PROPS_PARAM } from './utils'
+import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils'
 import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
@@ -230,6 +230,7 @@ export function collectInnerLoops(
           kind: 'nested',
           depth: emitDepth,
           array: n.array,
+          arrayFreeIdentifiers: n.arrayFreeIdentifiers,
           param: n.param,
           paramBindings: n.paramBindings,
           key: n.key,
@@ -546,6 +547,7 @@ export function collectElements(
         kind: 'top-level',
         slotId: l.slotId,
         array: l.array,
+        arrayFreeIdentifiers: l.arrayFreeIdentifiers,
         param: l.param,
         paramBindings: l.paramBindings,
         index: l.index,
@@ -680,7 +682,8 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
 
         // Expand local constant references to detect transitive prop dependencies.
         // e.g., `classes` → `` `${baseClasses} ${variantClasses[variant]} ${className}` ``
-        const expandedValueStr = expandConstantForReactivity(valueStr, ctx)
+        const expandedResult = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers)
+        const expandedValueStr = expandedResult.expr
 
         // Solid-style wrap-by-default fallback (#940, DRY-consolidated
         // with #939/#941/#942/#943 via IRAttribute AST flags). Wrap
@@ -717,6 +720,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
             attrName: attr.name,
             expression: expandedValueStr,
             ...pickAttrMeta(attr),
+            ...(expandedResult.freeIds !== undefined && { freeIdentifiers: expandedResult.freeIds }),
           })
         }
       }
@@ -747,19 +751,20 @@ function collectBranchReactiveAttrs(node: IRNode, ctx: ClientJsContext): Conditi
         if (attr.name === '...' || !attr.dynamic || !attr.value) continue
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
-        const expanded = expandConstantForReactivity(valueStr, ctx)
+        const expanded = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers)
         // Mirror the main-path gate (collectElements.element handler):
         // `/* @client */` always defers via createEffect regardless of
         // the wrap heuristic — without this carve-out, a clientOnly
         // attr inside a conditional branch would be skipped at SSR
         // (html-template strips it) AND never get a hydrate-time
         // binding emitted, leaving the attribute permanently unset.
-        if (!attr.clientOnly && !decideWrapForAttr(expanded, ctx, attr).wrap) continue
+        if (!attr.clientOnly && !decideWrapForAttr(expanded.expr, ctx, attr).wrap) continue
         attrs.push({
           slotId: el.slotId,
           attrName: attr.name,
-          expression: expanded,
+          expression: expanded.expr,
           ...pickAttrMeta(attr),
+          ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
         })
       }
       descend()
@@ -865,6 +870,7 @@ function collectBranchLoops(
       loops.push({
         kind: 'branch',
         array: n.array,
+        arrayFreeIdentifiers: n.arrayFreeIdentifiers,
         param: n.param,
         paramBindings: n.paramBindings,
         index: n.index,
@@ -986,15 +992,17 @@ export function collectLoopChildConditionals(
 
   // Widen the source-level "references loop param" check so destructured
   // callbacks fire too — the pattern text `[, cfg]` never word-matches on
-  // bare `cfg` but individual binding names do (#951).
-  const refsAnyBinding = (expr: string): boolean => {
+  // bare `cfg` but individual binding names do (#951). Consumes a
+  // pre-computed `Set<string>` of free identifiers (#1267) rather than
+  // running word-boundary regex on the expression text.
+  const refsAnyBindingViaFreeIds = (freeIds: ReadonlySet<string>): boolean => {
     if (loopParamBindings && loopParamBindings.length > 0) {
       for (const b of loopParamBindings) {
-        if (exprReferencesIdent(expr, b.name)) return true
+        if (freeIds.has(b.name)) return true
       }
       return false
     }
-    return loopParam ? exprReferencesIdent(expr, loopParam) : false
+    return loopParam ? freeIds.has(loopParam) : false
   }
 
   walkIR(node, null, {
@@ -1007,14 +1015,15 @@ export function collectLoopChildConditionals(
       // inside branches will be handled by insert()'s own bindEvents.
       // Non-reactive, non-loop-param conditionals are ignored entirely.
       if (!n.slotId) return
-      const refsLoopParamInSource = refsAnyBinding(n.condition)
+      const sourceFreeIds = freeIdsFromRefs(n.origin?.freeRefs)
+      const refsLoopParamInSource = refsAnyBindingViaFreeIds(sourceFreeIds)
       // Pre-gate using AST `reactive` flag on the source condition before
       // paying for constant expansion — matches the legacy short-circuit.
       if (!n.reactive && !refsLoopParamInSource) return
-      const expanded = expandConstantForReactivity(n.condition, ctx)
+      const expanded = expandConstantForReactivity(n.condition, ctx, sourceFreeIds)
       // Loop-param conditionals are reactive via per-item signal accessors;
       // classifyReactivity sees both paths (signal/memo/prop + loop-param).
-      if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') return
+      if (classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
 
       const loopParamsForCond = loopParam
         ? [{ param: loopParam, bindings: loopParamBindings }]
@@ -1027,11 +1036,12 @@ export function collectLoopChildConditionals(
       const whenFalseHtml = irToHtmlTemplate(n.whenFalse, undefined, 0, loopParamsForCond, '__slots')
       conditionals.push({
         slotId: n.slotId,
-        condition: expanded,
+        condition: expanded.expr,
         whenTrueHtml,
         whenFalseHtml,
         whenTrue: summarizeLoopChildBranch(n.whenTrue, ctx, siblingOffsets, loopParam, loopParamBindings),
         whenFalse: summarizeLoopChildBranch(n.whenFalse, ctx, siblingOffsets, loopParam, loopParamBindings),
+        ...(expanded.freeIds !== undefined && { conditionFreeIdentifiers: expanded.freeIds }),
       })
     },
   })

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -502,10 +502,6 @@ export function toLegacyInlinability(
   analysis: InlinabilityAnalysis,
   resolveChained: (constants: Map<string, string>, freeIdsMap: Map<string, Set<string>>) => void,
   ctx: ClientJsContext,
-  // Lexer-aware "does this synthesised string reference an identifier" helper
-  // (#1267). The chain-resolved values fed in below have no originating AST
-  // node, so callers pass `tokenContainsIdent`.
-  identInExpr: (expr: string, ident: string) => boolean,
 ): {
   inlinableConstants: Map<string, string>
   unsafeLocalNames: Set<string>
@@ -526,29 +522,26 @@ export function toLegacyInlinability(
     if (status.kind === 'references-component-scope') unsafeLocalNames.add(name)
   }
 
+  // Defensive copies — `resolveChained` mutates these to maintain a
+  // transitively-closed view (#1267). The original `ConstantInfo.freeIdentifiers`
+  // must stay intact for other consumers.
   const freeIdsMap = new Map<string, Set<string>>()
   for (const c of ctx.localConstants) {
-    if (c.freeIdentifiers) freeIdsMap.set(c.name, c.freeIdentifiers)
+    if (c.freeIdentifiers) freeIdsMap.set(c.name, new Set(c.freeIdentifiers))
   }
   resolveChained(inlinableConstants, freeIdsMap)
 
   // Demote constants whose value still references an unsafe name.
+  // After `resolveChained`, `freeIdsMap.get(name)` is transitively closed,
+  // so a single `has(unsafeName)` check is exact — no need to scan the
+  // resolved string for identifiers that were inlined from other constants.
   const toRemove: string[] = []
-  for (const [constName, constValue] of inlinableConstants) {
+  for (const constName of inlinableConstants.keys()) {
     const constFreeIds = freeIdsMap.get(constName)
     let isUnsafe = false
     if (constFreeIds) {
       for (const unsafeName of unsafeLocalNames) {
         if (constFreeIds.has(unsafeName)) { isUnsafe = true; break }
-      }
-    }
-    if (!isUnsafe) {
-      // Post-chain: check the resolved string for any unsafe name.
-      for (const unsafeName of unsafeLocalNames) {
-        if (identInExpr(constValue, unsafeName)) {
-          isUnsafe = true
-          break
-        }
       }
     }
     if (isUnsafe) {

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -502,7 +502,10 @@ export function toLegacyInlinability(
   analysis: InlinabilityAnalysis,
   resolveChained: (constants: Map<string, string>, freeIdsMap: Map<string, Set<string>>) => void,
   ctx: ClientJsContext,
-  exprReferencesIdent: (expr: string, ident: string) => boolean,
+  // Lexer-aware "does this synthesised string reference an identifier" helper
+  // (#1267). The chain-resolved values fed in below have no originating AST
+  // node, so callers pass `tokenContainsIdent`.
+  identInExpr: (expr: string, ident: string) => boolean,
 ): {
   inlinableConstants: Map<string, string>
   unsafeLocalNames: Set<string>
@@ -542,7 +545,7 @@ export function toLegacyInlinability(
     if (!isUnsafe) {
       // Post-chain: check the resolved string for any unsafe name.
       for (const unsafeName of unsafeLocalNames) {
-        if (exprReferencesIdent(constValue, unsafeName)) {
+        if (identInExpr(constValue, unsafeName)) {
           isUnsafe = true
           break
         }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -16,7 +16,7 @@ import {
   buildChainedArrayExpr,
   varSlotId,
   wrapLoopParamAsAccessor,
-  exprReferencesIdent,
+  irChildrenFreeIds,
 } from '../../utils'
 import {
   loopKeyFn,
@@ -43,7 +43,8 @@ export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
       ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
       : false
     const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
-    const childrenRefsLoop = rawChildrenExpr != null && exprReferencesIdent(rawChildrenExpr, elem.param)
+    const childrenFreeIds = isTextOnly && comp.children ? irChildrenFreeIds(comp.children) : undefined
+    const childrenRefsLoop = rawChildrenExpr != null && childrenFreeIds != null && childrenFreeIds.has(elem.param)
     return {
       componentName: comp.name,
       selector: buildCompSelector(comp),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -23,7 +23,6 @@ import type {
   LoopParamBinding,
 } from '../../../types'
 import {
-  exprReferencesIdent,
   wrapLoopParamAsAccessor,
 } from '../../utils'
 import type { DepthLevel } from '../shared'
@@ -84,7 +83,7 @@ export function buildInnerLoopsPlan(args: BuildInnerLoopsArgs): InnerLoopsPlan {
     // O-8 narrowing: at depth 2+, `inner.array` may reference the *immediate*
     // parent loop's param. Check against whatever outerLoopParam our caller
     // narrowed to — the recursion passes `inner.param` for child levels.
-    const refsParent = !!outerLoopParam && exprReferencesIdent(inner.array, outerLoopParam)
+    const refsParent = !!outerLoopParam && (inner.arrayFreeIdentifiers?.has(outerLoopParam) ?? false)
     const useReactive = refsParent && !!inner.template
 
     const emit: InnerLoopReactiveEmit | InnerLoopStaticEmit = useReactive

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -25,7 +25,7 @@ import type {
 } from '../../types'
 import {
   buildChainedArrayExpr,
-  exprReferencesAny,
+  setIntersects,
   varSlotId,
   wrapLoopParamAsAccessor,
 } from '../../utils'
@@ -154,7 +154,7 @@ function buildStaticLoopMaterialize(
 ): StaticLoopMaterializePlan | null {
   if (unsafeLocalNames.size === 0) return null
   if (!elem.staticItemTemplate) return null
-  if (!exprReferencesAny(elem.array, unsafeLocalNames)) return null
+  if (!setIntersects(elem.arrayFreeIdentifiers, unsafeLocalNames)) return null
   return {
     itemTemplate: elem.staticItemTemplate,
     mapPreamble: elem.mapPreamble ?? '',

--- a/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
@@ -14,7 +14,7 @@
 
 import type { LoopChildEvent, TopLevelLoop, NestedLoop, CollectedLoop } from '../types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../../types'
-import { quotePropName, wrapLoopParamAsAccessor, exprReferencesIdent } from '../utils'
+import { quotePropName, wrapLoopParamAsAccessor, irChildrenFreeIds } from '../utils'
 import { irChildrenToJsExpr } from '../html-template'
 import { emitListenerBlock } from './stringify/event-listener'
 import { nameForRegistryRef } from '../component-scope'
@@ -34,20 +34,23 @@ export function loopKeyFn(loop: CollectedLoop): string {
 }
 
 /**
- * Return true when `expr` references the loop's param — either the simple
- * identifier itself, or any of its destructured binding names (#951). The
- * pattern text (e.g. `[, cfg]`) never word-matches on a bare name, so the
- * simple `exprReferencesIdent(expr, elem.param)` check misses destructured
- * callbacks without this widening.
+ * Return true when an expression's free identifiers contain the loop's
+ * param — either the simple identifier itself, or any of its destructured
+ * binding names (#951). The pattern text (e.g. `[, cfg]`) never word-
+ * matches on a bare name, so we widen the check across `paramBindings`.
+ *
+ * Consumes a pre-computed `Set<string>` of free identifiers (#1267)
+ * rather than running word-boundary regex on the expression text — this
+ * avoids over-match against string literals and member-access tails.
  */
-function exprRefsLoopBinding(expr: string, loop: { param: string; paramBindings?: readonly LoopParamBinding[] }): boolean {
+function exprRefsLoopBinding(freeIds: ReadonlySet<string>, loop: { param: string; paramBindings?: readonly LoopParamBinding[] }): boolean {
   if (loop.paramBindings && loop.paramBindings.length > 0) {
     for (const b of loop.paramBindings) {
-      if (exprReferencesIdent(expr, b.name)) return true
+      if (freeIds.has(b.name)) return true
     }
     return false
   }
-  return exprReferencesIdent(expr, loop.param)
+  return freeIds.has(loop.param)
 }
 
 /**
@@ -243,8 +246,9 @@ export function emitComponentAndEventSetup(
       ? comp.children.every(c => c.type === 'expression' || c.type === 'text' || isTextOnlyConditional(c))
       : false
     const rawChildrenExpr = isTextOnly ? irChildrenToJsExpr(comp.children!) : null
-    const childrenRefsLoop = loopParam != null && rawChildrenExpr != null
-      && exprRefsLoopBinding(rawChildrenExpr, { param: loopParam, paramBindings: loopParamBindings })
+    const childrenFreeIds = isTextOnly && comp.children ? irChildrenFreeIds(comp.children) : undefined
+    const childrenRefsLoop = loopParam != null && rawChildrenExpr != null && childrenFreeIds != null
+      && exprRefsLoopBinding(childrenFreeIds, { param: loopParam, paramBindings: loopParamBindings })
 
     const slotIdLit = comp.slotId ? `'${comp.slotId}'` : 'null'
     const keyProp = comp.props.find(p => p.name === 'key')

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -6,7 +6,7 @@
 
 import type { ComponentIR, IRFragment, IRNode, ReferencesGraph } from '../types'
 import type { ClientJsContext } from './types'
-import { PROPS_PARAM, inferDefaultValue, exprReferencesIdent } from './utils'
+import { PROPS_PARAM, inferDefaultValue, tokenContainsIdent } from './utils'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability'
 import { isInlinableInTemplate } from '../relocate'
 import { buildEnvFromCtx } from './compute-inlinability'
@@ -77,7 +77,7 @@ export function buildInlinableConstants(
   unsafeLocalNames: Set<string>
 } {
   const analysis = computeInlinability(ctx, graph, irRoot)
-  return toLegacyInlinability(analysis, resolveChainedRefs, ctx, exprReferencesIdent)
+  return toLegacyInlinability(analysis, resolveChainedRefs, ctx, tokenContainsIdent)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -6,7 +6,7 @@
 
 import type { ComponentIR, IRFragment, IRNode, ReferencesGraph } from '../types'
 import type { ClientJsContext } from './types'
-import { PROPS_PARAM, inferDefaultValue, tokenContainsIdent } from './utils'
+import { PROPS_PARAM, inferDefaultValue } from './utils'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability'
 import { isInlinableInTemplate } from '../relocate'
 import { buildEnvFromCtx } from './compute-inlinability'
@@ -17,6 +17,13 @@ import { nameForRegistryRef } from './component-scope'
  * Resolve chained references within a constants map.
  * If constant A references constant B, replace B's name in A's value with B's resolved value.
  * Uses pre-computed freeIdentifiers to skip unnecessary regex replacements.
+ *
+ * When `freeIdsMap` is supplied, it is updated in place: each substitution
+ * removes the substituted name from the resolving constant's free-id set
+ * and unions in the substituted constant's own free ids. The result is a
+ * transitively-closed free-id map that downstream callers
+ * (`toLegacyInlinability` unsafe-ref check, #1267) can read without
+ * re-scanning the resolved string.
  */
 export function resolveChainedRefs(constants: Map<string, string>, freeIdsMap?: Map<string, Set<string>>): void {
   let changed = true
@@ -51,6 +58,16 @@ export function resolveChainedRefs(constants: Map<string, string>, freeIdsMap?: 
         if (replaced !== newValue) {
           newValue = replaced
           changed = true
+          // Maintain a transitively-closed free-id set on the resolving
+          // constant: drop the substituted name, union in the substituted
+          // constant's own free ids.
+          if (freeIds) {
+            freeIds.delete(otherName)
+            const otherFreeIds = freeIdsMap?.get(otherName)
+            if (otherFreeIds) {
+              for (const id of otherFreeIds) freeIds.add(id)
+            }
+          }
         }
       }
       newValue = restore(newValue)
@@ -77,7 +94,7 @@ export function buildInlinableConstants(
   unsafeLocalNames: Set<string>
 } {
   const analysis = computeInlinability(ctx, graph, irRoot)
-  return toLegacyInlinability(analysis, resolveChainedRefs, ctx, tokenContainsIdent)
+  return toLegacyInlinability(analysis, resolveChainedRefs, ctx)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -808,10 +808,16 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     // call sites (loop array, text expression, child component prop) decide
     // how to render that placeholder. The init function's createEffect /
     // initChild bindings repaint the real value once init runs.
+    //
+    // Lexer-based post-substitution check (#1267): pure IR-based checking
+    // would require tracking transitive free-id closure through the
+    // `csrInlinableConstants` re-promotion path (which substitutes
+    // signal/memo getters before re-classifying constants). That bookkeeping
+    // is non-trivial and bears no semantic benefit over the lexer, which
+    // already respects string-literal / member-access boundaries.
     if (unsafeLocalNames && unsafeLocalNames.size > 0 && tokenContainsAny(finalResult, unsafeLocalNames)) {
       return UNSAFE_TEMPLATE_EXPR
     }
-
     return finalResult
   }
 

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,7 +4,7 @@
 
 import type { IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, exprReferencesAny, wrapExprWithLoopParams } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, freeIdsFromRefs, setIntersects, tokenContainsAny, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
 
@@ -650,8 +650,8 @@ export function canGenerateStaticTemplate(
   inlinableConstants?: Map<string, string>,
   unsafeLocalNames?: Set<string>
 ): boolean {
-  const hasUnsafeRef = (expr: string): boolean => {
-    return !!(unsafeLocalNames && unsafeLocalNames.size > 0 && exprReferencesAny(expr, unsafeLocalNames))
+  const hasUnsafeRef = (freeIds: ReadonlySet<string> | undefined): boolean => {
+    return !!(unsafeLocalNames && unsafeLocalNames.size > 0 && setIntersects(freeIds, unsafeLocalNames))
   }
 
   switch (node.type) {
@@ -662,7 +662,7 @@ export function canGenerateStaticTemplate(
       return false
 
     case 'expression':
-      if (hasUnsafeRef(node.expr)) return false
+      if (hasUnsafeRef(freeIdsFromRefs(node.origin?.freeRefs))) return false
       // Use AST-derived flag when available, fall back to string check for older IR
       if ((node.hasFunctionCalls ?? node.expr.includes('()')) && !isSimplePropExpression(node.expr, propNames)) {
         return false
@@ -675,14 +675,14 @@ export function canGenerateStaticTemplate(
           // Computed local spreads are now handled by spreadAttrs() at runtime.
           // Only check for unsafe references that would fail at module scope.
           const valueStr = attrValueToString(attr.value)
-          if (valueStr && hasUnsafeRef(valueStr)) return false
+          if (valueStr && hasUnsafeRef(attr.freeIdentifiers)) return false
           if (valueStr && valueStr.includes('()') && !isSimplePropExpression(valueStr, propNames)) return false
           continue
         }
         if (attr.dynamic && attr.value) {
           const valueStr = attrValueToString(attr.value)
           if (valueStr) {
-            if (hasUnsafeRef(valueStr)) return false
+            if (hasUnsafeRef(attr.freeIdentifiers)) return false
             if (valueStr.includes('()') && !isSimplePropExpression(valueStr, propNames)) {
               return false
             }
@@ -692,7 +692,7 @@ export function canGenerateStaticTemplate(
       return node.children.every((c) => canGenerateStaticTemplate(c, propNames, inlinableConstants, unsafeLocalNames))
 
     case 'conditional':
-      if (hasUnsafeRef(node.condition)) return false
+      if (hasUnsafeRef(freeIdsFromRefs(node.origin?.freeRefs))) return false
       if (node.condition.includes('()') && !isSimplePropExpression(node.condition, propNames)) {
         return false
       }
@@ -808,7 +808,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     // call sites (loop array, text expression, child component prop) decide
     // how to render that placeholder. The init function's createEffect /
     // initChild bindings repaint the real value once init runs.
-    if (unsafeLocalNames && unsafeLocalNames.size > 0 && exprReferencesAny(finalResult, unsafeLocalNames)) {
+    if (unsafeLocalNames && unsafeLocalNames.size > 0 && tokenContainsAny(finalResult, unsafeLocalNames)) {
       return UNSAFE_TEMPLATE_EXPR
     }
 

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -29,7 +29,6 @@ import type {
 import { computeDeclarationScopes } from './compute-scope'
 import { graphUsedIdentifiers } from './build-references'
 import { getControlledPropName } from './prop-handling'
-import { exprReferencesIdent } from './utils'
 import { type Declaration, providedNames, sortDeclarations } from './declaration-sort'
 import { buildDeclarationEmitLookups, buildDeclarationEmitPlan } from './plan/build-declaration-emit'
 import { stringifyDeclarationEmit } from './stringify/declaration-emit'
@@ -205,15 +204,15 @@ export function addConstantPropRefsToSet(
   // `out` matches the pre-Stage E.3 behaviour — which downstream
   // `emitPropsExtraction` relies on for prop destructure line order.
   //
-  // Uses `exprReferencesIdent` (regex word-boundary) rather than
-  // `freeIdentifiers` because `freeIdentifiers` excludes member-access
-  // property names: when the source writes `props.className`,
-  // `freeIdentifiers` contains only `props`, not `className`. Falling
-  // back to regex keeps semantics identical to the old
-  // `valueReferencesReactiveData` check.
-  for (const prop of ctx.propsParams) {
-    if (exprReferencesIdent(constant.value, prop.name)) {
-      out.add(prop.name)
+  // Strict identifier check via the AST-derived `freeIdentifiers` set
+  // (#1267). Member-access tail names (e.g. the `className` in
+  // `props.className`) are not free identifiers and are picked up
+  // separately by the `propsObjectName.<tail>` regex below.
+  if (constant.freeIdentifiers) {
+    for (const prop of ctx.propsParams) {
+      if (constant.freeIdentifiers.has(prop.name)) {
+        out.add(prop.name)
+      }
     }
   }
   if (ctx.propsObjectName) {

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -28,12 +28,28 @@ export function expandDynamicPropValue(value: string, ctx: ClientJsContext): str
  * Stateful components use props.xxx directly, so expansion is unnecessary.
  *
  * e.g., `classes` → `` `${baseClasses} ${variantClasses[variant]} ${className}` ``
+ *
+ * Returns both the expanded expression and the free identifiers it
+ * references (#1267). When expansion occurred, `freeIds` is the substituted
+ * constant's own `freeIdentifiers` (already AST-computed in the analyzer).
+ * Otherwise it is `originalFreeIds` passed by the caller (typically derived
+ * from the IR node's `origin.freeRefs`) — `undefined` when the caller has
+ * no precomputed set.
  */
-export function expandConstantForReactivity(expr: string, ctx: ClientJsContext): string {
+export function expandConstantForReactivity(
+  expr: string,
+  ctx: ClientJsContext,
+  originalFreeIds?: ReadonlySet<string>,
+): { expr: string; freeIds: ReadonlySet<string> | undefined } {
   // Stateful components use props.xxx directly — reactivity is already detected.
-  if (ctx.propsObjectName) return expr
+  if (ctx.propsObjectName) return { expr, freeIds: originalFreeIds }
 
-  return expandDynamicPropValue(expr, ctx)
+  const trimmedValue = expr.trim()
+  const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
+  if (constant && constant.value) {
+    return { expr: constant.value, freeIds: constant.freeIdentifiers }
+  }
+  return { expr, freeIds: originalFreeIds }
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -12,7 +12,7 @@ import type {
   LoopChildReactiveText,
   NestedLoop,
 } from './types'
-import { attrValueToString, exprReferencesIdent } from './utils'
+import { attrValueToString, freeIdsFromRefs, tokenContainsIdent } from './utils'
 import { expandConstantForReactivity } from './prop-handling'
 import { walkIR, stopAt } from './walker'
 
@@ -123,7 +123,25 @@ export function decideWrapForChildProp(
   return decideWrapForAttr(expandedValue, ctx, prop)
 }
 
-export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean {
+/**
+ * Decide whether an expression should be re-evaluated inside `createEffect`.
+ *
+ * Optional `freeIdentifiers` (#1267) is the pre-computed `Set<string>` of
+ * identifiers referenced by `expr`. When supplied, prop-name detection uses
+ * `freeIdentifiers.has(name)` — an O(1) lookup that respects string-literal
+ * / member-access tail / comment boundaries. When absent (callers that
+ * synthesise the expression and have no AST source), the check falls back
+ * to the lexer-aware `tokenContainsIdent`.
+ *
+ * The signal-getter and memo regexes (`\b<name>\s*\(`) still run against
+ * the raw string — those are call-shape patterns, not bare-identifier
+ * checks, and are outside the scope of #1267.
+ */
+export function needsEffectWrapper(
+  expr: string,
+  ctx: ClientJsContext,
+  freeIdentifiers?: ReadonlySet<string>,
+): boolean {
   for (const signal of ctx.signals) {
     if (new RegExp(`\\b${signal.getter}\\s*\\(`).test(expr)) {
       return true
@@ -140,7 +158,7 @@ export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean 
   // and should not trigger effect wrapping on the client)
   for (const prop of ctx.propsParams) {
     if (prop.name === 'children') continue
-    if (exprReferencesIdent(expr, prop.name)) {
+    if (freeIdentifiers ? freeIdentifiers.has(prop.name) : tokenContainsIdent(expr, prop.name)) {
       return true
     }
   }
@@ -168,10 +186,9 @@ export function needsEffectWrapper(expr: string, ctx: ClientJsContext): boolean 
  *
  * `none` means neither applies and the collector can skip the expression.
  *
- * Consolidates the duplicated
- * `needsEffectWrapper(expanded, ctx) || exprReferencesIdent(expanded, loopParam)`
- * check shared by `collectLoopChildReactiveTexts`,
- * `collectLoopChildReactiveAttrs`, and `collectLoopChildConditionals`.
+ * Consolidates the duplicated reactive-classification check shared by
+ * `collectLoopChildReactiveTexts`, `collectLoopChildReactiveAttrs`, and
+ * `collectLoopChildConditionals`.
  */
 export type ReactivitySource =
   | { kind: 'none' }
@@ -196,17 +213,20 @@ export function classifyReactivity(
   ctx: ClientJsContext,
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
+  freeIdentifiers?: ReadonlySet<string>,
 ): ReactivitySource {
+  const has = (name: string): boolean =>
+    freeIdentifiers ? freeIdentifiers.has(name) : tokenContainsIdent(expr, name)
   if (loopParamBindings && loopParamBindings.length > 0) {
     for (const b of loopParamBindings) {
-      if (exprReferencesIdent(expr, b.name)) {
+      if (has(b.name)) {
         return { kind: 'loop-param', param: loopParam ?? b.name }
       }
     }
-  } else if (loopParam && exprReferencesIdent(expr, loopParam)) {
+  } else if (loopParam && has(loopParam)) {
     return { kind: 'loop-param', param: loopParam }
   }
-  if (needsEffectWrapper(expr, ctx)) {
+  if (needsEffectWrapper(expr, ctx, freeIdentifiers)) {
     return { kind: 'signal-or-memo-or-prop' }
   }
   return { kind: 'none' }
@@ -454,11 +474,17 @@ export function collectLoopChildReactiveTexts(
     ...stopAt<boolean>('loop', 'async', 'ifStatement'),
     expression: ({ node: n, scope: insideConditional }) => {
       if (!n.slotId) return
-      const expanded = expandConstantForReactivity(n.expr, ctx)
+      const originFreeIds = freeIdsFromRefs(n.origin?.freeRefs)
+      const expanded = expandConstantForReactivity(n.expr, ctx, originFreeIds)
       // Include if expression reads signals OR references the loop parameter
       // (loop param becomes a signal accessor via per-item signals).
-      if (classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') return
-      texts.push({ slotId: n.slotId, expression: expanded, insideConditional: insideConditional || undefined })
+      if (classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
+      texts.push({
+        slotId: n.slotId,
+        expression: expanded.expr,
+        insideConditional: insideConditional || undefined,
+        ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
+      })
     },
     conditional: ({ descend }) => {
       descend(true)
@@ -491,7 +517,7 @@ export function collectLoopChildReactiveAttrs(
         if (attr.name === 'key') continue
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
-        const expanded = expandConstantForReactivity(valueStr, ctx)
+        const expanded = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers)
         // `/* @client */` always defers via per-item createEffect
         // regardless of the reactivity classifier — matches the
         // top-level `collectElements.element` and the conditional
@@ -499,12 +525,13 @@ export function collectLoopChildReactiveAttrs(
         // SSR template strips the attribute (html-template) and no
         // hydrate-time binding is emitted, leaving the per-item
         // attribute permanently unset.
-        if (!attr.clientOnly && classifyReactivity(expanded, ctx, loopParam, loopParamBindings).kind === 'none') continue
+        if (!attr.clientOnly && classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') continue
         attrs.push({
           childSlotId: el.slotId,
           attrName: attr.name,
-          expression: expanded,
+          expression: expanded.expr,
           ...pickAttrMeta(attr),
+          ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
         })
       }
     }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -184,6 +184,13 @@ export interface LoopCore {
    * key tracks all of its DOM nodes (#1212).
    */
   bodyIsMultiRoot?: boolean
+  /**
+   * Pre-computed free identifiers referenced by the `array` expression
+   * (#1267). Populated during IR build from the originating AST node so
+   * downstream callers can ask `arrayFreeIdentifiers.has(name)` instead of
+   * running word-boundary regex against `array`.
+   */
+  arrayFreeIdentifiers?: ReadonlySet<string>
 }
 
 /** Loop info extracted from a conditional branch for reactive reconciliation. */
@@ -304,6 +311,13 @@ export interface LoopChildReactiveText {
   slotId: string // bf comment marker slot ID (e.g., 's7' → <!--bf:s7-->)
   expression: string // Expression that reads signals
   insideConditional?: boolean // true if text node is inside a conditional branch (insert() may replace it)
+  /**
+   * Pre-computed free identifiers referenced by `expression` (#1267).
+   * For expressions produced via `expandConstantForReactivity`, this is the
+   * union of the original AST node's free identifiers and the substituted
+   * constants' own `freeIdentifiers`.
+   */
+  freeIdentifiers?: ReadonlySet<string>
 }
 
 /**
@@ -343,6 +357,13 @@ export interface LoopChildConditional {
   whenFalseHtml: string // HTML template for false branch (usually comment markers)
   whenTrue: LoopChildBranchSummary
   whenFalse: LoopChildBranchSummary
+  /**
+   * Pre-computed free identifiers referenced by `condition` (#1267).
+   * For conditions produced via `expandConstantForReactivity`, this is the
+   * union of the original AST node's free identifiers and the substituted
+   * constants' own `freeIdentifiers`.
+   */
+  conditionFreeIdentifiers?: ReadonlySet<string>
 }
 
 export interface TopLevelLoop extends LoopCore {

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -3,7 +3,7 @@
  * No dependencies on ClientJsContext or other internal modules.
  */
 
-import type { IRTemplateLiteral, LoopParamBinding } from '../types'
+import type { IRTemplateLiteral, LoopParamBinding, FreeReference, IRNode } from '../types'
 import type { TopLevelLoop } from './types'
 import {
   BF_KEY as DATA_KEY,
@@ -256,50 +256,272 @@ export function inferDefaultValue(type: { kind: string; primitive?: string }): s
   return 'undefined'
 }
 
-/**
- * Check if a JS expression string references a given identifier.
- * Uses word-boundary matching with proper regex escaping.
- *
- * **Known limitation (#1267)**: regex `\b...\b` over-matches —
- *   - string literals (`'foo-className'` falsely matches `className`)
- *   - member-access property names (`a.className` falsely matches `className`)
- *   - comment contents
- *
- * All 12 callers in this directory want "is `ident` referenced as an
- * identifier?" (strict). The over-match is tolerated, not intended.
- * Single-shot AST replacement would re-parse per call and break the
- * project-wide "AST is parsed once" invariant — see #1267 for the
- * proper fix (extend `freeIdentifiers` to every expression-carrying
- * IR node so each caller looks up `node.freeIdentifiers.has(name)`
- * instead of running this regex).
- */
-export function exprReferencesIdent(expr: string, ident: string): boolean {
-  return new RegExp(`\\b${escapeRegExp(ident)}\\b`).test(expr)
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 /**
- * Check if `expr` references any identifier in `names`. Short-circuits on
- * the first hit.
- *
- * Canonical helper for the "does this expression depend on any of the
- * <unsafe / signal / prop / loop-param> names we're tracking" question.
- * Multiple callers used to inline this loop or define a private clone
- * (`expressionReferencesAny` in html-template.ts, `arrayReferencesAny`
- * in control-flow/plan/build-loop.ts) — having a single shared helper
- * keeps the semantic identical across the codebase.
- *
- * Inherits `exprReferencesIdent`'s regex over-match limitation; the
- * AST-driven follow-up is tracked in #1267.
+ * Flatten an `OriginInfo.freeRefs` list to a plain `Set<string>` of free
+ * identifier names (#1267). Skips `kind: 'reactive-brand'` entries whose
+ * `name` is a full property-access path (e.g. `props.form.isSubmitting`) —
+ * the root identifier of such paths is already reported separately under
+ * its own kind, so consumers checking `has(<bareIdent>)` get a clean view.
  */
-export function exprReferencesAny(expr: string, names: Iterable<string>): boolean {
-  for (const name of names) {
-    if (exprReferencesIdent(expr, name)) return true
+export function freeIdsFromRefs(refs: readonly FreeReference[] | undefined): Set<string> {
+  const out = new Set<string>()
+  if (!refs) return out
+  for (const ref of refs) {
+    if (ref.kind === 'reactive-brand') continue
+    out.add(ref.name)
+  }
+  return out
+}
+
+/**
+ * Walk an IR child subtree and return the union of free identifiers
+ * referenced by every expression-bearing node within it (#1267). Used by
+ * the synthesised-children check in component-loop / event-setup builders
+ * where the children string is reconstituted from IR via
+ * `irChildrenToJsExpr` and has no single AST node.
+ *
+ * Visits: IRExpression / IRConditional / IRElement (attrs only —
+ * children recurse) / IRComponent (attrs + children) / IRFragment /
+ * IRIfStatement / IRProvider / IRSlot. Skips IRText (no expr) and
+ * IRLoop (its body has its own param scope).
+ */
+export function irChildrenFreeIds(children: readonly IRNode[]): Set<string> {
+  const out = new Set<string>()
+  for (const child of children) {
+    collectIrFreeIds(child, out)
+  }
+  return out
+}
+
+function collectIrFreeIds(node: IRNode, out: Set<string>): void {
+  switch (node.type) {
+    case 'text':
+      return
+    case 'expression': {
+      addRefsToSet(node.origin?.freeRefs, out)
+      return
+    }
+    case 'conditional': {
+      addRefsToSet(node.origin?.freeRefs, out)
+      collectIrFreeIds(node.whenTrue, out)
+      collectIrFreeIds(node.whenFalse, out)
+      return
+    }
+    case 'element': {
+      for (const attr of node.attrs) {
+        if (attr.freeIdentifiers) {
+          for (const name of attr.freeIdentifiers) out.add(name)
+        }
+      }
+      for (const child of node.children) collectIrFreeIds(child, out)
+      return
+    }
+    case 'fragment':
+    case 'provider':
+    case 'async':
+    case 'if-statement': {
+      const anyNode = node as { children?: IRNode[] }
+      if (anyNode.children) {
+        for (const child of anyNode.children) collectIrFreeIds(child, out)
+      }
+      return
+    }
+    case 'component': {
+      for (const prop of node.props) {
+        // IRProp shares AttrMeta — pick up freeIdentifiers when present.
+        const p = prop as { freeIdentifiers?: ReadonlySet<string> }
+        if (p.freeIdentifiers) {
+          for (const name of p.freeIdentifiers) out.add(name)
+        }
+      }
+      for (const child of node.children) collectIrFreeIds(child, out)
+      return
+    }
+    case 'loop':
+    case 'slot':
+      // Loops introduce their own param scope; the parent-context's free
+      // identifiers don't propagate through. Slots resolve at the host.
+      return
+  }
+}
+
+function addRefsToSet(refs: readonly FreeReference[] | undefined, out: Set<string>): void {
+  if (!refs) return
+  for (const ref of refs) {
+    if (ref.kind === 'reactive-brand') continue
+    out.add(ref.name)
+  }
+}
+
+/**
+ * Set-intersection check that short-circuits on the first overlap.
+ * Iterates the smaller side for efficiency.
+ */
+export function setIntersects(a: ReadonlySet<string> | undefined, b: ReadonlySet<string> | undefined): boolean {
+  if (!a || !b || a.size === 0 || b.size === 0) return false
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a]
+  for (const name of small) {
+    if (large.has(name)) return true
   }
   return false
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+/**
+ * Lexer-aware fallback for "does this expression reference an identifier?"
+ *
+ * Reserved for the call sites that operate on **synthesised** expression
+ * strings with no originating AST node (post-constant-chain resolution,
+ * post-substitution CSR templates). All other callers should read
+ * `node.freeIdentifiers` populated during IR build — see #1267.
+ *
+ * Skips matches that occur inside:
+ * - string literals (`'...'`, `"..."`)
+ * - template literal text parts (between `` ` `` and `${`)
+ * - line comments (`// ...`)
+ * - block comments (`/* ... *\/`)
+ * - member-access tail names (identifier preceded by `.`)
+ *
+ * Matches inside template-literal `${ ... }` expression substitutions are
+ * still considered identifier references.
+ */
+export function tokenContainsIdent(expr: string, ident: string): boolean {
+  return scanForIdentifiers(expr, (token) => token === ident)
+}
+
+/**
+ * Lexer-aware variant of {@link tokenContainsIdent} that returns true on the
+ * first occurrence of *any* name in `names`. Short-circuits.
+ */
+export function tokenContainsAny(expr: string, names: Iterable<string>): boolean {
+  const set = names instanceof Set ? (names as Set<string>) : new Set(names)
+  if (set.size === 0) return false
+  return scanForIdentifiers(expr, (token) => set.has(token))
+}
+
+const IDENT_START_RE = /[A-Za-z_$]/
+const IDENT_PART_RE = /[A-Za-z0-9_$]/
+
+/**
+ * Single-pass scanner over a JS-like expression string. Walks character by
+ * character through a small state machine and invokes `predicate` on every
+ * identifier-like token it finds in a position where bare identifiers are
+ * semantically possible (i.e. not inside a string/comment, not the property
+ * name in a member-access expression). Returns true on the first hit.
+ */
+function scanForIdentifiers(expr: string, predicate: (token: string) => boolean): boolean {
+  const n = expr.length
+  let i = 0
+  // 0 = code, 1 = single-quote string, 2 = double-quote string,
+  // 3 = template literal text, 4 = template literal expression,
+  // 5 = line comment, 6 = block comment.
+  type State = 0 | 1 | 2 | 3 | 4 | 5 | 6
+  let state: State = 0
+  // For nested template expressions: stack of brace depths at each `${` push.
+  const tmplExprStack: number[] = []
+  // Brace depth tracked only inside template-expression state to detect when
+  // we close back to the surrounding template-literal text.
+  let braceDepth = 0
+
+  while (i < n) {
+    const ch = expr[i]
+
+    switch (state) {
+      case 0: // code
+      case 4: { // template expression — same lexing rules as code
+        // String / template literal openers
+        if (ch === "'") { state = 1; i++; continue }
+        if (ch === '"') { state = 2; i++; continue }
+        if (ch === '`') { state = 3; i++; continue }
+        // Comment openers
+        if (ch === '/' && i + 1 < n) {
+          const next = expr[i + 1]
+          if (next === '/') { state = 5; i += 2; continue }
+          if (next === '*') { state = 6; i += 2; continue }
+        }
+        // Track braces only inside template-expression state, so we know when
+        // we leave `${ ... }` back to the surrounding template text.
+        if (state === 4) {
+          if (ch === '{') { braceDepth++; i++; continue }
+          if (ch === '}') {
+            if (braceDepth === 0) {
+              // Closing `}` of `${ ... }` — pop back to enclosing tmpl state.
+              const restored = tmplExprStack.pop()
+              braceDepth = restored ?? 0
+              state = 3
+              i++
+              continue
+            }
+            braceDepth--
+            i++
+            continue
+          }
+        }
+        // Identifier start
+        if (IDENT_START_RE.test(ch)) {
+          let j = i + 1
+          while (j < n && IDENT_PART_RE.test(expr[j])) j++
+          const token = expr.slice(i, j)
+          // Skip member-access tail: identifier preceded by `.` (ignoring
+          // whitespace).
+          let prev = i - 1
+          while (prev >= 0 && (expr[prev] === ' ' || expr[prev] === '\t' || expr[prev] === '\n' || expr[prev] === '\r')) prev--
+          const isMemberTail = prev >= 0 && expr[prev] === '.' && (prev === 0 || expr[prev - 1] !== '.') // not `..` (spread)
+          if (!isMemberTail && predicate(token)) return true
+          i = j
+          continue
+        }
+        i++
+        continue
+      }
+      case 1: { // single-quote string
+        if (ch === '\\' && i + 1 < n) { i += 2; continue }
+        if (ch === "'") { state = 0; i++; continue }
+        i++
+        continue
+      }
+      case 2: { // double-quote string
+        if (ch === '\\' && i + 1 < n) { i += 2; continue }
+        if (ch === '"') { state = 0; i++; continue }
+        i++
+        continue
+      }
+      case 3: { // template literal text
+        if (ch === '\\' && i + 1 < n) { i += 2; continue }
+        if (ch === '`') {
+          // Closing the template literal; return to whatever code state we
+          // came from (either top-level code or an outer template expression).
+          state = tmplExprStack.length > 0 ? 4 : 0
+          i++
+          continue
+        }
+        if (ch === '$' && i + 1 < n && expr[i + 1] === '{') {
+          // Entering `${ ... }`: save current outer brace depth, reset for new.
+          tmplExprStack.push(braceDepth)
+          braceDepth = 0
+          state = 4
+          i += 2
+          continue
+        }
+        i++
+        continue
+      }
+      case 5: { // line comment
+        if (ch === '\n' || ch === '\r') { state = 0; i++; continue }
+        i++
+        continue
+      }
+      case 6: { // block comment
+        if (ch === '*' && i + 1 < n && expr[i + 1] === '/') { state = 0; i += 2; continue }
+        i++
+        continue
+      }
+    }
+  }
+  return false
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -35,6 +35,7 @@ import { createError, ErrorCodes } from './errors'
 import { containsReactiveExpression } from './reactivity-checker'
 import { rewriteBarePropRefs as rewriteBarePropRefsCore } from './prop-rewrite'
 import { resolveFreeRefs, type BindingEnvironment } from './free-refs'
+import { extractFreeIdentifiersFromNode } from './analyzer'
 
 // =============================================================================
 // Transform Context
@@ -2472,6 +2473,7 @@ function transformMapCall(
     indexType,
     typedMapPreamble,
     paramBindings,
+    arrayFreeIdentifiers: extractFreeIdentifiersFromNode(arrayExpr),
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -2573,19 +2575,26 @@ function expandSpreadAttribute(
   dynamic: true
   isLiteral: false
   loc: SourceLocation
+  freeIdentifiers?: ReadonlySet<string>
 }> {
   const spreadExpr = ctx.getJS(attr.expression)
   const expandedKeys = ctx.analyzer.restPropsExpandedKeys
   const restName = ctx.analyzer.restPropsName
   const loc = getSourceLocation(attr, ctx.sourceFile, ctx.filePath)
+  const spreadFreeIdentifiers = extractFreeIdentifiersFromNode(attr.expression)
 
   if (expandedKeys.length > 0 && restName && spreadExpr === restName) {
+    // Expanded per-key attrs reference `${restName}.${key}` — `restName` is
+    // the only free identifier (the `.${key}` tail is a member-access name,
+    // not an identifier reference).
+    const perKeyFreeIds: ReadonlySet<string> = new Set([restName])
     return expandedKeys.map(key => ({
       name: key,
       value: `${restName}.${key}`,
       dynamic: true,
       isLiteral: false,
       loc,
+      freeIdentifiers: perKeyFreeIds,
     }))
   }
 
@@ -2596,7 +2605,24 @@ function expandSpreadAttribute(
     dynamic: true,
     isLiteral: false,
     loc,
+    freeIdentifiers: spreadFreeIdentifiers,
   }]
+}
+
+// Extract free identifiers from an attribute's initializer expression
+// (#1267). Returns undefined for boolean shorthand / string-literal attrs
+// that have no expression. Downstream callers can ask
+// `attr.freeIdentifiers?.has(name)` instead of running word-boundary regex
+// against the value string.
+function attrFreeIdentifiers(attr: ts.JsxAttribute): ReadonlySet<string> | undefined {
+  if (
+    !attr.initializer
+    || !ts.isJsxExpression(attr.initializer)
+    || !attr.initializer.expression
+  ) {
+    return undefined
+  }
+  return extractFreeIdentifiersFromNode(attr.initializer.expression)
 }
 
 // AST-derived reactivity flags for the Solid-style wrap-by-default fallback
@@ -2690,6 +2716,7 @@ function processAttributes(
       }
     }
 
+    const freeIdentifiers = attrFreeIdentifiers(attr)
     attrs.push({
       name,
       value,
@@ -2700,6 +2727,7 @@ function processAttributes(
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
+      ...(freeIdentifiers !== undefined && { freeIdentifiers }),
     })
   }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -3217,6 +3217,7 @@ function processComponentProps(
       }
     }
 
+    const freeIdentifiers = attrFreeIdentifiers(attr)
     props.push({
       name,
       value: propValue,
@@ -3227,6 +3228,7 @@ function processComponentProps(
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
       ...pickAttrMeta(attrResult),
+      ...(freeIdentifiers !== undefined && { freeIdentifiers }),
     })
   }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -523,6 +523,13 @@ export interface IRLoop {
    * those cases raise `BF025` at Phase 1.
    */
   paramBindings?: LoopParamBinding[]
+  /**
+   * Pre-computed free identifiers referenced by the `array` expression
+   * (#1267). Populated during `transformMapCall` from the originating AST
+   * node so downstream callers can ask `arrayFreeIdentifiers.has(name)`
+   * instead of running word-boundary regex against `array`.
+   */
+  arrayFreeIdentifiers?: ReadonlySet<string>
 }
 
 /**
@@ -645,6 +652,12 @@ export type IRTemplatePart =
  */
 export interface AttrMeta {
   presenceOrUndefined?: boolean // true when `expr || undefined` pattern is detected
+  /**
+   * Pre-computed free identifiers referenced by the attribute's expression
+   * (#1267). Populated during IR build by walking the originating AST node.
+   * Optional so downstream IR consumers (adapters) remain compatible.
+   */
+  freeIdentifiers?: ReadonlySet<string>
 }
 
 /**
@@ -654,6 +667,7 @@ export interface AttrMeta {
 export function pickAttrMeta(src: AttrMeta): AttrMeta {
   return {
     ...(src.presenceOrUndefined !== undefined && { presenceOrUndefined: src.presenceOrUndefined }),
+    ...(src.freeIdentifiers !== undefined && { freeIdentifiers: src.freeIdentifiers }),
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `\b<ident>\b` regex in `exprReferencesIdent` / `exprReferencesAny` with AST-derived `freeIdentifiers` set lookups at every expression-carrying IR node. Eliminates the over-match against string literals, member-access tail names, and comment contents.

## Why

The regex helpers in `packages/jsx/src/ir-to-client-js/utils.ts` over-matched three classes of input:
- string literals: `'"some-className"'` falsely reported `className`
- member-access tail names: `a.className` falsely reported `className`
- comment contents

All 14 call sites wanted strict identifier semantics; the over-match was tolerated, not designed in. A naive `ts.createSourceFile` per call would re-parse on every check and break the project-wide "AST is parsed once" invariant.

The existing `ConstantInfo.freeIdentifiers` mechanism already proves the right approach: compute a `Set<string>` from the AST node during the single IR-build pass, then look up membership at the call site.

## What changed

### IR types (all optional, adapter-compatible)
- `AttrMeta.freeIdentifiers`
- `LoopChildReactiveText.freeIdentifiers`
- `LoopChildConditional.conditionFreeIdentifiers`
- `IRLoop.arrayFreeIdentifiers` (propagated to `TopLevelLoop` / `NestedLoop` / `BranchLoop`)

### Population during IR build
- `processAttributes` / `processComponentProps` / `expandSpreadAttribute` compute `freeIdentifiers` via `extractFreeIdentifiersFromNode` (exported from `analyzer.ts`)
- `transformMapCall` computes `arrayFreeIdentifiers` for `IRLoop`
- `expandConstantForReactivity` now returns `{ expr, freeIds }` so substituted constants' `freeIdentifiers` is unioned correctly when expansion occurs

### Call-site migration (14 sites)
- Sites 2–4 (`needsEffectWrapper` / `classifyReactivity`): signatures widened to accept optional `freeIdentifiers: ReadonlySet<string>`
- Sites 6–7, 8–13: read pre-computed sets from the IR carrier
- Site 5 (`compute-inlinability.ts:545`, post-chain-resolve): IR-only via a transitively-closed `freeIdsMap` updated during `resolveChainedRefs`. The helper now drops the substituted name and unions in the substituted constant's own free ids on each replacement, so a single `freeIdsMap.get(name).has(unsafeName)` check is exact.
- Site 14 (`html-template.ts:811`, post-substitution): retains a lexer-aware `tokenContainsAny` fallback. Pure IR-based checking would require threading transitive free-id closure through the `csrInlinableConstants` re-promotion pipeline (which substitutes signal/memo getters before re-classifying constants via `isInlinableInTemplate`) — that re-derivation is logically *analysis* sitting in the emit pass and should be moved into IR build. Tracked as a follow-up in #1277.
- Site 1 (`init-declarations.ts:215`): migrated to `constant.freeIdentifiers?.has(prop.name)`. The companion `propsObjectName.<tail>` regex (line 220) already handles the `props.className` member-access case, so dropping the over-matching identifier loop is behaviour-preserving.

### Helpers removed
- `exprReferencesIdent`, `exprReferencesAny` deleted from `utils.ts`

### New helpers in `utils.ts`
- `tokenContainsIdent` / `tokenContainsAny` — single-pass lexer over a JS-like expression string, respects string-literal / template-literal / comment / member-access boundaries. **Currently used only at the single Site 14 call site** as a post-substitution safety net; once #1277 lands these become deletable.
- `freeIdsFromRefs(refs)` — flattens `OriginInfo.freeRefs` to `Set<string>`, filtering `kind: 'reactive-brand'` entries
- `irChildrenFreeIds(children)` — walks an IR subtree and unions free identifiers across expression-bearing nodes
- `setIntersects(a, b)` — short-circuiting set-intersection check

## Test plan

- [x] `bun test packages/jsx` — 1132 pass / 0 fail (4 pre-existing failures observed on `main` resolved as a side effect of strict semantics — verified by git stash diff)
- [x] `bun test packages/adapter-tests` — 237 / 237 pass
- [x] `bun run build site/ui` — clean build
- [x] New `packages/jsx/src/__tests__/token-contains-ident.test.ts` — 35 cases pinning the lexer (string-literal / member-access / comment / template-literal classes)
- [x] New `packages/jsx/src/__tests__/over-match-regression.test.ts` — 3 integration regressions compiling JSX whose source contains identifier-shaped substrings in positions that should NOT count

## Follow-up

#1277 tracks moving the CSR-template re-derivation (`buildCsrInlinableConstants`, signal/memo string substitution in `transformExpr`) into IR build. That work deletes the residual Site 14 lexer and brings the `IR → emit = pure projection` invariant back to whole-file.

Closes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)