### PR TITLE
fix(#1298): emit valid Mojo template syntax for async_boundary

### DIFF
--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -222,6 +222,11 @@ sub streaming_bootstrap ($self) {
 }
 
 sub async_boundary ($self, $id, $fallback_html) {
+    # The fallback comes in via Mojo `begin %>...<% end` capture (see
+    # MojoAdapter::renderAsync), which produces a CODE ref returning a
+    # Mojo::ByteStream. Materialize it so the rendered HTML embeds in
+    # the placeholder rather than the CODE ref's stringification.
+    $fallback_html = $fallback_html->() if ref($fallback_html) eq 'CODE';
     return qq{<div bf-async="$id">$fallback_html</div>};
 }
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -52,13 +52,6 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
-    // #1298: the Mojo adapter emits `$bf->async_boundary('a0', begin
-    // %><p>Loading...</p><% end)` which is invalid Mojo template
-    // syntax — the `begin/end` block is being closed early by the
-    // surrounding parentheses. The fix is in the adapter's renderer;
-    // adapter conformance coverage for the IR `async` kind waits on
-    // it.
-    'async-boundary',
     // #1297-equivalent for Mojo: `compileJSX` with `outputIR: true`
     // does not emit an `ir` file for `'use client'` sources, so the
     // Mojo harness can't render the Provider fixture. Same harness-

--- a/packages/adapter-mojolicious/src/__tests__/mojo-streaming.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-streaming.test.ts
@@ -11,20 +11,22 @@ import type { IRAsync, IRElement, IRComponent } from '@barefootjs/jsx'
 describe('MojoAdapter - Streaming SSR', () => {
   const adapter = new MojoAdapter()
 
-  test('renderAsync generates bf->async_boundary call with fallback', () => {
-    const asyncNode: IRAsync = {
+  const loc = { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } as const
+
+  function asyncNode(id: string, fallbackText: string): IRAsync {
+    return {
       type: 'async',
-      id: 'a0',
+      id,
       fallback: {
         type: 'element',
         tag: 'p',
         attrs: [],
         events: [],
         ref: null,
-        children: [{ type: 'text', value: 'Loading...', loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } }],
+        children: [{ type: 'text', value: fallbackText, loc }],
         slotId: null,
         needsScope: false,
-        loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        loc,
       } as IRElement,
       children: [
         {
@@ -34,18 +36,68 @@ describe('MojoAdapter - Streaming SSR', () => {
           template: 'ProductDetail',
           slotId: null,
           children: [],
-          loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          loc,
         } as IRComponent,
       ],
-      loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+      loc,
     }
+  }
 
-    const output = adapter.renderAsync(asyncNode)
+  test('renderAsync generates bf->async_boundary call with fallback', () => {
+    const output = adapter.renderAsync(asyncNode('a0', 'Loading...'))
 
     // Should contain the async_boundary call with the ID
     expect(output).toContain("async_boundary('a0'")
     // Should contain the fallback content
     expect(output).toContain('Loading...')
+  })
+
+  // #1298: the previous renderAsync emitted
+  //   `<%== bf->async_boundary('a0', begin %>…<% end) %>`
+  // which split the call across template-text and `<%== %>` regions —
+  // the inner `%>` closed the outer interpolation, leaving the trailing
+  // `)` in plain template text and breaking Mojo's lexer. The fix is to
+  // capture the fallback into a CODE ref in its own action and pass the
+  // variable to async_boundary. These tests pin the structural
+  // invariants of the captured-variable shape so a regression to the
+  // inlined form (or any shape that re-introduces unbalanced `%>`)
+  // fails here, not at template-parse time.
+  describe('renderAsync emits balanced Mojo syntax (#1298)', () => {
+    test('captures fallback into its own `begin %>…<% end %>` action before calling async_boundary', () => {
+      const output = adapter.renderAsync(asyncNode('a0', 'Loading...'))
+
+      // A capture action precedes the call.
+      expect(output).toMatch(/<%\s*my\s+\$bf_async_fallback_a0\s*=\s*begin\s*%>/)
+      expect(output).toContain('<% end %>')
+      // The call site references the variable, not an inlined `begin`.
+      expect(output).toMatch(/<%==\s*bf->async_boundary\('a0',\s*\$bf_async_fallback_a0\s*\)\s*%>/)
+      // No nested `begin` inside the `<%== ... %>` block — that was the
+      // exact malformation #1298 fixed.
+      expect(output).not.toMatch(/<%==\s*bf->async_boundary\([^)]*begin/)
+    })
+
+    test('every `<%` / `<%==` opener has a matching `%>` closer', () => {
+      const output = adapter.renderAsync(asyncNode('a0', 'Loading...'))
+
+      // Count `<%`-prefixed openers (including `<%==`) vs `%>` closers.
+      // Unbalanced counts indicate a stray `%>` (the #1298 failure mode)
+      // or a stray opener.
+      const openers = (output.match(/<%/g) ?? []).length
+      const closers = (output.match(/%>/g) ?? []).length
+      expect(openers).toBe(closers)
+    })
+
+    test('multiple <Async> boundaries get distinct capture variable names', () => {
+      const a = adapter.renderAsync(asyncNode('a0', 'first'))
+      const b = adapter.renderAsync(asyncNode('a1', 'second'))
+
+      expect(a).toContain('$bf_async_fallback_a0')
+      expect(b).toContain('$bf_async_fallback_a1')
+      // Cross-contamination would let one boundary's resolve overwrite
+      // another's fallback variable on the page.
+      expect(a).not.toContain('$bf_async_fallback_a1')
+      expect(b).not.toContain('$bf_async_fallback_a0')
+    })
   })
 
   test('renderNode dispatches async type correctly', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -708,7 +708,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // bf->async_boundary() wraps the fallback in a <div bf-async="aX"> placeholder.
     // The resolved content is rendered below for non-streaming fallback;
     // in streaming mode, Mojo's write_chunk delivers it as a resolve chunk.
-    return `<%== bf->async_boundary('${node.id}', begin %>${fallback}<% end) %>\n${children}`
+    //
+    // The fallback is captured into a CODE ref via `begin %>…<% end` in
+    // its own action — embedding the `begin/end` inside the `<%== ... %>`
+    // that wraps `async_boundary` would let the inner `%>` close the
+    // outer tag, leaving the trailing `)` in plain template text and
+    // breaking Mojo's lexer (#1298). Same shape as `renderComponent`'s
+    // children capture.
+    const fallbackVar = `$bf_async_fallback_${node.id}`
+    return `<% my ${fallbackVar} = begin %>${fallback}<% end %><%== bf->async_boundary('${node.id}', ${fallbackVar}) %>\n${children}`
   }
 
   // ===========================================================================

--- a/packages/adapter-tests/src/__tests__/normalize-html.test.ts
+++ b/packages/adapter-tests/src/__tests__/normalize-html.test.ts
@@ -26,4 +26,31 @@ describe('normalizeHTML — async placeholder strip', () => {
     const html = '<div bf-async="a0">Wait<br/>just a moment</div><span>Done</span>'
     expect(normalizeHTML(html)).toBe('<span>Done</span>')
   })
+
+  test('attribute order — `bf-async` not first does not silently no-op the strip', () => {
+    const html = '<div class="root"><div data-foo="x" bf-async="a0"><p>Loading...</p></div><span>Resolved</span></div>'
+    expect(normalizeHTML(html)).toBe('<div class="root"><span>Resolved</span></div>')
+  })
+
+  test('tag-name word boundary — `<divider>` / `<div-foo>` are not counted as `<div>` openers', () => {
+    const html = '<section><divider>x</divider><div-foo>y</div-foo><div bf-async="a0"><p>L</p></div><span>R</span></section>'
+    // The unrelated <divider> / <div-foo> tags must survive intact, and
+    // the placeholder strip must terminate at its own `</div>` — not get
+    // confused by the `</divider>` close.
+    expect(normalizeHTML(html)).toBe('<section><divider>x</divider><div-foo>y</div-foo><span>R</span></section>')
+  })
+
+  test('self-closing `<div ... />` in fallback contributes zero net depth', () => {
+    // Without self-closing handling, `<div class="skeleton"/>` would
+    // increment depth without a matching `</div>`, so the strip would
+    // consume past the intended placeholder close and swallow the
+    // sibling `<span>`.
+    const html = '<div bf-async="a0"><div class="skeleton"/></div><span>Resolved</span>'
+    expect(normalizeHTML(html)).toBe('<span>Resolved</span>')
+  })
+
+  test('self-closing div with trailing space still resolves correctly', () => {
+    const html = '<div bf-async="a0"><div class="skeleton" /></div><span>R</span>'
+    expect(normalizeHTML(html)).toBe('<span>R</span>')
+  })
 })

--- a/packages/adapter-tests/src/__tests__/normalize-html.test.ts
+++ b/packages/adapter-tests/src/__tests__/normalize-html.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test'
+import { normalizeHTML } from '../jsx-runner'
+
+describe('normalizeHTML — async placeholder strip', () => {
+  test('removes a flat <div bf-async> placeholder, keeping the resolved siblings', () => {
+    const html = '<div><div bf-async="a0"><p>Loading...</p></div><span>Resolved</span></div>'
+    expect(normalizeHTML(html)).toBe('<div><span>Resolved</span></div>')
+  })
+
+  test('removes a placeholder whose fallback contains nested <div> without dangling </div>', () => {
+    const html = '<div><div bf-async="a0"><div class="skeleton"><div>Loading...</div></div></div><span>Resolved</span></div>'
+    expect(normalizeHTML(html)).toBe('<div><span>Resolved</span></div>')
+  })
+
+  test('strips multiple sibling placeholders in one pass', () => {
+    const html = '<main><div bf-async="a0"><p>A</p></div><div bf-async="a1"><p>B</p></div><section>Done</section></main>'
+    expect(normalizeHTML(html)).toBe('<main><section>Done</section></main>')
+  })
+
+  test('leaves unrelated <div> elements untouched', () => {
+    const html = '<div class="root"><div bf-async="a0"><p>L</p></div><div class="card">Card</div></div>'
+    expect(normalizeHTML(html)).toBe('<div class="root"><div class="card">Card</div></div>')
+  })
+
+  test('placeholder containing a void <br/> in its fallback closes correctly', () => {
+    const html = '<div bf-async="a0">Wait<br/>just a moment</div><span>Done</span>'
+    expect(normalizeHTML(html)).toBe('<span>Done</span>')
+  })
+})

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -89,6 +89,15 @@ export function normalizeHTML(html: string): string {
     // JS-runtime hydration path uses them, so removing them keeps
     // cross-adapter conformance comparisons apples-to-apples.
     .replace(/<!--bf-scope:[^>]*-->/g, '')
+    // Strip the streaming-SSR async-boundary placeholder. Mojo and Go
+    // template emit a `<div bf-async="aN">…fallback…</div>` placeholder
+    // alongside the resolved children (the placeholder is swapped by a
+    // streaming-runtime script when the boundary resolves). Hono uses
+    // `<Suspense>` which collapses synchronously for non-Promise
+    // children, so it emits only the resolved content. Strip the
+    // placeholder for cross-adapter conformance — the resolved
+    // children remain on both sides. (#1298)
+    .replace(/<div bf-async="[^"]*">[\s\S]*?<\/div>/g, '')
     // Normalize child scope ID prefix: bf-s="~parentId_sN" → bf-s="parentId_sN"
     .replace(/bf-s="~([^"]*)"/g, 'bf-s="$1"')
     // Normalize non-deterministic child scope IDs. Keep the trailing

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -55,6 +55,60 @@ export interface RunJSXConformanceOptions {
 const VOID_ELEMENTS = 'area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr'
 
 /**
+ * Remove every `<div bf-async="aN">…fallback…</div>` placeholder from `html`,
+ * walking the opening tag's children with a depth counter so a fallback that
+ * itself contains `<div>` (e.g. `<Skeleton><div class="..."/></Skeleton>`)
+ * does not terminate the match at the first inner `</div>`. Plain regex with
+ * `[\s\S]*?` cannot do this — it stops at the first close, leaving a
+ * dangling `</div>` behind.
+ *
+ * The streaming-SSR adapters (Mojo, Go template) emit the placeholder
+ * alongside the resolved children so the runtime can swap on resolve; Hono's
+ * `<Suspense>` collapses synchronously for non-Promise children and emits
+ * only the resolved content. Stripping the placeholder keeps cross-adapter
+ * conformance apples-to-apples — the resolved children remain on both sides.
+ */
+function stripAsyncPlaceholders(html: string): string {
+  const OPEN_PREFIX = '<div bf-async="'
+  let result = ''
+  let i = 0
+  while (i < html.length) {
+    const start = html.indexOf(OPEN_PREFIX, i)
+    if (start === -1) {
+      result += html.slice(i)
+      break
+    }
+    const tagEnd = html.indexOf('>', start)
+    if (tagEnd === -1) {
+      // Malformed — leave the remainder alone rather than risk a worse strip.
+      result += html.slice(i)
+      break
+    }
+    result += html.slice(i, start)
+    let depth = 1
+    let cursor = tagEnd + 1
+    while (depth > 0 && cursor < html.length) {
+      const nextOpen = html.indexOf('<div', cursor)
+      const nextClose = html.indexOf('</div>', cursor)
+      if (nextClose === -1) {
+        // Unbalanced — bail and leave the remainder.
+        cursor = html.length
+        break
+      }
+      if (nextOpen !== -1 && nextOpen < nextClose) {
+        depth += 1
+        cursor = nextOpen + 4
+      } else {
+        depth -= 1
+        cursor = nextClose + 6
+      }
+    }
+    i = cursor
+  }
+  return result
+}
+
+/**
  * Normalize rendered HTML for cross-adapter comparison.
  * Handles known formatting differences between adapters:
  * - Whitespace collapsing (template engine formatting)
@@ -63,7 +117,11 @@ const VOID_ELEMENTS = 'area|base|br|col|embed|hr|img|input|link|meta|param|sourc
  * - Trailing whitespace before closing > in tags
  */
 export function normalizeHTML(html: string): string {
-  return html
+  // Strip the streaming-SSR async-boundary placeholder ahead of the
+  // regex chain so a fallback containing nested `<div>` doesn't mislead
+  // any later matcher. See `stripAsyncPlaceholders` for the depth-
+  // counted match. (#1298)
+  return stripAsyncPlaceholders(html)
     // Remove loop boundary comment markers (template detail, not semantic).
     // Matches both legacy unscoped (`<!--bf-loop-->`) and scoped per-call-site
     // (`<!--bf-loop:l7-->`) forms (#1087). The marker id is `l\d+` — kept
@@ -89,15 +147,6 @@ export function normalizeHTML(html: string): string {
     // JS-runtime hydration path uses them, so removing them keeps
     // cross-adapter conformance comparisons apples-to-apples.
     .replace(/<!--bf-scope:[^>]*-->/g, '')
-    // Strip the streaming-SSR async-boundary placeholder. Mojo and Go
-    // template emit a `<div bf-async="aN">…fallback…</div>` placeholder
-    // alongside the resolved children (the placeholder is swapped by a
-    // streaming-runtime script when the boundary resolves). Hono uses
-    // `<Suspense>` which collapses synchronously for non-Promise
-    // children, so it emits only the resolved content. Strip the
-    // placeholder for cross-adapter conformance — the resolved
-    // children remain on both sides. (#1298)
-    .replace(/<div bf-async="[^"]*">[\s\S]*?<\/div>/g, '')
     // Normalize child scope ID prefix: bf-s="~parentId_sN" → bf-s="parentId_sN"
     .replace(/bf-s="~([^"]*)"/g, 'bf-s="$1"')
     // Normalize non-deterministic child scope IDs. Keep the trailing

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -55,55 +55,67 @@ export interface RunJSXConformanceOptions {
 const VOID_ELEMENTS = 'area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr'
 
 /**
- * Remove every `<div bf-async="aN">…fallback…</div>` placeholder from `html`,
- * walking the opening tag's children with a depth counter so a fallback that
- * itself contains `<div>` (e.g. `<Skeleton><div class="..."/></Skeleton>`)
- * does not terminate the match at the first inner `</div>`. Plain regex with
- * `[\s\S]*?` cannot do this — it stops at the first close, leaving a
- * dangling `</div>` behind.
+ * Remove every `<div … bf-async="…" …>…fallback…</div>` placeholder from
+ * `html`, walking the opener's descendants with a depth counter so a
+ * fallback that itself contains `<div>` (e.g. `<Skeleton><div
+ * class="..."/></Skeleton>`) does not terminate the match at the first
+ * inner `</div>`. Plain regex with `[\s\S]*?` cannot do this — it stops
+ * at the first close, leaving a dangling `</div>` behind.
+ *
+ * Robustness invariants the helper pins:
+ *
+ * - **Attribute order is not assumed.** The opener regex matches
+ *   `bf-async` anywhere in the attribute list, so an adapter is free to
+ *   emit `<div data-foo="x" bf-async="a0">` without silently no-opping
+ *   the strip.
+ * - **Tag-name word boundary.** A `(?=[\s/>])` lookahead after `<div`
+ *   keeps `<divider>` / `<div-foo>` from being miscounted as `<div>`
+ *   openers — `\b` alone would still match `<div-…` because `-` is a
+ *   non-word char.
+ * - **Self-closing `<div ... />` is zero net depth.** XHTML-style
+ *   self-closes have no matching `</div>`; incrementing on them would
+ *   make the strip consume past the intended placeholder close.
  *
  * The streaming-SSR adapters (Mojo, Go template) emit the placeholder
- * alongside the resolved children so the runtime can swap on resolve; Hono's
- * `<Suspense>` collapses synchronously for non-Promise children and emits
- * only the resolved content. Stripping the placeholder keeps cross-adapter
- * conformance apples-to-apples — the resolved children remain on both sides.
+ * alongside the resolved children so the runtime can swap on resolve;
+ * Hono's `<Suspense>` collapses synchronously for non-Promise children
+ * and emits only the resolved content. Stripping the placeholder keeps
+ * cross-adapter conformance apples-to-apples — the resolved children
+ * remain on both sides.
  */
 function stripAsyncPlaceholders(html: string): string {
-  const OPEN_PREFIX = '<div bf-async="'
+  const OPENER_RE = /<div(?=[\s/>])[^>]*\bbf-async="[^"]*"[^>]*>/g
+  const ANY_DIV_TAG_RE = /<div(?=[\s/>])[^>]*?(\/?)>|<\/div>/g
+
   let result = ''
   let i = 0
   while (i < html.length) {
-    const start = html.indexOf(OPEN_PREFIX, i)
-    if (start === -1) {
+    OPENER_RE.lastIndex = i
+    const opener = OPENER_RE.exec(html)
+    if (!opener) {
       result += html.slice(i)
       break
     }
-    const tagEnd = html.indexOf('>', start)
-    if (tagEnd === -1) {
-      // Malformed — leave the remainder alone rather than risk a worse strip.
-      result += html.slice(i)
-      break
-    }
-    result += html.slice(i, start)
+    result += html.slice(i, opener.index)
+
     let depth = 1
-    let cursor = tagEnd + 1
-    while (depth > 0 && cursor < html.length) {
-      const nextOpen = html.indexOf('<div', cursor)
-      const nextClose = html.indexOf('</div>', cursor)
-      if (nextClose === -1) {
-        // Unbalanced — bail and leave the remainder.
-        cursor = html.length
-        break
+    ANY_DIV_TAG_RE.lastIndex = opener.index + opener[0].length
+    while (depth > 0) {
+      const m = ANY_DIV_TAG_RE.exec(html)
+      if (!m) {
+        // Unbalanced — leave the rest of `html` alone rather than risk a
+        // worse strip.
+        result += html.slice(opener.index)
+        return result
       }
-      if (nextOpen !== -1 && nextOpen < nextClose) {
-        depth += 1
-        cursor = nextOpen + 4
-      } else {
+      if (m[0] === '</div>') {
         depth -= 1
-        cursor = nextClose + 6
+      } else if (m[1] !== '/') {
+        // Open tag (and not self-closing): nested.
+        depth += 1
       }
     }
-    i = cursor
+    i = ANY_DIV_TAG_RE.lastIndex
   }
   return result
 }


### PR DESCRIPTION
## Summary

- Capture the `<Async>` fallback into a CODE ref in its own `<% my $fb = begin %>…<% end %>` action, then call `<%== bf->async_boundary('aN', $fb) %>` as a self-contained interpolation. The previous emit (`<%== bf->async_boundary('a0', begin %>…<% end) %>`) split the call across template-text and interpolation regions, leaving the trailing `)` outside any `<%== %>` block — Mojo's lexer rejected it with `Scalar found where operator expected`.
- Materialize the CODE ref inside `BarefootJS::async_boundary` so the fallback HTML embeds in the placeholder rather than stringifying as `CODE(0x…)`. Same pattern `render_child` already uses for captured children.
- Strip the streaming-SSR `<div bf-async="aN">` placeholder in `normalizeHTML` for cross-adapter conformance. Mojo and Go template emit the placeholder alongside the resolved children (it's swapped by a streaming-runtime script when the boundary resolves); Hono uses `<Suspense>` which collapses synchronously for non-Promise children. Mirrors the existing `bf-h` / `bf-m` / `bf-scope:` strips.
- Remove `async-boundary` from the Mojo adapter's `skipJsx` list.

## Test plan

- [x] `bun test packages/adapter-mojolicious` — 131 pass, 0 fail (previously skipped `async-boundary` now passes)
- [x] `bun test packages/adapter-go-template` — 153 pass, 0 fail (no regression from the `normalizeHTML` change)
- [x] `bun test packages` — 2667 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1298