### PR TITLE
fix(#1335): unwrap hoisted fragment for parent-scope placeholder

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -71,6 +71,11 @@ runAdapterConformanceTests({
     // case is handled by routing the hoisted JSX through the same
     // `begin %>…<% end` capture as nested children (see #1326 fix).
     'children-jsx-expression',
+    // #1335: fragment-wrapped form of the same shape. Now that the IR
+    // unwraps `<><span/></>` into the bare-element form, the Go adapter
+    // hits the identical `template.HTML` interpolation gap as
+    // `children-jsx-expression` above.
+    'fragment-wrapped-children-jsx-expression',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-tests/fixtures/fragment-wrapped-children-jsx-expression.ts
+++ b/packages/adapter-tests/fixtures/fragment-wrapped-children-jsx-expression.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Compiler stress (#1335 follow-up to #1320): a `children` prop whose JSX
+ * value is wrapped in a fragment (`<><span/></>`) must render the same
+ * shape as the bare-element form pinned in `children-jsx-expression`.
+ * IR collection unwraps the single-element hoisted fragment so the
+ * inner element inherits `needsScope`; the existing #1320 placeholder
+ * path then injects `bf-s="__BF_PARENT_SCOPE__"` and `renderChild`
+ * substitutes the outer scope.
+ */
+export const fixture = createFixture({
+  id: 'fragment-wrapped-children-jsx-expression',
+  description: 'fragment-wrapped children JSX-expression renders the same shape as the element form',
+  source: `
+function Box({ children }: { children: any }) { return <div>{children}</div> }
+export function FragmentWrappedChildrenJsxExpression() {
+  return <Box children={<><span>x</span></>} />
+}
+`,
+  expectedHtml: `
+    <div bf-s="test_s0"><span bf-s="test">x</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -73,6 +73,7 @@ import { fixture as taggedTemplateClassname } from './tagged-template-classname'
 import { fixture as memberExpressionTag } from './member-expression-tag'
 import { fixture as arrowComponent } from './arrow-component'
 import { fixture as childrenJsxExpression } from './children-jsx-expression'
+import { fixture as fragmentWrappedChildrenJsxExpression } from './fragment-wrapped-children-jsx-expression'
 import { fixture as restDestructureObjectInMap } from './rest-destructure-object-in-map'
 import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
 import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
@@ -155,6 +156,7 @@ export const jsxFixtures: JSXFixture[] = [
   memberExpressionTag,
   arrowComponent,
   childrenJsxExpression,
+  fragmentWrappedChildrenJsxExpression,
   // #1310: rest destructure in .map() — Hono/CSR lowers via #1309,
   // Go/Mojo refuse the loop destructure shape with BF104.
   restDestructureObjectInMap,

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1148,6 +1148,22 @@ describe('children passed as a JSX expression value (not nested)', () => {
     expectNoFatalErrors(result)
     expect(result.clientJs).toContain('<span bf-s="__BF_PARENT_SCOPE__">x</span>')
   })
+
+  // #1335: the fragment-wrapped variant must produce the same CSR
+  // emit as the bare-element form above. IR collection unwraps the
+  // single-element fragment so the inner element inherits
+  // `needsScope: true` and reaches the same #1320 placeholder gate.
+  test('children={<><span/></>}: CSR emits the parent-scope placeholder on the unwrapped element (#1335)', () => {
+    const src = `
+      function Box({ children }: { children: any }) { return <div>{children}</div> }
+      export function Demo() {
+        return <Box children={<><span>x</span></>} />
+      }
+    `
+    const result = compile(src)
+    expectNoFatalErrors(result)
+    expect(result.clientJs).toContain('<span bf-s="__BF_PARENT_SCOPE__">x</span>')
+  })
 })
 
 describe('Fragment with siblings as a top-level return', () => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -46,11 +46,12 @@ function childrenPropEntry(
   return `children: \`${children.map(recurse).join('')}\``
 }
 
-// #1320: emit a `bf-s` placeholder on the top-level hoisted element so
-// the runtime can substitute the outer component's scope. Limitation
-// for fragment-wrapped jsx-children tracked in #1335 — those land
-// with `needsScope: false` and a `needsScopeComment` fragment parent,
-// which this attribute-form gate doesn't reach.
+// #1320 / #1335: emit a `bf-s` placeholder on the top-level hoisted
+// element so the runtime can substitute the outer component's scope.
+// The bare-element form (`children={<span/>}`) sets `needsScope: true`
+// directly; the fragment-wrapped form (`children={<><span/></>}`) is
+// unwrapped at IR-collection time (`unwrapHoistedFragment` in
+// `jsx-to-ir.ts`) into the same shape, so both forms reach this gate.
 function maybeHoistedScopeAttr(
   inHoistedChildren: boolean,
   node: { needsScope?: boolean },

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -977,6 +977,29 @@ function isTransparentFragment(
   return false
 }
 
+// #1335: a fragment-wrapped jsx-children prop value lands as
+// `IRFragment{ needsScopeComment: true, children: [IRElement{ needsScope: false }] }`
+// because `transformFragment` runs while `ctx.isRoot` is still true at the
+// processComponentProps call site. The comment-based scope marker is
+// meaningful only at the component-render root; for a hoisted-children
+// prop the inner element must instead participate in #1320's
+// `bf-s="__BF_PARENT_SCOPE__"` placeholder path. Unwrap the single-element
+// case here so the IR shape mirrors the bare-element form. Multi-element
+// fragments stay unchanged (out of scope per #1335) — the comment-marker
+// approach in direction 2 is the follow-up.
+function unwrapHoistedFragment(node: IRNode): IRNode {
+  if (
+    node.type !== 'fragment' ||
+    !node.needsScopeComment ||
+    node.children.length !== 1
+  ) {
+    return node
+  }
+  const only = node.children[0]
+  if (only.type !== 'element') return node
+  return { ...only, needsScope: true }
+}
+
 function transformFragment(
   node: ts.JsxFragment,
   ctx: TransformContext
@@ -3297,7 +3320,7 @@ function processComponentProps(
         if (irNode) {
           props.push({
             name,
-            value: AttrValueOf.jsxChildren([irNode]),
+            value: AttrValueOf.jsxChildren([unwrapHoistedFragment(irNode)]),
             loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
           })
           continue


### PR DESCRIPTION
Closes #1335.

## Summary

`children={<><span/></>}` reached the CSR emit path with the inner span flagged `needsScope: false` and the enclosing fragment carrying `needsScopeComment: true`, so the element-level `bf-s="__BF_PARENT_SCOPE__"` gate from #1320 never fired and the rendered HTML diverged from the bare-element form pinned in `children-jsx-expression`.

### Root cause

`processComponentProps` builds the `jsx-children` IR while `ctx.isRoot` is still `true`. For the bare element form (`children={<span/>}`) this is correct — the span gets `needsScope: true` as it would on a component root. For a fragment in the same position (`children={<><span/></>}`), `transformFragment` reads the same `ctx.isRoot` and sets `needsScopeComment: true` on the fragment while suppressing `needsScope` on its element children. The comment-marker is meaningful only at the component-render root, not at a hoisted-children prop, so the inner element never reaches #1320's placeholder gate.

### Fix

Direction 1 from the issue: unwrap the single-element hoisted fragment at IR-collection time (`unwrapHoistedFragment` in `jsx-to-ir.ts`) so the IR shape mirrors the bare-element form, and the existing #1320 placeholder path naturally catches it. Multi-element fragments stay unchanged — direction 2 (the comment-marker placeholder) is the follow-up.

### Acceptance criteria

- [x] `fragment-wrapped-children-jsx-expression` fixture added pinning the expected `<div bf-s="test_s0"><span bf-s="test">x</span></div>` shape across Hono / CSR.
- [x] CSR conformance renders `<span bf-s="test">x</span>` inside the fragment-wrapped JSX prop.
- [x] Limitation comments at the emit sites in `html-template.ts` are removed (the single shared `maybeHoistedScopeAttr` helper that all three element-case sites call).

The Go adapter inherits the same `template.HTML` interpolation gap as `children-jsx-expression` (the `{{bfScopeAttr .}}` action survives as literal text through the parent's `{{.Children}}` pipeline), so the new fixture joins the existing Go `skipJsx` entry with a back-reference.

## Test plan

- [x] `bun test packages/adapter-tests/` — 316 → 317 pass (new fixture)
- [x] `bun test packages/jsx/` — only pre-existing `primitive-resolver-alias` failure remains
- [x] New CSR conformance fixture renders `<span bf-s="test">x</span>`
- [x] New compiler unit test in `compiler-stress-1244.test.ts` asserts `<span bf-s="__BF_PARENT_SCOPE__">x</span>` in `clientJs`
- [x] `children-jsx-expression` element-form fixture still green (no regression to #1320)

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQJRcguerj4RQjrwXfXiL)_