### PR TITLE
refactor(#1250): adapter contract phase 2 — typed sections + boundary cleanup

### DIFF
--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -28,7 +28,7 @@ import type {
   IRAsync,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
-import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, isBooleanAttr, parseExpression, isSupported, identifierPath } from '@barefootjs/jsx'
+import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, type TemplateSections, isBooleanAttr, parseExpression, isSupported, identifierPath } from '@barefootjs/jsx'
 
 /**
  * Extended nested component info that tracks whether the component
@@ -241,8 +241,19 @@ export class GoTemplateAdapter extends BaseAdapter {
       ir.errors.push(...this.errors)
     }
 
+    // Go templates have no JS-style imports / types / default-export sections;
+    // the entire `{{define}}…{{end}}` block is the component body. The compiler
+    // assembles multi-component files by concatenating the `component` parts.
+    const sections: TemplateSections = {
+      imports: '',
+      types: '',
+      component: template,
+      defaultExport: '',
+    }
+
     return {
       template,
+      sections,
       types: types || undefined,
       extension: this.extension,
     }

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -399,8 +399,10 @@ export class HonoAdapter extends JsxAdapter {
     }
 
     const lines: string[] = []
-    // Adapter always emits without 'export'; compiler handles export keywords
-    lines.push(`function ${name}(${fullPropsDestructure}${typeAnnotation}) {`)
+    // Module-export keyword belongs to the adapter: it knows the target language
+    // and whether the source declared the component as exported.
+    const exportPrefix = ir.metadata.isExported === false ? '' : 'export '
+    lines.push(`${exportPrefix}function ${name}(${fullPropsDestructure}${typeAnnotation}) {`)
 
     // Add props extraction for SolidJS-style pattern
     if (propsExtraction) {

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -25,6 +25,7 @@ import {
   type JsxAdapterConfig,
   JsxAdapter,
   isBooleanAttr,
+  rewriteImportsForTemplate,
 } from '@barefootjs/jsx'
 import { BF_SCOPE, BF_HOST, BF_AT, BF_ROOT, BF_PROPS } from '@barefootjs/shared'
 
@@ -167,9 +168,14 @@ export class HonoAdapter extends JsxAdapter {
       lines.push(`import { Suspense } from 'hono/jsx/streaming'`)
     }
 
-    // Re-emit template imports (compiler already rewrote @barefootjs/client to
-    // the shim source).
-    for (const imp of ir.metadata.templateImports) {
+    // Re-emit template imports, rewriting `@barefootjs/client` to this
+    // adapter's SSR shim. Adapters own the rewrite; the compiler hands us
+    // the raw import list.
+    const templateImports = rewriteImportsForTemplate(
+      ir.metadata.templateImports,
+      this.clientShimSource,
+    )
+    for (const imp of templateImports) {
       if (imp.specifiers.length === 0) {
         if (!imp.isTypeOnly) {
           lines.push(`import '${imp.source}'`)

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -23,7 +23,7 @@ import type {
   CompilerError,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
-import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, isBooleanAttr, parseExpression, identifierPath, stringifyParsedExpr } from '@barefootjs/jsx'
+import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, type TemplateSections, isBooleanAttr, parseExpression, identifierPath, stringifyParsedExpr } from '@barefootjs/jsx'
 import type { ParsedExpr, ParsedStatement } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND } from '@barefootjs/shared'
 
@@ -152,8 +152,20 @@ export class MojoAdapter extends BaseAdapter {
       ir.errors.push(...this.errors)
     }
 
+    // Mojo templates have no JS-style imports / types / default-export sections.
+    // The `templatesPerComponent` mode emits one file per component using the
+    // raw `template` value; sections are populated for contract uniformity so
+    // the compiler never has to fall back to string-parsing the template.
+    const sections: TemplateSections = {
+      imports: '',
+      types: '',
+      component: template,
+      defaultExport: '',
+    }
+
     return {
       template,
+      sections,
       extension: this.extension,
     }
   }

--- a/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
+++ b/packages/jsx/src/__tests__/reactivity-classification/_helpers.ts
@@ -93,7 +93,7 @@ export function compileToComponentIR(
   }
   const componentIR: ComponentIR = {
     version: '0.1',
-    metadata: buildMetadata(ctx, ''),
+    metadata: buildMetadata(ctx),
     root,
     errors: [],
   }

--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -31,11 +31,11 @@ export interface TemplateSections {
 }
 
 export interface AdapterOutput {
-  /** Complete assembled template string (backward compat for external consumers) */
+  /** Complete assembled template string (kept for external consumers and debugging). */
   template: string
