### PR TITLE
fix(#1295): wire up Context plumbing in CSR test harness

### DIFF
--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -59,12 +59,6 @@ describe('CSR Conformance Tests', () => {
     // template-based adapters; the duplicate-`bf-s` issue is its own
     // follow-up.
     'record-index-lookup-via-child-prop',
-    // #1295: the CSR mock runtime in `csr-render.ts` does not stub
-    // `createContext`, so any fixture that declares `const Ctx =
-    // createContext(...)` at module scope ReferenceErrors when the
-    // template lambda runs. SSR conformance covers Provider correctly
-    // via the real Hono runtime — see #1295 for the harness fix.
-    'context-provider',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -12,6 +12,7 @@ import {
   jsxToIR,
   generateClientJs,
   analyzeClientNeeds,
+  listComponentFunctions,
   type ComponentIR,
 } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
@@ -40,27 +41,56 @@ function throwIfErrors(ctx: { errors: Array<{ severity: string; message: string 
 }
 
 function compileToClientJs(source: string, filePath: string): string {
-  const ctx = analyzeComponent(source, filePath)
-
-  if (!ctx.jsxReturn) {
+  // Compile every component declared in the source file, mirroring the
+  // production `compileMultipleComponents` flow (`packages/jsx/src/compiler.ts`).
+  // A single-component compile would miss sibling components defined in the
+  // same file — including module-scope declarations such as
+  // `const Ctx = createContext(...)` that only the Provider-owning sibling
+  // emits at module level. The CSR harness needs the full set so the
+  // template lambdas can resolve cross-component module references (#1295).
+  const componentNames = listComponentFunctions(source, filePath)
+  if (componentNames.length === 0) {
+    // Fall back to default-export resolution (preserves prior behaviour for
+    // sources where `listComponentFunctions` returns nothing).
+    const ctx = analyzeComponent(source, filePath)
+    if (!ctx.jsxReturn) {
+      throwIfErrors(ctx, filePath)
+      return ''
+    }
+    const ir = jsxToIR(ctx)
+    if (!ir) return ''
     throwIfErrors(ctx, filePath)
-    return ''
+    const componentIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(ctx),
+      root: ir,
+      errors: [],
+    }
+    componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
+    return generateClientJs(componentIR)
   }
 
-  const ir = jsxToIR(ctx)
-  if (!ir) return ''
-
-  throwIfErrors(ctx, filePath)
-
-  const componentIR: ComponentIR = {
-    version: '0.1',
-    metadata: buildMetadata(ctx),
-    root: ir,
-    errors: [],
+  const outputs: string[] = []
+  for (const componentName of componentNames) {
+    const ctx = analyzeComponent(source, filePath, componentName)
+    if (!ctx.jsxReturn) {
+      throwIfErrors(ctx, filePath)
+      continue
+    }
+    const ir = jsxToIR(ctx)
+    if (!ir) continue
+    throwIfErrors(ctx, filePath)
+    const componentIR: ComponentIR = {
+      version: '0.1',
+      metadata: buildMetadata(ctx),
+      root: ir,
+      errors: [],
+    }
+    componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
+    const js = generateClientJs(componentIR, componentNames)
+    if (js) outputs.push(js)
   }
-  componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
-
-  return generateClientJs(componentIR)
+  return outputs.join('\n')
 }
 
 export async function renderCsrComponent(options: CsrRenderOptions): Promise<string> {
@@ -115,11 +145,26 @@ function buildCsrEvalModule(clientJs: string, props: Record<string, unknown>): s
   return `
 // --- Mock runtime ---
 const __templates = new Map()
+const __inits = new Map()
 let __lastComponent = null
 
 function hydrate(name, def) {
   if (def.template) __templates.set(name, def.template)
+  if (def.init) __inits.set(name, def.init)
   __lastComponent = name
+}
+
+// Minimal stub scope so init bodies that read \`__scope.getAttribute\`
+// don't throw. Real CSR runs init against the live DOM root; this mock
+// substitutes a no-op object since template-eval doesn't depend on the
+// scope's identity, only on what init writes to module-level state
+// (e.g. provideContext for context-provider fixtures).
+const __stubScope = { getAttribute: () => 'test', querySelectorAll: () => [], children: [] }
+function __runInit(name, props) {
+  const init = __inits.get(name)
+  if (init) {
+    try { init(__stubScope, props ?? {}) } catch {}
+  }
 }
 
 function renderChild(name, props, key, suffix) {
@@ -145,7 +190,19 @@ function renderChild(name, props, key, suffix) {
   const slotAttrs = suffix ? ' bf-h="test" bf-m="' + suffix + '"' : ''
   if (!template) return '<div bf-s="' + scopeId + '"' + slotAttrs + keyAttr + '>[' + name + ']</div>'
   const html = template(props).trim()
-  return html.replace(/^(<\\w+)/, '$1 bf-s="' + scopeId + '"' + slotAttrs + keyAttr)
+  // Same attribute-ordering rule as the root-injection block below: when
+  // the child root has user attributes (\`class\`, \`id\`, …) but no
+  // \`bf="..."\` to anchor on, append \`bf-s\` at the end of the opening
+  // tag so static attributes precede it — matching SSR's attribute
+  // order (#1295 / Hono renderElement).
+  const childAttrs = ' bf-s="' + scopeId + '"' + slotAttrs + keyAttr
+  if (html.match(/^<\\w+[^>]* bf="/)) {
+    return html.replace(/ bf="/, childAttrs + ' bf="')
+  }
+  if (html.match(/^<\\w+\\s[^>]*>/)) {
+    return html.replace(/^(<\\w+\\s[^>]*?)(\\s*\\/?>)/, '$1' + childAttrs + '$2')
+  }
+  return html.replace(/^(<\\w+)/, '$1' + childAttrs)
 }
 
 // Noop stubs for init-phase functions (not needed for template evaluation)
@@ -160,12 +217,20 @@ const onCleanup = () => {}
 const insert = () => {}
 const reconcileElements = () => {}
 const updateClientMarker = () => {}
-const initChild = () => {}
+const initChild = (name, _scope, props) => { __runInit(name, props) }
 const createComponent = () => null
 const createPortal = () => {}
 const applyRestAttrs = () => {}
-const provideContext = () => {}
-const useContext = () => undefined
+// Minimal Context model so fixtures with \`createContext\`/\`Provider\`
+// (e.g. \`context-provider\`) can resolve \`useContext(ctx)\` during
+// template eval. Real \`@barefootjs/client/runtime\` walks the DOM scope
+// chain; the harness collapses that to a single global Map keyed by
+// context identity since CSR conformance only renders one component tree
+// at a time. (#1295)
+const __ctxStore = new Map()
+const createContext = (defaultValue) => ({ __bfCtxId: Symbol(), defaultValue })
+const provideContext = (ctx, value) => { __ctxStore.set(ctx.__bfCtxId, value) }
+const useContext = (ctx) => __ctxStore.has(ctx.__bfCtxId) ? __ctxStore.get(ctx.__bfCtxId) : ctx?.defaultValue
 function styleToCss(value) {
   if (value == null) return null
   if (typeof value !== 'object') return String(value)
@@ -181,13 +246,23 @@ function styleToCss(value) {
 // --- Execute client JS (registers templates via hydrate()) ---
 ${strippedCode}
 
+// --- Run main component init (so Provider state is set, child inits cascade) ---
+__runInit(__lastComponent, ${JSON.stringify(props)})
+
 // --- Evaluate main component template ---
 const __templateFn = __templates.get(__lastComponent)
 let __html = __templateFn ? __templateFn(${JSON.stringify(props)}) : ''
 // Inject bf-s="test" on root element to match SSR scope ID convention.
-// Insert before bf= marker to match SSR attribute order.
+// SSR (Hono renderElement) appends bf-s AFTER user-defined attributes,
+// so for stateful roots the order is \`class="..." bf-s="..." bf="..."\`.
+// Insert before \`bf="..."\` when present (preserves bf-s adjacency to the
+// reactive marker); otherwise append at the end of the opening tag so
+// existing static attributes (e.g. \`class\`) come first. Falls back to
+// the tag-name-only case for tags with no attributes.
 if (__html.match(/^<\\w+[^>]* bf="/)) {
   __html = __html.replace(/ bf="/, ' bf-s="test" bf="')
+} else if (__html.match(/^<\\w+\\s[^>]*>/)) {
+  __html = __html.replace(/^(<\\w+\\s[^>]*?)(\\s*\\/?>)/, '$1 bf-s="test"$2')
 } else {
   __html = __html.replace(/^(<\\w+)/, '$1 bf-s="test"')
 }

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -644,9 +644,21 @@ export function collectElements(
       descendJsxChildren()
     },
     provider: ({ node: p, descend }) => {
+      // Literal `<Ctx.Provider value="dark">` must emit `"dark"` (a
+      // quoted JS string) at the `provideContext(...)` call site, not
+      // the bare identifier `dark` that `attrValueToString` returns for
+      // the literal kind. The other AttrValue kinds already serialise to
+      // valid JS expressions (`expr` for expression / spread, the
+      // template parts for `template`), so they pass through unchanged.
+      // Mirrors the Hono adapter's `emitProvider` (`hono-adapter.ts`)
+      // which JSON-stringifies the literal value for the same reason.
+      const v = p.valueProp.value
+      const valueExpr = v.kind === 'literal'
+        ? JSON.stringify(v.value)
+        : (attrValueToString(v) ?? '')
       ctx.providerSetups.push({
         contextName: p.contextName,
-        valueExpr: attrValueToString(p.valueProp.value) ?? '',
+        valueExpr,
       })
       descend()
     },


### PR DESCRIPTION
## Summary

- Add `createContext`, real `provideContext` / `useContext` stubs to the CSR mock runtime (`csr-render.ts`) so fixtures with `const Ctx = createContext(...)` no longer ReferenceError on template eval.
- Compile every component in a source file (mirroring `compileMultipleComponents`) so module-scope declarations from a Provider-owning sibling reach the CSR module — previously only one component was compiled, leaving `var ThemeContext = …` missing whenever the Provider lived on a different sibling.
- Run init for `__lastComponent` (and cascaded children via `initChild`) before evaluating the template, so the Provider's `provideContext(...)` call actually writes into the context store before descendant `useContext` reads it.
- Quote literal `<Ctx.Provider value="...">` values in the client-JS provider-setup emit (`collect-elements.ts`) — matches the Hono adapter's `emitProvider`, which already `JSON.stringify`s for the same reason. Without this, the generated `provideContext(Ctx, dark)` referenced an undefined identifier.
- Append `bf-s="test"` at the end of the opening tag (after `class` etc.) when no `bf="..."` marker is present, matching Hono's `renderElement` attribute order. The previous fallback inserted `bf-s` right after the tag name, which only worked when a `bf="..."` reactive marker was emitted alongside.
- Remove `context-provider` from the `skipFixtures` set in `csr-conformance.test.ts`.

## Test plan

- [x] `bun test packages/adapter-tests` — 256 pass / 0 fail (includes the previously-skipped `context-provider` CSR test).
- [x] `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts -t "context-provider"` — 1 pass.
- [x] `bun test packages/jsx` — 4 pre-existing failures only; no new regressions from the `collect-elements.ts` change.
- [x] `bun test packages/adapter-hono` — 4 pre-existing failures only (`ssr-context-bridge`); unaffected by this PR.
- [x] `bun test packages/adapter-go-template` / `packages/adapter-mojolicious` — green.

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)