### PR TITLE
test(#1310): pin Go/Mojo BF104 contract for .map() rest destructure

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -114,6 +114,17 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) likewise can't lower into Go template
     // syntax — same BF101 refusal.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #1310: rest destructure in .map() callback. Hono / CSR lower
+    // these via the inline residual-object accessor (#1309), but the
+    // Go template adapter has no analogous lowering — `paramBindings`
+    // is non-empty so the generic destructure-refusal at
+    // `go-template-adapter.ts` fires BF104 regardless of whether the
+    // binding is rest or plain. Pinning the contract here makes the
+    // limitation declarative: when the Go adapter grows a native
+    // rest-lowering, dropping these entries flips the contract on.
+    'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
+    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
+    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -103,6 +103,14 @@ runAdapterConformanceTests({
       { code: 'BF103', severity: 'error' },
       { code: 'BF104', severity: 'error' },
     ],
+    // #1310: rest destructure in .map() callback. Hono / CSR lower
+    // these via the inline residual-object accessor (#1309); the Mojo
+    // adapter's loop emitter raises the generic BF104 destructure
+    // refusal regardless of whether the binding is rest or plain.
+    // Pinning the contract here makes the limitation declarative.
+    'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
+    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
+    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -73,6 +73,9 @@ import { fixture as taggedTemplateClassname } from './tagged-template-classname'
 import { fixture as memberExpressionTag } from './member-expression-tag'
 import { fixture as arrowComponent } from './arrow-component'
 import { fixture as childrenJsxExpression } from './children-jsx-expression'
+import { fixture as restDestructureObjectInMap } from './rest-destructure-object-in-map'
+import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
+import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
 
 import type { JSXFixture } from '../src/types'
 
@@ -152,4 +155,9 @@ export const jsxFixtures: JSXFixture[] = [
   memberExpressionTag,
   arrowComponent,
   childrenJsxExpression,
+  // #1310: rest destructure in .map() — Hono/CSR lowers via #1309,
+  // Go/Mojo refuse the loop destructure shape with BF104.
+  restDestructureObjectInMap,
+  restDestructureArrayInMap,
+  restDestructureNestedInMap,
 ]

--- a/packages/adapter-tests/fixtures/rest-destructure-array-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-array-in-map.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Array rest destructure in a `.map()` callback (`[first, ...tail]`).
+ *
+ * Counterpart to `rest-destructure-object-in-map`. The Hono / CSR emit
+ * path lowers the rest binding to `__bfItem().slice(n)`. Text-template
+ * adapters refuse the whole destructure shape with BF104. See #1310.
+ */
+export const fixture = createFixture({
+  id: 'rest-destructure-array-in-map',
+  description: 'Array rest destructure in .map() callback (#1310)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Row = readonly [string, string, string]
+export function RestArray() {
+  const [rows, setRows] = createSignal<Row[]>([
+    ['r1', 'a', 'b'],
+    ['r2', 'c', 'd'],
+  ])
+  return (
+    <ul onClick={() => setRows(r => r)}>
+      {rows().map(([first, ...tail]) => (
+        <li key={first}>{first}:{String(tail.length)}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="r1"><!--bf:s0-->r1<!--/-->:<!--bf:s1-->2<!--/--></li>
+      <li data-key="r2"><!--bf:s0-->r2<!--/-->:<!--bf:s1-->2<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/rest-destructure-nested-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-nested-in-map.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Nested rest destructure in a `.map()` callback
+ * (`{ id, cells: [head, ...rest] }`).
+ *
+ * Exercises the IR walker recursing into a nested array binding inside an
+ * object pattern, where the inner pattern carries the rest token. Same
+ * adapter parity contract as the flat-rest fixtures: Hono / CSR lowers it;
+ * Go / Mojo refuse the loop destructure with BF104. See #1310.
+ */
+export const fixture = createFixture({
+  id: 'rest-destructure-nested-in-map',
+  description: 'Nested rest destructure inside object pattern in .map() (#1310)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Row = { id: string; cells: readonly string[] }
+export function RestNested() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 'r1', cells: ['a', 'b', 'c'] },
+    { id: 'r2', cells: ['x', 'y'] },
+  ])
+  return (
+    <ul onClick={() => setRows(r => r)}>
+      {rows().map(({ id, cells: [head, ...rest] }) => (
+        <li key={id}>{head}:{String(rest.length)}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="r1"><!--bf:s0-->a<!--/-->:<!--bf:s1-->2<!--/--></li>
+      <li data-key="r2"><!--bf:s0-->x<!--/-->:<!--bf:s1-->1<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/rest-destructure-object-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-object-in-map.ts
@@ -1,0 +1,46 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Object rest destructure in a `.map()` callback (`{ id, title, ...rest }`).
+ *
+ * #1309 / #1244 added IR-level support for rest patterns and the Hono / CSR
+ * emit path lowers them to an inline residual-object accessor
+ * (`(({ id: __bfR0, title: __bfR1, ...__bfRest }) => __bfRest)(__bfItem())`).
+ * Text-template adapters (Go, Mojo) have no analogous lowering — they
+ * already refuse any loop destructure (`paramBindings.length > 0`) with
+ * BF104, but no fixture pinned that contract for the rest variant.
+ *
+ * This fixture lets each adapter declare its position against the rest
+ * shape (currently both Go and Mojo expect BF104 via `expectedDiagnostics`).
+ * When either adapter grows a native lowering, dropping the diagnostic
+ * here is the single edit that flips the contract on. See #1310.
+ */
+export const fixture = createFixture({
+  id: 'rest-destructure-object-in-map',
+  description: 'Object rest destructure in .map() callback (#1310)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Task = { id: string; title: string; flag: string }
+export function RestObject() {
+  const [tasks, setTasks] = createSignal<Task[]>([
+    { id: 't1', title: 'one', flag: 'a' },
+    { id: 't2', title: 'two', flag: 'b' },
+  ])
+  return (
+    <ul onClick={() => setTasks(t => t)}>
+      {tasks().map(({ id, title, ...rest }) => (
+        <li key={id}>{title}:{rest.flag}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="t1"><!--bf:s0-->one<!--/-->:<!--bf:s1-->a<!--/--></li>
+      <li data-key="t2"><!--bf:s0-->two<!--/-->:<!--bf:s1-->b<!--/--></li>
+    </ul>
+  `,
+})


### PR DESCRIPTION
Closes #1310.

## Summary

- Adds three adapter-tests fixtures exercising rest destructure in `.map()` callbacks: flat object (`{ id, title, ...rest }`), flat array (`[first, ...tail]`), and a nested rest inside an object pattern (`{ id, cells: [head, ...rest] }`).
- Declares the BF104 contract on both Go and Mojo adapters via `expectedDiagnostics`. The fixture corpus stays adapter-agnostic; each adapter's refusal set lives on its own test file.

## Why declare, not implement

The issue offers two routes per adapter: declare (`expectedDiagnostics`) or implement (native lowering to Go `index` + comparable / Mojo hash difference).

Both Go and Mojo already raise BF104 today via the generic destructure-refusal at `loop.paramBindings.length > 0` — rest patterns produce `paramBindings`, so the refusal already fires. The only gap was that no fixture pinned that behavior for the rest variant, leaving future implementers without a regression target. These fixtures fill that gap; when either adapter grows a native rest-lowering, dropping its `rest-destructure-*` entries from `expectedDiagnostics` is the single edit that flips the contract on.

Implementing native lowering is genuinely out of scope here — it would touch the per-adapter expression emitters and span lines / iterators / scope-context separately for each backend.

## Test plan

- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — generates expectedHtml for the new fixtures from the Hono reference adapter (per the project's pre-generate convention)
- [x] `bun test packages/adapter-hono packages/adapter-tests packages/adapter-go-template packages/adapter-mojolicious` — 818 pass / 0 fail
- [x] `bun test packages/jsx` — 1239 pass / 0 fail (no compiler-side regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)