### PR TITLE
chore(site/core): align landing description with Hero tagline

### DIFF
--- a/site/core/landing/renderer.tsx
+++ b/site/core/landing/renderer.tsx
@@ -45,7 +45,7 @@ export const landingRenderer = jsxRenderer(
     const uiHref = hostname === 'localhost' ? 'http://localhost:3002/' : 'https://ui.barefootjs.dev'
 
     const pageTitle = title || 'Barefoot.js'
-    const pageDescription = description || 'Reactive JSX for any backend'
+    const pageDescription = description || 'TSX in. Your stack out.'
     return (
       <WithPredictableIds>
         <html lang="en">

--- a/site/core/landing/routes.tsx
+++ b/site/core/landing/routes.tsx
@@ -33,8 +33,7 @@ export async function createLandingApp() {
       </>,
       {
         title: 'Barefoot.js - Reactive TSX for any backend',
-        description:
-          'Type-safe TSX with signals and selective hydration for server-first applications.',
+        description: 'TSX in. Your stack out.',
       }
     )
   })


### PR DESCRIPTION
## Summary

- Update the landing route description and `landingRenderer` fallback to `TSX in. Your stack out.`, matching the Hero heading in `site/core/landing/components/hero.tsx`.
- `site/core/renderer.tsx` already uses this tagline as its `ogDescription` default — this brings the landing surface in line.

## Test plan

- [ ] Visit `/` locally and confirm `<meta name="description">` / `og:description` / `twitter:description` all render `TSX in. Your stack out.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)