### PR TITLE
fix(#1326): route hoisted children through Mojo's children capture

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -56,13 +56,20 @@ runAdapterConformanceTests({
     // `Theme` field. Provider SSR coverage on go-template waits on
     // that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: `children={<span/>}` — the Hono reference
-    // emits `bf-s` on the inner `<span>` (it tracks the span as a
-    // hoisted child of Demo). The Go adapter doesn't carry that
-    // scope through `.Children` interpolation, so the rendered HTML
-    // omits the inner `bf-s` and diverges from expectedHtml. Same
-    // class as the existing `record-index-lookup-via-child-prop`
-    // CSR divergence; sub-issue of #1244.
+    // #1244 stress catalog (#1326): `children={<span/>}` — the IR
+    // hoists the span with `needsScope: true` so the Hono reference
+    // emits `bf-s` on the inner `<span>`. The Go adapter renders the
+    // span up front as a compile-time HTML fragment containing the
+    // `{{bfScopeAttr .}}` action, then passes it via `template.HTML`
+    // through the parent's `{{.Children}}` interpolation — but
+    // `template.HTML` is marked-as-safe-output, not recursively
+    // parsed, so the action survives as literal text in the rendered
+    // HTML. Fixing this requires either (a) re-emitting the inner
+    // span as its own named template definition the outer template
+    // can pass its struct to, or (b) embedding the resolved scope ID
+    // at compile time. Neither lands in this PR; the Mojo sibling
+    // case is handled by routing the hoisted JSX through the same
+    // `begin %>…<% end` capture as nested children (see #1326 fix).
     'children-jsx-expression',
   ],
   // Per-fixture build-time contracts for shapes the Go template

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -60,12 +60,6 @@ runAdapterConformanceTests({
     // never receives a `theme` key. Provider SSR coverage on Mojo
     // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
-    // #1244 stress catalog: `children={<span/>}` — the Hono reference
-    // tracks the span as a hoisted child of Demo and emits `bf-s` on
-    // it. Mojo doesn't carry that scope through `<%= $children %>`
-    // interpolation, so the rendered HTML omits the inner `bf-s`
-    // and diverges from expectedHtml. Sub-issue of #1244.
-    'children-jsx-expression',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -634,7 +634,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
     const propsStr = propParts.length > 0 ? ', ' + propParts.join(', ') : ''
     const tplName = this.toTemplateName(comp.name)
-    if (comp.children.length > 0) {
+    // Resolve the effective children: a nested `<Box>…</Box>` populates
+    // `comp.children`; an attribute-form `<Box children={<jsx/>} />`
+    // lands in a `jsx-children` AttrValue on the corresponding prop
+    // (#1326). The parent's scope marker is already attached to each
+    // hoisted root by the IR collector (`needsScope: true`), so the
+    // adapter just needs to render the IR through the same children
+    // pipeline as the nested form.
+    const effectiveChildren: IRNode[] = comp.children.length > 0
+      ? comp.children
+      : (comp.props.find(p => p.name === 'children' && p.value.kind === 'jsx-children')?.value as { kind: 'jsx-children'; children: IRNode[] } | undefined)?.children ?? []
+    if (effectiveChildren.length > 0) {
       // Forward JSX children via Mojo's `begin %>...<% end` capture so
       // dynamic segments inside the children (signals, conditionals)
       // get evaluated in the parent's template scope before reaching
@@ -643,7 +653,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // `render_child` would let the inner `%>` close the outer tag.
       // `render_child` materializes the resulting CODE ref into the
       // captured Mojo::ByteStream.
-      const childrenBody = this.renderChildren(comp.children)
+      const childrenBody = this.renderChildren(effectiveChildren)
       const varName = `$bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       return `<% my ${varName} = begin %>${childrenBody}<% end %><%== bf->render_child('${tplName}'${propsStr}, children => ${varName}) %>`
     }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -18,6 +18,7 @@ import type {
   IRIfStatement,
   IRProvider,
   IRAsync,
+  IRProp,
   IRTemplatePart,
   AttrValue,
   CompilerError,
@@ -103,6 +104,20 @@ const MOJO_PRIMITIVE_EMIT_MAP: Record<string, (args: string[]) => string> =
   Object.fromEntries(
     Object.entries(MOJO_TEMPLATE_PRIMITIVES).map(([k, v]) => [k, v.emit])
   )
+
+/**
+ * Find the `children` prop's `jsx-children` payload (#1326). Narrowed
+ * via the AttrValue `kind` discriminator so adapter code stays type-
+ * safe if the IR shape evolves — adding a new AttrValue variant or
+ * renaming `children` to `jsxChildren` becomes a TS compile error
+ * here instead of silently dropping the children at runtime.
+ */
+function resolveJsxChildrenProp(props: readonly IRProp[]): IRNode[] {
+  const prop = props.find(p => p.name === 'children')
+  if (!prop) return []
+  if (prop.value.kind !== 'jsx-children') return []
+  return prop.value.children
+}
 
 export interface MojoAdapterOptions {
   /** Base path for client JS files (default: '/static/components/') */
@@ -640,10 +655,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // (#1326). The parent's scope marker is already attached to each
     // hoisted root by the IR collector (`needsScope: true`), so the
     // adapter just needs to render the IR through the same children
-    // pipeline as the nested form.
+    // pipeline as the nested form. Narrow the prop value via the
+    // `kind` discriminator instead of casting to a hand-written shape;
+    // any future change to the `jsx-children` AttrValue surface will
+    // surface here as a TS compile error.
     const effectiveChildren: IRNode[] = comp.children.length > 0
       ? comp.children
-      : (comp.props.find(p => p.name === 'children' && p.value.kind === 'jsx-children')?.value as { kind: 'jsx-children'; children: IRNode[] } | undefined)?.children ?? []
+      : resolveJsxChildrenProp(comp.props)
     if (effectiveChildren.length > 0) {
       // Forward JSX children via Mojo's `begin %>...<% end` capture so
       // dynamic segments inside the children (signals, conditionals)


### PR DESCRIPTION
Resolves #1326 (Mojo half). Partial — Go half deferred with structural reason recorded in `skipJsx`. Stacked on #1333 (#1325) in the #1244 series.

## Root cause

`<Box children={<span/>} />` reached the adapter with `comp.children = []` — the hoisted span lived inside a `jsx-children` AttrValue on the corresponding prop. Mojo's `renderComponent` only checks `comp.children.length > 0` to decide whether to attach the `<% my $bf_children_sN = begin %>…<% end %>` capture, so the inner span disappeared from the rendered HTML entirely.

## Fix (Mojo)

Resolve effective children before deciding whether to attach the capture: prefer `comp.children` when populated, else read the `children` prop's `jsx-children` value. The remaining pipeline already does the right thing — the inner span renders in the parent's template scope, `bf->scope_attr` resolves to the outer component's scope, and `bf->render_child(..., children => $bf_children_sN)` ends up matching the Hono / CSR shape.

Drop `children-jsx-expression` from Mojo's `skipJsx`.

## Go: deferred

Go has the same structural shape but a different blocker: when the adapter renders the inner span up front it produces `<span bf-s="{{bfScopeAttr .}}" ...>`. That fragment then passes through `template.HTML(...)` → the parent's `{{.Children}}` interpolation, which is "mark as safe HTML" not "recursively parse as template" — so `{{bfScopeAttr .}}` survives as literal text in the rendered HTML. Fixing requires one of:

- Re-emitting the inner JSX as its own named Go template that the outer can pass its struct to.
- Embedding the resolved scope ID at compile time (only possible when the outer's scope is known statically — which it isn't).

Neither lands here. The Go `skipJsx` comment is updated to record the structural reason and point at the Mojo sibling as the easier path the catalog now has.

## Test plan
- [x] `bun test packages/adapter-mojolicious` — 157 pass, 0 fail (19 skip are perl-binary-missing)
- [x] `bun test packages/client packages/jsx packages/test packages/adapter-tests packages/adapter-mojolicious packages/adapter-go-template` — 2187 pass, 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_015hQVe7HdB1ciLQU3cuwFrc)_