### PR TITLE
fix(#1277): lift CSR template substitution into IR build via AST

### DIFF
--- a/packages/jsx/src/__tests__/token-contains-ident.test.ts
+++ b/packages/jsx/src/__tests__/token-contains-ident.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for `tokenContainsIdent` / `tokenContainsAny` — the lexer-aware
+ * Unit tests for `tokenContainsIdent` — the lexer-aware
  * fallback for the call sites that operate on **synthesised** expression
  * strings with no originating AST node (post-substitution CSR templates,
  * post-chain-resolve constant values).
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { tokenContainsIdent, tokenContainsAny } from '../ir-to-client-js/utils'
+import { tokenContainsIdent } from '../ir-to-client-js/utils'
 
 describe('tokenContainsIdent', () => {
   describe('positive controls', () => {
@@ -144,34 +144,3 @@ describe('tokenContainsIdent', () => {
   })
 })
 
-describe('tokenContainsAny', () => {
-  test('returns true if any name matches', () => {
-    expect(tokenContainsAny('foo + bar', ['baz', 'bar'])).toBe(true)
-  })
-
-  test('returns false if no name matches', () => {
-    expect(tokenContainsAny('foo + bar', ['baz', 'qux'])).toBe(false)
-  })
-
-  test('respects string literal boundaries for all candidates', () => {
-    expect(tokenContainsAny("'foo bar'", ['foo', 'bar'])).toBe(false)
-  })
-
-  test('respects member-access tail for all candidates', () => {
-    expect(tokenContainsAny('a.foo + b.bar', ['foo', 'bar'])).toBe(false)
-  })
-
-  test('accepts a Set<string>', () => {
-    expect(tokenContainsAny('foo + bar', new Set(['bar']))).toBe(true)
-  })
-
-  test('empty name set returns false', () => {
-    expect(tokenContainsAny('foo', [])).toBe(false)
-  })
-
-  test('short-circuits at first hit', () => {
-    // Cannot directly observe short-circuit without instrumentation; the
-    // semantic check is sufficient and consistent with the API contract.
-    expect(tokenContainsAny('x', ['x', 'y'])).toBe(true)
-  })
-})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -49,6 +49,7 @@ export interface PendingSignalTuple {
   loc: SourceLocation
   getter: string | null
   setter: string | null
+  initialFreeIdentifiers: ReadonlySet<string>
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -985,6 +985,9 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
     type,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    initialFreeIdentifiers: callExpr.arguments[0]
+      ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
+      : new Set(),
   })
 }
 
@@ -1077,6 +1080,9 @@ function collectSignalTupleRef(
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     getter: null,
     setter: null,
+    initialFreeIdentifiers: callExpr.arguments[0]
+      ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
+      : new Set(),
   })
 }
 
@@ -1104,6 +1110,9 @@ function collectSignalFromIndexAccess(
     }
 
     const loc = getSourceLocation(node, ctx.sourceFile, ctx.filePath)
+    const initialFreeIdentifiers = callExpr.arguments[0]
+      ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
+      : new Set<string>()
     if (match.index === 0) {
       ctx.signals.push({
         getter: varName,
@@ -1112,6 +1121,7 @@ function collectSignalFromIndexAccess(
         typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
         type,
         loc,
+        initialFreeIdentifiers,
       })
     } else {
       // Setter-only access: emission requires a getter name. Synthesize one
@@ -1124,6 +1134,7 @@ function collectSignalFromIndexAccess(
         typedInitialValue: typedInitialValue !== initialValue ? typedInitialValue : undefined,
         type,
         loc,
+        initialFreeIdentifiers,
       })
     }
     return
@@ -1158,6 +1169,7 @@ function flushPendingSignalTuples(ctx: AnalyzerContext): void {
       typedInitialValue: pending.typedInitialValue,
       type: pending.type,
       loc: pending.loc,
+      initialFreeIdentifiers: pending.initialFreeIdentifiers,
     })
   }
   ctx.signalTupleRefs.clear()
@@ -1195,6 +1207,9 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
     type,
     deps,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+    computationFreeIdentifiers: callExpr.arguments[0]
+      ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
+      : new Set(),
   })
 }
 

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -32,6 +32,7 @@ import type { RelocateEnv, RelocateDecision } from '../relocate'
 import { createError, ErrorCodes } from '../errors'
 import { attrValueToString } from './utils'
 import { walkIR, type IRVisitor } from './walker'
