### PR TITLE
fix(#1317): wire spreadAttrs into CSR conformance harness

### DIFF
--- a/packages/adapter-tests/fixtures/jsx-spread-reactive.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-reactive.ts
@@ -2,11 +2,9 @@ import { createFixture } from '../src/types'
 
 /**
  * Compiler stress (#1244): `<div {...signal()} />` — JSX spread of a
- * reactive object. SSR renders the initial keys correctly. CSR
- * currently throws `ReferenceError: spreadAttrs is not defined` because
- * the emitted client JS template calls `spreadAttrs(...)` without
- * importing it — surfaced limitation, skipped in CSR conformance until
- * the import is wired in. Sub-issue of #1244.
+ * reactive object. SSR renders the initial keys correctly, and the CSR
+ * client JS imports `spreadAttrs` from `@barefootjs/client/runtime`
+ * so the template lambda resolves it at hydration time (#1317).
  */
 export const fixture = createFixture({
   id: 'jsx-spread-reactive',

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -63,14 +63,11 @@ describe('CSR Conformance Tests', () => {
     // docstrings record the symptom in detail; tracked as sub-issues
     // of #1244 for individual fix-up.
     //
-    // - jsx-spread-reactive: CSR template calls `spreadAttrs(...)`
-    //   without importing it → ReferenceError at hydration.
     // - member-expression-tag: CSR renders `<Pkg.Comp />` as literal
     //   text `[Pkg.Comp]` instead of resolving the component.
     // - children-jsx-expression: CSR emits duplicate `bf-s` attrs and
     //   drops the inner scope marker (same family as the
     //   `record-index-lookup-via-child-prop` entry above).
-    'jsx-spread-reactive',
     'member-expression-tag',
     'children-jsx-expression',
   ])

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -221,6 +221,30 @@ const initChild = (name, _scope, props) => { __runInit(name, props) }
 const createComponent = () => null
 const createPortal = () => {}
 const applyRestAttrs = () => {}
+// Mirror @barefootjs/client/runtime/spread-attrs.ts: format a record of
+// attributes as an HTML attribute string for use inside template literals.
+// The real runtime helper is imported by generated client JS, but the
+// CSR harness strips imports and provides its own stubs, so this mock
+// has to match the production behaviour or templates calling
+// \`spreadAttrs(signal())\` will throw at template-eval time (#1317).
+function spreadAttrs(obj) {
+  if (!obj || typeof obj !== 'object') return ''
+  const parts = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (value == null || value === false) continue
+    if (key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()) continue
+    if (key === 'children') continue
+    if (key === 'style') {
+      const css = styleToCss(value)
+      if (css != null) parts.push(\`style="\${css}"\`)
+      continue
+    }
+    const attr = key === 'className' ? 'class' : key === 'htmlFor' ? 'for'
+      : key.replace(/([A-Z])/g, '-$1').toLowerCase()
+    parts.push(value === true ? attr : \`\${attr}="\${value}"\`)
+  }
+  return parts.join(' ')
+}
 // Minimal Context model so fixtures with \`createContext\`/\`Provider\`
 // (e.g. \`context-provider\`) can resolve \`useContext(ctx)\` during
 // template eval. Real \`@barefootjs/client/runtime\` walks the DOM scope

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1908,6 +1908,31 @@ describe('Client JS generation', () => {
       expect(content).toMatch(/import \{[^}]*spreadAttrs[^}]*\} from '@barefootjs\/client\/runtime'/)
     })
 
+    test('issue #1317: stateful component with reactive spread imports spreadAttrs', () => {
+      // Surfaced limitation #7 from PR #1306. A `'use client'` component
+      // that spreads a signal-returned object on a DOM element
+      // (`<div {...attrs()} />`) emits a `spreadAttrs(...)` call in the
+      // template lambda; the import line must include `spreadAttrs` or
+      // hydration throws `ReferenceError: spreadAttrs is not defined`.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        export function JsxSpreadReactive() {
+          const [attrs, setAttrs] = createSignal<Record<string, string>>({ id: 'a', class: 'on' })
+          return <div onClick={() => setAttrs({ id: 'b', class: 'off' })} {...attrs()} />
+        }
+      `
+      const result = compileJSX(source, 'JsxSpreadReactive.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      expect(content).toContain('spreadAttrs(')
+      expect(content).toMatch(/import \{[^}]*spreadAttrs[^}]*\} from '@barefootjs\/client\/runtime'/)
+    })
+
     test('computed spread with conditional expression emits spreadAttrs (#545)', () => {
       const source = `
         export function Icon(props: { large?: boolean }) {


### PR DESCRIPTION
Resolves #1317. Stacked on top of #1327 (#1321) in the #1244 series.

## Root cause

The issue's premise — that the import isn't injected — is half right. Production client JS does include `import { spreadAttrs } from '@barefootjs/client/runtime'` (matched by `detectUsedImports` in `imports.ts:14`, verified by `<svg {...sizeAttrs} ...>` tests already pinned at #545). The runtime resolves it correctly during hydration.

The visible breakage was in the CSR conformance harness (`packages/adapter-tests/src/csr-render.ts`): it strips all imports from the generated client JS before eval and provides its own mock runtime. The mock had `applyRestAttrs`, `styleToCss`, etc., but **no `spreadAttrs` stub**, so the `jsx-spread-reactive` fixture threw `ReferenceError: spreadAttrs is not defined` at template-eval time, and the fixture sat in `skipFixtures`.

## Fix

1. `csr-render.ts` — add a `spreadAttrs` stub that mirrors `packages/client/src/runtime/spread-attrs.ts` (same key→attr mapping, event-handler / `children` / nullish skips, `style` → `styleToCss`).
2. `csr-conformance.test.ts` — drop `'jsx-spread-reactive'` from `skipFixtures` and update the in-line catalog comment.
3. `client-js-generation.test.ts` — add a unit test pinning the **stateful** import-injection contract (`'use client'` + `createSignal` + reactive spread). The existing #545 tests cover only the stateless path.
4. `jsx-spread-reactive.ts` fixture — drop the "surfaced limitation, skipped" preamble now that the contract is locked.

## Test plan
- [x] `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts -t "jsx-spread-reactive"` — green
- [x] `bun test packages/jsx/src/__tests__/client-js-generation.test.ts -t "1317"` — green
- [x] `bun test packages/adapter-tests packages/jsx` — 1554 pass, 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_