### PR TITLE
fix(#1320): preserve hoisted-children scope and dedupe bf-s in renderChild

### DIFF
--- a/packages/adapter-tests/fixtures/children-jsx-expression.ts
+++ b/packages/adapter-tests/fixtures/children-jsx-expression.ts
@@ -3,11 +3,11 @@ import { createFixture } from '../src/types'
 /**
  * Compiler stress (#1244): `children` passed as an explicit attribute
  * value (not nested between the opening / closing tags). Functionally
- * identical to nested children but parsed via a different path. SSR
- * renders the right shape; CSR currently emits duplicate `bf-s`
- * attributes (`bf-s="test_s0" bf-s="test"`) and drops the inner scope
- * marker. Surfaced limitation, skipped in CSR conformance. Sub-issue
- * of #1244.
+ * identical to nested children but parsed via a different path. Both
+ * SSR and CSR render the same shape after #1320 — the hoisted JSX
+ * carries a `bf-s` placeholder substituted by `renderChild` with the
+ * outer component's scope, and `renderChild` no longer double-injects
+ * `bf-s` when its template body root already carries one.
  */
 export const fixture = createFixture({
   id: 'children-jsx-expression',

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -49,24 +49,6 @@ describe('CSR Conformance Tests', () => {
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
-    // CSR's child-component render emits the parent's scope marker
-    // alongside the child's, producing duplicate `bf-s` attributes
-    // (e.g. `bf-s="test_s0" ... bf-s="test"`). Same class of
-    // CSR/SSR attribute-shape divergence as `top-level-ternary` /
-    // `return-*` above. The contract this fixture pins —
-    // `<Slot className={\`base \${MAP[KEY]}\`}>` rendering the right
-    // class — is verified at the SSR conformance layer for all
-    // template-based adapters; the duplicate-`bf-s` issue is its own
-    // follow-up.
-    'record-index-lookup-via-child-prop',
-    // #1244 stress catalog: surfaced CSR-only divergences. The fixture
-    // docstrings record the symptom in detail; tracked as sub-issues
-    // of #1244 for individual fix-up.
-    //
-    // - children-jsx-expression: CSR emits duplicate `bf-s` attrs and
-    //   drops the inner scope marker (same family as the
-    //   `record-index-lookup-via-child-prop` entry above).
-    'children-jsx-expression',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -189,13 +189,28 @@ function renderChild(name, props, key, suffix) {
   // needs to be rewritten to track the actual parent scope at call time.
   const slotAttrs = suffix ? ' bf-h="test" bf-m="' + suffix + '"' : ''
   if (!template) return '<div bf-s="' + scopeId + '"' + slotAttrs + keyAttr + '>[' + name + ']</div>'
-  const html = template(props).trim()
+  let html = template(props).trim()
+  // Substitute the hoisted-children scope placeholder (#1320) with the
+  // current parent scope — \`test\` in this harness because the outer
+  // fixture root is hardcoded to that ID. Mirrors the production
+  // renderChild path in @barefootjs/client/runtime.
+  if (html.indexOf('__BF_PARENT_SCOPE__') !== -1) {
+    html = html.split('__BF_PARENT_SCOPE__').join('test')
+  }
   // Same attribute-ordering rule as the root-injection block below: when
   // the child root has user attributes (\`class\`, \`id\`, …) but no
   // \`bf="..."\` to anchor on, append \`bf-s\` at the end of the opening
   // tag so static attributes precede it — matching SSR's attribute
   // order (#1295 / Hono renderElement).
   const childAttrs = ' bf-s="' + scopeId + '"' + slotAttrs + keyAttr
+  // Deduplicate: if the inner template body already carries \`bf-s\` on
+  // its root (because it itself is just another renderChild call), the
+  // caller's scope is already there. Adding another \`bf-s\` produces
+  // \`<div bf-s="..." bf-s="...">\`, the duplicate-marker shape from
+  // #1320. Return the html as-is.
+  if (/^<\\w+[^>]*\\sbf-s="/.test(html)) {
+    return html
+  }
   if (html.match(/^<\\w+[^>]* bf="/)) {
     return html.replace(/ bf="/, childAttrs + ' bf="')
   }
@@ -276,6 +291,12 @@ __runInit(__lastComponent, ${JSON.stringify(props)})
 // --- Evaluate main component template ---
 const __templateFn = __templates.get(__lastComponent)
 let __html = __templateFn ? __templateFn(${JSON.stringify(props)}) : ''
+// Resolve any hoisted-children placeholder that did not pass through a
+// nested renderChild call (#1320). The outermost \`bf-s="test"\` is
+// injected below, so this substitution must run first.
+if (__html.indexOf('__BF_PARENT_SCOPE__') !== -1) {
+  __html = __html.split('__BF_PARENT_SCOPE__').join('test')
+}
 // Inject bf-s="test" on root element to match SSR scope ID convention.
 // SSR (Hono renderElement) appends bf-s AFTER user-defined attributes,
 // so for stateful roots the order is \`class="..." bf-s="..." bf="..."\`.
@@ -283,12 +304,18 @@ let __html = __templateFn ? __templateFn(${JSON.stringify(props)}) : ''
 // reactive marker); otherwise append at the end of the opening tag so
 // existing static attributes (e.g. \`class\`) come first. Falls back to
 // the tag-name-only case for tags with no attributes.
+//
+// Skip the injection when the template body's root already carries a
+// \`bf-s\` from a nested renderChild call (#1320 dedup). Adding another
+// would produce \`<div bf-s="..." bf-s="test">\`.
+if (!/^<\\w+[^>]*\\sbf-s="/.test(__html)) {
 if (__html.match(/^<\\w+[^>]* bf="/)) {
   __html = __html.replace(/ bf="/, ' bf-s="test" bf="')
 } else if (__html.match(/^<\\w+\\s[^>]*>/)) {
   __html = __html.replace(/^(<\\w+\\s[^>]*?)(\\s*\\/?>)/, '$1 bf-s="test"$2')
 } else {
   __html = __html.replace(/^(<\\w+)/, '$1 bf-s="test"')
+}
 }
 export default __html
 `

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -189,28 +189,17 @@ function renderChild(name, props, key, suffix) {
   // needs to be rewritten to track the actual parent scope at call time.
   const slotAttrs = suffix ? ' bf-h="test" bf-m="' + suffix + '"' : ''
   if (!template) return '<div bf-s="' + scopeId + '"' + slotAttrs + keyAttr + '>[' + name + ']</div>'
-  let html = template(props).trim()
-  // Substitute the hoisted-children scope placeholder (#1320) with the
-  // current parent scope — \`test\` in this harness because the outer
-  // fixture root is hardcoded to that ID. Anchored to the exact
-  // \`bf-s="__BF_PARENT_SCOPE__"\` attribute so user text that happens to
-  // contain the sentinel is left untouched. Mirrors the production
-  // renderChild path in @barefootjs/client/runtime.
-  html = html.replace(/(\\s+)?bf-s="__BF_PARENT_SCOPE__"/g, (_m, lead) => (lead ?? ' ') + 'bf-s="test"')
-  // Same attribute-ordering rule as the root-injection block below: when
-  // the child root has user attributes (\`class\`, \`id\`, …) but no
-  // \`bf="..."\` to anchor on, append \`bf-s\` at the end of the opening
-  // tag so static attributes precede it — matching SSR's attribute
-  // order (#1295 / Hono renderElement).
+  // #1320: substitute the hoisted-children placeholder with the harness's
+  // hardcoded outer scope (\`test\`). Mirrors the production renderChild
+  // in @barefootjs/client/runtime. Anchored to the exact attribute
+  // shape so user text containing the sentinel is left alone.
+  const html = template(props).trim()
+    .replace(/\\s+bf-s="__BF_PARENT_SCOPE__"/g, ' bf-s="test"')
   const bfsAttr = ' bf-s="' + scopeId + '"'
   const extraAttrs = slotAttrs + keyAttr
-  // Deduplicate \`bf-s\` only: if the inner template body already carries
-  // \`bf-s\` on its root (because it itself is just another renderChild
-  // call), the caller's scope is already there. Still inject
-  // \`slotAttrs\` / \`keyAttr\` though — \`data-key\` is the reconciliation
-  // contract mapArray reads, and \`bf-h\` / \`bf-m\` mark child membership
-  // in the parent scope; dropping them would silently regress list
-  // reconciliation conformance.
+  // Dedupe bf-s only when the child template already carries one
+  // (it was itself a renderChild call). slotAttrs / keyAttr still inject —
+  // dropping them would regress list reconciliation. (#1320)
   const childRootHasBfs = /^<\\w+[^>]*\\sbf-s="/.test(html)
   const childAttrs = childRootHasBfs ? extraAttrs : bfsAttr + extraAttrs
   if (childRootHasBfs && !extraAttrs) return html
@@ -294,23 +283,14 @@ __runInit(__lastComponent, ${JSON.stringify(props)})
 // --- Evaluate main component template ---
 const __templateFn = __templates.get(__lastComponent)
 let __html = __templateFn ? __templateFn(${JSON.stringify(props)}) : ''
-// Resolve any hoisted-children placeholder that did not pass through a
-// nested renderChild call (#1320). The outermost \`bf-s="test"\` is
-// injected below, so this substitution must run first. Anchored to
-// the exact \`bf-s="__BF_PARENT_SCOPE__"\` attribute so fixture content
-// that happens to contain the sentinel as text isn't rewritten.
-__html = __html.replace(/(\\s+)?bf-s="__BF_PARENT_SCOPE__"/g, (_m, lead) => (lead ?? ' ') + 'bf-s="test"')
-// Inject bf-s="test" on root element to match SSR scope ID convention.
-// SSR (Hono renderElement) appends bf-s AFTER user-defined attributes,
-// so for stateful roots the order is \`class="..." bf-s="..." bf="..."\`.
-// Insert before \`bf="..."\` when present (preserves bf-s adjacency to the
-// reactive marker); otherwise append at the end of the opening tag so
-// existing static attributes (e.g. \`class\`) come first. Falls back to
-// the tag-name-only case for tags with no attributes.
-//
-// Skip the injection when the template body's root already carries a
-// \`bf-s\` from a nested renderChild call (#1320 dedup). Adding another
-// would produce \`<div bf-s="..." bf-s="test">\`.
+// #1320: resolve any hoisted-children placeholder that didn't pass
+// through a nested renderChild. The outer bf-s="test" injection
+// below runs second, so this substitution must precede it.
+__html = __html.replace(/\\s+bf-s="__BF_PARENT_SCOPE__"/g, ' bf-s="test"')
+// Inject bf-s="test" on the root element to match SSR scope ID
+// convention — appended AFTER user-defined attributes, mirroring
+// Hono renderElement (#1295). Skip when the root already carries
+// bf-s from a nested renderChild call (#1320 dedup).
 if (!/^<\\w+[^>]*\\sbf-s="/.test(__html)) {
 if (__html.match(/^<\\w+[^>]* bf="/)) {
   __html = __html.replace(/ bf="/, ' bf-s="test" bf="')

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -192,25 +192,28 @@ function renderChild(name, props, key, suffix) {
   let html = template(props).trim()
   // Substitute the hoisted-children scope placeholder (#1320) with the
   // current parent scope — \`test\` in this harness because the outer
-  // fixture root is hardcoded to that ID. Mirrors the production
+  // fixture root is hardcoded to that ID. Anchored to the exact
+  // \`bf-s="__BF_PARENT_SCOPE__"\` attribute so user text that happens to
+  // contain the sentinel is left untouched. Mirrors the production
   // renderChild path in @barefootjs/client/runtime.
-  if (html.indexOf('__BF_PARENT_SCOPE__') !== -1) {
-    html = html.split('__BF_PARENT_SCOPE__').join('test')
-  }
+  html = html.replace(/(\\s+)?bf-s="__BF_PARENT_SCOPE__"/g, (_m, lead) => (lead ?? ' ') + 'bf-s="test"')
   // Same attribute-ordering rule as the root-injection block below: when
   // the child root has user attributes (\`class\`, \`id\`, …) but no
   // \`bf="..."\` to anchor on, append \`bf-s\` at the end of the opening
   // tag so static attributes precede it — matching SSR's attribute
   // order (#1295 / Hono renderElement).
-  const childAttrs = ' bf-s="' + scopeId + '"' + slotAttrs + keyAttr
-  // Deduplicate: if the inner template body already carries \`bf-s\` on
-  // its root (because it itself is just another renderChild call), the
-  // caller's scope is already there. Adding another \`bf-s\` produces
-  // \`<div bf-s="..." bf-s="...">\`, the duplicate-marker shape from
-  // #1320. Return the html as-is.
-  if (/^<\\w+[^>]*\\sbf-s="/.test(html)) {
-    return html
-  }
+  const bfsAttr = ' bf-s="' + scopeId + '"'
+  const extraAttrs = slotAttrs + keyAttr
+  // Deduplicate \`bf-s\` only: if the inner template body already carries
+  // \`bf-s\` on its root (because it itself is just another renderChild
+  // call), the caller's scope is already there. Still inject
+  // \`slotAttrs\` / \`keyAttr\` though — \`data-key\` is the reconciliation
+  // contract mapArray reads, and \`bf-h\` / \`bf-m\` mark child membership
+  // in the parent scope; dropping them would silently regress list
+  // reconciliation conformance.
+  const childRootHasBfs = /^<\\w+[^>]*\\sbf-s="/.test(html)
+  const childAttrs = childRootHasBfs ? extraAttrs : bfsAttr + extraAttrs
+  if (childRootHasBfs && !extraAttrs) return html
   if (html.match(/^<\\w+[^>]* bf="/)) {
     return html.replace(/ bf="/, childAttrs + ' bf="')
   }
@@ -293,10 +296,10 @@ const __templateFn = __templates.get(__lastComponent)
 let __html = __templateFn ? __templateFn(${JSON.stringify(props)}) : ''
 // Resolve any hoisted-children placeholder that did not pass through a
 // nested renderChild call (#1320). The outermost \`bf-s="test"\` is
-// injected below, so this substitution must run first.
-if (__html.indexOf('__BF_PARENT_SCOPE__') !== -1) {
-  __html = __html.split('__BF_PARENT_SCOPE__').join('test')
-}
+// injected below, so this substitution must run first. Anchored to
+// the exact \`bf-s="__BF_PARENT_SCOPE__"\` attribute so fixture content
+// that happens to contain the sentinel as text isn't rewritten.
+__html = __html.replace(/(\\s+)?bf-s="__BF_PARENT_SCOPE__"/g, (_m, lead) => (lead ?? ' ') + 'bf-s="test"')
 // Inject bf-s="test" on root element to match SSR scope ID convention.
 // SSR (Hono renderElement) appends bf-s AFTER user-defined attributes,
 // so for stateful roots the order is \`class="..." bf-s="..." bf="..."\`.

--- a/packages/client/__tests__/runtime/create-component-parent-scope.test.ts
+++ b/packages/client/__tests__/runtime/create-component-parent-scope.test.ts
@@ -104,13 +104,6 @@ describe('createComponent + hoisted-children scope (#1320)', () => {
   test('restores _parentScopeId after the template call (re-entrant safety)', async () => {
     const { hydrate, createComponent, renderChild } = await import('../../src/runtime')
 
-    // Two layers: Outer creates Inner, then renders a sibling span
-    // that should also see the SAME parent scope on its placeholder.
-    // If `_parentScopeId` wasn't restored on the way out of the inner
-    // `createComponent` call, the outer renderChild would see stale
-    // state on its subsequent template work. We verify the
-    // restoration by mounting two siblings via the same outer scope
-    // and checking both ended up with identical substituted scopes.
     hydrate('InnerLeaf_test1320', {
       init: () => {},
       template: (p: any) => `<div>${p.children}</div>`,
@@ -118,27 +111,75 @@ describe('createComponent + hoisted-children scope (#1320)', () => {
 
     hydrate('OuterTwo_test1320', {
       init: () => {},
-      template: () => {
-        const a = renderChild('InnerLeaf_test1320', { children: '<span data-pos="a" bf-s="__BF_PARENT_SCOPE__">A</span>' }, undefined, 's0')
-        const b = renderChild('InnerLeaf_test1320', { children: '<span data-pos="b" bf-s="__BF_PARENT_SCOPE__">B</span>' }, undefined, 's1')
-        return `<section>${a}${b}</section>`
-      },
+      template: () =>
+        `${renderChild('InnerLeaf_test1320', { children: '<span data-pos="x" bf-s="__BF_PARENT_SCOPE__">x</span>' }, undefined, 's0')}`,
     })
 
+    // First mount: creates a fresh element with slot.parent set so the
+    // placeholder substitutes to `parentScopeId`. This call sets
+    // `_parentScopeId` for the duration of the inner template eval —
+    // the assertion below catches the substitution working.
     const parentScopeId = 'OuterTwo_xyz789'
-    const el = createComponent(
+    const elWithParent = createComponent(
       'OuterTwo_test1320',
       {},
       undefined,
       { parent: parentScopeId, mount: 's0' },
     )
-    document.body.appendChild(el)
+    const innerWithParent = elWithParent.querySelector('span')
+    expect(innerWithParent!.getAttribute('bf-s')).toBe(parentScopeId)
 
-    const spans = el.querySelectorAll('span')
-    expect(spans).toHaveLength(2)
-    expect(spans[0].getAttribute('data-pos')).toBe('a')
-    expect(spans[0].getAttribute('bf-s')).toBe(parentScopeId)
-    expect(spans[1].getAttribute('data-pos')).toBe('b')
-    expect(spans[1].getAttribute('bf-s')).toBe(parentScopeId)
+    // Immediately after, mount a second instance WITHOUT slot.parent.
+    // If the first call had leaked `_parentScopeId` (no finally
+    // restore), this template eval would inherit `parentScopeId` and
+    // the placeholder would substitute. The restore makes
+    // `_parentScopeId` null at this point, so the placeholder strips.
+    const elWithoutParent = createComponent('OuterTwo_test1320', {})
+    const innerWithoutParent = elWithoutParent.querySelector('span')
+    expect(innerWithoutParent!.hasAttribute('bf-s')).toBe(false)
+  })
+
+  test('restores _parentScopeId even when the template throws', async () => {
+    const { hydrate, createComponent, renderChild } = await import('../../src/runtime')
+
+    hydrate('ThrowingChild_test1320', {
+      init: () => {},
+      template: () => { throw new Error('boom') },
+    })
+
+    hydrate('PassThroughLeaf_test1320', {
+      init: () => {},
+      template: (p: any) => `<div>${p.children}</div>`,
+    })
+
+    hydrate('PassThroughOuter_test1320', {
+      init: () => {},
+      template: () =>
+        `${renderChild('PassThroughLeaf_test1320', { children: '<span bf-s="__BF_PARENT_SCOPE__">y</span>' }, undefined, 's0')}`,
+    })
+
+    hydrate('Thrower_test1320', {
+      init: () => {},
+      template: () => `${renderChild('ThrowingChild_test1320', {}, undefined, 's0')}`,
+    })
+
+    // First call throws inside the template. The `finally` in
+    // createComponent must restore `_parentScopeId` regardless.
+    expect(() =>
+      createComponent(
+        'Thrower_test1320',
+        {},
+        undefined,
+        { parent: 'LeakedScope_abc', mount: 's0' },
+      ),
+    ).toThrow(/boom/)
+
+    // Second call: no slot.parent. If the throw had short-circuited the
+    // restore, this template would inherit `LeakedScope_abc` and the
+    // placeholder would substitute. With the finally in place,
+    // `_parentScopeId` is null and the placeholder strips.
+    const el = createComponent('PassThroughOuter_test1320', {})
+    const inner = el.querySelector('span')
+    expect(inner!.hasAttribute('bf-s')).toBe(false)
   })
 })

--- a/packages/client/__tests__/runtime/create-component-parent-scope.test.ts
+++ b/packages/client/__tests__/runtime/create-component-parent-scope.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression test for #1320: `createComponent` must thread its
+ * `slot.parent` scope through `_parentScopeId` so any hoisted-children
+ * placeholder (`bf-s="__BF_PARENT_SCOPE__"`) the template body emits
+ * resolves to the calling site's scope.
+ *
+ * Pre-fix, `createComponent` called `templateFn(unwrappedProps)`
+ * without touching `_parentScopeId`, so a component rendered via the
+ * dynamic-instance path (loop bodies, conditional branches, manual
+ * `createComponent` calls) lost its hoisted child's `bf-s` — the
+ * substitution-or-strip logic in `renderChild` stripped the
+ * placeholder on the null-parent branch, and the inner span landed
+ * in the DOM with no scope marker. This test pins the contract that
+ * `slot.parent`'s scope reaches `_parentScopeId` for the duration of
+ * the inner template eval.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('createComponent + hoisted-children scope (#1320)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('substitutes __BF_PARENT_SCOPE__ with slot.parent for a child rendered via createComponent', async () => {
+    const { hydrate, createComponent, renderChild } = await import('../../src/runtime')
+
+    // Box renders its children inline. Its template references
+    // `_p.children` verbatim — the children string is built by the
+    // outer `renderChild` call before reaching Box.
+    hydrate('Box_test1320', {
+      init: () => {},
+      template: (p: any) => `<div>${p.children}</div>`,
+    })
+
+    // Outer carries `<Box children={<span/>} />`. The compiler emits
+    // the hoisted `<span>` with the placeholder; `renderChild('Box')`
+    // substitutes it with the current `_parentScopeId` (the outer's
+    // own scope), so the rendered span ends up with the outer's
+    // bf-s value.
+    hydrate('Outer_test1320', {
+      init: () => {},
+      template: () =>
+        `${renderChild('Box_test1320', { children: '<span bf-s="__BF_PARENT_SCOPE__">x</span>' }, undefined, 's0')}`,
+      comment: true,
+    })
+
+    // Mount via `createComponent` with a slot.parent — this is the
+    // path #1320 broke. Pre-fix, the template's renderChild call saw
+    // `_parentScopeId === null` and stripped the placeholder; after
+    // the fix, `slot.parent` propagates into `_parentScopeId` for the
+    // duration of the template eval and the substitution succeeds.
+    const parentScopeId = 'OuterParent_abc123'
+    const el = createComponent(
+      'Outer_test1320',
+      {},
+      undefined,
+      { parent: parentScopeId, mount: 's0' },
+    )
+    document.body.appendChild(el)
+
+    const span = el.querySelector('span')
+    expect(span).not.toBeNull()
+    // Before the fix: `span.getAttribute('bf-s')` was `null` (placeholder
+    // stripped). After the fix: it carries the outer parent scope ID.
+    expect(span!.getAttribute('bf-s')).toBe(parentScopeId)
+  })
+
+  test('strips the placeholder when no slot.parent is provided (top-level mount)', async () => {
+    const { hydrate, createComponent, renderChild } = await import('../../src/runtime')
+
+    hydrate('TopBox_test1320', {
+      init: () => {},
+      template: (p: any) => `<div>${p.children}</div>`,
+    })
+
+    hydrate('TopOuter_test1320', {
+      init: () => {},
+      template: () =>
+        `${renderChild('TopBox_test1320', { children: '<span bf-s="__BF_PARENT_SCOPE__">x</span>' }, undefined, 's0')}`,
+      comment: true,
+    })
+
+    // No slot — top-level / standalone mount. No outer scope exists,
+    // so the placeholder strips and the span renders without a
+    // `bf-s`. (The alternative — emitting `bf-s=""` — produces an
+    // empty attribute the hydration runtime treats as a malformed
+    // scope, worse than no attribute at all.)
+    const el = createComponent('TopOuter_test1320', {})
+    document.body.appendChild(el)
+
+    const span = el.querySelector('span')
+    expect(span).not.toBeNull()
+    expect(span!.hasAttribute('bf-s')).toBe(false)
+  })
+
+  test('restores _parentScopeId after the template call (re-entrant safety)', async () => {
+    const { hydrate, createComponent, renderChild } = await import('../../src/runtime')
+
+    // Two layers: Outer creates Inner, then renders a sibling span
+    // that should also see the SAME parent scope on its placeholder.
+    // If `_parentScopeId` wasn't restored on the way out of the inner
+    // `createComponent` call, the outer renderChild would see stale
+    // state on its subsequent template work. We verify the
+    // restoration by mounting two siblings via the same outer scope
+    // and checking both ended up with identical substituted scopes.
+    hydrate('InnerLeaf_test1320', {
+      init: () => {},
+      template: (p: any) => `<div>${p.children}</div>`,
+    })
+
+    hydrate('OuterTwo_test1320', {
+      init: () => {},
+      template: () => {
+        const a = renderChild('InnerLeaf_test1320', { children: '<span data-pos="a" bf-s="__BF_PARENT_SCOPE__">A</span>' }, undefined, 's0')
+        const b = renderChild('InnerLeaf_test1320', { children: '<span data-pos="b" bf-s="__BF_PARENT_SCOPE__">B</span>' }, undefined, 's1')
+        return `<section>${a}${b}</section>`
+      },
+    })
+
+    const parentScopeId = 'OuterTwo_xyz789'
+    const el = createComponent(
+      'OuterTwo_test1320',
+      {},
+      undefined,
+      { parent: parentScopeId, mount: 's0' },
+    )
+    document.body.appendChild(el)
+
+    const spans = el.querySelectorAll('span')
+    expect(spans).toHaveLength(2)
+    expect(spans[0].getAttribute('data-pos')).toBe('a')
+    expect(spans[0].getAttribute('bf-s')).toBe(parentScopeId)
+    expect(spans[1].getAttribute('data-pos')).toBe('b')
+    expect(spans[1].getAttribute('bf-s')).toBe(parentScopeId)
+  })
+})

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -273,29 +273,39 @@ export function renderChild(
   // hoisted root carries the outer component's scope (the scope of the
   // call site that wrote `<Box children={<jsx/>} />`). When
   // `_parentScopeId` is null (top-level render), drop the attribute
-  // rather than emitting an empty `bf-s=""`.
-  if (html.includes(BF_PARENT_SCOPE)) {
-    const replacement = _parentScopeId ?? ''
-    html = replacement
-      ? html.replaceAll(BF_PARENT_SCOPE, replacement)
-      : html.replace(new RegExp(`\\s*bf-s="${BF_PARENT_SCOPE}"`, 'g'), '')
+  // rather than emitting an empty `bf-s=""`. The replacement is
+  // anchored to the exact `bf-s="..."` attribute shape so user text
+  // (or unrelated attribute values) that happens to contain the
+  // sentinel survives unchanged.
+  const placeholderAttrPattern = new RegExp(`(\\s+)?bf-s="${BF_PARENT_SCOPE}"`, 'g')
+  if (placeholderAttrPattern.test(html)) {
+    placeholderAttrPattern.lastIndex = 0
+    html = _parentScopeId
+      ? html.replace(placeholderAttrPattern, (_m, lead) => `${lead ?? ' '}bf-s="${_parentScopeId}"`)
+      : html.replace(placeholderAttrPattern, '')
   }
   // Templates may start with comment markers (e.g. <!--bf-cond-start:...-->)
   // so we find the first element tag rather than assuming index 0.
   const firstElMatch = html.match(/<(\w+)/)
   if (!firstElMatch) return html
   const insertPos = html.indexOf(firstElMatch[0])
-  // Deduplicate: when the inner template body is just a renderChild
-  // call (#1320), its returned html already carries a `bf-s` on the
-  // root and adding another one produces `<div bf-s="..." bf-s="...">`.
-  // The renderChild caller's scope is what already lives on the root,
-  // so the outer injection is the duplicate to drop.
+  // Deduplicate `bf-s` only: when the inner template body is itself a
+  // renderChild call (#1320), its returned html already carries a
+  // `bf-s` on the root, so adding another would produce
+  // `<div bf-s="..." bf-s="...">`. Still inject `slotAttrs` / `keyAttr`
+  // even in that branch — `data-key` is the reconciliation contract
+  // mapArray reads, and `bf-h` / `bf-m` mark child membership in the
+  // parent scope; dropping them along with the duplicate `bf-s` would
+  // silently regress list reconciliation.
   const afterInsert = html.slice(insertPos)
+  const extraAttrs = `${slotAttrs}${keyAttr}`
   if (/^<\w+[^>]*\sbf-s="/.test(afterInsert)) {
-    return html
+    if (!extraAttrs) return html
+    return html.slice(0, insertPos) +
+      afterInsert.replace(/^(<\w+)/, `$1${extraAttrs}`)
   }
   return html.slice(0, insertPos) +
-    afterInsert.replace(/^(<\w+)/, `$1 ${bfsAttr}${slotAttrs}${keyAttr}`)
+    afterInsert.replace(/^(<\w+)/, `$1 ${bfsAttr}${extraAttrs}`)
 }
 
 const BF_PARENT_SCOPE = '__BF_PARENT_SCOPE__'

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -11,7 +11,7 @@ import { getRegisteredDef } from './hydrate'
 import { hydratedScopes } from './hydration-state'
 import { untrack } from '@barefootjs/client/reactive'
 import { setCurrentScope } from './context'
-import { BF_SCOPE, BF_KEY, BF_HOST, BF_AT } from '@barefootjs/shared'
+import { BF_SCOPE, BF_KEY, BF_HOST, BF_AT, BF_PARENT_SCOPE_PLACEHOLDER } from '@barefootjs/shared'
 import type { ComponentDef } from './types'
 
 // Parent scope ID context for renderChild() inside insert() branch templates.
@@ -294,12 +294,11 @@ export function renderChild(
   // anchored to the exact `bf-s="..."` attribute shape so user text
   // (or unrelated attribute values) that happens to contain the
   // sentinel survives unchanged.
-  const placeholderAttrPattern = new RegExp(`(\\s+)?bf-s="${BF_PARENT_SCOPE}"`, 'g')
-  if (placeholderAttrPattern.test(html)) {
-    placeholderAttrPattern.lastIndex = 0
+  if (PLACEHOLDER_ATTR_PATTERN.test(html)) {
+    PLACEHOLDER_ATTR_PATTERN.lastIndex = 0
     html = _parentScopeId
-      ? html.replace(placeholderAttrPattern, (_m, lead) => `${lead ?? ' '}bf-s="${_parentScopeId}"`)
-      : html.replace(placeholderAttrPattern, '')
+      ? html.replace(PLACEHOLDER_ATTR_PATTERN, (_m, lead) => `${lead ?? ' '}bf-s="${_parentScopeId}"`)
+      : html.replace(PLACEHOLDER_ATTR_PATTERN, '')
   }
   // Templates may start with comment markers (e.g. <!--bf-cond-start:...-->)
   // so we find the first element tag rather than assuming index 0.
@@ -325,7 +324,15 @@ export function renderChild(
     afterInsert.replace(/^(<\w+)/, `$1 ${bfsAttr}${extraAttrs}`)
 }
 
-const BF_PARENT_SCOPE = '__BF_PARENT_SCOPE__'
+/**
+ * Module-scope regex hoisted so each `renderChild` call reuses the
+ * compiled pattern instead of allocating a fresh one. Matches the
+ * exact `bf-s="<placeholder>"` attribute shape (with optional
+ * preceding whitespace captured so dedupe-on-empty doesn't leave a
+ * dangling space). Sourced from `@barefootjs/shared` to keep emit
+ * and consume sides in lockstep (#1320).
+ */
+const PLACEHOLDER_ATTR_PATTERN = new RegExp(`(\\s+)?bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`, 'g')
 
 /**
  * Generate a random ID for scope identification

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -126,13 +126,8 @@ export function createComponent(
 
   // 4. Generate HTML from props.
   //
-  // Establish `_parentScopeId` so any hoisted-children placeholder in
-  // the template body (#1320) resolves to the calling site's scope.
-  // For components rendered as a child of a known parent, the slot
-  // info carries that scope; for top-level / standalone mounts no
-  // parent context exists, so the placeholder strips. Restore the
-  // previous value on the way out so nested createComponent calls
-  // don't see stale state.
+  // Thread `slot.parent` into `_parentScopeId` so any hoisted-children
+  // placeholder (#1320) resolves to the calling site's scope.
   const prevParentScopeId = _parentScopeId
   if (slot?.parent) {
     _parentScopeId = slot.parent
@@ -283,39 +278,27 @@ export function renderChild(
     return `<div ${bfsAttr}${slotAttrs}${keyAttr}></div>`
   }
 
-  let html = templateFn(props).trim()
-  // Hoisted JSX children embedded by the compile-time emit carry a
-  // placeholder `bf-s="__BF_PARENT_SCOPE__"` (#1320). Substitute with
-  // the current parent scope before scope marker injection so each
-  // hoisted root carries the outer component's scope (the scope of the
-  // call site that wrote `<Box children={<jsx/>} />`). When
-  // `_parentScopeId` is null (top-level render), drop the attribute
-  // rather than emitting an empty `bf-s=""`. The replacement is
-  // anchored to the exact `bf-s="..."` attribute shape so user text
-  // (or unrelated attribute values) that happens to contain the
-  // sentinel survives unchanged.
-  if (PLACEHOLDER_ATTR_PATTERN.test(html)) {
-    PLACEHOLDER_ATTR_PATTERN.lastIndex = 0
-    html = _parentScopeId
-      ? html.replace(PLACEHOLDER_ATTR_PATTERN, (_m, lead) => `${lead ?? ' '}bf-s="${_parentScopeId}"`)
-      : html.replace(PLACEHOLDER_ATTR_PATTERN, '')
-  }
+  // The placeholder substitution is anchored to the exact `bf-s="…"`
+  // shape so user content that contains the sentinel as text survives
+  // unchanged. When `_parentScopeId` is null (top-level render) the
+  // attribute strips rather than emitting `bf-s=""`. (#1320)
+  let html = templateFn(props).trim().replace(
+    PLACEHOLDER_ATTR_PATTERN,
+    _parentScopeId ? ` bf-s="${_parentScopeId}"` : '',
+  )
   // Templates may start with comment markers (e.g. <!--bf-cond-start:...-->)
   // so we find the first element tag rather than assuming index 0.
   const firstElMatch = html.match(/<(\w+)/)
   if (!firstElMatch) return html
-  const insertPos = html.indexOf(firstElMatch[0])
-  // Deduplicate `bf-s` only: when the inner template body is itself a
-  // renderChild call (#1320), its returned html already carries a
-  // `bf-s` on the root, so adding another would produce
-  // `<div bf-s="..." bf-s="...">`. Still inject `slotAttrs` / `keyAttr`
-  // even in that branch — `data-key` is the reconciliation contract
-  // mapArray reads, and `bf-h` / `bf-m` mark child membership in the
-  // parent scope; dropping them along with the duplicate `bf-s` would
-  // silently regress list reconciliation.
+  const insertPos = firstElMatch.index!
+  // Dedupe `bf-s` only when the template body's root already carries
+  // one (the body was itself a renderChild call). Still inject
+  // `slotAttrs` / `keyAttr` — `data-key` is the reconciliation
+  // contract `mapArray` reads, and `bf-h` / `bf-m` mark child
+  // membership in the parent scope. (#1320)
   const afterInsert = html.slice(insertPos)
   const extraAttrs = `${slotAttrs}${keyAttr}`
-  if (/^<\w+[^>]*\sbf-s="/.test(afterInsert)) {
+  if (ROOT_HAS_BFS_PATTERN.test(afterInsert)) {
     if (!extraAttrs) return html
     return html.slice(0, insertPos) +
       afterInsert.replace(/^(<\w+)/, `$1${extraAttrs}`)
@@ -324,15 +307,11 @@ export function renderChild(
     afterInsert.replace(/^(<\w+)/, `$1 ${bfsAttr}${extraAttrs}`)
 }
 
-/**
- * Module-scope regex hoisted so each `renderChild` call reuses the
- * compiled pattern instead of allocating a fresh one. Matches the
- * exact `bf-s="<placeholder>"` attribute shape (with optional
- * preceding whitespace captured so dedupe-on-empty doesn't leave a
- * dangling space). Sourced from `@barefootjs/shared` to keep emit
- * and consume sides in lockstep (#1320).
- */
-const PLACEHOLDER_ATTR_PATTERN = new RegExp(`(\\s+)?bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`, 'g')
+// The leading `\s+` is part of the match so dropping the attribute
+// doesn't leave a dangling space; the compiler always emits the
+// placeholder preceded by whitespace from an enclosing tag.
+const PLACEHOLDER_ATTR_PATTERN = new RegExp(`\\s+bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`, 'g')
+const ROOT_HAS_BFS_PATTERN = /^<\w+[^>]*\sbf-s="/
 
 /**
  * Generate a random ID for scope identification

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -124,8 +124,25 @@ export function createComponent(
     return result
   })
 
-  // 4. Generate HTML from props
-  const html = templateFn(unwrappedProps)
+  // 4. Generate HTML from props.
+  //
+  // Establish `_parentScopeId` so any hoisted-children placeholder in
+  // the template body (#1320) resolves to the calling site's scope.
+  // For components rendered as a child of a known parent, the slot
+  // info carries that scope; for top-level / standalone mounts no
+  // parent context exists, so the placeholder strips. Restore the
+  // previous value on the way out so nested createComponent calls
+  // don't see stale state.
+  const prevParentScopeId = _parentScopeId
+  if (slot?.parent) {
+    _parentScopeId = slot.parent
+  }
+  let html: string
+  try {
+    html = templateFn(unwrappedProps)
+  } finally {
+    _parentScopeId = prevParentScopeId
+  }
 
   // 5. Create DOM element
   const element = parseHTML(html.trim()).firstChild as HTMLElement

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -266,15 +266,39 @@ export function renderChild(
     return `<div ${bfsAttr}${slotAttrs}${keyAttr}></div>`
   }
 
-  const html = templateFn(props).trim()
+  let html = templateFn(props).trim()
+  // Hoisted JSX children embedded by the compile-time emit carry a
+  // placeholder `bf-s="__BF_PARENT_SCOPE__"` (#1320). Substitute with
+  // the current parent scope before scope marker injection so each
+  // hoisted root carries the outer component's scope (the scope of the
+  // call site that wrote `<Box children={<jsx/>} />`). When
+  // `_parentScopeId` is null (top-level render), drop the attribute
+  // rather than emitting an empty `bf-s=""`.
+  if (html.includes(BF_PARENT_SCOPE)) {
+    const replacement = _parentScopeId ?? ''
+    html = replacement
+      ? html.replaceAll(BF_PARENT_SCOPE, replacement)
+      : html.replace(new RegExp(`\\s*bf-s="${BF_PARENT_SCOPE}"`, 'g'), '')
+  }
   // Templates may start with comment markers (e.g. <!--bf-cond-start:...-->)
   // so we find the first element tag rather than assuming index 0.
   const firstElMatch = html.match(/<(\w+)/)
   if (!firstElMatch) return html
   const insertPos = html.indexOf(firstElMatch[0])
+  // Deduplicate: when the inner template body is just a renderChild
+  // call (#1320), its returned html already carries a `bf-s` on the
+  // root and adding another one produces `<div bf-s="..." bf-s="...">`.
+  // The renderChild caller's scope is what already lives on the root,
+  // so the outer injection is the duplicate to drop.
+  const afterInsert = html.slice(insertPos)
+  if (/^<\w+[^>]*\sbf-s="/.test(afterInsert)) {
+    return html
+  }
   return html.slice(0, insertPos) +
-    html.slice(insertPos).replace(/^(<\w+)/, `$1 ${bfsAttr}${slotAttrs}${keyAttr}`)
+    afterInsert.replace(/^(<\w+)/, `$1 ${bfsAttr}${slotAttrs}${keyAttr}`)
 }
+
+const BF_PARENT_SCOPE = '__BF_PARENT_SCOPE__'
 
 /**
  * Generate a random ID for scope identification

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1132,6 +1132,22 @@ describe('children passed as a JSX expression value (not nested)', () => {
     `
     expectNoFatalErrors(compile(src))
   })
+
+  // #1320: a hoisted JSX child carries the outer scope, not the inner
+  // template's. The CSR emit injects `bf-s="__BF_PARENT_SCOPE__"` on
+  // the top-level hoisted element; renderChild substitutes it with
+  // `_parentScopeId` at the layer where that is the outer scope.
+  test('children={<span/>}: CSR emits the parent-scope placeholder on hoisted root (#1320)', () => {
+    const src = `
+      function Box({ children }: { children: any }) { return <div>{children}</div> }
+      export function Demo() {
+        return <Box children={<span>x</span>} />
+      }
+    `
+    const result = compile(src)
+    expectNoFatalErrors(result)
+    expect(result.clientJs).toContain('<span bf-s="__BF_PARENT_SCOPE__">x</span>')
+  })
 })
 
 describe('Fragment with siblings as a top-level return', () => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -8,9 +8,7 @@ import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
 import { assertNever } from './walker'
-import { BF_PARENT_SCOPE_PLACEHOLDER } from '@barefootjs/shared'
-
-export { BF_PARENT_SCOPE_PLACEHOLDER }
+import { BF_PARENT_SCOPE_PLACEHOLDER, BF_SCOPE } from '@barefootjs/shared'
 
 /**
  * Protect string literals from regex-based replacements.
@@ -48,11 +46,19 @@ function childrenPropEntry(
   return `children: \`${children.map(recurse).join('')}\``
 }
 
-// `BF_PARENT_SCOPE_PLACEHOLDER` is the single source of truth shared by
-// emit (this file) and the runtime consumers (renderChild + CSR harness).
-// See `@barefootjs/shared/src/markers.ts` for its docstring and contract;
-// re-exported above so existing import paths into this file continue to
-// resolve.
+// #1320: emit a `bf-s` placeholder on the top-level hoisted element so
+// the runtime can substitute the outer component's scope. Limitation
+// for fragment-wrapped jsx-children tracked in #1335 — those land
+// with `needsScope: false` and a `needsScopeComment` fragment parent,
+// which this attribute-form gate doesn't reach.
+function maybeHoistedScopeAttr(
+  inHoistedChildren: boolean,
+  node: { needsScope?: boolean },
+): string | null {
+  return inHoistedChildren && node.needsScope
+    ? `${BF_SCOPE}="${BF_PARENT_SCOPE_PLACEHOLDER}"`
+    : null
+}
 
 /**
  * Sentinel returned by the CSR template's `transformExpr` when the expression
@@ -196,25 +202,8 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
         })
         .filter(Boolean)
 
-      // Hoisted JSX children that need a scope marker carry the outer
-      // component's scope, not the inner template's. The placeholder is
-      // substituted by `renderChild` (production + CSR harness) at the
-      // layer where `_parentScopeId` is the outer scope. Only the
-      // top-level hoisted element matters; nested children inside it
-      // have `needsScope: false` and inherit the parent template's
-      // scope chain. (#1320)
-      //
-      // Known limitation tracked in #1335: `children={<><span/></>}`
-      // (fragment-wrapped jsx-children) lands in the IR as a fragment
-      // with `needsScopeComment: true` whose direct child has
-      // `needsScope: false`, so no element-level placeholder is
-      // emitted here. The fragment-marker path is a separate scope
-      // mechanism that the current placeholder design doesn't extend
-      // to — needs either an IR-level `needsScope` promotion or a
-      // comment-marker placeholder mirroring this attribute one.
-      if (inHoistedChildren && node.needsScope) {
-        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
-      }
+      const hoistedScopeAttr = maybeHoistedScopeAttr(inHoistedChildren, node)
+      if (hoistedScopeAttr) attrParts.push(hoistedScopeAttr)
 
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)
@@ -586,12 +575,7 @@ export interface TemplateOptions {
   memoMap?: Map<string, string>
   insideLoop?: boolean
   loopDepth?: number
-  /**
-   * When true, the current emit is generating HTML for a hoisted-JSX
-   * children prop (`<Box children={<span/>} />`). Elements with
-   * `needsScope: true` emit a `bf-s` placeholder (#1320); the
-   * runtime substitutes it with the outer component's scope.
-   */
+  /** Emit `bf-s` placeholder on scoped elements inside a jsx-children prop (#1320). */
   inHoistedChildren?: boolean
 }
 
@@ -615,13 +599,9 @@ export function irToComponentTemplate(
 
 function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
   const { inlinableConstants, restSpreadNames, propsObjectName, loopDepth = 0 } = opts
-  // `recurse` preserves `inHoistedChildren` so structural pass-through
-  // nodes (fragment / conditional) keep the flag alive on the way down
-  // to the element root that actually consumes it (#1320). The element
-  // case below uses `childrenRecurse` instead to clear the flag for
-  // its own descendants — only the top-level hoisted element carries
-  // the placeholder; nested descendants take the parent template's
-  // scope chain.
+  // `recurse` preserves `inHoistedChildren` for structural pass-through
+  // (fragment / conditional); `childrenRecurse` clears it so element
+  // descendants don't re-emit the placeholder. (#1320)
   const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, opts)
   const childrenRecurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
   // Transform expression for client JS template.
@@ -701,12 +681,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
         })
         .filter(Boolean)
 
-      // See the matching block in irToHtmlTemplate (#1320). The
-      // placeholder is substituted by renderChild at the layer where
-      // `_parentScopeId` is the outer component's scope.
-      if (opts.inHoistedChildren && node.needsScope) {
-        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
-      }
+      const hoistedScopeAttr = maybeHoistedScopeAttr(!!opts.inHoistedChildren, node)
+      if (hoistedScopeAttr) attrParts.push(hoistedScopeAttr)
 
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)
@@ -1004,14 +980,10 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     return finalResult
   }
 
-  // `recurse` preserves `inHoistedChildren` so structural pass-through
-  // nodes (fragment / conditional) keep the flag alive until the
-  // element root that actually consumes it (#1320). The element case
-  // below uses `childrenRecurse` instead to clear the flag for its
-  // own descendants — only the top-level hoisted element carries the
-  // placeholder; nested descendants take the parent template's scope
-  // chain. `recurseInLoop` always clears because a loop body starts
-  // its own iteration scope.
+  // `recurse` preserves `inHoistedChildren` for structural pass-through
+  // (fragment / conditional); `childrenRecurse` and `recurseInLoop`
+  // clear it — a new element root or loop iteration starts a fresh
+  // scope. (#1320)
   const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, opts)
   const childrenRecurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
   const recurseInLoop = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, insideLoop: true, loopDepth: loopDepth + 1, inHoistedChildren: false })