+import { buildSignalMemoEnv, csrSubstitute, type CsrEnv, type CsrSubstitution } from './csr-substitute'
 
 /**
  * Build a `RelocateEnv` from a live `ClientJsContext`. The IR-keyed env
@@ -41,9 +42,9 @@ import { walkIR, type IRVisitor } from './walker'
  *
  * Adapter capabilities (`templatePrimitives` / `acceptsTemplateCall`) are
  * threaded through so a registered call escapes the bridged-arg / zero-arg
- * inline-safety rejections (#1187 phase 3). The three call sites in this
- * package — `computeInlinability`, `buildCsrInlinableConstants`,
- * `hasInitScopeOnlyConstant` — share this helper to stay byte-identical.
+ * inline-safety rejections (#1187 phase 3). The two call sites in this
+ * package — `computeInlinability` (Stage 1 + Stage 2 `populateCsrInlinable`)
+ * and `hasInitScopeOnlyConstant` — share this helper to stay byte-identical.
  */
 export function buildEnvFromCtx(ctx: ClientJsContext): RelocateEnv {
   return buildRelocateEnvFromIR(
@@ -254,7 +255,144 @@ export function computeInlinability(
 
   const templateRiskyNames = collectTemplateRiskyNames(irRoot)
 
+  // Populate `ConstantInfo.csrInlinable` on each constant via AST
+  // substitution (#1277). This bakes the CSR-form (with signals, memos,
+  // and chained const refs expanded) into the IR so the template emitter
+  // can read it directly with no further string transformation.
+  populateCsrInlinable(ctx, env)
+
   return { constants, functions, decisionsByName, templateRiskyNames }
+}
+
+/**
+ * Compute `csrInlinable` for every `ctx.localConstants` entry via AST
+ * substitution. Constants form a DAG by name reference; we iterate
+ * to a fixed point so chained inlines (`const A = B; const B = ...`)
+ * close transitively. Each round substitutes only the consts whose
+ * `csrInlinable` has been resolved in a previous round — earliest-ready
+ * first, no name-position ambiguity (the AST walker keys on identifier
+ * names, which are unique per scope).
+ *
+ * A const ends with `csrInlinable: null` when:
+ *   - it has no `value` (placeholder-let)
+ *   - the value contains an arrow / function expression (identity per render)
+ *   - it's a system construct (`createContext`, `new WeakMap`)
+ *   - it's a JSX literal (handled by jsx-inline routing)
+ *   - the substituted form fails `isInlinableInTemplate` (would re-execute
+ *     a non-pure call at template-eval time — #1138)
+ *
+ * Order of operations matters: signals/memos substitute first via the
+ * base env, then const-on-const substitutions layer in as the chain
+ * resolves. The IIFE form for non-trivial memo bodies preserves
+ * intermediate local bindings (matches the legacy
+ * `buildSignalAndMemoMaps` extraction in `emit-registration.ts`).
+ */
+function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): void {
+  if (ctx.localConstants.length === 0) return
+
+  // Base env: signal getters + memo calls in raw (props.X) form. We
+  // keep the substitution map raw so the post-substitution
+  // `isInlinableInTemplate` check sees bridged prop references (the
+  // form `useYjs(props.X)`) and rejects them via
+  // `hasCallWithBridgedArg` (#1138). The final `_p.X` rewrite happens
+  // when the template emitter calls `csrSubstitute` on the IR text —
+  // by then it's safe because we already know the form is inline-safe.
+  const baseEnv = buildSignalMemoEnv(ctx.signals, ctx.memos, ctx.propsObjectName)
+  const constSubs = new Map<string, CsrSubstitution>()
+  const finalised = new Set<string>()
+
+  const buildEnvWithConsts = (): CsrEnv => ({
+    substitutions: new Map([...baseEnv.substitutions, ...constSubs]),
+    propsObjectName: baseEnv.propsObjectName,
+  })
+
+  // Pre-mark consts that are structurally ineligible — their
+  // `csrInlinable` stays null. The check mirrors `classifyConstantInitial`
+  // for the kinds that have no value to substitute.
+  for (const c of ctx.localConstants) {
+    if (c.isJsx || !c.value || c.containsArrow || c.systemConstructKind) {
+      c.csrInlinable = null
+      finalised.add(c.name)
+    }
+  }
+
+  // Fixed-point loop: each iteration resolves any const whose
+  // substitution succeeds. Bounded by `localConstants.length + 1` —
+  // longest possible chain.
+  const maxIter = ctx.localConstants.length + 1
+  for (let iter = 0; iter < maxIter; iter++) {
+    let progressed = false
+    const env = buildEnvWithConsts()
+    for (const c of ctx.localConstants) {
+      if (finalised.has(c.name)) continue
+      // Use raw `value` (not `templateValue`) so the relocate gate
+      // sees `props.X` and can detect bridged-arg calls. The final
+      // emit-time substitution applies the bare-prop rewrite.
+      const source = c.value!.trim()
+      const { rewritten, freeIdentifiers } = csrSubstitute(source, env)
+
+      // If the rewrite still references any unresolved local constant
+      // by name, defer to a later iteration — its substitution may
+      // become available then.
+      let pendingDependency = false
+      for (const id of freeIdentifiers) {
+        if (id === c.name) continue // self-reference: not deferrable
+        const dep = ctx.localConstants.find(o => o.name === id)
+        if (dep && !finalised.has(dep.name)) {
+          pendingDependency = true
+          break
+        }
+      }
+      if (pendingDependency) continue
+
+      // Final stage-safety check on the substituted form. The relocate
+      // gate catches the case where the post-substitution value still
+      // calls a non-pure helper with bridged args (#1138) — those must
+      // stay out of the template lambda. The relocate output
+      // (`rewrittenValue`) is the bridged form (bare destructured prop
+      // refs lifted to `_p.X`); we store that so the emit-time
+      // `applyPropsRewrite` doesn't need to redo the AST work. The
+      // free identifiers are re-extracted from the bridged form so
+      // the post-substitution unsafe-name check stays exact.
+      const inlineResult = isInlinableInTemplate(rewritten, relocateEnv)
+      if (!inlineResult.ok) {
+        c.csrInlinable = null
+      } else {
+        const bridgedRewritten = inlineResult.rewrittenValue
+        const bridgedFreeIdentifiers = recomputeFreeIdentifiers(bridgedRewritten, freeIdentifiers)
+        c.csrInlinable = { rewrittenValue: bridgedRewritten, freeIdentifiers: bridgedFreeIdentifiers }
+        constSubs.set(c.name, {
+          kind: 'identifier',
+          replacement: bridgedRewritten,
+          freeIdentifiers: bridgedFreeIdentifiers,
+        })
+      }
+      finalised.add(c.name)
+      progressed = true
+    }
+    if (!progressed) break
+  }
+
+  // Any consts left unfinalised are part of an unresolvable cycle — mark
+  // them null so the IR shape is total. In practice this is unreachable
+  // (a cycle in const-on-const refs would be a TDZ violation in source).
+  for (const c of ctx.localConstants) {
+    if (!finalised.has(c.name)) c.csrInlinable = null
+  }
+}
+
+/**
+ * Recompute free identifiers after `relocate` has rewritten bare prop
+ * refs to `_p.X`. The pre-rewrite free-id set may still mention the
+ * destructured prop names (which are now property tails under `_p`)
+ * or the source-level props object name; both stop being free
+ * identifiers in the bridged form. We re-parse the bridged text via
+ * `csrSubstitute` with an empty env to recover the post-rewrite set.
+ */
+function recomputeFreeIdentifiers(bridged: string, fallback: ReadonlySet<string>): ReadonlySet<string> {
+  const probe = csrSubstitute(bridged, { substitutions: new Map(), propsObjectName: null })
+  if (probe.rewritten === bridged) return probe.freeIdentifiers
+  return fallback
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -255,37 +255,37 @@ export function computeInlinability(
 
   const templateRiskyNames = collectTemplateRiskyNames(irRoot)
 
-  // Populate `ConstantInfo.csrInlinable` on each constant via AST
-  // substitution (#1277). This bakes the CSR-form (with signals, memos,
-  // and chained const refs expanded) into the IR so the template emitter
-  // can read it directly with no further string transformation.
+  // Populate `ctx.csrInlinable` for every constant via AST substitution
+  // (#1277). This bakes the CSR-form (with signals, memos, and chained
+  // const refs expanded) into a CSR-internal side map on the context so
+  // the template emitter can read it directly with no further string
+  // transformation. The map lives on `ClientJsContext` — not on the
+  // cross-adapter `ConstantInfo` IR — so SSR adapters don't see CSR
+  // substitution semantics they have no use for.
   populateCsrInlinable(ctx, env)
 
   return { constants, functions, decisionsByName, templateRiskyNames }
 }
 
 /**
- * Compute `csrInlinable` for every `ctx.localConstants` entry via AST
- * substitution. Constants form a DAG by name reference; we iterate
- * to a fixed point so chained inlines (`const A = B; const B = ...`)
- * close transitively. Each round substitutes only the consts whose
- * `csrInlinable` has been resolved in a previous round — earliest-ready
- * first, no name-position ambiguity (the AST walker keys on identifier
- * names, which are unique per scope).
+ * Compute the CSR-substituted form for every `ctx.localConstants` entry
+ * via AST substitution. Constants form a DAG by name reference; we
+ * iterate to a fixed point so chained inlines (`const A = B; const B = ...`)
+ * close transitively. Each round substitutes only the consts already
+ * finalised in a previous round.
  *
- * A const ends with `csrInlinable: null` when:
+ * Results land in `ctx.csrInlinable` (a CSR-internal Map on the client
+ * context), NOT on `ConstantInfo` — the substitution semantics are
+ * specific to the CSR client-JS adapter, so leaking them into the
+ * cross-adapter IR would violate the open-closed principle (#1277).
+ *
+ * A const ends with `ctx.csrInlinable.get(name) === null` when:
  *   - it has no `value` (placeholder-let)
  *   - the value contains an arrow / function expression (identity per render)
  *   - it's a system construct (`createContext`, `new WeakMap`)
  *   - it's a JSX literal (handled by jsx-inline routing)
  *   - the substituted form fails `isInlinableInTemplate` (would re-execute
  *     a non-pure call at template-eval time — #1138)
- *
- * Order of operations matters: signals/memos substitute first via the
- * base env, then const-on-const substitutions layer in as the chain
- * resolves. The IIFE form for non-trivial memo bodies preserves
- * intermediate local bindings (matches the legacy
- * `buildSignalAndMemoMaps` extraction in `emit-registration.ts`).
  */
 function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): void {
   if (ctx.localConstants.length === 0) return
@@ -306,12 +306,12 @@ function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): v
     propsObjectName: baseEnv.propsObjectName,
   })
 
-  // Pre-mark consts that are structurally ineligible — their
-  // `csrInlinable` stays null. The check mirrors `classifyConstantInitial`
+  // Pre-mark consts that are structurally ineligible — they record
+  // `null` in `ctx.csrInlinable`. Mirrors `classifyConstantInitial`
   // for the kinds that have no value to substitute.
   for (const c of ctx.localConstants) {
     if (c.isJsx || !c.value || c.containsArrow || c.systemConstructKind) {
-      c.csrInlinable = null
+      ctx.csrInlinable.set(c.name, null)
       finalised.add(c.name)
     }
   }
