### PR TITLE
fix(#1252): make IR-to-client-js emit switches exhaustiveness-checked + close coverage gaps

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -46,6 +46,17 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
+    // #1296: test harness only loads `bf.FuncMap()`, which omits
+    // `bfAsyncBoundary` (lives in `StreamingFuncMap()`). The adapter
+    // correctly emits the call; the harness needs to merge the
+    // streaming map before the fixture can pass.
+    'async-boundary',
+    // #1297: `compileJSX` with `outputIR: true` does not emit an `ir`
+    // file for `'use client'` sources when the go-template adapter
+    // is selected, even though the Hono path does. The harness then
+    // throws "No IR output (set outputIR: true)" before any rendering
+    // happens. Provider IR coverage on go-template waits on the fix.
+    'context-provider',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -52,6 +52,19 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
+    // #1298: the Mojo adapter emits `$bf->async_boundary('a0', begin
+    // %><p>Loading...</p><% end)` which is invalid Mojo template
+    // syntax — the `begin/end` block is being closed early by the
+    // surrounding parentheses. The fix is in the adapter's renderer;
+    // adapter conformance coverage for the IR `async` kind waits on
+    // it.
+    'async-boundary',
+    // #1297-equivalent for Mojo: `compileJSX` with `outputIR: true`
+    // does not emit an `ir` file for `'use client'` sources, so the
+    // Mojo harness can't render the Provider fixture. Same harness-
+    // level gap class as the go-template adapter; coverage tracked
+    // there.
+    'context-provider',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-tests/fixtures/async-boundary.ts
+++ b/packages/adapter-tests/fixtures/async-boundary.ts
@@ -1,0 +1,20 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'async-boundary',
+  description: 'Async streaming boundary with synchronous-resolved children',
+  source: `
+export function ProductPage() {
+  return (
+    <div>
+      <Async fallback={<p>Loading...</p>}>
+        <span>Resolved</span>
+      </Async>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><span>Resolved</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/context-provider.ts
+++ b/packages/adapter-tests/fixtures/context-provider.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'context-provider',
+  description: 'Context.Provider passes value to descendant via useContext',
+  source: `
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+
+const ThemeContext = createContext('light')
+
+function ThemeLabel() {
+  const theme = useContext(ThemeContext)
+  return <span class="theme">{theme}</span>
+}
+
+export function ThemeRoot() {
+  return (
+    <div class="root">
+      <ThemeContext.Provider value="dark">
+        <ThemeLabel />
+      </ThemeContext.Provider>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div class="root" bf-s="test"><span class="theme" bf-s="test_s0">dark</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -63,6 +63,9 @@ import { fixture as childComponentInit } from './child-component-init'
 import { fixture as reactivePropBinding } from './reactive-prop-binding'
 import { fixture as recordIndexLookup } from './record-index-lookup'
 import { fixture as recordIndexLookupViaChildProp } from './record-index-lookup-via-child-prop'
+// Priority 9: Provider / Async (IR-kind coverage, #1252 Phase 0)
+import { fixture as contextProvider } from './context-provider'
+import { fixture as asyncBoundary } from './async-boundary'
 
 import type { JSXFixture } from '../src/types'
 
@@ -132,4 +135,7 @@ export const jsxFixtures: JSXFixture[] = [
   reactivePropBinding,
   recordIndexLookup,
   recordIndexLookupViaChildProp,
+  // Priority 9: Provider / Async (IR-kind coverage, #1252 Phase 0)
+  contextProvider,
+  asyncBoundary,
 ]

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -59,6 +59,12 @@ describe('CSR Conformance Tests', () => {
     // template-based adapters; the duplicate-`bf-s` issue is its own
     // follow-up.
     'record-index-lookup-via-child-prop',
+    // #1295: the CSR mock runtime in `csr-render.ts` does not stub
+    // `createContext`, so any fixture that declares `const Ctx =
+    // createContext(...)` at module scope ReferenceErrors when the
+    // template lambda runs. SSR conformance covers Provider correctly
+    // via the real Hono runtime — see #1295 for the harness fix.
+    'context-provider',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -7,6 +7,7 @@ import { isBooleanAttr } from '../html-constants'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, freeIdsFromRefs, setIntersects, tokenContainsAny, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
+import { assertNever } from './walker'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -298,8 +299,14 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     case 'async':
       return node.children.map(recurse).join('')
 
-    default:
+    case 'slot':
+      // Slots resolve at the host (parent component / template caller); they
+      // never appear in the embedded HTML template. Preserves the pre-#1252
+      // fall-through behaviour now that the switch is exhaustiveness-checked.
       return ''
+
+    default:
+      return assertNever(node)
   }
 }
 
@@ -391,8 +398,12 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
     case 'async':
       return node.children.map(recurse).join('')
 
-    default:
+    case 'slot':
+      // Hosted by the parent template; emits nothing in the placeholder body.
       return ''
+
+    default:
+      return assertNever(node)
   }
 }
 
@@ -466,8 +477,25 @@ function irNodeToJsExprs(node: IRNode): string[] {
     case 'conditional':
       return [`${node.condition} ? ${irChildrenToJsExpr([node.whenTrue])} : ${irChildrenToJsExpr([node.whenFalse])}`]
 
-    default:
+    // The kinds below previously fell through to `default: return []` and so
+    // were silently dropped when used as a component child. The explicit
+    // cases preserve that behaviour but make the exhaustiveness check
+    // visible: any new IRNode kind added to the union will now be a
+    // compile error here rather than disappearing at runtime (#1252).
+    //
+    // The historical drop is *not* obviously correct for `provider`,
+    // `async`, `if-statement`, or `loop` appearing as a component child;
+    // tracking those is a follow-up — this PR only locks in the schema
+    // exhaustiveness, not behaviour fixes.
+    case 'loop':
+    case 'slot':
+    case 'if-statement':
+    case 'provider':
+    case 'async':
       return []
+
+    default:
+      return assertNever(node)
   }
 }
 