@@ -1054,12 +1026,8 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         })
         .filter(Boolean)
 
-      // See the matching block in irToHtmlTemplate (#1320). The
-      // placeholder is substituted by renderChild at the layer where
-      // `_parentScopeId` is the outer component's scope.
-      if (opts.inHoistedChildren && node.needsScope) {
-        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
-      }
+      const hoistedScopeAttr = maybeHoistedScopeAttr(!!opts.inHoistedChildren, node)
+      if (hoistedScopeAttr) attrParts.push(hoistedScopeAttr)
 
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -206,6 +206,13 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // top-level hoisted element matters; nested children inside it
       // have `needsScope: false` and inherit the parent template's
       // scope chain. (#1320)
+      //
+      // Known limitation: `children={<><span/></>}` (fragment-wrapped
+      // jsx-children) lands in the IR as a fragment with
+      // `needsScopeComment: true` whose direct child has
+      // `needsScope: false`, so no element-level placeholder is emitted
+      // here. The fragment-marker path is a separate scope mechanism
+      // that the current placeholder design doesn't extend to.
       if (inHoistedChildren && node.needsScope) {
         attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
       }

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -46,6 +46,18 @@ function childrenPropEntry(
 }
 
 /**
+ * Placeholder substituted by `renderChild` with the current parent scope
+ * ID at render time. Embedded on hoisted JSX children whose IR carries
+ * `needsScope: true` — the hoisted element is owned by the outer
+ * component (the one that wrote the `<Box children={<span/>} />`
+ * expression), so its `bf-s` must match the outer's scope, not the
+ * inner template's. The substitution happens inside `renderChild`
+ * (production runtime + CSR harness) because that is the layer at
+ * which `_parentScopeId` is the outer scope. (#1320)
+ */
+export const BF_PARENT_SCOPE_PLACEHOLDER = '__BF_PARENT_SCOPE__'
+
+/**
  * Sentinel returned by the CSR template's `transformExpr` when the expression
  * references an init-body-only name (#1128). Equality with this sentinel is
  * how downstream emit sites decide to drop a renderChild prop, swap a loop
@@ -169,8 +181,8 @@ function renderTemplateAttrPart(
  *    `generateCsrTemplate` (case `'component'`). Set to `true` when generating
  *    the per-iteration `staticItemTemplate` for static loops.
  */
