### PR TITLE
feat(#1073): wire localImportPrefixes through CLI build pipeline

### DIFF
--- a/packages/adapter-go-template/src/build.ts
+++ b/packages/adapter-go-template/src/build.ts
@@ -247,6 +247,7 @@ export function createConfig(options: GoTemplateBuildOptions = {}) {
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,
+    localImportPrefixes: options.localImportPrefixes,
     outputLayout: options.outputLayout ?? {
       templates: 'templates',
       clientJs: 'client',

--- a/packages/adapter-hono/src/__tests__/build.test.ts
+++ b/packages/adapter-hono/src/__tests__/build.test.ts
@@ -213,6 +213,16 @@ export function Counter() {
     expect(config.externals).toBeUndefined()
     expect(config.externalsBasePath).toBeUndefined()
   })
+
+  test('passes through localImportPrefixes', () => {
+    const config = createConfig({ localImportPrefixes: ['@/', '@ui/'] })
+    expect(config.localImportPrefixes).toEqual(['@/', '@ui/'])
+  })
+
+  test('localImportPrefixes defaults to undefined', () => {
+    const config = createConfig()
+    expect(config.localImportPrefixes).toBeUndefined()
+  })
 })
 
 // ── maskComments ────────────────────────────────────────────────────

--- a/packages/adapter-hono/src/build.ts
+++ b/packages/adapter-hono/src/build.ts
@@ -32,6 +32,7 @@ export function createConfig(options: HonoBuildOptions = {}) {
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,
+    localImportPrefixes: options.localImportPrefixes,
     transformMarkedTemplate: useScriptCollection
       ? (content: string, componentId: string, clientJsPath: string) =>
           addScriptCollection(content, componentId, clientJsPath, options.scriptBasePath)

--- a/packages/adapter-mojolicious/src/build.ts
+++ b/packages/adapter-mojolicious/src/build.ts
@@ -26,6 +26,7 @@ export function createConfig(options: MojoBuildOptions = {}) {
     externals: options.externals,
     externalsBasePath: options.externalsBasePath,
     bundleEntries: options.bundleEntries,
+    localImportPrefixes: options.localImportPrefixes,
     outputLayout: options.outputLayout ?? {
       templates: 'templates',
       clientJs: 'client',

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -161,6 +161,21 @@ describe('resolveBuildConfigFromTs', () => {
 
     expect(config.outDir).toBe('/test/project/build/output')
   })
+
+  test('passes through localImportPrefixes', () => {
+    const config = resolveBuildConfigFromTs(projectDir, {
+      adapter: mockAdapter,
+      localImportPrefixes: ['@/', '@ui/'],
+    })
+
+    expect(config.localImportPrefixes).toEqual(['@/', '@ui/'])
+  })
+
+  test('localImportPrefixes defaults to undefined when omitted', () => {
+    const config = resolveBuildConfigFromTs(projectDir, { adapter: mockAdapter })
+
+    expect(config.localImportPrefixes).toBeUndefined()
+  })
 })
 
 // ── collectRelativeImportDeps ───────────────────────────────────────────

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -51,6 +51,12 @@ export interface BuildConfig {
   externalsBasePath?: string
   /** Additional entry points to bundle with esbuild, with config.externals auto-applied */
   bundleEntries?: BundleEntry[]
+  /**
+   * Import prefixes resolved at build time rather than left as bare
+   * specifiers in the emitted client JS (e.g. `['@/', '@ui/']` for
+   * tsconfig `paths` aliases). Forwarded to `compileJSX`.
+   */
+  localImportPrefixes?: string[]
 }
 
 export interface BuildResult {
@@ -161,7 +167,7 @@ export function generateHash(content: string): string {
  */
 export function resolveBuildConfigFromTs(
   projectDir: string,
-  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bundleEntries?: BundleEntry[] },
+  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bundleEntries?: BundleEntry[]; localImportPrefixes?: string[] },
   overrides?: { minify?: boolean }
 ): BuildConfig {
   const componentDirs = (tsConfig.components ?? ['components']).map(
@@ -187,6 +193,7 @@ export function resolveBuildConfigFromTs(
       outfile: e.outfile,
       externals: e.externals,
     })),
+    localImportPrefixes: tsConfig.localImportPrefixes,
   }
 }
 
@@ -1243,6 +1250,7 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
       // lookups BF103 warns about resolve correctly. Tell the adapter
       // it can suppress that diagnostic for CLI-managed builds.
       siblingTemplatesRegistered: true,
+      localImportPrefixes: config.localImportPrefixes,
     },
   )
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -204,6 +204,15 @@ export interface BuildOptions {
    * Each entry is bundled as ESM with all `externals` automatically excluded.
    */
   bundleEntries?: BundleEntry[]
+  /**
+   * Import prefixes resolved at build time rather than left as bare
+   * specifiers in the emitted client JS. Use this for tsconfig `paths`
+   * aliases like `@/`, `@ui/`, `@app/` so the compiler does not emit
+   * them as browser imports.
+   *
+   * Forwarded to `compileJSX` as `CompileOptions.localImportPrefixes`.
+   */
+  localImportPrefixes?: string[]
 }
 
 // AttrValue constructors


### PR DESCRIPTION
## Summary

`compileJSX` already accepts `localImportPrefixes` to skip emitting bare specifiers for tsconfig path aliases (`@/`, `@ui/`, ...) in client JS, but the CLI build pipeline never threaded the option through — projects using `barefoot.config.ts` could not configure it. `site/ui/build.ts:261` works around this with its own bespoke `compileJSX` call.

This PR plumbs the field through the missing layers:

- `BuildOptions` (public config surface in `@barefootjs/jsx`)
- `BuildConfig` + `resolveBuildConfigFromTs` (CLI)
- `compileEntry`'s `compileJSX` call
- `createConfig` for all three adapters: hono / go-template / mojolicious

Closes #1073.

## Test plan

- [x] Unit test in `packages/cli/src/__tests__/build.test.ts`: `resolveBuildConfigFromTs` passes through `localImportPrefixes`, defaults to `undefined` when omitted
- [x] Unit test in `packages/adapter-hono/src/__tests__/build.test.ts`: `createConfig` passes through `localImportPrefixes`, defaults to `undefined`
- [x] `bun test` green for `@barefootjs/cli` (436 pass), `@barefootjs/hono` (194 pass), `@barefootjs/go-template` (172 pass), `@barefootjs/mojolicious` (159 pass)
- [x] `tsc --noEmit` clean for the four packages with tsconfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)