### PR TITLE
fix(#1296): merge StreamingFuncMap into go-template test harness

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -46,11 +46,6 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
-    // #1296: test harness only loads `bf.FuncMap()`, which omits
-    // `bfAsyncBoundary` (lives in `StreamingFuncMap()`). The adapter
-    // correctly emits the call; the harness needs to merge the
-    // streaming map before the fixture can pass.
-    'async-boundary',
     // #1297: `compileJSX` with `outputIR: true` does not emit an `ir`
     // file for `'use client'` sources when the go-template adapter
     // is selected, even though the Hono path does. The harness then

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -167,6 +167,18 @@ import (
 // Silence unused import for bf if only FuncMap is used
 var _ = bf.FuncMap
 
+// Merge StreamingFuncMap into the base FuncMap so fixtures using
+// <Async> (which compiles to a bfAsyncBoundary call) can be parsed
+// by the test harness. See packages/adapter-go-template/runtime/streaming.go
+// for the recommended merge recipe.
+func bfTestFuncMap() template.FuncMap {
+	funcMap := bf.FuncMap()
+	for k, v := range bf.StreamingFuncMap() {
+		funcMap[k] = v
+	}
+	return funcMap
+}
+
 const tmplContent = \`${escapedTemplate}\`
 
 // randomID generates a random alphanumeric string of given length.
@@ -181,7 +193,7 @@ func randomID(n int) string {
 }
 
 func main() {
-	tmpl := template.Must(template.New("").Funcs(bf.FuncMap()).Parse(tmplContent))
+	tmpl := template.Must(template.New("").Funcs(bfTestFuncMap()).Parse(tmplContent))
 	props := New${componentName}Props(${componentName}Input{
 		ScopeID: "test",
 ${propsInit}


### PR DESCRIPTION
## Summary

- The go-template test renderer at `packages/adapter-go-template/src/test-render.ts` constructed templates with only `bf.FuncMap()`, which omits `bfAsyncBoundary`. Any fixture containing `<Async>` panicked at template parse, even though the adapter emitted the call correctly. The streaming helpers live in `bf.StreamingFuncMap()` and are intended to be merged onto the base FuncMap per the `runtime/streaming.go` doc comment.
- The generated `main.go` now merges both maps via a small `bfTestFuncMap()` helper before parsing. The `async-boundary` fixture is removed from `skipJsx` for go-template, closing a silent IR-coverage gap for the `async` kind.
- Cross-adapter normalization of the `<div bf-async="…">` placeholder is **handled by `normalizeHTML.stripAsyncPlaceholders` shipped in #1301** (now on `main`). This PR previously added a duplicate regex strip to `stripConditionalMarkersForCrossAdapter`; that has been removed in the rebase since the merged helper is depth-counted and already covers Go's output.

## Test plan

- [x] `bun test packages/adapter-go-template` — 154 pass, 0 fail (previously 153 pass + 1 skip)
- [x] `bun test packages/adapter-go-template packages/adapter-tests` — 419 pass, 0 fail
- [x] Pre-existing `@barefootjs/client` resolution failures from this worktree are unchanged from `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1296