### PR TITLE
fix: add key={inv.invoice} to TableRow .map() in table-demo

### DIFF
--- a/site/ui/components/table-demo.tsx
+++ b/site/ui/components/table-demo.tsx
@@ -43,7 +43,7 @@ export function TablePreviewDemo() {
       </TableHeader>
       <TableBody>
         {invoices.map((inv) => (
-          <TableRow>
+          <TableRow key={inv.invoice}>
             <TableCell className="font-medium">{inv.invoice}</TableCell>
             <TableCell>{inv.status}</TableCell>
             <TableCell>{inv.method}</TableCell>
@@ -77,7 +77,7 @@ export function TableBasicDemo() {
       </TableHeader>
       <TableBody>
         {invoices.slice(0, 4).map((inv) => (
-          <TableRow>
+          <TableRow key={inv.invoice}>
             <TableCell className="font-medium">{inv.invoice}</TableCell>
             <TableCell>{inv.status}</TableCell>
             <TableCell>{inv.method}</TableCell>
@@ -106,7 +106,7 @@ export function TableWithFooterDemo() {
       </TableHeader>
       <TableBody>
         {invoices.map((inv) => (
-          <TableRow>
+          <TableRow key={inv.invoice}>
             <TableCell className="font-medium">{inv.invoice}</TableCell>
             <TableCell>{inv.status}</TableCell>
             <TableCell>{inv.method}</TableCell>


### PR DESCRIPTION
## Summary

Three `.map((inv) => <TableRow>...</TableRow>)` calls in `site/ui/components/table-demo.tsx` had no `key` prop. The compiler flagged each on every `site/ui` build:

```
Errors compiling .../site/ui/components/table-demo.tsx:
  Missing key attribute in list rendering. Add a key prop for efficient updates
  Missing key attribute in list rendering. Add a key prop for efficient updates
  Missing key attribute in list rendering. Add a key prop for efficient updates
```

`inv.invoice` is the natural unique key — the invoice list is static fixture data, one row per invoice ID.

Since these are doc-page demos and the build kept proceeding through the warning, the impact is cosmetic at the compiler-output level. The fix removes a recurring source of console noise and a poor example for anyone reading the Table doc page as a reference.

## Test plan

- [x] `bun run build.ts --clean` in `site/ui`: zero `Missing key` warnings remain (verified by `grep -iE "error|missing key|warning"` returning no matches)
- [x] `bun test packages/`: 2703 pass / 0 fail / 33 skip (one unrelated CLI stale-dist failure on first run cleared after a `bun run --filter '@barefootjs/cli' build`)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)