### PR TITLE
test(#1244): rewrite style-3-signals contract as a structural emit-shape check

### DIFF
--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -46,18 +46,55 @@ function expectNoFatalErrors(c: Compiled): void {
   }
 }
 
+/**
+ * Return the body (between the outer `{` and `}`) of the Nth
+ * `createEffect(() => { ... })` call in `source`. Uses brace counting
+ * so a body that itself contains `{}` is captured correctly. Returns
+ * `null` if the Nth occurrence does not exist.
+ *
+ * Prefer this over `source.match(/createEffect/g)` length: regex token
+ * counts also catch the import statement and any structurally-unrelated
+ * tokens, which is how the original `style-3-signals` assertion
+ * silently over-counted.
+ */
+function getCreateEffectBody(source: string, index = 0): string | null {
+  const marker = 'createEffect(() => {'
+  let pos = -1
+  for (let i = 0; i <= index; i++) {
+    pos = source.indexOf(marker, pos + 1)
+    if (pos === -1) return null
+  }
+  let depth = 1
+  let cursor = pos + marker.length
+  while (depth > 0 && cursor < source.length) {
+    const c = source[cursor]
+    if (c === '{') depth++
+    else if (c === '}') depth--
+    cursor++
+  }
+  return depth === 0 ? source.slice(pos + marker.length, cursor - 1) : null
+}
+
 // ---------------------------------------------------------------------------
 // Reactive primitive × binding site
 // ---------------------------------------------------------------------------
 
 describe('style={{}} object — multiple signal members', () => {
-  // SURFACED LIMITATION (#1244 sub-issue): a `style={{ a: s1(), b: s2(), c: s3() }}`
-  // object with three independent signals currently emits only two
-  // reactive update paths instead of one per signal-bearing member —
-  // either two members share an effect or one is dropped. The body
-  // below asserts the intended behaviour (>= 3 reactive paths). Drop
-  // `.todo` once fixed.
-  test.todo('3 members each read a different signal — one reactive update per member', () => {
+  // Contract: a `style={{ a: s1(), b: s2(), c: s3() }}` object compiles
+  // to one reactive binding per attribute (not per member). The single
+  // `createEffect` block's body invokes every signal getter, so the
+  // runtime tracker subscribes to each — updating any one of the three
+  // signals re-runs the effect and re-applies the full `style` string.
+  //
+  // The original PR #1306 entry asserted `match(/createEffect|effect\(/g).length >= 3`,
+  // expecting one effect per signal-bearing member. That regex also
+  // matched the `createEffect` token inside the import statement, and
+  // the assertion was based on a per-member-effect model that the
+  // compiler does not (and need not) implement: per-attribute effects
+  // are equivalently correct because the runtime tracks every signal
+  // read during the effect's body. Per-member splitting would be an
+  // optimisation, not a correctness fix.
+  test('all 3 signals participate in one reactive style update path', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -70,8 +107,16 @@ describe('style={{}} object — multiple signal members', () => {
     `
     const c = compile(src)
     expectNoFatalErrors(c)
-    const effectCount = (c.clientJs.match(/createEffect|effect\(/g) || []).length
-    expect(effectCount).toBeGreaterThanOrEqual(3)
+
+    const effectBody = getCreateEffectBody(c.clientJs)
+    expect(effectBody).not.toBeNull()
+    expect(effectBody!).toContain("setAttribute('style'")
+    expect(effectBody!).toContain('bg()')
+    expect(effectBody!).toContain('fg()')
+    expect(effectBody!).toContain('pad()')
+
+    // No second `createEffect` block: one binding per attribute.
+    expect(getCreateEffectBody(c.clientJs, 1)).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes the first item in the #1306 surfaced-limitations list (`style={{ a: s1(), b: s2(), c: s3() }}` — \"only 2 of 3 reactive update paths emit\").

The catalog entry asserted `match(/createEffect|effect\(/g).length >= 3`. Two things hid behind that:

1. The regex also matched the `createEffect` token in the import statement, so a correct one-effect emit always read as "two", not the intuitive "one".
2. The "one effect per signal-bearing member" model is not the compiler's contract. A `style={{}}` attribute compiles to a single reactive binding whose body reads every signal in the object literal — the runtime tracker subscribes to each, so updating any one signal re-runs the effect and re-applies the whole `style` string. Per-member splitting would be an optimisation, not a correctness fix.

So the surfaced "limitation" was a misperception of correct behaviour. The root cause was the assertion shape, not the compiler emit.

## What changed

Replace the regex count with an **emit-shape contract** in `packages/jsx/src/__tests__/compiler-stress-1244.test.ts`:

- `getCreateEffectBody(source, index)` brace-counts the body of the Nth `createEffect(() => { ... })` block.
- The test now asserts:
  - The first effect body invokes `bg()`, `fg()`, `pad()` and writes `setAttribute('style', ...)`.
  - There is no second `createEffect` block (one binding per attribute).

This makes the catalog test resistant to the same false-positive class — regex token counts that catch unrelated occurrences (imports, type names, comments) — and turns the entry into executable documentation of the actual contract.

`test.todo` is dropped; the test runs.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/compiler-stress-1244.test.ts` — 58 pass / 5 todo / 0 fail (was 57 / 6 / 0 on `main`).
- [x] `bun test packages/adapter-tests packages/adapter-go-template packages/adapter-mojolicious` — 600 pass / 21 skip / 0 fail.
- [x] `bun test packages/jsx packages/client` — 1492 pass / 5 todo / 4 fail; the 4 failures are the pre-existing `primitive-resolver-alias` failures called out on `main` in PR #1306's description (Layer 1 entries #5 and #6 from the surfaced list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)