### PR TITLE
refactor(#1250) phase 1A: shared ParsedExpr emitter + Go adapter migration

### DIFF
--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -23,12 +23,26 @@ import type {
   SourceLocation,
   ParsedExpr,
   ParsedStatement,
+  TemplatePart,
   IRIfStatement,
   IRProvider,
   IRAsync,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
-import { BaseAdapter, type AdapterOutput, type AdapterGenerateOptions, type TemplateSections, isBooleanAttr, parseExpression, isSupported, identifierPath } from '@barefootjs/jsx'
+import {
+  BaseAdapter,
+  type AdapterOutput,
+  type AdapterGenerateOptions,
+  type TemplateSections,
+  type ParsedExprEmitter,
+  type HigherOrderMethod,
+  type LiteralType,
+  isBooleanAttr,
+  parseExpression,
+  isSupported,
+  identifierPath,
+  emitParsedExpr,
+} from '@barefootjs/jsx'
 
 /**
  * Extended nested component info that tracks whether the component
@@ -112,7 +126,7 @@ const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
   'Math.round':     { arity: 1, emit: (args) => `bf_round ${args[0]}` },
 }
 
-export class GoTemplateAdapter extends BaseAdapter {
+export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter {
   name = 'go-template'
   extension = '.tmpl'
 
@@ -1717,222 +1731,219 @@ export class GoTemplateAdapter extends BaseAdapter {
   }
 
   /**
-   * Render a ParsedExpr to Go template syntax.
+   * Render a ParsedExpr to Go template syntax via the shared
+   * dispatcher (#1250 phase 1). The per-kind logic lives in the
+   * `ParsedExprEmitter` methods below; this method is a thin wrapper
+   * so existing call sites keep working.
    */
   private renderParsedExpr(expr: ParsedExpr): string {
-    switch (expr.kind) {
-      case 'identifier':
-        return `.${this.capitalizeFieldName(expr.name)}`
+    return emitParsedExpr(expr, this)
+  }
 
-      case 'literal':
-        if (expr.literalType === 'string') {
-          return `"${expr.value}"`
-        }
-        if (expr.literalType === 'null') {
-          return '""'
-        }
-        return String(expr.value)
+  // ===========================================================================
+  // ParsedExprEmitter implementation (Go template syntax)
+  // ===========================================================================
 
-      case 'call': {
-        // Handle signal calls: count() -> .Count
-        if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
-          return `.${this.capitalizeFieldName(expr.callee.name)}`
-        }
-        // Identifier-path primitive callee (#1188): if the JS call
-        // resolves to a path registered on `templatePrimitives`
-        // (e.g. `JSON.stringify`, `Math.floor`), substitute the Go
-        // template form. The emit fn receives args already rendered
-        // to Go template syntax. Wrap in parens to preserve operator
-        // precedence in the surrounding expression (e.g. `bf_floor x`
-        // composed inside `gt (bf_floor x) 3`).
-        //
-        // Arity is checked against `templatePrimitiveArities` so a
-        // wrong-arity call (`JSON.stringify()`, `JSON.stringify(x,
-        // replacer)`) falls through to the standard BF101 path
-        // instead of emitting invalid Go template syntax via
-        // `args[0]` on a missing or extra argument.
-        const path = identifierPath(expr.callee)
-        if (path && this.templatePrimitives[path]) {
-          const expected = this.templatePrimitiveArities[path]
-          if (expected === undefined || expr.args.length === expected) {
-            const renderedArgs = expr.args.map(a => this.renderParsedExpr(a))
-            return `(${this.templatePrimitives[path](renderedArgs)})`
-          }
-          // Arity mismatch — record a diagnostic and continue to the
-          // generic call rendering (which will surface a BF101 if
-          // `convertExpressionToGo`'s `isSupported` rejects the
-          // shape). We don't return here so the fallback path runs.
-          this.errors.push({
-            code: 'BF101',
-            severity: 'error',
-            message: `templatePrimitive '${path}' expects ${expected} arg(s), got ${expr.args.length}`,
-            loc: this.makeLoc(),
-            suggestion: {
-              message: `Call '${path}' with exactly ${expected} argument(s), or wrap the JSX expression in /* @client */ to defer evaluation.`,
-            },
-          })
-        }
-        // Handle method calls on objects: items().length is handled by member
-        // For other calls, render callee and args
-        const callee = this.renderParsedExpr(expr.callee)
-        if (expr.args.length === 0) {
-          return callee
-        }
-        // Function calls with args - this is unusual in templates
-        const args = expr.args.map(a => this.renderParsedExpr(a)).join(' ')
-        return `${callee} ${args}`
-      }
+  identifier(name: string): string {
+    return `.${this.capitalizeFieldName(name)}`
+  }
 
-      case 'member': {
-        // Handle .length with higher-order filter → len (bf_filter ...)
-        if (expr.property === 'length' && expr.object.kind === 'higher-order') {
-          const result = this.renderFilterLengthExpr(expr.object, e => this.renderParsedExpr(e))
-          if (result) {
-            return result
-          }
-        }
+  literal(value: string | number | boolean | null, literalType: LiteralType): string {
+    if (literalType === 'string') return `"${value}"`
+    if (literalType === 'null') return '""'
+    return String(value)
+  }
 
-        // Handle find().property → {{with bf_find ...}}{{.Property}}{{end}}
-        if (expr.object.kind === 'higher-order' && expr.object.method === 'find') {
-          const findResult = this.renderHigherOrderExpr(expr.object, e => this.renderParsedExpr(e))
-          if (findResult) {
-            return `{{with ${findResult}}}{{.${this.capitalizeFieldName(expr.property)}}}{{end}}`
-          }
-          // Fall back to template iteration for complex predicates
-          const templateBlock = this.renderFindTemplateBlock(
-            expr.object, e => this.renderParsedExpr(e), this.capitalizeFieldName(expr.property)
-          )
-          if (templateBlock) return templateBlock
-        }
-
-        // Handle SolidJS-style props pattern: props.xxx -> .Xxx
-        // When object is the propsObjectName (e.g., "props"), skip the object part
-        // and directly access the property on the root context
-        if (expr.object.kind === 'identifier' && this.propsObjectName && expr.object.name === this.propsObjectName) {
-          return `.${this.capitalizeFieldName(expr.property)}`
-        }
-
-        // Inside a loop, the loop param variable refers to the current item (dot).
-        // e.g., `msg.role` inside `{{range $_, $msg := .Messages}}` → `.Role`
-        const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
-        if (expr.object.kind === 'identifier' && currentLoopParam && expr.object.name === currentLoopParam) {
-          return `.${this.capitalizeFieldName(expr.property)}`
-        }
-
-        const obj = this.renderParsedExpr(expr.object)
-        // Handle .length -> len
-        if (expr.property === 'length') {
-          return `len ${obj}`
-        }
-        // Normal property access: .User.Name
-        return `${obj}.${this.capitalizeFieldName(expr.property)}`
-      }
-
-      case 'binary': {
-        const left = this.renderParsedExpr(expr.left)
-        const right = this.renderParsedExpr(expr.right)
-
-        // Comparison operators -> Go template functions
-        switch (expr.op) {
-          case '===':
-          case '==':
-            return `eq ${left} ${right}`
-          case '!==':
-          case '!=':
-            return `ne ${left} ${right}`
-          case '>':
-            return `gt ${left} ${right}`
-          case '<':
-            return `lt ${left} ${right}`
-          case '>=':
-            return `ge ${left} ${right}`
-          case '<=':
-            return `le ${left} ${right}`
-
-          // Arithmetic operators -> runtime functions
-          case '+':
-            return `bf_add ${left} ${right}`
-          case '-':
-            return `bf_sub ${left} ${right}`
-          case '*':
-            return `bf_mul ${left} ${right}`
-          case '/':
-            return `bf_div ${left} ${right}`
-          case '%':
-            return `bf_mod ${left} ${right}`
-
-          default:
-            return `${left} ${expr.op} ${right}`
-        }
-      }
-
-      case 'unary': {
-        const arg = this.renderParsedExpr(expr.argument)
-        if (expr.op === '!') {
-          return `not ${arg}`
-        }
-        if (expr.op === '-') {
-          return `bf_neg ${arg}`
-        }
-        return arg
-      }
-
-      case 'logical': {
-        const left = this.renderParsedExpr(expr.left)
-        const right = this.renderParsedExpr(expr.right)
-        // Wrap in parentheses if needed for complex expressions
-        const wrapLeft = this.needsParens(expr.left) ? `(${left})` : left
-        const wrapRight = this.needsParens(expr.right) ? `(${right})` : right
-        if (expr.op === '&&') {
-          return `and ${wrapLeft} ${wrapRight}`
-        }
-        return `or ${wrapLeft} ${wrapRight}`
-      }
-
-      case 'conditional': {
-        const test = this.renderParsedExpr(expr.test)
-        // Nested conditionals already return complete {{if}}...{{end}} blocks
-        // Literals return bare text (used within attributes)
-        const consequent = this.renderConditionalBranch(expr.consequent)
-        const alternate = this.renderConditionalBranch(expr.alternate)
-        return `{{if ${test}}}${consequent}{{else}}${alternate}{{end}}`
-      }
-
-      case 'template-literal': {
-        let result = ''
-        for (const part of expr.parts) {
-          if (part.type === 'string') {
-            result += part.value
-          } else {
-            const partExpr = this.renderParsedExpr(part.expr)
-            result += `{{${partExpr}}}`
-          }
-        }
-        return result
-      }
-
-      case 'arrow-fn':
-        // Arrow functions shouldn't appear standalone in rendering
-        return `[ARROW-FN: ${expr.param} => ...]`
-
-      case 'higher-order': {
-        const result = this.renderHigherOrderExpr(expr, e => this.renderParsedExpr(e))
-        if (result) return result
-        if (expr.method === 'find' || expr.method === 'findIndex') {
-          const templateBlock = this.renderFindTemplateBlock(expr, e => this.renderParsedExpr(e))
-          if (templateBlock) return templateBlock
-        }
-        if (expr.method === 'every' || expr.method === 'some') {
-          const templateBlock = this.renderEverySomeTemplateBlock(expr, e => this.renderParsedExpr(e))
-          if (templateBlock) return templateBlock
-        }
-        return `[UNSUPPORTED: ${expr.method}]`
-      }
-
-      case 'unsupported':
-        // This should not happen if isSupported was checked
-        return `[UNSUPPORTED: ${expr.raw}]`
+  call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
+    // Signal call: count() -> .Count
+    if (callee.kind === 'identifier' && args.length === 0) {
+      return `.${this.capitalizeFieldName(callee.name)}`
     }
+    // Identifier-path primitive callee (#1188): if the JS call resolves
+    // to a path registered on `templatePrimitives` (e.g. `JSON.stringify`,
+    // `Math.floor`), substitute the Go template form. The emit fn
+    // receives args already rendered to Go template syntax. Wrap in
+    // parens to preserve operator precedence in the surrounding
+    // expression (e.g. `bf_floor x` composed inside `gt (bf_floor x) 3`).
+    //
+    // Arity is checked against `templatePrimitiveArities` so a wrong-arity
+    // call (`JSON.stringify()`, `JSON.stringify(x, replacer)`) falls
+    // through to the standard BF101 path instead of emitting invalid
+    // Go template syntax via `args[0]` on a missing or extra argument.
+    const path = identifierPath(callee)
+    if (path && this.templatePrimitives[path]) {
+      const expected = this.templatePrimitiveArities[path]
+      if (expected === undefined || args.length === expected) {
+        const renderedArgs = args.map(emit)
+        return `(${this.templatePrimitives[path](renderedArgs)})`
+      }
+      this.errors.push({
+        code: 'BF101',
+        severity: 'error',
+        message: `templatePrimitive '${path}' expects ${expected} arg(s), got ${args.length}`,
+        loc: this.makeLoc(),
+        suggestion: {
+          message: `Call '${path}' with exactly ${expected} argument(s), or wrap the JSX expression in /* @client */ to defer evaluation.`,
+        },
+      })
+    }
+    // Generic call: render callee and args.
+    const calleeStr = emit(callee)
+    if (args.length === 0) return calleeStr
+    const argsStr = args.map(emit).join(' ')
+    return `${calleeStr} ${argsStr}`
+  }
+
+  member(
+    object: ParsedExpr,
+    property: string,
+    _computed: boolean,
+    emit: (e: ParsedExpr) => string,
+  ): string {
+    // .length on higher-order filter → len (bf_filter ...)
+    if (property === 'length' && object.kind === 'higher-order') {
+      const result = this.renderFilterLengthExpr(object, emit)
+      if (result) return result
+    }
+
+    // find().property → {{with bf_find ...}}{{.Property}}{{end}}
+    if (object.kind === 'higher-order' && object.method === 'find') {
+      const findResult = this.renderHigherOrderExpr(object, emit)
+      if (findResult) {
+        return `{{with ${findResult}}}{{.${this.capitalizeFieldName(property)}}}{{end}}`
+      }
+      const templateBlock = this.renderFindTemplateBlock(
+        object, emit, this.capitalizeFieldName(property),
+      )
+      if (templateBlock) return templateBlock
+    }
+
+    // SolidJS-style props pattern: props.xxx -> .Xxx
+    if (object.kind === 'identifier' && this.propsObjectName && object.name === this.propsObjectName) {
+      return `.${this.capitalizeFieldName(property)}`
+    }
+
+    // Inside a loop, the loop param variable refers to the current item
+    // (dot). e.g. `msg.role` inside `{{range $_, $msg := .Messages}}` → `.Role`
+    const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
+    if (object.kind === 'identifier' && currentLoopParam && object.name === currentLoopParam) {
+      return `.${this.capitalizeFieldName(property)}`
+    }
+
+    const obj = emit(object)
+    if (property === 'length') return `len ${obj}`
+    return `${obj}.${this.capitalizeFieldName(property)}`
+  }
+
+  binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    const l = emit(left)
+    const r = emit(right)
+    switch (op) {
+      case '===':
+      case '==':
+        return `eq ${l} ${r}`
+      case '!==':
+      case '!=':
+        return `ne ${l} ${r}`
+      case '>':
+        return `gt ${l} ${r}`
+      case '<':
+        return `lt ${l} ${r}`
+      case '>=':
+        return `ge ${l} ${r}`
+      case '<=':
+        return `le ${l} ${r}`
+      case '+':
+        return `bf_add ${l} ${r}`
+      case '-':
+        return `bf_sub ${l} ${r}`
+      case '*':
+        return `bf_mul ${l} ${r}`
+      case '/':
+        return `bf_div ${l} ${r}`
+      case '%':
+        return `bf_mod ${l} ${r}`
+      default:
+        return `${l} ${op} ${r}`
+    }
+  }
+
+  unary(op: string, argument: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    const arg = emit(argument)
+    if (op === '!') return `not ${arg}`
+    if (op === '-') return `bf_neg ${arg}`
+    return arg
+  }
+
+  logical(
+    op: '&&' | '||' | '??',
+    left: ParsedExpr,
+    right: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string {
+    const l = emit(left)
+    const r = emit(right)
+    const wrapLeft = this.needsParens(left) ? `(${l})` : l
+    const wrapRight = this.needsParens(right) ? `(${r})` : r
+    if (op === '&&') return `and ${wrapLeft} ${wrapRight}`
+    return `or ${wrapLeft} ${wrapRight}`
+  }
+
+  conditional(
+    test: ParsedExpr,
+    consequent: ParsedExpr,
+    alternate: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string {
+    const t = emit(test)
+    // Nested conditionals already return complete {{if}}...{{end}} blocks;
+    // literals return bare text (used within attributes).
+    const c = this.renderConditionalBranch(consequent)
+    const a = this.renderConditionalBranch(alternate)
+    return `{{if ${t}}}${c}{{else}}${a}{{end}}`
+  }
+
+  templateLiteral(parts: TemplatePart[], emit: (e: ParsedExpr) => string): string {
+    let result = ''
+    for (const part of parts) {
+      if (part.type === 'string') {
+        result += part.value
+      } else {
+        result += `{{${emit(part.expr)}}}`
+      }
+    }
+    return result
+  }
+
+  arrowFn(param: string, _body: ParsedExpr, _emit: (e: ParsedExpr) => string): string {
+    // Arrow functions shouldn't appear standalone in rendering.
+    return `[ARROW-FN: ${param} => ...]`
+  }
+
+  higherOrder(
+    method: HigherOrderMethod,
+    object: ParsedExpr,
+    param: string,
+    predicate: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string {
+    const reconstructed = { kind: 'higher-order' as const, method, object, param, predicate }
+    const result = this.renderHigherOrderExpr(reconstructed, emit)
+    if (result) return result
+    if (method === 'find' || method === 'findIndex') {
+      const templateBlock = this.renderFindTemplateBlock(reconstructed, emit)
+      if (templateBlock) return templateBlock
+    }
+    if (method === 'every' || method === 'some') {
+      const templateBlock = this.renderEverySomeTemplateBlock(reconstructed, emit)
+      if (templateBlock) return templateBlock
+    }
+    return `[UNSUPPORTED: ${method}]`
+  }
+
+  unsupported(raw: string, _reason: string): string {
+    // Should not happen if `isSupported` was checked at parse time.
+    return `[UNSUPPORTED: ${raw}]`
   }
 
   /**

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared ParsedExpr emitter (#1250 phase 1).
+ *
+ * Each adapter used to carry its own `renderParsedExpr` switch over
+ * every `ParsedExpr.kind` (identifier, literal, call, member, binary,
+ * unary, logical, conditional, template-literal, higher-order, …). Two
+ * problems followed:
+ *
+ *  1. Drift: adding a new kind required editing every adapter's switch.
+ *     The TS compiler couldn't enforce that every adapter handled it;
+ *     a forgotten case fell through to a default branch and emitted
+ *     placeholder garbage at runtime.
+ *  2. Duplication: the recursive traversal — paren wrapping, child
+ *     emission, kind-discrimination — was identical across adapters
+ *     and rewritten each time.
+ *
+ * The fix is a single recursion in the compiler that dispatches each
+ * kind to a method on an adapter-provided `ParsedExprEmitter`. Every
+ * `ParsedExpr.kind` maps to exactly one interface method, so a new
+ * kind becomes a TS compile error in every adapter that hasn't been
+ * updated. Adapters keep ownership of the target-language details
+ * (operator names, capitalisation, primitive registry) because those
+ * are not shareable.
+ *
+ * Method receives:
+ *   - The structured children directly (`left`, `right`, `args`, …),
+ *     not pre-rendered strings — that lets an emitter inspect a child
+ *     before emitting (e.g. Go's `find().prop` short-circuit).
+ *   - An `emit` callback to recurse into a child node when it does
+ *     want the default rendering. Passing `emit` (rather than letting
+ *     emitters call a global) keeps the recursion in this module's
+ *     control so future hooks (depth limits, source-map tracking) can
+ *     be added in one place.
+ */
+
+import type { ParsedExpr, TemplatePart } from '../expression-parser'
+
+export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex'
+
+export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
+
+/**
+ * Adapter-side ParsedExpr lowering surface. One method per
+ * `ParsedExpr.kind`. The shared `emitParsedExpr` runner dispatches
+ * here based on `expr.kind`.
+ *
+ * Each method receives the structured children (not pre-rendered) so
+ * the emitter can inspect their kinds before deciding how to lower
+ * them, plus an `emit` callback to recurse on any child it wants the
+ * default rendering for.
+ */
+export interface ParsedExprEmitter {
+  identifier(name: string): string
+  literal(value: string | number | boolean | null, literalType: LiteralType): string
+  call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string
+  member(
+    object: ParsedExpr,
+    property: string,
+    computed: boolean,
+    emit: (e: ParsedExpr) => string,
+  ): string
+  binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string
+  unary(op: string, argument: ParsedExpr, emit: (e: ParsedExpr) => string): string
+  logical(
+    op: '&&' | '||' | '??',
+    left: ParsedExpr,
+    right: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string
+  conditional(
+    test: ParsedExpr,
+    consequent: ParsedExpr,
+    alternate: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string
+  templateLiteral(parts: TemplatePart[], emit: (e: ParsedExpr) => string): string
+  arrowFn(param: string, body: ParsedExpr, emit: (e: ParsedExpr) => string): string
+  higherOrder(
+    method: HigherOrderMethod,
+    object: ParsedExpr,
+    param: string,
+    predicate: ParsedExpr,
+    emit: (e: ParsedExpr) => string,
+  ): string
+  unsupported(raw: string, reason: string): string
+}
+
+/**
+ * Single point of dispatch from `ParsedExpr.kind` to the adapter's
+ * method. Adapters call this once at their entry point; the recursion
+ * threads the `emit` callback for child nodes.
+ *
+ * The `assertNever` default arm makes adding a new `ParsedExpr.kind`
+ * a TS compile error here — and, transitively, in every adapter that
+ * hasn't extended its `ParsedExprEmitter` implementation.
+ */
+export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): string {
+  const emit = (child: ParsedExpr): string => emitParsedExpr(child, emitter)
+  switch (expr.kind) {
+    case 'identifier':
+      return emitter.identifier(expr.name)
+    case 'literal':
+      return emitter.literal(expr.value, expr.literalType)
+    case 'call':
+      return emitter.call(expr.callee, expr.args, emit)
+    case 'member':
+      return emitter.member(expr.object, expr.property, expr.computed, emit)
+    case 'binary':
+      return emitter.binary(expr.op, expr.left, expr.right, emit)
+    case 'unary':
+      return emitter.unary(expr.op, expr.argument, emit)
+    case 'logical':
+      return emitter.logical(expr.op, expr.left, expr.right, emit)
+    case 'conditional':
+      return emitter.conditional(expr.test, expr.consequent, expr.alternate, emit)
+    case 'template-literal':
+      return emitter.templateLiteral(expr.parts, emit)
+    case 'arrow-fn':
+      return emitter.arrowFn(expr.param, expr.body, emit)
+    case 'higher-order':
+      return emitter.higherOrder(expr.method, expr.object, expr.param, expr.predicate, emit)
+    case 'unsupported':
+      return emitter.unsupported(expr.raw, expr.reason)
+    default: {
+      const _exhaustive: never = expr
+      throw new Error(
+        `emitParsedExpr: unhandled ParsedExpr kind ${(_exhaustive as { kind: string }).kind}`,
+      )
+    }
+  }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -65,6 +65,8 @@ export type {
 export { JsxAdapter } from './adapters/jsx-adapter'
 export type { JsxAdapterConfig } from './adapters/jsx-adapter'
 export { rewriteImportsForTemplate } from './adapters/template-imports'
+export { emitParsedExpr } from './adapters/parsed-expr-emitter'
+export type { ParsedExprEmitter, HigherOrderMethod, LiteralType } from './adapters/parsed-expr-emitter'
 
 // Client JS Generator
 export { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'


### PR DESCRIPTION
## Summary

Phase 1A of #1250. Splits the ParsedExpr emitter extraction into two
PRs to keep the diff reviewable; this PR introduces the shared
dispatcher and migrates the Go template adapter. Phase 1B (Mojo
adapter migration) follows separately.

### What changes

- **New shared dispatcher** (`packages/jsx/src/adapters/parsed-expr-emitter.ts`).
  Single recursion over `ParsedExpr`; routes each kind to a method on
  the adapter-provided `ParsedExprEmitter` interface. The dispatcher's
  `assertNever` default arm makes adding a new `ParsedExpr.kind` a TS
  compile error in every adapter that hasn't extended its emitter —
  closing the "silent drift when a new kind ships" gap the issue
  calls out.
- **Go template adapter** now implements `ParsedExprEmitter`. The
  ~210-line `renderParsedExpr` switch is replaced by per-kind visitor
  methods; the original `renderParsedExpr` becomes a thin
  `emitParsedExpr(expr, this)` wrapper so existing call sites are
  unchanged. Adapter-specific lowering (props-object pattern,
  loop-param dot rewrite, `find().property` short-circuit,
  `templatePrimitives` dispatch) moves into the matching visitor
  method — the shared dispatcher itself stays target-language-neutral.

### Out of scope (Phase 1B PR)

Mojo adapter's `convertExpressionToPerl` / `renderParsedExprToPerl` /
`renderPerlFilterExpr` switches still exist. They migrate to the
shared dispatcher in the follow-up PR.

## Test plan

- [x] `packages/adapter-go-template`: 151 pass / 2 skip / 0 fail
- [x] `packages/adapter-tests`: 246 pass / 0 fail (cross-adapter
      marker conformance still green)
- [x] `packages/jsx`: 1131 pass / 4 pre-existing environment-dependent
      fails (unchanged from main)

## Acceptance criteria coverage

- [x] `packages/jsx/src/adapters/parsed-expr-emitter.ts` exists; the
      Go template adapter no longer carries its own `renderParsedExpr`
      switch.
- [ ] Per-adapter `renderParsedExpr` switches are deleted — Mojo's
      switches remain pending Phase 1B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)