-export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string, insideLoop = false): string {
-  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop)
+export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, loopDepth = 0, loopParams?: ReadonlyArray<string | LoopParamSpec>, branchSlotsVar?: string, insideLoop = false, inHoistedChildren = false): string {
+  const recurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop, inHoistedChildren)
   const wrapExpr = (expr: string) => wrapExprWithLoopParams(expr, loopParams)
   const wrapInterpolation = (expr: string): string => branchSlotsVar
     ? `__bfSlot(${expr}, ${branchSlotsVar})`
@@ -187,12 +199,24 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
         })
         .filter(Boolean)
 
+      // Hoisted JSX children that need a scope marker carry the outer
+      // component's scope, not the inner template's. The placeholder is
+      // substituted by `renderChild` (production + CSR harness) at the
+      // layer where `_parentScopeId` is the outer scope. Only the
+      // top-level hoisted element matters; nested children inside it
+      // have `needsScope: false` and inherit the parent template's
+      // scope chain. (#1320)
+      if (inHoistedChildren && node.needsScope) {
+        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
+      }
+
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(recurse).join('')
+      const childrenRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop, false)
+      const children = node.children.map(childrenRecurse).join('')
 
       // Non-void elements must use open+close tags (HTML parsers ignore self-closing on div, span, etc.)
       if (children || !VOID_ELEMENTS.has(node.tag)) {
@@ -240,7 +264,8 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
           if (p.clientOnly) return null
           switch (p.value.kind) {
             case 'jsx-children': {
-              const childHtml = p.value.children.map(c => recurse(c)).join('')
+              const hoistedRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop, true)
+              const childHtml = p.value.children.map(c => hoistedRecurse(c)).join('')
               return `${quotePropName(p.name)}: \`${childHtml}\``
             }
             case 'literal':
@@ -555,6 +580,13 @@ export interface TemplateOptions {
   memoMap?: Map<string, string>
   insideLoop?: boolean
   loopDepth?: number
+  /**
+   * When true, the current emit is generating HTML for a hoisted-JSX
+   * children prop (`<Box children={<span/>} />`). Elements with
+   * `needsScope: true` emit a `bf-s` placeholder (#1320); the
+   * runtime substitutes it with the outer component's scope.
+   */
+  inHoistedChildren?: boolean
 }
 
 /**
@@ -577,7 +609,10 @@ export function irToComponentTemplate(
 
 function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
   const { inlinableConstants, restSpreadNames, propsObjectName, loopDepth = 0 } = opts
-  const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, opts)
+  // Hoisted JSX children's placeholder only applies to the immediate
+  // root of the hoisted subtree (#1320); nested elements take the
+  // outer template's scope chain. Strip the flag on the recursive call.
+  const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
   // Transform expression for client JS template.
   // Bare prop name prefixing (org → _p.org) is handled by templateExpr
   // from Phase 1 AST rewrite. Only constant inlining and props object
@@ -655,6 +690,13 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
         })
         .filter(Boolean)
 
+      // See the matching block in irToHtmlTemplate (#1320). The
+      // placeholder is substituted by renderChild at the layer where
+      // `_parentScopeId` is the outer component's scope.
+      if (opts.inHoistedChildren && node.needsScope) {
+        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
+      }
+
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)
       }
@@ -703,7 +745,8 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           if (p.clientOnly) return null
           switch (p.value.kind) {
             case 'jsx-children': {
-              const childHtml = p.value.children.map(recurse).join('')
+              const hoistedRecurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, { ...opts, inHoistedChildren: true })
+              const childHtml = p.value.children.map(c => hoistedRecurse(c)).join('')
               return `${quotePropName(p.name)}: \`${childHtml}\``
             }
             case 'literal':
@@ -950,8 +993,12 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     return finalResult
   }
 
-  const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, opts)
-  const recurseInLoop = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, insideLoop: true, loopDepth: loopDepth + 1 })
+  // Hoisted JSX children inherit the placeholder only on their root
+  // element; nested descendants take the parent template's scope chain
+  // and must not also emit the placeholder. Strip the flag for the
+  // recursive call. (#1320)
+  const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
+  const recurseInLoop = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, insideLoop: true, loopDepth: loopDepth + 1, inHoistedChildren: false })
 
   switch (node.type) {
     case 'element': {
@@ -990,6 +1037,13 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           }
         })
         .filter(Boolean)
+
+      // See the matching block in irToHtmlTemplate (#1320). The
+      // placeholder is substituted by renderChild at the layer where
+      // `_parentScopeId` is the outer component's scope.
+      if (opts.inHoistedChildren && node.needsScope) {
+        attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
+      }
 
       if (node.slotId) {
         attrParts.push(`bf="${node.slotId}"`)
@@ -1051,7 +1105,8 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           if (p.clientOnly) return null
           switch (p.value.kind) {
             case 'jsx-children': {
-              const childHtml = p.value.children.map(c => recurse(c)).join('')
+              const hoistedRecurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, inHoistedChildren: true })
+              const childHtml = p.value.children.map(c => hoistedRecurse(c)).join('')
               return `${quotePropName(p.name)}: \`${childHtml}\``
             }
             case 'literal':

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -609,10 +609,15 @@ export function irToComponentTemplate(
 
 function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
   const { inlinableConstants, restSpreadNames, propsObjectName, loopDepth = 0 } = opts
-  // Hoisted JSX children's placeholder only applies to the immediate
-  // root of the hoisted subtree (#1320); nested elements take the
-  // outer template's scope chain. Strip the flag on the recursive call.
-  const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
+  // `recurse` preserves `inHoistedChildren` so structural pass-through
+  // nodes (fragment / conditional) keep the flag alive on the way down
+  // to the element root that actually consumes it (#1320). The element
+  // case below uses `childrenRecurse` instead to clear the flag for
+  // its own descendants — only the top-level hoisted element carries
+  // the placeholder; nested descendants take the parent template's
+  // scope chain.
+  const recurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, opts)
+  const childrenRecurse = (n: IRNode): string => irToComponentTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
   // Transform expression for client JS template.
   // Bare prop name prefixing (org → _p.org) is handled by templateExpr
   // from Phase 1 AST rewrite. Only constant inlining and props object
@@ -702,7 +707,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(recurse).join('')
+      const children = node.children.map(childrenRecurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -993,11 +998,16 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     return finalResult
   }
 
-  // Hoisted JSX children inherit the placeholder only on their root
-  // element; nested descendants take the parent template's scope chain
-  // and must not also emit the placeholder. Strip the flag for the
-  // recursive call. (#1320)
-  const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
+  // `recurse` preserves `inHoistedChildren` so structural pass-through
+  // nodes (fragment / conditional) keep the flag alive until the
+  // element root that actually consumes it (#1320). The element case
+  // below uses `childrenRecurse` instead to clear the flag for its
+  // own descendants — only the top-level hoisted element carries the
+  // placeholder; nested descendants take the parent template's scope
+  // chain. `recurseInLoop` always clears because a loop body starts
+  // its own iteration scope.
+  const recurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, opts)
+  const childrenRecurse = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, inHoistedChildren: false })
   const recurseInLoop = (n: IRNode): string => generateCsrTemplateWithOpts(n, { ...opts, insideLoop: true, loopDepth: loopDepth + 1, inHoistedChildren: false })
 
   switch (node.type) {
@@ -1050,7 +1060,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(recurse).join('')
+      const children = node.children.map(childrenRecurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -8,6 +8,9 @@ import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
 import { assertNever } from './walker'
+import { BF_PARENT_SCOPE_PLACEHOLDER } from '@barefootjs/shared'
+
+export { BF_PARENT_SCOPE_PLACEHOLDER }
 
 /**
  * Protect string literals from regex-based replacements.
@@ -45,17 +48,11 @@ function childrenPropEntry(
   return `children: \`${children.map(recurse).join('')}\``
 }
 
-/**
- * Placeholder substituted by `renderChild` with the current parent scope
- * ID at render time. Embedded on hoisted JSX children whose IR carries
- * `needsScope: true` — the hoisted element is owned by the outer
- * component (the one that wrote the `<Box children={<span/>} />`
- * expression), so its `bf-s` must match the outer's scope, not the
- * inner template's. The substitution happens inside `renderChild`
- * (production runtime + CSR harness) because that is the layer at
- * which `_parentScopeId` is the outer scope. (#1320)
- */
-export const BF_PARENT_SCOPE_PLACEHOLDER = '__BF_PARENT_SCOPE__'
+// `BF_PARENT_SCOPE_PLACEHOLDER` is the single source of truth shared by
+// emit (this file) and the runtime consumers (renderChild + CSR harness).
+// See `@barefootjs/shared/src/markers.ts` for its docstring and contract;
+// re-exported above so existing import paths into this file continue to
+// resolve.
 
 /**
  * Sentinel returned by the CSR template's `transformExpr` when the expression
@@ -207,12 +204,14 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
       // have `needsScope: false` and inherit the parent template's
       // scope chain. (#1320)
       //
-      // Known limitation: `children={<><span/></>}` (fragment-wrapped
-      // jsx-children) lands in the IR as a fragment with
-      // `needsScopeComment: true` whose direct child has
-      // `needsScope: false`, so no element-level placeholder is emitted
-      // here. The fragment-marker path is a separate scope mechanism
-      // that the current placeholder design doesn't extend to.
+      // Known limitation tracked in #1335: `children={<><span/></>}`
+      // (fragment-wrapped jsx-children) lands in the IR as a fragment
+      // with `needsScopeComment: true` whose direct child has
+      // `needsScope: false`, so no element-level placeholder is
+      // emitted here. The fragment-marker path is a separate scope
+      // mechanism that the current placeholder design doesn't extend
+      // to — needs either an IR-level `needsScope` promotion or a
+      // comment-marker placeholder mirroring this attribute one.
       if (inHoistedChildren && node.needsScope) {
         attrParts.push(`bf-s="${BF_PARENT_SCOPE_PLACEHOLDER}"`)
       }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,4 +22,5 @@ export {
   BF_PLACEHOLDER,
   BF_ASYNC,
   BF_ASYNC_RESOLVE,
+  BF_PARENT_SCOPE_PLACEHOLDER,
 } from './markers'

--- a/packages/shared/src/markers.ts
+++ b/packages/shared/src/markers.ts
@@ -154,3 +154,25 @@ export const BF_ASYNC = 'bf-async'
 
 /** Async resolve template: `<template bf-async-resolve="a0">` */
 export const BF_ASYNC_RESOLVE = 'bf-async-resolve'
+
+// ---------------------------------------------------------------------------
+// Hoisted-children scope placeholder (#1320)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sentinel value embedded by the compiler on hoisted JSX children that
+ * need a `bf-s` scope marker. The runtime `renderChild` substitutes the
+ * value with the current `_parentScopeId` — i.e. the scope of the
+ * call site that wrote `<Box children={<jsx/>} />` — at render time.
+ *
+ * The placeholder is the literal `bf-s` attribute value (not just a
+ * textual marker), so substitution regexes anchor to
+ * `bf-s="<this>"` to avoid rewriting user content that happens to
+ * contain the sentinel as text.
+ *
+ * Single source of truth shared between:
+ *   - emit (`@barefootjs/jsx/ir-to-client-js/html-template.ts`)
+ *   - production runtime (`@barefootjs/client/runtime/component.ts`)
+ *   - CSR conformance harness (`@barefootjs/adapter-tests/src/csr-render.ts`)
+ */
+export const BF_PARENT_SCOPE_PLACEHOLDER = '__BF_PARENT_SCOPE__'


### PR DESCRIPTION
Resolves #1320. Stacked on top of #1329 (#1319) in the #1244 series.

## Root cause

`<Box children={<span/>} />` produced CSR client JS with two related defects:

1. **Inner span lost its `bf-s`.** The IR carries `needsScope: true` on the hoisted span, but none of the three template-emit paths (`irToHtmlTemplate`, `irToComponentTemplate`, `generateCsrTemplate`) honored that flag for elements that landed inside a `jsx-children` prop value. The SSR markedTemplate path had been masking the bug by re-emitting the JSX as TSX with an `__scopeId` closure variable — Hono's JSX runtime resolved it. The CSR string-template path had no closure.

2. **Outer wrapper had a duplicate `bf-s`.** When the outer component's template body was just a `${renderChild('Box', ...)}` call, the renderChild return already had `bf-s` on its root. The CSR conformance harness (and production `renderChild`, on cascading renderChild bodies) added another `bf-s` on top.

## Fix

1. **Placeholder injection.** Add `inHoistedChildren?: boolean` to `TemplateOptions` and to `irToHtmlTemplate`'s positional signature. When the flag is true and `node.needsScope` is true, push `bf-s="__BF_PARENT_SCOPE__"` (`BF_PARENT_SCOPE_PLACEHOLDER`) into the element's attribute list. The recursive descent strips the flag so only the top-level hoisted element gets the placeholder — nested descendants take the parent template's scope chain.

2. **Set the flag at the jsx-children prop site.** All three component-emit paths (`irToHtmlTemplate.case 'component'`, `irToComponentTemplateWithOpts.case 'component'`, `generateCsrTemplateWithOpts.case 'component'`) now build a `hoistedRecurse` that walks the children with `inHoistedChildren: true`.

3. **Substitute in `renderChild`.** Both the production runtime (`packages/client/src/runtime/component.ts`) and the CSR harness mock (`packages/adapter-tests/src/csr-render.ts`) `.replaceAll` the placeholder with the current `_parentScopeId` (the outer component's scope at this layer). When `_parentScopeId` is null, strip the attribute entirely.

4. **Dedupe.** Both `renderChild` implementations skip the wrapper `bf-s` injection if the template body's first element already carries one — that case is "this template body is itself a renderChild call."

## Side effect

The duplicate-bf-s dedup also clears `record-index-lookup-via-child-prop`, which sat in `skipFixtures` with the same symptom — both fixtures drop out of the skip set.

## Tests

- `compiler-stress-1244.test.ts` — a Layer 1 test pinning the placeholder shape in the emitted client JS.
- `csr-conformance.test.ts` — `children-jsx-expression` and `record-index-lookup-via-child-prop` are removed from `skipFixtures`.
- Fixture docstring updated.

## Test plan
- [x] `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts -t "children-jsx-expression"` — green
- [x] `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts -t "record-index-lookup-via-child-prop"` — green
- [x] `bun test packages/jsx/src/__tests__/compiler-stress-1244.test.ts -t "1320"` — green
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests` — 1835 pass, 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_