### PR TITLE
refactor(#1290): introduce AttrValueEmitter across all adapters

### DIFF
--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -39,12 +39,14 @@ import {
   type LiteralType,
   type IRNodeEmitter,
   type EmitIRNode,
+  type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
   isSupported,
   identifierPath,
   emitParsedExpr,
   emitIRNode,
+  emitAttrValue,
 } from '@barefootjs/jsx'
 
 /**
@@ -3091,53 +3093,51 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
   }
 
+  /**
+   * AttrValue lowering for intrinsic-element attributes (Go templates).
+   * Per-kind logic that used to live in a `switch (v.kind)` inside
+   * `renderAttributes`; routed through the shared dispatcher so a new
+   * AttrValue kind becomes a TS compile error here (#1290 step 2).
+   *
+   * Components have no equivalent AttrValueEmitter on this adapter:
+   * Go templates pass component-instance props as Go struct fields
+   * (`collectStaticChildInstances` builds them), not as string-emitted
+   * markup, so that path does not share a contract with the
+   * intrinsic-attribute one.
+   */
+  private readonly elementAttrEmitter: AttrValueEmitter = {
+    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitExpression: (value, name) => {
+      if (isBooleanAttr(name) || value.presenceOrUndefined) {
+        const { condition: goCond, preamble } = this.convertConditionToGo(value.expr)
+        return `${preamble}{{if ${goCond}}}${name}{{end}}`
+      }
+      const parsed = parseExpression(value.expr.trim())
+      if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
+        // Inline Go template syntax with embedded `{{...}}` actions.
+        return `${name}="${this.renderParsedExpr(parsed)}"`
+      }
+      return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`
+    },
+    emitBooleanAttr: (_value, name) => name,
+    // Spread attributes are not directly supported in Go templates —
+    // return empty so the caller skips the entry. Matches pre-#1290
+    // `continue` behavior.
+    emitSpread: () => '',
+    emitTemplate: (value, name) => `${name}="${this.renderTemplateLiteralParts(value.parts)}"`,
+    // Neither variant is legal on intrinsic elements.
+    emitBooleanShorthand: () => '',
+    emitJsxChildren: () => '',
+  }
+
   private renderAttributes(element: IRElement): string {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
       // Convert JSX className to HTML class attribute
       const attrName = attr.name === 'className' ? 'class' : attr.name
-      const v = attr.value
-
-      switch (v.kind) {
-        case 'spread':
-          // Spread attributes not directly supported in Go templates
-          continue
-        case 'boolean-attr':
-          parts.push(attrName)
-          break
-        case 'literal':
-          parts.push(`${attrName}="${v.value}"`)
-          break
-        case 'template': {
-          const output = this.renderTemplateLiteralParts(v.parts)
-          parts.push(`${attrName}="${output}"`)
-          break
-        }
-        case 'expression': {
-          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
-            // Boolean attrs: render attr name only when truthy, omit when falsy
-            const { condition: goCond, preamble } = this.convertConditionToGo(v.expr)
-            parts.push(`${preamble}{{if ${goCond}}}${attrName}{{end}}`)
-          } else {
-            // Check for ternary/conditional or template literal expressions using the parser
-            const parsed = parseExpression(v.expr.trim())
-            if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
-              // These produce inline Go template syntax with embedded {{...}} actions
-              const goValue = this.renderParsedExpr(parsed)
-              parts.push(`${attrName}="${goValue}"`)
-            } else {
-              const goValue = this.convertExpressionToGo(v.expr)
-              parts.push(`${attrName}="{{${goValue}}}"`)
-            }
-          }
-          break
-        }
-        case 'boolean-shorthand':
-        case 'jsx-children':
-          // Neither variant is legal on intrinsic elements. Skip silently.
-          break
-      }
+      const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
+      if (lowered) parts.push(lowered)
     }
 
     return parts.length > 0 ? ' ' + parts.join(' ') : ''

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -26,10 +26,12 @@ import {
   type JsxAdapterConfig,
   type IRNodeEmitter,
   type EmitIRNode,
+  type AttrValueEmitter,
   JsxAdapter,
   isBooleanAttr,
   rewriteImportsForTemplate,
   emitIRNode,
+  emitAttrValue,
 } from '@barefootjs/jsx'
 
 /**
@@ -871,42 +873,63 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
   // Attribute Rendering
   // ===========================================================================
 
+  /**
+   * AttrValue lowering for intrinsic-element attributes (Hono JSX).
+   * Per-kind logic that used to live in a `switch (v.kind)` inside
+   * `renderAttributes`; routed through the shared dispatcher so a new
+   * AttrValue kind becomes a TS compile error here (#1290 step 2).
+   */
+  private readonly elementAttrEmitter: AttrValueEmitter = {
+    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitExpression: (value, name) => {
+      // Boolean attrs / presence-folded expressions: pass `undefined` when
+      // falsy so Hono omits the attribute. Wrap in parens to keep `??`
+      // operators inside `expr` from breaking the surrounding `|| undefined`.
+      if (isBooleanAttr(name) || value.presenceOrUndefined) {
+        return `${name}={(${value.expr}) || undefined}`
+      }
+      return `${name}={${value.expr}}`
+    },
+    emitBooleanAttr: (_value, name) => name,
+    emitBooleanShorthand: () => '',
+    emitTemplate: (value, name) => `${name}={${this.renderTemplateLiteralParts(value.parts)}}`,
+    emitSpread: (value) => `{...${value.expr}}`,
+    // Neither boolean-shorthand nor jsx-children is legal on intrinsic
+    // elements. Returning empty string drops the entry silently — matches
+    // pre-#1290 behavior.
+    emitJsxChildren: () => '',
+  }
+
+  /**
+   * AttrValue lowering for component-invocation props (Hono JSX).
+   * Component props differ from intrinsic attrs in several places —
+   * `jsx-children` is rendered as `<>…</>`, `expression` skips the
+   * boolean-attr fold, etc. Kept as a separate emitter so each method
+   * does one thing.
+   */
+  private readonly componentPropEmitter: AttrValueEmitter = {
+    emitLiteral: (value, name) =>
+      // IR-authoritative string literal: `<X fill="var(--c)" />`.
+      // Emitting verbatim is what distinguishes a CSS-shaped value
+      // (`var(...)`, `url(...)`, `calc(...)`) from a JS expression.
+      `${name}="${value.value}"`,
+    emitExpression: (value, name) => `${name}={${value.expr}}`,
+    emitBooleanAttr: (_value, name) => name,
+    emitBooleanShorthand: (_value, name) => name,
+    emitTemplate: (value, name) => `${name}={${this.renderTemplateLiteralParts(value.parts)}}`,
+    emitSpread: (value) => `{...${value.expr}}`,
+    emitJsxChildren: (value, name) => {
+      const rendered = value.children.map((c) => this.renderNode(c)).join('')
+      return `${name}={<>${rendered}</>}`
+    },
+  }
+
   private renderAttributes(element: IRElement): string {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
-      const attrName = attr.name
-      const v = attr.value
-
-      switch (v.kind) {
-        case 'spread':
-          parts.push(`{...${v.expr}}`)
-          break
-        case 'boolean-attr':
-          parts.push(attrName)
-          break
-        case 'literal':
-          parts.push(`${attrName}="${v.value}"`)
-          break
-        case 'template': {
-          const output = this.renderTemplateLiteralParts(v.parts)
-          parts.push(`${attrName}={${output}}`)
-          break
-        }
-        case 'expression':
-          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
-            // Boolean attrs: pass undefined when falsy so Hono omits the attribute
-            // Wrap in parentheses to avoid syntax error when value contains ?? operator
-            parts.push(`${attrName}={(${v.expr}) || undefined}`)
-          } else {
-            parts.push(`${attrName}={${v.expr}}`)
-          }
-          break
-        case 'boolean-shorthand':
-        case 'jsx-children':
-          // Neither variant is legal on intrinsic elements. Skip silently.
-          break
-      }
+      const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attr.name)
+      if (lowered) parts.push(lowered)
     }
 
     // Add event handlers (as no-op for SSR)
@@ -923,16 +946,6 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     let keyValue: string | null = null
 
     for (const prop of comp.props) {
-      if (prop.value.kind === 'jsx-children') {
-        // JSX prop: render children inline as JSX fragment
-        const rendered = prop.value.children.map(c => this.renderNode(c)).join('')
-        parts.push(`${prop.name}={<>${rendered}</>}`)
-        continue
-      }
-      if (prop.value.kind === 'spread') {
-        parts.push(`{...${prop.value.expr}}`)
-        continue
-      }
       if (prop.name === 'key') {
         // JSX key → data-key only. Hono JSX strips `key` from HTML output
         // (delete props["key"]), so emitting key={} is a no-op. We only need
@@ -940,28 +953,8 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
         keyValue = this.attrValueToJsExpr(prop.value)
         continue
       }
-      switch (prop.value.kind) {
-        case 'expression':
-          parts.push(`${prop.name}={${prop.value.expr}}`)
-          break
-        case 'template':
-          parts.push(`${prop.name}={${this.renderTemplateLiteralParts(prop.value.parts)}}`)
-          break
-        case 'literal':
-          // IR-authoritative string literal: <X fill="var(--c)" />. Emitting
-          // this verbatim is what distinguishes a CSS-shaped value (`var(...)`,
-          // `url(...)`, `calc(...)`) from a JS expression.
-          parts.push(`${prop.name}="${prop.value.value}"`)
-          break
-        case 'boolean-shorthand':
-          // <X disabled /> → emit bare `disabled`
-          parts.push(prop.name)
-          break
-        case 'boolean-attr':
-          // Element-only variant; component props use boolean-shorthand. Defensive.
-          parts.push(prop.name)
-          break
-      }
+      const lowered = emitAttrValue(prop.value, this.componentPropEmitter, prop.name)
+      if (lowered) parts.push(lowered)
     }
 
     // Add data-key prop when key is present for client-side reconciliation

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -33,12 +33,14 @@ import {
   type LiteralType,
   type IRNodeEmitter,
   type EmitIRNode,
+  type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
   identifierPath,
   stringifyParsedExpr,
   emitParsedExpr,
   emitIRNode,
+  emitAttrValue,
 } from '@barefootjs/jsx'
 
 /**
@@ -574,52 +576,55 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   // Component Rendering
   // ===========================================================================
 
+  /**
+   * AttrValue lowering for component invocation props (Mojo / Perl
+   * named-arg form). Routed through the shared dispatcher so a new
+   * AttrValue kind becomes a TS compile error here (#1290 step 2).
+   *
+   * `jsx-children` returns empty — children are captured via Mojo's
+   * `begin %>…<% end` block below, not threaded through the
+   * `render_child` named-arg list.
+   */
+  private readonly componentPropEmitter: AttrValueEmitter = {
+    emitLiteral: (value, name) => `${name} => '${value.value}'`,
+    emitExpression: (value, name) => {
+      // The IR producer collapses component-prop `template` kinds
+      // into `expression` for client-runtime reasons but preserves
+      // the parsed parts on `v.parts`. Prefer the structured form
+      // when available — the bare-expression path can't handle
+      // `${MAP[KEY]}` shapes (the JS object literal leaks into the
+      // Perl template).
+      if (value.parts) {
+        return `${name} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`
+      }
+      return `${name} => ${this.convertExpressionToPerl(value.expr)}`
+    },
+    emitSpread: (value) => {
+      // Perl has no JS-style spread — emit the source as a hash
+      // dereference so its entries flatten into the named-arg list
+      // `render_child` accepts. `$props` already comes in as a hashref
+      // by `render_child`'s calling convention; deref with `%{}`. If
+      // `convertExpressionToPerl` already produced a hash variable
+      // (`%foo`), leave as-is.
+      const perlExpr = this.convertExpressionToPerl(value.expr)
+      return perlExpr.startsWith('%') ? perlExpr : `%{${perlExpr}}`
+    },
+    emitTemplate: (value, name) =>
+      `${name} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`,
+    emitBooleanAttr: (_value, name) => `${name} => 1`,
+    emitBooleanShorthand: (_value, name) => `${name} => 1`,
+    // JSX children flow through Mojo's `begin %>…<% end` capture
+    // below; they're not part of the named-arg list.
+    emitJsxChildren: () => '',
+  }
+
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
     for (const p of comp.props) {
-      const v = p.value
       // Skip callback props (onXxx) — event handlers are client-only for SSR.
-      if (p.name.match(/^on[A-Z]/) && v.kind === 'expression') continue
-      switch (v.kind) {
-        case 'literal':
-          propParts.push(`${p.name} => '${v.value}'`)
-          break
-        case 'expression':
-          // The IR producer collapses component-prop `template` kinds
-          // into `expression` for client-runtime reasons but preserves
-          // the parsed parts on `v.parts`. Prefer the structured form
-          // when available — the bare-expression path can't handle
-          // `${MAP[KEY]}` shapes (the JS object literal leaks into the
-          // Perl template).
-          if (v.parts) {
-            propParts.push(`${p.name} => ${this.convertTemplateLiteralPartsToPerl(v.parts)}`)
-          } else {
-            propParts.push(`${p.name} => ${this.convertExpressionToPerl(v.expr)}`)
-          }
-          break
-        case 'spread': {
-          // Perl has no JS-style spread operator — emit the source as
-          // a hash dereference so its entries flatten into the named-arg
-          // list `render_child` accepts. The placeholder `p.name` is
-          // typically `'...'` for spreads and must NOT appear as a key.
-          const perlExpr = this.convertExpressionToPerl(v.expr)
-          // `$props` already comes in as a hashref in `render_child`'s
-          // calling convention; deref with `%{}`. If `convertExpressionToPerl`
-          // produced a hash variable (`%foo`) we leave it as-is.
-          propParts.push(perlExpr.startsWith('%') ? perlExpr : `%{${perlExpr}}`)
-          break
-        }
-        case 'template':
-          propParts.push(`${p.name} => ${this.convertTemplateLiteralPartsToPerl(v.parts)}`)
-          break
-        case 'boolean-shorthand':
-        case 'boolean-attr':
-          propParts.push(`${p.name} => 1`)
-          break
-        case 'jsx-children':
-          // JSX children are handled via the captured render below.
-          break
-      }
+      if (p.name.match(/^on[A-Z]/) && p.value.kind === 'expression') continue
+      const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
+      if (lowered) propParts.push(lowered)
     }
     // Pass slot ID so the child renderer can set correct scope ID for hydration
     // Skip for loop children — they use ComponentName_random pattern instead
@@ -710,41 +715,36 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   // Attribute Rendering
   // ===========================================================================
 
+  /**
+   * AttrValue lowering for intrinsic-element attributes (Mojo / EP
+   * template). Routed through the shared dispatcher (#1290 step 2).
+   */
+  private readonly elementAttrEmitter: AttrValueEmitter = {
+    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitExpression: (value, name) => {
+      if (isBooleanAttr(name) || value.presenceOrUndefined) {
+        // Boolean attributes: render conditionally (present or absent).
+        return `<%= ${this.convertExpressionToPerl(value.expr)} ? '${name}' : '' %>`
+      }
+      return `${name}="<%= ${this.convertExpressionToPerl(value.expr)} %>"`
+    },
+    emitBooleanAttr: (_value, name) => name,
+    emitTemplate: (value, name) =>
+      `${name}="<%= ${this.convertTemplateLiteralPartsToPerl(value.parts)} %>"`,
+    // Spread attributes are not directly supported on intrinsic elements yet.
+    emitSpread: () => '',
+    // Neither variant is legal on intrinsic elements.
+    emitBooleanShorthand: () => '',
+    emitJsxChildren: () => '',
+  }
+
   private renderAttributes(element: IRElement): string {
     const parts: string[] = []
 
     for (const attr of element.attrs) {
       const attrName = attr.name === 'className' ? 'class' : attr.name
-      const v = attr.value
-
-      switch (v.kind) {
-        case 'spread':
-          // Spread attributes — skip for now
-          continue
-        case 'boolean-attr':
-          parts.push(attrName)
-          break
-        case 'literal':
-          parts.push(`${attrName}="${v.value}"`)
-          break
-        case 'template': {
-          const perlExpr = this.convertTemplateLiteralPartsToPerl(v.parts)
-          parts.push(`${attrName}="<%= ${perlExpr} %>"`)
-          break
-        }
-        case 'expression':
-          if (isBooleanAttr(attrName) || v.presenceOrUndefined) {
-            // Boolean attributes: render conditionally (present or absent)
-            parts.push(`<%= ${this.convertExpressionToPerl(v.expr)} ? '${attrName}' : '' %>`)
-          } else {
-            parts.push(`${attrName}="<%= ${this.convertExpressionToPerl(v.expr)} %>"`)
-          }
-          break
-        case 'boolean-shorthand':
-        case 'jsx-children':
-          // Neither variant is legal on intrinsic elements. Skip silently.
-          break
-      }
+      const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
+      if (lowered) parts.push(lowered)
     }
 
     return parts.length > 0 ? ' ' + parts.join(' ') : ''

--- a/packages/jsx/src/adapters/attr-value-emitter.ts
+++ b/packages/jsx/src/adapters/attr-value-emitter.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared AttrValue emitter (#1290 step 2).
+ *
+ * The same drift hazard that motivated `ParsedExprEmitter` and
+ * `IRNodeEmitter` also lives in every adapter's
+ * `switch (v.kind)` over `AttrValue`. Two switches per adapter:
+ *
+ *   - `renderAttributes` (intrinsic-element attribute lowering)
+ *   - `renderComponentProps` (component-prop lowering)
+ *
+ * Each adapter writes its own `default` arm; a new `AttrValue.kind`
+ * silently disappears in any adapter that didn't get updated.
+ *
+ * This module gives `AttrValue` the same shape: one shared dispatcher
+ * with an `assertNever` default, and a visitor interface
+ * (`AttrValueEmitter`) per emission context.
+ *
+ * Two contexts → two emitters:
+ *
+ *   - **Element attribute** context (`renderAttributes`) — the result
+ *     is an HTML attribute (`name="value"` or `name={expr}` in JSX).
+ *   - **Component prop** context (`renderComponentProps`) — the result
+ *     is a JSX-style prop on a component invocation
+ *     (`propName={value}`, etc.).
+ *
+ * The two contexts produce different output for the same kind
+ * (e.g. `expression` carries the boolean-attr fold in the attribute
+ * context but not in the prop context). Rather than ctx-switching
+ * inside each visitor method (which would re-introduce the very kind
+ * of in-method branching the visitor is trying to eliminate),
+ * adapters provide two `AttrValueEmitter` instances — one per context.
+ *
+ * Both emitters implement the same `AttrValueEmitter` interface, so
+ * the kind-exhaustiveness check applies to both.
+ */
+
+import type {
+  AttrValue,
+  LiteralAttr,
+  ExpressionAttr,
+  BooleanAttr,
+  BooleanShorthandAttr,
+  TemplateAttr,
+  SpreadAttr,
+  JsxChildrenAttr,
+} from '../types'
+
+/**
+ * Per-kind methods carry an `emit` prefix (same convention as
+ * `IRNodeEmitter`) so a single adapter class can implement multiple
+ * visitor interfaces without name collisions. The `name` argument is
+ * the attribute / prop name the kind is being lowered for; adapters
+ * fold it into the emitted string (`name="value"`, `name={expr}`, …).
+ */
+export interface AttrValueEmitter {
+  emitLiteral(value: LiteralAttr, name: string): string
+  emitExpression(value: ExpressionAttr, name: string): string
+  emitBooleanAttr(value: BooleanAttr, name: string): string
+  emitBooleanShorthand(value: BooleanShorthandAttr, name: string): string
+  emitTemplate(value: TemplateAttr, name: string): string
+  emitSpread(value: SpreadAttr, name: string): string
+  emitJsxChildren(value: JsxChildrenAttr, name: string): string
+}
+
+/**
+ * Dispatch one `AttrValue` through the supplied visitor. The `name`
+ * argument threads the attribute / prop name into the visitor methods
+ * unchanged.
+ *
+ * The `assertNever` arm in the `default` makes a new `AttrValue.kind`
+ * a TS compile error in every adapter that hasn't extended its
+ * emitter implementations.
+ */
+export function emitAttrValue(
+  value: AttrValue,
+  emitter: AttrValueEmitter,
+  name: string,
+): string {
+  switch (value.kind) {
+    case 'literal':
+      return emitter.emitLiteral(value, name)
+    case 'expression':
+      return emitter.emitExpression(value, name)
+    case 'boolean-attr':
+      return emitter.emitBooleanAttr(value, name)
+    case 'boolean-shorthand':
+      return emitter.emitBooleanShorthand(value, name)
+    case 'template':
+      return emitter.emitTemplate(value, name)
+    case 'spread':
+      return emitter.emitSpread(value, name)
+    case 'jsx-children':
+      return emitter.emitJsxChildren(value, name)
+    default: {
+      const _exhaustive: never = value
+      throw new Error(
+        `emitAttrValue: unhandled AttrValue kind ${(_exhaustive as { kind: string }).kind}`,
+      )
+    }
+  }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -69,6 +69,8 @@ export { emitParsedExpr } from './adapters/parsed-expr-emitter'
 export type { ParsedExprEmitter, HigherOrderMethod, LiteralType } from './adapters/parsed-expr-emitter'
 export { emitIRNode } from './adapters/ir-node-emitter'
 export type { IRNodeEmitter, EmitIRNode } from './adapters/ir-node-emitter'
+export { emitAttrValue } from './adapters/attr-value-emitter'
+export type { AttrValueEmitter } from './adapters/attr-value-emitter'
 
 // Client JS Generator
 export { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'


### PR DESCRIPTION
## Summary

Second step of #1290. Same shape as #1291 (\`IRNodeEmitter\`), applied
to the \`switch (v.kind)\` over \`AttrValue\` that lived inside every
adapter's \`renderAttributes\` (and Hono / Mojo's component-prop
loops).

Adding a new \`AttrValue.kind\` is now a **TS compile error** in every
adapter that hasn't extended its emitter — same guarantee
\`ParsedExpr\` and \`IRNode\` already have.

## What's different from #1291

\`IRNodeEmitter\` (step 1) used thin delegates — each per-kind method
called back into the existing \`renderElement\` / \`renderConditional\`
/ … methods. This PR replaces the per-kind logic itself: each adapter
declares one or two \`AttrValueEmitter\` object literals carrying the
actual lowering code that used to live inside the switch cases. The
original \`switch\` statements are gone; \`renderAttributes\` /
\`renderComponentProps\` reduce to a loop calling
\`emitAttrValue(value, emitter, name)\`.

## Two contexts → two emitters per adapter (where applicable)

- **Hono**: \`elementAttrEmitter\` + \`componentPropEmitter\`. Both
  emit JSX, but with different per-kind output (boolean-attr fold
  applies only in the element context, jsx-children renders as
  \`<>…</>\` only in the prop context, etc.).
- **Go**: \`elementAttrEmitter\` only. Go templates pass component
  props as Go struct fields (\`collectStaticChildInstances\` builds
  them), so that path does not share a contract with the
  intrinsic-attribute one.
- **Mojo**: \`elementAttrEmitter\` + \`componentPropEmitter\` (named-arg
  form for \`render_child\`).

Per-kind method names carry the \`emit\` prefix (\`emitLiteral\`,
\`emitExpression\`, …) already established for \`IRNodeEmitter\`, so the
visitor methods don't collide with \`ParsedExprEmitter.literal\` etc.

The \`key\` prop fast-path on Hono's component-prop emitter remains
outside the visitor — it short-circuits the loop before
\`emitAttrValue\` is called.

## Test plan

- [x] \`packages/adapter-hono\`: 165 pass / 12 skip / 3 pre-existing
      env-dependent fails (unchanged)
- [x] \`packages/adapter-go-template\`: 151 pass / 2 skip / 0 fail
- [x] \`packages/adapter-mojolicious\`: 128 pass / 19 skip / 0 fail
- [x] \`packages/adapter-tests\`: 246 pass / 0 fail (cross-adapter
      marker conformance still green)
- [x] \`packages/jsx\`: 1131 pass / 4 pre-existing env-dependent fails
      (unchanged from main)

## Acceptance criteria progress

From #1290:

- [x] \`packages/jsx/src/adapters/attr-value-emitter.ts\` exists; every
      adapter's attribute / component-prop value handling is replaced
      by the visitor pattern.
- [ ] \`IRSignalEmitter\` (next step)
- [ ] \`spec/compiler.md\` update (deferred until the pattern is
      complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)