### PR TITLE
fix(#1322): lift Mojo attribute-expression refusal into BF101

### DIFF
--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -60,14 +60,6 @@ runAdapterConformanceTests({
     // never receives a `theme` key. Provider SSR coverage on Mojo
     // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: same shapes the Mojo adapter silently
-    // emits as invalid Perl that the Go adapter rejects at compile
-    // time with BF101. Stays on skipJsx (not expectedDiagnostics)
-    // until the Mojo expression gate lifts the same failures into
-    // CompilerError, matching the existing `style-object-dynamic`
-    // precedent above.
-    'style-3-signals',
-    'tagged-template-classname',
     // #1244 stress catalog: JSX spread of a reactive object — the
     // Mojo adapter silently drops the spread at emit time, same
     // shape as the Go adapter (the resulting `<div>` is missing the
@@ -111,6 +103,16 @@ runAdapterConformanceTests({
     'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1244 stress catalog #11 (#1322): JS object literal in an
+    // attribute value (`style={{ background: bg(), color: fg() }}`) has
+    // no idiomatic Mojo template form. `refuseUnsupportedAttrExpression`
+    // surfaces BF101 with a wrap-in-`/* @client */` suggestion, matching
+    // the Go adapter's behaviour.
+    'style-3-signals': [{ code: 'BF101', severity: 'error' }],
+    // #1244 stress catalog #12 (#1323): tagged-template-literal call
+    // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
+    // via the same gate.
+    'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -984,19 +984,30 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * should drop the attribute / skip the emit).
    */
   private refuseUnsupportedAttrExpression(expr: string, attrName: string): boolean {
-    const trimmed = expr.trim()
-    const startsAsObjectLiteral = trimmed.startsWith('{')
-    const hasTaggedTemplate = /[A-Za-z_$][\w$]*\s*`/.test(trimmed)
+    // Strip leading parens / whitespace so wrapped forms reach the
+    // shape pre-check — `style={({ a: b() })}` and
+    // `className={(cn`base ${tone()}`)}` are the same logical shape
+    // as their unwrapped variants and should hit the same gate.
+    let probe = expr.trim()
+    while (probe.startsWith('(')) probe = probe.slice(1).trimStart()
+    const startsAsObjectLiteral = probe.startsWith('{')
+    const hasTaggedTemplate = /[A-Za-z_$][\w$]*\s*`/.test(probe)
     if (!startsAsObjectLiteral && !hasTaggedTemplate) return false
-    const parsed = parseExpression(trimmed)
-    if (parsed.kind !== 'unsupported' && isSupported(parsed).supported) return false
+    const parsed = parseExpression(expr.trim())
+    const support = isSupported(parsed)
+    if (parsed.kind !== 'unsupported' && support.supported) return false
+    // Surface the `isSupported` reason so the diagnostic is as
+    // actionable as the Go adapter's BF101 — keeps cross-adapter
+    // diagnostics aligned on the same expression-shape gate.
+    const reason = support.reason ?? (parsed.kind === 'unsupported' ? parsed.reason : undefined)
+    const reasonLine = reason ? `\n${reason}` : ''
     this.errors.push({
       code: 'BF101',
       severity: 'error',
-      message: `Expression not supported on attribute '${attrName}': ${trimmed}`,
+      message: `Expression not supported on attribute '${attrName}': ${expr.trim()}${reasonLine}`,
       loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
       suggestion: {
-        message: 'The Mojo adapter cannot lower JS object literals or tagged-template-literal expressions into Embedded Perl. Wrap the JSX expression in /* @client */ to defer evaluation to the hydrated component, or precompute the value before the JSX site.',
+        message: 'The Mojo adapter cannot lower JS object literals or tagged-template-literal expressions into Embedded Perl. Move the expression into a `\'use client\'` component (so hydration computes it), or expand it into discrete attributes whose values are values the adapter can lower.',
       },
     })
     return true

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -36,6 +36,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  isSupported,
   identifierPath,
   stringifyParsedExpr,
   emitParsedExpr,
@@ -730,6 +731,18 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private readonly elementAttrEmitter: AttrValueEmitter = {
     emitLiteral: (value, name) => `${name}="${value.value}"`,
     emitExpression: (value, name) => {
+      // Refuse shapes that the regex pipeline silently mangles into
+      // invalid Perl (#1322). Object literals (`style={{...}}`) and
+      // tagged-template-literal call expressions (`cn\`base \${tone()}\``)
+      // have no idiomatic Mojo template form; the Go adapter raises
+      // BF101 here via `convertExpressionToGo` + `isSupported`. Lift the
+      // same gate so the user gets a clear diagnostic instead of broken
+      // output. The check runs before `convertExpressionToPerl` so the
+      // regex pipeline never produces template-text fragments for a
+      // shape we've already rejected.
+      if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
+        return ''
+      }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
         // Boolean attributes: render conditionally (present or absent).
         return `<%= ${this.convertExpressionToPerl(value.expr)} ? '${name}' : '' %>`
@@ -951,6 +964,42 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
     if (segments.length === 0) return `''`
     return segments.length === 1 ? segments[0] : `(${segments.join(' . ')})`
+  }
+
+  /**
+   * Refuse JS expression shapes that have no idiomatic Mojo template
+   * representation (#1322). Currently catches:
+   *
+   *   - Object literals (`style={{ background: bg(), color: fg() }}`):
+   *     the regex pipeline strips signal calls but leaves the
+   *     surrounding `{ k: v, ... }` syntax intact, producing invalid
+   *     Perl inside `<%= ... %>`.
+   *   - Tagged-template-literal call expressions
+   *     (`className={cn\`base \${tone()}\`}`): regex translation
+   *     produces malformed Perl with no callable target.
+   *
+   * Records `BF101` with the same shape the Go adapter emits via
+   * `convertExpressionToGo`, so cross-adapter diagnostics stay
+   * consistent. Returns `true` when the shape was rejected (caller
+   * should drop the attribute / skip the emit).
+   */
+  private refuseUnsupportedAttrExpression(expr: string, attrName: string): boolean {
+    const trimmed = expr.trim()
+    const startsAsObjectLiteral = trimmed.startsWith('{')
+    const hasTaggedTemplate = /[A-Za-z_$][\w$]*\s*`/.test(trimmed)
+    if (!startsAsObjectLiteral && !hasTaggedTemplate) return false
+    const parsed = parseExpression(trimmed)
+    if (parsed.kind !== 'unsupported' && isSupported(parsed).supported) return false
+    this.errors.push({
+      code: 'BF101',
+      severity: 'error',
+      message: `Expression not supported on attribute '${attrName}': ${trimmed}`,
+      loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+      suggestion: {
+        message: 'The Mojo adapter cannot lower JS object literals or tagged-template-literal expressions into Embedded Perl. Wrap the JSX expression in /* @client */ to defer evaluation to the hydrated component, or precompute the value before the JSX site.',
+      },
+    })
+    return true
   }
 
   private convertExpressionToPerl(expr: string): string {


### PR DESCRIPTION
Resolves #1322. Also closes #1323 (same fix covers both shapes). Stacked on #1330 (#1320) in the #1244 series.

## Root cause

Mojo's `convertExpressionToPerl` is regex-based: it substitutes `signalGetter()` → `$signal`, `props.x` → `$x`, and a handful of other shapes, then returns the result for `<%= ... %>` interpolation. JS object literals (`style={{ background: bg(), color: fg() }}`) and tagged-template-literal calls (`className={cn\`base \${tone()}\`}`) have no idiomatic Embedded Perl form. The regex strips the inner calls but leaves the surrounding `{ k: v, ... }` / tagged-template syntax intact, producing invalid Perl that renders as garbage.

The Go adapter already raises **BF101** for both shapes via `convertExpressionToGo` + `isSupported` from `expression-parser.ts`. Mojo had no equivalent gate, so it silently miscompiled and the two fixtures (`style-3-signals`, `tagged-template-classname`) sat in `skipJsx`.

## Fix

Add `refuseUnsupportedAttrExpression(expr, name)` to `MojoAdapter`. It runs at the front of `elementAttrEmitter.emitExpression`, parses the expression with the shared `parseExpression`/`isSupported`, and records BF101 with a wrap-in-`/* @client */` suggestion when the shape is rejected. A cheap pre-check (`startsWith('{')` / tagged-template regex) keeps the call out of the hot path for the common case.

Move both fixtures from `skipJsx` to `expectedDiagnostics`:
- `style-3-signals` — catalog #11 (#1322).
- `tagged-template-classname` — catalog #12 (#1323) — same family, naturally caught by the same gate.

Cross-adapter diagnostics on these two shapes now agree (BF101 on both Go and Mojo).

## Test plan
- [x] `bun test packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts` — 144 pass, 0 fail
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/adapter-mojolicious packages/adapter-go-template` — 2182 pass, 0 fail (21 skip from missing perl/go binaries — pre-existing)


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_