@@ -356,11 +356,11 @@ function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): v
       // the post-substitution unsafe-name check stays exact.
       const inlineResult = isInlinableInTemplate(rewritten, relocateEnv)
       if (!inlineResult.ok) {
-        c.csrInlinable = null
+        ctx.csrInlinable.set(c.name, null)
       } else {
         const bridgedRewritten = inlineResult.rewrittenValue
         const bridgedFreeIdentifiers = recomputeFreeIdentifiers(bridgedRewritten, freeIdentifiers)
-        c.csrInlinable = { rewrittenValue: bridgedRewritten, freeIdentifiers: bridgedFreeIdentifiers }
+        ctx.csrInlinable.set(c.name, { rewrittenValue: bridgedRewritten, freeIdentifiers: bridgedFreeIdentifiers })
         constSubs.set(c.name, {
           kind: 'identifier',
           replacement: bridgedRewritten,
@@ -374,10 +374,10 @@ function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): v
   }
 
   // Any consts left unfinalised are part of an unresolvable cycle — mark
-  // them null so the IR shape is total. In practice this is unreachable
+  // them null so the map is total. In practice this is unreachable
   // (a cycle in const-on-const refs would be a TDZ violation in source).
   for (const c of ctx.localConstants) {
-    if (!finalised.has(c.name)) c.csrInlinable = null
+    if (!finalised.has(c.name)) ctx.csrInlinable.set(c.name, null)
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -1,0 +1,405 @@
+/**
+ * AST-based CSR template substitution (#1277).
+ *
+ * The CSR template lambda runs at module scope, so any expression that
+ * lands inside it must have its component-scope-only references rewritten:
+ *
+ *   - signal getter calls (`count()`)            → `(initialValue)`
+ *   - memo getter calls   (`bars()`)             → `(computationBody)`
+ *   - bare inlinable-const refs (`label`)        → `(csrInlinable.rewrittenValue)`
+ *   - bare source-level props refs (`props.x`)   → `_p.x`
+ *
+ * Pre-#1277 this happened twice: once over const initializers
+ * (`buildCsrInlinableConstants` in `emit-registration.ts`) and once over
+ * every template expression position (the four regex loops in
+ * `transformExpr`). The second pass needed a defensive lexer scan
+ * (`tokenContainsAny`) to catch unsafe leakage that the regex couldn't
+ * prevent on its own. The duplication was the failure mode #1100 was
+ * filed against — a local memo named `bars` corrupted `ctx.bars()`
+ * because the substitution didn't respect member access.
+ *
+ * This module makes substitution AST-aware (member-access shadowing
+ * works for free), tracks the post-substitution free-id set exactly,
+ * and is run once at IR-build time. Emit reads the precomputed values
+ * directly with no string transformation of its own.
+ */
+
+import ts from 'typescript'
+import { PROPS_PARAM, inferDefaultValue } from './utils'
+import { extractFreeIdentifiersFromNode } from '../analyzer'
+import type { ClientJsContext } from './types'
+import type { ConstantInfo, MemoInfo, SignalInfo } from '../types'
+
+/**
+ * A single substitution: when the source expression mentions `name`
+ * (either bare or as a zero-arg call, depending on `kind`), the AST
+ * walker splices `replacement` in place.
+ */
+export interface CsrSubstitution {
+  kind: 'call' | 'identifier'
+  /** Replacement expression text — wrapped in parens by the splicer. */
+  replacement: string
+  /** Free identifiers of `replacement` — feeds the post-substitution free-id union. */
+  freeIdentifiers: ReadonlySet<string>
+}
+
+export interface CsrEnv {
+  /**
+   * Map of name → substitution. Call-kind entries match `name()`
+   * (zero-arg call with bare-ident callee) and replace the entire
+   * call expression; identifier-kind entries match bare uses of
+   * `name` outside member-access tails.
+   */
+  substitutions: Map<string, CsrSubstitution>
+  /** Source-level props object name (`props`); null for destructured-args. */
+  propsObjectName: string | null
+}
+
+/**
+ * Substitute an expression for CSR template scope. Returns the rewritten
+ * text plus the free identifiers of the rewritten form.
+ *
+ * Substitutions are applied via AST position scanning: the AST walk
+ * collects (start, end, replacement) tuples and the source string is
+ * spliced in a single pass. This means member-access shadowing
+ * (`ctx.bars()` when a local memo `bars` exists, #1100) is handled
+ * structurally — the property-name `bars` is never visited as a free
+ * identifier — and no `(?<![-.])` lookbehind is needed.
+ *
+ * The post-substitution free-id set is computed by re-parsing the result
+ * so chained inline expansions (const A inlines to a form that mentions
+ * const B's already-rewritten value) stay accurate without analytical
+ * bookkeeping.
+ */
+export function csrSubstitute(
+  value: string,
+  env: CsrEnv,
+): { rewritten: string; freeIdentifiers: ReadonlySet<string> } {
+  if (!value || value.trim().length === 0) {
+    return { rewritten: value, freeIdentifiers: new Set() }
+  }
+
+  // Fixed-point iteration handles substitutions whose replacements
+  // themselves mention env-resolvable names (memo body references
+  // another memo / inlinable const). Bounded by env size so we can't
+  // loop on a pathological mutual reference.
+  const maxIter = env.substitutions.size + 1
+  let current = value
+  let lastFreeIdentifiers: ReadonlySet<string> = new Set()
+  for (let i = 0; i < maxIter; i++) {
+    const step = csrSubstituteOnce(current, env)
+    lastFreeIdentifiers = step.freeIdentifiers
+    if (step.rewritten === current) break
+    current = step.rewritten
+  }
+  return { rewritten: current, freeIdentifiers: lastFreeIdentifiers }
+}
+
+function csrSubstituteOnce(
+  value: string,
+  env: CsrEnv,
+): { rewritten: string; freeIdentifiers: ReadonlySet<string> } {
+  if (!value || value.trim().length === 0) {
+    return { rewritten: value, freeIdentifiers: new Set() }
+  }
+  const sourceFile = ts.createSourceFile(
+    '__csr_substitute__.ts',
+    `(${value});`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  )
+  const stmt = sourceFile.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt)) {
+    return { rewritten: value, freeIdentifiers: extractFreeIdentifiersFromText(value) }
+  }
+  const exprNode = ts.isParenthesizedExpression(stmt.expression)
+    ? stmt.expression.expression
+    : stmt.expression
+
+  // Offset between the source positions in `sourceFile` (which prepended
+  // "(" to make the source parse as a statement) and the user's value.
+  // The opening "(" is one char; subtract it to map back.
+  const OFFSET = 1
+
+  type Splice = { start: number; end: number; text: string }
+  const splices: Splice[] = []
+
+  // Track the bound names in nested arrow/function scopes so we don't
+  // substitute identifiers shadowed by a parameter or local binding.
+  const boundStack: Array<Set<string>> = []
+  const isBound = (name: string): boolean => {
+    for (let i = boundStack.length - 1; i >= 0; i--) {
+      if (boundStack[i].has(name)) return true
+    }
+    return false
+  }
+
+  const recordSubstitution = (start: number, end: number, sub: CsrSubstitution): void => {
+    splices.push({ start: start - OFFSET, end: end - OFFSET, text: `(${sub.replacement})` })
+  }
+
+  const collectBindingNames = (name: ts.BindingName, out: Set<string>): void => {
+    if (ts.isIdentifier(name)) out.add(name.text)
+    else if (ts.isObjectBindingPattern(name)) {
+      for (const el of name.elements) collectBindingNames(el.name, out)
+    } else if (ts.isArrayBindingPattern(name)) {
+      for (const el of name.elements) {
+        if (!ts.isOmittedExpression(el)) collectBindingNames(el.name, out)
+      }
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    // Zero-arg call with bare-ident callee: `name()`. May be a signal
+    // getter or memo call we should substitute. The callee identifier is
+    // visited as part of the call (we don't recurse into it separately).
+    if (ts.isCallExpression(node) && node.arguments.length === 0 && ts.isIdentifier(node.expression)) {
+      const calleeName = node.expression.text
+      if (!isBound(calleeName)) {
+        const sub = env.substitutions.get(calleeName)
+        if (sub && sub.kind === 'call') {
+          recordSubstitution(node.getStart(sourceFile), node.getEnd(), sub)
+          return
+        }
+      }
+      // Fall through: descend into arguments (none, but keep the contract).
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    // Property access: `obj.prop` — visit `obj` (free ref), skip `prop`
+    // (member tail, structurally not a free ref). This is the structural
+    // protection that #1100 needs — `ctx.bars()` exposes `ctx` as the
+    // free ref, never `bars`.
+    if (ts.isPropertyAccessExpression(node)) {
+      visit(node.expression)
+      return
+    }
+
+    // Property assignment in object literal: `{ X: value }` — `X` is a
+    // key, not a free ref. `value` is.
+    if (ts.isPropertyAssignment(node)) {
+      visit(node.initializer)
+      return
+    }
+
+    // Shorthand property: `{ X }` — `X` IS both a key and a value
+    // reference. Treat the value side as a free ref.
+    if (ts.isShorthandPropertyAssignment(node)) {
+      if (ts.isIdentifier(node.name) && !isBound(node.name.text)) {
+        const sub = env.substitutions.get(node.name.text)
+        if (sub && sub.kind === 'identifier') {
+          // The shorthand expands to a key-value pair when we substitute,
+          // so emit `name: (replacement)` to keep the object literal
+          // grammatical. Position spans the whole shorthand.
+          splices.push({
+            start: node.getStart(sourceFile) - OFFSET,
+            end: node.getEnd() - OFFSET,
+            text: `${node.name.text}: (${sub.replacement})`,
+          })
+        }
+      }
+      return
+    }
+
+    // Arrow function: bind params, recurse, unbind.
+    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+      const bound = new Set<string>()
+      for (const p of node.parameters) collectBindingNames(p.name, bound)
+      boundStack.push(bound)
+      // Visit body only (parameter type-annotations are stripped at IR
+      // build, and we don't substitute in parameter defaults — same as
+      // the analyzer's free-id extraction).
+      if (node.body) visit(node.body)
+      boundStack.pop()
+      return
+    }
+
+    // Variable declaration introduces a local binding visible to
+    // sibling/later code in the same block; tracking that precisely
+    // would need full block-scope analysis. Same-scope substitution
+    // collisions are rare in IR expressions (`let x = ...; x + 1`
+    // appears only in `mapPreamble` style fragments), and a false
+    // positive there is detectable downstream. Visit children
+    // normally; the bound name is captured by the enclosing arrow/
+    // function's scope when one exists.
+    if (ts.isVariableDeclaration(node)) {
+      // Skip the binding name (it's a declaration, not a free ref).
+      if (node.initializer) visit(node.initializer)
+      return
+    }
+
+    // Bare identifier reference.
+    if (ts.isIdentifier(node)) {
+      if (isBound(node.text)) return
+      const sub = env.substitutions.get(node.text)
+      if (sub && sub.kind === 'identifier') {
+        recordSubstitution(node.getStart(sourceFile), node.getEnd(), sub)
+      }
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(exprNode)
+
+  // Apply splices in reverse order so earlier positions stay valid.
+  splices.sort((a, b) => b.start - a.start)
+  let rewritten = value
+  for (const s of splices) {
+    rewritten = rewritten.slice(0, s.start) + s.text + rewritten.slice(s.end)
+  }
+
+  // Note: the `propsObjectName.X → _p.X` rewrite is intentionally NOT
+  // done here. Keeping the substitution output in raw (props.X) form
+  // lets `isInlinableInTemplate` see bridged prop references and
+  // reject calls like `useYjs(props.X)` from the inline path (#1138).
+  // Callers that want the emit-form (`_p.X`) apply the rewrite via
+  // `applyPropsRewrite` after the inline-safety check.
+
+  // Compute free identifiers of the rewritten form by re-parsing. Avoids
+  // having to track analytically through nested substitutions, which is
+  // exactly the bookkeeping that made the legacy code drift from emission.
+  return { rewritten, freeIdentifiers: extractFreeIdentifiersFromText(rewritten) }
+}
+
+/**
+ * Apply the source-level `propsObjectName.X → _p.X` rewrite. Runs as
+ * a separate step (not inside `csrSubstitute`) so the substitution
+ * output stays in raw form long enough for `isInlinableInTemplate`
+ * to detect bridged-arg calls (#1138).
+ */
+export function applyPropsRewrite(text: string, propsObjectName: string | null): string {
+  if (!propsObjectName || propsObjectName === PROPS_PARAM) return text
+  return text.replace(new RegExp(`\\b${propsObjectName}\\.`, 'g'), `${PROPS_PARAM}.`)
+}
+
+function extractFreeIdentifiersFromText(text: string): Set<string> {
+  if (!text || text.trim().length === 0) return new Set()
+  const sf = ts.createSourceFile(
+    '__free_ids__.ts',
+    `(${text});`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt)) return new Set()
+  const expr = ts.isParenthesizedExpression(stmt.expression) ? stmt.expression.expression : stmt.expression
+  return extractFreeIdentifiersFromNode(expr)
+}
+
+/**
+ * Reduce a memo's `() => expr` source to the expression that should be
+ * substituted in for `memoName()`. Matches the extraction done by the
+ * legacy `buildSignalAndMemoMaps` in `emit-registration.ts`:
+ *
+ *   - `() => expr`               → `expr`
+ *   - `() => { return e; }`      → `e`
+ *   - `() => { ...complex... }`  → `(() => { ...complex... })()`
+ *
+ * The IIFE form for non-trivial blocks keeps intermediate `const`/`let`
+ * bindings in scope; inlining the block bare would dangle them.
+ */
+export function extractMemoBodyExpr(computation: string): string {
+  const arrowMatch = computation.match(/^\(\)\s*=>\s*(.+)$/s)
+  if (!arrowMatch) return computation
+  const body = arrowMatch[1].trim()
+  if (!body.startsWith('{')) return body
+  const simpleReturn = body.match(/^\{\s*return\s+([\s\S]+?)\s*;?\s*\}$/)
+  if (simpleReturn) return simpleReturn[1]
+  return `(() => ${body})()`
+}
+
+/**
+ * Build the CSR substitution env from the live `ClientJsContext`.
+ *
+ * Signals contribute call-kind entries (`count()` → `(initialValue)`).
+ * Memos contribute call-kind entries (`bars()` → `(memoBody)`).
+ *
+ * Constants are NOT added here — they're resolved separately because
+ * the `csrInlinable` AST substitution itself can reference other
+ * constants, and the chain must close at IR-build time
+ * (see `computeCsrInlinabilityChain` in `compute-inlinability.ts`).
+ * Inlinable-const substitutions are added per-component when emitting
+ * template positions via `buildExpressionSubstitutionEnv`.
+ */
+export function buildSignalMemoEnv(
+  signals: readonly SignalInfo[],
+  memos: readonly MemoInfo[],
+  propsObjectName: string | null,
+): CsrEnv {
+  const substitutions = new Map<string, CsrSubstitution>()
+  for (const s of signals) {
+    substitutions.set(s.getter, {
+      kind: 'call',
+      replacement: normalizeSignalInitial(s, propsObjectName),
+      freeIdentifiers: s.initialFreeIdentifiers ?? new Set(),
+    })
+  }
+  for (const m of memos) {
+    substitutions.set(m.name, {
+      kind: 'call',
+      replacement: extractMemoBodyExpr(m.computation),
+      freeIdentifiers: m.computationFreeIdentifiers ?? new Set(),
+    })
+  }
+  return { substitutions, propsObjectName }
+}
+
+/**
+ * Add the `?? <default>` SSR fallback to a signal's initial value when
+ * the value is a bare `propsName.X` reference. Returns the value in raw
+ * (props.X) form — the `propsObjectName → _p` rewrite is deferred to
+ * `applyPropsRewrite` at emit time so the post-substitution
+ * `isInlinableInTemplate` check still sees bridged-arg shapes (#1138).
+ *
+ * The `??` fallback prevents literal `undefined` from leaking into the
+ * SSR HTML when the prop is omitted — `inferDefaultValue` picks a
+ * type-appropriate sentinel (`0` for number, `''` for string, etc.).
+ * Skipped when the value already carries its own `??` so user-supplied
+ * defaults aren't masked.
+ */
+function normalizeSignalInitial(signal: SignalInfo, propsObjectName: string | null): string {
+  const initialValue = signal.initialValue
+  const propsName = propsObjectName ?? 'props'
+  const propsPrefix = `${propsName}.`
+  if (initialValue.startsWith(propsPrefix) && !initialValue.includes('??')) {
+    return `${initialValue} ?? ${inferDefaultValue(signal.type)}`
+  }
+  return initialValue
+}
+
+/**
+ * Extend a base env (signal+memo substitutions) with constant-inlining
+ * substitutions for the consts that have a non-null `csrInlinable`
+ * entry. Returns a fresh env so callers can layer per-position context
+ * without mutating the base.
+ */
+export function withConstantSubstitutions(
+  base: CsrEnv,
+  constants: readonly ConstantInfo[],
+): CsrEnv {
+  const substitutions = new Map(base.substitutions)
+  for (const c of constants) {
+    if (c.csrInlinable) {
+      substitutions.set(c.name, {
+        kind: 'identifier',
+        replacement: c.csrInlinable.rewrittenValue,
+        freeIdentifiers: c.csrInlinable.freeIdentifiers,
+      })
+    }
+  }
+  return { substitutions, propsObjectName: base.propsObjectName }
+}
+
+/**
+ * Convenience: build a fully-loaded CSR env (signals + memos + consts).
+ * Used by the per-template-position substitution at emit time.
+ */
+export function buildFullCsrEnv(ctx: ClientJsContext): CsrEnv {
+  const base = buildSignalMemoEnv(ctx.signals, ctx.memos, ctx.propsObjectName)
+  return withConstantSubstitutions(base, ctx.localConstants)
+}

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -27,7 +27,6 @@
 import ts from 'typescript'
 import { PROPS_PARAM, inferDefaultValue } from './utils'
 import { extractFreeIdentifiersFromNode } from '../analyzer'
-import type { ClientJsContext } from './types'
 import type { MemoInfo, SignalInfo } from '../types'
 
 /**
@@ -175,6 +174,22 @@ function csrSubstituteOnce(
     }
   }
 
+  // Walk a function body Block collecting names introduced by
+  // `var`/`let`/`const` declarations, so the enclosing function-scope
+  // bound set shadows them. Does not descend into nested functions —
+  // those have their own scope handled when `visit` reaches them.
+  const collectBlockDeclarations = (block: ts.Block, out: Set<string>): void => {
+    for (const stmt of block.statements) {
+      if (ts.isVariableStatement(stmt)) {
+        for (const decl of stmt.declarationList.declarations) {
+          collectBindingNames(decl.name, out)
+        }
+      } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+        out.add(stmt.name.text)
+      }
+    }
+  }
+
   function visit(node: ts.Node): void {
     // Zero-arg call with bare-ident callee: `name()`. May be a signal
     // getter or memo call we should substitute. The callee identifier is
@@ -228,29 +243,36 @@ function csrSubstituteOnce(
       return
     }
 
-    // Arrow function: bind params, recurse, unbind.
+    // Arrow function: bind params + any block-scoped locals declared
+    // inside the body, recurse, unbind. Pre-collecting body locals
+    // before descending matters for the IIFE shape that
+    // `extractMemoBodyExpr` produces for non-trivial memo bodies:
+    //
+    //   (() => { const items = foo; return items.length })()
+    //
+    // If a component-scope signal also happens to be named `items`,
+    // descending without binding the inner `const` would substitute
+    // `items.length` with `(initialValue).length` — wrong, because
+    // the inner `const` shadows the signal. Hoisting the binding to
+    // the function's scope here mirrors JS block-scope semantics
+    // closely enough for the shapes IR expressions take.
     if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
       const bound = new Set<string>()
       for (const p of node.parameters) collectBindingNames(p.name, bound)
+      if (node.body && ts.isBlock(node.body)) {
+        collectBlockDeclarations(node.body, bound)
+      }
       boundStack.push(bound)
-      // Visit body only (parameter type-annotations are stripped at IR
-      // build, and we don't substitute in parameter defaults — same as
-      // the analyzer's free-id extraction).
       if (node.body) visit(node.body)
       boundStack.pop()
       return
     }
 
-    // Variable declaration introduces a local binding visible to
-    // sibling/later code in the same block; tracking that precisely
-    // would need full block-scope analysis. Same-scope substitution
-    // collisions are rare in IR expressions (`let x = ...; x + 1`
-    // appears only in `mapPreamble` style fragments), and a false
-    // positive there is detectable downstream. Visit children
-    // normally; the bound name is captured by the enclosing arrow/
-    // function's scope when one exists.
+    // Variable declaration: descend into the initializer only. The
+    // binding name itself is collected at the enclosing function's
+    // scope (above) — visiting it here as an identifier would falsely
+    // count it as a free ref.
     if (ts.isVariableDeclaration(node)) {
-      // Skip the binding name (it's a declaration, not a free ref).
       if (node.initializer) visit(node.initializer)
       return
     }
@@ -345,11 +367,11 @@ export function extractMemoBodyExpr(computation: string): string {
  * Memos contribute call-kind entries (`bars()` → `(memoBody)`).
  *
  * Constants are NOT added here — they're resolved separately because
- * the `csrInlinable` AST substitution itself can reference other
- * constants, and the chain must close at IR-build time
- * (see `computeCsrInlinabilityChain` in `compute-inlinability.ts`).
- * Inlinable-const substitutions are added per-component when emitting
- * template positions via `buildExpressionSubstitutionEnv`.
+ * the substitution of a const value can itself reference other consts,
+ * and the chain must close at IR-build time (see `populateCsrInlinable`
+ * in `compute-inlinability.ts`). Inlinable-const substitutions are
+ * layered into a copy of this env at `generateCsrTemplate`'s entry,
+ * reading from `ClientJsContext.csrInlinable`.
  */
 export function buildSignalMemoEnv(
   signals: readonly SignalInfo[],
@@ -397,34 +419,3 @@ function normalizeSignalInitial(signal: SignalInfo, propsObjectName: string | nu
   return initialValue
 }
 
-/**
- * Extend a base env (signal+memo substitutions) with constant-inlining
- * substitutions for the consts whose `csrInlinable` map entry is
- * non-null. Returns a fresh env so callers can layer per-position
- * context without mutating the base.
- */
-export function withConstantSubstitutions(
-  base: CsrEnv,
-  csrInlinable: CsrInlinabilityMap,
-): CsrEnv {
-  const substitutions = new Map(base.substitutions)
-  for (const [name, entry] of csrInlinable) {
-    if (entry) {
-      substitutions.set(name, {
-        kind: 'identifier',
-        replacement: entry.rewrittenValue,
-        freeIdentifiers: entry.freeIdentifiers,
-      })
-    }
-  }
-  return { substitutions, propsObjectName: base.propsObjectName }
-}
-
-/**
- * Convenience: build a fully-loaded CSR env (signals + memos + consts).
- * Used by the per-template-position substitution at emit time.
- */
-export function buildFullCsrEnv(ctx: ClientJsContext): CsrEnv {
-  const base = buildSignalMemoEnv(ctx.signals, ctx.memos, ctx.propsObjectName)
-  return withConstantSubstitutions(base, ctx.csrInlinable)
-}

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -28,7 +28,32 @@ import ts from 'typescript'
 import { PROPS_PARAM, inferDefaultValue } from './utils'
 import { extractFreeIdentifiersFromNode } from '../analyzer'
 import type { ClientJsContext } from './types'
-import type { ConstantInfo, MemoInfo, SignalInfo } from '../types'
+import type { MemoInfo, SignalInfo } from '../types'
+
+/**
+ * CSR-substituted const value: the const's initializer with every
+ * signal getter call, memo call, and reference to another CSR-inlinable
+ * constant expanded via AST substitution (#1277). `freeIdentifiers` is
+ * the free-id set of the rewritten AST — already transitively closed
+ * through chained inlines — and is what the unsafe-name check
+ * intersects with `unsafeLocalNames`.
+ *
+ * Lives on `ClientJsContext` (`csrInlinable`), NOT on the cross-adapter
+ * `ConstantInfo` IR — substitution semantics are specific to the CSR
+ * client-JS adapter and would be dead weight for SSR consumers.
+ */
+export interface CsrInlinableEntry {
+  rewrittenValue: string
+  freeIdentifiers: ReadonlySet<string>
+}
+
+/**
+ * Constant-name → resolved CSR form. `null` marks the const as unsafe
+ * to inline (placeholder-let, arrow-literal, system-construct,
+ * jsx-inline, or post-substitution form that fails the relocate
+ * inline-safety gate — #1138).
+ */
+export type CsrInlinabilityMap = Map<string, CsrInlinableEntry | null>
 
 /**
  * A single substitution: when the source expression mentions `name`
@@ -374,21 +399,21 @@ function normalizeSignalInitial(signal: SignalInfo, propsObjectName: string | nu
 
 /**
  * Extend a base env (signal+memo substitutions) with constant-inlining
- * substitutions for the consts that have a non-null `csrInlinable`
- * entry. Returns a fresh env so callers can layer per-position context
- * without mutating the base.
+ * substitutions for the consts whose `csrInlinable` map entry is
+ * non-null. Returns a fresh env so callers can layer per-position
+ * context without mutating the base.
  */
 export function withConstantSubstitutions(
   base: CsrEnv,
-  constants: readonly ConstantInfo[],
+  csrInlinable: CsrInlinabilityMap,
 ): CsrEnv {
   const substitutions = new Map(base.substitutions)
-  for (const c of constants) {
-    if (c.csrInlinable) {
-      substitutions.set(c.name, {
+  for (const [name, entry] of csrInlinable) {
+    if (entry) {
+      substitutions.set(name, {
         kind: 'identifier',
-        replacement: c.csrInlinable.rewrittenValue,
-        freeIdentifiers: c.csrInlinable.freeIdentifiers,
+        replacement: entry.rewrittenValue,
+        freeIdentifiers: entry.freeIdentifiers,
       })
     }
   }
@@ -401,5 +426,5 @@ export function withConstantSubstitutions(
  */
 export function buildFullCsrEnv(ctx: ClientJsContext): CsrEnv {
   const base = buildSignalMemoEnv(ctx.signals, ctx.memos, ctx.propsObjectName)
-  return withConstantSubstitutions(base, ctx.localConstants)
+  return withConstantSubstitutions(base, ctx.csrInlinable)
 }

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -96,20 +96,19 @@ export function buildInlinableConstants(
 }
 
 /**
- * Materialise the CSR-inlining map from each constant's `csrInlinable`
- * IR entry (#1277). Replaces `buildCsrInlinableConstants` (the AST
- * substitution + chain resolution now lives in `compute-inlinability`).
+ * Materialise the CSR-inlining map from the context's `csrInlinable`
+ * side map (populated by `populateCsrInlinable` during
+ * `compute-inlinability`, #1277). Replaces `buildCsrInlinableConstants`
+ * — the AST substitution + chain resolution now lives upstream.
  *
- * Excludes constants whose `csrInlinable` is null — those stay in
- * `unsafeLocalNames` and the CSR template's expression substitution
- * surfaces the UNSAFE sentinel for any reference to them.
+ * Excludes constants whose entry is `null` (unsafe to inline) — those
+ * stay in `unsafeLocalNames` and the CSR template's expression
+ * substitution surfaces the UNSAFE sentinel for any reference to them.
  */
-export function csrInlinableConstantsFromIR(ctx: ClientJsContext): Map<string, string> {
+export function csrInlinableConstantsFromCtx(ctx: ClientJsContext): Map<string, string> {
   const out = new Map<string, string>()
-  for (const c of ctx.localConstants) {
-    if (c.csrInlinable) {
-      out.set(c.name, c.csrInlinable.rewrittenValue)
-    }
+  for (const [name, entry] of ctx.csrInlinable) {
+    if (entry) out.set(name, entry.rewrittenValue)
   }
   return out
 }
@@ -163,10 +162,11 @@ export function emitRegistrationAndHydration(
     // Components may be imported and used in conditional branches in other files,
     // where renderChild() needs a registered template to render HTML correctly.
     // Substitution data (signal initial values, memo bodies, chain-resolved
-    // const inlines) is read directly from `ConstantInfo.csrInlinable` /
-    // `SignalInfo.initialFreeIdentifiers` / `MemoInfo.computationFreeIdentifiers`
-    // — no post-hoc string transformation runs at this layer (#1277).
-    const csrInlinableConstants = csrInlinableConstantsFromIR(ctx)
+    // const inlines) is read directly from `ctx.csrInlinable` (CSR-internal
+    // side map) / `SignalInfo.initialFreeIdentifiers` /
+    // `MemoInfo.computationFreeIdentifiers` — no post-hoc string
+    // transformation runs at this layer (#1277).
+    const csrInlinableConstants = csrInlinableConstantsFromCtx(ctx)
     const templateHtml = generateCsrTemplate(
       _ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
     )

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -6,10 +6,8 @@
 
 import type { ComponentIR, IRFragment, IRNode, ReferencesGraph } from '../types'
 import type { ClientJsContext } from './types'
-import { PROPS_PARAM, inferDefaultValue } from './utils'
+import { PROPS_PARAM } from './utils'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability'
-import { isInlinableInTemplate } from '../relocate'
-import { buildEnvFromCtx } from './compute-inlinability'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, createStringProtector } from './html-template'
 import { nameForRegistryRef } from './component-scope'
 
@@ -98,154 +96,22 @@ export function buildInlinableConstants(
 }
 
 /**
- * Build signal and memo maps for CSR template generation.
- * Signal map: getter name → initial value expression
- * Memo map: memo name → computation expression with signal calls replaced by initial values
- */
-export function buildSignalAndMemoMaps(ctx: ClientJsContext): {
-  signalMap: Map<string, string>
-  memoMap: Map<string, string>
-} {
-  const propsName = ctx.propsObjectName ?? 'props'
-  const propsPrefix = `${propsName}.`
-
-  const signalMap = new Map<string, string>()
-  for (const signal of ctx.signals) {
-    let initialValue = signal.initialValue
-    // Normalize custom props object name to PROPS_PARAM and add default fallback
-    // to match emitSignalsAndMemos() behavior (prevents undefined rendering in CSR)
-    if (ctx.propsObjectName && initialValue.startsWith(propsPrefix)) {
-      const propRef = `${PROPS_PARAM}.` + initialValue.slice(propsPrefix.length)
-      if (!initialValue.includes('??')) {
-        initialValue = `${propRef} ?? ${inferDefaultValue(signal.type)}`
-      } else {
-        initialValue = propRef
-      }
-    } else if (initialValue.startsWith('props.') && !initialValue.includes('??')) {
-      initialValue = `${PROPS_PARAM}.${initialValue.slice('props.'.length)} ?? ${inferDefaultValue(signal.type)}`
-    }
-    signalMap.set(signal.getter, initialValue)
-  }
-
-  const memoMap = new Map<string, string>()
-  for (const memo of ctx.memos) {
-    let expr = memo.computation
-    // Extract the function body from arrow function: () => count() * 2 → count() * 2
-    // Supports both expression arrows `() => expr` and block arrows `() => { return expr }`
-    const arrowMatch = expr.match(/^\(\)\s*=>\s*(.+)$/s)
-    if (arrowMatch) {
-      const body = arrowMatch[1].trim()
-      if (body.startsWith('{')) {
-        // Block body: detect the trivial `{ return <expr>; }` shape. A bare
-        // return expression can be inlined directly. Any other body (local
-        // `const`/`let` declarations, guard clauses, multiple statements)
-        // must be wrapped in an IIFE so that intermediate bindings remain in
-        // scope when the expression is inlined into the SSR template.
-        const simpleReturn = body.match(/^\{\s*return\s+([\s\S]+?)\s*;?\s*\}$/)
-        if (simpleReturn) {
-          expr = simpleReturn[1]
-        } else {
-          expr = `(() => ${body})()`
-        }
-      } else {
-        expr = body
-      }
-    }
-    // Replace signal getter calls with initial values.
-    // `(?<![-.])` skips member accesses (e.g. `ctx.count()`) so a local
-    // signal whose name matches a context method is preserved (#1100).
-    for (const [getter, initial] of signalMap) {
-      expr = expr.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${initial})`)
-    }
-    memoMap.set(memo.name, expr)
-  }
-
-  // Resolve chained memo references: if memo A references memo B(),
-  // replace B() with B's resolved computation expression.
-  let changed = true
-  const maxIter = memoMap.size + 1
-  let iter = 0
-  while (changed && iter < maxIter) {
-    changed = false
-    iter++
-    for (const [memoName, memoExpr] of memoMap) {
-      let newExpr = memoExpr
-      for (const [otherName, otherExpr] of memoMap) {
-        if (otherName === memoName) continue
-        // `(?<![-.])` keeps the substitution off member accesses such as
-        // `ctx.bars()` when a local memo `bars` exists (#1100).
-        const replaced = newExpr.replace(new RegExp(`(?<![-.])\\b${otherName}\\(\\)`, 'g'), `(${otherExpr})`)
-        if (replaced !== newExpr) {
-          newExpr = replaced
-          changed = true
-        }
-      }
-      if (newExpr !== memoExpr) {
-        memoMap.set(memoName, newExpr)
-      }
-    }
-  }
-
-  return { signalMap, memoMap }
-}
-
-/**
- * Build an expanded inlinable constants map for CSR template generation.
- * Re-promotes constants that were demoted to unsafeLocalNames by resolving
- * signal/memo call expressions with their initial values.
+ * Materialise the CSR-inlining map from each constant's `csrInlinable`
+ * IR entry (#1277). Replaces `buildCsrInlinableConstants` (the AST
+ * substitution + chain resolution now lives in `compute-inlinability`).
  *
- * `propsObjectName`, when supplied, is the source-level name the user gave
- * the props parameter (e.g. `props`). A re-promoted value that still
- * contains a bare reference to it (`makeStore(props)`) is rejected: the
- * template lambda's regex-based `propsObjectName.x → _p.x` rewrite only
- * catches the dotted form, so a bare `props` token would survive into the
- * module-scope template and ReferenceError at template-call time (#1137).
- * The init-body path uses `rewritePropsObjectRef` (AST-based) which
- * handles bare refs correctly, but that rewrite isn't applied to the
- * template body — the constant must instead stay in `unsafeLocalNames`,
- * letting `expressionReferencesAny` swap the getter call for the
- * `UNSAFE_TEMPLATE_EXPR` sentinel and init's `createEffect` repaint.
+ * Excludes constants whose `csrInlinable` is null — those stay in
+ * `unsafeLocalNames` and the CSR template's expression substitution
+ * surfaces the UNSAFE sentinel for any reference to them.
  */
-export function buildCsrInlinableConstants(
-  ctx: ClientJsContext,
-  inlinableConstants: Map<string, string>,
-  unsafeLocalNames: Set<string>,
-  signalMap: Map<string, string>,
-  memoMap: Map<string, string>,
-  _propsObjectName?: string | null,
-): Map<string, string> {
-  const csrInlinableConstants = new Map(inlinableConstants)
-  // Build relocate env once. The CSR re-promotion path tries to lift
-  // unsafe-but-non-arrow constants back into the inline map AFTER
-  // substituting signal / memo getter calls with their initial values
-  // (so `const x = computeCache(count())` becomes inlinable as
-  // `computeCache((0))` for SSR initial render). Whether the
-  // post-substitution form is inline-safe is the same canonical
-  // question that `compute-inlinability` asks for non-substituted
-  // values — delegate to `relocate.isInlinableInTemplate` instead of
-  // re-deriving discriminators here. This was the path that let
-  // `useYjs(props.x, props.y)` slip through (#1138, #1137 follow-up):
-  // the legacy regex caught only bare `props`, not `props.X`.
-  const env = buildEnvFromCtx(ctx)
-  for (const constant of ctx.localConstants) {
-    if (unsafeLocalNames.has(constant.name) && constant.value && !constant.containsArrow) {
-      let value = constant.value.trim()
-      // `(?<![-.])` skips member accesses (e.g. `ctx.count()`) so a local
-      // signal/memo whose name matches a context method is preserved (#1100).
-      for (const [getter, initial] of signalMap) {
-        value = value.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${initial})`)
-      }
-      for (const [memoName, computation] of memoMap) {
-        value = value.replace(new RegExp(`(?<![-.])\\b${memoName}\\(\\)`, 'g'), `(${computation})`)
-      }
-      const { ok, rewrittenValue } = isInlinableInTemplate(value, env)
-      if (ok) {
-        csrInlinableConstants.set(constant.name, rewrittenValue)
-      }
+export function csrInlinableConstantsFromIR(ctx: ClientJsContext): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const c of ctx.localConstants) {
+    if (c.csrInlinable) {
+      out.set(c.name, c.csrInlinable.rewrittenValue)
     }
   }
-  resolveChainedRefs(csrInlinableConstants)
-  return csrInlinableConstants
+  return out
 }
 
 /** Emit hydrate() call that registers component, template, and hydrates. */
@@ -296,11 +162,13 @@ export function emitRegistrationAndHydration(
     // CSR fallback: emit for all components that can't generate static templates.
     // Components may be imported and used in conditional branches in other files,
     // where renderChild() needs a registered template to render HTML correctly.
-    const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap, ctx.propsObjectName)
-
+    // Substitution data (signal initial values, memo bodies, chain-resolved
+    // const inlines) is read directly from `ConstantInfo.csrInlinable` /
+    // `SignalInfo.initialFreeIdentifiers` / `MemoInfo.computationFreeIdentifiers`
+    // — no post-hoc string transformation runs at this layer (#1277).
+    const csrInlinableConstants = csrInlinableConstantsFromIR(ctx)
     const templateHtml = generateCsrTemplate(
-      _ir.root, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
+      _ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
     )
     if (templateHtml) {
       defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -4,10 +4,12 @@
 
 import type { AttrValue, IRAttribute, IRNode } from '../types'
 import { isBooleanAttr } from '../html-constants'
-import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, freeIdsFromRefs, setIntersects, tokenContainsAny, wrapExprWithLoopParams } from './utils'
+import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, freeIdsFromRefs, setIntersects, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
 import { nameForRegistryRef } from './component-scope'
 import { assertNever } from './walker'
+import { buildSignalMemoEnv, csrSubstitute, applyPropsRewrite, type CsrEnv } from './csr-substitute'
+import type { ClientJsContext } from './types'
 import { BF_PARENT_SCOPE_PLACEHOLDER, BF_SCOPE } from '@barefootjs/shared'
 
 /**
@@ -571,9 +573,15 @@ export interface TemplateOptions {
    * the sentinel into something safe for that AST position.
    */
   unsafeLocalNames?: Set<string>
-  // generateCsrTemplate-specific fields
-  signalMap?: Map<string, string>
-  memoMap?: Map<string, string>
+  /**
+   * Signal+memo substitution env for the CSR template path. Built once
+   * per component from `ClientJsContext` (signal initial values + memo
+   * bodies, with the `propsObjectName.X → _p.X` props normalization
+   * baked in). Constants flow through `inlinableConstants` separately
+   * since their `csrInlinable.rewrittenValue` is already chain-closed
+   * by `compute-inlinability` (#1277).
+   */
+  csrEnv?: CsrEnv
   insideLoop?: boolean
   loopDepth?: number
   /** Emit `bf-s` placeholder on scoped elements inside a jsx-children prop (#1320). */
@@ -891,94 +899,77 @@ export function canGenerateStaticTemplate(
  * - Loops generate .map().join('') for inline rendering
  * - Child components use renderChild() for runtime template lookup
  *
+ * The substitution data — signal initial values, memo bodies, and the
+ * chain-closed inlinable-const values — is sourced from the IR's
+ * `csrInlinable` / `initialFreeIdentifiers` / `computationFreeIdentifiers`
+ * fields populated by `compute-inlinability` (#1277). `csrSubstitute`
+ * walks the AST so member-access shadowing (`ctx.bars()`) is preserved
+ * structurally instead of via the legacy `(?<![-.])` lookbehind.
+ *
  * @param node - IR node to render
- * @param inlinableConstants - Map of constant names to their resolved values
- * @param signalMap - Map of signal getter names to their initial value expressions
- * @param memoMap - Map of memo names to their computation expressions (with signals already replaced)
+ * @param inlinableConstants - Map of constant names to their resolved CSR values
+ * @param ctx - ClientJsContext supplying signals/memos for `csrSubstitute`
  */
 export function generateCsrTemplate(
   node: IRNode,
-  inlinableConstants?: Map<string, string>,
-  signalMap?: Map<string, string>,
-  memoMap?: Map<string, string>,
+  inlinableConstants: Map<string, string> | undefined,
+  ctx: ClientJsContext,
   insideLoop?: boolean,
   restSpreadNames?: Set<string>,
   propsObjectName?: string | null,
   unsafeLocalNames?: Set<string>,
 ): string {
-  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, signalMap, memoMap, insideLoop, unsafeLocalNames, loopDepth: -1 })
+  // Build the substitution env once per component. Signals + memos come
+  // from `buildSignalMemoEnv`; inlinable constants layer in here so
+  // each call to `transformExpr` is a pure AST projection over the
+  // shared env (no per-call Map cloning).
+  const base = buildSignalMemoEnv(ctx.signals, ctx.memos, propsObjectName ?? null)
+  const csrEnv: CsrEnv = { substitutions: new Map(base.substitutions), propsObjectName: base.propsObjectName }
+  if (inlinableConstants) {
+    for (const [name, value] of inlinableConstants) {
+      if (!csrEnv.substitutions.has(name)) {
+        csrEnv.substitutions.set(name, { kind: 'identifier', replacement: value, freeIdentifiers: new Set() })
+      }
+    }
+  }
+  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames, loopDepth: -1 })
 }
 
 function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
-  const { inlinableConstants, restSpreadNames, propsObjectName, signalMap, memoMap, insideLoop, unsafeLocalNames, loopDepth = 0 } = opts
+  const { restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames, loopDepth = 0 } = opts
+  const env: CsrEnv = csrEnv ?? { substitutions: new Map(), propsObjectName: propsObjectName ?? null }
   const transformExpr = (expr: string, templateExpr?: string): string => {
-    const { protect, restore } = createStringProtector()
-    let result = protect(templateExpr ?? expr)
+    // Single AST substitution pass: replaces signal getter calls
+    // (`count()` → `(initialValue)`), memo calls (`bars()` → `(body)`),
+    // and inlinable-const refs (`label` → `(rewrittenValue)`) in one
+    // walk. The walker uses structural position checks instead of
+    // regex lookbehind, so `ctx.bars()` survives intact when a local
+    // memo `bars` exists (#1100). All substitution values come from
+    // the IR — emit does no string transformation of its own (#1277).
+    const source = templateExpr ?? expr
+    if (!source) return source
+    const { rewritten, freeIdentifiers } = csrSubstitute(source, env)
 
-    // Replace signal getter calls with initial values: count() → (props.initial ?? 0).
-    // The negative lookbehind `(?<![-.])` skips member accesses such as
-    // `ctx.count()` so a local signal whose name happens to match a
-    // context method does not corrupt the embedded template (#1100).
-    if (signalMap && signalMap.size > 0) {
-      for (const [getter, initialValue] of signalMap) {
-        result = result.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
-      }
-    }
-
-    // Replace memo getter calls with computation expressions.
-    // Same lookbehind as above — see signalMap comment.
-    if (memoMap && memoMap.size > 0) {
-      for (const [name, computation] of memoMap) {
-        result = result.replace(new RegExp(`(?<![-.])\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
-      }
-    }
-
-    // Inline constant references with their resolved values.
-    if (inlinableConstants && inlinableConstants.size > 0) {
-      for (const [constName, constValue] of inlinableConstants) {
-        result = result.replace(new RegExp(`(?<![-.])\\b${constName}\\b`, 'g'), `(${protect(constValue)})`)
-      }
-    }
-
-    // Re-run signal/memo replacement after constant inlining.
-    if (signalMap && signalMap.size > 0) {
-      for (const [getter, initialValue] of signalMap) {
-        result = result.replace(new RegExp(`(?<![-.])\\b${getter}\\(\\)`, 'g'), `(${protect(initialValue)})`)
-      }
-    }
-    if (memoMap && memoMap.size > 0) {
-      for (const [name, computation] of memoMap) {
-        result = result.replace(new RegExp(`(?<![-.])\\b${name}\\(\\)`, 'g'), `(${protect(computation)})`)
-      }
-    }
-
-    // Normalize source-level props object access (e.g., props.xxx → _p.xxx)
-    if (propsObjectName && propsObjectName !== PROPS_PARAM) {
-      result = result.replace(
-        new RegExp(`\\b${propsObjectName}\\.`, 'g'),
-        `${PROPS_PARAM}.`,
-      )
-    }
-
-    const finalResult = restore(result)
-
-    // The CSR template runs at module scope (via render() / renderChild()),
-    // so any reference to an init-body-only name would ReferenceError at
-    // template-call time (#1128). Substitute the sentinel; per-AST-context
-    // call sites (loop array, text expression, child component prop) decide
-    // how to render that placeholder. The init function's createEffect /
-    // initChild bindings repaint the real value once init runs.
+    // The CSR template runs at module scope, so any post-substitution
+    // free identifier that lands in `unsafeLocalNames` (init-body-only
+    // bindings, demoted const refs) is unreachable. Surface the UNSAFE
+    // sentinel; per-AST-context call sites translate it (loop array →
+    // `[]`, text expression → `''`, child component prop → drop) and
+    // init's createEffect / initChild bindings repaint the real value
+    // once init runs (#1128).
     //
-    // Lexer-based post-substitution check (#1267): pure IR-based checking
-    // would require tracking transitive free-id closure through the
-    // `csrInlinableConstants` re-promotion path (which substitutes
-    // signal/memo getters before re-classifying constants). That bookkeeping
-    // is non-trivial and bears no semantic benefit over the lexer, which
-    // already respects string-literal / member-access boundaries.
-    if (unsafeLocalNames && unsafeLocalNames.size > 0 && tokenContainsAny(finalResult, unsafeLocalNames)) {
+    // The check is now a pure set intersection of IR-tracked
+    // identifiers; the legacy `tokenContainsAny` lexer scan
+    // (and its `'foo-className'` / `a.className` false-match risk)
+    // is gone (#1267 / #1277).
+    if (unsafeLocalNames && unsafeLocalNames.size > 0 && setIntersects(freeIdentifiers, unsafeLocalNames)) {
       return UNSAFE_TEMPLATE_EXPR
     }
-    return finalResult
+    // Final emit-form: rewrite `propsName.X → _p.X`. Deferred until
+    // after the unsafe-name check because the check used raw form
+    // (consistent with `populateCsrInlinable`'s `isInlinableInTemplate`
+    // gate — #1138).
+    return applyPropsRewrite(rewritten, propsObjectName ?? null)
   }
 
   // `recurse` preserves `inHoistedChildren` for structural pass-through

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -578,8 +578,8 @@ export interface TemplateOptions {
    * per component from `ClientJsContext` (signal initial values + memo
    * bodies, with the `propsObjectName.X → _p.X` props normalization
    * baked in). Constants flow through `inlinableConstants` separately
-   * since their `csrInlinable.rewrittenValue` is already chain-closed
-   * by `compute-inlinability` (#1277).
+   * since their `ctx.csrInlinable` entry is already chain-closed by
+   * `compute-inlinability` (#1277).
    */
   csrEnv?: CsrEnv
   insideLoop?: boolean
@@ -900,11 +900,12 @@ export function canGenerateStaticTemplate(
  * - Child components use renderChild() for runtime template lookup
  *
  * The substitution data — signal initial values, memo bodies, and the
- * chain-closed inlinable-const values — is sourced from the IR's
- * `csrInlinable` / `initialFreeIdentifiers` / `computationFreeIdentifiers`
- * fields populated by `compute-inlinability` (#1277). `csrSubstitute`
- * walks the AST so member-access shadowing (`ctx.bars()`) is preserved
- * structurally instead of via the legacy `(?<![-.])` lookbehind.
+ * chain-closed inlinable-const values — comes from
+ * `SignalInfo.initialFreeIdentifiers` / `MemoInfo.computationFreeIdentifiers`
+ * (core IR) and `ctx.csrInlinable` (CSR-internal side map populated by
+ * `compute-inlinability`, #1277). `csrSubstitute` walks the AST so
+ * member-access shadowing (`ctx.bars()`) is preserved structurally
+ * instead of via the legacy `(?<![-.])` lookbehind.
  *
  * @param node - IR node to render
  * @param inlinableConstants - Map of constant names to their resolved CSR values

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -16,7 +16,7 @@ import { buildReferencesGraph, graphUsedIdentifiers } from './build-references'
 import { addConstantPropRefsToSet } from './init-declarations'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
 import { PROPS_PARAM } from './utils'
-import { buildInlinableConstants, buildSignalAndMemoMaps, buildCsrInlinableConstants } from './emit-registration'
+import { buildInlinableConstants, csrInlinableConstantsFromIR } from './emit-registration'
 import { buildEnvFromCtx } from './compute-inlinability'
 import { nameForRegistryRef } from './component-scope'
 import { IMPORT_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectExternalImports } from './imports'
@@ -255,11 +255,9 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   // CSR fallback: when static template generation fails (e.g., components with
   // nested child components or loops), try generateCsrTemplate() (#536).
   if (!templateHtml) {
-    const { signalMap, memoMap } = buildSignalAndMemoMaps(ctx)
-    const csrInlinableConstants = buildCsrInlinableConstants(ctx, inlinableConstants, unsafeLocalNames, signalMap, memoMap, ctx.propsObjectName)
-
+    const csrInlinableConstants = csrInlinableConstantsFromIR(ctx)
     templateHtml = generateCsrTemplate(
-      ir.root, csrInlinableConstants, signalMap, memoMap, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
+      ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
     )
   }
 

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -16,7 +16,7 @@ import { buildReferencesGraph, graphUsedIdentifiers } from './build-references'
 import { addConstantPropRefsToSet } from './init-declarations'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate } from './html-template'
 import { PROPS_PARAM } from './utils'
-import { buildInlinableConstants, csrInlinableConstantsFromIR } from './emit-registration'
+import { buildInlinableConstants, csrInlinableConstantsFromCtx } from './emit-registration'
 import { buildEnvFromCtx } from './compute-inlinability'
 import { nameForRegistryRef } from './component-scope'
 import { IMPORT_PLACEHOLDER, RUNTIME_MODULE, detectUsedImports, collectExternalImports } from './imports'
@@ -186,6 +186,7 @@ function createContext(
     warnings: [],
     templatePrimitives: adapterCapabilities?.templatePrimitives,
     acceptsTemplateCall: adapterCapabilities?.acceptsTemplateCall,
+    csrInlinable: new Map(),
   }
 }
 
@@ -255,7 +256,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
   // CSR fallback: when static template generation fails (e.g., components with
   // nested child components or loops), try generateCsrTemplate() (#536).
   if (!templateHtml) {
-    const csrInlinableConstants = csrInlinableConstantsFromIR(ctx)
+    const csrInlinableConstants = csrInlinableConstantsFromCtx(ctx)
     templateHtml = generateCsrTemplate(
       ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
     )

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -20,6 +20,7 @@ import type {
   ParamInfo,
   CompilerError,
 } from '../types'
+import type { CsrInlinabilityMap } from './csr-substitute'
 
 export interface ClientJsContext {
   componentName: string
@@ -81,6 +82,21 @@ export interface ClientJsContext {
    * JS runtimes). Consulted when a callee isn't in `templatePrimitives`.
    */
   acceptsTemplateCall?: TemplateCallAcceptor
+  /**
+   * CSR-only: per-constant inlinability resolved by `populateCsrInlinable`
+   * during Stage 2 of `compute-inlinability`. The map is keyed by the
+   * constant's name; the value is `null` when the const can't be safely
+   * inlined into CSR template scope (placeholder-let, arrow-literal,
+   * system-construct, jsx-inline, or a substituted form that fails
+   * `isInlinableInTemplate`), otherwise the `{ rewrittenValue,
+   * freeIdentifiers }` pair the emitter splices in.
+   *
+   * Lives on the context — not on `ConstantInfo` — so the CSR-specific
+   * substitution result doesn't leak into the cross-adapter IR (#1277).
+   * SSR adapters (Hono, Go, Mojo) don't substitute signals at template
+   * time, so they have no use for this data.
+   */
+  csrInlinable: CsrInlinabilityMap
 }
 
 export interface InteractiveElement {

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -439,16 +439,6 @@ export function tokenContainsIdent(expr: string, ident: string): boolean {
   return scanForIdentifiers(expr, (token) => token === ident)
 }
 
-/**
- * Lexer-aware variant of {@link tokenContainsIdent} that returns true on the
- * first occurrence of *any* name in `names`. Short-circuits.
- */
-export function tokenContainsAny(expr: string, names: Iterable<string>): boolean {
-  const set = names instanceof Set ? (names as Set<string>) : new Set(names)
-  if (set.size === 0) return false
-  return scanForIdentifiers(expr, (token) => set.has(token))
-}
-
 const IDENT_START_RE = /[A-Za-z_$]/
 const IDENT_PART_RE = /[A-Za-z0-9_$]/
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -913,6 +913,15 @@ export interface SignalInfo {
   typedInitialValue?: string
   type: TypeInfo
   loc: SourceLocation
+  /**
+   * Free identifiers in `initialValue`, computed at analysis time. Drives
+   * the CSR-substitution propagation in `ir-to-client-js` (#1277): when an
+   * expression references `getter()` and the substitution expands it to
+   * `(initialValue)`, the post-substitution free-id set must add these
+   * names so the unsafe-name check stays exact instead of regex-scanning
+   * the final string.
+   */
+  initialFreeIdentifiers?: ReadonlySet<string>
 }
 
 export interface MemoInfo {
@@ -923,6 +932,12 @@ export interface MemoInfo {
   type: TypeInfo
   deps: string[]
   loc: SourceLocation
+  /**
+   * Free identifiers in `computation`, computed at analysis time. Same role
+   * as `SignalInfo.initialFreeIdentifiers` — feeds the CSR-substitution
+   * propagation in `ir-to-client-js` (#1277).
+   */
+  computationFreeIdentifiers?: ReadonlySet<string>
 }
 
 export interface EffectInfo {
@@ -1102,6 +1117,29 @@ export interface ConstantInfo {
   systemConstructKind?: 'createContext' | 'weakMap'
   /** Value with destructured prop refs rewritten to _p.propName, for template inlining. */
   templateValue?: string
+  /**
+   * Fully-resolved CSR-template form: `templateValue` with every signal
+   * getter call, memo call, and reference to another CSR-inlinable
+   * constant expanded via AST substitution. The substitution preserves
+   * member-access shadowing (`ctx.count()` is left intact when a local
+   * signal `count` exists — #1100) because it walks the AST instead of
+   * regex-scanning text.
+   *
+   * Populated for **every** constant by `compute-inlinability`. `null`
+   * marks the constant as unsafe to inline into CSR template scope
+   * (because the substitution would still mention a name unreachable
+   * there, or the construction itself is reactive / system-construct /
+   * placeholder-let / arrow-literal). Emit reads this directly; no
+   * post-hoc string transformation runs at template-emit time (#1277).
+   *
+   * `freeIdentifiers` is the free-id set of the rewritten AST — already
+   * transitively closed through chained `csrInlinable` references — and
+   * is what the unsafe-name check intersects with `unsafeLocalNames`,
+   * replacing the legacy lexer-based defensive guard.
+   *
+   * IR-internal: consumed only by `packages/jsx/src/ir-to-client-js`.
+   */
+  csrInlinable?: { rewrittenValue: string; freeIdentifiers: ReadonlySet<string> } | null
   /**
    * Staged-IR origin info (#1138). For locals declared in a component
    * body, `origin.scope` is `init` (or `sub-init` for nested-arrow

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1118,29 +1118,6 @@ export interface ConstantInfo {
   /** Value with destructured prop refs rewritten to _p.propName, for template inlining. */
   templateValue?: string
   /**
-   * Fully-resolved CSR-template form: `templateValue` with every signal
-   * getter call, memo call, and reference to another CSR-inlinable
-   * constant expanded via AST substitution. The substitution preserves
-   * member-access shadowing (`ctx.count()` is left intact when a local
-   * signal `count` exists — #1100) because it walks the AST instead of
-   * regex-scanning text.
-   *
-   * Populated for **every** constant by `compute-inlinability`. `null`
-   * marks the constant as unsafe to inline into CSR template scope
-   * (because the substitution would still mention a name unreachable
-   * there, or the construction itself is reactive / system-construct /
-   * placeholder-let / arrow-literal). Emit reads this directly; no
-   * post-hoc string transformation runs at template-emit time (#1277).
-   *
-   * `freeIdentifiers` is the free-id set of the rewritten AST — already
-   * transitively closed through chained `csrInlinable` references — and
-   * is what the unsafe-name check intersects with `unsafeLocalNames`,
-   * replacing the legacy lexer-based defensive guard.
-   *
-   * IR-internal: consumed only by `packages/jsx/src/ir-to-client-js`.
-   */
-  csrInlinable?: { rewrittenValue: string; freeIdentifiers: ReadonlySet<string> } | null
-  /**
    * Staged-IR origin info (#1138). For locals declared in a component
    * body, `origin.scope` is `init` (or `sub-init` for nested-arrow
    * declarations). For module-level constants, `origin.scope` is


### PR DESCRIPTION
Closes #1277.

## Summary

Move signal / memo / inlinable-const substitution from emit-time regex loops into a single AST-aware pass at IR-build time. The CSR template emitter is now a pure projection of IR data — no string transformation of its own.

## What changed

**IR additions** (`packages/jsx/src/types.ts`)
- `ConstantInfo.csrInlinable?: { rewrittenValue; freeIdentifiers } | null` — chain-closed CSR form, populated by `compute-inlinability` for every local constant.
- `SignalInfo.initialFreeIdentifiers` / `MemoInfo.computationFreeIdentifiers` — drive the post-substitution unsafe-name check.

**New module** (`packages/jsx/src/ir-to-client-js/csr-substitute.ts`)
- `csrSubstitute(value, env)` walks the AST, collects substitution positions, splices them in. `ctx.bars()` survives intact when a local memo `bars` exists (#1100) because the walker descends only the `expression` side of a `PropertyAccessExpression` — the legacy `(?<[-.])` lookbehind is gone.
- Fixed-point iteration handles nested substitutions (memo body references another memo / inlinable const).

**`compute-inlinability.ts`**
- `populateCsrInlinable` runs after Stage 1. Substitutes via `csrSubstitute`, gates the result through `isInlinableInTemplate` so `useYjs(props.X)`-shape bridged-arg calls still get rejected (#1138), stores the relocate-rewritten bridged form (`_p.X`).
- Free identifiers re-extracted from the bridged form so the unsafe-name check stays exact across chained inlines.

**`emit-registration.ts`**
- `buildCsrInlinableConstants` deleted (replaced by `csrInlinableConstantsFromIR` reading directly from IR).
- `buildSignalAndMemoMaps` deleted (replaced by `buildSignalMemoEnv` in `csr-substitute.ts`).
- `resolveChainedRefs` kept — still used by the static-template path (Stage-1 inlinable chain, out of scope).

**`html-template.ts`**
- `generateCsrTemplate` now takes a `ClientJsContext` and builds the CSR env once per component.
- `transformExpr` is a single AST substitution + final `applyPropsRewrite` + set-intersection check. The 4–5 regex substitution loops (signal, memo, const, signal-rerun, memo-rerun) are gone.
- Defensive `tokenContainsAny(finalResult, unsafeLocalNames)` lexer scan replaced by `setIntersects(freeIdentifiers, unsafeLocalNames)` — exact, no `'foo-className'` / `a.className` false-match risk.

**Helper cleanup**
- `tokenContainsAny` deleted from `utils.ts` (no remaining callers). Corresponding `describe` block removed from `token-contains-ident.test.ts`. `tokenContainsIdent` stays — `reactivity.ts` still uses it as the fallback when `freeIdentifiers` isn't tracked.

## Test plan

- [x] `packages/jsx/src/__tests__/csr-template-context-method-shadow.test.ts` — both `#1100` shadow cases green
- [x] `packages/jsx/src/__tests__/staged-ir/` — 115 / 115 green (incl. `01-template-scope createMemo getter is referenced` and `06-multi-stage-soak createMemo body does not leak init-locals`)
- [x] `packages/jsx/src/__tests__/` full — same pre-existing 4 failures as baseline (`primitive-resolver-alias`, unrelated)
- [x] `packages/adapter-tests/` — 316 / 316 green
- [x] `packages/client/__tests__/` — 267 / 267 green
- [x] `tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNYv9ZHDhJmpyTiYLxVURE)_