-  /** Structured sections for compiler assembly. When present, compiler uses these
-   *  instead of re-parsing template. */
-  sections?: TemplateSections
+  /** Structured sections used by the compiler to assemble the final module
+   *  file. Required: the compiler does not parse the raw `template`. */
+  sections: TemplateSections
   types?: string // Generated types (for typed languages)
   extension: string
 }

--- a/packages/jsx/src/adapters/template-imports.ts
+++ b/packages/jsx/src/adapters/template-imports.ts
@@ -1,0 +1,66 @@
+/**
+ * Adapter helper: prepare a component's import list for re-emission into
+ * an SSR template.
+ *
+ * `@barefootjs/client` and `@barefootjs/client/runtime` are client-side
+ * sources whose runtime symbols must not appear unmodified in SSR output.
+ * Adapters resolve them in one of two ways:
+ *
+ * - Provide a `clientShimSource` (a module that re-exports SSR-safe stubs):
+ *   matching imports are rewritten to that shim. Multiple originals collapse
+ *   into a single import statement so the SSR template stays clean.
+ * - Provide no shim (`undefined`): matching imports are dropped. Suitable
+ *   for adapters whose templates do not execute JS at SSR (Go templates,
+ *   Mojo `.html.ep`).
+ *
+ * Adapters are responsible for calling this themselves before emitting any
+ * import block. The compiler hands them `metadata.imports` unchanged.
+ */
+import type { ImportInfo, ImportSpecifier } from '../types'
+
+const CLIENT_PACKAGE_SOURCES = new Set([
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+])
+
+export function rewriteImportsForTemplate(
+  imports: ImportInfo[],
+  shimSource: string | undefined,
+): ImportInfo[] {
+  if (!shimSource) {
+    return imports.filter((imp) => !CLIENT_PACKAGE_SOURCES.has(imp.source))
+  }
+  const merged = new Map<string, ImportInfo>()
+  const result: ImportInfo[] = []
+  for (const imp of imports) {
+    if (!CLIENT_PACKAGE_SOURCES.has(imp.source)) {
+      result.push(imp)
+      continue
+    }
+    const existing = merged.get(shimSource)
+    if (existing) {
+      const seen = new Set(existing.specifiers.map(specKey))
+      for (const spec of imp.specifiers) {
+        if (!seen.has(specKey(spec))) {
+          existing.specifiers.push(spec)
+          seen.add(specKey(spec))
+        }
+      }
+      // Type-only stays only if every contributing import is type-only.
+      existing.isTypeOnly = existing.isTypeOnly && imp.isTypeOnly
+    } else {
+      const rewritten: ImportInfo = {
+        ...imp,
+        source: shimSource,
+        specifiers: imp.specifiers.map((s) => ({ ...s })),
+      }
+      merged.set(shimSource, rewritten)
+      result.push(rewritten)
+    }
+  }
+  return result
+}
+
+function specKey(s: ImportSpecifier): string {
+  return `${s.isDefault ? 'd' : ''}${s.isNamespace ? 'n' : ''}:${s.name}:${s.alias ?? ''}`
+}

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -19,6 +19,7 @@ import type {
 } from '../types'
 import type { AdapterOutput, TemplateSections } from './interface'
 import { type JsxAdapterConfig, JsxAdapter } from './jsx-adapter'
