### PR TITLE
fix(#1324): record BF101 instead of silently dropping JSX spread (Go / Mojo)

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -56,14 +56,6 @@ runAdapterConformanceTests({
     // `Theme` field. Provider SSR coverage on go-template waits on
     // that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: JSX spread of a reactive object
-    // (`<div {...attrs()} />`). The Go template adapter silently
-    // drops the spread at emit time — the resulting `<div bf-s=...>`
-    // has none of the spread's keys, diverging from the Hono / CSR
-    // reference (`<div id="a" class="on" ...>`). Tracked as a sub-
-    // issue of #1244; lift into `expectedDiagnostics` once the
-    // adapter raises a CompilerError for the unsupported shape.
-    'jsx-spread-reactive',
     // #1244 stress catalog: member-expression JSX tag (`<Pkg.Comp />`).
     // The adapter lowers the tag to `{{template "Pkg.Comp" .Pkg.CompSlot0}}`
     // — a Go template name containing a `.` and a struct path that
@@ -125,6 +117,12 @@ runAdapterConformanceTests({
     'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1244 stress catalog #13 (#1324): JSX spread of a reactive object
+    // (`<div {...attrs()} />`). Go templates can't iterate a runtime
+    // hash into `key="value"` pairs with the escaping / event-filter
+    // semantics that Hono / CSR's `applyRestAttrs` provides, so the
+    // adapter surfaces BF101 instead of silently dropping the spread.
+    'jsx-spread-reactive': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3155,7 +3155,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Go template lowering`,
         loc: this.makeLoc(),
         suggestion: {
-          message: 'Wrap the JSX expression in /* @client */ (or in a `\'use client\'` component) to defer evaluation, or expand the spread into discrete attribute props at the call site.',
+          // The Go SSR path doesn't currently honor
+          // `IRAttribute.clientOnly` for non-rest spreads, and the
+          // client-JS pipeline skips them too — `/* @client */`
+          // wouldn't apply the spread at hydration either. Recommend
+          // the two workarounds that actually work: move the JSX
+          // into a `'use client'` component (so hydration's
+          // `spreadAttrs` helper applies the bag), or expand the
+          // spread into discrete attribute props at the call site.
+          message: 'Move the JSX into a `\'use client\'` component (so hydration applies the spread via `spreadAttrs`), or expand the spread into discrete attribute props at the call site.',
         },
       })
       return ''

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3139,10 +3139,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`
     },
     emitBooleanAttr: (_value, name) => name,
-    // Spread attributes are not directly supported in Go templates —
-    // return empty so the caller skips the entry. Matches pre-#1290
-    // `continue` behavior.
-    emitSpread: () => '',
+    // Spread attributes (`<div {...attrs()} />`) have no idiomatic Go
+    // template form — Go's `{{range}}` over a map can't emit
+    // `key="value"` pairs with HTML escaping in a way that round-trips
+    // through Hono / CSR's `applyRestAttrs` semantics. Record BF101 so
+    // the user gets a clear diagnostic instead of a silently dropped
+    // spread (#1324). The empty return drops the entry from the
+    // attribute list; `${expr}` still appears as the spread's runtime
+    // value in init code, so wrapping in `'use client'` (or pre-
+    // computing the spread as discrete props) recovers the keys.
+    emitSpread: (value) => {
+      this.errors.push({
+        code: 'BF101',
+        severity: 'error',
+        message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Go template lowering`,
+        loc: this.makeLoc(),
+        suggestion: {
+          message: 'Wrap the JSX expression in /* @client */ (or in a `\'use client\'` component) to defer evaluation, or expand the spread into discrete attribute props at the call site.',
+        },
+      })
+      return ''
+    },
     emitTemplate: (value, name) => `${name}="${this.renderTemplateLiteralParts(value.parts)}"`,
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -60,11 +60,6 @@ runAdapterConformanceTests({
     // never receives a `theme` key. Provider SSR coverage on Mojo
     // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: JSX spread of a reactive object — the
-    // Mojo adapter silently drops the spread at emit time, same
-    // shape as the Go adapter (the resulting `<div>` is missing the
-    // spread's keys). Sub-issue of #1244.
-    'jsx-spread-reactive',
     // #1244 stress catalog: member-expression JSX tag (`<Pkg.Comp />`).
     // Mojo emits the inner `Comp` template definition but the outer
     // wrapper doesn't reference it correctly, so render output
@@ -113,6 +108,12 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #1244 stress catalog #13 (#1324): JSX spread of a reactive object
+    // (`<div {...attrs()} />`). Mojo can't loop a runtime hash into
+    // `key="value"` pairs with the escaping / event-filter semantics
+    // that Hono / CSR's `applyRestAttrs` provides — surfaces BF101
+    // instead of silently dropping the spread.
+    'jsx-spread-reactive': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -765,7 +765,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Mojo template lowering`,
         loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
-          message: 'Wrap the JSX expression in /* @client */ (or in a `\'use client\'` component) to defer evaluation, or expand the spread into discrete attribute props at the call site.',
+          // The Mojo SSR path doesn't currently honor
+          // `IRAttribute.clientOnly` for non-rest spreads, and the
+          // client-JS pipeline skips them too — `/* @client */`
+          // wouldn't apply the spread at hydration either. Recommend
+          // the only two workarounds that actually work today: move
+          // the JSX into a `'use client'` component (where the
+          // hydrated runtime's `spreadAttrs` helper handles the bag),
+          // or expand the spread into discrete attribute props at the
+          // call site so each key reaches a lowering the adapter
+          // supports.
+          message: 'Move the JSX into a `\'use client\'` component (so hydration applies the spread via `spreadAttrs`), or expand the spread into discrete attribute props at the call site.',
         },
       })
       return ''

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -752,8 +752,24 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     emitBooleanAttr: (_value, name) => name,
     emitTemplate: (value, name) =>
       `${name}="<%= ${this.convertTemplateLiteralPartsToPerl(value.parts)} %>"`,
