### PR TITLE
refactor(jsx): lift IR attribute value to AttrValue discriminated union (#1264)

### DIFF
--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -16,7 +16,7 @@ import type {
   IRComponent,
   IRFragment,
   IRSlot,
-  IRTemplateLiteral,
+  IRTemplatePart,
   IRProp,
   TypeInfo,
   CompilerError,
@@ -724,19 +724,35 @@ export class GoTemplateAdapter extends BaseAdapter {
       lines.push(`\t\t\tScopeID: scopeID + "_${child.slotId}",`)
       // Add prop values
       for (const prop of child.props) {
-        if (prop.isLiteral) {
-          lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${this.goLiteral(prop.value)},`)
-        } else {
-          // Dynamic prop - resolve to parent's initial signal/memo value
-          const resolvedValue = this.resolveDynamicPropValue(
-            prop.value,
-            ir.metadata.signals,
-            ir.metadata.memos,
-            ir.metadata.propsParams
-          )
-          if (resolvedValue !== null) {
-            lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${resolvedValue},`)
+        switch (prop.value.kind) {
+          case 'literal':
+            lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${this.goLiteral(prop.value.value)},`)
+            break
+          case 'boolean-shorthand':
+          case 'boolean-attr':
+            lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: true,`)
+            break
+          case 'expression':
+          case 'spread':
+          case 'template': {
+            const exprText = prop.value.kind === 'template'
+              ? '' // template literals collapse to runtime expressions; resolveDynamicPropValue does not handle them yet
+              : prop.value.expr
+            if (!exprText) break
+            const resolvedValue = this.resolveDynamicPropValue(
+              exprText,
+              ir.metadata.signals,
+              ir.metadata.memos,
+              ir.metadata.propsParams
+            )
+            if (resolvedValue !== null) {
+              lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${resolvedValue},`)
+            }
+            break
           }
+          case 'jsx-children':
+            // Handled separately via `child.childrenText` / `child.childrenHtml` below.
+            break
         }
       }
       // Pass through JSX children as the child slot's `Children` input.
@@ -2756,41 +2772,48 @@ export class GoTemplateAdapter extends BaseAdapter {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
-      if (attr.name === '...') {
-        // Spread attributes not directly supported in Go templates
-        continue
-      }
-
       // Convert JSX className to HTML class attribute
       const attrName = attr.name === 'className' ? 'class' : attr.name
+      const v = attr.value
 
-      if (attr.value === null) {
-        // Boolean attribute
-        parts.push(attrName)
-      } else if (typeof attr.value === 'object' && attr.value.type === 'template-literal') {
-        // Template literal with structured ternaries
-        const output = this.renderTemplateLiteral(attr.value)
-        parts.push(`${attrName}="${output}"`)
-      } else if (attr.dynamic) {
-        const value = attr.value as string
-        if (isBooleanAttr(attrName) || attr.presenceOrUndefined) {
-          // Boolean attrs: render attr name only when truthy, omit when falsy
-          const { condition: goCond, preamble } = this.convertConditionToGo(value)
-          parts.push(`${preamble}{{if ${goCond}}}${attrName}{{end}}`)
-        } else {
-          // Check for ternary/conditional or template literal expressions using the parser
-          const parsed = parseExpression(value.trim())
-          if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
-            // These produce inline Go template syntax with embedded {{...}} actions
-            const goValue = this.renderParsedExpr(parsed)
-            parts.push(`${attrName}="${goValue}"`)
-          } else {
-            const goValue = this.convertExpressionToGo(value)
-            parts.push(`${attrName}="{{${goValue}}}"`)
-          }
+      switch (v.kind) {
+        case 'spread':
+          // Spread attributes not directly supported in Go templates
+          continue
+        case 'boolean-attr':
+          parts.push(attrName)
+          break
+        case 'literal':
+          parts.push(`${attrName}="${v.value}"`)
+          break
+        case 'template': {
+          const output = this.renderTemplateLiteralParts(v.parts)
+          parts.push(`${attrName}="${output}"`)
+          break
         }
-      } else {
-        parts.push(`${attrName}="${attr.value}"`)
+        case 'expression': {
+          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
+            // Boolean attrs: render attr name only when truthy, omit when falsy
+            const { condition: goCond, preamble } = this.convertConditionToGo(v.expr)
+            parts.push(`${preamble}{{if ${goCond}}}${attrName}{{end}}`)
+          } else {
+            // Check for ternary/conditional or template literal expressions using the parser
+            const parsed = parseExpression(v.expr.trim())
+            if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
+              // These produce inline Go template syntax with embedded {{...}} actions
+              const goValue = this.renderParsedExpr(parsed)
+              parts.push(`${attrName}="${goValue}"`)
+            } else {
+              const goValue = this.convertExpressionToGo(v.expr)
+              parts.push(`${attrName}="{{${goValue}}}"`)
+            }
+          }
+          break
+        }
+        case 'boolean-shorthand':
+        case 'jsx-children':
+          // Neither variant is legal on intrinsic elements. Skip silently.
+          break
       }
     }
 
@@ -2887,9 +2910,9 @@ export class GoTemplateAdapter extends BaseAdapter {
       .replace(/>/g, '&gt;')
   }
 
-  private renderTemplateLiteral(literal: IRTemplateLiteral): string {
+  private renderTemplateLiteralParts(parts: IRTemplatePart[]): string {
     let output = ''
-    for (const part of literal.parts) {
+    for (const part of parts) {
       if (part.type === 'string') {
         // String parts can carry unresolved `${expr}` placeholders
         // (e.g. for function params like `className` that the IR

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -17,7 +17,8 @@ import {
   type IRIfStatement,
   type IRProvider,
   type IRAsync,
-  type IRTemplateLiteral,
+  type AttrValue,
+  type IRTemplatePart,
   type ParamInfo,
   type AdapterOutput,
   type TemplateSections,
@@ -488,9 +489,20 @@ export class HonoAdapter extends JsxAdapter {
       case 'provider': {
         const provider = node as IRProvider
         const children = this.renderChildren(provider.children)
-        // Quote string-literal values; dynamic expressions emit raw.
-        const rawValue = provider.valueProp.value ?? ''
-        const valueExpr = provider.valueProp.dynamic ? rawValue : JSON.stringify(rawValue)
+        // Quote literal values; expression / template / spread variants emit
+        // their JS source verbatim into the Hono JSX output.
+        const valueExpr = (() => {
+          const v = provider.valueProp.value
+          switch (v.kind) {
+            case 'literal': return JSON.stringify(v.value)
+            case 'expression':
+            case 'spread': return v.expr
+            case 'template': return this.renderTemplateLiteralParts(v.parts)
+            case 'boolean-attr':
+            case 'boolean-shorthand': return 'true'
+            case 'jsx-children': return 'undefined'
+          }
+        })()
         // Bridge BarefootJS Context to Hono's per-render context stack so
         // descendants that call useContext() at SSR see the provided value.
         // `provideContextSSR` is a helper exported from the client shim
@@ -814,29 +826,36 @@ export class HonoAdapter extends JsxAdapter {
 
     for (const attr of element.attrs) {
       const attrName = attr.name
+      const v = attr.value
 
-      if (attr.name === '...') {
-        // Spread attribute
-        parts.push(`{...${attr.value}}`)
-      } else if (attr.value === null) {
-        // Boolean attribute
-        parts.push(attrName)
-      } else if (typeof attr.value === 'object' && attr.value.type === 'template-literal') {
-        // Template literal with structured ternaries
-        const output = this.renderTemplateLiteral(attr.value)
-        parts.push(`${attrName}={${output}}`)
-      } else if (attr.dynamic) {
-        // Dynamic attribute
-        if (isBooleanAttr(attrName) || attr.presenceOrUndefined) {
-          // Boolean attrs: pass undefined when falsy so Hono omits the attribute
-          // Wrap in parentheses to avoid syntax error when value contains ?? operator
-          parts.push(`${attrName}={(${attr.value}) || undefined}`)
-        } else {
-          parts.push(`${attrName}={${attr.value}}`)
+      switch (v.kind) {
+        case 'spread':
+          parts.push(`{...${v.expr}}`)
+          break
+        case 'boolean-attr':
+          parts.push(attrName)
+          break
+        case 'literal':
+          parts.push(`${attrName}="${v.value}"`)
+          break
+        case 'template': {
+          const output = this.renderTemplateLiteralParts(v.parts)
+          parts.push(`${attrName}={${output}}`)
+          break
         }
-      } else {
-        // Static attribute
-        parts.push(`${attrName}="${attr.value}"`)
+        case 'expression':
+          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
+            // Boolean attrs: pass undefined when falsy so Hono omits the attribute
+            // Wrap in parentheses to avoid syntax error when value contains ?? operator
+            parts.push(`${attrName}={(${v.expr}) || undefined}`)
+          } else {
+            parts.push(`${attrName}={${v.expr}}`)
+          }
+          break
+        case 'boolean-shorthand':
+        case 'jsx-children':
+          // Neither variant is legal on intrinsic elements. Skip silently.
+          break
       }
     }
 
@@ -854,37 +873,44 @@ export class HonoAdapter extends JsxAdapter {
     let keyValue: string | null = null
 
     for (const prop of comp.props) {
-      if (prop.jsxChildren?.length) {
+      if (prop.value.kind === 'jsx-children') {
         // JSX prop: render children inline as JSX fragment
-        const rendered = prop.jsxChildren.map(c => this.renderNode(c)).join('')
+        const rendered = prop.value.children.map(c => this.renderNode(c)).join('')
         parts.push(`${prop.name}={<>${rendered}</>}`)
         continue
       }
-      if (prop.name === '...') {
-        parts.push(`{...${prop.value}}`)
-      } else if (prop.name === 'key') {
+      if (prop.value.kind === 'spread') {
+        parts.push(`{...${prop.value.expr}}`)
+        continue
+      }
+      if (prop.name === 'key') {
         // JSX key → data-key only. Hono JSX strips `key` from HTML output
         // (delete props["key"]), so emitting key={} is a no-op. We only need
         // data-key which the BarefootJS client runtime uses for reconciliation.
-        keyValue = prop.value
-      } else if (prop.dynamic) {
-        // JSX expression container: <X onClick={() => 1} />, <X foo={false} />
-        parts.push(`${prop.name}={${prop.value}}`)
-      } else if (prop.isLiteral) {
-        // IR-authoritative string literal: <X fill="var(--c)" />. Emitting
-        // this verbatim is what distinguishes a CSS-shaped value (`var(...)`,
-        // `url(...)`, `calc(...)`) from a JS expression — both look alike
-        // after the IR collapses to `string + flags`, but `isLiteral` carries
-        // the parser's original answer.
-        parts.push(`${prop.name}="${prop.value}"`)
-      } else if (prop.value === 'true') {
-        // Boolean shorthand: <X disabled /> (no initializer → propValue 'true')
-        parts.push(prop.name)
-      } else {
-        // Unreachable from the JSX → IR pipeline: Phase 1 always emits one of
-        // (dynamic | isLiteral | boolean-shorthand) for every prop. Defensive
-        // string fallback for hand-built IRs from external producers.
-        parts.push(`${prop.name}="${prop.value}"`)
+        keyValue = this.attrValueToJsExpr(prop.value)
+        continue
+      }
+      switch (prop.value.kind) {
+        case 'expression':
+          parts.push(`${prop.name}={${prop.value.expr}}`)
+          break
+        case 'template':
+          parts.push(`${prop.name}={${this.renderTemplateLiteralParts(prop.value.parts)}}`)
+          break
+        case 'literal':
+          // IR-authoritative string literal: <X fill="var(--c)" />. Emitting
+          // this verbatim is what distinguishes a CSS-shaped value (`var(...)`,
+          // `url(...)`, `calc(...)`) from a JS expression.
+          parts.push(`${prop.name}="${prop.value.value}"`)
+          break
+        case 'boolean-shorthand':
+          // <X disabled /> → emit bare `disabled`
+          parts.push(prop.name)
+          break
+        case 'boolean-attr':
+          // Element-only variant; component props use boolean-shorthand. Defensive.
+          parts.push(prop.name)
+          break
       }
     }
 
@@ -897,9 +923,21 @@ export class HonoAdapter extends JsxAdapter {
     return parts.length > 0 ? ' ' + parts.join(' ') : ''
   }
 
-  private renderTemplateLiteral(literal: IRTemplateLiteral): string {
+  private attrValueToJsExpr(value: AttrValue): string {
+    switch (value.kind) {
+      case 'literal': return JSON.stringify(value.value)
+      case 'expression':
+      case 'spread': return value.expr
+      case 'template': return this.renderTemplateLiteralParts(value.parts)
+      case 'boolean-shorthand':
+      case 'boolean-attr': return 'true'
+      case 'jsx-children': return 'undefined'
+    }
+  }
+
+  private renderTemplateLiteralParts(parts: IRTemplatePart[]): string {
     let output = '`'
-    for (const part of literal.parts) {
+    for (const part of parts) {
       if (part.type === 'string') {
         output += part.value
       } else if (part.type === 'ternary') {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -18,7 +18,8 @@ import type {
   IRIfStatement,
   IRProvider,
   IRAsync,
-  IRTemplateLiteral,
+  IRTemplatePart,
+  AttrValue,
   CompilerError,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
@@ -384,12 +385,27 @@ export class MojoAdapter extends BaseAdapter {
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
     for (const p of comp.props) {
-      // Skip callback props (onXxx) — event handlers are client-only for SSR
-      if (p.name.match(/^on[A-Z]/) && p.dynamic) continue
-      if (p.dynamic) {
-        propParts.push(`${p.name} => ${this.convertExpressionToPerl(typeof p.value === 'string' ? p.value : '')}`)
-      } else {
-        propParts.push(`${p.name} => '${p.value}'`)
+      const v = p.value
+      // Skip callback props (onXxx) — event handlers are client-only for SSR.
+      if (p.name.match(/^on[A-Z]/) && v.kind === 'expression') continue
+      switch (v.kind) {
+        case 'literal':
+          propParts.push(`${p.name} => '${v.value}'`)
+          break
+        case 'expression':
+        case 'spread':
+          propParts.push(`${p.name} => ${this.convertExpressionToPerl(v.expr)}`)
+          break
+        case 'template':
+          propParts.push(`${p.name} => ${this.convertTemplateLiteralPartsToPerl(v.parts)}`)
+          break
+        case 'boolean-shorthand':
+        case 'boolean-attr':
+          propParts.push(`${p.name} => 1`)
+          break
+        case 'jsx-children':
+          // JSX children are handled via the captured render below.
+          break
       }
     }
     // Pass slot ID so the child renderer can set correct scope ID for hydration
@@ -486,26 +502,35 @@ export class MojoAdapter extends BaseAdapter {
 
     for (const attr of element.attrs) {
       const attrName = attr.name === 'className' ? 'class' : attr.name
+      const v = attr.value
 
-      if (attr.name === '...') {
-        // Spread attributes — skip for now
-        continue
-      } else if (attr.value === null) {
-        parts.push(attrName)
-      } else if (attr.dynamic) {
-        if (typeof attr.value !== 'string') {
-          // IRTemplateLiteral — convert to Perl string expression
-          const perlExpr = this.convertTemplateLiteralToPerl(attr.value as IRTemplateLiteral)
+      switch (v.kind) {
+        case 'spread':
+          // Spread attributes — skip for now
+          continue
+        case 'boolean-attr':
+          parts.push(attrName)
+          break
+        case 'literal':
+          parts.push(`${attrName}="${v.value}"`)
+          break
+        case 'template': {
+          const perlExpr = this.convertTemplateLiteralPartsToPerl(v.parts)
           parts.push(`${attrName}="<%= ${perlExpr} %>"`)
-        } else if (isBooleanAttr(attrName)) {
-          // Boolean attributes: render conditionally (present or absent)
-          parts.push(`<%= ${this.convertExpressionToPerl(attr.value)} ? '${attrName}' : '' %>`)
-        } else {
-          parts.push(`${attrName}="<%= ${this.convertExpressionToPerl(attr.value)} %>"`)
+          break
         }
-      } else {
-        parts.push(`${attrName}="${attr.value ?? ''}"`)
-
+        case 'expression':
+          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
+            // Boolean attributes: render conditionally (present or absent)
+            parts.push(`<%= ${this.convertExpressionToPerl(v.expr)} ? '${attrName}' : '' %>`)
+          } else {
+            parts.push(`${attrName}="<%= ${this.convertExpressionToPerl(v.expr)} %>"`)
+          }
+          break
+        case 'boolean-shorthand':
+        case 'jsx-children':
+          // Neither variant is legal on intrinsic elements. Skip silently.
+          break
       }
     }
 
@@ -722,9 +747,9 @@ export class MojoAdapter extends BaseAdapter {
   // Expression Conversion: JS → Perl
   // ===========================================================================
 
-  private convertTemplateLiteralToPerl(literal: IRTemplateLiteral): string {
+  private convertTemplateLiteralPartsToPerl(literalParts: IRTemplatePart[]): string {
     const parts: string[] = []
-    for (const part of literal.parts) {
+    for (const part of literalParts) {
       if (part.type === 'string') {
         parts.push(`'${part.value}'`)
       } else if (part.type === 'ternary') {

--- a/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
+++ b/packages/jsx/src/__tests__/css-layer-prefixer.test.ts
@@ -10,7 +10,7 @@ import {
   applyCssLayerPrefix,
   extractIdentifiers,
 } from '../css-layer-prefixer'
-import type { ComponentIR, IRElement, IRMetadata, IRTemplateLiteral, ConstantInfo } from '../types'
+import type { ComponentIR, IRElement, IRMetadata, IRTemplatePart, ConstantInfo, TemplateAttr, LiteralAttr } from '../types'
 
 describe('prefixClass', () => {
   test('prefixes a simple class', () => {
@@ -203,7 +203,7 @@ describe('applyCssLayerPrefix', () => {
         type: 'element',
         tag: 'div',
         attrs: [
-          { name: 'className', value: 'bg-primary text-white', dynamic: false, isLiteral: true, loc: makeLoc() },
+          { name: 'className', value: { kind: 'literal', value: 'bg-primary text-white' }, loc: makeLoc() },
         ],
         events: [],
         ref: null,
@@ -217,7 +217,7 @@ describe('applyCssLayerPrefix', () => {
     applyCssLayerPrefix(ir, 'components')
 
     const classAttr = ir.root.type === 'element' ? ir.root.attrs[0] : null
-    expect(classAttr?.value).toBe('layer-components:bg-primary layer-components:text-white')
+    expect((classAttr?.value as LiteralAttr).value).toBe('layer-components:bg-primary layer-components:text-white')
   })
 
   test('prefixes static class attribute (HTML name)', () => {
@@ -226,7 +226,7 @@ describe('applyCssLayerPrefix', () => {
         type: 'element',
         tag: 'div',
         attrs: [
-          { name: 'class', value: 'flex gap-2', dynamic: false, isLiteral: true, loc: makeLoc() },
+          { name: 'class', value: { kind: 'literal', value: 'flex gap-2' }, loc: makeLoc() },
         ],
         events: [],
         ref: null,
@@ -240,7 +240,7 @@ describe('applyCssLayerPrefix', () => {
     applyCssLayerPrefix(ir, 'components')
 
     const classAttr = ir.root.type === 'element' ? ir.root.attrs[0] : null
-    expect(classAttr?.value).toBe('layer-components:flex layer-components:gap-2')
+    expect((classAttr?.value as LiteralAttr).value).toBe('layer-components:flex layer-components:gap-2')
   })
 
   test('prefixes constants referenced from dynamic className', () => {
@@ -251,9 +251,7 @@ describe('applyCssLayerPrefix', () => {
         attrs: [
           {
             name: 'className',
-            value: '`${buttonClasses} ${props.class ?? \'\'}`',
-            dynamic: true,
-            isLiteral: false,
+            value: { kind: 'expression', expr: '`${buttonClasses} ${props.class ?? \'\'}`' },
             loc: makeLoc(),
           },
         ],
@@ -288,9 +286,7 @@ describe('applyCssLayerPrefix', () => {
         attrs: [
           {
             name: 'className',
-            value: "`${baseClasses} ${variantClasses[props.variant ?? 'default']} ${props.class ?? ''}`",
-            dynamic: true,
-            isLiteral: false,
+            value: { kind: 'expression', expr: "`${baseClasses} ${variantClasses[props.variant ?? 'default']} ${props.class ?? ''}`" },
             loc: makeLoc(),
           },
         ],
@@ -322,21 +318,18 @@ describe('applyCssLayerPrefix', () => {
     expect(variants?.value).toContain("'layer-components:bg-destructive layer-components:hover:bg-destructive/90'")
   })
 
-  test('prefixes IRTemplateLiteral ternary parts', () => {
-    const templateLiteral: IRTemplateLiteral = {
-      type: 'template-literal',
-      parts: [
-        { type: 'string', value: 'btn ' },
-        { type: 'ternary', condition: 'disabled()', whenTrue: 'btn-disabled opacity-50', whenFalse: 'btn-enabled' },
-      ],
-    }
+  test('prefixes `template` AttrValue ternary parts', () => {
+    const templateParts: IRTemplatePart[] = [
+      { type: 'string', value: 'btn ' },
+      { type: 'ternary', condition: 'disabled()', whenTrue: 'btn-disabled opacity-50', whenFalse: 'btn-enabled' },
+    ]
 
     const ir = makeIR({
       root: {
         type: 'element',
         tag: 'button',
         attrs: [
-          { name: 'className', value: templateLiteral, dynamic: true, isLiteral: false, loc: makeLoc() },
+          { name: 'className', value: { kind: 'template', parts: templateParts }, loc: makeLoc() },
         ],
         events: [],
         ref: null,
@@ -350,7 +343,7 @@ describe('applyCssLayerPrefix', () => {
     applyCssLayerPrefix(ir, 'components')
 
     const attr = (ir.root as IRElement).attrs[0]
-    const tl = attr.value as IRTemplateLiteral
+    const tl = attr.value as TemplateAttr
     expect(tl.parts[0]).toEqual({ type: 'string', value: 'layer-components:btn ' })
     expect(tl.parts[1]).toEqual({
       type: 'ternary',
@@ -366,9 +359,9 @@ describe('applyCssLayerPrefix', () => {
         type: 'element',
         tag: 'div',
         attrs: [
-          { name: 'id', value: 'main-content', dynamic: false, isLiteral: true, loc: makeLoc() },
-          { name: 'data-state', value: 'open', dynamic: false, isLiteral: true, loc: makeLoc() },
-          { name: 'className', value: 'flex', dynamic: false, isLiteral: true, loc: makeLoc() },
+          { name: 'id', value: { kind: 'literal', value: 'main-content' }, loc: makeLoc() },
+          { name: 'data-state', value: { kind: 'literal', value: 'open' }, loc: makeLoc() },
+          { name: 'className', value: { kind: 'literal', value: 'flex' }, loc: makeLoc() },
         ],
         events: [],
         ref: null,
@@ -382,9 +375,9 @@ describe('applyCssLayerPrefix', () => {
     applyCssLayerPrefix(ir, 'components')
 
     const root = ir.root as IRElement
-    expect(root.attrs[0].value).toBe('main-content')
-    expect(root.attrs[1].value).toBe('open')
-    expect(root.attrs[2].value).toBe('layer-components:flex')
+    expect((root.attrs[0].value as LiteralAttr).value).toBe('main-content')
+    expect((root.attrs[1].value as LiteralAttr).value).toBe('open')
+    expect((root.attrs[2].value as LiteralAttr).value).toBe('layer-components:flex')
   })
 
   test('handles nested elements', () => {
@@ -393,7 +386,7 @@ describe('applyCssLayerPrefix', () => {
         type: 'element',
         tag: 'div',
         attrs: [
-          { name: 'className', value: 'container', dynamic: false, isLiteral: true, loc: makeLoc() },
+          { name: 'className', value: { kind: 'literal', value: 'container' }, loc: makeLoc() },
         ],
         events: [],
         ref: null,
@@ -402,7 +395,7 @@ describe('applyCssLayerPrefix', () => {
             type: 'element',
             tag: 'span',
             attrs: [
-              { name: 'className', value: 'text-sm', dynamic: false, isLiteral: true, loc: makeLoc() },
+              { name: 'className', value: { kind: 'literal', value: 'text-sm' }, loc: makeLoc() },
             ],
             events: [],
             ref: null,
@@ -421,9 +414,9 @@ describe('applyCssLayerPrefix', () => {
     applyCssLayerPrefix(ir, 'components')
 
     const root = ir.root as IRElement
-    expect(root.attrs[0].value).toBe('layer-components:container')
+    expect((root.attrs[0].value as LiteralAttr).value).toBe('layer-components:container')
     const child = root.children[0] as IRElement
-    expect(child.attrs[0].value).toBe('layer-components:text-sm')
+    expect((child.attrs[0].value as LiteralAttr).value).toBe('layer-components:text-sm')
   })
 
   test('resolves transitive constant references', () => {
@@ -434,9 +427,7 @@ describe('applyCssLayerPrefix', () => {
         attrs: [
           {
             name: 'className',
-            value: 'fullClasses',
-            dynamic: true,
-            isLiteral: false,
+            value: { kind: 'expression', expr: 'fullClasses' },
             loc: makeLoc(),
           },
         ],

--- a/packages/jsx/src/__tests__/ir-const-resolution.test.ts
+++ b/packages/jsx/src/__tests__/ir-const-resolution.test.ts
@@ -11,7 +11,7 @@
 import { describe, test, expect } from 'bun:test'
 import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
-import type { IRNode, IRElement, IRTemplateLiteral } from '../types'
+import type { IRNode, IRElement, AttrValue, TemplateAttr } from '../types'
 
 const adapter = new TestAdapter()
 
@@ -22,11 +22,11 @@ function compileToIR(source: string) {
   return JSON.parse(ir.content)
 }
 
-function findClassNameValue(node: IRNode): IRTemplateLiteral | string | null {
+function findClassNameValue(node: IRNode): AttrValue | null {
   if (node.type === 'element') {
     const el = node as IRElement
     for (const attr of el.attrs) {
-      if (attr.name === 'className') return attr.value as IRTemplateLiteral | string | null
+      if (attr.name === 'className') return attr.value
     }
     for (const child of el.children) {
       const v = findClassNameValue(child)
@@ -76,8 +76,8 @@ export function Demo() {
   return <span className={classes}>x</span>
 }
 `)
-    const v = findClassNameValue(ir.root) as IRTemplateLiteral
-    expect(v.type).toBe('template-literal')
+    const v = findClassNameValue(ir.root) as TemplateAttr
+    expect(v.kind).toBe('template')
     // The first non-empty static part should carry the resolved baseClasses.
     const concat = v.parts.map(p => (p.type === 'string' ? p.value : '')).join('')
     expect(concat).toContain('inline-flex items-center')
@@ -96,8 +96,8 @@ export function Tag(props: { variant?: 'default' | 'secondary' }) {
   return <span className={classes}>x</span>
 }
 `)
-    const v = findClassNameValue(ir.root) as IRTemplateLiteral
-    expect(v.type).toBe('template-literal')
+    const v = findClassNameValue(ir.root) as TemplateAttr
+    expect(v.kind).toBe('template')
     const lookup = v.parts.find(p => p.type === 'lookup') as Extract<typeof v.parts[number], { type: 'lookup' }>
     expect(lookup).toBeDefined()
     expect(lookup.cases).toEqual({ default: 'bg-primary', secondary: 'bg-secondary' })
@@ -114,8 +114,8 @@ export function Demo() {
   return <span className={classes}>x</span>
 }
 `)
-    const v = findClassNameValue(ir.root) as IRTemplateLiteral
-    expect(v.type).toBe('template-literal')
+    const v = findClassNameValue(ir.root) as TemplateAttr
+    expect(v.kind).toBe('template')
     expect(v.parts).toEqual([{ type: 'string', value: 'function-scope' }])
     // Negative assertion: the module-level binding must NOT win.
     const concat = v.parts.map(p => (p.type === 'string' ? p.value : '')).join('')
@@ -140,7 +140,7 @@ export function Tag(props: { variant?: 'default' | 'secondary' }) {
 `)
     const v = findClassNameValue(ir.root)
     // Falls back to the raw identifier reference when un-lowerable.
-    if (typeof v === 'object' && v !== null && v.type === 'template-literal') {
+    if (v && v.kind === 'template') {
       const hasLookup = v.parts.some(p => p.type === 'lookup')
       expect(hasLookup).toBe(false)
     }

--- a/packages/jsx/src/__tests__/ir-jsx-props.test.ts
+++ b/packages/jsx/src/__tests__/ir-jsx-props.test.ts
@@ -28,7 +28,7 @@ function findComponent(node: any, name?: string): IRComponent | undefined {
 
 describe('JSX props (#559)', () => {
   describe('Phase 1: JSX → IR', () => {
-    test('JSX element prop produces jsxChildren in IR', () => {
+    test('JSX element prop produces jsx-children AttrValue', () => {
       const source = `
         'use client'
         import { createSignal } from '@barefootjs/client'
@@ -49,13 +49,14 @@ describe('JSX props (#559)', () => {
 
       const controlsProp = layout!.props.find(p => p.name === 'controls')
       expect(controlsProp).toBeDefined()
-      expect(controlsProp!.jsxChildren).toBeDefined()
-      expect(controlsProp!.jsxChildren).toHaveLength(1)
-      expect(controlsProp!.jsxChildren![0].type).toBe('element')
-      expect((controlsProp!.jsxChildren![0] as IRElement).tag).toBe('input')
+      expect(controlsProp!.value.kind).toBe('jsx-children')
+      const v = controlsProp!.value as Extract<typeof controlsProp.value, { kind: 'jsx-children' }>
+      expect(v.children).toHaveLength(1)
+      expect(v.children[0].type).toBe('element')
+      expect((v.children[0] as IRElement).tag).toBe('input')
     })
 
-    test('parenthesized JSX prop produces jsxChildren', () => {
+    test('parenthesized JSX prop produces jsx-children AttrValue', () => {
       const source = `
         'use client'
         import { createSignal } from '@barefootjs/client'
@@ -72,10 +73,11 @@ describe('JSX props (#559)', () => {
 
       const layout = findComponent(ir!, 'Layout')
       const controlsProp = layout!.props.find(p => p.name === 'controls')
-      expect(controlsProp!.jsxChildren).toBeDefined()
-      expect(controlsProp!.jsxChildren).toHaveLength(1)
-      expect(controlsProp!.jsxChildren![0].type).toBe('element')
-      expect((controlsProp!.jsxChildren![0] as IRElement).tag).toBe('div')
+      expect(controlsProp!.value.kind).toBe('jsx-children')
+      const v = controlsProp!.value as Extract<typeof controlsProp.value, { kind: 'jsx-children' }>
+      expect(v.children).toHaveLength(1)
+      expect(v.children[0].type).toBe('element')
+      expect((v.children[0] as IRElement).tag).toBe('div')
     })
 
     test('elements inside JSX props get ^-prefixed slot IDs', () => {
@@ -97,7 +99,8 @@ describe('JSX props (#559)', () => {
 
       const layout = findComponent(ir!, 'Layout')
       const controlsProp = layout!.props.find(p => p.name === 'controls')
-      const button = controlsProp!.jsxChildren![0] as IRElement
+      const v = controlsProp!.value as Extract<typeof controlsProp.value, { kind: 'jsx-children' }>
+      const button = v.children[0] as IRElement
       expect(button.tag).toBe('button')
       // Elements in JSX props are parent-owned, so get ^ prefix
       expect(button.slotId).toMatch(/^\^s\d+$/)
@@ -128,15 +131,14 @@ describe('JSX props (#559)', () => {
       expect(layout!.props).toHaveLength(3)
 
       const titleProp = layout!.props.find(p => p.name === 'title')
-      expect(titleProp!.jsxChildren).toBeUndefined()
-      expect(titleProp!.value).toBe('Hello')
+      expect(titleProp!.value).toEqual({ kind: 'literal', value: 'Hello' })
 
       const controlsProp = layout!.props.find(p => p.name === 'controls')
-      expect(controlsProp!.jsxChildren).toBeDefined()
+      expect(controlsProp!.value.kind).toBe('jsx-children')
 
       const countProp = layout!.props.find(p => p.name === 'count')
-      expect(countProp!.jsxChildren).toBeUndefined()
-      expect(countProp!.value).toBe('42')
+      expect(countProp!.value.kind).toBe('expression')
+      expect((countProp!.value as Extract<typeof countProp.value, { kind: 'expression' }>).expr).toBe('42')
     })
   })
 

--- a/packages/jsx/src/__tests__/ir-provider.test.ts
+++ b/packages/jsx/src/__tests__/ir-provider.test.ts
@@ -41,8 +41,7 @@ describe('Context.Provider JSX', () => {
       contextName: 'MenuContext',
       valueProp: {
         name: 'value',
-        value: '{ open, setOpen }',
-        dynamic: true,
+        value: { kind: 'expression', expr: '{ open, setOpen }' },
       },
       children: [
         {
@@ -82,10 +81,10 @@ describe('Context.Provider JSX', () => {
     expect(ir).toMatchObject({
       type: 'provider',
       contextName: 'Ctx',
-      valueProp: { name: 'value', value: '{ active, setActive }' },
+      valueProp: { name: 'value', value: { kind: 'expression', expr: '{ active, setActive }' } },
       children: [
-        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: 'tabs-header' }] },
-        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: 'tabs-body' }] },
+        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: { kind: 'literal', value: 'tabs-header' } }] },
+        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: { kind: 'literal', value: 'tabs-body' } }] },
       ],
     })
   })
@@ -159,7 +158,7 @@ describe('Context.Provider JSX', () => {
       type: 'element',
       tag: 'div',
       needsScope: true,
-      attrs: [{ name: 'style', value: 'display:contents' }],
+      attrs: [{ name: 'style', value: { kind: 'literal', value: 'display:contents' } }],
       children: [
         {
           type: 'provider',
@@ -319,8 +318,7 @@ describe('Context.Provider JSX', () => {
       contextName: 'Ctx',
       valueProp: {
         name: 'value',
-        value: '{ val, setVal }',
-        dynamic: true,
+        value: { kind: 'expression', expr: '{ val, setVal }' },
       },
       children: [],
     })

--- a/packages/jsx/src/__tests__/ir-walker.test.ts
+++ b/packages/jsx/src/__tests__/ir-walker.test.ts
@@ -143,9 +143,7 @@ describe('walkIR', () => {
       props: [
         {
           name: 'header',
-          value: '',
-          dynamic: false,
-          jsxChildren: [expr('in-jsx-prop')],
+          value: { kind: 'jsx-children', children: [expr('in-jsx-prop')] },
         } as any,
       ],
       propsType: null,

--- a/packages/jsx/src/__tests__/jsx-to-ir.test.ts
+++ b/packages/jsx/src/__tests__/jsx-to-ir.test.ts
@@ -105,8 +105,10 @@ describe('jsxToIR', () => {
         // The 'd' attribute should be marked as dynamic
         const dAttr = pathElement.attrs.find(a => a.name === 'd')
         expect(dAttr).toBeDefined()
-        expect(dAttr?.value).toBe("paths['icon']")
-        expect(dAttr?.dynamic).toBe(true)
+        expect(dAttr?.value.kind).toBe('expression')
+        if (dAttr?.value.kind === 'expression') {
+          expect(dAttr.value.expr).toBe("paths['icon']")
+        }
       }
     }
   })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -258,14 +258,26 @@ export class TestAdapter extends JsxAdapter {
     for (const attr of element.attrs) {
       const attrName = attr.name === 'class' ? 'className' : attr.name
 
-      if (attr.name === '...') {
-        parts.push(`{...${attr.value}}`)
-      } else if (attr.value === null) {
-        parts.push(attrName)
-      } else if (attr.dynamic) {
-        parts.push(`${attrName}={${attr.value}}`)
-      } else {
-        parts.push(`${attrName}="${attr.value}"`)
+      switch (attr.value.kind) {
+        case 'spread':
+          parts.push(`{...${attr.value.expr}}`)
+          break
+        case 'boolean-attr':
+          parts.push(attrName)
+          break
+        case 'expression':
+          parts.push(`${attrName}={${attr.value.expr}}`)
+          break
+        case 'template':
+          parts.push(`${attrName}={${this.flattenTemplate(attr.value)}}`)
+          break
+        case 'literal':
+          parts.push(`${attrName}="${attr.value.value}"`)
+          break
+        case 'boolean-shorthand':
+        case 'jsx-children':
+          // Not legal on intrinsic elements; emit nothing.
+          break
       }
     }
 
@@ -277,25 +289,46 @@ export class TestAdapter extends JsxAdapter {
     return parts.length > 0 ? ' ' + parts.join(' ') : ''
   }
 
+  private flattenTemplate(value: { kind: string }): string {
+    // Simple stringifier for `template`-kind values; tests only need a
+    // recognisable JSX shape, not byte-exact reproduction.
+    const v = value as { kind: 'template'; parts: import('../types').IRTemplatePart[] }
+    return '`' + v.parts.map(p => {
+      if (p.type === 'string') return p.value
+      if (p.type === 'ternary') return `\${${p.condition} ? '${p.whenTrue}' : '${p.whenFalse}'}`
+      return `\${(${JSON.stringify(p.cases)})[${p.key}]}`
+    }).join('') + '`'
+  }
+
   private renderComponentProps(comp: IRComponent): string {
     const parts: string[] = []
 
     for (const prop of comp.props) {
-      if (prop.jsxChildren?.length) {
-        const rendered = prop.jsxChildren.map(c => this.renderNode(c)).join('')
-        parts.push(`${prop.name}={<>${rendered}</>}`)
-        continue
-      }
-      if (prop.name === '...') {
-        parts.push(`{...${prop.value}}`)
-      } else if (prop.dynamic) {
-        parts.push(`${prop.name}={${prop.value}}`)
-      } else if (prop.value === 'true') {
-        parts.push(prop.name)
-      } else if (prop.value === 'false') {
-        parts.push(`${prop.name}={false}`)
-      } else {
-        parts.push(`${prop.name}="${prop.value}"`)
+      switch (prop.value.kind) {
+        case 'jsx-children': {
+          const rendered = prop.value.children.map(c => this.renderNode(c)).join('')
+          parts.push(`${prop.name}={<>${rendered}</>}`)
+          break
+        }
+        case 'spread':
+          parts.push(`{...${prop.value.expr}}`)
+          break
+        case 'expression':
+          parts.push(`${prop.name}={${prop.value.expr}}`)
+          break
+        case 'template':
+          parts.push(`${prop.name}={${this.flattenTemplate(prop.value)}}`)
+          break
+        case 'boolean-shorthand':
+          parts.push(prop.name)
+          break
+        case 'literal':
+          parts.push(`${prop.name}="${prop.value.value}"`)
+          break
+        case 'boolean-attr':
+          // Element-only variant; component props use boolean-shorthand.
+          parts.push(prop.name)
+          break
       }
     }
 

--- a/packages/jsx/src/css-layer-prefixer.ts
+++ b/packages/jsx/src/css-layer-prefixer.ts
@@ -5,7 +5,7 @@
  * for CSS cascade ordering. Un-layered user classes always beat layered component classes.
  */
 
-import type { ComponentIR, IRNode, IRTemplateLiteral } from './types'
+import type { ComponentIR, IRNode, IRTemplatePart } from './types'
 
 /**
  * Prefix a single CSS class token with a layer variant.
@@ -89,29 +89,31 @@ export function applyCssLayerPrefix(ir: ComponentIR, layerName: string): void {
 
     for (const attr of node.attrs) {
       if (attr.name !== 'class' && attr.name !== 'className') continue
-      if (attr.value === null) continue
 
-      // Static className: prefix value directly
-      if (typeof attr.value === 'string' && attr.isLiteral) {
-        attr.value = prefixClassString(attr.value, layerName)
-        continue
-      }
-
-      // IRTemplateLiteral: prefix ternary branches and static string parts
-      if (typeof attr.value === 'object' && attr.value.type === 'template-literal') {
-        prefixIRTemplateLiteral(attr.value, layerName)
-        // Extract constant references from ${expr} in string parts
-        for (const part of attr.value.parts) {
-          if (part.type === 'string' && part.value.includes('${')) {
-            collectConstantRefs(part.value, referencedConstants, constantNames)
+      switch (attr.value.kind) {
+        case 'literal':
+          attr.value.value = prefixClassString(attr.value.value, layerName)
+          break
+        case 'template': {
+          prefixIRTemplateParts(attr.value.parts, layerName)
+          // Extract constant references from ${expr} in string parts
+          for (const part of attr.value.parts) {
+            if (part.type === 'string' && part.value.includes('${')) {
+              collectConstantRefs(part.value, referencedConstants, constantNames)
+            }
           }
+          break
         }
-        continue
-      }
-
-      // Dynamic expression: extract referenced constants
-      if (typeof attr.value === 'string' && !attr.isLiteral) {
-        collectConstantRefs(attr.value, referencedConstants, constantNames)
+        case 'expression':
+          collectConstantRefs(attr.value.expr, referencedConstants, constantNames)
+          break
+        case 'spread':
+          collectConstantRefs(attr.value.expr, referencedConstants, constantNames)
+          break
+        case 'boolean-attr':
+        case 'boolean-shorthand':
+        case 'jsx-children':
+          break
       }
     }
   })
@@ -145,10 +147,11 @@ export function applyCssLayerPrefix(ir: ComponentIR, layerName: string): void {
 // =============================================================================
 
 /**
- * Prefix ternary parts and pure static text in an IRTemplateLiteral.
+ * Prefix ternary parts and pure static text in a structured `template`
+ * AttrValue's parts.
  */
-function prefixIRTemplateLiteral(tl: IRTemplateLiteral, layerName: string): void {
-  for (const part of tl.parts) {
+function prefixIRTemplateParts(parts: IRTemplatePart[], layerName: string): void {
+  for (const part of parts) {
     if (part.type === 'ternary') {
       part.whenTrue = prefixClassString(part.whenTrue, layerName)
       part.whenFalse = prefixClassString(part.whenFalse, layerName)

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -12,7 +12,7 @@ import type {
   IRConditional,
   IRElement,
   IRLoop,
-  IRTemplateLiteral,
+  AttrValue,
   SignalInfo,
   MemoInfo,
   EffectInfo,
@@ -578,7 +578,7 @@ function collectDomBindings(
       // both recognise known signal / memo / prop names, so a non-empty
       // deps list is the statically-proven-reactive case.
       for (const attr of node.attrs) {
-        if (!attr.dynamic) continue
+        if (attr.value.kind !== 'expression' && attr.value.kind !== 'template' && attr.value.kind !== 'spread') continue
         const expr = attrValueToString(attr.value)
         if (!expr) continue
         const deps = extractReactiveDeps(expr, signalGetters, memoNames)
@@ -712,9 +712,11 @@ function collectDomBindings(
       // type union stable for consumers).
       for (const prop of node.props) {
         if (prop.name === '...' || prop.name.startsWith('...')) continue
-        if (!prop.dynamic) continue
-        if (prop.jsxChildren) continue // JSX-as-prop handled via child traversal
-        const propValue = typeof prop.value === 'string' ? prop.value : ''
+        // Only `expression` / `template` / `spread` carry a runtime expression
+        // worth probing for reactive deps. `jsx-children` is handled via child
+        // traversal below; literal / boolean produce no reactive bindings.
+        if (prop.value.kind !== 'expression' && prop.value.kind !== 'template' && prop.value.kind !== 'spread') continue
+        const propValue = attrValueToString(prop.value) ?? ''
         if (!propValue) continue
         const deps = extractReactiveDeps(propValue, signalGetters, memoNames)
         const hasPropsRef = propValue.includes('props.')
@@ -755,14 +757,24 @@ function collectDomBindings(
   }
 }
 
-/** Convert an IRAttribute value to a flat string for reactive dep extraction. */
-function attrValueToString(value: string | IRTemplateLiteral | null): string | null {
-  if (value === null) return null
-  if (typeof value === 'string') return value
-  // IRTemplateLiteral: join all ternary expressions
-  return value.parts
-    .map(p => p.type === 'ternary' ? `${p.condition} ${p.whenTrue} ${p.whenFalse}` : '')
-    .join(' ')
+/** Convert an `AttrValue` to a flat string for reactive dep extraction. */
+function attrValueToString(value: AttrValue): string | null {
+  switch (value.kind) {
+    case 'literal':
+      return value.value
+    case 'expression':
+      return value.expr
+    case 'spread':
+      return value.expr
+    case 'template':
+      return value.parts
+        .map(p => p.type === 'ternary' ? `${p.condition} ${p.whenTrue} ${p.whenFalse}` : '')
+        .join(' ')
+    case 'boolean-attr':
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      return null
+  }
 }
 
 /** Extract reactive getter names (signal/memo calls) from an expression. */

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -25,7 +25,14 @@ export type {
   IRProvider,
   IRAsync,
   IRMetadata,
-  IRTemplateLiteral,
+  AttrValue,
+  LiteralAttr,
+  ExpressionAttr,
+  BooleanAttr,
+  BooleanShorthandAttr,
+  TemplateAttr,
+  SpreadAttr,
+  JsxChildrenAttr,
   IRTemplatePart,
   IRProp,
   ParamInfo,
@@ -191,6 +198,9 @@ export interface BuildOptions {
    */
   bundleEntries?: BundleEntry[]
 }
+
+// AttrValue constructors
+export { AttrValueOf } from './types'
 
 // CSS Layer Prefixer
 export { applyCssLayerPrefix } from './css-layer-prefixer'

--- a/packages/jsx/src/ir-to-client-js/build-references.ts
+++ b/packages/jsx/src/ir-to-client-js/build-references.ts
@@ -137,13 +137,15 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
     }
     if (elem.childComponent) {
       for (const prop of elem.childComponent.props) {
-        addExprEdges(ROOT_SOURCE, prop.value, 'template-closure')
+        const v = attrValueToString(prop.value)
+        if (v) addExprEdges(ROOT_SOURCE, v, 'template-closure')
       }
     }
     if (elem.nestedComponents) {
       for (const comp of elem.nestedComponents) {
         for (const prop of comp.props) {
-          addExprEdges(ROOT_SOURCE, prop.value, 'template-closure')
+          const v = attrValueToString(prop.value)
+          if (v) addExprEdges(ROOT_SOURCE, v, 'template-closure')
         }
       }
     }
@@ -263,10 +265,11 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
         // `clientOnly` carve-out below so usage-aware diagnostics
         // (BF060/BF061) don't false-positive against them.
         if (attr.clientOnly) continue
-        if (attr.dynamic && attr.value) {
-          const v = typeof attr.value === 'string' ? attr.value : attrValueToString(attr.value)
-          if (v) addExprEdges(ROOT_SOURCE, v, 'template-closure')
-        }
+        // Only `expression` / `template` / `spread` variants carry a runtime
+        // expression worth tracing; literals and boolean attrs reference no
+        // identifiers. `attrValueToString` returns null for the latter.
+        const v = attrValueToString(attr.value)
+        if (v && attr.value.kind !== 'literal') addExprEdges(ROOT_SOURCE, v, 'template-closure')
       }
       for (const ev of el.events) addExprEdges(ROOT_SOURCE, ev.handler, 'init-body')
       descend()
@@ -278,7 +281,8 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
         // init scope, not template scope, so no template-closure
         // edge.
         if (prop.clientOnly) continue
-        if (prop.dynamic) addExprEdges(ROOT_SOURCE, prop.value, 'template-closure')
+        const v = attrValueToString(prop.value)
+        if (v && prop.value.kind !== 'literal') addExprEdges(ROOT_SOURCE, v, 'template-closure')
       }
       descend()
       descendJsxChildren()
@@ -316,14 +320,16 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
     },
     provider: ({ node: p, descend }) => {
       addExprEdges(ROOT_SOURCE, p.contextName, 'init-body')
-      if (p.valueProp.dynamic) addExprEdges(ROOT_SOURCE, p.valueProp.value, 'template-closure')
+      const v = attrValueToString(p.valueProp.value)
+      if (v && p.valueProp.value.kind !== 'literal') addExprEdges(ROOT_SOURCE, v, 'template-closure')
       descend()
     },
   }
 
   const walkChildComponent = (comp: IRLoopChildComponent): void => {
     for (const prop of comp.props) {
-      addExprEdges(ROOT_SOURCE, prop.value, 'template-closure')
+      const v = attrValueToString(prop.value)
+      if (v) addExprEdges(ROOT_SOURCE, v, 'template-closure')
     }
     for (const child of comp.children) walkIR(child, null, visitor)
   }

--- a/packages/jsx/src/ir-to-client-js/child-components.ts
+++ b/packages/jsx/src/ir-to-client-js/child-components.ts
@@ -56,8 +56,8 @@ export function collectComponentNamesFromIR(nodes: IRNode[], names: Set<string>)
       collectComponentNamesFromIR(node.children, names)
       // Traverse JSX prop children for nested component references
       for (const prop of node.props) {
-        if (prop.jsxChildren) {
-          collectComponentNamesFromIR(prop.jsxChildren, names)
+        if (prop.value.kind === 'jsx-children') {
+          collectComponentNamesFromIR(prop.value.children, names)
         }
       }
     } else if (node.type === 'element' || node.type === 'fragment' || node.type === 'provider') {

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -2,7 +2,7 @@
  * IR tree traversal → collect elements into ClientJsContext.
  */
 
-import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMeta } from '../types'
+import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMetaFromIR } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
 import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils'
 import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
@@ -199,8 +199,6 @@ export function collectInnerLoops(
               props: c.props.map(p => ({
                 name: p.name,
                 value: p.value,
-                dynamic: p.dynamic ?? false,
-                isLiteral: p.isLiteral ?? false,
                 isEventHandler: p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase(),
               })),
               children: c.children,
@@ -311,10 +309,12 @@ function buildRestSpreadNames(ctx: ClientJsContext): Set<string> {
 function buildComponentPropsExpr(props: IRProp[], ctx: ClientJsContext): string {
   const restName = ctx.restPropsName
   const propsObjName = ctx.propsObjectName
-  const knownSpreadProp = props.find(p =>
-    (p.name === '...' || p.name.startsWith('...')) &&
-    (p.value === restName || p.value === propsObjName)
-  )
+  const knownSpreadProp = props.find(p => {
+    if (p.name !== '...' && !p.name.startsWith('...')) return false
+    if (p.value.kind !== 'spread' && p.value.kind !== 'expression') return false
+    const expr = p.value.kind === 'spread' ? p.value.expr : p.value.expr
+    return expr === restName || expr === propsObjName
+  })
   const spreadSource = knownSpreadProp ? PROPS_PARAM : null
 
   const propsForInit: string[] = []
@@ -327,21 +327,39 @@ function buildComponentPropsExpr(props: IRProp[], ctx: ClientJsContext): string 
       prop.name.length > 2 &&
       prop.name[2] === prop.name[2].toUpperCase()
     if (isEventHandler) {
-      propsForInit.push(`${quotePropName(prop.name)}: ${prop.value}`)
-    } else if (prop.jsxChildren) {
-      const jsxExpr = irChildrenToJsExpr(prop.jsxChildren)
-      if (jsxChildrenContainComponent(prop.jsxChildren)) {
-        propsForInit.push(`get ${quotePropName(prop.name)}() { return __slot(() => ${jsxExpr}) }`)
-      } else {
-        propsForInit.push(`get ${quotePropName(prop.name)}() { return ${jsxExpr} }`)
+      // Event handlers reach here only as `expression` variants.
+      propsForInit.push(`${quotePropName(prop.name)}: ${attrValueToString(prop.value) ?? prop.name}`)
+      continue
+    }
+    switch (prop.value.kind) {
+      case 'jsx-children': {
+        const jsxExpr = irChildrenToJsExpr(prop.value.children)
+        if (jsxChildrenContainComponent(prop.value.children)) {
+          propsForInit.push(`get ${quotePropName(prop.name)}() { return __slot(() => ${jsxExpr}) }`)
+        } else {
+          propsForInit.push(`get ${quotePropName(prop.name)}() { return ${jsxExpr} }`)
+        }
+        break
       }
-    } else if (prop.dynamic) {
-      const expandedValue = expandDynamicPropValue(prop.value, ctx)
-      propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
-    } else if (prop.isLiteral) {
-      propsForInit.push(`${quotePropName(prop.name)}: ${JSON.stringify(prop.value)}`)
-    } else {
-      propsForInit.push(`${quotePropName(prop.name)}: ${prop.value}`)
+      case 'expression':
+      case 'template':
+      case 'spread': {
+        const valueExpr = attrValueToString(prop.value)!
+        const expandedValue = expandDynamicPropValue(valueExpr, ctx)
+        propsForInit.push(`get ${quotePropName(prop.name)}() { return ${expandedValue} }`)
+        break
+      }
+      case 'literal':
+        propsForInit.push(`${quotePropName(prop.name)}: ${JSON.stringify(prop.value.value)}`)
+        break
+      case 'boolean-shorthand':
+        propsForInit.push(`${quotePropName(prop.name)}: true`)
+        break
+      case 'boolean-attr':
+        // Should not reach here for component props (processComponentProps
+        // promotes to boolean-shorthand), but handle defensively.
+        propsForInit.push(`${quotePropName(prop.name)}: true`)
+        break
     }
   }
 
@@ -361,14 +379,16 @@ function buildComponentPropsExpr(props: IRProp[], ctx: ClientJsContext): string 
 function collectReactiveChildProps(node: IRComponent, ctx: ClientJsContext): void {
   for (const prop of node.props) {
     if (prop.name === '...' || prop.name.startsWith('...')) continue
-    if (prop.jsxChildren) continue
+    if (prop.value.kind === 'jsx-children') continue
     const isEventHandler =
       prop.name.startsWith('on') &&
       prop.name.length > 2 &&
       prop.name[2] === prop.name[2].toUpperCase()
     if (isEventHandler) continue
-    if (!prop.dynamic) continue
-    const expandedValue = expandDynamicPropValue(prop.value, ctx)
+    // Only `expression` / `template` variants drive reactive prop forwarding.
+    if (prop.value.kind !== 'expression' && prop.value.kind !== 'template') continue
+    const valueExpr = attrValueToString(prop.value)!
+    const expandedValue = expandDynamicPropValue(valueExpr, ctx)
     if (!decideWrapForChildProp(expandedValue, ctx, prop).wrap) continue
     const attrName = prop.name === 'className' ? 'class' : prop.name
     ctx.reactiveChildProps.push({
@@ -377,7 +397,7 @@ function collectReactiveChildProps(node: IRComponent, ctx: ClientJsContext): voi
       propName: prop.name,
       attrName,
       expression: expandedValue,
-      ...pickAttrMeta(prop),
+      ...pickAttrMetaFromIR(prop),
     })
   }
 }
@@ -485,7 +505,10 @@ export function collectElements(
 
       if (l.childComponent) {
         for (const prop of l.childComponent.props) {
-          if (prop.isEventHandler) childHandlers.push(prop.value)
+          if (prop.isEventHandler) {
+            const handler = attrValueToString(prop.value)
+            if (handler) childHandlers.push(handler)
+          }
         }
       }
 
@@ -585,9 +608,13 @@ export function collectElements(
       if (c.slotId) {
         // Reactive props need effects to update the element when values change.
         for (const prop of c.props) {
-          if (prop.jsxChildren) continue
+          if (prop.value.kind === 'jsx-children') continue
           if (prop.name.startsWith('on') && prop.name.length > 2) continue
-          const value = prop.value
+          // Only `expression` variants reach the signal/memo getter heuristic
+          // — literal / template / spread / boolean forms don't have a single
+          // bare-identifier shape to lookup.
+          if (prop.value.kind !== 'expression') continue
+          const value = prop.value.expr
           if (value.endsWith('()')) {
             const fnName = value.slice(0, -2)
             const isMemo = ctx.memos.some((m) => m.name === fnName)
@@ -620,7 +647,7 @@ export function collectElements(
     provider: ({ node: p, descend }) => {
       ctx.providerSetups.push({
         contextName: p.contextName,
-        valueExpr: p.valueProp.value,
+        valueExpr: attrValueToString(p.valueProp.value) ?? '',
       })
       descend()
     },
@@ -676,7 +703,10 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
         continue
       }
 
-      if (attr.dynamic && attr.value) {
+      // Literal / boolean variants need no reactive binding — they're
+      // already in the SSR DOM and never change. Only `expression` /
+      // `template` / `spread` reach the wrap decision.
+      if (attr.value.kind === 'expression' || attr.value.kind === 'template' || attr.value.kind === 'spread') {
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
 
@@ -719,7 +749,7 @@ function collectFromElement(element: IRElement, ctx: ClientJsContext, insideCond
             slotId: element.slotId,
             attrName: attr.name,
             expression: expandedValueStr,
-            ...pickAttrMeta(attr),
+            ...pickAttrMetaFromIR(attr),
             ...(expandedResult.freeIds !== undefined && { freeIdentifiers: expandedResult.freeIds }),
           })
         }
@@ -748,7 +778,9 @@ function collectBranchReactiveAttrs(node: IRNode, ctx: ClientJsContext): Conditi
         return
       }
       for (const attr of el.attrs) {
-        if (attr.name === '...' || !attr.dynamic || !attr.value) continue
+        if (attr.name === '...') continue
+        // Only `expression` / `template` / `spread` carry a reactive expression.
+        if (attr.value.kind !== 'expression' && attr.value.kind !== 'template' && attr.value.kind !== 'spread') continue
         const valueStr = attrValueToString(attr.value)
         if (!valueStr) continue
         const expanded = expandConstantForReactivity(valueStr, ctx, attr.freeIdentifiers)
@@ -763,7 +795,7 @@ function collectBranchReactiveAttrs(node: IRNode, ctx: ClientJsContext): Conditi
           slotId: el.slotId,
           attrName: attr.name,
           expression: expanded.expr,
-          ...pickAttrMeta(attr),
+          ...pickAttrMetaFromIR(attr),
           ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
         })
       }

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -309,10 +309,10 @@ function collectTemplateRiskyNames(irRoot: IRNode): Set<string> {
         // so their identifiers never reach a risky template
         // position. Same carve-out the build-references walker uses.
         if (attr.clientOnly) continue
-        if (!attr.dynamic || !attr.value) continue
-        const text = typeof attr.value === 'string'
-          ? (attr.templateValue ?? attr.value)
-          : (attrValueToString(attr.value, { useTemplate: true }) ?? '')
+        // Literal / boolean / jsx-children variants carry no template-time
+        // identifiers worth probing.
+        if (attr.value.kind !== 'expression' && attr.value.kind !== 'template' && attr.value.kind !== 'spread') continue
+        const text = attrValueToString(attr.value, { useTemplate: true }) ?? ''
         if (text) addExprIdents(text)
       }
       // Event handlers run in init-body context, not template. Skip.

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -18,13 +18,41 @@ import type {
   NestedLoop,
 } from '../../types'
 import type {
+  AttrValue,
   IRLoopChildComponent,
   IRNode,
   LoopParamBinding,
 } from '../../../types'
+import { AttrValueOf } from '../../../types'
 import {
   wrapLoopParamAsAccessor,
+  attrValueToString,
 } from '../../utils'
+
+/**
+ * Mirror of the helper in `build-loop-child-arm.ts` — kept local to avoid
+ * a cross-file import for what is structurally a two-line switch.
+ */
+function wrapAttrValueExpression(value: AttrValue, wrap: (s: string) => string): AttrValue {
+  switch (value.kind) {
+    case 'literal':
+    case 'boolean-attr':
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      return value
+    case 'expression':
+      return AttrValueOf.expression(wrap(value.expr), {
+        ...(value.templateExpr !== undefined && { templateExpr: wrap(value.templateExpr) }),
+        ...(value.presenceOrUndefined !== undefined && { presenceOrUndefined: value.presenceOrUndefined }),
+      })
+    case 'template': {
+      const flat = attrValueToString(value)
+      return AttrValueOf.expression(wrap(flat ?? 'undefined'))
+    }
+    case 'spread':
+      return AttrValueOf.spread(wrap(value.expr), value.templateExpr ? wrap(value.templateExpr) : undefined)
+  }
+}
 import type { DepthLevel } from '../shared'
 import {
   destructureLoopParam,
@@ -138,7 +166,7 @@ function buildReactiveEmit(
     if (node.type === 'component') {
       return {
         ...node,
-        props: node.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+        props: node.props.map(p => ({ ...p, value: wrapAttrValueExpression(p.value, wrapInner) })),
         children: node.children?.map(wrapIRNode),
       }
     }
@@ -155,7 +183,7 @@ function buildReactiveEmit(
   }
   const components: IRLoopChildComponent[] = level.comps.map(comp => ({
     ...comp,
-    props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+    props: comp.props.map(p => ({ ...p, value: wrapAttrValueExpression(p.value, wrapInner) })),
     children: comp.children?.map(wrapIRNode),
   }))
   const events: LoopChildEvent[] = level.events.map(ev => ({

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
@@ -14,13 +14,49 @@ import type {
   NestedLoop,
 } from '../../types'
 import type {
+  AttrValue,
   IRLoopChildComponent,
   IRNode,
   IRProp,
   LoopParamBinding,
 } from '../../../types'
-import { quotePropName, wrapLoopParamAsAccessor } from '../../utils'
+import { AttrValueOf } from '../../../types'
+import { quotePropName, wrapLoopParamAsAccessor, attrValueToString } from '../../utils'
 import { addCondAttrToTemplate, irChildrenToJsExpr } from '../../html-template'
+
+/**
+ * Apply a string-level expression rewriter (loop-param-accessor wrap, prop
+ * rebase, etc.) to every runtime-evaluated part of an `AttrValue`. Static
+ * variants (`literal`, `boolean-attr`, `boolean-shorthand`) and JSX children
+ * pass through unchanged.
+ *
+ * Currently used by the inner-loop / branch plan builders that need to
+ * rewrite `param.foo` → `param().foo` everywhere a loop iteration's prop
+ * value would be evaluated.
+ */
+function wrapAttrValueExpression(value: AttrValue, wrap: (s: string) => string): AttrValue {
+  switch (value.kind) {
+    case 'literal':
+    case 'boolean-attr':
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      return value
+    case 'expression':
+      return AttrValueOf.expression(wrap(value.expr), {
+        ...(value.templateExpr !== undefined && { templateExpr: wrap(value.templateExpr) }),
+        ...(value.presenceOrUndefined !== undefined && { presenceOrUndefined: value.presenceOrUndefined }),
+      })
+    case 'template': {
+      // Collapse to an `expression` after the wrap. Template structure is
+      // an SSR-adapter optimization; the inner-loop path emits client JS
+      // directly so a flat string suffices.
+      const flat = attrValueToString(value)
+      return AttrValueOf.expression(wrap(flat ?? 'undefined'))
+    }
+    case 'spread':
+      return AttrValueOf.spread(wrap(value.expr), value.templateExpr ? wrap(value.templateExpr) : undefined)
+  }
+}
 import { destructureLoopParam, loopKeyFn } from '../shared'
 import type {
   BranchChildComponentInit,
@@ -112,12 +148,22 @@ export function buildBranchChildComponentInitsPlan(
       .filter(p => p.name !== 'key')
       .map(p => {
         if (p.name.startsWith('on') && p.name.length > 2) {
-          return `${quotePropName(p.name)}: ${wrap(p.value)}`
+          return `${quotePropName(p.name)}: ${wrap(attrValueToString(p.value) ?? 'undefined')}`
         }
-        if (p.isLiteral) {
-          return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
+        switch (p.value.kind) {
+          case 'literal':
+            return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value.value)} }`
+          case 'boolean-shorthand':
+          case 'boolean-attr':
+            return `get ${quotePropName(p.name)}() { return true }`
+          case 'jsx-children':
+          case 'expression':
+          case 'template':
+          case 'spread': {
+            const expr = attrValueToString(p.value) ?? 'undefined'
+            return `get ${quotePropName(p.name)}() { return ${wrap(expr)} }`
+          }
         }
-        return `get ${quotePropName(p.name)}() { return ${wrap(p.value)} }`
       })
 
     // Children are needed for CSR createComponent; SSR initChild ignores them
@@ -197,7 +243,7 @@ export function buildBranchInnerLoopsPlan(
       if (node.type === 'component') {
         return {
           ...node,
-          props: node.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+          props: node.props.map(p => ({ ...p, value: wrapAttrValueExpression(p.value, wrapInner) })),
           children: node.children?.map(wrapIRNode),
         }
       }
@@ -214,7 +260,7 @@ export function buildBranchInnerLoopsPlan(
     }
     const legacyComponents: IRLoopChildComponent[] = (inner.childComponents ?? []).map(comp => ({
       ...comp,
-      props: comp.props.map(p => p.isLiteral ? p : ({ ...p, value: wrapInner(p.value) })),
+      props: comp.props.map(p => ({ ...p, value: wrapAttrValueExpression(p.value, wrapInner) })),
       children: comp.children?.map(wrapIRNode),
     }))
     const legacyEvents: LoopChildEvent[] = (inner.childEvents ?? []).map(ev => ({

--- a/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/shared.ts
@@ -14,7 +14,7 @@
 
 import type { LoopChildEvent, TopLevelLoop, NestedLoop, CollectedLoop } from '../types'
 import type { IRLoopChildComponent, LoopParamBinding } from '../../types'
-import { quotePropName, wrapLoopParamAsAccessor, irChildrenFreeIds } from '../utils'
+import { quotePropName, wrapLoopParamAsAccessor, irChildrenFreeIds, attrValueToString } from '../utils'
 import { irChildrenToJsExpr } from '../html-template'
 import { emitListenerBlock } from './stringify/event-listener'
 import { nameForRegistryRef } from '../component-scope'
@@ -102,19 +102,33 @@ export function destructureLoopParam(
  * Shared by emitComponentLoopReconciliation and emitCompositeElementReconciliation.
  */
 export function buildComponentPropsExpr(
-  comp: { props: Array<{ name: string; value: string; isEventHandler: boolean; isLiteral: boolean }>, children?: import('../../types').IRNode[] },
+  comp: { props: Array<{ name: string; value: import('../../types').AttrValue; isEventHandler: boolean }>, children?: import('../../types').IRNode[] },
   loopParam?: string,
   loopParamBindings?: readonly LoopParamBinding[],
 ): string {
   const wrap = loopParam ? (expr: string) => wrapLoopParamAsAccessor(expr, loopParam, loopParamBindings) : (expr: string) => expr
   const entries = comp.props.map((p) => {
     if (p.isEventHandler) {
-      return `${quotePropName(p.name)}: ${wrap(p.value)}`
-    } else if (p.isLiteral) {
-      // Literal string values must NOT be wrapped — they don't reference loop params
-      return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
-    } else {
-      return `get ${quotePropName(p.name)}() { return ${wrap(p.value)} }`
+      const handlerExpr = attrValueToString(p.value) ?? 'undefined'
+      return `${quotePropName(p.name)}: ${wrap(handlerExpr)}`
+    }
+    switch (p.value.kind) {
+      case 'literal':
+        // Literal string values must NOT be wrapped — they don't reference loop params
+        return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value.value)} }`
+      case 'boolean-shorthand':
+      case 'boolean-attr':
+        return `get ${quotePropName(p.name)}() { return true }`
+      case 'jsx-children': {
+        const childExpr = irChildrenToJsExpr(p.value.children)
+        return `get ${quotePropName(p.name)}() { return ${wrap(childExpr)} }`
+      }
+      case 'expression':
+      case 'template':
+      case 'spread': {
+        const valueExpr = attrValueToString(p.value)!
+        return `get ${quotePropName(p.name)}() { return ${wrap(valueExpr)} }`
+      }
     }
   })
   if ('children' in comp && Array.isArray(comp.children) && comp.children.length > 0) {
@@ -252,7 +266,7 @@ export function emitComponentAndEventSetup(
 
     const slotIdLit = comp.slotId ? `'${comp.slotId}'` : 'null'
     const keyProp = comp.props.find(p => p.name === 'key')
-    const keyArg = keyProp ? `, ${wrap(keyProp.value)}` : ', undefined'
+    const keyArg = keyProp ? `, ${wrap(attrValueToString(keyProp.value) ?? 'undefined')}` : ', undefined'
     // Pass the surrounding component's __scope so upsertChild can derive
     // bf-parent / bf-mount even when the loop-item element (`elVar`) is a
     // freshly-created detached fragment. Without this anchor, the new

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -2,7 +2,7 @@
  * IR → HTML template string generation and validation.
  */
 
-import type { IRNode } from '../types'
+import type { AttrValue, IRAttribute, IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, freeIdsFromRefs, setIntersects, tokenContainsAny, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
@@ -64,8 +64,8 @@ const UNSAFE_TEMPLATE_EXPR = 'undefined'
  * @param valExpr - The already-transformed value expression string
  * @param attr - Attribute metadata (only presenceOrUndefined flag is used)
  */
-function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrUndefined?: boolean }): string {
-  if (isBooleanAttr(attrName) || attr.presenceOrUndefined) {
+function templateAttrExpr(attrName: string, valExpr: string, presenceOrUndefined?: boolean): string {
+  if (isBooleanAttr(attrName) || presenceOrUndefined) {
     return `\${${valExpr} ? '${attrName}' : ''}`
   }
   if (attrName === 'style') {
@@ -79,6 +79,74 @@ function templateAttrExpr(attrName: string, valExpr: string, attr: { presenceOrU
     return `${attrName}="\${${valExpr}}"`
   }
   return `\${(${valExpr}) != null ? '${attrName}="' + (${valExpr}) + '"' : ''}`
+}
+
+/**
+ * Project a prop's `AttrValue` into its JS-expression string form suitable
+ * for the `renderChild(..., propsObj, KEY)` `KEY` argument. `transformExpr`
+ * applies the constant-inlining / props-rewrite pass used by the CSR
+ * template path; for non-`expression`/`spread`/`template` variants we
+ * delegate to the canonical projection.
+ */
+function transformKeyValue(value: AttrValue, transformExpr: (expr: string, templateExpr?: string) => string): string {
+  switch (value.kind) {
+    case 'expression':
+    case 'spread':
+      return transformExpr(value.expr, value.templateExpr)
+    case 'template':
+      return transformExpr(attrValueToString(value, { useTemplate: true }) ?? '')
+    case 'literal':
+      return JSON.stringify(value.value)
+    case 'boolean-shorthand':
+    case 'boolean-attr':
+      return 'true'
+    case 'jsx-children':
+      return 'undefined'
+  }
+}
+
+/**
+ * Render one element attribute into its template-literal substring for the
+ * SSR template path. Switches on `AttrValue.kind` exhaustively so a new
+ * variant becomes a type error.
+ *
+ * `wrap` is the loop-param-accessor rewrite (`task.title` → `task().title`)
+ * applied to any runtime-evaluated expression.
+ *
+ * Returns `''` to skip the attribute entirely (spread whose source is a
+ * known rest-prop, or `jsx-children` which never appears on intrinsic
+ * elements in well-formed IR).
+ */
+function renderTemplateAttrPart(
+  attr: IRAttribute,
+  attrName: string,
+  wrap: (expr: string) => string,
+  restSpreadNames?: Set<string>,
+): string {
+  const v = attr.value
+  switch (v.kind) {
+    case 'boolean-attr':
+      return attrName
+    case 'literal':
+      return `${attrName}="${v.value}"`
+    case 'expression': {
+      const valExpr = wrap(v.expr)
+      return templateAttrExpr(attrName, valExpr, v.presenceOrUndefined)
+    }
+    case 'template': {
+      const tmplStr = attrValueToString(v) ?? ''
+      return templateAttrExpr(attrName, wrap(tmplStr))
+    }
+    case 'spread': {
+      if (restSpreadNames?.has(v.expr)) return ''
+      return `\${spreadAttrs(${v.expr})}`
+    }
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      // Neither variant is legal as an intrinsic-element attribute in
+      // well-formed IR. Emit nothing rather than crashing.
+      return ''
+  }
 }
 
 /** Convert an IR node tree to an HTML template string (for conditionals/loops).
@@ -106,24 +174,10 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
-          if (a.name === '...') {
-            const spreadValue = typeof a.value === 'string' ? a.value : null
-            if (!spreadValue) return ''
-            if (restSpreadNames?.has(spreadValue)) return ''
-            return `\${spreadAttrs(${spreadValue})}`
-          }
-          // Convert JSX `key` to `data-key` (or `data-key-N` for nested loops)
-          const attrName = a.name === 'key'
-            ? keyAttrName(loopDepth)
-            : toHtmlAttrName(a.name)
-          if (a.value === null) return attrName
-          // Resolve IRTemplateLiteral to string expression for use in template literals
-          const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
-          if (a.dynamic) {
-            const wrappedVal = wrapExpr(valExpr)
-            return templateAttrExpr(attrName, wrappedVal, a)
-          }
-          return `${attrName}="${valExpr}"`
+          const attrName = a.name === '...'
+            ? '...'
+            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
+          return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
         })
         .filter(Boolean)
 
@@ -178,20 +232,31 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
         .map(p => {
           // `/* @client */` defers the prop to hydrate via initChild.
           if (p.clientOnly) return null
-          // JSX prop: render children inline as template literal
-          if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
-            return `${quotePropName(p.name)}: \`${childHtml}\``
+          switch (p.value.kind) {
+            case 'jsx-children': {
+              const childHtml = p.value.children.map(c => recurse(c)).join('')
+              return `${quotePropName(p.name)}: \`${childHtml}\``
+            }
+            case 'literal':
+              return `${quotePropName(p.name)}: ${JSON.stringify(p.value.value)}`
+            case 'boolean-shorthand':
+              return `${quotePropName(p.name)}: true`
+            case 'boolean-attr':
+              return `${quotePropName(p.name)}: true`
+            case 'expression':
+            case 'template':
+            case 'spread': {
+              const expr = attrValueToString(p.value) ?? 'undefined'
+              return `${quotePropName(p.name)}: ${expr}`
+            }
           }
-          if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-          return `${quotePropName(p.name)}: ${p.value}`
         })
         .filter((entry): entry is string => entry !== null)
       const childrenEntry = childrenPropEntry(node.children, recurse)
       if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
-      const keyArg = keyProp ? `, ${keyProp.value}` : ''
+      const keyArg = keyProp ? `, ${attrValueToString(keyProp.value) ?? 'undefined'}` : ''
       // Pass slotId as suffix so $c() can find the child component by slot after branch swap.
       // Inside a loop body each iteration owns a separate scope (identified by
       // `data-key`), so the parent-slot suffix is dropped — matching the
@@ -251,24 +316,10 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
     case 'element': {
       const attrParts = node.attrs
         .map((a) => {
-          if (a.name === '...') {
-            const spreadValue = typeof a.value === 'string' ? a.value : null
-            if (!spreadValue) return ''
-            if (restSpreadNames?.has(spreadValue)) return ''
-            return `\${spreadAttrs(${spreadValue})}`
-          }
-          const attrName = a.name === 'key'
-            ? keyAttrName(loopDepth)
-            : toHtmlAttrName(a.name)
-          if (a.value === null) return attrName
-          const valExpr = typeof a.value === 'string' ? a.value : (attrValueToString(a.value) ?? '')
-          // Only wrap dynamic expression values, not string literals that happen
-          // to be marked dynamic (e.g., className="cart-item" where "item" matches a loop param)
-          if (a.dynamic) {
-            const wrappedVal = wrapExpr(valExpr)
-            return templateAttrExpr(attrName, wrappedVal, a)
-          }
-          return `${attrName}="${valExpr}"`
+          const attrName = a.name === '...'
+            ? '...'
+            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
+          return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
         })
         .filter(Boolean)
 
@@ -371,16 +422,21 @@ function irNodeToJsExprs(node: IRNode): string[] {
         .filter(p => p.name !== 'key' && p.name !== '...' && !p.name.startsWith('...'))
         .map(p => {
           if (p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()) {
-            return `${quotePropName(p.name)}: ${p.value}`
+            return `${quotePropName(p.name)}: ${attrValueToString(p.value) ?? 'undefined'}`
           }
-          // JSX prop: generate getter using IR children → JS expression
-          if (p.jsxChildren?.length) {
-            return `get ${quotePropName(p.name)}() { return ${irChildrenToJsExpr(p.jsxChildren)} }`
+          switch (p.value.kind) {
+            case 'jsx-children':
+              return `get ${quotePropName(p.name)}() { return ${irChildrenToJsExpr(p.value.children)} }`
+            case 'literal':
+              return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value.value)} }`
+            case 'boolean-shorthand':
+            case 'boolean-attr':
+              return `get ${quotePropName(p.name)}() { return true }`
+            case 'expression':
+            case 'template':
+            case 'spread':
+              return `get ${quotePropName(p.name)}() { return ${attrValueToString(p.value) ?? 'undefined'} }`
           }
-          if (p.isLiteral) {
-            return `get ${quotePropName(p.name)}() { return ${JSON.stringify(p.value)} }`
-          }
-          return `get ${quotePropName(p.name)}() { return ${p.value} }`
         })
 
       if (node.children.length > 0) {
@@ -523,27 +579,46 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           // `reactiveAttrs`. Skip from the SSR template so init's
           // createEffect is the sole authority on the attribute.
           if (a.clientOnly) return ''
-          if (a.name === '...') {
-            const spreadValue = attrValueToString(a.value, { useTemplate: true })
-            if (!spreadValue) return ''
-            if (restSpreadNames?.has(spreadValue)) return ''
-            return `\${spreadAttrs(${transformExpr(spreadValue, a.templateValue ?? undefined)})}`
+          const v = a.value
+          if (v.kind === 'spread') {
+            const spreadExpr = v.templateExpr ?? v.expr
+            if (restSpreadNames?.has(spreadExpr)) return ''
+            return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           // Skip key for outer loop elements (reconcileTemplates sets data-key at runtime).
           // But render data-key-N for inner loop elements (needed for event delegation).
           if (a.name === 'key') {
             if (loopDepth === 0) return ''  // outer loop: skip (runtime handles it)
-            const valStr = attrValueToString(a.value, { useTemplate: true })
-            if (valStr && a.dynamic) return templateAttrExpr(keyAttrName(loopDepth), transformExpr(valStr, a.templateValue ?? undefined), a)
-            if (valStr) return `${keyAttrName(loopDepth)}="${valStr}"`
-            return ''
+            const keyName = keyAttrName(loopDepth)
+            switch (v.kind) {
+              case 'expression':
+                return templateAttrExpr(keyName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
+              case 'template': {
+                const tmplStr = attrValueToString(v, { useTemplate: true }) ?? ''
+                return templateAttrExpr(keyName, transformExpr(tmplStr))
+              }
+              case 'literal':
+                return `${keyName}="${v.value}"`
+              default:
+                return ''
+            }
           }
           const attrName = toHtmlAttrName(a.name)
-          if (a.value === null) return attrName
-          const valueStr = attrValueToString(a.value, { useTemplate: true })
-          if (a.dynamic && valueStr) return templateAttrExpr(attrName, transformExpr(valueStr, a.templateValue ?? undefined), a)
-          if (valueStr) return `${attrName}="${valueStr}"`
-          return attrName
+          switch (v.kind) {
+            case 'boolean-attr':
+              return attrName
+            case 'literal':
+              return `${attrName}="${v.value}"`
+            case 'expression':
+              return templateAttrExpr(attrName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
+            case 'template': {
+              const tmplStr = attrValueToString(v, { useTemplate: true }) ?? ''
+              return templateAttrExpr(attrName, transformExpr(tmplStr))
+            }
+            case 'boolean-shorthand':
+            case 'jsx-children':
+              return ''
+          }
         })
         .filter(Boolean)
 
@@ -593,20 +668,32 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
         .map(p => {
           // `/* @client */` defers the prop to hydrate via initChild.
           if (p.clientOnly) return null
-          if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(recurse).join('')
-            return `${quotePropName(p.name)}: \`${childHtml}\``
+          switch (p.value.kind) {
+            case 'jsx-children': {
+              const childHtml = p.value.children.map(recurse).join('')
+              return `${quotePropName(p.name)}: \`${childHtml}\``
+            }
+            case 'literal':
+              return `${quotePropName(p.name)}: ${JSON.stringify(p.value.value)}`
+            case 'boolean-shorthand':
+            case 'boolean-attr':
+              return `${quotePropName(p.name)}: true`
+            case 'expression':
+              return `${quotePropName(p.name)}: ${transformExpr(p.value.expr, p.value.templateExpr)}`
+            case 'spread':
+              return `${quotePropName(p.name)}: ${transformExpr(p.value.expr, p.value.templateExpr)}`
+            case 'template': {
+              const valueStr = attrValueToString(p.value, { useTemplate: true })!
+              return `${quotePropName(p.name)}: ${transformExpr(valueStr)}`
+            }
           }
-          if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-          const valueStr = attrValueToString(p.value, { useTemplate: true })
-          return `${quotePropName(p.name)}: ${valueStr ? transformExpr(valueStr, p.templateValue) : JSON.stringify(p.value)}`
         })
         .filter((entry): entry is string => entry !== null)
       const childrenEntry = childrenPropEntry(node.children, recurse)
       if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
-      const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
+      const keyArg = keyProp ? `, ${transformKeyValue(keyProp.value, transformExpr)}` : ''
       return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg})}`
     }
 
@@ -679,7 +766,8 @@ export function canGenerateStaticTemplate(
           if (valueStr && valueStr.includes('()') && !isSimplePropExpression(valueStr, propNames)) return false
           continue
         }
-        if (attr.dynamic && attr.value) {
+        // Only `expression` / `template` carry runtime references worth probing.
+        if (attr.value.kind === 'expression' || attr.value.kind === 'template' || attr.value.kind === 'spread') {
           const valueStr = attrValueToString(attr.value)
           if (valueStr) {
             if (hasUnsafeRef(attr.freeIdentifiers)) return false
@@ -835,20 +923,30 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           // by emitting an initial value, so skip the attribute
           // entirely here.
           if (a.clientOnly) return ''
-          if (a.name === '...') {
-            const spreadValue = attrValueToString(a.value, { useTemplate: true })
-            if (!spreadValue) return ''
-            if (restSpreadNames?.has(spreadValue)) return ''
-            return `\${spreadAttrs(${transformExpr(spreadValue, a.templateValue ?? undefined)})}`
+          const v = a.value
+          if (v.kind === 'spread') {
+            const spreadExpr = v.templateExpr ?? v.expr
+            if (restSpreadNames?.has(spreadExpr)) return ''
+            return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           const attrName = a.name === 'key'
             ? keyAttrName(loopDepth)
             : toHtmlAttrName(a.name)
-          if (a.value === null) return attrName
-          const valueStr = attrValueToString(a.value, { useTemplate: true })
-          if (a.dynamic && valueStr) return templateAttrExpr(attrName, transformExpr(valueStr, a.templateValue ?? undefined), a)
-          if (valueStr) return `${attrName}="${valueStr}"`
-          return attrName
+          switch (v.kind) {
+            case 'boolean-attr':
+              return attrName
+            case 'literal':
+              return `${attrName}="${v.value}"`
+            case 'expression':
+              return templateAttrExpr(attrName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
+            case 'template': {
+              const valueStr = attrValueToString(v, { useTemplate: true })
+              return valueStr ? templateAttrExpr(attrName, transformExpr(valueStr)) : ''
+            }
+            case 'boolean-shorthand':
+            case 'jsx-children':
+              return ''
+          }
         })
         .filter(Boolean)
 
@@ -910,26 +1008,40 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           // (built in collect-elements) reads the value once init
           // runs, mirroring the existing UNSAFE strip path below.
           if (p.clientOnly) return null
-          if (p.jsxChildren?.length) {
-            const childHtml = p.jsxChildren.map(c => recurse(c)).join('')
-            return `${quotePropName(p.name)}: \`${childHtml}\``
+          switch (p.value.kind) {
+            case 'jsx-children': {
+              const childHtml = p.value.children.map(c => recurse(c)).join('')
+              return `${quotePropName(p.name)}: \`${childHtml}\``
+            }
+            case 'literal':
+              return `${quotePropName(p.name)}: ${JSON.stringify(p.value.value)}`
+            case 'boolean-shorthand':
+            case 'boolean-attr':
+              return `${quotePropName(p.name)}: true`
+            case 'expression':
+            case 'spread': {
+              const transformed = transformExpr(p.value.expr, p.value.templateExpr)
+              // When transformExpr emits the unsafe sentinel for an init-scope-only
+              // reference (#1128), drop the prop from renderChild — initChild's
+              // getter binding will populate it once init runs.
+              if (transformed === UNSAFE_TEMPLATE_EXPR) return null
+              return `${quotePropName(p.name)}: ${transformed}`
+            }
+            case 'template': {
+              const valueStr = attrValueToString(p.value, { useTemplate: true })
+              if (!valueStr) return null
+              const transformed = transformExpr(valueStr)
+              if (transformed === UNSAFE_TEMPLATE_EXPR) return null
+              return `${quotePropName(p.name)}: ${transformed}`
+            }
           }
-          if (p.isLiteral) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-          const valueStr = attrValueToString(p.value, { useTemplate: true })
-          if (!valueStr) return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
-          const transformed = transformExpr(valueStr, p.templateValue)
-          // When transformExpr emits the unsafe sentinel for an init-scope-only
-          // reference (#1128), drop the prop from renderChild — initChild's
-          // getter binding will populate it once init runs.
-          if (transformed === UNSAFE_TEMPLATE_EXPR) return null
-          return `${quotePropName(p.name)}: ${transformed}`
         })
         .filter((entry): entry is string => entry !== null)
       const childrenEntry = childrenPropEntry(node.children, recurse)
       if (childrenEntry) propsEntries.push(childrenEntry)
       const propsExpr = propsEntries.length > 0 ? `{${propsEntries.join(', ')}}` : '{}'
       const keyProp = node.props.find(p => p.name === 'key')
-      const keyArg = keyProp ? `, ${transformExpr(keyProp.value, keyProp.templateValue)}` : ''
+      const keyArg = keyProp ? `, ${transformKeyValue(keyProp.value, transformExpr)}` : ''
       const slotArg = (!insideLoop && node.slotId) ? `, '${node.slotId}'` : ''
       return `\${renderChild('${nameForRegistryRef(node.name)}', ${propsExpr}${keyArg || (slotArg ? ', undefined' : '')}${slotArg})}`
     }

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -16,7 +16,8 @@
 import type { IRLoopChildComponent } from '../../types'
 import type { NestedLoop, TopLevelLoop } from '../types'
 import type { ClientJsContext } from '../types'
-import { quotePropName, varSlotId } from '../utils'
+import { quotePropName, varSlotId, attrValueToString } from '../utils'
+import { irChildrenToJsExpr } from '../html-template'
 import { buildCompSelector } from '../control-flow/shared'
 
 /** The inline prop shape carried on `IRLoopChildComponent.props`. */
@@ -158,12 +159,21 @@ function buildInnerLoopNestedPlan(
 function buildStaticPropsExpr(props: readonly LoopChildCompProp[]): PropsExpr {
   const entries = props.map(p => {
     if (p.isEventHandler) {
-      return `${quotePropName(p.name)}: ${p.value}`
+      return `${quotePropName(p.name)}: ${attrValueToString(p.value) ?? 'undefined'}`
     }
-    if (p.isLiteral) {
-      return `${quotePropName(p.name)}: ${JSON.stringify(p.value)}`
+    switch (p.value.kind) {
+      case 'literal':
+        return `${quotePropName(p.name)}: ${JSON.stringify(p.value.value)}`
+      case 'boolean-shorthand':
+      case 'boolean-attr':
+        return `${quotePropName(p.name)}: true`
+      case 'jsx-children':
+        return `get ${quotePropName(p.name)}() { return ${irChildrenToJsExpr(p.value.children)} }`
+      case 'expression':
+      case 'template':
+      case 'spread':
+        return `get ${quotePropName(p.name)}() { return ${attrValueToString(p.value) ?? 'undefined'} }`
     }
-    return `get ${quotePropName(p.name)}() { return ${p.value} }`
   })
   return entries.length > 0 ? `{ ${entries.join(', ')} }` : '{}'
 }

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -2,7 +2,7 @@
  * Reactivity detection: reactive expression checking, event/ref collection.
  */
 
-import { type IRNode, type IRElement, type IRProp, type LoopParamBinding, type OriginInfo, pickAttrMeta, isReactiveOrigin } from '../types'
+import { type IRNode, type IRElement, type IRProp, type LoopParamBinding, type OriginInfo, pickAttrMetaFromIR, isReactiveOrigin } from '../types'
 import type {
   ClientJsContext,
   ConditionalBranchEvent,
@@ -246,7 +246,8 @@ export function collectEventHandlersFromIR(node: IRNode): string[] {
     component: ({ node, descend }) => {
       for (const prop of node.props) {
         if (prop.name.startsWith('on') && prop.name.length > 2) {
-          handlers.push(prop.value)
+          const handler = attrValueToString(prop.value)
+          if (handler) handlers.push(handler)
         }
       }
       descend()
@@ -508,7 +509,10 @@ export function collectLoopChildReactiveAttrs(
   traverseElements(node, (el) => {
     if (el.slotId) {
       for (const attr of el.attrs) {
-        if (attr.name === '...' || !attr.dynamic || !attr.value) continue
+        if (attr.name === '...') continue
+        // Literal / boolean variants are baked into the SSR template and
+        // never react — skip them up front.
+        if (attr.value.kind !== 'expression' && attr.value.kind !== 'template' && attr.value.kind !== 'spread') continue
         // `key` is a reconciliation-only prop: the html-template path renames
         // it to `data-key` for SSR + mapArray uses it via keyFn. Wiring it
         // again as a reactive DOM attr would (a) emit a non-standard `key=`
@@ -530,7 +534,7 @@ export function collectLoopChildReactiveAttrs(
           childSlotId: el.slotId,
           attrName: attr.name,
           expression: expanded.expr,
-          ...pickAttrMeta(attr),
+          ...pickAttrMetaFromIR(attr),
           ...(expanded.freeIds !== undefined && { freeIdentifiers: expanded.freeIds }),
         })
       }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -3,7 +3,7 @@
  * No dependencies on ClientJsContext or other internal modules.
  */
 
-import type { IRTemplateLiteral, LoopParamBinding, FreeReference, IRNode } from '../types'
+import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode } from '../types'
 import type { TopLevelLoop } from './types'
 import {
   BF_KEY as DATA_KEY,
@@ -41,15 +41,13 @@ export function varSlotId(slotId: string): string {
 }
 
 /**
- * Convert an attribute value to a string expression.
- * Handles both string values and IRTemplateLiteral.
+ * Convert a `template` variant's parts into a JS template-literal string.
+ * Shared by both `attrValueToString` and any consumer that wants to flatten
+ * a structured template into JS-level concatenation.
  */
-export function attrValueToString(value: string | IRTemplateLiteral | null, opts?: { useTemplate?: boolean }): string | null {
-  if (value === null) return null
-  if (typeof value === 'string') return value
-
+export function templatePartsToJsExpr(parts: readonly IRTemplatePart[], opts?: { useTemplate?: boolean }): string {
   let result = '`'
-  for (const part of value.parts) {
+  for (const part of parts) {
     if (part.type === 'string') {
       result += (opts?.useTemplate && part.templateValue) ? part.templateValue : part.value
     } else if (part.type === 'ternary') {
@@ -70,6 +68,54 @@ export function attrValueToString(value: string | IRTemplateLiteral | null, opts
   }
   result += '`'
   return result
+}
+
+/**
+ * Flatten an `AttrValue` to its raw string form, suitable for HTML attribute
+ * body insertion (literal) or for raw JS expression substitution (expression
+ * / template / spread).
+ *
+ * Returns `null` for variants that have no string projection (`boolean-attr`,
+ * `boolean-shorthand`, `jsx-children`) — callers must branch on `value.kind`
+ * before reaching them.
+ *
+ * When `opts.useTemplate` is set, prefers `templateExpr` / `templateValue` /
+ * `templateCondition` / `templateKey` (the prop-rewritten variant) over the
+ * raw source form, for use in SSR template-literal interpolation.
+ */
+export function attrValueToString(value: AttrValue, opts?: { useTemplate?: boolean }): string | null {
+  switch (value.kind) {
+    case 'literal':
+      return value.value
+    case 'expression':
+      return opts?.useTemplate ? (value.templateExpr ?? value.expr) : value.expr
+    case 'spread':
+      return opts?.useTemplate ? (value.templateExpr ?? value.expr) : value.expr
+    case 'template':
+      return templatePartsToJsExpr(value.parts, opts)
+    case 'boolean-attr':
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      return null
+  }
+}
+
+/**
+ * True when the value is fully resolvable at compile time (a string literal
+ * or a bare boolean attribute). The remaining variants depend on runtime
+ * values and must be inlined as `${...}` rather than embedded verbatim.
+ */
+export function isStaticAttrValue(value: AttrValue): boolean {
+  return value.kind === 'literal' || value.kind === 'boolean-attr' || value.kind === 'boolean-shorthand'
+}
+
+/**
+ * Exhaustiveness sentinel for `switch (value.kind)` blocks. If a future
+ * variant lands without a corresponding `case`, the parameter type
+ * collapses to `never` and the call site fails to type-check.
+ */
+export function exhaustiveAttrValue(value: never): never {
+  throw new Error(`Unhandled AttrValue kind: ${JSON.stringify(value)}`)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/walker.ts
+++ b/packages/jsx/src/ir-to-client-js/walker.ts
@@ -122,8 +122,8 @@ function descendComponentJsxChildren<Scope>(
   walk: (n: IRNode, s: Scope) => void,
 ): void {
   for (const prop of node.props) {
-    if (!prop.jsxChildren) continue
-    for (const child of prop.jsxChildren) walk(child, scope)
+    if (prop.value.kind !== 'jsx-children') continue
+    for (const child of prop.value.children) walk(child, scope)
   }
 }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -20,14 +20,14 @@ import {
   type IRAttribute,
   type IREvent,
   type IRProp,
-  type IRTemplateLiteral,
+  type AttrValue,
   type IRTemplatePart,
   type LoopParamBinding,
   type SourceLocation,
   type TypeInfo,
   type OriginInfo,
-  pickAttrMeta,
   isReactiveOrigin,
+  AttrValueOf,
 } from './types'
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
@@ -409,9 +409,7 @@ function wrapInScopeElement(node: IRNode): IRElement {
     tag: 'div',
     attrs: [{
       name: 'style',
-      value: 'display:contents',
-      dynamic: false,
-      isLiteral: true,
+      value: AttrValueOf.literal('display:contents'),
       loc: node.loc,
     }],
     events: [],
@@ -714,26 +712,16 @@ function parseFallbackProp(
   ctx: TransformContext,
   parentNode: ts.Node
 ): IRNode {
-  // Walk the parent node's attributes to find the actual AST node for fallback
-  const openingEl = (parentNode as ts.JsxElement).openingElement
-  for (const attr of openingEl.attributes.properties) {
-    if (ts.isJsxAttribute(attr) && attr.name.getText(ctx.sourceFile) === 'fallback') {
-      const initializer = attr.initializer
-      if (initializer && ts.isJsxExpression(initializer) && initializer.expression) {
-        const expr = initializer.expression
-        // If it's a JSX element, transform it
-        if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
-          const result = transformNode(expr, ctx)
-          if (result) return result
-        }
-      }
-    }
+  // The JSX-as-prop case is now structurally captured by processComponentProps
+  // as a `jsx-children` AttrValue variant — pluck the IR node directly.
+  if (prop.value.kind === 'jsx-children' && prop.value.children.length > 0) {
+    return prop.value.children[0]
   }
 
-  // Fallback to a text node with the prop value
+  // Fallback to a text node with the prop value's string form
   return {
     type: 'text',
-    value: prop.value,
+    value: prop.value.kind === 'literal' ? prop.value.value : prop.value.kind === 'expression' ? prop.value.expr : '',
     loc: getSourceLocation(parentNode, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -750,24 +738,19 @@ function transformSelfClosingAsyncElement(
     return stubFragment(ctx, node, () => [])
   }
 
-  // Parse fallback from the self-closing element's attributes
-  let fallbackNode: IRNode | null = null
-  for (const attr of node.attributes.properties) {
-    if (ts.isJsxAttribute(attr) && attr.name.getText(ctx.sourceFile) === 'fallback') {
-      const initializer = attr.initializer
-      if (initializer && ts.isJsxExpression(initializer) && initializer.expression) {
-        const expr = initializer.expression
-        if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
-          fallbackNode = transformNode(expr, ctx)
-        }
-      }
-    }
-  }
-
-  if (!fallbackNode) {
+  // The JSX-as-prop case is structurally captured by processComponentProps
+  // as a `jsx-children` AttrValue variant — pluck the IR node directly.
+  let fallbackNode: IRNode
+  if (fallbackProp.value.kind === 'jsx-children' && fallbackProp.value.children.length > 0) {
+    fallbackNode = fallbackProp.value.children[0]
+  } else {
     fallbackNode = {
       type: 'text',
-      value: fallbackProp.value,
+      value: fallbackProp.value.kind === 'literal'
+        ? fallbackProp.value.value
+        : fallbackProp.value.kind === 'expression'
+          ? fallbackProp.value.expr
+          : '',
       loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     }
   }
@@ -1880,13 +1863,13 @@ function findKeyJsxAttribute(
 function extractLoopKey(node: IRNode): string | null {
   if (node.type === 'element') {
     const keyAttr = node.attrs.find((a) => a.name === 'key')
-    if (!keyAttr || !keyAttr.value || typeof keyAttr.value !== 'string') return null
-    return keyAttr.value
+    if (!keyAttr) return null
+    return keyAttrValueToExpr(keyAttr.value)
   }
   if (node.type === 'component') {
     const keyProp = node.props.find((p) => p.name === 'key')
-    if (!keyProp || !keyProp.value || typeof keyProp.value !== 'string') return null
-    return keyProp.value
+    if (!keyProp) return null
+    return keyAttrValueToExpr(keyProp.value)
   }
   if (node.type === 'conditional') {
     const a = extractLoopKey(node.whenTrue)
@@ -1896,6 +1879,20 @@ function extractLoopKey(node: IRNode): string | null {
     return normalizeKeyExpr(a) === normalizeKeyExpr(b) ? a : null
   }
   return null
+}
+
+/**
+ * Project the `key={...}` AttrValue into the raw expression string used
+ * by `loopKeyFn` for `mapArray`'s key callback. Only `expression`,
+ * `literal`, and `template` make sense as key sources at runtime.
+ */
+function keyAttrValueToExpr(v: AttrValue): string | null {
+  switch (v.kind) {
+    case 'expression': return v.expr
+    case 'literal': return JSON.stringify(v.value)
+    case 'template': return null
+    default: return null
+  }
 }
 
 /**
@@ -2396,8 +2393,6 @@ function transformMapCall(
         .map((p) => ({
           name: p.name,
           value: p.value,
-          dynamic: p.dynamic,
-          isLiteral: p.isLiteral,
           isEventHandler: p.name.startsWith('on') && p.name.length > 2,
         })),
       children: comp.children,
@@ -2496,8 +2491,6 @@ function collectNestedComponents(nodes: IRNode[]): IRLoopChildComponent[] {
           .map(p => ({
             name: p.name,
             value: p.value,
-            dynamic: p.dynamic,
-            isLiteral: p.isLiteral,
             isEventHandler: p.name.startsWith('on') && p.name.length > 2,
           })),
         children: node.children,
@@ -2563,17 +2556,13 @@ interface ProcessedAttributes {
 // rest-prop itself: arbitrary `{...someObject}` spreads can't be unrolled
 // because we don't have a static key list for them.
 //
-// The shape returned satisfies both IRAttribute and IRProp (string value,
-// dynamic, isLiteral=false).
+// The shape returned satisfies both IRAttribute and IRProp.
 function expandSpreadAttribute(
   attr: ts.JsxSpreadAttribute,
   ctx: TransformContext,
 ): Array<{
   name: string
-  value: string
-  templateValue?: string
-  dynamic: true
-  isLiteral: false
+  value: AttrValue
   loc: SourceLocation
   freeIdentifiers?: ReadonlySet<string>
 }> {
@@ -2590,9 +2579,7 @@ function expandSpreadAttribute(
     const perKeyFreeIds: ReadonlySet<string> = new Set([restName])
     return expandedKeys.map(key => ({
       name: key,
-      value: `${restName}.${key}`,
-      dynamic: true,
-      isLiteral: false,
+      value: AttrValueOf.expression(`${restName}.${key}`),
       loc,
       freeIdentifiers: perKeyFreeIds,
     }))
@@ -2600,10 +2587,7 @@ function expandSpreadAttribute(
 
   return [{
     name: '...',
-    value: spreadExpr,
-    templateValue: ctx.getTemplateJS(attr.expression),
-    dynamic: true,
-    isLiteral: false,
+    value: AttrValueOf.spread(spreadExpr, ctx.getTemplateJS(attr.expression)),
     loc,
     freeIdentifiers: spreadFreeIdentifiers,
   }]
@@ -2697,13 +2681,14 @@ function processAttributes(
       continue
     }
 
-    const attrResult = getAttributeValue(attr, ctx)
-    const { value, dynamic, isLiteral } = attrResult
-    let templateValue: string | undefined
+    let value = getAttributeValue(attr, ctx)
     let clientOnly: boolean | undefined
     if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      if (dynamic && typeof value === 'string') {
-        templateValue = rewriteBarePropRefs(value, attr.initializer.expression, ctx)
+      if (value.kind === 'expression' && value.templateExpr === undefined) {
+        const rewritten = rewriteBarePropRefs(value.expr, attr.initializer.expression, ctx)
+        if (rewritten !== value.expr) {
+          value = { ...value, templateExpr: rewritten }
+        }
       }
       // `/* @client */` in attribute initializer position: defer the
       // attribute to hydrate. Detection routed through the shared
@@ -2720,13 +2705,9 @@ function processAttributes(
     attrs.push({
       name,
       value,
-      templateValue,
-      dynamic,
-      isLiteral,
       clientOnly,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
-      ...pickAttrMeta(attrResult),
       ...(freeIdentifiers !== undefined && { freeIdentifiers }),
     })
   }
@@ -2734,18 +2715,15 @@ function processAttributes(
   return { attrs, events, ref }
 }
 
-function getAttributeValue(
-  attr: ts.JsxAttribute,
-  ctx: TransformContext
-): { value: string | IRTemplateLiteral | null; dynamic: boolean; isLiteral: boolean; presenceOrUndefined?: boolean } {
+function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrValue {
   // Boolean attribute: <button disabled />
   if (!attr.initializer) {
-    return { value: null, dynamic: false, isLiteral: false }
+    return AttrValueOf.booleanAttr()
   }
 
   // String literal: <div id="main" />
   if (ts.isStringLiteral(attr.initializer)) {
-    return { value: attr.initializer.text, dynamic: false, isLiteral: true }
+    return AttrValueOf.literal(attr.initializer.text)
   }
 
   // Expression: <div class={className} />
@@ -2762,7 +2740,7 @@ function getAttributeValue(
     if (attr.name.getText(ctx.sourceFile) === 'style' && ts.isObjectLiteralExpression(expr)) {
       const cssString = tryStaticStyleObjectToCss(expr)
       if (cssString !== null) {
-        return { value: cssString, dynamic: false, isLiteral: true }
+        return AttrValueOf.literal(cssString)
       }
     }
 
@@ -2774,11 +2752,7 @@ function getAttributeValue(
     if (ts.isTemplateExpression(expr)) {
       const parts = parseTemplateLiteral(expr, ctx)
       if (parts.some(p => p.type === 'ternary' || p.type === 'lookup')) {
-        return {
-          value: { type: 'template-literal', parts },
-          dynamic: true,
-          isLiteral: false,
-        }
+        return AttrValueOf.template(parts)
       }
     }
 
@@ -2789,7 +2763,7 @@ function getAttributeValue(
     if (ts.isIdentifier(expr)) {
       const resolved = tryResolveIdentifierAsTemplateLiteral(expr, ctx)
       if (resolved) {
-        return { value: resolved, dynamic: true, isLiteral: false }
+        return AttrValueOf.template(resolved)
       }
     }
 
@@ -2797,11 +2771,7 @@ function getAttributeValue(
     if (ts.isConditionalExpression(expr)) {
       const ternary = parseTernary(expr, ctx)
       if (ternary) {
-        return {
-          value: { type: 'template-literal', parts: [ternary] },
-          dynamic: true,
-          isLiteral: false,
-        }
+        return AttrValueOf.template([ternary])
       }
     }
 
@@ -2809,15 +2779,15 @@ function getAttributeValue(
     if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
       if (ts.isIdentifier(expr.right) && expr.right.text === 'undefined') {
         const baseExpr = ctx.getJS(expr.left)
-        return { value: baseExpr, dynamic: true, isLiteral: false, presenceOrUndefined: true }
+        return AttrValueOf.expression(baseExpr, { presenceOrUndefined: true })
       }
     }
 
     const exprText = ctx.getJS(expr)
-    return { value: exprText, dynamic: true, isLiteral: false }
+    return AttrValueOf.expression(exprText)
   }
 
-  return { value: null, dynamic: false, isLiteral: false }
+  return AttrValueOf.booleanAttr()
 }
 
 /**
@@ -3005,14 +2975,14 @@ function findLocalConst(name: string, ctx: TransformContext) {
 function tryResolveIdentifierAsTemplateLiteral(
   ident: ts.Identifier,
   ctx: TransformContext,
-): IRTemplateLiteral | null {
+): IRTemplatePart[] | null {
   const constInfo = findLocalConst(ident.text, ctx)
   if (!constInfo) return null
   const ast = parseConstInitializer(constInfo)
   if (!ast) return null
 
   if (ts.isNoSubstitutionTemplateLiteral(ast) || ts.isStringLiteral(ast)) {
-    return { type: 'template-literal', parts: [{ type: 'string', value: ast.text }] }
+    return [{ type: 'string', value: ast.text }]
   }
 
   if (!ts.isTemplateExpression(ast)) return null
@@ -3046,7 +3016,7 @@ function tryResolveIdentifierAsTemplateLiteral(
     if (span.literal.text) parts.push({ type: 'string', value: span.literal.text })
   }
 
-  return resolvedAny ? { type: 'template-literal', parts } : null
+  return resolvedAny ? parts : null
 }
 
 /**
@@ -3166,8 +3136,8 @@ function processComponentProps(
     const name = attr.name.getText(ctx.sourceFile)
 
     // JSX element/fragment as prop value: controls={<select />} or
-    // controls={(<div/>)}. Stored on `jsxChildren` so the adapter can render
-    // it inline rather than passing a string.
+    // controls={(<div/>)}. Carried as a `jsx-children` AttrValue variant
+    // so adapters render the JSX inline rather than passing a string.
     if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
       let jsxExpr = attr.initializer.expression
       while (ts.isParenthesizedExpression(jsxExpr)) {
@@ -3181,30 +3151,31 @@ function processComponentProps(
         if (irNode) {
           props.push({
             name,
-            value: '__jsx_prop',
-            dynamic: true,
-            isLiteral: false,
+            value: AttrValueOf.jsxChildren([irNode]),
             loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
-            jsxChildren: [irNode],
           })
           continue
         }
       }
     }
 
-    const attrResult = getAttributeValue(attr, ctx)
-    const { value, dynamic, isLiteral } = attrResult
+    let value = getAttributeValue(attr, ctx)
+    // Components receive props as runtime values, so collapse a structured
+    // template literal back into a JS expression, and promote `boolean-attr`
+    // to `boolean-shorthand` (`<X disabled />` → `disabled={true}`).
+    if (value.kind === 'template') {
+      value = AttrValueOf.expression(templatePartsToJsString(value.parts))
+    } else if (value.kind === 'boolean-attr') {
+      value = AttrValueOf.booleanShorthand()
+    }
 
-    // Components receive props as runtime values, so collapse IRTemplateLiteral
-    // back to a JS expression and fall back to 'true' for boolean shorthand
-    // (`<X disabled />` → `disabled={true}`).
-    const propValue = templateLiteralToString(value) ?? 'true'
-
-    let propTemplateValue: string | undefined
     let clientOnly: boolean | undefined
     if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-      if (dynamic && typeof value === 'string') {
-        propTemplateValue = rewriteBarePropRefs(propValue, attr.initializer.expression, ctx)
+      if (value.kind === 'expression' && value.templateExpr === undefined) {
+        const rewritten = rewriteBarePropRefs(value.expr, attr.initializer.expression, ctx)
+        if (rewritten !== value.expr) {
+          value = { ...value, templateExpr: rewritten }
+        }
       }
       // `/* @client */` in component-prop initializer position: defer
       // to hydrate. Detection routed through the shared helper so it
@@ -3220,14 +3191,10 @@ function processComponentProps(
     const freeIdentifiers = attrFreeIdentifiers(attr)
     props.push({
       name,
-      value: propValue,
-      templateValue: propTemplateValue,
-      dynamic,
-      isLiteral,
+      value,
       clientOnly,
       loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
       ...computeReactivityFlags(attr, ctx),
-      ...pickAttrMeta(attrResult),
       ...(freeIdentifiers !== undefined && { freeIdentifiers }),
     })
   }
@@ -3236,24 +3203,19 @@ function processComponentProps(
 }
 
 /**
- * Convert an IRTemplateLiteral back to its JavaScript string representation.
- * Returns the original value if it's already a string.
+ * Flatten a structured template-literal's parts back into a JS expression
+ * string. Used at IR construction time when a structured `template` variant
+ * needs to be collapsed into an `expression` for component-prop forwarding —
+ * component props are runtime JS values, not HTML attribute bodies.
  */
-function templateLiteralToString(value: string | IRTemplateLiteral | null): string | null {
-  if (value === null) return null
-  if (typeof value === 'string') return value
-
-  // Reconstruct the template literal as a JS expression
+function templatePartsToJsString(parts: readonly IRTemplatePart[]): string {
   let result = '`'
-  for (const part of value.parts) {
+  for (const part of parts) {
     if (part.type === 'string') {
       result += part.value
     } else if (part.type === 'ternary') {
       result += `\${${part.condition} ? '${part.whenTrue}' : '${part.whenFalse}'}`
     } else if (part.type === 'lookup') {
-      // Rebuild the indexed lookup as runtime JS so the JSX runtime
-      // path (Hono component-prop forwarding, client-side template
-      // generation) keeps producing the same value.
       const obj = '{' + Object.entries(part.cases).map(
         ([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`
       ).join(', ') + '}'
@@ -3450,19 +3412,17 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
     // element MUST have a slotId for runtime lookup — even if the
     // expression itself doesn't trip the signal/memo/prop heuristics.
     if (attr.clientOnly) return true
-    if (attr.dynamic && attr.value) {
-      const valueToCheck = getAttributeValueAsString(attr.value)
-      if (!valueToCheck) continue
+    const valueToCheck = attrValueReactivityProbe(attr.value)
+    if (!valueToCheck) continue
 
-      if (isSignalOrMemoReference(valueToCheck, ctx) || isPropsReference(valueToCheck, ctx)) {
-        return true
-      }
-      // Check if attribute references any active loop parameters —
-      // loop root elements need a slotId so className can be updated reactively.
-      if (ctx.loopParams.size > 0) {
-        for (const p of ctx.loopParams) {
-          if (new RegExp(`\\b${p}\\b`).test(valueToCheck)) return true
-        }
+    if (isSignalOrMemoReference(valueToCheck, ctx) || isPropsReference(valueToCheck, ctx)) {
+      return true
+    }
+    // Check if attribute references any active loop parameters —
+    // loop root elements need a slotId so className can be updated reactively.
+    if (ctx.loopParams.size > 0) {
+      for (const p of ctx.loopParams) {
+        if (new RegExp(`\\b${p}\\b`).test(valueToCheck)) return true
       }
     }
   }
@@ -3470,20 +3430,28 @@ function hasReactiveAttributes(attrs: IRAttribute[], ctx: TransformContext): boo
 }
 
 /**
- * Get the string representation of an attribute value for reactivity checking.
+ * Extract a string representation of an `AttrValue` suitable for the
+ * reactivity heuristics (regex tests against signal / memo / prop names).
+ * Returns null for variants whose body never references runtime values.
  */
-function getAttributeValueAsString(value: string | IRTemplateLiteral | null): string | null {
-  if (value === null) return null
-  if (typeof value === 'string') return value
-  // For template literals, concatenate all parts for reactivity checking.
-  // We reach into the part-specific reactive-relevant expression: the
-  // ternary `condition`, or the lookup `key`. The string part is a
-  // literal, no further inspection needed.
-  return value.parts.map(p => {
-    if (p.type === 'string') return p.value
-    if (p.type === 'ternary') return p.condition
-    return p.key
-  }).join('')
+function attrValueReactivityProbe(value: AttrValue): string | null {
+  switch (value.kind) {
+    case 'expression':
+      return value.expr
+    case 'spread':
+      return value.expr
+    case 'template':
+      return value.parts.map((p: IRTemplatePart) => {
+        if (p.type === 'string') return p.value
+        if (p.type === 'ternary') return p.condition
+        return p.key
+      }).join('')
+    case 'literal':
+    case 'boolean-attr':
+    case 'boolean-shorthand':
+    case 'jsx-children':
+      return null
+  }
 }
 
 /**

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -368,9 +368,7 @@ export interface IRLoopChildComponent {
   slotId: string | null // Slot ID for querySelector targeting
   props: Array<{
     name: string
-    value: string // Expression (can use loop variables)
-    dynamic: boolean
-    isLiteral: boolean // true if value came from a string literal attribute
+    value: AttrValue
     isEventHandler: boolean
   }>
   children: IRNode[] // Child nodes for nested component rendering
@@ -619,16 +617,6 @@ export interface IRIfStatement {
 // IR Attributes & Events
 // =============================================================================
 
-/**
- * Template literal with ternary expressions for structured conditional rendering.
- * Used when attribute values contain template literals with ternaries like:
- * style={`background: ${on() ? '#4caf50' : '#ccc'}`}
- */
-export interface IRTemplateLiteral {
-  type: 'template-literal'
-  parts: IRTemplatePart[]
-}
-
 export type IRTemplatePart =
   | { type: 'string'; value: string; templateValue?: string }
   | { type: 'ternary'; condition: string; templateCondition?: string; whenTrue: string; whenFalse: string }
@@ -646,12 +634,142 @@ export type IRTemplatePart =
   | { type: 'lookup'; cases: Record<string, string>; key: string; templateKey?: string }
 
 /**
- * Attribute metadata shared across all attribute-like interfaces.
- * Adding a field here automatically propagates it through the entire pipeline
- * (IRAttribute → ReactiveAttribute / ReactiveChildProp / LoopChildReactiveAttr → emit).
+ * Discriminated union for attribute / component-prop values (#1264).
+ *
+ * Replaces the legacy `value: string | IRTemplateLiteral | null` plus
+ * sibling `dynamic` / `isLiteral` boolean flags. Every adapter switches on
+ * `value.kind` exhaustively, so adding a new shape becomes a type error
+ * at every emit site instead of a silent fallthrough.
+ *
+ * Variants:
+ * - `literal`  — value came from a string-literal attribute (`<X y="z" />`).
+ * - `expression` — value came from a JSX expression (`<X y={e} />`).
+ *   Carries the optional `templateExpr` (prop-rewritten form for SSR
+ *   template inlining) and `presenceOrUndefined` (the `expr || undefined`
+ *   peel result for boolean-presence attrs).
+ * - `boolean-attr` — bare attribute on an intrinsic element
+ *   (`<button disabled />`). Element-only.
+ * - `boolean-shorthand` — bare attribute on a component (`<X disabled />`),
+ *   which becomes `disabled={true}` at the call site. Component-only.
+ * - `template` — structured template literal with ternaries / Record-lookups
+ *   (the shape previously called `IRTemplateLiteral`). Adapters that can
+ *   run JS at SSR re-emit the JS; adapters that can't (Go-template) walk
+ *   the parts.
+ * - `spread` — JSX spread (`<X {...rest} />`). The IR attribute / prop
+ *   keeps `name === '...'` as a companion marker but `kind === 'spread'`
+ *   is the authoritative discriminator.
+ * - `jsx-children` — a component prop whose value is JSX
+ *   (`<X header={<h1/>} />`). Component-only.
+ */
+export type AttrValue =
+  | LiteralAttr
+  | ExpressionAttr
+  | BooleanAttr
+  | BooleanShorthandAttr
+  | TemplateAttr
+  | SpreadAttr
+  | JsxChildrenAttr
+
+export interface LiteralAttr {
+  kind: 'literal'
+  /** Raw string from the source. Emitted unquoted into HTML attribute body,
+   *  JSON.stringify'd when re-rendered as a component prop. */
+  value: string
+}
+
+export interface ExpressionAttr {
+  kind: 'expression'
+  /** Source-level JS expression text (e.g. `count()`, `props.checked`). */
+  expr: string
+  /** `expr` with destructured prop refs rewritten to `_p.xxx`, for SSR
+   *  template inlining. Absent when no rewrite was needed. */
+  templateExpr?: string
+  /** Set when the producer peeled an `expr || undefined` boolean-presence
+   *  pattern; adapters fold this back into `(expr) || undefined` at emit. */
+  presenceOrUndefined?: boolean
+}
+
+export interface BooleanAttr {
+  kind: 'boolean-attr'
+}
+
+export interface BooleanShorthandAttr {
+  kind: 'boolean-shorthand'
+}
+
+export interface TemplateAttr {
+  kind: 'template'
+  parts: IRTemplatePart[]
+}
+
+export interface SpreadAttr {
+  kind: 'spread'
+  expr: string
+  templateExpr?: string
+}
+
+export interface JsxChildrenAttr {
+  kind: 'jsx-children'
+  children: IRNode[]
+}
+
+/**
+ * Constructors for `AttrValue` variants. Centralised so the producer
+ * (`jsx-to-ir.ts`) and any future hand-built IR fixture share the same
+ * canonical shape — and so optional fields (`templateExpr`, `presenceOrUndefined`)
+ * are only set when present.
+ */
+export const AttrValueOf = {
+  literal(value: string): LiteralAttr {
+    return { kind: 'literal', value }
+  },
+  expression(expr: string, opts?: { templateExpr?: string; presenceOrUndefined?: boolean }): ExpressionAttr {
+    return {
+      kind: 'expression',
+      expr,
+      ...(opts?.templateExpr !== undefined && { templateExpr: opts.templateExpr }),
+      ...(opts?.presenceOrUndefined !== undefined && { presenceOrUndefined: opts.presenceOrUndefined }),
+    }
+  },
+  booleanAttr(): BooleanAttr {
+    return { kind: 'boolean-attr' }
+  },
+  booleanShorthand(): BooleanShorthandAttr {
+    return { kind: 'boolean-shorthand' }
+  },
+  template(parts: IRTemplatePart[]): TemplateAttr {
+    return { kind: 'template', parts }
+  },
+  spread(expr: string, templateExpr?: string): SpreadAttr {
+    return {
+      kind: 'spread',
+      expr,
+      ...(templateExpr !== undefined && { templateExpr }),
+    }
+  },
+  jsxChildren(children: IRNode[]): JsxChildrenAttr {
+    return { kind: 'jsx-children', children }
+  },
+} as const
+
+/**
+ * Attribute metadata shared by `IRAttribute` / `IRProp` and the emit-time
+ * collection types (`ReactiveAttribute`, `ReactiveChildProp`,
+ * `LoopChildReactiveAttr`, `ConditionalBranchReactiveAttr`,
+ * `ArmReactiveAttr`). Adding a field here propagates it through the entire
+ * pipeline.
+ *
+ * Note: on `IRAttribute` / `IRProp` the `presenceOrUndefined` flag is
+ * never populated directly — the canonical location is
+ * `ExpressionAttr.presenceOrUndefined` on the `value` field. The field
+ * is retained on `AttrMeta` so the emit-time accumulators can carry it
+ * forward through their pipeline without inventing a parallel type.
  */
 export interface AttrMeta {
-  presenceOrUndefined?: boolean // true when `expr || undefined` pattern is detected
+  /** True when the producer peeled an `expr || undefined` boolean-presence
+   *  pattern. Emit-time accumulators read this; on `IRAttribute` / `IRProp`
+   *  consult `value.kind === 'expression' && value.presenceOrUndefined`. */
+  presenceOrUndefined?: boolean
   /**
    * Pre-computed free identifiers referenced by the attribute's expression
    * (#1267). Populated during IR build by walking the originating AST node.
@@ -671,13 +789,23 @@ export function pickAttrMeta(src: AttrMeta): AttrMeta {
   }
 }
 
+/**
+ * Pull the `AttrMeta` slice from an `IRAttribute` / `IRProp`. Unlike
+ * `pickAttrMeta`, which reads from a parent extending `AttrMeta`, this
+ * helper resolves `presenceOrUndefined` from the underlying `AttrValue`
+ * variant (only `ExpressionAttr` carries it).
+ */
+export function pickAttrMetaFromIR(src: { value: AttrValue; freeIdentifiers?: ReadonlySet<string> }): AttrMeta {
+  const presenceOrUndefined = src.value.kind === 'expression' ? src.value.presenceOrUndefined : undefined
+  return {
+    ...(presenceOrUndefined !== undefined && { presenceOrUndefined }),
+    ...(src.freeIdentifiers !== undefined && { freeIdentifiers: src.freeIdentifiers }),
+  }
+}
+
 export interface IRAttribute extends AttrMeta {
   name: string
-  value: string | IRTemplateLiteral | null // null for boolean attrs like 'disabled'
-  /** Pre-transformed value string with destructured prop refs rewritten to _p.xxx. */
-  templateValue?: string
-  dynamic: boolean
-  isLiteral: boolean // true if value came from a string literal attribute
+  value: AttrValue
   loc: SourceLocation
   /** When true, attr expression calls signal getters or memos (computed from AST). (#940 DRY consolidation) */
   callsReactiveGetters?: boolean
@@ -704,14 +832,8 @@ export interface IREvent {
 
 export interface IRProp extends AttrMeta {
   name: string
-  value: string
-  /** Pre-transformed value with destructured prop refs rewritten to _p.xxx. */
-  templateValue?: string
-  dynamic: boolean
-  isLiteral: boolean // true if value came from a string literal attribute (e.g., value="account")
+  value: AttrValue
   loc: SourceLocation
-  /** When the prop value is a JSX element/fragment, store the transformed IR nodes here */
-  jsxChildren?: IRNode[]
   /** When true, prop expression calls signal getters or memos (computed from AST). (#942 DRY consolidation) */
   callsReactiveGetters?: boolean
   /** When true, prop expression contains any `identifier()` pattern (computed from AST). (#942 DRY consolidation) */

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -20,7 +20,8 @@ import type {
 } from '@barefootjs/jsx'
 
 type IRAttribute = IRElement['attrs'][number]
-type IRTemplateLiteral = Exclude<IRAttribute['value'], string | null>
+type AttrValue = IRAttribute['value']
+type TemplateAttr = Extract<AttrValue, { kind: 'template' }>
 import { TestNode } from './test-node'
 
 export function irNodeToTestNode(node: IRNode, constantMap?: Map<string, string>): TestNode {
@@ -75,7 +76,8 @@ function convertElement(node: IRElement, cmap: Map<string, string>): TestNode {
 
     if (attr.name === 'className' || attr.name === 'class') {
       if (typeof value === 'string') {
-        if (attr.dynamic && cmap.size > 0) {
+        const isDynamic = attr.value.kind === 'expression' || attr.value.kind === 'template' || attr.value.kind === 'spread'
+        if (isDynamic && cmap.size > 0) {
           const resolved = resolveClassValue(value, cmap)
           if (resolved !== null) {
             classes = resolved.split(/\s+/).filter(Boolean)
@@ -224,7 +226,25 @@ function convertLoop(node: IRLoop, cmap: Map<string, string>): TestNode {
 function convertComponent(node: IRComponent, cmap: Map<string, string>): TestNode {
   const props: Record<string, string | boolean | null> = {}
   for (const prop of node.props) {
-    props[prop.name] = prop.value
+    switch (prop.value.kind) {
+      case 'literal':
+        props[prop.name] = prop.value.value
+        break
+      case 'expression':
+      case 'spread':
+        props[prop.name] = prop.value.expr
+        break
+      case 'template':
+        props[prop.name] = resolveTemplateAttr(prop.value)
+        break
+      case 'boolean-shorthand':
+      case 'boolean-attr':
+        props[prop.name] = true
+        break
+      case 'jsx-children':
+        props[prop.name] = null
+        break
+    }
   }
 
   const children = node.children.map(c => convert(c, cmap))
@@ -392,15 +412,25 @@ function resolveClassValue(value: string, cmap: Map<string, string>): string | n
 // ---------------------------------------------------------------------------
 
 function resolveAttrValue(attr: IRAttribute): string | boolean | null {
-  if (attr.value === null) return true // boolean attribute
-
-  if (typeof attr.value === 'string') return attr.value
-
-  // IRTemplateLiteral
-  return resolveTemplateLiteral(attr.value)
+  switch (attr.value.kind) {
+    case 'boolean-attr':
+      return true
+    case 'literal':
+      return attr.value.value
+    case 'expression':
+      return attr.value.expr
+    case 'spread':
+      return attr.value.expr
+    case 'template':
+      return resolveTemplateAttr(attr.value)
+    case 'boolean-shorthand':
+      return true
+    case 'jsx-children':
+      return null
+  }
 }
 
-function resolveTemplateLiteral(tl: IRTemplateLiteral): string {
+function resolveTemplateAttr(tl: TemplateAttr): string {
   return tl.parts
     .map(part => {
       if (part.type === 'string') return part.value

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -183,6 +183,54 @@ createEffect(() => {
 
 ---
 
+## Attribute & Prop Value Representation
+
+`IRAttribute` and `IRProp` carry their right-hand-side value through a
+single discriminated union `AttrValue` (#1264). Every adapter switches
+on `value.kind` exhaustively so a new variant becomes a type error at
+every emit site rather than a silent fallthrough.
+
+| Variant | Source shape | `IRAttribute` (element) | `IRProp` (component) |
+|---------|--------------|-------------------------|----------------------|
+| `literal` | `<X y="z" />` | ✓ | ✓ |
+| `expression` | `<X y={expr} />` | ✓ | ✓ |
+| `boolean-attr` | `<button disabled />` (intrinsic) | ✓ | – |
+| `boolean-shorthand` | `<X disabled />` (component) | – | ✓ |
+| `template` | `class={`${a} ${cond ? 'on' : 'off'}`}` | ✓ | ✓ |
+| `spread` | `<X {...rest} />` (with `name === '...'`) | ✓ | ✓ |
+| `jsx-children` | `<X header={<h1/>} />` | – | ✓ |
+
+Notable fields per variant:
+
+- `expression` carries `expr` (source-level JS), optional `templateExpr`
+  (the `_p.xxx`-rewritten variant used in SSR template inlining), and an
+  optional `presenceOrUndefined` set when the producer peeled an
+  `expr || undefined` boolean-presence pattern.
+- `template.parts` reuses `IRTemplatePart` (`string` / `ternary` / `lookup`).
+  Adapters that can run JS at SSR (Hono) re-emit a JS template literal;
+  adapters that can't (Go-template, Mojolicious) walk the parts.
+- `spread` keeps the legacy `name === '...'` marker for backward
+  compatibility, but `kind === 'spread'` is the authoritative
+  discriminator going forward.
+- The `freeIdentifiers`, `callsReactiveGetters`, `hasFunctionCalls`, and
+  `clientOnly` fields ride on the parent `IRAttribute` / `IRProp` (via
+  `AttrMeta`), not the variant — they apply orthogonally to every kind.
+
+Helpers exported from `@barefootjs/jsx`:
+
+- `AttrValueOf.literal(value)` / `.expression(expr, opts?)` /
+  `.booleanAttr()` / `.booleanShorthand()` / `.template(parts)` /
+  `.spread(expr, templateExpr?)` / `.jsxChildren(children)` — variant
+  constructors used by the producer and any hand-built IR fixture.
+- `attrValueToString(value, opts?)` — flatten to a JS expression string;
+  returns `null` for variants with no string projection (`boolean-attr`,
+  `boolean-shorthand`, `jsx-children`).
+- `isStaticAttrValue(value)` — true when the value is fully resolvable
+  at compile time.
+- `exhaustiveAttrValue(value)` — type-level sentinel for `switch`
+  defaults; if a future variant lands without a matching `case`, the
+  parameter collapses to `never` and the call site fails to type-check.
+
 ## Transformation Rules
 
 ### Categories


### PR DESCRIPTION
## Summary

Closes #1264.

Lifts `IRAttribute` / `IRProp` attribute-value representation from
`value: string | IRTemplateLiteral | null` plus sibling
`dynamic` / `isLiteral` / `templateValue` / `jsxChildren` boolean &
sentinel flags to a single discriminated union `AttrValue` with 7
variants:

```ts
type AttrValue =
  | { kind: 'literal'; value: string }
  | { kind: 'expression'; expr: string; templateExpr?: string; presenceOrUndefined?: boolean }
  | { kind: 'boolean-attr' }                  // element-only
  | { kind: 'boolean-shorthand' }             // component-only
  | { kind: 'template'; parts: IRTemplatePart[] }
  | { kind: 'spread'; expr: string; templateExpr?: string }
  | { kind: 'jsx-children'; children: IRNode[] }
```

Every adapter and the client-JS generator now `switch (value.kind)`
exhaustively — a future variant becomes a type error at every emit
site instead of a silent fallthrough, closing the recurring shape
captured in #1244 §F at the level below the #1255 fix.

## Design

Split into four semantic commits:

1. `feat(jsx): introduce AttrValue discriminated union for IR attributes` — type
   definitions, `AttrValueOf` constructors, `pickAttrMetaFromIR` helper,
   spec doc.
2. `refactor(jsx): migrate IR pipeline to AttrValue` — producer
   (`jsx-to-ir.ts`) emits the union; every consumer in `ir-to-client-js/*`
   (`html-template.ts`, `collect-elements.ts`, `build-references.ts`,
   `reactivity.ts`, `compute-inlinability.ts`, `child-components.ts`,
   `walker.ts`, control-flow / plan builders), plus `css-layer-prefixer.ts`,
   `debug.ts`, `adapters/test-adapter.ts`, and `packages/test/src/ir-to-test-node.ts`
   read it back via kind switches.
3. `refactor(adapters): switch SSR adapters to AttrValue.kind` — Hono,
   Go-template, and Mojolicious adapters all switch on `value.kind`.
4. `test(jsx): migrate handwritten IR fixtures to AttrValue shape` —
   the small set of tests that build IR nodes by hand (rather than via
   `compile()`).

### Design decisions

- **`boolean-attr` (element) vs `boolean-shorthand` (component) stay separate.**
  They emit differently (`<button disabled />` HTML vs `disabled={true}` JSX prop),
  so unifying them would only push the position check elsewhere. Keeping them
  distinct sets up a future per-position narrowed union.
- **`presenceOrUndefined` lives on `ExpressionAttr` (the IR-side canonical
  location).** `AttrMeta` retains the field so emit-time accumulator types
  (`ReactiveAttribute`, `ReactiveChildProp`, …) keep propagating it through
  the pipeline; `pickAttrMetaFromIR` resolves it from the variant when copying
  metadata off `IRAttribute` / `IRProp`.
- **`freeIdentifiers`, `callsReactiveGetters`, `hasFunctionCalls`, `clientOnly`
  stay on the parent (`IRAttribute` / `IRProp`)** — they're attribute-level
  metadata that applies orthogonally to every variant.
- **`spread` keeps the legacy `name === '...'` marker for back-compat**, but
  `kind === 'spread'` is the authoritative discriminator going forward.
- **`templateValue` collapses into `expression.templateExpr` /
  `spread.templateExpr`** — variants that have no template-side rewrite
  (`literal`, `boolean-*`, `jsx-children`, `template` itself) no longer
  carry the field at all.

## Test plan

- [x] `bun test packages/jsx` — 1132 / 1132 pass
- [x] `bun test packages/adapter-hono` — adapter unit tests pass (worktree
      `@barefootjs/client` resolution issue causes 3 pre-existing SSR-context
      failures, same as `main` in the worktree).
- [x] `bun test packages/adapter-go-template` — 86 / 86 pass
- [x] `bun test packages/adapter-mojolicious` — 67 / 67 pass
- [x] `bun test packages/adapter-tests` — **242 / 242 pass** (adapter conformance
      = byte-identical HTML output → confirms no regression in any adapter)
- [x] `bun test packages/client` — 261 / 261 pass
- [x] `bun test ui/components/ui` — **1222 / 1222 pass** (IR-level component
      tests)
- [x] `bun run build` — all packages build (full workspace build green,
      including `barefootjs-components` with UnoCSS)
- [ ] CI E2E (Playwright) on the PR