### PR TITLE
refactor(#1290): introduce IRNodeEmitter across all adapters

### DIFF
--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -37,12 +37,25 @@ import {
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type LiteralType,
+  type IRNodeEmitter,
+  type EmitIRNode,
   isBooleanAttr,
   parseExpression,
   isSupported,
   identifierPath,
   emitParsedExpr,
+  emitIRNode,
 } from '@barefootjs/jsx'
+
+/**
+ * Go-template adapter's IRNode render context. Only `isRootOfClientComponent`
+ * is consumed today (forwarded into `renderComponent` / `renderIfStatement`);
+ * the type stays open so future render-position flags can be added without
+ * widening the `IRNodeEmitter` contract.
+ */
+type GoRenderCtx = {
+  isRootOfClientComponent?: boolean
+}
 
 /**
  * Extended nested component info that tracks whether the component
@@ -126,7 +139,7 @@ const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
   'Math.round':     { arity: 1, emit: (args) => `bf_round ${args[0]}` },
 }
 
-export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter {
+export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
   name = 'go-template'
   extension = '.tmpl'
 
@@ -1632,33 +1645,61 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter 
     return `"${value}"`
   }
 
-  renderNode(node: IRNode, ctx?: { isRootOfClientComponent?: boolean }): string {
-    switch (node.type) {
-      case 'element':
-        return this.renderElement(node)
-      case 'text':
-        return (node as IRText).value
-      case 'expression':
-        return this.renderExpression(node)
-      case 'conditional':
-        return this.renderConditional(node)
-      case 'loop':
-        return this.renderLoop(node)
-      case 'component':
-        return this.renderComponent(node, ctx)
-      case 'fragment':
-        return this.renderFragment(node as IRFragment)
-      case 'slot':
-        return this.renderSlot(node as IRSlot)
-      case 'if-statement':
-        return this.renderIfStatement(node as IRIfStatement, ctx)
-      case 'provider':
-        return this.renderChildren((node as IRProvider).children)
-      case 'async':
-        return this.renderAsync(node as IRAsync)
-      default:
-        return ''
-    }
+  /**
+   * Public entry point for node rendering. Delegates to the shared
+   * `IRNodeEmitter` dispatcher (#1290 step 1); per-kind logic lives in
+   * the `IRNodeEmitter` methods below.
+   */
+  renderNode(node: IRNode, ctx?: GoRenderCtx): string {
+    return emitIRNode<GoRenderCtx>(node, this, ctx ?? {})
+  }
+
+  // ===========================================================================
+  // IRNodeEmitter implementation (Go templates)
+  // ===========================================================================
+
+  emitElement(node: IRElement, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderElement(node)
+  }
+
+  emitText(node: IRText): string {
+    return node.value
+  }
+
+  emitExpression(node: IRExpression): string {
+    return this.renderExpression(node)
+  }
+
+  emitConditional(node: IRConditional, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderConditional(node)
+  }
+
+  emitLoop(node: IRLoop, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderLoop(node)
+  }
+
+  emitComponent(node: IRComponent, ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderComponent(node, ctx)
+  }
+
+  emitFragment(node: IRFragment, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderFragment(node)
+  }
+
+  emitSlot(node: IRSlot): string {
+    return this.renderSlot(node)
+  }
+
+  emitIfStatement(node: IRIfStatement, ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderIfStatement(node, ctx)
+  }
+
+  emitProvider(node: IRProvider, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderChildren(node.children)
+  }
+
+  emitAsync(node: IRAsync, _ctx: GoRenderCtx, _emit: EmitIRNode<GoRenderCtx>): string {
+    return this.renderAsync(node)
   }
 
   renderElement(element: IRElement): string {

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -17,16 +17,32 @@ import {
   type IRIfStatement,
   type IRProvider,
   type IRAsync,
+  type IRSlot,
   type AttrValue,
   type IRTemplatePart,
   type ParamInfo,
   type AdapterOutput,
   type TemplateSections,
   type JsxAdapterConfig,
+  type IRNodeEmitter,
+  type EmitIRNode,
   JsxAdapter,
   isBooleanAttr,
   rewriteImportsForTemplate,
+  emitIRNode,
 } from '@barefootjs/jsx'
+
+/**
+ * Hono adapter's IRNode render context: which surrounding render
+ * state matters when lowering a node. The `IRNodeEmitter` dispatcher
+ * threads this `Ctx` unchanged into per-kind methods; per-method
+ * documentation below records which flags each kind consults.
+ */
+type HonoRenderCtx = {
+  isRootOfClientComponent?: boolean
+  isInsideLoop?: boolean
+  isLoopItemRoot?: boolean
+}
 import { BF_SCOPE, BF_HOST, BF_AT, BF_ROOT, BF_PROPS } from '@barefootjs/shared'
 
 export interface HonoAdapterOptions {
@@ -49,7 +65,7 @@ export interface HonoAdapterOptions {
   clientJsFilename?: string
 }
 
-export class HonoAdapter extends JsxAdapter {
+export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderCtx> {
   name = 'hono'
   extension = '.tsx'
   clientShimSource = '@barefootjs/hono/client-shim'
@@ -469,59 +485,86 @@ export class HonoAdapter extends JsxAdapter {
   // Node Rendering
   // ===========================================================================
 
-  renderNode(node: IRNode, ctx?: { isRootOfClientComponent?: boolean; isInsideLoop?: boolean; isLoopItemRoot?: boolean }): string {
-    switch (node.type) {
-      case 'element':
-        return this.renderElement(node, ctx)
-      case 'text':
-        return this.renderText(node)
-      case 'expression':
-        return this.renderExpression(node)
-      case 'conditional':
-        return this.renderConditional(node)
-      case 'loop':
-        return this.renderLoop(node)
-      case 'component':
-        return this.renderComponent(node, ctx)
-      case 'fragment':
-        return this.renderFragment(node)
-      case 'slot':
-        return '{children}'
-      case 'if-statement':
-        // If-statements are rendered at the component level, not inline
-        // This case shouldn't normally be hit, but return empty for safety
-        return ''
-      case 'provider': {
-        const provider = node as IRProvider
-        const children = this.renderChildren(provider.children)
-        // Quote literal values; expression / template / spread variants emit
-        // their JS source verbatim into the Hono JSX output.
-        const valueExpr = (() => {
-          const v = provider.valueProp.value
-          switch (v.kind) {
-            case 'literal': return JSON.stringify(v.value)
-            case 'expression':
-            case 'spread': return v.expr
-            case 'template': return this.renderTemplateLiteralParts(v.parts)
-            case 'boolean-attr':
-            case 'boolean-shorthand': return 'true'
-            case 'jsx-children': return 'undefined'
-          }
-        })()
-        // Bridge BarefootJS Context to Hono's per-render context stack so
-        // descendants that call useContext() at SSR see the provided value.
-        // `provideContextSSR` is a helper exported from the client shim
-        // (`@barefootjs/hono/client-shim`); generateImports auto-injects the
-        // import when this expression is present in the rendered output.
-        // The outer fragment makes the form valid JSX whether the provider
-        // appears as the component root or nested inside JSX siblings.
-        return `<>{provideContextSSR(${provider.contextName}, ${valueExpr}, <>${children}</>)}</>`
+  /**
+   * Public entry point for node rendering. Delegates to the shared
+   * `IRNodeEmitter` dispatcher (#1290 step 1); per-kind logic lives in
+   * the `IRNodeEmitter` methods below.
+   */
+  renderNode(node: IRNode, ctx?: HonoRenderCtx): string {
+    return emitIRNode<HonoRenderCtx>(node, this, ctx ?? {})
+  }
+
+  // ===========================================================================
+  // IRNodeEmitter implementation (Hono JSX)
+  // ===========================================================================
+
+  emitElement(node: IRElement, ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderElement(node, ctx)
+  }
+
+  emitText(node: IRText): string {
+    return this.renderText(node)
+  }
+
+  emitExpression(node: IRExpression): string {
+    return this.renderExpression(node)
+  }
+
+  emitConditional(node: IRConditional, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderConditional(node)
+  }
+
+  emitLoop(node: IRLoop, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderLoop(node)
+  }
+
+  emitComponent(node: IRComponent, ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderComponent(node, ctx)
+  }
+
+  emitFragment(node: IRFragment, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderFragment(node)
+  }
+
+  emitSlot(_node: IRSlot): string {
+    return '{children}'
+  }
+
+  emitIfStatement(_node: IRIfStatement, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    // If-statements are rendered at the component level (early-return pattern),
+    // never inline. This arm is unreachable in practice but is required by
+    // the IRNodeEmitter exhaustiveness contract.
+    return ''
+  }
+
+  emitProvider(node: IRProvider, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    const children = this.renderChildren(node.children)
+    // Quote literal values; expression / template / spread variants emit
+    // their JS source verbatim into the Hono JSX output.
+    const valueExpr = (() => {
+      const v = node.valueProp.value
+      switch (v.kind) {
+        case 'literal': return JSON.stringify(v.value)
+        case 'expression':
+        case 'spread': return v.expr
+        case 'template': return this.renderTemplateLiteralParts(v.parts)
+        case 'boolean-attr':
+        case 'boolean-shorthand': return 'true'
+        case 'jsx-children': return 'undefined'
       }
-      case 'async':
-        return this.renderAsync(node as IRAsync)
-      default:
-        return ''
-    }
+    })()
+    // Bridge BarefootJS Context to Hono's per-render context stack so
+    // descendants that call useContext() at SSR see the provided value.
+    // `provideContextSSR` is a helper exported from the client shim
+    // (`@barefootjs/hono/client-shim`); generateImports auto-injects the
+    // import when this expression is present in the rendered output.
+    // The outer fragment makes the form valid JSX whether the provider
+    // appears as the component root or nested inside JSX siblings.
+    return `<>{provideContextSSR(${node.contextName}, ${valueExpr}, <>${children}</>)}</>`
+  }
+
+  emitAsync(node: IRAsync, _ctx: HonoRenderCtx, _emit: EmitIRNode<HonoRenderCtx>): string {
+    return this.renderAsync(node)
   }
 
   renderElement(element: IRElement, ctx?: { isLoopItemRoot?: boolean }): string {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -31,12 +31,24 @@ import {
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type LiteralType,
+  type IRNodeEmitter,
+  type EmitIRNode,
   isBooleanAttr,
   parseExpression,
   identifierPath,
   stringifyParsedExpr,
   emitParsedExpr,
+  emitIRNode,
 } from '@barefootjs/jsx'
+
+/**
+ * Mojo adapter's IRNode render context. Mojo's lowering currently
+ * doesn't consume any render-position flags (`isRootOfClientComponent`
+ * is handled differently here than in Hono/Go), so the Ctx is empty.
+ * Kept as a named alias so future flags can extend it without changing
+ * the `IRNodeEmitter` interface.
+ */
+type MojoRenderCtx = Record<string, never>
 import type { ParsedExpr, ParsedStatement, TemplatePart } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND } from '@barefootjs/shared'
 
@@ -97,7 +109,7 @@ export interface MojoAdapterOptions {
   barefootJsPath?: string
 }
 
-export class MojoAdapter extends BaseAdapter {
+export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRenderCtx> {
   name = 'mojolicious'
   extension = '.html.ep'
   templatesPerComponent = true
@@ -215,33 +227,61 @@ export class MojoAdapter extends BaseAdapter {
   // Node Rendering
   // ===========================================================================
 
+  /**
+   * Public entry point for node rendering. Delegates to the shared
+   * `IRNodeEmitter` dispatcher (#1290 step 1); per-kind logic lives in
+   * the `IRNodeEmitter` methods below.
+   */
   renderNode(node: IRNode): string {
-    switch (node.type) {
-      case 'element':
-        return this.renderElement(node)
-      case 'text':
-        return (node as IRText).value
-      case 'expression':
-        return this.renderExpression(node)
-      case 'conditional':
-        return this.renderConditional(node)
-      case 'loop':
-        return this.renderLoop(node)
-      case 'component':
-        return this.renderComponent(node)
-      case 'fragment':
-        return this.renderFragment(node as IRFragment)
-      case 'slot':
-        return this.renderSlot(node as IRSlot)
-      case 'if-statement':
-        return this.renderIfStatement(node as IRIfStatement)
-      case 'provider':
-        return this.renderChildren((node as IRProvider).children)
-      case 'async':
-        return this.renderAsync(node as IRAsync)
-      default:
-        return ''
-    }
+    return emitIRNode<MojoRenderCtx>(node, this, {} as MojoRenderCtx)
+  }
+
+  // ===========================================================================
+  // IRNodeEmitter implementation (Mojo / Perl)
+  // ===========================================================================
+
+  emitElement(node: IRElement, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderElement(node)
+  }
+
+  emitText(node: IRText): string {
+    return node.value
+  }
+
+  emitExpression(node: IRExpression): string {
+    return this.renderExpression(node)
+  }
+
+  emitConditional(node: IRConditional, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderConditional(node)
+  }
+
+  emitLoop(node: IRLoop, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderLoop(node)
+  }
+
+  emitComponent(node: IRComponent, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderComponent(node)
+  }
+
+  emitFragment(node: IRFragment, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderFragment(node)
+  }
+
+  emitSlot(node: IRSlot): string {
+    return this.renderSlot(node)
+  }
+
+  emitIfStatement(node: IRIfStatement, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderIfStatement(node)
+  }
+
+  emitProvider(node: IRProvider, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderChildren(node.children)
+  }
+
+  emitAsync(node: IRAsync, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
+    return this.renderAsync(node)
   }
 
   // ===========================================================================

--- a/packages/jsx/src/adapters/ir-node-emitter.ts
+++ b/packages/jsx/src/adapters/ir-node-emitter.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared IRNode emitter (#1290 step 1).
+ *
+ * The same drift hazard that motivated `ParsedExprEmitter` for
+ * `ParsedExpr.kind` (#1250 phase 1) also exists for `IRNode.type`:
+ * each adapter writes its own `switch (node.type)` and ships its own
+ * `default` arm, so a new IR node kind can land in core and silently
+ * fall through in one or more adapters.
+ *
+ * This module gives `IRNode` the same shape: one shared recursive
+ * dispatcher whose `assertNever` default arm forces every adapter to
+ * extend a per-kind visitor method when a new kind is introduced.
+ *
+ * Why this dispatcher is generic over `Ctx` (and `ParsedExprEmitter`
+ * is not):
+ *
+ * IRNode rendering is **render-context-sensitive** in ways the IR
+ * itself does not record: whether the current scope is the root of a
+ * client component, whether the current node is the root of a loop
+ * iteration, etc. Each adapter records these via its own pass-through
+ * shape (Hono carries three flags, Go-template one, Mojo none). A
+ * generic `Ctx` lets every adapter declare its own context shape
+ * without leaking it into core, while the shared dispatcher still
+ * threads the context unchanged into the per-kind methods.
+ *
+ * Leaf-kind methods (`text`, `expression`, `slot`) do not take `Ctx`
+ * because none of them have children to recurse into — passing
+ * context through them would be noise.
+ */
+
+import type {
+  IRNode,
+  IRElement,
+  IRText,
+  IRExpression,
+  IRConditional,
+  IRLoop,
+  IRComponent,
+  IRFragment,
+  IRSlot,
+  IRIfStatement,
+  IRProvider,
+  IRAsync,
+} from '../types'
+
+/**
+ * Recursive emit callback handed to each visitor method. Adapters
+ * decide what `Ctx` to pass when recursing into children — that's
+ * how loop-item / root-of-client / scope-comment-wrap state
+ * propagates without the dispatcher knowing about it.
+ */
+export type EmitIRNode<Ctx> = (node: IRNode, ctx: Ctx) => string
+
+/**
+ * Per-kind method names carry an `emit` prefix to avoid collision when
+ * a single adapter class implements multiple visitor interfaces
+ * (`ParsedExprEmitter` already owns `conditional`, future
+ * `AttrValueEmitter` will own `literal`, etc.). The prefix also reads
+ * naturally with the dispatcher: `emitIRNode` → `emitter.emitElement`.
+ */
+export interface IRNodeEmitter<Ctx = unknown> {
+  emitElement(node: IRElement, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitText(node: IRText): string
+  emitExpression(node: IRExpression): string
+  emitConditional(node: IRConditional, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitLoop(node: IRLoop, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitComponent(node: IRComponent, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitFragment(node: IRFragment, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitSlot(node: IRSlot): string
+  emitIfStatement(node: IRIfStatement, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitProvider(node: IRProvider, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+  emitAsync(node: IRAsync, ctx: Ctx, emit: EmitIRNode<Ctx>): string
+}
+
+export function emitIRNode<Ctx>(
+  node: IRNode,
+  emitter: IRNodeEmitter<Ctx>,
+  ctx: Ctx,
+): string {
+  const emit: EmitIRNode<Ctx> = (child, childCtx) => emitIRNode(child, emitter, childCtx)
+  switch (node.type) {
+    case 'element':
+      return emitter.emitElement(node, ctx, emit)
+    case 'text':
+      return emitter.emitText(node)
+    case 'expression':
+      return emitter.emitExpression(node)
+    case 'conditional':
+      return emitter.emitConditional(node, ctx, emit)
+    case 'loop':
+      return emitter.emitLoop(node, ctx, emit)
+    case 'component':
+      return emitter.emitComponent(node, ctx, emit)
+    case 'fragment':
+      return emitter.emitFragment(node, ctx, emit)
+    case 'slot':
+      return emitter.emitSlot(node)
+    case 'if-statement':
+      return emitter.emitIfStatement(node, ctx, emit)
+    case 'provider':
+      return emitter.emitProvider(node, ctx, emit)
+    case 'async':
+      return emitter.emitAsync(node, ctx, emit)
+    default: {
+      const _exhaustive: never = node
+      throw new Error(
+        `emitIRNode: unhandled IRNode kind ${(_exhaustive as { type: string }).type}`,
+      )
+    }
+  }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -67,6 +67,8 @@ export type { JsxAdapterConfig } from './adapters/jsx-adapter'
 export { rewriteImportsForTemplate } from './adapters/template-imports'
 export { emitParsedExpr } from './adapters/parsed-expr-emitter'
 export type { ParsedExprEmitter, HigherOrderMethod, LiteralType } from './adapters/parsed-expr-emitter'
+export { emitIRNode } from './adapters/ir-node-emitter'
+export type { IRNodeEmitter, EmitIRNode } from './adapters/ir-node-emitter'
 
 // Client JS Generator
 export { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'


### PR DESCRIPTION
## Summary

First step of #1290. Applies the per-kind Emitter pattern that #1250
established for \`ParsedExpr\` to \`IRNode.type\` as well: a shared
recursive dispatcher with an \`assertNever\` default, and a visitor
interface (\`IRNodeEmitter<Ctx>\`) that every adapter implements.

Adding a new \`IRNode.type\` kind now becomes a **TS compile error** in
every adapter that hasn't extended its emitter — the same guarantee
\`ParsedExpr\` already had since #1287/#1288. Previously each adapter's
\`renderNode\` switch carried its own \`default: return ''\` arm, so a
new kind would silently fall through with no surface signal.

## Why generic over \`Ctx\`

Unlike \`ParsedExpr\` rendering, \`IRNode\` rendering is
**render-context-sensitive** in ways the IR itself doesn't record
(whether the current scope is the root of a client component, whether
the current node is the root of a loop iteration, etc.). Each adapter
records these differently:

- **Hono**: \`{ isRootOfClientComponent?, isInsideLoop?, isLoopItemRoot? }\`
- **Go-template**: \`{ isRootOfClientComponent? }\`
- **Mojo**: empty record (no render-position state)

A generic \`Ctx\` lets every adapter declare its own context shape
without leaking the shape into core, while the shared dispatcher
still threads the value unchanged into per-kind methods.

## Method naming

Per-kind methods carry an \`emit\` prefix (\`emitElement\`,
\`emitConditional\`, …) so they don't collide with
\`ParsedExprEmitter.conditional\` when the same adapter class
implements both visitor interfaces. The dispatcher reads naturally:
\`emitIRNode\` → \`emitter.emitElement(...)\`.

## Step scope

This step keeps per-kind methods as **thin delegates** to the existing
\`renderElement\` / \`renderConditional\` / … methods, so the diff is
mechanical and behavior is unchanged. The \`switch\` is gone from every
adapter; the actual rendering bodies stay where they are. Future
steps (\`AttrValueEmitter\`, \`IRSignalEmitter\`) extend the same shape
to the remaining switches and gradually pull rendering bodies into
the visitor methods themselves.

## Test plan

- [x] \`packages/adapter-hono\`: 165 pass / 12 skip / 3 pre-existing
      env-dependent fails (unchanged)
- [x] \`packages/adapter-go-template\`: 151 pass / 2 skip / 0 fail
- [x] \`packages/adapter-mojolicious\`: 128 pass / 19 skip / 0 fail
- [x] \`packages/adapter-tests\`: 246 pass / 0 fail (cross-adapter
      marker conformance still green)
- [x] \`packages/jsx\`: 1131 pass / 4 pre-existing env-dependent fails
      (unchanged from main)

## Acceptance criteria progress

From #1290's checklist:

- [x] \`packages/jsx/src/adapters/ir-node-emitter.ts\` exists; every
      adapter's \`renderNode\` is replaced by
      \`emitIRNode(node, this, ctx)\`; no \`switch (node.type)\`
      remains in any adapter source.
- [ ] \`AttrValueEmitter\` (next step)
- [ ] \`IRSignalEmitter\` (later step)
- [ ] \`spec/compiler.md\` update (deferred until the pattern is
      complete across all switches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)