### PR TITLE
fix(#1297): emit IR per component for multi-component sources

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -46,11 +46,15 @@ runAdapterConformanceTests({
     'nullish-coalescing-jsx',
     'return-nullish-coalescing',
     'return-map',
-    // #1297: `compileJSX` with `outputIR: true` does not emit an `ir`
-    // file for `'use client'` sources when the go-template adapter
-    // is selected, even though the Hono path does. The harness then
-    // throws "No IR output (set outputIR: true)" before any rendering
-    // happens. Provider IR coverage on go-template waits on the fix.
+    // #1297 fixed the harness-side IR emission gate (multi-component
+    // sources now emit one `ir` file per component, and the harness
+    // picks the entry-point IR). The remaining gap is adapter-side:
+    // the go-template adapter has no SSR context-propagation
+    // mechanism, so `<Ctx.Provider value="dark">` doesn't make
+    // `useContext(Ctx)` resolve to `"dark"` at template-eval time —
+    // the template emits `.Theme` against a struct that has no
+    // `Theme` field. Provider SSR coverage on go-template waits on
+    // that adapter feature; see #1297 follow-up.
     'context-provider',
   ],
   // Per-fixture build-time contracts for shapes the Go template

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1130,6 +1130,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (cond.whenFalse) {
         this.collectStaticChildInstancesRecursive(cond.whenFalse, result, inLoop)
       }
+    } else if (node.type === 'provider') {
+      // Provider is a transparent wrapper at the SSR layer — context
+      // propagation is purely a client-runtime concern. Recurse into
+      // its children so any static <Child/> nested under <Ctx.Provider>
+      // still gets a slot field generated on the parent's props type.
+      const p = node as IRProvider
+      for (const child of p.children) {
+        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+      }
+    } else if (node.type === 'async') {
+      // Async fallback + children render server-side via the OOS
+      // protocol; static child components inside them still need slot
+      // fields on the parent struct.
+      const a = node as IRAsync
+      this.collectStaticChildInstancesRecursive(a.fallback, result, inLoop)
+      for (const child of a.children) {
+        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+      }
     }
   }
 

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -76,8 +76,8 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
       if (!childTemplate) throw new Error(`No marked template for ${filename}`)
       childTemplates.push(childTemplate.content)
 
