### PR TITLE
fix(playground): move highlight fns into shared module to fix IIFE scope error

### DIFF
--- a/site/ui/components/button-group-playground.tsx
+++ b/site/ui/components/button-group-playground.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { Button } from '@ui/components/ui/button'
@@ -16,35 +16,24 @@ import { ButtonGroup } from '@ui/components/ui/button-group'
 
 type Orientation = 'horizontal' | 'vertical'
 
-function highlightButtonGroupJsx(orientation: string): string {
-  const props: string[] = []
-  if (orientation !== 'horizontal') props.push(` ${hlAttr('orientation')}${hlPlain('=')}${hlStr(`&quot;${orientation}&quot;`)}`)
-
-  return [
-    `${hlPlain('&lt;')}${hlTag('ButtonGroup')}${props.join('')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}First${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}Second${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('Button')} ${hlAttr('variant')}${hlPlain('=')}${hlStr('&quot;outline&quot;')}${hlPlain('&gt;')}Third${hlPlain('&lt;/')}${hlTag('Button')}${hlPlain('&gt;')}`,
-    `${hlPlain('&lt;/')}${hlTag('ButtonGroup')}${hlPlain('&gt;')}`,
-  ].join('\n')
-}
-
 function ButtonGroupPlayground(_props: {}) {
   const [orientation, setOrientation] = createSignal<Orientation>('horizontal')
 
-  const codeText = createMemo(() => {
-    const parts: string[] = []
-    if (orientation() !== 'horizontal') parts.push(`orientation="${orientation()}"`)
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<ButtonGroup${propsStr}>\n  <Button variant="outline">First</Button>\n  <Button variant="outline">Second</Button>\n  <Button variant="outline">Third</Button>\n</ButtonGroup>`
+  const tree = (): JsxTreeNode => ({
+    tag: 'ButtonGroup',
+    props: [{ name: 'orientation', value: orientation(), defaultValue: 'horizontal' }],
+    children: [
+      { tag: 'Button', props: [{ name: 'variant', value: 'outline', defaultValue: '' }], children: 'First' },
+      { tag: 'Button', props: [{ name: 'variant', value: 'outline', defaultValue: '' }], children: 'Second' },
+      { tag: 'Button', props: [{ name: 'variant', value: 'outline', defaultValue: '' }], children: 'Third' },
+    ],
   })
 
+  const codeText = createMemo(() => plainJsxTree(tree()))
+
   createEffect(() => {
-    const o = orientation()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightButtonGroupJsx(o)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(tree())
   })
 
   return (

--- a/site/ui/components/command-playground.tsx
+++ b/site/ui/components/command-playground.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightCommandJsx } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import {
@@ -21,30 +21,6 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from '@ui/components/ui/command'
-
-function highlightCommandJsx(placeholder: string, showShortcuts: boolean): string {
-  return [
-    `${hlPlain('&lt;')}${hlTag('Command')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('CommandInput')} ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${placeholder}&quot;`)} ${hlPlain('/&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('CommandList')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('CommandEmpty')}${hlPlain('&gt;')}No results found.${hlPlain('&lt;/')}${hlTag('CommandEmpty')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('CommandGroup')} ${hlAttr('heading')}${hlPlain('=')}${hlStr('&quot;Suggestions&quot;')}${hlPlain('&gt;')}`,
-    `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Calendar${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
-    `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Search Emoji${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;/')}${hlTag('CommandGroup')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('CommandSeparator')} ${hlPlain('/&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('CommandGroup')} ${hlAttr('heading')}${hlPlain('=')}${hlStr('&quot;Settings&quot;')}${hlPlain('&gt;')}`,
-    showShortcuts
-      ? `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Profile${hlPlain('&lt;')}${hlTag('CommandShortcut')}${hlPlain('&gt;')}\u2318P${hlPlain('&lt;/')}${hlTag('CommandShortcut')}${hlPlain('&gt;&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`
-      : `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Profile${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
-    showShortcuts
-      ? `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Settings${hlPlain('&lt;')}${hlTag('CommandShortcut')}${hlPlain('&gt;')}\u2318S${hlPlain('&lt;/')}${hlTag('CommandShortcut')}${hlPlain('&gt;&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`
-      : `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Settings${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;/')}${hlTag('CommandGroup')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;/')}${hlTag('CommandList')}${hlPlain('&gt;')}`,
-    `${hlPlain('&lt;/')}${hlTag('Command')}${hlPlain('&gt;')}`,
-  ].join('\n')
-}
 
 function CommandPlayground(_props: {}) {
   const [showShortcuts, setShowShortcuts] = createSignal(true)

--- a/site/ui/components/context-menu-playground.tsx
+++ b/site/ui/components/context-menu-playground.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import {
   ContextMenu,
@@ -20,37 +20,29 @@ import {
 } from '@ui/components/ui/context-menu'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 
-function highlightContextMenuJsx(variant: string): string {
-  const variantAttr = variant !== 'default'
-    ? ` ${hlAttr('variant')}${hlPlain('=')}${hlStr(`&quot;${variant}&quot;`)}`
-    : ''
-
-  const lines = [
-    `${hlPlain('&lt;')}${hlTag('ContextMenu')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('ContextMenuTrigger')}${hlPlain('&gt;')}...${hlPlain('&lt;/')}${hlTag('ContextMenuTrigger')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('ContextMenuContent')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('ContextMenuItem')}${variantAttr}${hlPlain('&gt;')}Back${hlPlain('&lt;/')}${hlTag('ContextMenuItem')}${hlPlain('&gt;')}`,
-    `    ${hlPlain('&lt;')}${hlTag('ContextMenuItem')}${variantAttr}${hlPlain('&gt;')}Forward${hlPlain('&lt;/')}${hlTag('ContextMenuItem')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;/')}${hlTag('ContextMenuContent')}${hlPlain('&gt;')}`,
-    `${hlPlain('&lt;/')}${hlTag('ContextMenu')}${hlPlain('&gt;')}`,
-  ]
-  return lines.join('\n')
-}
-
 function ContextMenuPlayground(_props: {}) {
   const [open, setOpen] = createSignal(false)
   const [variant, setVariant] = createSignal('default')
 
-  const codeText = () => {
-    const v = variant()
-    const variantProp = v !== 'default' ? ` variant="${v}"` : ''
-    return `<ContextMenu>\n  <ContextMenuTrigger>...</ContextMenuTrigger>\n  <ContextMenuContent>\n    <ContextMenuItem${variantProp}>Back</ContextMenuItem>\n    <ContextMenuItem${variantProp}>Forward</ContextMenuItem>\n  </ContextMenuContent>\n</ContextMenu>`
-  }
+  const tree = (): JsxTreeNode => ({
+    tag: 'ContextMenu',
+    children: [
+      { tag: 'ContextMenuTrigger', children: '...' },
+      {
+        tag: 'ContextMenuContent',
+        children: [
+          { tag: 'ContextMenuItem', props: [{ name: 'variant', value: variant(), defaultValue: 'default' }], children: 'Back' },
+          { tag: 'ContextMenuItem', props: [{ name: 'variant', value: variant(), defaultValue: 'default' }], children: 'Forward' },
+        ],
+      },
+    ],
+  })
+
+  const codeText = () => plainJsxTree(tree())
 
   createEffect(() => {
-    const v = variant()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) codeEl.innerHTML = highlightContextMenuJsx(v)
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(tree())
   })
 
   // Update variant classes on live items

--- a/site/ui/components/input-otp-playground.tsx
+++ b/site/ui/components/input-otp-playground.tsx
@@ -8,25 +8,11 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@ui/components/ui/input-otp'
-
-function highlightInputOTPJsx(maxLength: number, disabled: boolean): string {
-  const disabledProp = disabled ? ` ${hlAttr('disabled')}` : ''
-  const lines = [
-    `${hlPlain('&lt;')}${hlTag('InputOTP')} ${hlAttr('maxLength')}${hlPlain('={')}${maxLength}${hlPlain('}')}${disabledProp}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`,
-  ]
-  for (let i = 0; i < maxLength; i++) {
-    lines.push(`    ${hlPlain('&lt;')}${hlTag('InputOTPSlot')} ${hlAttr('index')}${hlPlain('={')}${i}${hlPlain('}')} ${hlPlain('/&gt;')}`)
-  }
-  lines.push(`  ${hlPlain('&lt;/')}${hlTag('InputOTPGroup')}${hlPlain('&gt;')}`)
-  lines.push(`${hlPlain('&lt;/')}${hlTag('InputOTP')}${hlPlain('&gt;')}`)
-  return lines.join('\n')
-}
 
 function InputOTPPlayground(_props: {}) {
   const [maxLength, setMaxLength] = createSignal('6')
@@ -34,21 +20,26 @@ function InputOTPPlayground(_props: {}) {
 
   const maxLengthNum = createMemo(() => parseInt(maxLength(), 10))
 
-  const codeText = createMemo(() => {
-    const ml = maxLengthNum()
-    const parts: string[] = [`maxLength={${ml}}`]
-    if (disabled()) parts.push('disabled')
-    const slots = Array.from({ length: ml }, (_, i) => `    <InputOTPSlot index={${i}} />`).join('\n')
-    return `<InputOTP ${parts.join(' ')}>\n  <InputOTPGroup>\n${slots}\n  </InputOTPGroup>\n</InputOTP>`
+  const tree = (): JsxTreeNode => ({
+    tag: 'InputOTP',
+    props: [
+      { name: 'maxLength', value: String(maxLengthNum()), defaultValue: '', kind: 'expression' as const },
+      { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' as const },
+    ],
+    children: [{
+      tag: 'InputOTPGroup',
+      children: Array.from({ length: maxLengthNum() }, (_, i) => ({
+        tag: 'InputOTPSlot',
+        props: [{ name: 'index', value: String(i), defaultValue: '', kind: 'expression' as const }],
+      })),
+    }],
   })
 
+  const codeText = createMemo(() => plainJsxTree(tree()))
+
   createEffect(() => {
-    const ml = maxLengthNum()
-    const d = disabled()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightInputOTPJsx(ml, d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(tree())
   })
 
   // Toggle visibility of pre-rendered variants based on maxLength

--- a/site/ui/components/portal-playground.tsx
+++ b/site/ui/components/portal-playground.tsx
@@ -6,7 +6,7 @@
  * Allows toggling portal visibility and switching between default and custom container.
  */
 
-import { createSignal, createEffect, createPortal, type Portal } from '@barefootjs/client'
+import { createSignal, createEffect, createPortal } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
 import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
@@ -18,7 +18,7 @@ type ContainerTarget = 'body' | 'custom'
 function PortalPlayground(_props: {}) {
   const [visible, setVisible] = createSignal(false)
   const [target, setTarget] = createSignal<ContainerTarget>('body')
-  const state: { portal: Portal | null; container: HTMLElement | null } = { portal: null, container: null }
+  const state: { portal: { unmount: () => void } | null; container: HTMLElement | null } = { portal: null, container: null }
 
   const setContainerRef = (el: HTMLElement) => {
     state.container = el

--- a/site/ui/components/progress-playground.tsx
+++ b/site/ui/components/progress-playground.tsx
@@ -8,17 +8,10 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Slider } from '@ui/components/ui/slider'
 import { Progress } from '@ui/components/ui/progress'
-
-function highlightProgressJsx(value: number, max: number): string {
-  const props: string[] = []
-  props.push(` ${hlAttr('value')}${hlPlain('={')}${value}${hlPlain('}')}`)
-  if (max !== 100) props.push(` ${hlAttr('max')}${hlPlain('={')}${max}${hlPlain('}')}`)
-  return `${hlPlain('&lt;')}${hlTag('Progress')}${props.join('')} ${hlPlain('/&gt;')}`
-}
 
 function ProgressPlayground(_props: {}) {
   const [value, setValue] = createSignal(50)
@@ -28,19 +21,16 @@ function ProgressPlayground(_props: {}) {
     Math.round((value() / max()) * 100)
   )
 
-  const codeText = createMemo(() => {
-    const parts: string[] = [`value={${value()}}`]
-    if (max() !== 100) parts.push(`max={${max()}}`)
-    return `<Progress ${parts.join(' ')} />`
-  })
+  const progressProps = (): HighlightProp[] => [
+    { name: 'value', value: String(value()), defaultValue: '', kind: 'expression' as const },
+    { name: 'max', value: String(max()), defaultValue: '100', kind: 'expression' as const },
+  ]
+
+  const codeText = createMemo(() => plainJsxSelfClosing('Progress', progressProps()))
 
   createEffect(() => {
-    const v = value()
-    const m = max()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightProgressJsx(v, m)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Progress', progressProps())
   })
 
   return (

--- a/site/ui/components/radio-group-playground.tsx
+++ b/site/ui/components/radio-group-playground.tsx
@@ -8,36 +8,31 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group'
 
-function highlightRadioGroupJsx(disabled: boolean): string {
-  const disabledProp = disabled ? ` ${hlAttr('disabled')}` : ''
-  return [
-    `${hlPlain('&lt;')}${hlTag('RadioGroup')} ${hlAttr('defaultValue')}${hlPlain('=')}${hlStr('&quot;option-1&quot;')}${disabledProp}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('RadioGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;option-1&quot;')} ${hlPlain('/&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('RadioGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;option-2&quot;')} ${hlPlain('/&gt;')}`,
-    `${hlPlain('&lt;/')}${hlTag('RadioGroup')}${hlPlain('&gt;')}`,
-  ].join('\n')
-}
-
 function RadioGroupPlayground(_props: {}) {
   const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const parts: string[] = ['defaultValue="option-1"']
-    if (disabled()) parts.push('disabled')
-    return `<RadioGroup ${parts.join(' ')}>\n  <RadioGroupItem value="option-1" />\n  <RadioGroupItem value="option-2" />\n</RadioGroup>`
+  const tree = (): JsxTreeNode => ({
+    tag: 'RadioGroup',
+    props: [
+      { name: 'defaultValue', value: 'option-1', defaultValue: '' },
+      { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' as const },
+    ],
+    children: [
+      { tag: 'RadioGroupItem', props: [{ name: 'value', value: 'option-1', defaultValue: '' }] },
+      { tag: 'RadioGroupItem', props: [{ name: 'value', value: 'option-2', defaultValue: '' }] },
+    ],
   })
 
+  const codeText = createMemo(() => plainJsxTree(tree()))
+
   createEffect(() => {
-    const d = disabled()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightRadioGroupJsx(d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(tree())
   })
 
   return (

--- a/site/ui/components/shared/playground-highlight.ts
+++ b/site/ui/components/shared/playground-highlight.ts
@@ -157,3 +157,31 @@ export function plainJsxTree(node: JsxTreeNode, indent = 0): string {
   const childLines = node.children.map(c => plainJsxTree(c, indent + 1))
   return [`${pad}<${node.tag}${renderedProps}>`, ...childLines, `${pad}</${node.tag}>`].join('\n')
 }
+
+/**
+ * Generate syntax-highlighted JSX for the Command component tree.
+ * Exported here so it's properly bundled in the client JS IIFE scope.
+ */
+export function highlightCommandJsx(placeholder: string, showShortcuts: boolean): string {
+  return [
+    `${hlPlain('&lt;')}${hlTag('Command')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('CommandInput')} ${hlAttr('placeholder')}${hlPlain('=')}${hlStr(`&quot;${escapeHtml(placeholder)}&quot;`)} ${hlPlain('/&gt;')}`,
+    `  ${hlPlain('&lt;')}${hlTag('CommandList')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('CommandEmpty')}${hlPlain('&gt;')}No results found.${hlPlain('&lt;/')}${hlTag('CommandEmpty')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('CommandGroup')} ${hlAttr('heading')}${hlPlain('=')}${hlStr('&quot;Suggestions&quot;')}${hlPlain('&gt;')}`,
+    `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Calendar${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
+    `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Search Emoji${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;/')}${hlTag('CommandGroup')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('CommandSeparator')} ${hlPlain('/&gt;')}`,
+    `    ${hlPlain('&lt;')}${hlTag('CommandGroup')} ${hlAttr('heading')}${hlPlain('=')}${hlStr('&quot;Settings&quot;')}${hlPlain('&gt;')}`,
+    showShortcuts
+      ? `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Profile${hlPlain('&lt;')}${hlTag('CommandShortcut')}${hlPlain('&gt;')}⌘P${hlPlain('&lt;/')}${hlTag('CommandShortcut')}${hlPlain('&gt;&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`
+      : `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Profile${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
+    showShortcuts
+      ? `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Settings${hlPlain('&lt;')}${hlTag('CommandShortcut')}${hlPlain('&gt;')}⌘S${hlPlain('&lt;/')}${hlTag('CommandShortcut')}${hlPlain('&gt;&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`
+      : `      ${hlPlain('&lt;')}${hlTag('CommandItem')}${hlPlain('&gt;')}Settings${hlPlain('&lt;/')}${hlTag('CommandItem')}${hlPlain('&gt;')}`,
+    `    ${hlPlain('&lt;/')}${hlTag('CommandGroup')}${hlPlain('&gt;')}`,
+    `  ${hlPlain('&lt;/')}${hlTag('CommandList')}${hlPlain('&gt;')}`,
+    `${hlPlain('&lt;/')}${hlTag('Command')}${hlPlain('&gt;')}`,
+  ].join('\n')
+}

--- a/site/ui/components/slider-playground.tsx
+++ b/site/ui/components/slider-playground.tsx
@@ -8,37 +8,25 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr } from './shared/playground-highlight'
+import { highlightJsxSelfClosing, plainJsxSelfClosing, type HighlightProp } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Slider } from '@ui/components/ui/slider'
-
-function highlightSliderJsx(value: number, disabled: boolean): string {
-  const props: string[] = []
-  if (value !== 50) props.push(` ${hlAttr('defaultValue')}${hlPlain('={')}${value}${hlPlain('}')}`)
-  if (disabled) props.push(` ${hlAttr('disabled')}`)
-  return `${hlPlain('&lt;')}${hlTag('Slider')}${props.join('')} ${hlPlain('/&gt;')}`
-}
 
 function SliderPlayground(_props: {}) {
   const [value, setValue] = createSignal(50)
   const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const parts: string[] = []
-    if (value() !== 50) parts.push(`defaultValue={${value()}}`)
-    if (disabled()) parts.push('disabled')
-    const propsStr = parts.length > 0 ? ` ${parts.join(' ')}` : ''
-    return `<Slider${propsStr} />`
-  })
+  const sliderProps = (): HighlightProp[] => [
+    { name: 'defaultValue', value: String(value()), defaultValue: '50', kind: 'expression' as const },
+    { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' as const },
+  ]
+
+  const codeText = createMemo(() => plainJsxSelfClosing('Slider', sliderProps()))
 
   createEffect(() => {
-    const v = value()
-    const d = disabled()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightSliderJsx(v, d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxSelfClosing('Slider', sliderProps())
   })
 
   return (

--- a/site/ui/components/toggle-group-playground.tsx
+++ b/site/ui/components/toggle-group-playground.tsx
@@ -8,7 +8,7 @@
 
 import { createSignal, createMemo, createEffect } from '@barefootjs/client'
 import { CopyButton } from './copy-button'
-import { hlPlain, hlTag, hlAttr, hlStr } from './shared/playground-highlight'
+import { highlightJsxTree, plainJsxTree, type JsxTreeNode } from './shared/playground-highlight'
 import { PlaygroundLayout, PlaygroundControl } from './shared/PlaygroundLayout'
 import { Checkbox } from '@ui/components/ui/checkbox'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@ui/components/ui/select'
@@ -18,45 +18,32 @@ type GroupType = 'single' | 'multiple'
 type GroupVariant = 'default' | 'outline'
 type GroupSize = 'default' | 'sm' | 'lg'
 
-function highlightToggleGroupJsx(type: string, variant: string, size: string, disabled: boolean): string {
-  const props: string[] = []
-  props.push(` ${hlAttr('type')}${hlPlain('=')}${hlStr(`&quot;${type}&quot;`)}`)
-  if (variant !== 'default') props.push(` ${hlAttr('variant')}${hlPlain('=')}${hlStr(`&quot;${variant}&quot;`)}`)
-  if (size !== 'default') props.push(` ${hlAttr('size')}${hlPlain('=')}${hlStr(`&quot;${size}&quot;`)}`)
-  if (disabled) props.push(` ${hlAttr('disabled')}`)
-
-  return [
-    `${hlPlain('&lt;')}${hlTag('ToggleGroup')}${props.join('')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;a&quot;')}${hlPlain('&gt;')}A${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;b&quot;')}${hlPlain('&gt;')}B${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
-    `  ${hlPlain('&lt;')}${hlTag('ToggleGroupItem')} ${hlAttr('value')}${hlPlain('=')}${hlStr('&quot;c&quot;')}${hlPlain('&gt;')}C${hlPlain('&lt;/')}${hlTag('ToggleGroupItem')}${hlPlain('&gt;')}`,
-    `${hlPlain('&lt;/')}${hlTag('ToggleGroup')}${hlPlain('&gt;')}`,
-  ].join('\n')
-}
-
 function ToggleGroupPlayground(_props: {}) {
   const [type, setType] = createSignal<GroupType>('single')
   const [variant, setVariant] = createSignal<GroupVariant>('outline')
   const [size, setSize] = createSignal<GroupSize>('default')
   const [disabled, setDisabled] = createSignal(false)
 
-  const codeText = createMemo(() => {
-    const parts: string[] = [`type="${type()}"`]
-    if (variant() !== 'default') parts.push(`variant="${variant()}"`)
-    if (size() !== 'default') parts.push(`size="${size()}"`)
-    if (disabled()) parts.push('disabled')
-    return `<ToggleGroup ${parts.join(' ')}>\n  <ToggleGroupItem value="a">A</ToggleGroupItem>\n  <ToggleGroupItem value="b">B</ToggleGroupItem>\n  <ToggleGroupItem value="c">C</ToggleGroupItem>\n</ToggleGroup>`
+  const tree = (): JsxTreeNode => ({
+    tag: 'ToggleGroup',
+    props: [
+      { name: 'type', value: type(), defaultValue: '' },
+      { name: 'variant', value: variant(), defaultValue: 'default' },
+      { name: 'size', value: size(), defaultValue: 'default' },
+      { name: 'disabled', value: String(disabled()), defaultValue: 'false', kind: 'boolean' as const },
+    ],
+    children: [
+      { tag: 'ToggleGroupItem', props: [{ name: 'value', value: 'a', defaultValue: '' }], children: 'A' },
+      { tag: 'ToggleGroupItem', props: [{ name: 'value', value: 'b', defaultValue: '' }], children: 'B' },
+      { tag: 'ToggleGroupItem', props: [{ name: 'value', value: 'c', defaultValue: '' }], children: 'C' },
+    ],
   })
 
+  const codeText = createMemo(() => plainJsxTree(tree()))
+
   createEffect(() => {
-    const t = type()
-    const v = variant()
-    const s = size()
-    const d = disabled()
     const codeEl = document.querySelector('[data-playground-code]') as HTMLElement
-    if (codeEl) {
-      codeEl.innerHTML = highlightToggleGroupJsx(t, v, s, d)
-    }
+    if (codeEl) codeEl.innerHTML = highlightJsxTree(tree())
   })
 
   return (

--- a/site/ui/e2e/playground-code-block.spec.ts
+++ b/site/ui/e2e/playground-code-block.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Regression tests for playground code-block population.
+ *
+ * Root cause: highlight helpers (hlPlain, hlTag, etc.) imported from
+ * `playground-highlight.ts` were compiled outside the `__bf_inline_0` IIFE
+ * scope in the client JS bundle when used inside component-local functions.
+ * The createEffect that populates [data-playground-code] threw a
+ * ReferenceError, leaving the code block empty.
+ *
+ * Fix: all highlight logic now lives in the shared module itself, so the
+ * compiler inlines it inside the IIFE where signal-driven effects can reach it.
+ */
+
+const codeBlock = (page: Page) => page.locator('[data-playground-code]')
+
+async function selectOption(page: Page, value: string) {
+  const trigger = page.locator('#preview [data-slot="select-trigger"]').first()
+  await trigger.click()
+  await page.locator(`[data-slot="select-item"][data-value="${value}"]`).click()
+}
+
+async function clickCheckbox(page: Page) {
+  await page.locator('#preview [data-slot="checkbox"]').first().click()
+}
+
+test.describe('Button Group Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/button-group')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('ButtonGroup')
+  })
+
+  test('changing orientation to vertical updates code block', async ({ page }) => {
+    await selectOption(page, 'vertical')
+    await expect(codeBlock(page)).toContainText('vertical')
+  })
+})
+
+test.describe('Input OTP Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/input-otp')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('InputOTP')
+  })
+
+  test('toggling disabled adds disabled prop to code block', async ({ page }) => {
+    await clickCheckbox(page)
+    await expect(codeBlock(page)).toContainText('disabled')
+  })
+})
+
+test.describe('Slider Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/slider')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('Slider')
+  })
+
+  test('toggling disabled adds disabled prop to code block', async ({ page }) => {
+    await clickCheckbox(page)
+    await expect(codeBlock(page)).toContainText('disabled')
+  })
+})
+
+test.describe('Toggle Group Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/toggle-group')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('ToggleGroup')
+  })
+
+  test('toggling disabled adds disabled prop to code block', async ({ page }) => {
+    await clickCheckbox(page)
+    await expect(codeBlock(page)).toContainText('disabled')
+  })
+})
+
+test.describe('Progress Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/progress')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('Progress')
+  })
+})
+
+test.describe('Command Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/command')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('Command')
+  })
+
+  test('unchecking shortcuts removes CommandShortcut from code block', async ({ page }) => {
+    await expect(codeBlock(page)).toContainText('CommandShortcut')
+    await clickCheckbox(page)
+    await expect(codeBlock(page)).not.toContainText('CommandShortcut')
+  })
+})
+
+test.describe('Context Menu Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/context-menu')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('ContextMenu')
+  })
+
+  test('changing variant to destructive updates code block', async ({ page }) => {
+    await selectOption(page, 'destructive')
+    await expect(codeBlock(page)).toContainText('destructive')
+  })
+})
+
+test.describe('Portal Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/portal')
+  })
+
+  test('populates code block on load', async ({ page }) => {
+    await expect(codeBlock(page)).not.toBeEmpty()
+    await expect(codeBlock(page)).toContainText('createPortal')
+  })
+
+  test('switching to custom container adds container prop to code block', async ({ page }) => {
+    await selectOption(page, 'custom')
+    await expect(codeBlock(page)).toContainText('container')
+  })
+})


### PR DESCRIPTION
## Summary

- Component-local highlight functions (`highlightButtonGroupJsx` etc.) were defined **outside** the `__bf_inline_0` IIFE that the BarefootJS compiler wraps around inlined module imports. At runtime this threw `ReferenceError: hlPlain is not defined` inside the `createEffect` that populates `[data-playground-code]`, leaving the code block empty and controls non-functional.
- Fix: move all highlight logic into `playground-highlight.ts` as exported functions. The compiler inlines the entire shared module inside the IIFE, putting the helpers in scope for every signal-driven effect.
- Also fix `portal-playground`'s `type Portal` import: the TS type was compiled as a value import, causing a `SyntaxError` at runtime. Replaced with an inline structural type `{ unmount: () => void } | null`.

**Affected playgrounds:** Button Group, Input OTP, Radio Group, Slider, Toggle Group, Progress, Command, Context Menu, Portal

## Test plan

- [x] New E2E spec `playground-code-block.spec.ts` (15 tests): verifies `[data-playground-code]` is non-empty after hydration and that controls update the code block
- [x] All 15 tests pass against the worktree server (`PORT=3003`)
- [x] Manually verified all 9 playground pages in Chromium: no console errors, preview and code block both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)