### PR TITLE
fix(compiler): strip module-export lines from per-component template output

### DIFF
--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -262,6 +262,31 @@ export function Page() {
     expect(result.template).not.toContain('begin %>')
     expect(result.template).not.toContain('children =>')
   })
+
+  test('does not leak module-level export statements into the .html.ep template', () => {
+    // Regression: trailing `export { Name }` / `export type { ... }` lines
+    // were concatenated into the single-component template content, so
+    // Mojolicious rendered them as visible HTML text (the create-barefootjs
+    // scaffold's registry Button has this shape).
+    const result = compileJSX(
+      `
+type ButtonVariant = 'default' | 'secondary'
+
+function Button(props: { variant?: ButtonVariant, children?: unknown }) {
+  return <button className={props.variant ?? 'default'}>{props.children}</button>
+}
+
+export { Button }
+export type { ButtonVariant }
+`.trimStart(),
+      'button.tsx',
+      { adapter: new MojoAdapter() },
+    )
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    expect(template).toBeDefined()
+    expect(template!.content).not.toContain('export {')
+    expect(template!.content).not.toContain('export type')
+  })
 })
 
 describe('MojoAdapter - templatePrimitives (#1189)', () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -316,21 +316,23 @@ function printAppNextSteps(projectDir: string, adapter: AdapterTemplate): void {
     console.log(`  ${deployCmd}${dim(`   # deploy to ${adapter.deploy.target}`)}`)
   }
 
-  // A playful aside — give first-time users a concrete sense of what
-  // "AI + barefoot CLI" looks like in practice. The CLI surfaces
-  // (`barefoot ui`, `barefoot inspect`, registry add) are what make
-  // these prompts work without the AI having to read source, so the
-  // footnote names them explicitly. Visible in TTY contexts only:
-  // CI / piped output skips the section to keep logs grep-friendly.
+  // A playful aside — hand the first-time user one concrete prompt
+  // that exercises the full barefoot workflow: discover a registry
+  // component, add it, integrate it into the starter Counter, then
+  // assert the result with an IR test. The prompt assumes the AI
+  // editor already has the `barefootjs` skill loaded (Claude Code's
+  // bundled skill wraps `barefoot ui` / `barefoot inspect` /
+  // `barefoot add`), so we don't spell out the CLI invocations.
+  // Visible in TTY contexts only: CI / piped output skips the
+  // section to keep logs grep-friendly.
   if (process.stdout.isTTY) {
     console.log('')
     console.log(`${heading('Try it with AI:')}`)
-    console.log(`  ${dim('Drop any of these into Claude Code / Cursor / your AI editor —')}`)
-    console.log(`  ${dim('it uses the barefoot CLI to learn your components without reading source.')}`)
+    console.log(`  ${dim('Drop this into Claude Code (with the `barefootjs` skill loaded):')}`)
     console.log('')
-    console.log(`    "Make the Reset button look dangerous (destructive variant)"`)
-    console.log(`    "Pull a Card from the registry and wrap the Counter inside it"`)
-    console.log(`    "Add a step input so I can change the increment amount"`)
+    console.log(`    "Add a Milestone Badge to the Counter — show it when count hits`)
+    console.log(`     a non-zero multiple of 5. Use signal-driven conditional rendering,`)
+    console.log(`     plus an IR test asserting the Badge appears as a conditional child."`)
   }
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -315,6 +315,23 @@ function printAppNextSteps(projectDir: string, adapter: AdapterTemplate): void {
     console.log(`${heading('Deploy:')}`)
     console.log(`  ${deployCmd}${dim(`   # deploy to ${adapter.deploy.target}`)}`)
   }
+
+  // A playful aside — give first-time users a concrete sense of what
+  // "AI + barefoot CLI" looks like in practice. The CLI surfaces
+  // (`barefoot ui`, `barefoot inspect`, registry add) are what make
+  // these prompts work without the AI having to read source, so the
+  // footnote names them explicitly. Visible in TTY contexts only:
+  // CI / piped output skips the section to keep logs grep-friendly.
+  if (process.stdout.isTTY) {
+    console.log('')
+    console.log(`${heading('Try it with AI:')}`)
+    console.log(`  ${dim('Drop any of these into Claude Code / Cursor / your AI editor —')}`)
+    console.log(`  ${dim('it uses the barefoot CLI to learn your components without reading source.')}`)
+    console.log('')
+    console.log(`    "Make the Reset button look dangerous (destructive variant)"`)
+    console.log(`    "Pull a Card from the registry and wrap the Counter inside it"`)
+    console.log(`    "Add a step input so I can change the increment amount"`)
+  }
 }
 
 // ANSI helpers for the next-steps block. All three apply only in a

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -315,25 +315,6 @@ function printAppNextSteps(projectDir: string, adapter: AdapterTemplate): void {
     console.log(`${heading('Deploy:')}`)
     console.log(`  ${deployCmd}${dim(`   # deploy to ${adapter.deploy.target}`)}`)
   }
-
-  // A playful aside — hand the first-time user one concrete prompt
-  // that exercises the full barefoot workflow: discover a registry
-  // component, add it, integrate it into the starter Counter, then
-  // assert the result with an IR test. The prompt assumes the AI
-  // editor already has the `barefootjs` skill loaded (Claude Code's
-  // bundled skill wraps `barefoot ui` / `barefoot inspect` /
-  // `barefoot add`), so we don't spell out the CLI invocations.
-  // Visible in TTY contexts only: CI / piped output skips the
-  // section to keep logs grep-friendly.
-  if (process.stdout.isTTY) {
-    console.log('')
-    console.log(`${heading('Try it with AI:')}`)
-    console.log(`  ${dim('Drop this into Claude Code (with the `barefootjs` skill loaded):')}`)
-    console.log('')
-    console.log(`    "Add a Milestone Badge to the Counter — show it when count hits`)
-    console.log(`     a non-zero multiple of 5. Use signal-driven conditional rendering,`)
-    console.log(`     plus an IR test asserting the Badge appears as a conditional child."`)
-  }
 }
 
 // ANSI helpers for the next-steps block. All three apply only in a

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -485,11 +485,21 @@ export function compileJSX(
     scriptBaseName: options.scriptBaseName,
     siblingTemplatesRegistered: options.siblingTemplatesRegistered,
   })
-  const moduleExports = generateModuleExports(componentIR)
 
+  // `templatesPerComponent` adapters (Mojolicious) emit non-JS template files
+  // (`.html.ep`), so imports / types / module exports / default-export
+  // sections don't belong in the output — the template engine renders them
+  // as plain text. Mirror `compileMultipleComponents`'s `templatesPerComponent`
+  // branch and use the raw template directly.
   const s = adapterOutput.sections
-  const content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, s.component]
-    .filter(Boolean).join('\n\n') + (s.defaultExport || '')
+  let content: string
+  if (adapter.templatesPerComponent) {
+    content = adapterOutput.template
+  } else {
+    const moduleExports = generateModuleExports(componentIR)
+    content = [s.imports, s.moduleConstants ?? '', s.types, moduleExports, s.component]
+      .filter(Boolean).join('\n\n') + (s.defaultExport || '')
+  }
 
   files.push({
     path: filePath.replace(/\.tsx?$/, adapter.extension),


### PR DESCRIPTION
## Summary

- The `compileJSX` single-component flow concatenated `imports / moduleConstants / types / moduleExports / component` into the emitted template regardless of `adapter.templatesPerComponent`. For Mojolicious (`.html.ep`), this leaked trailing `export { ... }` / `export type { ... }` declarations into the rendered HTML.
- The multi-component flow (`compileMultipleComponents`) already writes `output.rawTemplate` directly for `templatesPerComponent` adapters; mirror that branch on the single-component path so JS-only sections never reach the template engine.
- Reproduced via `create-barefootjs` with the Mojolicious adapter: the registry `Button` component (single export + trailing `export type { ButtonVariant, ButtonSize, ButtonProps }`) rendered `export type { ButtonVariant, ButtonSize, ButtonProps }` as visible text around each button.

## Test plan

- [x] `bun test packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts` — added regression test asserting the emitted `.html.ep` for a single component with trailing `export { Name }` / `export type { Foo }` carries neither `export {` nor `export type`.
- [x] `bun test packages/jsx/src/__tests__/compiler-runtime-contract.test.ts packages/jsx/src/__tests__/ir-multi-component-emission.test.ts` — no regressions in the shared compiler flows.
- [x] `bun test packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts` — confirms the non-`templatesPerComponent` branch is unchanged.