### PR TITLE
fix(#1244): lower object/array rest patterns in .map() callbacks to inline accessors

### DIFF
--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -439,13 +439,7 @@ describe('4+ same-name child components as siblings in one loop body', () => {
 })
 
 describe('destructured loop param with rest spread back onto the root', () => {
-  // SURFACED LIMITATION (#1244 sub-issue): BF025 currently rejects rest
-  // elements in a `.map()` callback destructure
-  // (`({ id, title, ...rest }) => …`). The intended behaviour is to
-  // lift `rest` into a per-item accessor that remaining-key reflection
-  // can spread back onto the root. The body asserts a clean compile.
-  // Drop `.todo` once fixed.
-  test.todo('{ id, title, ...rest } and {...rest} on the root element', () => {
+  test('{ id, title, ...rest } and {...rest} on the root element', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -466,11 +460,7 @@ describe('destructured loop param with rest spread back onto the root', () => {
 })
 
 describe('nested destructuring in loop param', () => {
-  // SURFACED LIMITATION (#1244 sub-issue): BF025 fires on the nested
-  // `[first, ...rest]` array-pattern with rest. Intended behaviour is
-  // per-position rewrite for the array members; the outer object
-  // destructure already works. Drop `.todo` once fixed.
-  test.todo('{ rows: [first, ...rest] } at the loop param', () => {
+  test('{ rows: [first, ...rest] } at the loop param', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/destructured-map-params.test.ts
+++ b/packages/jsx/src/__tests__/destructured-map-params.test.ts
@@ -173,29 +173,43 @@ describe('destructured .map() param rewriting (#951)', () => {
     expect(js).toContain('__bfItem().label')
   })
 
-  test('rest element in destructure raises BF025', () => {
+  test('object rest in destructure lowers to a residual-object accessor', () => {
+    // Pre-#1244 fix this combination raised BF025 and bailed out of
+    // destructure rewriting; rest props are now lifted into a per-item
+    // accessor that subtracts the explicitly destructured sibling keys
+    // (`a` here), so a spread back onto the root forwards everything else.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
 
       export function RestUser() {
-        const [items, setItems] = createSignal<{ a: number; b: number }[]>([])
+        const [items, setItems] = createSignal<{ a: number; b: number; c: number }[]>([])
         return (
           <ul onClick={() => setItems(i => i)}>
             {items().map(({ a, ...rest }) => (
-              <li key={a}>{a}</li>
+              <li key={a} {...rest}>{a}</li>
             ))}
           </ul>
         )
       }
     `
     const result = compile(source, 'RestUser.tsx')
-    const errs = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST)
-    expect(errs.length).toBe(1)
-    expect(errs[0].severity).toBe('error')
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')?.content ?? ''
+
+    // `a` keeps the existing fixed-binding rewrite, and `rest` is rebuilt
+    // at each read site from `__bfItem()` minus the destructured keys.
+    expect(js).toContain('__bfItem().a')
+    expect(js).toContain('(({ a: __r0, ...__rest }) => __rest)(__bfItem())')
+    // The body-entry `const { a, ...rest } = __bfItem();` unwrap from the
+    // legacy #950 path is intentionally absent — accessors are inlined.
+    expect(js).not.toContain('const { a, ...rest } = __bfItem();')
   })
 
-  test('array rest element in destructure also raises BF025', () => {
+  test('array rest in destructure lowers to `.slice(n)`', () => {
+    // Array rest in a tuple destructure used to also raise BF025. It now
+    // lowers each `tail` reference into `__bfItem().slice(n)` using the
+    // native array method, no runtime helper required.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -205,15 +219,72 @@ describe('destructured .map() param rewriting (#951)', () => {
         return (
           <ul onClick={() => setItems(i => i)}>
             {items().map(([first, ...tail]) => (
-              <li key={first}>{first}</li>
+              <li key={first}>{first} (+{tail.length})</li>
             ))}
           </ul>
         )
       }
     `
     const result = compile(source, 'RestTuple.tsx')
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')?.content ?? ''
+
+    expect(js).toContain('__bfItem()[0]')
+    expect(js).toContain('__bfItem().slice(1)')
+    expect(js).not.toContain('const [first, ...tail] = __bfItem();')
+  })
+
+  test('nested array-rest inside an object destructure also lowers', () => {
+    // `{ rows: [first, ...tail] }` is the surfaced shape from PR #1306. The
+    // outer object destructure walks into `.rows`; the inner array
+    // destructure rewrites `first` to `__bfItem().rows[0]` and `tail` to
+    // `__bfItem().rows.slice(1)`.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Group = { id: string; rows: { id: string; label: string }[] }
+      export function Demo() {
+        const [groups, setGroups] = createSignal<Group[]>([])
+        return (
+          <ul onClick={() => setGroups(g => g)}>
+            {groups().map(({ id, rows: [first, ...rest] }) => (
+              <li key={id}>{first ? first.label : ''} (+{rest.length})</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'Demo.tsx')
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')?.content ?? ''
+
+    expect(js).toContain('__bfItem().rows[0]')
+    expect(js).toContain('__bfItem().rows[0].label')
+    expect(js).toContain('__bfItem().rows.slice(1)')
+  })
+
+  test('computed property key in destructure still raises BF025', () => {
+    // Computed keys have no static path to lower to, so the BF025 escape
+    // hatch is preserved.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const KEY = 'a' as const
+      export function Computed() {
+        const [items, setItems] = createSignal<Record<string, number>[]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ [KEY]: v }) => <li key={v}>{v}</li>)}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'Computed.tsx')
     const errs = result.errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST)
     expect(errs.length).toBe(1)
+    expect(errs[0].severity).toBe('error')
   })
 
   test('event delegation lands on a plain local before destructuring (TDZ-safe)', () => {

--- a/packages/jsx/src/__tests__/destructured-map-params.test.ts
+++ b/packages/jsx/src/__tests__/destructured-map-params.test.ts
@@ -200,7 +200,7 @@ describe('destructured .map() param rewriting (#951)', () => {
     // `a` keeps the existing fixed-binding rewrite, and `rest` is rebuilt
     // at each read site from `__bfItem()` minus the destructured keys.
     expect(js).toContain('__bfItem().a')
-    expect(js).toContain('(({ a: __r0, ...__rest }) => __rest)(__bfItem())')
+    expect(js).toContain('(({ a: __bfR0, ...__bfRest }) => __bfRest)(__bfItem())')
     // The body-entry `const { a, ...rest } = __bfItem();` unwrap from the
     // legacy #950 path is intentionally absent — accessors are inlined.
     expect(js).not.toContain('const { a, ...rest } = __bfItem();')
@@ -262,6 +262,63 @@ describe('destructured .map() param rewriting (#951)', () => {
     expect(js).toContain('__bfItem().rows[0]')
     expect(js).toContain('__bfItem().rows[0].label')
     expect(js).toContain('__bfItem().rows.slice(1)')
+  })
+
+  test('array rest with leading holes uses the element-position index for slice', () => {
+    // `[, , ...tail]` has two omitted slots before the rest. The `from`
+    // index recorded in the IR must reflect the rest's position in the
+    // element list (2 here), not the count of named bindings (0). Lowering
+    // to `__bfItem().slice(2)` is what matches the native destructure's
+    // observable shape — `tail.length === item.length - 2`.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function HoleRest() {
+        const [items, setItems] = createSignal<string[][]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(([, , ...tail], idx) => (
+              <li key={idx}>{tail.length}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'HoleRest.tsx')
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')?.content ?? ''
+
+    expect(js).toContain('__bfItem().slice(2)')
+  })
+
+  test('object rest with a non-identifier sibling key quotes it in the IIFE pattern', () => {
+    // `'data-priority'` is not a valid IdentifierName, so the destructure
+    // pattern must quote it. Classification is precomputed at IR-build
+    // time via `RestExcludeKey.isIdent`, not re-derived in the emitter.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; 'data-priority': string; flag: string }
+      export function HyphenKey() {
+        const [items, setItems] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ id, 'data-priority': prio, ...rest }) => (
+              <li key={id} {...rest}>{prio}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compile(source, 'HyphenKey.tsx')
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const js = result.files.find(f => f.type === 'clientJs')?.content ?? ''
+
+    // The non-identifier key is rendered as a quoted property name in the
+    // destructure pattern, while the identifier keys stay bare.
+    expect(js).toContain('(({ id: __bfR0, "data-priority": __bfR1, ...__bfRest }) => __bfRest)(__bfItem())')
   })
 
   test('computed property key in destructure still raises BF025', () => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -140,7 +140,12 @@ function renderTemplateAttrPart(
     }
     case 'spread': {
       if (restSpreadNames?.has(v.expr)) return ''
-      return `\${spreadAttrs(${v.expr})}`
+      // `wrap` lowers loop-param references — including destructured rest
+      // bindings (`...rest` lifted via `paramBindings`) — into their item
+      // accessor. Skipping it here meant `{...rest}` inside a `.map()`
+      // emitted `spreadAttrs(rest)` with `rest` undefined at the render-item
+      // scope (#1244).
+      return `\${spreadAttrs(${wrap(v.expr)})}`
     }
     case 'boolean-shorthand':
     case 'jsx-children':

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -578,10 +578,12 @@ function scanForIdentifiers(expr: string, predicate: (token: string) => boolean)
  * - Fixed bindings → `${base}${path}` (e.g. `__bfItem().foo`).
  * - Object rest → an IIFE that destructures the parent and returns the
  *   residual, so `({ id, title, ...rest })` lowers each reference to `rest`
- *   into `(({ id: __r0, title: __r1, ...__rest }) => __rest)(__bfItem())`.
- *   The synthesized `__r${i}` locals are unused — keys that are not valid
- *   identifiers are quoted in source-shape so the emitted pattern stays
- *   syntactically valid.
+ *   into `(({ id: __bfR0, title: __bfR1, ...__bfRest }) => __bfRest)(__bfItem())`.
+ *   The synthesized `__bfR${i}` / `__bfRest` locals live in the
+ *   barefoot-reserved `__bf*` namespace so they cannot collide with user
+ *   bindings. Identifier-vs-string-literal classification of each excluded
+ *   key is precomputed at IR-build time (`RestExcludeKey.isIdent`), so this
+ *   emitter is pure formatting — no identifier regex runs here.
  * - Array rest → `${base}${path}.slice(${from})`, falling through to the
  *   native array method (no runtime helper required).
  */
@@ -589,14 +591,18 @@ function renderLoopBindingAccess(b: LoopParamBinding, base: string): string {
   const parent = `${base}${b.path}`
   if (b.rest?.kind === 'object') {
     if (b.rest.exclude.length === 0) {
-      // No sibling keys to omit — a fresh shallow clone matches user intent.
+      // No sibling keys to omit. A fresh shallow clone — not a direct alias
+      // to `parent` — is what the user-visible `rest` semantics require:
+      // mutations against the residual (e.g. `delete rest.foo`) must not
+      // leak back into the underlying item accessor's value.
       return `({...${parent}})`
     }
-    const parts = b.rest.exclude.map((k, i) => {
-      const isIdent = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k)
-      return isIdent ? `${k}: __r${i}` : `${JSON.stringify(k)}: __r${i}`
+    const parts = b.rest.exclude.map((e, i) => {
+      return e.isIdent
+        ? `${e.key}: __bfR${i}`
+        : `${JSON.stringify(e.key)}: __bfR${i}`
     }).join(', ')
-    return `(({ ${parts}, ...__rest }) => __rest)(${parent})`
+    return `(({ ${parts}, ...__bfRest }) => __bfRest)(${parent})`
   }
   if (b.rest?.kind === 'array') {
     return `${parent}.slice(${b.rest.from})`

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -572,6 +572,39 @@ function scanForIdentifiers(expr: string, predicate: (token: string) => boolean)
 }
 
 /**
+ * Render a single destructured `.map()` binding as the JS expression that
+ * yields its value, given the accessor for the loop item.
+ *
+ * - Fixed bindings → `${base}${path}` (e.g. `__bfItem().foo`).
+ * - Object rest → an IIFE that destructures the parent and returns the
+ *   residual, so `({ id, title, ...rest })` lowers each reference to `rest`
+ *   into `(({ id: __r0, title: __r1, ...__rest }) => __rest)(__bfItem())`.
+ *   The synthesized `__r${i}` locals are unused — keys that are not valid
+ *   identifiers are quoted in source-shape so the emitted pattern stays
+ *   syntactically valid.
+ * - Array rest → `${base}${path}.slice(${from})`, falling through to the
+ *   native array method (no runtime helper required).
+ */
+function renderLoopBindingAccess(b: LoopParamBinding, base: string): string {
+  const parent = `${base}${b.path}`
+  if (b.rest?.kind === 'object') {
+    if (b.rest.exclude.length === 0) {
+      // No sibling keys to omit — a fresh shallow clone matches user intent.
+      return `({...${parent}})`
+    }
+    const parts = b.rest.exclude.map((k, i) => {
+      const isIdent = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k)
+      return isIdent ? `${k}: __r${i}` : `${JSON.stringify(k)}: __r${i}`
+    }).join(', ')
+    return `(({ ${parts}, ...__rest }) => __rest)(${parent})`
+  }
+  if (b.rest?.kind === 'array') {
+    return `${parent}.slice(${b.rest.from})`
+  }
+  return parent
+}
+
+/**
  * Transform loop param references to signal accessor calls in an expression.
  * e.g., "item.text" → "item().text", "item" → "item()"
  * Does not double-wrap: "item().text" stays "item().text"
@@ -591,11 +624,11 @@ export function wrapLoopParamAsAccessor(expr: string, paramName: string, binding
     // Iterating per-binding risks re-matching the replacement text (e.g. a
     // binding named `a` with path `.a` would cascade into `__bfItem().a`
     // then back into `__bfItem().__bfItem().a`).
-    const byName = new Map<string, string>()
-    for (const b of bindings) byName.set(b.name, b.path)
+    const byName = new Map<string, LoopParamBinding>()
+    for (const b of bindings) byName.set(b.name, b)
     const alt = bindings.map(b => escapeRegExp(b.name)).join('|')
     const re = new RegExp(`\\b(${alt})\\b`, 'g')
-    return replaceInExprContexts(expr, re, (_m: string, name: string) => `__bfItem()${byName.get(name)!}`)
+    return replaceInExprContexts(expr, re, (_m: string, name: string) => renderLoopBindingAccess(byName.get(name)!, '__bfItem()'))
   }
   const re = new RegExp(`\\b${escapeRegExp(paramName)}\\b(?!\\s*\\()(?!-)`, 'g')
   return replaceInExprContexts(expr, re, `${paramName}()`)
@@ -616,11 +649,11 @@ export function substituteLoopBindings(
   accessor: string,
 ): string {
   if (!bindings || bindings.length === 0) return expr
-  const byName = new Map<string, string>()
-  for (const b of bindings) byName.set(b.name, b.path)
+  const byName = new Map<string, LoopParamBinding>()
+  for (const b of bindings) byName.set(b.name, b)
   const alt = bindings.map(b => escapeRegExp(b.name)).join('|')
   const re = new RegExp(`\\b(${alt})\\b`, 'g')
-  return replaceInExprContexts(expr, re, (_m: string, name: string) => `${accessor}${byName.get(name)!}`)
+  return replaceInExprContexts(expr, re, (_m: string, name: string) => renderLoopBindingAccess(byName.get(name)!, accessor))
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -23,6 +23,7 @@ import {
   type AttrValue,
   type IRTemplatePart,
   type LoopParamBinding,
+  type RestExcludeKey,
   type SourceLocation,
   type TypeInfo,
   type OriginInfo,
@@ -1770,11 +1771,29 @@ function extractLoopParamBindings(
   const bindings: LoopParamBinding[] = []
   let unsupported = false
 
-  // `.foo` is only valid when `foo` parses as an IdentifierName. Numeric or
-  // reserved-keyed properties fall back to `["foo"]` bracket access so the
-  // emitted JS accessor suffix is always syntactically valid.
+  // Authoritative IdentifierName classification, built on TS's own
+  // `isIdentifierStart` / `isIdentifierPart` primitives so the rule is
+  // Unicode-aware and stays aligned with whatever spelling TS itself
+  // considers a legal identifier. Single source of truth for both the
+  // `.foo` vs `["foo"]` accessor decision (below) AND the residual-object
+  // destructure-pattern quoting consumed downstream by the emitter, which
+  // reads `RestExcludeKey.isIdent` rather than re-running its own
+  // identifier regex (#1244 patterns D and F).
+  const isIdent = (key: string): boolean => {
+    if (key.length === 0) return false
+    for (let i = 0; i < key.length; ) {
+      const cp = key.codePointAt(i)!
+      const ok = i === 0
+        ? ts.isIdentifierStart(cp, ts.ScriptTarget.Latest)
+        : ts.isIdentifierPart(cp, ts.ScriptTarget.Latest)
+      if (!ok) return false
+      i += cp > 0xFFFF ? 2 : 1
+    }
+    return true
+  }
+
   const appendDotAccess = (prefix: string, key: string): string => {
-    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    return isIdent(key)
       ? `${prefix}.${key}`
       : `${prefix}[${JSON.stringify(key)}]`
   }
@@ -1814,7 +1833,7 @@ function extractLoopParamBindings(
       return
     }
     // ObjectBindingPattern
-    const collectedKeys: string[] = []
+    const collectedKeys: RestExcludeKey[] = []
     const elements = p.elements
     for (let i = 0; i < elements.length; i++) {
       if (unsupported) return
@@ -1822,7 +1841,9 @@ function extractLoopParamBindings(
       if (el.dotDotDotToken) {
         // Same shape constraint as array rest: must be last, must be a plain
         // identifier. `exclude` is the list of sibling keys destructured at
-        // this level so the emitter can subtract them at runtime.
+        // this level so the emitter can subtract them at runtime — each entry
+        // already carries its `isIdent` classification so no further regex
+        // runs downstream.
         if (i !== elements.length - 1 || !ts.isIdentifier(el.name)) {
           unsupported = true
           return
@@ -1847,7 +1868,7 @@ function extractLoopParamBindings(
         unsupported = true
         return
       }
-      collectedKeys.push(keyText)
+      collectedKeys.push({ key: keyText, isIdent: isIdent(keyText) })
       const path = appendDotAccess(prefix, keyText)
       if (ts.isIdentifier(el.name)) {
         bindings.push({ name: el.name.text, path })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1753,16 +1753,17 @@ function extractFilterPredicate(
  *
  * Returns:
  * - `null` when the parameter is a plain identifier (no destructuring).
- * - `{ unsupported: true }` when the pattern contains a rest element or a
- *   non-literal computed property key — shapes that can't be expressed as a
- *   single fixed accessor path. Callers surface these as `BF025`.
- * - An array of `{ name, path }` otherwise. Each `path` is a JS accessor
- *   suffix starting with `.` or `[` and is appended to the synthetic
- *   `__bfItem()` call in the emitted client JS.
+ * - `{ unsupported: true }` when the pattern contains a non-literal computed
+ *   property key — that shape can't be expressed as a fixed accessor path
+ *   and is surfaced as `BF025`.
+ * - An array of `LoopParamBinding` otherwise.
+ *
+ * Fixed bindings carry a JS accessor suffix in `path`; rest bindings carry
+ * the parent prefix plus a `rest` descriptor that the emitter expands to a
+ * runtime residual expression. See the `LoopParamBinding` jsdoc.
  */
 function extractLoopParamBindings(
   pattern: ts.BindingName,
-  ctx: TransformContext,
 ): LoopParamBinding[] | { unsupported: true } | null {
   if (ts.isIdentifier(pattern)) return null
 
@@ -1781,23 +1782,58 @@ function extractLoopParamBindings(
   const walk = (p: ts.ArrayBindingPattern | ts.ObjectBindingPattern, prefix: string): void => {
     if (unsupported) return
     if (ts.isArrayBindingPattern(p)) {
-      p.elements.forEach((el, index) => {
+      const elements = p.elements
+      for (let index = 0; index < elements.length; index++) {
         if (unsupported) return
-        if (ts.isOmittedExpression(el)) return
-        if (el.dotDotDotToken) { unsupported = true; return }
+        const el = elements[index]
+        if (ts.isOmittedExpression(el)) continue
+        if (el.dotDotDotToken) {
+          // In JS, the rest element in destructuring must be the final element;
+          // the rest target must be a simple identifier (cannot itself be a
+          // nested binding pattern). TS will syntax-error otherwise, but we
+          // guard defensively so a malformed AST falls back to BF025 instead
+          // of emitting invalid JS.
+          if (index !== elements.length - 1 || !ts.isIdentifier(el.name)) {
+            unsupported = true
+            return
+          }
+          bindings.push({
+            name: el.name.text,
+            path: prefix,
+            rest: { kind: 'array', from: index },
+          })
+          return
+        }
         const path = `${prefix}[${index}]`
         if (ts.isIdentifier(el.name)) {
           bindings.push({ name: el.name.text, path })
         } else {
           walk(el.name, path)
         }
-      })
+      }
       return
     }
     // ObjectBindingPattern
-    for (const el of p.elements) {
+    const collectedKeys: string[] = []
+    const elements = p.elements
+    for (let i = 0; i < elements.length; i++) {
       if (unsupported) return
-      if (el.dotDotDotToken) { unsupported = true; return }
+      const el = elements[i]
+      if (el.dotDotDotToken) {
+        // Same shape constraint as array rest: must be last, must be a plain
+        // identifier. `exclude` is the list of sibling keys destructured at
+        // this level so the emitter can subtract them at runtime.
+        if (i !== elements.length - 1 || !ts.isIdentifier(el.name)) {
+          unsupported = true
+          return
+        }
+        bindings.push({
+          name: el.name.text,
+          path: prefix,
+          rest: { kind: 'object', exclude: collectedKeys },
+        })
+        return
+      }
       let keyText: string | null = null
       if (el.propertyName) {
         const pn = el.propertyName
@@ -1811,6 +1847,7 @@ function extractLoopParamBindings(
         unsupported = true
         return
       }
+      collectedKeys.push(keyText)
       const path = appendDotAccess(prefix, keyText)
       if (ts.isIdentifier(el.name)) {
         bindings.push({ name: el.name.text, path })
@@ -2239,11 +2276,12 @@ function transformMapCall(
       }
       // Destructured param (`([, cfg]) => ...`, `({ x, y }) => ...`): walk
       // the binding pattern into per-binding accessor paths so the client
-      // JS emitter can rewrite references to `__bfItem().path` (#951). Rest
-      // elements and computed keys can't be expressed as a fixed path — we
-      // raise `BF025` and leave `paramBindings` undefined so the emitter
-      // falls back to the #950 unwrap behaviour.
-      const bindingResult = extractLoopParamBindings(firstParam.name, ctx)
+      // JS emitter can rewrite references to `__bfItem().path` (#951).
+      // Rest elements (`{ a, ...rest }`, `[first, ...tail]`) lower into a
+      // residual-object / `.slice(n)` accessor at each reference. Only
+      // computed property keys remain unsupported — those raise `BF025`
+      // and the emitter falls back to the #950 body-entry unwrap.
+      const bindingResult = extractLoopParamBindings(firstParam.name)
       if (bindingResult && !Array.isArray(bindingResult)) {
         ctx.analyzer.errors.push(
           createError(ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -531,6 +531,21 @@ export interface IRLoop {
 }
 
 /**
+ * A property key destructured at a `.map()` callback's item parameter, with
+ * its `IdentifierName` classification pre-computed at IR-build time. The
+ * emitter uses `isIdent` to decide between unquoted (`foo: ...`) and quoted
+ * (`"data-foo": ...`) destructure-pattern forms without re-running an
+ * identifier regex of its own — single source of truth for the
+ * classification (#1244 pattern F).
+ */
+export interface RestExcludeKey {
+  /** Raw key text, as it appeared in the source destructure pattern. */
+  key: string
+  /** True when `key` parses as a JS `IdentifierName` (`ts.isIdentifierText`). */
+  isIdent: boolean
+}
+
+/**
  * Destructured binding extracted from a `.map()` callback's item parameter.
  *
  * For *fixed* bindings (plain identifier, alias, nested access), `path` is a
@@ -543,7 +558,8 @@ export interface IRLoop {
  *
  * - `kind: 'object'`: references compile to an IIFE that destructures the
  *   parent and returns the residual object — `__bfItem()${path}` minus the
- *   sibling keys listed in `exclude`.
+ *   sibling keys listed in `exclude`. Each entry is already classified as
+ *   identifier-or-not by the IR builder.
  * - `kind: 'array'`: references compile to `__bfItem()${path}.slice(from)`.
  *
  * Computed property keys can't be expressed in any of these forms and still
@@ -553,7 +569,7 @@ export interface LoopParamBinding {
   name: string
   path: string
   rest?:
-    | { kind: 'object'; exclude: readonly string[] }
+    | { kind: 'object'; exclude: readonly RestExcludeKey[] }
     | { kind: 'array'; from: number }
 }
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -532,12 +532,29 @@ export interface IRLoop {
 
 /**
  * Destructured binding extracted from a `.map()` callback's item parameter.
- * The `path` is a JS accessor suffix (starts with `.` or `[`) appended to
- * the synthetic `__bfItem()` call in the emitted client JS.
+ *
+ * For *fixed* bindings (plain identifier, alias, nested access), `path` is a
+ * JS accessor suffix (starts with `.` or `[`) appended to the synthetic
+ * `__bfItem()` call. References to the binding compile to
+ * `__bfItem()${path}`.
+ *
+ * When `rest` is set, the binding is a rest element. `path` is the parent
+ * accessor (`''` at the loop root, `.rows` etc. when nested):
+ *
+ * - `kind: 'object'`: references compile to an IIFE that destructures the
+ *   parent and returns the residual object — `__bfItem()${path}` minus the
+ *   sibling keys listed in `exclude`.
+ * - `kind: 'array'`: references compile to `__bfItem()${path}.slice(from)`.
+ *
+ * Computed property keys can't be expressed in any of these forms and still
+ * raise `BF025` at Phase 1.
  */
 export interface LoopParamBinding {
   name: string
   path: string
+  rest?:
+    | { kind: 'object'; exclude: readonly string[] }
+    | { kind: 'array'; from: number }
 }
 
 export interface IRComponent {


### PR DESCRIPTION
Closes #2 of the surfaced limitations in #1306 (parent issue #1244).

## Summary

Rest destructuring in a `.map()` callback (`({ id, title, ...rest }) =>`, `({ rows: [first, ...tail] }) =>`) used to bail out of #951's per-binding rewrite and raise **BF025**, leaving the surrounding loop body without per-item reactivity. Object rest now lowers to a one-shot destructure IIFE, array rest to native `.slice(n)`. No runtime helper is added — both forms are pure JS.

```js
// {...rest} on a loop-item root, inside the renderItem closure
spreadAttrs((({ id: __r0, title: __r1, ...__rest }) => __rest)(__bfItem()))
// `tail.length` inside `{ rows: [first, ...tail] }`
__bfItem().rows.slice(1).length
```

## Root-cause framing (vs. patching the BF025 site)

`extractLoopParamBindings` was a binary "fully expressible as a fixed accessor path or give up" walker. Pattern (C) "Implicit DOM-attr vs JSX-prop classification" from #1244's recurring-defect catalog — short-circuiting on shapes the lower couldn't directly express, instead of representing the shape and letting the emitter handle it.

The shape is now carried in the IR via `LoopParamBinding.rest: { kind: 'object' | 'array', ... }`. The emitter dispatches on it through `renderLoopBindingAccess`. Adding another rest variant (e.g. nested rest under another rest, once TS allows it) would extend the discriminator rather than re-architect the walker.

Drive-by: `renderTemplateAttrPart`'s `spread` case wasn't running its expression through `wrap`, so the destructured `rest` token was passing through unrewritten in the loop-item CSR template. That's pattern (B) "Two emit paths for reactive attributes" from the same catalog — fixed in the same hunk because the destructure rewrite would otherwise still emit `spreadAttrs(rest)` with `rest` out of scope.

**Out of scope:** Computed property keys (`{ [KEY]: v }`) keep their BF025 diagnostic — no static path to lower to, runtime reflection on a dynamic key isn't worth the complexity at the loop layer.

## Test plan

- [x] `bun test packages/jsx` — 1237 pass / 3 todo / 0 fail
- [x] `bun test packages/adapter-tests packages/client packages/test packages/adapter-hono packages/adapter-go-template packages/adapter-mojolicious` — 1059 pass / 33 skip / 0 fail
- [x] BF025 expectations in `destructured-map-params.test.ts` replaced with structural assertions on the emitted IIFE / `.slice(n)` shape
- [x] `test.todo` entries in `compiler-stress-1244.test.ts` (`{ id, title, ...rest }` and `{ rows: [first, ...rest] }`) converted to real assertions
- [x] Added positive coverage for the computed-key BF025 escape hatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)