### PR TITLE
refactor(#1290): lift generateSignalInitializers to TemplateAdapter interface

### DIFF
--- a/packages/jsx/src/adapters/interface.ts
+++ b/packages/jsx/src/adapters/interface.ts
@@ -165,6 +165,28 @@ export interface TemplateAdapter {
 
   // Type generation (for typed languages)
   generateTypes?(ir: ComponentIR): string | null
+
+  /**
+   * Generate the SSR declaration block for the user's reactive bindings
+   * (signals, memos, locally-declared functions/constants) at the top
+   * of the rendered component body.
+   *
+   * Only adapters whose target is a JS runtime — Hono and the test
+   * adapter — implement this. The shared `JsxAdapter` base class owns
+   * the implementation; adapters that extend `JsxAdapter` pick it up
+   * transparently.
+   *
+   * DSL adapters (Go template, Mojolicious) leave this `undefined` by
+   * design: their target languages never declare the user's reactive
+   * bindings inside the template body. Instead, signal/memo values
+   * reach the template via target-language-native mechanisms (Go
+   * struct fields built by `collectStaticChildInstances`, Mojo stash
+   * variables threaded from the controller). Surfacing this divergence
+   * as an optional interface method makes "DSL adapters do not declare
+   * signal inits" type-visible — previously it was hidden inside the
+   * `JsxAdapter` inheritance branch.
+   */
+  generateSignalInitializers?(ir: ComponentIR, body: string): string
 }
 
 // Base class with common functionality

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -61,10 +61,17 @@ export abstract class JsxAdapter extends BaseAdapter {
   // ===========================================================================
 
   /**
-   * Generate SSR no-op initializers for signals, memos, constants, and functions.
-   * Performs transitive dependency analysis to skip unreachable declarations.
+   * Generate SSR no-op initializers for signals, memos, constants, and
+   * functions. Performs transitive dependency analysis to skip
+   * unreachable declarations.
+   *
+   * Public (and contracted at the `TemplateAdapter` level as an
+   * optional method) since #1290 step 3: the divergence between
+   * JS-runtime adapters (which implement this) and DSL adapters
+   * (which leave it `undefined`) is now type-visible instead of
+   * hidden inside the `JsxAdapter` inheritance branch.
    */
-  protected generateSignalInitializers(ir: ComponentIR, jsxBody: string): string {
+  generateSignalInitializers(ir: ComponentIR, jsxBody: string): string {
     const lines: string[] = []
     const { preserveTypes } = this.jsxConfig
 

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -451,6 +451,68 @@ IR (ComponentIR)
 
 The **hydration contract** between template and client JS is maintained through shared marker constants (`bf-s`, `bf`, `bf-c`). The marker conformance suite (`packages/adapter-tests/src/marker-conformance.ts`, wired up by `runAdapterConformanceTests`) compiles every shared JSX fixture through the adapter under test and asserts the slot / conditional / loop ids the template emits match the set the IR computed. Each adapter package runs the suite against its own adapter; the shared layer never imports concrete adapters, so adding a new one is a one-package edit.
 
+#### Per-kind Emitter pattern (drift defence)
+
+Each adapter used to write its own `switch (kind)` over `ParsedExpr`,
+`IRNode`, and `AttrValue`, with its own `default` arm. A new kind
+landing in core silently fell through in any adapter that hadn't been
+updated. The fix is a **single shared dispatcher per kind-space, with
+an `assertNever` default**, paired with a per-adapter visitor
+interface:
+
+| Kind-space | Dispatcher | Visitor interface |
+|---|---|---|
+| `ParsedExpr.kind` | `emitParsedExpr` | `ParsedExprEmitter` |
+| `IRNode.type` | `emitIRNode<Ctx>` | `IRNodeEmitter<Ctx>` |
+| `AttrValue.kind` | `emitAttrValue` | `AttrValueEmitter` |
+
+Adding a new kind in any of those unions is now a TS compile error in
+every adapter that hasn't extended its emitter. Per-kind method names
+carry an `emit` prefix (`emitElement`, `emitLiteral`, …) so a single
+adapter class can implement multiple visitor interfaces without name
+collisions.
+
+`IRNodeEmitter` is generic over `Ctx` because IRNode rendering is
+render-context-sensitive in ways the IR itself doesn't record
+(root-of-client-component, inside-loop, etc.); each adapter declares
+its own `Ctx` shape. `AttrValueEmitter` separates element-attribute
+emission from component-prop emission via two emitter instances per
+adapter — same context separation that used to be a `switch` on the
+caller side.
+
+#### Capability flags
+
+A few adapter capabilities differ by target runtime and are surfaced
+on the `TemplateAdapter` interface as **optional** members rather than
+hidden in an inheritance branch — so an adapter's lack of a capability
+is type-visible:
+
+- `clientShimSource?: string` — module specifier for the SSR shim of
+  `@barefootjs/client`. Set on adapters whose template runtime can
+  execute JS (Hono); left `undefined` on DSL adapters that strip
+  client-package imports outright.
+- `acceptsTemplateCall?: (calleeName) => boolean` — broad-acceptance
+  predicate for adapters whose template runtime is a full JS engine
+  (Hono). DSL adapters leave this `undefined` and rely on the explicit
+  `templatePrimitives` map.
+- `templatePrimitives?: TemplatePrimitiveRegistry` — identifier-path
+  callees the adapter promises to render in template scope
+  (`JSON.stringify`, `Math.floor`, …).
+- `generateSignalInitializers?(ir, body): string` — SSR declaration
+  block for the user's reactive bindings (signals, memos,
+  locally-declared functions/constants). Implemented by JS-runtime
+  adapters via the `JsxAdapter` base class; **deliberately left
+  undefined** on DSL adapters (Go, Mojo) because their target
+  languages never declare reactive bindings inside the template body —
+  values reach the template via target-language-native mechanisms
+  (Go struct fields, Mojo stash).
+
+`JsxAdapter` is an internal helper base class that JS-runtime adapters
+(Hono, TestAdapter) extend for shared TS-output utilities (signal-init
+generation, import-specifier formatting). DSL adapters extend
+`BaseAdapter` directly. The contract is at the `TemplateAdapter`
+interface level; `JsxAdapter` is purely code reuse.
+
 ### Available Adapters
 
 - **HonoAdapter** (`@barefootjs/hono`) - Generates hono/jsx compatible TSX


### PR DESCRIPTION
## Summary

Third (and final) step of #1290. \`generateSignalInitializers\` used
to live as a \`protected\` method on the \`JsxAdapter\` base class. That
meant DSL adapters' **lack** of it was hidden inside the inheritance
branch, not visible on the public contract — which is exactly the
hazard #1290 set out to remove.

Lift it to \`TemplateAdapter\` as an **optional** interface method.
JS-runtime adapters (Hono, TestAdapter) inherit the implementation
from \`JsxAdapter\` (now public, formerly protected). DSL adapters
(Go, Mojo) leave it \`undefined\` — their target languages never
declare the user's reactive bindings inside the template body
(values reach the template via Go struct fields / Mojo stash
variables instead). The divergence is now **type-visible** rather
than inheritance-hidden.

This is the lighter shape the issue body explicitly allowed:

> JS-runtime adapter signal init is contracted at the
> \`TemplateAdapter\` level (either via a new emitter or **as an
> optional interface method that DSL adapters declare \`undefined\`**)

— I went with the optional-method shape because \`generateSignalInitializers\`
isn't a kind-discriminated dispatch (signals / memos / locals are
processed sequentially in one routine), so a per-kind visitor would
have been ceremony without the drift-defence payoff.

## Spec doc

\`spec/compiler.md\` updated with two new subsections under "Adapter
Responsibility Boundary":

- **Per-kind Emitter pattern (drift defence)** — documents the three
  dispatchers (\`emitParsedExpr\` / \`emitIRNode\` / \`emitAttrValue\`)
  introduced across #1287, #1288, #1291, #1292. This is the
  post-#1290 picture with all three steps landed.
- **Capability flags** — enumerates the optional \`TemplateAdapter\`
  members (\`clientShimSource\`, \`acceptsTemplateCall\`,
  \`templatePrimitives\`, \`generateSignalInitializers\`) and explicitly
  notes that DSL adapters leave each one undefined by design.
  \`JsxAdapter\` is described as an internal helper for code reuse,
  not part of the contract.

## Test plan

- [x] \`packages/adapter-hono\`: 165 pass / 12 skip / 3 pre-existing
      env-dependent fails (unchanged)
- [x] \`packages/adapter-go-template\`: 151 pass / 2 skip / 0 fail
- [x] \`packages/adapter-mojolicious\`: 128 pass / 19 skip / 0 fail
- [x] \`packages/adapter-tests\`: 246 pass / 0 fail
- [x] \`packages/jsx\`: 1131 pass / 4 pre-existing env-dependent fails
      (unchanged from main)

## Acceptance criteria — final

From #1290:

- [x] \`packages/jsx/src/adapters/ir-node-emitter.ts\` exists; no
      \`switch (node.type)\` remains in any adapter source. (#1291)
- [x] \`packages/jsx/src/adapters/attr-value-emitter.ts\` exists;
      attribute / component-prop value handling replaced by visitor
      pattern. (#1292)
- [x] JS-runtime adapter signal init contracted at the
      \`TemplateAdapter\` level as an optional method; DSL adapters'
      \`undefined\` is type-visible. (this PR)
- [x] \`spec/compiler.md\` "Adapter Responsibility Boundary"
      updated. (this PR)
- [x] All existing per-adapter test suites still pass without skip
      changes.

Issue #1290 can close once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)