@@ -711,8 +739,12 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
     case 'async':
       return node.children.map(recurse).join('')
 
-    default:
+    case 'slot':
+      // Hosted by the parent template.
       return ''
+
+    default:
+      return assertNever(node)
   }
 }
 
@@ -807,8 +839,13 @@ export function canGenerateStaticTemplate(
     case 'text':
       return true
 
-    default:
+    case 'slot':
+      // Slots resolve at the host — they don't disqualify static generation
+      // on their own. Preserves the pre-#1252 `default: true` behaviour.
       return true
+
+    default:
+      return assertNever(node)
   }
 }
 
@@ -1075,8 +1112,12 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     case 'async':
       return node.children.map(recurse).join('')
 
-    default:
+    case 'slot':
+      // Hosted by the parent template.
       return ''
+
+    default:
+      return assertNever(node)
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -399,7 +399,6 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       return node.children.map(recurse).join('')
 
     case 'slot':
-      // Hosted by the parent template; emits nothing in the placeholder body.
       return ''
 
     default:
@@ -740,7 +739,6 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       return node.children.map(recurse).join('')
 
     case 'slot':
-      // Hosted by the parent template.
       return ''
 
     default:
@@ -1113,7 +1111,6 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       return node.children.map(recurse).join('')
 
     case 'slot':
-      // Hosted by the parent template.
       return ''
 
     default:

--- a/packages/jsx/src/ir-to-client-js/walker.ts
+++ b/packages/jsx/src/ir-to-client-js/walker.ts
@@ -291,7 +291,7 @@ export function walkIR<Scope>(
 }
 
 export function assertNever(x: never): never {
-  throw new Error(`IRWalker: unhandled IRNode kind: ${JSON.stringify(x)}`)
+  throw new Error(`unhandled IRNode kind: ${JSON.stringify(x)}`)
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/walker.ts
+++ b/packages/jsx/src/ir-to-client-js/walker.ts
@@ -290,7 +290,7 @@ export function walkIR<Scope>(
   walk(root, initialScope)
 }
 
-function assertNever(x: never): never {
+export function assertNever(x: never): never {
   throw new Error(`IRWalker: unhandled IRNode kind: ${JSON.stringify(x)}`)
 }
 


### PR DESCRIPTION
## Summary

Closes the silent-loss gap documented in #1252 for the schema that exists today, in two passes:

- **Phase 0 — fixtures.** Adapter conformance previously had **zero** fixtures using `Provider` or `Async`. Two new fixtures (`context-provider`, `async-boundary`) pin the SSR contract on Hono and surface four pre-existing adapter-level defects that were invisible without them — each filed as its own follow-up issue.
- **Phase 1 — exhaustive switches.** The six hand-rolled `switch (node.type)` statements in `packages/jsx/src/ir-to-client-js/html-template.ts` all ended with `default: return ''` (or `[]` / `true`), so any unhandled `IRNode` kind was silently dropped. Each switch now lists every kind explicitly and ends with `default: return assertNever(node)`. Adding a new kind to `types.ts` is now a compile-time error in every emit pass that has not been updated.

Behaviour is unchanged: every kind that previously fell through to the default still returns the same value, just via an explicit labelled case. The `irNodeToJsExprs` switch is the one with the most historical drops (5 kinds via `default: return []`) — these are preserved with a TODO comment, since fixing the underlying semantics (e.g. async children inside a component should probably not be silently dropped) is a separate scope.

## Follow-up issues filed during Phase 0

| # | Adapter | Symptom |
|---|---|---|
| #1295 | CSR test harness | `createContext` not stubbed → `context-provider` ReferenceErrors |
| #1296 | go-template test harness | `bfAsyncBoundary` missing from `bf.FuncMap()` (lives in `StreamingFuncMap`) |
| #1297 | go-template + compileJSX | `'use client'` source emits no IR file with `outputIR: true` |
| #1298 | mojolicious adapter | `async_boundary` emits invalid `begin/end` block syntax |

Each fixture is skipped on the relevant adapter with an in-source comment pointing at the tracking issue. SSR conformance on Hono passes for both new fixtures.

## Test plan

- [x] `bun test packages/adapter-tests` — 993 pass, 0 fail
- [x] `bun test packages/adapter-hono` — 172 pass, 12 skip, 0 fail
- [x] `bun test packages/adapter-go-template` — 153 pass, 2 skip, 0 fail
- [x] `bun test packages/adapter-mojolicious` — 130 pass, 19 skip, 0 fail
- [x] `bun test packages/client` — 263 pass, 0 fail
- [x] `bun test packages/jsx` from inside the package — 1135 pass, 0 fail
- [x] `bun run build:types` in `packages/jsx` — exits 0

## Why this split is the right scope

Long-term proposal in #1252 — parameterising the six visitors over a rendering strategy + a CI lint rule banning `switch (node.type)` outside `walker.ts` — is deferred. Once exhaustiveness is enforced, the marginal benefit of de-duplicating the six visitor bodies drops a lot: the schema-evolution risk (the actual hazard) is already mitigated. The duplication can be revisited if a seventh emit pass appears or if cross-cutting refactors become a recurring tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)