+import { rewriteImportsForTemplate } from './template-imports'
 
 export class TestAdapter extends JsxAdapter {
   name = 'test'
@@ -58,8 +59,12 @@ export class TestAdapter extends JsxAdapter {
   private generateImports(ir: ComponentIR): string {
     const lines: string[] = []
 
-    // Use templateImports (client-side packages already filtered by compiler)
-    for (const imp of ir.metadata.templateImports) {
+    // TestAdapter has no client shim, so client-side packages are dropped.
+    const templateImports = rewriteImportsForTemplate(
+      ir.metadata.templateImports,
+      undefined,
+    )
+    for (const imp of templateImports) {
       if (imp.specifiers.length === 0) {
         if (!imp.isTypeOnly) {
           lines.push(`import '${imp.source}'`)

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -134,8 +134,10 @@ export class TestAdapter extends JsxAdapter {
     const fullPropsDestructure = `{ ${parts.join(', ')} }`
 
     const lines: string[] = []
-    // Adapter always emits without 'export'; compiler handles export keywords
-    lines.push(`function ${name}(${fullPropsDestructure}${typeAnnotation}) {`)
+    // Module-export keyword belongs to the adapter: it knows the target language
+    // and whether the source declared the component as exported.
+    const exportPrefix = ir.metadata.isExported === false ? '' : 'export '
+    lines.push(`${exportPrefix}function ${name}(${fullPropsDestructure}${typeAnnotation}) {`)
 
     // Generate scope ID
     if (hasClientInteractivity) {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -196,49 +196,14 @@ function compileMultipleComponents(
     })
     const moduleExports = generateModuleExports(componentIR, fileWideInlineExported)
 
-    let imports: string
-    let types: string
-    let component: string
-
-    if (adapterOutput.sections) {
-      // Use structured sections directly — no string parsing needed
-      const s = adapterOutput.sections
-      imports = s.imports
-      types = s.types
-      component = s.component + (s.defaultExport || '')
-      const mc = s.moduleConstants
-      if (mc && !moduleConstantsSet.has(mc)) {
-        moduleConstantsSet.add(mc)
-        moduleConstantsOrdered.push(mc)
-      }
-    } else {
-      // Fallback: parse template string (for adapters without sections)
-      const lines = adapterOutput.template.split('\n')
-      const importLines: string[] = []
-      const typeLines: string[] = []
-      const componentLines: string[] = []
-      let inComponent = false
-
-      for (const line of lines) {
-        if (line.startsWith('export function ') || line.startsWith('function ')) {
-          const funcName = line.match(/^(?:export )?function (\w+)/)?.[1]
-          if (funcName && componentNames.includes(funcName)) {
-            inComponent = true
-          }
-        }
-
-        if (inComponent) {
-          componentLines.push(line)
-        } else if (line.startsWith('import ')) {
-          importLines.push(line)
-        } else if (line.trim()) {
-          typeLines.push(line)
-        }
-      }
-
-      imports = importLines.join('\n')
-      types = typeLines.join('\n')
-      component = componentLines.join('\n')
+    const s = adapterOutput.sections
+    const imports = s.imports
+    const types = s.types
+    const component = s.component + (s.defaultExport || '')
+    const mc = s.moduleConstants
+    if (mc && !moduleConstantsSet.has(mc)) {
+      moduleConstantsSet.add(mc)
+      moduleConstantsOrdered.push(mc)
     }
 
     allOutputs.push({
@@ -558,15 +523,9 @@ export function compileJSX(
   })
   const moduleExports = generateModuleExports(componentIR)
 
-  // Use structured sections if available, otherwise fall back to template
-  let content: string
-  if (adapterOutput.sections) {
-    const s = adapterOutput.sections
-    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, s.component]
-      .filter(Boolean).join('\n\n') + (s.defaultExport || '')
-  } else {
-    content = adapterOutput.template
-  }
+  const s = adapterOutput.sections
+  const content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, s.component]
+    .filter(Boolean).join('\n\n') + (s.defaultExport || '')
 
   files.push({
     path: filePath.replace(/\.tsx?$/, adapter.extension),

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -6,8 +6,6 @@
 
 import type {
   ComponentIR,
-  ImportInfo,
-  ImportSpecifier,
   IRMetadata,
   CompileOptions,
   CompileResult,
@@ -28,62 +26,6 @@ import { preprocessInlineJsxCallbacks } from './preprocess-inline-jsx-callbacks'
 export interface CompileOptionsWithAdapter extends CompileOptions {
   /** Template adapter for generating output (required) */
   adapter: TemplateAdapter
-}
-
-/**
- * Client-side package sources that need adapter-specific SSR handling.
- * When the adapter provides a `clientShimSource`, imports from these paths
- * are rewritten to that shim. Otherwise (e.g. go-template, which has no JS
- * runtime at SSR), the imports are stripped wholesale.
- */
-const CLIENT_PACKAGE_SOURCES = new Set([
-  '@barefootjs/client',
-  '@barefootjs/client/runtime',
-])
-
-function rewriteTemplateImports(
-  imports: ImportInfo[],
-  shimSource: string | undefined,
-): ImportInfo[] {
-  if (!shimSource) {
-    return imports.filter(imp => !CLIENT_PACKAGE_SOURCES.has(imp.source))
-  }
-  const merged = new Map<string, ImportInfo>()
-  const result: ImportInfo[] = []
-  for (const imp of imports) {
-    if (!CLIENT_PACKAGE_SOURCES.has(imp.source)) {
-      result.push(imp)
-      continue
-    }
-    // Rewrite to the shim source. Multiple original sources collapse into a
-    // single import statement so the SSR template stays clean.
-    const existing = merged.get(shimSource)
-    if (existing) {
-      // Merge specifiers, deduplicating by (name, alias, isDefault, isNamespace)
-      const seen = new Set(existing.specifiers.map(specKey))
-      for (const spec of imp.specifiers) {
-        if (!seen.has(specKey(spec))) {
-          existing.specifiers.push(spec)
-          seen.add(specKey(spec))
-        }
-      }
-      // Type-only stays only if every contributing import is type-only
-      existing.isTypeOnly = existing.isTypeOnly && imp.isTypeOnly
-    } else {
-      const rewritten: ImportInfo = {
-        ...imp,
-        source: shimSource,
-        specifiers: imp.specifiers.map(s => ({ ...s })),
-      }
-      merged.set(shimSource, rewritten)
-      result.push(rewritten)
-    }
-  }
-  return result
-}
-
-function specKey(s: ImportSpecifier): string {
-  return `${s.isDefault ? 'd' : ''}${s.isNamespace ? 'n' : ''}:${s.name}:${s.alias ?? ''}`
 }
 
 // =============================================================================
@@ -120,7 +62,7 @@ function compileMultipleComponents(
 
     const componentIR: ComponentIR = {
       version: '0.1',
-      metadata: buildMetadata(ctx, options.adapter.clientShimSource),
+      metadata: buildMetadata(ctx),
       root: ir,
       errors: [],
     }
@@ -420,7 +362,6 @@ function compileMultipleComponents(
 
 export function buildMetadata(
   ctx: ReturnType<typeof analyzeComponent>,
-  clientShimSource?: string
 ): IRMetadata {
   return {
     componentName: ctx.componentName || 'Unknown',
@@ -439,7 +380,12 @@ export function buildMetadata(
     onMounts: ctx.onMounts,
     initStatements: ctx.initStatements,
     imports: ctx.imports,
-    templateImports: rewriteTemplateImports(ctx.imports, clientShimSource),
+    // `templateImports` is the raw import list adapters consider for SSR
+    // re-emission. Adapters that re-emit imports (Hono, test) call
+    // `rewriteImportsForTemplate` themselves to apply client-shim rewrite or
+    // strip behaviour; adapters whose templates never carry imports (Go,
+    // Mojo) only consult this list for diagnostics like BF103.
+    templateImports: ctx.imports,
     namedExports: ctx.namedExports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,
@@ -495,7 +441,7 @@ export function compileJSX(
 
   const componentIR: ComponentIR = {
     version: '0.1',
-    metadata: buildMetadata(ctx, options.adapter.clientShimSource),
+    metadata: buildMetadata(ctx),
     root: ir,
     errors: [],
   }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -86,16 +86,6 @@ function specKey(s: ImportSpecifier): string {
   return `${s.isDefault ? 'd' : ''}${s.isNamespace ? 'n' : ''}:${s.name}:${s.alias ?? ''}`
 }
 
-/**
- * Add 'export' keyword to the component function declaration if needed.
- * Adapters emit plain `function Name(...)` — the compiler adds module-level export.
- */
-function applyExportKeyword(component: string, ir: ComponentIR): string {
-  if (ir.metadata.isExported === false) return component
-  // Prepend 'export ' to the first 'function' declaration
-  return component.replace(/^function /, 'export function ')
-}
-
 // =============================================================================
 // Multiple Component Compilation
 // =============================================================================
@@ -215,7 +205,7 @@ function compileMultipleComponents(
       const s = adapterOutput.sections
       imports = s.imports
       types = s.types
-      component = applyExportKeyword(s.component, componentIR) + (s.defaultExport || '')
+      component = s.component + (s.defaultExport || '')
       const mc = s.moduleConstants
       if (mc && !moduleConstantsSet.has(mc)) {
         moduleConstantsSet.add(mc)
@@ -572,8 +562,7 @@ export function compileJSX(
   let content: string
   if (adapterOutput.sections) {
     const s = adapterOutput.sections
-    const component = applyExportKeyword(s.component, componentIR)
-    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, component]
+    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, s.component]
       .filter(Boolean).join('\n\n') + (s.defaultExport || '')
   } else {
     content = adapterOutput.template

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -64,6 +64,7 @@ export type {
 } from './adapters/interface'
 export { JsxAdapter } from './adapters/jsx-adapter'
 export type { JsxAdapterConfig } from './adapters/jsx-adapter'
+export { rewriteImportsForTemplate } from './adapters/template-imports'
 
 // Client JS Generator
 export { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'


### PR DESCRIPTION
## Summary

Phase 2 of #1250: enforce module-structure boundaries via typed sections.
The compiler used to regex-mutate adapter output and decide adapter-specific
import policy; both responsibilities now live with the adapters that own
the target language.

- **Adapters emit `export` directly.** Hono and test adapters now prefix
  their `function ${name}` with `export ` based on `ir.metadata.isExported`.
  `compileJSX.applyExportKeyword` (a regex pass over assembled output) is
  deleted.
- **`AdapterOutput.sections` is required.** Go-template and Mojolicious
  adapters now fill `sections` (whole template into `component`; the other
  fields are empty since those target languages have no JS-style module
  structure). The compiler no longer falls back to `lines.startsWith('import ')`
  / `'function '` parsing — the field is type-checked instead of
  convention-enforced.
- **Client-shim rewrite moves to adapters.** `rewriteTemplateImports`
  becomes `rewriteImportsForTemplate` in `packages/jsx/src/adapters/`;
  Hono and test adapters call it themselves with their own
  `clientShimSource`. Go and Mojo never re-emit imports into their
  templates, so they don't need the helper. `buildMetadata` no longer
  takes a `clientShimSource` argument.

Phase 1 (`ParsedExpr` shared emitter) and Phase 3 (cross-adapter
conformance suite) will land as separate PRs.

## Test plan

- [x] \`packages/jsx\`: 1131 pass / 4 pre-existing fails (alias-resolver
      checker tests, environment-dependent — unchanged from main)
- [x] \`packages/adapter-tests\`: 246 pass / 0 fail
- [x] \`packages/adapter-go-template\`: 94 pass / 0 fail
- [x] \`packages/adapter-mojolicious\`: 73 pass / 0 fail

## Acceptance criteria coverage

- [x] \`applyExportKeyword\` removed.
- [x] \`rewriteTemplateImports\` removed (moved to adapter-side helper).
- [x] \`adapter.generate(ir)\` returns \`AdapterOutput.sections\` (now required);
      compiler never regex-mutates the template part.
- [ ] Cross-adapter conformance suite (Phase 3, separate PR).
- [ ] Spec doc update for "Adapter Responsibility Boundary" (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)