-      const childIrFile = childResult.files.find(f => f.type === 'ir')
-      if (childIrFile) {
+      const childIrFiles = childResult.files.filter(f => f.type === 'ir')
+      for (const childIrFile of childIrFiles) {
         const childIR = JSON.parse(childIrFile.content) as ComponentIR
         let childTypes = adapter.generateTypes!(childIR)
         if (childTypes) {
@@ -102,10 +102,22 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   const templateFile = result.files.find(f => f.type === 'markedTemplate')
   if (!templateFile) throw new Error('No marked template in compile output')
 
-  const irFile = result.files.find(f => f.type === 'ir')
-  if (!irFile) throw new Error('No IR output (set outputIR: true)')
-  const ir = JSON.parse(irFile.content) as ComponentIR
+  // Collect every IR emitted from the parent source. Single-component
+  // files yield one file; multi-component files yield one per component
+  // (#1297). Pick the entry-point IR — default export wins, else the
+  // first inline-exported component, else the first IR.
+  const irFiles = result.files.filter(f => f.type === 'ir')
+  if (irFiles.length === 0) throw new Error('No IR output (set outputIR: true)')
+  const irs = irFiles.map(f => JSON.parse(f.content) as ComponentIR)
+  const ir =
+    irs.find(i => i.metadata.hasDefaultExport) ??
+    irs.find(i => i.metadata.isExported) ??
+    irs[0]
 
+  // Generate types for the entry-point component first, then append
+  // types for every sibling component in the same source file so the
+  // generated `types.go` is self-contained (multi-component test
+  // fixtures otherwise lose helper-component struct definitions).
   let goTypes = adapter.generateTypes(ir)
   if (!goTypes) throw new Error('generateTypes() returned null')
 
@@ -114,6 +126,17 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
 
   // Remove "math/rand" import from types (randomID is defined in main.go)
   goTypes = goTypes.replace(/\t"math\/rand"\n/, '')
+
+  // Append sibling-component type definitions (multi-component source).
+  for (const siblingIR of irs) {
+    if (siblingIR === ir) continue
+    let siblingTypes = adapter.generateTypes(siblingIR)
+    if (!siblingTypes) continue
+    siblingTypes = siblingTypes.replace(/^package \w+\n*/, '')
+    siblingTypes = siblingTypes.replace(/import\s*\([^)]*\)\n*/g, '')
+    siblingTypes = siblingTypes.replace(/\t"math\/rand"\n/g, '')
+    goTypes += '\n\n' + siblingTypes.trim()
+  }
 
   // Append child type definitions
   if (childTypeBlocks.length > 0) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -52,11 +52,13 @@ runAdapterConformanceTests({
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
-    // #1297-equivalent for Mojo: `compileJSX` with `outputIR: true`
-    // does not emit an `ir` file for `'use client'` sources, so the
-    // Mojo harness can't render the Provider fixture. Same harness-
-    // level gap class as the go-template adapter; coverage tracked
-    // there.
+    // #1297 fixed the harness-side IR emission gate. The remaining
+    // gap is adapter-side: the Mojo adapter has no SSR context-
+    // propagation mechanism, so `<Ctx.Provider value="dark">` doesn't
+    // make `useContext(Ctx)` resolve to `"dark"` at template-eval
+    // time — the template emits `<%= $theme %>` against a hash that
+    // never receives a `theme` key. Provider SSR coverage on Mojo
+    // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter

--- a/packages/adapter-mojolicious/src/__tests__/template-base-name.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/template-base-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'bun:test'
+import { templateBaseName } from '../test-render'
+
+describe('templateBaseName (#1297)', () => {
+  test('strips Mojo adapter `.html.ep` extension, not just the last dot segment', () => {
+    // The crux of the #1297 follow-up: a naive `/\.[^.]+$/` would leave
+    // `Counter.html` here, which would miss the `irsByName` lookup
+    // (componentName is `Counter`) and pair every sibling template to
+    // the entry-point IR.
+    expect(templateBaseName('component/Counter.html.ep', '.html.ep')).toBe('Counter')
+    expect(templateBaseName('theme/ThemeLabel.html.ep', '.html.ep')).toBe('ThemeLabel')
+    expect(templateBaseName('src/very/nested/path/Outer.html.ep', '.html.ep')).toBe('Outer')
+  })
+
+  test('works for single-segment extensions too', () => {
+    expect(templateBaseName('dir/Counter.tmpl', '.tmpl')).toBe('Counter')
+  })
+
+  test('returns the bare filename when the extension does not match', () => {
+    expect(templateBaseName('dir/Counter.txt', '.html.ep')).toBe('Counter.txt')
+  })
+
+  test('handles paths with no directory component', () => {
+    expect(templateBaseName('Counter.html.ep', '.html.ep')).toBe('Counter')
+  })
+})

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -59,12 +59,24 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
       if (childErrors.length > 0) {
         throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
       }
-      const childTemplate = childResult.files.find(f => f.type === 'markedTemplate')
-      if (!childTemplate) throw new Error(`No marked template for ${filename}`)
-      const childIrFile = childResult.files.find(f => f.type === 'ir')
-      if (!childIrFile) throw new Error(`No IR output for ${filename}`)
-      const childIR = JSON.parse(childIrFile.content) as ComponentIR
-      childTemplates.set(childIR.metadata.componentName, { template: childTemplate.content, ir: childIR })
+      const childTemplateFiles = childResult.files.filter(f => f.type === 'markedTemplate')
+      if (childTemplateFiles.length === 0) throw new Error(`No marked template for ${filename}`)
+      const childIrFiles = childResult.files.filter(f => f.type === 'ir')
+      if (childIrFiles.length === 0) throw new Error(`No IR output for ${filename}`)
+      const childIrs = childIrFiles.map(f => JSON.parse(f.content) as ComponentIR)
+      if (childTemplateFiles.length === 1) {
+        // Single-component child source: only one template + one IR.
+        childTemplates.set(childIrs[0].metadata.componentName, { template: childTemplateFiles[0].content, ir: childIrs[0] })
+      } else {
+        // Multi-component child source: pair template ↔ IR by basename
+        // (Mojo's templatesPerComponent names files <ComponentName>.html.ep).
+        const childIrsByName = new Map(childIrs.map(i => [i.metadata.componentName, i]))
+        for (const tf of childTemplateFiles) {
+          const baseName = tf.path.substring(tf.path.lastIndexOf('/') + 1).replace(/\.[^.]+$/, '')
+          const matchedIR = childIrsByName.get(baseName) ?? childIrs[0]
+          childTemplates.set(matchedIR.metadata.componentName, { template: tf.content, ir: matchedIR })
+        }
+      }
     }
   }
 
@@ -76,12 +88,48 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
     throw new Error(`Compilation errors:\n${errors.map(e => e.message).join('\n')}`)
   }
 
-  const templateFile = result.files.find(f => f.type === 'markedTemplate')
-  if (!templateFile) throw new Error('No marked template in compile output')
+  // Collect every IR + template emitted from the parent source. Single-
+  // component files yield one `markedTemplate` named after the source
+  // file (e.g. `component.html.ep`); multi-component files with
+  // `templatesPerComponent` yield one named after each component (e.g.
+  // `Counter.html.ep`). Multi-component sources also emit one IR per
+  // component (#1297) — pick the entry-point IR (default export wins;
+  // else first inline-exported; else first) and route sibling
+  // components through `childTemplates` so cross-component references
+  // resolve at render time.
+  const templateFiles = result.files.filter(f => f.type === 'markedTemplate')
+  if (templateFiles.length === 0) throw new Error('No marked template in compile output')
 
-  const irFile = result.files.find(f => f.type === 'ir')
-  if (!irFile) throw new Error('No IR output (set outputIR: true)')
-  const ir = JSON.parse(irFile.content) as ComponentIR
+  const irFiles = result.files.filter(f => f.type === 'ir')
+  if (irFiles.length === 0) throw new Error('No IR output (set outputIR: true)')
+  const irs = irFiles.map(f => JSON.parse(f.content) as ComponentIR)
+  const ir =
+    irs.find(i => i.metadata.hasDefaultExport) ??
+    irs.find(i => i.metadata.isExported) ??
+    irs[0]
+
+  let templateFile: { content: string } | undefined
+  if (templateFiles.length === 1) {
+    // Single-component source: the one template file is the entry-point
+    // template regardless of its basename (which comes from the source
+    // filename, not the component name).
+    templateFile = templateFiles[0]
+  } else {
+    // Multi-component source: templates are named by component
+    // (templatesPerComponent). Match each template file to its IR by
+    // basename so we can split the entry-point from siblings.
+    const irsByName = new Map(irs.map(i => [i.metadata.componentName, i]))
+    for (const tf of templateFiles) {
+      const baseName = tf.path.substring(tf.path.lastIndexOf('/') + 1).replace(/\.[^.]+$/, '')
+      const matchedIR = irsByName.get(baseName)
+      if (matchedIR === ir) {
+        templateFile = tf
+      } else if (matchedIR) {
+        childTemplates.set(matchedIR.metadata.componentName, { template: tf.content, ir: matchedIR })
+      }
+    }
+  }
+  if (!templateFile) throw new Error('No marked template in compile output')
 
   const componentName = ir.metadata.componentName
 

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -20,6 +20,29 @@ export class PerlNotAvailableError extends Error {
   }
 }
 
