### PR TITLE
refactor(#1311): split internal AST-shape invariants from user-facing BF025

### DIFF
--- a/packages/jsx/src/__tests__/internal-invariant.test.ts
+++ b/packages/jsx/src/__tests__/internal-invariant.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for #1311: `internalInvariant` separates AST-shape contract
+ * violations (upstream tooling produced a node that shouldn't exist) from
+ * user-facing BF0xx diagnostics. Throwing surfaces a stack at the broken
+ * caller rather than dressing up the failure as a per-source error.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  InternalInvariantError,
+  internalInvariant,
+} from '../errors'
+
+describe('internalInvariant (#1311)', () => {
+  test('passes through when condition is truthy', () => {
+    expect(() => internalInvariant(true, 'should not throw')).not.toThrow()
+    expect(() => internalInvariant(1, 'should not throw')).not.toThrow()
+    expect(() => internalInvariant({}, 'should not throw')).not.toThrow()
+  })
+
+  test('throws InternalInvariantError when condition is falsy', () => {
+    expect(() => internalInvariant(false, 'rest token must be last')).toThrow(
+      InternalInvariantError,
+    )
+    expect(() => internalInvariant(0, 'rest token must be last')).toThrow(
+      InternalInvariantError,
+    )
+    expect(() => internalInvariant(null, 'rest token must be last')).toThrow(
+      InternalInvariantError,
+    )
+    expect(() =>
+      internalInvariant(undefined, 'rest token must be last'),
+    ).toThrow(InternalInvariantError)
+  })
+
+  test('error message is prefixed so producers can recognize it', () => {
+    let caught: unknown
+    try {
+      internalInvariant(false as boolean, 'rest target must be an identifier')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(InternalInvariantError)
+    expect((caught as Error).message).toBe(
+      'barefoot internal invariant: rest target must be an identifier',
+    )
+    expect((caught as Error).name).toBe('InternalInvariantError')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -112,7 +112,13 @@ const errorMessages: Record<ErrorCode, string> = {
   [ErrorCodes.MISSING_KEY_IN_NESTED_LIST]:
     'Nested .map() loop requires key attribute for event delegation. Add a key prop to elements in the inner loop',
   [ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST]:
-    'Rest element or computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
+    // Despite the legacy `UNSUPPORTED_DESTRUCTURE_REST` name, this code now
+    // fires only for shapes that are valid TypeScript but unrepresentable in
+    // IR — currently just non-literal computed property keys (`{ [KEY]: v }`).
+    // Rest elements themselves were lowered in #1244 / #1309; the constant
+    // keeps its name so external consumers' `e.code === 'BF025'` checks remain
+    // stable.
+    'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
   [ErrorCodes.TYPE_INFERENCE_FAILED]: 'Failed to infer type',
   [ErrorCodes.PROPS_TYPE_MISMATCH]: 'Props type mismatch',
@@ -292,6 +298,34 @@ export function formatError(error: CompilerError, source?: string): string {
   }
 
   return lines.join('\n')
+}
+
+// =============================================================================
+// Internal Invariants
+// =============================================================================
+
+/**
+ * Throws when an internal compiler contract is violated. Use for AST shapes
+ * the TypeScript parser already rules out — if the branch fires, an upstream
+ * producer (codemod, AST transformer, malformed-source path) handed us a node
+ * that should not exist. Distinct from user-facing diagnostics (BF0xx) so a
+ * thrown stack points at the broken caller instead of being swallowed into a
+ * misleading per-source error message.
+ */
+export class InternalInvariantError extends Error {
+  constructor(message: string) {
+    super(`barefoot internal invariant: ${message}`)
+    this.name = 'InternalInvariantError'
+  }
+}
+
+export function internalInvariant(
+  cond: unknown,
+  message: string,
+): asserts cond {
+  if (!cond) {
+    throw new InternalInvariantError(message)
+  }
 }
 
 // =============================================================================

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -32,7 +32,7 @@ import {
 } from './types'
 import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, type ParsedExpr, type ParsedStatement } from './expression-parser'
-import { createError, ErrorCodes } from './errors'
+import { createError, ErrorCodes, internalInvariant } from './errors'
 import { containsReactiveExpression } from './reactivity-checker'
 import { rewriteBarePropRefs as rewriteBarePropRefsCore } from './prop-rewrite'
 import { resolveFreeRefs, type BindingEnvironment } from './free-refs'
@@ -1807,15 +1807,19 @@ function extractLoopParamBindings(
         const el = elements[index]
         if (ts.isOmittedExpression(el)) continue
         if (el.dotDotDotToken) {
-          // In JS, the rest element in destructuring must be the final element;
-          // the rest target must be a simple identifier (cannot itself be a
-          // nested binding pattern). TS will syntax-error otherwise, but we
-          // guard defensively so a malformed AST falls back to BF025 instead
-          // of emitting invalid JS.
-          if (index !== elements.length - 1 || !ts.isIdentifier(el.name)) {
-            unsupported = true
-            return
-          }
+          // TS already rejects rest tokens in non-final slots and rest targets
+          // that are not plain identifiers at parse time; reaching either
+          // branch here means an upstream tool produced a malformed AST. Throw
+          // instead of falling through to BF025 so the stack points at the
+          // broken caller. See #1311.
+          internalInvariant(
+            index === elements.length - 1,
+            'extractLoopParamBindings: array rest token in non-final position (parser should reject)',
+          )
+          internalInvariant(
+            ts.isIdentifier(el.name),
+            'extractLoopParamBindings: array rest target is not an identifier (parser should reject)',
+          )
           bindings.push({
             name: el.name.text,
             path: prefix,
@@ -1839,15 +1843,19 @@ function extractLoopParamBindings(
       if (unsupported) return
       const el = elements[i]
       if (el.dotDotDotToken) {
-        // Same shape constraint as array rest: must be last, must be a plain
-        // identifier. `exclude` is the list of sibling keys destructured at
-        // this level so the emitter can subtract them at runtime — each entry
-        // already carries its `isIdent` classification so no further regex
-        // runs downstream.
-        if (i !== elements.length - 1 || !ts.isIdentifier(el.name)) {
-          unsupported = true
-          return
-        }
+        // Same parser-enforced shape constraint as array rest: must be last,
+        // must be a plain identifier. `exclude` is the list of sibling keys
+        // destructured at this level so the emitter can subtract them at
+        // runtime — each entry already carries its `isIdent` classification so
+        // no further regex runs downstream.
+        internalInvariant(
+          i === elements.length - 1,
+          'extractLoopParamBindings: object rest token in non-final position (parser should reject)',
+        )
+        internalInvariant(
+          ts.isIdentifier(el.name),
+          'extractLoopParamBindings: object rest target is not an identifier (parser should reject)',
+        )
         bindings.push({
           name: el.name.text,
           path: prefix,


### PR DESCRIPTION
Closes #1311.

## Summary

- Adds `internalInvariant` / `InternalInvariantError` to `packages/jsx/src/errors.ts` for AST-shape contract violations that the TS parser already rules out.
- Routes the two rest-shape guards in `extractLoopParamBindings` (rest token must be final; rest target must be a plain identifier) through `internalInvariant`, so they no longer fall through to BF025.
- Drops the now-stale "Rest element or" prefix from the BF025 message. The `UNSUPPORTED_DESTRUCTURE_REST` constant name is preserved so external consumers checking `e.code === 'BF025'` keep working.

## Why

Before this change, a malformed AST produced by upstream tooling (codemod, AST transformer) would surface as a generic per-source BF025 — sending the developer down the wrong rabbit hole investigating their `.tsx` source rather than the broken caller. The invariant throw surfaces a stack pointing at the AST producer, which is the actual broken party.

This is one of #1244's broader "trust the IR" cleanups: signals that are *valid TS but unrepresentable in IR* (BF025) and signals that are *AST shapes which should not exist* (invariant) are now distinct channels.

## Test plan

- [x] `bun test packages/jsx` — 1242 pass / 0 fail
- [x] `bun test packages/adapter-{go-template,mojolicious,hono,tests}` — 784 pass / 0 fail
- [x] New `internal-invariant.test.ts` covers the helper directly
- [x] Existing `destructured-map-params.test.ts > 'computed property key in destructure still raises BF025'` still passes (BF025 remains the user-facing channel for computed keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)