### PR TITLE
fix(#1325): unblock Go / Mojo member-expression-tag via #1319 resolver

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -56,11 +56,6 @@ runAdapterConformanceTests({
     // `Theme` field. Provider SSR coverage on go-template waits on
     // that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: member-expression JSX tag (`<Pkg.Comp />`).
-    // The adapter lowers the tag to `{{template "Pkg.Comp" .Pkg.CompSlot0}}`
-    // — a Go template name containing a `.` and a struct path that
-    // doesn't exist. Same sub-issue follow-up as above.
-    'member-expression-tag',
     // #1244 stress catalog: `children={<span/>}` — the Hono reference
     // emits `bf-s` on the inner `<span>` (it tracks the span as a
     // hoisted child of Demo). The Go adapter doesn't carry that

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -60,11 +60,6 @@ runAdapterConformanceTests({
     // never receives a `theme` key. Provider SSR coverage on Mojo
     // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: member-expression JSX tag (`<Pkg.Comp />`).
-    // Mojo emits the inner `Comp` template definition but the outer
-    // wrapper doesn't reference it correctly, so render output
-    // diverges from the Hono / CSR reference. Sub-issue of #1244.
-    'member-expression-tag',
     // #1244 stress catalog: `children={<span/>}` — the Hono reference
     // tracks the span as a hoisted child of Demo and emits `bf-s` on
     // it. Mojo doesn't carry that scope through `<%= $children %>`


### PR DESCRIPTION
Resolves #1325. Stacked on #1332 (#1324) in the #1244 series.

## Root cause

Both text-template adapters had `member-expression-tag` in `skipJsx`. Go emitted `{{template "Pkg.Comp" .Pkg.CompSlot0}}` — a name with a `.` (invalid in Go templates) and a struct path that didn't exist. Mojo emitted the inner `Comp` definition but the outer wrapper didn't reference it.

Both failures shared a root cause with the CSR-side gap (#1319): `<Pkg.Comp />` arrived at emit with `IRComponent.name = "Pkg.Comp"`, a two-segment string the adapters then forwarded verbatim.

## Fix

The `buildComponentNamespaces` resolver landed in #1319 already rewrites the IR name to `"Comp"` at jsx-to-ir time for `const Pkg = { Comp }` namespaces. Verified end-to-end:

- Go: `{{template "Comp" .CompSlot0}}` — correct.
- Mojo: `<%== bf->render_child('comp', _bf_slot => 's0') %>` — correct.

So this PR just drops `member-expression-tag` from both adapters' `skipJsx` and lets the existing conformance suite pin the contract. No adapter-side code changes.

## Test plan
- [x] Verified Go markedTemplate output emits `{{template "Comp" .CompSlot0}}` (no dotted name).
- [x] Verified Mojo markedTemplate output emits `bf->render_child('comp', ...)` from the outer wrapper.
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/adapter-mojolicious packages/adapter-go-template` — 2186 pass, 0 fail.

> Note: live Go / Mojo template execution is skipped in CI environments without the `go` / `perl` binaries; the structural-shape conformance covers everything we can pin without those binaries.


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_