+/**
+ * Recover the bare component name from a compiler-emitted template
+ * file path. `templatesPerComponent` adapters write each component to
+ * `<dir>/<ComponentName><adapter.extension>` (Mojo: `.html.ep`), and
+ * downstream pairing logic needs the raw component name back so it can
+ * look up the matching IR in `irsByName`.
+ *
+ * Stripping the *full* adapter extension matters because Mojo's
+ * extension is multi-segment (`.html.ep`). A naive `\.[^.]+$/` strips
+ * only the last segment, leaves `<ComponentName>.html`, misses the
+ * IR map, and silently pairs every sibling template to the
+ * entry-point IR — exactly the silent-gap class issue #1297 was
+ * filed to surface.
+ *
+ * Exported for testing.
+ */
+export function templateBaseName(path: string, extension: string): string {
+  const filename = path.substring(path.lastIndexOf('/') + 1)
+  return filename.endsWith(extension)
+    ? filename.slice(0, -extension.length)
+    : filename
+}
+
 let _perlAvailable: boolean | null = null
 async function isPerlAvailable(): Promise<boolean> {
   if (_perlAvailable !== null) return _perlAvailable
@@ -68,11 +91,16 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
         // Single-component child source: only one template + one IR.
         childTemplates.set(childIrs[0].metadata.componentName, { template: childTemplateFiles[0].content, ir: childIrs[0] })
       } else {
-        // Multi-component child source: pair template ↔ IR by basename
-        // (Mojo's templatesPerComponent names files <ComponentName>.html.ep).
+        // Multi-component child source: pair template ↔ IR by basename.
+        // The Mojo adapter's `templatesPerComponent` emits files named
+        // `<ComponentName><adapter.extension>` (e.g. `Counter.html.ep`),
+        // so we strip the *full* `.html.ep` — not just the last dot
+        // segment — to recover the componentName. A naive `\.[^.]+$/`
+        // would leave `Counter.html`, miss the IR map, and silently
+        // pair every sibling to the entry-point IR.
         const childIrsByName = new Map(childIrs.map(i => [i.metadata.componentName, i]))
         for (const tf of childTemplateFiles) {
-          const baseName = tf.path.substring(tf.path.lastIndexOf('/') + 1).replace(/\.[^.]+$/, '')
+          const baseName = templateBaseName(tf.path, adapter.extension)
           const matchedIR = childIrsByName.get(baseName) ?? childIrs[0]
           childTemplates.set(matchedIR.metadata.componentName, { template: tf.content, ir: matchedIR })
         }
@@ -117,10 +145,12 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
   } else {
     // Multi-component source: templates are named by component
     // (templatesPerComponent). Match each template file to its IR by
-    // basename so we can split the entry-point from siblings.
+    // basename so we can split the entry-point from siblings. See
+    // `templateBaseName` for why the full `adapter.extension` is
+    // stripped rather than the last dot segment alone.
     const irsByName = new Map(irs.map(i => [i.metadata.componentName, i]))
     for (const tf of templateFiles) {
-      const baseName = tf.path.substring(tf.path.lastIndexOf('/') + 1).replace(/\.[^.]+$/, '')
+      const baseName = templateBaseName(tf.path, adapter.extension)
       const matchedIR = irsByName.get(baseName)
       if (matchedIR === ir) {
         templateFile = tf

--- a/packages/jsx/src/__tests__/ir-multi-component-emission.test.ts
+++ b/packages/jsx/src/__tests__/ir-multi-component-emission.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression for #1297: `outputIR: true` must emit an IR file for every
+ * component in a multi-component source — `compileMultipleComponents`
+ * previously skipped IR emission entirely, so any source with two or
+ * more components (including `'use client'` files with a helper) silently
+ * returned `markedTemplate` + `clientJs` + `types` but no `ir` file even
+ * when the caller explicitly opted in.
+ *
+ * The contract this pins: "if the user asks for IR, they get IR" — one
+ * `*.ir.json` `FileOutput` per component, regardless of `isClient` or
+ * the selected adapter.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('outputIR contract (#1297)', () => {
+  test("multi-component 'use client' source emits one IR file per component", () => {
+    const source = `
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+
+const ThemeContext = createContext('light')
+
+function ThemeLabel() {
+  const theme = useContext(ThemeContext)
+  return <span>{theme}</span>
+}
+
+export function ThemeRoot() {
+  return (
+    <ThemeContext.Provider value="dark">
+      <ThemeLabel />
+    </ThemeContext.Provider>
+  )
+}
+`
+    const result = compileJSX(source, 'theme.tsx', { adapter, outputIR: true })
+    const errors = result.errors.filter(e => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const irFiles = result.files.filter(f => f.type === 'ir')
+    const names = irFiles
+      .map(f => (JSON.parse(f.content) as { metadata: { componentName: string } }).metadata.componentName)
+      .sort()
+    expect(names).toEqual(['ThemeLabel', 'ThemeRoot'])
+    // Paths must be unique so callers can address each IR individually.
+    const paths = irFiles.map(f => f.path)
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  test('single-component source emits exactly one IR file at the canonical path', () => {
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(n => n + 1)}>{count()}</button>
+}
+`
+    const result = compileJSX(source, 'counter.tsx', { adapter, outputIR: true })
+    const errors = result.errors.filter(e => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const irFiles = result.files.filter(f => f.type === 'ir')
+    expect(irFiles).toHaveLength(1)
+    expect(irFiles[0].path).toBe('counter.ir.json')
+  })
+
+  test("multi-component non-'use client' source still emits one IR per component", () => {
+    const source = `
+function Inner() {
+  return <span>inner</span>
+}
+
+export function Outer() {
+  return <div><Inner /></div>
+}
+`
+    const result = compileJSX(source, 'static.tsx', { adapter, outputIR: true })
+    const errors = result.errors.filter(e => e.severity === 'error')
+    expect(errors).toEqual([])
+
+    const irFiles = result.files.filter(f => f.type === 'ir')
+    const names = irFiles
+      .map(f => (JSON.parse(f.content) as { metadata: { componentName: string } }).metadata.componentName)
+      .sort()
+    expect(names).toEqual(['Inner', 'Outer'])
+  })
+})

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -76,6 +76,24 @@ function compileMultipleComponents(
     entries.push({ componentIR, ctx })
   }
 
+  // Emit IR files per component when requested. The contract is "if the
+  // user asks for IR, they get IR" regardless of `isClientComponent` or
+  // adapter (#1297). Single-component files emit `<base>.ir.json`; multi-
+  // component files emit one file per component as
+  // `<base>.<ComponentName>.ir.json` to keep paths unique. Test harnesses
+  // (go-template, Mojo) pick the IR for the primary component by matching
+  // `metadata.hasDefaultExport` / `metadata.isExported`.
+  if (options.outputIR) {
+    for (const { componentIR } of entries) {
+      const componentName = componentIR.metadata.componentName
+      files.push({
+        path: filePath.replace(/\.tsx?$/, `.${componentName}.ir.json`),
+        content: JSON.stringify(componentIR, null, 2),
+        type: 'ir',
+      })
+    }
+  }
+
   // --- Pass 2: adapter.generate + generateClientJs ---
   const allOutputs: { componentName: string; rawTemplate: string; imports: string; types: string; moduleExports: string; component: string; clientJs?: string; adapterTypes?: string }[] = []
 


### PR DESCRIPTION
## Summary

- `compileMultipleComponents` now emits one `*.<ComponentName>.ir.json` file per component when `outputIR: true` is passed. The previous code path skipped IR emission entirely for any source with two or more components — including every `'use client'` file that defines a helper alongside the exported component — silently returning `markedTemplate` + `clientJs` + `types` and no `ir`.
- Updated the go-template and Mojo test renderers to handle the multi-IR result: pick the entry-point IR by `hasDefaultExport` → `isExported` → first, and concatenate type definitions for sibling components.
- For the Mojo harness specifically, replaced the basename-derivation regex with a `templateBaseName` helper that strips the full multi-segment `adapter.extension` (`.html.ep`). The previous `/\.[^.]+$/` regex left `Counter.html`, silently pairing every sibling template to the entry-point IR via the `?? irs[0]` fallback. No existing fixture exercised this gap (the only multi-component Mojo case is `skipJsx`-ed for a separate SSR-provider issue), so the bug was invisible.
- Side-fix in `GoTemplateAdapter.collectStaticChildInstancesRecursive`: walk `provider` and `async` node children so a static `<Child/>` nested under a context provider still gets a slot field generated on the parent's props struct.

The contract this restores: "if the user asks for IR, they get IR" — regardless of `isClientComponent` and regardless of adapter.

## Scope clarification — `context-provider` JSX fixture

The issue asked for the previously-skipped `context-provider` fixture to pass on both adapters once IR emission is fixed. The IR-emission gate is now correct, but the fixture **still cannot pass** on go-template / Mojo because those adapters have no SSR-side context-propagation mechanism:

- The Hono adapter rewrites `<Ctx.Provider value="dark">…</Ctx.Provider>` into a `provideContextSSR(Ctx, "dark", …)` call that the Hono SSR JS runtime resolves; `useContext(Ctx)` then returns `"dark"`.
- Go template and Mojo emit `{{template "Child" .ChildSlot0}}` / `<%== bf->render_child('child') %>` against templates that reference `.Theme` / `<%= $theme %>` — but neither adapter threads the provider value into the child template's data, so the field is unresolved at template-eval time.

Implementing SSR context resolution on the two template-based adapters is an adapter-feature task, not an IR-emission gap. The fixture stays in `skipJsx` with a rewritten comment that points at the actual remaining gap on each adapter (please open a follow-up issue if SSR provider coverage is wanted on go-template / Mojo).

## Test plan

- [x] `bun test --cwd packages/jsx` — includes the new `ir-multi-component-emission.test.ts` regression
- [x] `bun test --cwd packages/adapter-mojolicious` — includes the new `template-base-name.test.ts` unit test
- [x] `bun test --cwd packages/adapter-go-template` / `packages/adapter-tests` / `packages/adapter-hono` — no new regressions
- [x] Rebased onto current `main` (includes #1301, #1302, #1304)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1297