### PR TITLE
fix(#1321): preserve rest spread on typed function parameters

### DIFF
--- a/packages/adapter-tests/fixtures/tagged-template-classname.ts
+++ b/packages/adapter-tests/fixtures/tagged-template-classname.ts
@@ -4,19 +4,10 @@ import { createFixture } from '../src/types'
  * Compiler stress (#1244): `className={cn\`base \${signal()}\`}` —
  * tagged template literal as className.
  *
- * SURFACED: the compiler's type-strip step drops the `...` rest spread
- * from function parameters along with the type annotation, so
- * `function cn(parts, ...args)` becomes `function cn(parts, args)`.
- * The tag function then receives a single string instead of an array,
- * and indexing into a string per-character produces nonsense
- * (`'primary'[0] === 'p'`, `[1] === 'r'`) — hence the locked-in
- * `class="base pr"` rather than the correct `class="base primary"`.
- *
- * Both SSR and CSR produce the same wrong output, so the fixture
- * passes conformance. The expectedHtml below records the *current*
- * wrong shape so that, when the rest-spread strip is fixed, this
- * fixture flips red and prompts the expectedHtml to be regenerated
- * to the corrected `class="base primary"`. Sub-issue of #1244.
+ * Resolved by #1321: rest-parameter `...` token now survives the type-strip
+ * pass and module-level helper emission, so `function cn(parts, ...args)`
+ * stays variadic and the tagged-template result resolves to the expected
+ * `class="base primary"`.
  */
 export const fixture = createFixture({
   id: 'tagged-template-classname',
@@ -33,6 +24,6 @@ export function TaggedTemplateClassname() {
 }
 `,
   expectedHtml: `
-    <div class="base pr" bf-s="test" bf="s0">x</div>
+    <div class="base primary" bf-s="test" bf="s0">x</div>
   `,
 })

--- a/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
+++ b/packages/jsx/src/__tests__/compiler-runtime-contract.test.ts
@@ -260,6 +260,25 @@ describe('Compiler-Runtime Contract', () => {
       expect(helperPos).toBeLessThan(initPos)
     })
 
+    test('issue #1321: rest spread on typed module-level function param survives emit', () => {
+      const js = compileClient(`
+        "use client"
+        import { createSignal } from '@barefootjs/client'
+        function cn(parts: TemplateStringsArray, ...args: unknown[]): string {
+          return parts.reduce<string>((acc, p, i) => acc + p + (args[i] ?? ''), '')
+        }
+        export function TagDemo() {
+          const [tone, setTone] = createSignal('primary')
+          return <div className={cn\`base \${tone()}\`} onClick={() => setTone('secondary')}>x</div>
+        }
+      `)
+      // The variadic helper must keep its `...` token after type-strip + emit;
+      // dropping it (#1321) turned `cn(parts, ...args)` into `cn(parts, args)`
+      // and produced per-character indexing into the joined argument.
+      expect(js).toContain('var cn = cn ?? function(parts, ...args)')
+      expect(js).not.toMatch(/function\(parts,\s*args\)/)
+    })
+
     test('component-level function referencing signals stays inside init', () => {
       const js = compileClient(`
         "use client"

--- a/packages/jsx/src/__tests__/strip-types.test.ts
+++ b/packages/jsx/src/__tests__/strip-types.test.ts
@@ -78,6 +78,18 @@ describe('strip-types', () => {
         '(x) => String(x)'
       )
     })
+
+    test('issue #1321: keeps rest spread on a typed parameter', () => {
+      expect(stripExpr('(parts: TemplateStringsArray, ...args: unknown[]) => parts.join("")')).toBe(
+        '(parts, ...args) => parts.join("")'
+      )
+    })
+
+    test('issue #1321: keeps rest spread on a single typed parameter', () => {
+      expect(stripExpr('(...args: number[]) => args.length')).toBe(
+        '(...args) => args.length'
+      )
+    })
   })
 
   describe('type assertions (as)', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1684,6 +1684,7 @@ function collectFunction(
     },
     optional: !!p.questionToken,
     defaultValue: p.initializer ? ctx.getJS(p.initializer) : undefined,
+    isRest: !!p.dotDotDotToken || undefined,
   }))
   const body = node.body ? ctx.getJS(node.body) : ''
   const typedBody = node.body ? node.body.getText(ctx.sourceFile) : undefined

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -51,9 +51,10 @@ export function emitModuleLevelDeclarations(
   // entry points, not imported by other modules. Add export when a concrete
   // cross-module use case arises.
   for (const fn of moduleLevelFunctions) {
-    const paramStr = fn.params.map(p =>
-      p.defaultValue !== undefined ? `${p.name} = ${p.defaultValue}` : p.name,
-    ).join(', ')
+    const paramStr = fn.params.map(p => {
+      const rest = p.isRest ? '...' : ''
+      return p.defaultValue !== undefined ? `${rest}${p.name} = ${p.defaultValue}` : `${rest}${p.name}`
+    }).join(', ')
     const asyncKw = fn.isAsync ? 'async ' : ''
     // Generator functions (`function*`) cannot be lowered to an arrow
     // form (arrows can't yield) — preserve the `*` here so emit reads

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -68,9 +68,10 @@ export function buildDeclarationEmitPlan(
       return {
         kind: 'function',
         name: fn.name,
-        paramList: fn.params.map(p =>
-          p.defaultValue !== undefined ? `${p.name} = ${p.defaultValue}` : p.name,
-        ).join(', '),
+        paramList: fn.params.map(p => {
+          const rest = p.isRest ? '...' : ''
+          return p.defaultValue !== undefined ? `${rest}${p.name} = ${p.defaultValue}` : `${rest}${p.name}`
+        }).join(', '),
         body: fn.body,
         isAsync: fn.isAsync ?? false,
       }

--- a/packages/jsx/src/module-exports.ts
+++ b/packages/jsx/src/module-exports.ts
@@ -95,10 +95,11 @@ export function collectInlineExportedNames(ir: ComponentIR): Set<string> {
  * NaN/undefined at render time.
  */
 export function formatParamWithType(p: ParamInfo): string {
+  const rest = p.isRest ? '...' : ''
   const optional = p.optional ? '?' : ''
   const typeAnnotation = p.type?.raw && p.type.raw !== 'unknown' ? `: ${p.type.raw}` : ''
   const defaultPart = p.defaultValue !== undefined ? ` = ${p.defaultValue}` : ''
-  return `${p.name}${optional}${typeAnnotation}${defaultPart}`
+  return `${rest}${p.name}${optional}${typeAnnotation}${defaultPart}`
 }
 
 /**

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -69,6 +69,8 @@ export interface ParamInfo {
   defaultValue?: string
   /** When true, the default value contains an arrow function or function expression (computed from AST). */
   defaultContainsArrow?: boolean
+  /** When true, the parameter is a rest spread (`...args`) — emit must prepend `...`. */
+  isRest?: boolean
 }
 
 // =============================================================================


### PR DESCRIPTION
Resolves #1321. Part of the #1244 stacked series.

## Root cause

The bug is **not** in `strip-types.ts` (which already preserves `...` on typed parameters), but in the function-emission path that reconstructs parameter lists from `ParamInfo`. The analyzer collected `ParamInfo` without recording `p.dotDotDotToken`, so every emit site that re-derived the param list — `emit-module-level`, `plan/build-declaration-emit`, `module-exports.formatParamWithType` — dropped the rest marker.

`function cn(parts: TemplateStringsArray, ...args: unknown[])` became `function cn(parts, args)` in the emitted client JS and marked-template adapter output, turning the variadic helper into a binary one. The tag-function then received a single string instead of an array; per-character indexing produced `'primary'[0] === 'p'`, `[1] === 'r'`, hence the locked-wrong `class="base pr"`.

## Fix

1. `types.ts` — add `isRest?: boolean` to `ParamInfo`.
2. `analyzer.ts` — set `isRest: !!p.dotDotDotToken || undefined` when collecting `localFunctions` params.
3. `emit-module-level.ts`, `plan/build-declaration-emit.ts`, `module-exports.ts` — prepend `...` from `isRest` at emit time.
4. `packages/adapter-tests/fixtures/tagged-template-classname.ts` — flip `expectedHtml` from the locked-wrong `class="base pr"` to the correct `class="base primary"` and drop the surfaced-limitation preamble.

## Tests

- `strip-types.test.ts` — regression tests pinning `(...args: number[])` and `(a: T, ...rest: U[])` stripping.
- `compiler-runtime-contract.test.ts` — asserts the emitted helper is `var cn = cn ?? function(parts, ...args)`, not `(parts, args)`.
- The `tagged-template-classname` adapter fixture now expects the correct `class="base primary"` across hono / csr (go-template / mojo still skip via their own `skipJsx` set, tracked by #1323).

## Test plan
- [x] `bun test packages/jsx/src/__tests__/strip-types.test.ts packages/jsx/src/__tests__/compiler-runtime-contract.test.ts` — green
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests` — 1827 pass, 0 fail
- [x] `bun test ui/components/` — 1227 pass, 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_