-    // Spread attributes are not directly supported on intrinsic elements yet.
-    emitSpread: () => '',
+    // Spread attributes (`<div {...attrs()} />`) have no idiomatic
+    // Embedded Perl form — looping over a hash with key-by-key
+    // attribute emission requires HTML escaping and event-handler
+    // filtering that don't round-trip through Hono / CSR's
+    // `applyRestAttrs` semantics. Record BF101 so the user gets a
+    // diagnostic instead of a silently dropped spread (#1324).
+    emitSpread: (value) => {
+      this.errors.push({
+        code: 'BF101',
+        severity: 'error',
+        message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Mojo template lowering`,
+        loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        suggestion: {
+          message: 'Wrap the JSX expression in /* @client */ (or in a `\'use client\'` component) to defer evaluation, or expand the spread into discrete attribute props at the call site.',
+        },
+      })
+      return ''
+    },
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',
     emitJsxChildren: () => '',


### PR DESCRIPTION
Resolves #1324. Stacked on #1331 (#1322) in the #1244 series.

## Root cause

Both text-template adapters had `emitSpread: () => ''` on their `elementAttrEmitter`. JSX spread (`<div {...attrs()} />`) silently disappeared at emit time — no diagnostic, no warning, just `<div bf-s="...">` with none of the spread's keys. The user got a working build that didn't match the Hono / CSR reference (which routes the shape through the `spreadAttrs(...)` runtime helper).

## Fix

Replace the empty stub on both adapters' spread emitter with a `BF101` error push that mirrors the existing object-literal / tagged-template refusals already declared on each adapter (e.g. `style-object-dynamic`, `style-3-signals`, `tagged-template-classname`). Both implementations still return `''` so the attribute drops out of the emitted markup — the diagnostic is the new behavioural contract, the dropped attribute is fallout the user is now told about. The suggestion text points at `/* @client */` (defer to hydration) or expanding the spread into discrete props at the call site.

Move `jsx-spread-reactive` from `skipJsx` to `expectedDiagnostics` on both Go and Mojo so the contract is pinned in the conformance suite.

## Test plan
- [x] `bun test packages/adapter-go-template packages/adapter-mojolicious` — 325 pass, 0 fail
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/adapter-mojolicious packages/adapter-go-template` — 2184 pass, 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_