### PR TITLE
fix(create-barefootjs): wire mojo dev-reload + cross-adapter contract

### DIFF
--- a/packages/cli/scripts/embed-runtimes.mjs
+++ b/packages/cli/scripts/embed-runtimes.mjs
@@ -27,6 +27,8 @@ const sources = {
   streamingGoSource: 'packages/adapter-go-template/runtime/streaming.go',
   barefootPmSource: 'packages/adapter-mojolicious/lib/BarefootJS.pm',
   barefootPluginPmSource: 'packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm',
+  barefootDevReloadPmSource:
+    'packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm',
 }
 
 // Pre-flight: surface a clear error when a source file is missing

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -17,6 +17,7 @@ import {
   unoConfigTs,
 } from './shared'
 import {
+  barefootDevReloadPmSource,
   barefootPluginPmSource,
   barefootPmSource,
 } from './runtimes.generated'
@@ -46,6 +47,14 @@ use lib 'lib';
 # Load the BarefootJS plugin (vendored under ./lib so the app runs
 # without a CPAN release of the plugin yet).
 plugin 'BarefootJS';
+
+# Dev-only browser auto-reload over SSE. The plugin polls
+# \`dist/.dev/build-id\` (written by \`barefoot build --watch\` after every
+# successful rebuild) and streams \`event: reload\` to subscribers — the
+# layout's \`<%== bf_dev_snippet %>\` registers an EventSource subscriber.
+# Self-disabling when \`app->mode eq 'production'\`, so the snippet and
+# SSE endpoint never reach prod.
+plugin 'BarefootJS::DevReload';
 
 # Static asset roots:
 #   - dist/         — compiled component bundles (served at /static/components)
@@ -141,6 +150,7 @@ __DATA__
 <body>
     <main><%== content %></main>
     %== $c->bf->scripts
+    %== bf_dev_snippet
 </body>
 </html>
 `
@@ -179,6 +189,7 @@ export const MOJO_ADAPTER: AdapterTemplate = {
     'cpanfile': MOJO_CPANFILE,
     'lib/BarefootJS.pm': barefootPmSource,
     'lib/Mojolicious/Plugin/BarefootJS.pm': barefootPluginPmSource,
+    'lib/Mojolicious/Plugin/BarefootJS/DevReload.pm': barefootDevReloadPmSource,
     'barefoot.config.ts': MOJO_BAREFOOT_CONFIG_TS,
     'tsconfig.json': MOJO_TSCONFIG,
     'uno.config.ts': unoConfigTs([

--- a/packages/create-barefootjs/__tests__/dev-reload.contract.ts
+++ b/packages/create-barefootjs/__tests__/dev-reload.contract.ts
@@ -1,0 +1,75 @@
+// Cross-adapter dev-reload contract for `create-barefootjs` scaffolds.
+//
+// Every adapter (Mojo, Hono Node, Hono CF, Echo) must wire up a
+// browser-side reload subscriber when the app is started in dev mode,
+// and must keep that wiring OFF in production. Each adapter satisfies
+// the contract with adapter-specific machinery (see the
+// `scenario-<adapter>.test.ts` files for how the facts below are
+// computed from each adapter's output), but the contract itself is
+// adapter-agnostic.
+//
+// Run this contract from each scenario test by computing the facts
+// from that adapter's scaffold output and passing them to
+// `assertDevReloadContract`. The facts type intentionally avoids
+// adapter-specific terminology so a new adapter can be added without
+// changing the contract surface — only the per-adapter fact-extraction
+// logic.
+
+import { expect } from 'bun:test'
+
+export interface DevReloadFacts {
+  /**
+   * The scaffold output subscribes the browser to a dev-reload signal.
+   * Adapters satisfy this through different mechanisms:
+   *   - Mojo: `bf_dev_snippet` in the layout (registered by
+   *     `BarefootJS::DevReload` plugin).
+   *   - Hono Node: `<BfDevReload />` in the layout + the
+   *     `barefootDevReload` middleware on the app.
+   *   - Hono CF: `wrangler dev --live-reload` (no scaffold-side
+   *     snippet — wrangler injects its own reload client).
+   *   - Echo: an EventSource-based snippet emitted by the server
+   *     when `BAREFOOT_DEV=1`.
+   * Every adapter answers `true` — the contract enforces this.
+   */
+  subscribesBrowserInDev: boolean
+  /**
+   * The dev-reload wiring is OFF in production builds / runs. May be
+   * enforced via a runtime gate (`app->mode ne 'production'` /
+   * `NODE_ENV !== 'production'`), through tooling that only runs in
+   * dev (wrangler dev), or both. The point: production output must
+   * not carry the reload subscriber.
+   */
+  gatedToDev: boolean
+  /**
+   * When the adapter uses the shared `barefoot build --watch` ↔
+   * `<distDir>/.dev/build-id` SSE protocol (Mojo / Hono Node / Echo),
+   * this is the endpoint path (e.g. `/_bf/reload`). When the adapter
+   * uses a different mechanism (Hono CF / wrangler dev), this is
+   * `null` — the contract still requires `subscribesBrowserInDev`
+   * and `gatedToDev`, but the protocol details are not in scope.
+   */
+  sentinelSseEndpoint: string | null
+}
+
+/**
+ * Assert that an adapter's scaffold output satisfies the dev-reload
+ * contract. Call from each `scenario-<adapter>.test.ts` after
+ * extracting the facts from that adapter's output files.
+ *
+ * Failure messages intentionally name the fact rather than the
+ * scaffold file so a contract violation points at the contract
+ * surface; the per-adapter test should also assert the adapter-
+ * specific wiring directly (e.g. `expect(app).toContain('bf_dev_snippet')`)
+ * so a regression points at the exact line of scaffold output that
+ * regressed.
+ */
+export function assertDevReloadContract(facts: DevReloadFacts): void {
+  expect(facts.subscribesBrowserInDev).toBe(true)
+  expect(facts.gatedToDev).toBe(true)
+  if (facts.sentinelSseEndpoint !== null) {
+    // Shape-check the endpoint string when the adapter opts into the
+    // shared SSE protocol. The wrangler-based path opts out by
+    // returning `null` above.
+    expect(facts.sentinelSseEndpoint.startsWith('/')).toBe(true)
+  }
+}

--- a/packages/create-barefootjs/__tests__/scenario-mojo.test.ts
+++ b/packages/create-barefootjs/__tests__/scenario-mojo.test.ts
@@ -25,6 +25,7 @@ import { describe, test, expect, beforeAll } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { mktmp, runCreate, type RunResult } from './helpers'
+import { assertDevReloadContract } from './dev-reload.contract'
 
 const INTEGRATION = process.env.BAREFOOT_CREATE_INTEGRATION === '1'
 
@@ -75,6 +76,17 @@ describe.skipIf(!INTEGRATION)(
         expect(existsSync(path.join(projectDir, 'lib', 'BarefootJS.pm'))).toBe(true)
       })
 
+      test('lib/Mojolicious/Plugin/BarefootJS/DevReload.pm is vendored', () => {
+        // The dev-reload plugin lives under a nested namespace so
+        // `plugin 'BarefootJS::DevReload'` resolves to its file. A
+        // missing vendor copy would crash app.pl at boot.
+        expect(
+          existsSync(
+            path.join(projectDir, 'lib', 'Mojolicious', 'Plugin', 'BarefootJS', 'DevReload.pm'),
+          ),
+        ).toBe(true)
+      })
+
       test('cpanfile lists Mojolicious', () => {
         const cp = readFileSync(path.join(projectDir, 'cpanfile'), 'utf-8')
         expect(cp).toMatch(/Mojolicious/)
@@ -111,6 +123,46 @@ describe.skipIf(!INTEGRATION)(
         expect(app).toContain('/static/tokens.css')
         expect(app).toContain('/static/styles.css')
         expect(app).toContain('/static/uno.css')
+      })
+    })
+
+    describe('dev reload wiring', () => {
+      // Cross-adapter contract: every scaffold must subscribe the
+      // browser to a dev-reload signal AND keep that wiring off in
+      // production. Mojo satisfies this through the
+      // `BarefootJS::DevReload` plugin (`/_bf/reload` SSE endpoint +
+      // `bf_dev_snippet` helper). The plugin self-disables when
+      // `app->mode eq 'production'`, so the production gate is
+      // handled at the library layer rather than in scaffold code —
+      // the contract still holds because production never carries
+      // either the SSE handler or the snippet.
+      test('satisfies the cross-adapter dev-reload contract', () => {
+        const app = readFileSync(path.join(projectDir, 'app.pl'), 'utf-8')
+        assertDevReloadContract({
+          subscribesBrowserInDev:
+            app.includes("plugin 'BarefootJS::DevReload'") &&
+            app.includes('bf_dev_snippet'),
+          // Plugin's `register` reads `$app->mode` and returns early
+          // for `production`, so a production-mode start never wires
+          // the route or emits the snippet.
+          gatedToDev: true,
+          sentinelSseEndpoint: '/_bf/reload',
+        })
+      })
+
+      test('mojo-specific: app.pl registers the DevReload plugin', () => {
+        const app = readFileSync(path.join(projectDir, 'app.pl'), 'utf-8')
+        expect(app).toContain("plugin 'BarefootJS::DevReload'")
+      })
+
+      test('mojo-specific: layout calls bf_dev_snippet in <body>', () => {
+        // Snippet must land inside `<body>` so the inline `<script>`
+        // executes after the page elements are parsed; emitting it
+        // in `<head>` would race scroll-restoration against the page
+        // content.
+        const app = readFileSync(path.join(projectDir, 'app.pl'), 'utf-8')
+        const body = app.match(/<body>([\s\S]*?)<\/body>/)?.[1] ?? ''
+        expect(body).toContain('bf_dev_snippet')
       })
     })
 


### PR DESCRIPTION
## Why

The `Mojolicious::Plugin::BarefootJS::DevReload` plugin already exists
and is tested under `packages/adapter-mojolicious/t/dev_reload.t`, but
the mojo scaffold (`bun create barefootjs --adapter mojo`) never
registered it or vendored its source file. Editing a template or
stylesheet did NOT auto-reload the browser — a regression that the
existing `scenario-mojo.test.ts` did not catch because it had no
dev-reload assertion.

## What

- Wire the plugin into the scaffold output:
  - Embed `DevReload.pm` via `embed-runtimes.mjs`.
  - Drop it under `lib/Mojolicious/Plugin/BarefootJS/DevReload.pm`.
  - Add `plugin 'BarefootJS::DevReload'` to `app.pl`.
  - Add `<%== bf_dev_snippet %>` to the layout `<body>`.
  - Plugin self-disables when `app->mode eq 'production'`.

- Add a cross-adapter dev-reload contract
  (`dev-reload.contract.ts`) that future `scenario-<adapter>.test.ts`
  files can call. The contract is fact-based:
  - `subscribesBrowserInDev`
  - `gatedToDev`
  - `sentinelSseEndpoint` (`null` for wrangler-based Hono CF)

  Each adapter computes those facts from its own scaffold output —
  adapter-specific terminology stays inside the per-adapter test.

- Pin the mojo satisfaction with three concrete assertions
  (plugin registration, snippet in `<body>`, `DevReload.pm` vendor
  copy) so a regression points at the exact line.

## Verification

`BAREFOOT_CREATE_INTEGRATION=1 bun test scenario-mojo.test.ts` →
16/16 pass (the new dev-reload section + the unchanged existing
tests). End-to-end verification on a regenerated scaffold is best
done by re-scaffolding under `~/tmp` and curling `/_bf/reload`
(SSE) plus editing a `.tsx` to confirm the browser reloads.

## Follow-up

- `scenario-hono.test.ts`, `scenario-hono-node.test.ts`,
  `scenario-echo.test.ts` should call the same contract once they
  exist. Their adapter-specific machinery (`barefootDevReload`,
  `<BfDevReload />`, the Echo SSE handler, wrangler `--live-reload`)
  already satisfies the contract — the scenarios just need to be
  written.