### PR TITLE
feat(#1243): follow stub-rewrite edges from page-level script loader

### DIFF
--- a/packages/adapter-hono/src/__tests__/stub-deps-scripts.test.ts
+++ b/packages/adapter-hono/src/__tests__/stub-deps-scripts.test.ts
@@ -40,6 +40,50 @@ describe('collectStubDepScripts (#1243)', () => {
     expect(new Set([...out.keys()])).toEqual(new Set(['B', 'C']))
   })
 
+  // Issue #1243 — Copilot review:
+  // `<script type="module">` tags execute in document order with
+  // microtask checkpoints between them. A's `hydrate()` schedules a
+  // walk that fires before later scripts evaluate, so any stub call
+  // from A.init must resolve against a registry the LATER scripts
+  // populated. Emitting B before C in document order would let B's
+  // `createComponent('C', ...)` fail. The walker must produce
+  // post-order (deepest first → A→B→C ships C, then B).
+  test('emits a transitive chain in post-order (C before B for A → B → C)', () => {
+    const out = collectStubDepScripts(
+      {
+        A: { clientJs: 'components/A.client.js', stubDeps: ['B'] },
+        B: { clientJs: 'components/B.client.js', stubDeps: ['C'] },
+        C: { clientJs: 'components/C.client.js' },
+      },
+      '/static/components/',
+      new Set(['A']),
+      new Set(['A']),
+    )
+    // Map preserves insertion order; iteration = emission order in DOM.
+    expect([...out.keys()]).toEqual(['C', 'B'])
+  })
+
+  // Post-order isn't just leaves-first; for a DAG where a sibling
+  // depends on another sibling (A → B, A → C, C → B), `B` must
+  // precede `C` in the output even though both are direct children
+  // of A. BFS+reverse can't express this — DFS post-order does.
+  test('emits DAG edges in topological order (B before C for A → B, A → C, C → B)', () => {
+    const out = collectStubDepScripts(
+      {
+        A: { clientJs: 'components/A.client.js', stubDeps: ['B', 'C'] },
+        B: { clientJs: 'components/B.client.js' },
+        C: { clientJs: 'components/C.client.js', stubDeps: ['B'] },
+      },
+      '/static/components/',
+      new Set(['A']),
+      new Set(['A']),
+    )
+    // A's first dep is B → visited (no further deps) → emit B.
+    // A's second dep is C → recurse into C's deps → B already visited
+    // → emit C. So order is B then C.
+    expect([...out.keys()]).toEqual(['B', 'C'])
+  })
+
   test('short-circuits on a cycle (A → B → A)', () => {
     const out = collectStubDepScripts(
       {

--- a/packages/adapter-hono/src/__tests__/stub-deps-scripts.test.ts
+++ b/packages/adapter-hono/src/__tests__/stub-deps-scripts.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect } from 'bun:test'
+import { collectStubDepScripts } from '../scripts'
+
+// Issue #1243: the per-page script collector emits a <script src> for
+// every rendered component, but until #1243 a component reached ONLY
+// through an imperative `createComponent('Foo', ...)` stub call (no
+// JSX render) never had its `.client.js` shipped. `collectStubDepScripts`
+// closes the gap: given the manifest and the set of names whose SSR
+// function did execute, it returns the script URLs for every transitively
+// reachable stubDep.
+
+describe('collectStubDepScripts (#1243)', () => {
+  test('emits a script for a single-hop stubDep', () => {
+    const out = collectStubDepScripts(
+      {
+        IssueCardNode: {
+          clientJs: 'components/IssueCardNode.client.js',
+          stubDeps: ['DraftTitleEditor'],
+        },
+        DraftTitleEditor: { clientJs: 'components/DraftTitleEditor.client.js' },
+      },
+      '/static/components/',
+      new Set(['IssueCardNode']),
+      new Set(['IssueCardNode']),
+    )
+    expect([...out.values()]).toEqual([{ src: '/static/components/DraftTitleEditor.client.js' }])
+  })
+
+  test('walks transitively (A → B → C)', () => {
+    const out = collectStubDepScripts(
+      {
+        A: { clientJs: 'components/A.client.js', stubDeps: ['B'] },
+        B: { clientJs: 'components/B.client.js', stubDeps: ['C'] },
+        C: { clientJs: 'components/C.client.js' },
+      },
+      '/static/components/',
+      new Set(['A']),
+      new Set(['A']),
+    )
+    expect(new Set([...out.keys()])).toEqual(new Set(['B', 'C']))
+  })
+
+  test('short-circuits on a cycle (A → B → A)', () => {
+    const out = collectStubDepScripts(
+      {
+        A: { clientJs: 'components/A.client.js', stubDeps: ['B'] },
+        B: { clientJs: 'components/B.client.js', stubDeps: ['A'] },
+      },
+      '/static/components/',
+      new Set(['A']),
+      new Set(['A']),
+    )
+    // A is in `excluded` so it's not re-emitted; B is reached once.
+    expect([...out.keys()]).toEqual(['B'])
+  })
+
+  test('skips deps already in excluded set', () => {
+    const out = collectStubDepScripts(
+      {
+        Parent: { clientJs: 'components/Parent.client.js', stubDeps: ['AlreadyEmitted'] },
+        AlreadyEmitted: { clientJs: 'components/AlreadyEmitted.client.js' },
+      },
+      '/static/components/',
+      new Set(['Parent']),
+      // Caller already emitted AlreadyEmitted's script some other way.
+      new Set(['Parent', 'AlreadyEmitted']),
+    )
+    expect(out.size).toBe(0)
+  })
+
+  test('mutates excluded so caller can pass it to a later pass', () => {
+    const excluded = new Set(['Root'])
+    collectStubDepScripts(
+      {
+        Root: { clientJs: 'components/Root.client.js', stubDeps: ['Leaf'] },
+        Leaf: { clientJs: 'components/Leaf.client.js' },
+      },
+      '/static/components/',
+      new Set(['Root']),
+      excluded,
+    )
+    expect(excluded.has('Leaf')).toBe(true)
+  })
+
+  test('honors a base path with no trailing slash', () => {
+    const out = collectStubDepScripts(
+      {
+        Parent: { clientJs: 'components/Parent.client.js', stubDeps: ['Child'] },
+        Child: { clientJs: 'components/Child.client.js' },
+      },
+      '/assets/bf',
+      new Set(['Parent']),
+      new Set(['Parent']),
+    )
+    expect(out.get('Child')?.src).toBe('/assets/bf/Child.client.js')
+  })
+
+  test('returns an empty map when no stubDeps are present', () => {
+    const out = collectStubDepScripts(
+      {
+        Solo: { clientJs: 'components/Solo.client.js' },
+      },
+      '/static/components/',
+      new Set(['Solo']),
+      new Set(['Solo']),
+    )
+    expect(out.size).toBe(0)
+  })
+
+  test('skips a dep whose manifest entry has no clientJs', () => {
+    // A misconfigured manifest could list a stubDep that resolves to
+    // an SSR-only entry. The walker still records it as visited (so
+    // it doesn't loop) but emits no script for it.
+    const out = collectStubDepScripts(
+      {
+        Parent: { clientJs: 'components/Parent.client.js', stubDeps: ['Phantom'] },
+        Phantom: { clientJs: undefined },
+      },
+      '/static/components/',
+      new Set(['Parent']),
+      new Set(['Parent']),
+    )
+    expect(out.size).toBe(0)
+  })
+
+  test('ignores __barefoot__ as a root (it has no stubDeps and would noise the walk)', () => {
+    const out = collectStubDepScripts(
+      {
+        __barefoot__: { clientJs: 'components/barefoot.js' },
+        Parent: { clientJs: 'components/Parent.client.js', stubDeps: ['Child'] },
+        Child: { clientJs: 'components/Child.client.js' },
+      },
+      '/static/components/',
+      new Set(['__barefoot__', 'Parent']),
+      new Set(['__barefoot__', 'Parent']),
+    )
+    expect([...out.keys()]).toEqual(['Child'])
+  })
+})

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -41,10 +41,17 @@ const DEV_RELOAD_ENDPOINT_KEY = 'bfDevReloadEndpoint'
  * component is keyed by its manifest name; `__barefoot__` is the
  * runtime entry. `clientJs` is a path under `dist/`, e.g.
  * `"components/Counter.client.js"`.
+ *
+ * `stubDeps` lists the registry names of every `'use client'` sibling
+ * this bundle reaches via a stub rewrite (i.e. via an imperative
+ * `createComponent(name, ...)` call rather than a JSX render). The
+ * per-page script collector follows these edges so pages that only
+ * touch a child through a stub still ship its `.client.js`. See
+ * issue #1243.
  */
 export interface BarefootBuildManifest {
   __barefoot__?: { clientJs?: string }
-  [componentName: string]: { clientJs?: string } | undefined
+  [componentName: string]: { clientJs?: string; stubDeps?: string[] } | undefined
 }
 
 /**

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -42,12 +42,19 @@ const DEV_RELOAD_ENDPOINT_KEY = 'bfDevReloadEndpoint'
  * runtime entry. `clientJs` is a path under `dist/`, e.g.
  * `"components/Counter.client.js"`.
  *
- * `stubDeps` lists the registry names of every `'use client'` sibling
+ * `stubDeps` lists the manifest keys of every `'use client'` sibling
  * this bundle reaches via a stub rewrite (i.e. via an imperative
  * `createComponent(name, ...)` call rather than a JSX render). The
  * per-page script collector follows these edges so pages that only
  * touch a child through a stub still ship its `.client.js`. See
  * issue #1243.
+ *
+ * Note: the entries are manifest keys (e.g. `"ui/button/index"` for
+ * `ui/button/index.tsx`), not the runtime registry name passed to
+ * `createComponent(...)` (e.g. `"Button"`). For top-level
+ * single-component files the two coincide; for nested layouts they
+ * differ. `build.ts` does the path → manifest-key conversion before
+ * writing this field.
  */
 export interface BarefootBuildManifest {
   __barefoot__?: { clientJs?: string }
@@ -75,7 +82,7 @@ export function manifestToScriptUrls(
   return out
 }
 
-function relPathFromComponentsBase(p: string): string {
+export function relPathFromComponentsBase(p: string): string {
   return p.startsWith('components/') ? p.slice('components/'.length) : p
 }
 

--- a/packages/adapter-hono/src/scripts.tsx
+++ b/packages/adapter-hono/src/scripts.tsx
@@ -90,17 +90,22 @@ export function BfScripts(props: BfScriptsProps = {}) {
     // then child components add their scripts. But for hydration, children
     // need to register their templates before parents try to use createComponent().
     // barefoot.js must stay first since it provides the runtime.
+    //
+    // Stub-derived scripts must come BEFORE the component scripts in the
+    // emitted order — `<script type="module">` tags evaluate in document
+    // order with microtask checkpoints between them, so a parent's
+    // `hydrate()`-scheduled walk fires (and its `init` calls
+    // `createComponent(...)` against the stub) before any later module
+    // script has registered. Within stubScripts, `collectStubDepScripts`
+    // already returns DFS post-order (deps before their dependent), so
+    // a chain A→B→C ships C, B, then the component bundle that stubs A.
     const barefootScript = scripts.find(s => s.src.includes('barefoot.js'))
     const componentScripts = scripts.filter(s => !s.src.includes('barefoot.js'))
-    const orderedScripts = barefootScript
-      ? [barefootScript, ...componentScripts.reverse()]
-      : componentScripts.reverse()
-    // Stub-derived scripts come after the component scripts so they
-    // load earliest in the document (existing scripts go through a
-    // reversal that puts children first; stub deps are conceptually
-    // "even deeper" — their registries must exist before any
-    // imperative stub call fires).
-    const finalScripts = [...orderedScripts, ...stubScripts.values()]
+    const finalScripts = [
+      ...(barefootScript ? [barefootScript] : []),
+      ...stubScripts.values(),
+      ...componentScripts.reverse(),
+    ]
 
     return (
       <Fragment>
@@ -118,10 +123,11 @@ export function BfScripts(props: BfScriptsProps = {}) {
 /**
  * Walk stub-rewrite edges from each manifest entry in `roots`,
  * returning the script URLs for every transitively reachable
- * `.client.js`. Skips any name already present in `excluded` (these
- * have a script tag elsewhere). Mutates `excluded` to record every
- * dep that's been resolved so the caller can pass it to the next
- * SSR pass without double-emitting. Exported for tests.
+ * `.client.js` in **DFS post-order** — every dep precedes its
+ * dependent in iteration order. Skips any name already present in
+ * `excluded` (these have a script tag elsewhere). Mutates `excluded`
+ * to record every dep that's been resolved so the caller can pass
+ * it to the next SSR pass without double-emitting. Exported for tests.
  *
  * Typical call shape: `roots` ⊆ `excluded`. The caller passes the
  * set of components whose SSR function already pushed a `<script>`
@@ -129,6 +135,15 @@ export function BfScripts(props: BfScriptsProps = {}) {
  * emitted, now walk their stubDeps." A `roots` value already in
  * `excluded` is still walked (we need its `stubDeps`); a `dep`
  * already in `excluded` is recorded as visited but not re-emitted.
+ *
+ * Why post-order: `<script type="module">` tags evaluate in document
+ * order with microtask checkpoints between them, so the first
+ * script's `hydrate()`-scheduled walk fires before any later
+ * module loads. A chain A→B→C must ship C, B, then A's bundle —
+ * BFS order (B, C) would let B's hydration call
+ * `createComponent('C', ...)` against an empty registry. Post-order
+ * also handles DAG edges like A→B, A→C, C→B correctly
+ * (deepest-first, dependencies-first).
  *
  * Cycle-safe: a visited set short-circuits any A → B → A loop.
  */
@@ -140,38 +155,27 @@ export function collectStubDepScripts(
 ): Map<string, CollectedScript> {
   const result = new Map<string, CollectedScript>()
   const prefix = base.endsWith('/') ? base : base + '/'
-
-  // Walk the stubDep graph starting from `roots`. `visited` guards
-  // against cycles and double-enqueue; `excluded` is consulted only
-  // when deciding whether to EMIT a script — a node already in
-  // `excluded` has its script tag elsewhere, but we still walk its
-  // own stubDeps so a transitively-deeper miss gets emitted here.
   const visited = new Set<string>()
-  const queue: string[] = []
-  for (const name of roots) {
-    if (name === '__barefoot__') continue
-    if (visited.has(name)) continue
-    visited.add(name)
-    queue.push(name)
-  }
 
-  while (queue.length > 0) {
-    const name = queue.shift()!
+  function visit(name: string): void {
+    if (name === '__barefoot__') return
+    if (visited.has(name)) return
+    visited.add(name)
     const entry = manifest[name]
-    const deps = entry?.stubDeps
-    if (!deps) continue
-    for (const dep of deps) {
-      if (visited.has(dep)) continue
-      visited.add(dep)
-      queue.push(dep)
-      if (excluded.has(dep)) continue
-      excluded.add(dep)
-      const depEntry = manifest[dep]
-      if (depEntry?.clientJs) {
-        const src = prefix + relPathFromComponentsBase(depEntry.clientJs)
-        result.set(dep, { src })
-      }
+    if (entry?.stubDeps) {
+      // Recurse FIRST so deps are emitted before this node — that's
+      // what produces post-order. Cycles short-circuit at the
+      // `visited.has(name)` check at the top of each call.
+      for (const dep of entry.stubDeps) visit(dep)
+    }
+    if (excluded.has(name)) return
+    excluded.add(name)
+    if (entry?.clientJs) {
+      const src = prefix + relPathFromComponentsBase(entry.clientJs)
+      result.set(name, { src })
     }
   }
+
+  for (const name of roots) visit(name)
   return result
 }

--- a/packages/adapter-hono/src/scripts.tsx
+++ b/packages/adapter-hono/src/scripts.tsx
@@ -28,7 +28,7 @@
 
 import { useRequestContext } from 'hono/jsx-renderer'
 import { Fragment } from 'hono/jsx'
-import type { BarefootBuildManifest } from './app'
+import { relPathFromComponentsBase, type BarefootBuildManifest } from './app'
 
 export type CollectedScript = {
   src: string
@@ -123,6 +123,13 @@ export function BfScripts(props: BfScriptsProps = {}) {
  * dep that's been resolved so the caller can pass it to the next
  * SSR pass without double-emitting. Exported for tests.
  *
+ * Typical call shape: `roots` ⊆ `excluded`. The caller passes the
+ * set of components whose SSR function already pushed a `<script>`
+ * (`bfOutputScripts`) as BOTH arguments — "these are already
+ * emitted, now walk their stubDeps." A `roots` value already in
+ * `excluded` is still walked (we need its `stubDeps`); a `dep`
+ * already in `excluded` is recorded as visited but not re-emitted.
+ *
  * Cycle-safe: a visited set short-circuits any A → B → A loop.
  */
 export function collectStubDepScripts(
@@ -167,8 +174,4 @@ export function collectStubDepScripts(
     }
   }
   return result
-}
-
-function relPathFromComponentsBase(p: string): string {
-  return p.startsWith('components/') ? p.slice('components/'.length) : p
 }

--- a/packages/adapter-hono/src/scripts.tsx
+++ b/packages/adapter-hono/src/scripts.tsx
@@ -12,19 +12,47 @@
  * <html>
  *   <body>
  *     {children}
- *     <BfScripts />
+ *     <BfScripts manifest={manifest} base="/static/components/" />
  *   </body>
  * </html>
  * ```
+ *
+ * Pass `manifest` + `base` to follow stub references emitted by the
+ * 'use client' import rewriter (#1241). Without those props the
+ * component falls back to the JSX-driven script set, which misses
+ * components reached only through imperative `createComponent()`
+ * stub calls — see issue #1243.
  */
 
 /** @jsxImportSource hono/jsx */
 
 import { useRequestContext } from 'hono/jsx-renderer'
 import { Fragment } from 'hono/jsx'
+import type { BarefootBuildManifest } from './app'
 
 export type CollectedScript = {
   src: string
+}
+
+export interface BfScriptsProps {
+  /**
+   * Build manifest from `dist/components/manifest.json`. When supplied
+   * alongside `base`, the component follows each rendered entry's
+   * `stubDeps` transitively and emits a `<script>` for every reachable
+   * `.client.js` — necessary for pages that only touch a child
+   * component through an imperative stub call (issue #1243).
+   *
+   * When omitted, behavior matches the pre-#1243 collector: only
+   * components whose SSR function executed get a script tag.
+   */
+  manifest?: BarefootBuildManifest
+  /**
+   * URL base where the component bundles are served (e.g.
+   * `/static/components/`). Required when `manifest` is supplied —
+   * stubDep entries store dist-relative paths and the component
+   * needs the URL prefix to emit a working `<script src>`.
+   */
+  base?: string
 }
 
 /**
@@ -36,7 +64,7 @@ export type CollectedScript = {
  * will check this flag and output their scripts inline instead of
  * collecting them here.
  */
-export function BfScripts() {
+export function BfScripts(props: BfScriptsProps = {}) {
   try {
     const c = useRequestContext()
 
@@ -46,6 +74,16 @@ export function BfScripts() {
     c.set('bfScriptsRendered', true)
 
     const scripts: CollectedScript[] = c.get('bfCollectedScripts') || []
+    const outputSet: Set<string> = c.get('bfOutputScripts') || new Set()
+    const { manifest, base } = props
+    const stubScripts = manifest && base
+      ? collectStubDepScripts(manifest, base, outputSet, outputSet)
+      : new Map<string, CollectedScript>()
+    // Record stub-derived names on the same context flag so any later
+    // SSR pass (e.g. a Suspense boundary that renders after this point)
+    // won't double-emit the same `.client.js`. The flag's name keeps
+    // it symmetric with the snippet in `addScriptCollection`.
+    if (stubScripts.size > 0) c.set('bfOutputScripts', outputSet)
 
     // Reverse script order so child components load before parents.
     // During SSR, parent components render first and collect their scripts,
@@ -57,10 +95,16 @@ export function BfScripts() {
     const orderedScripts = barefootScript
       ? [barefootScript, ...componentScripts.reverse()]
       : componentScripts.reverse()
+    // Stub-derived scripts come after the component scripts so they
+    // load earliest in the document (existing scripts go through a
+    // reversal that puts children first; stub deps are conceptually
+    // "even deeper" — their registries must exist before any
+    // imperative stub call fires).
+    const finalScripts = [...orderedScripts, ...stubScripts.values()]
 
     return (
       <Fragment>
-        {orderedScripts.map(({ src }) => (
+        {finalScripts.map(({ src }) => (
           <script type="module" src={src} />
         ))}
       </Fragment>
@@ -69,4 +113,62 @@ export function BfScripts() {
     // Context unavailable (e.g., not using jsxRenderer)
     return null
   }
+}
+
+/**
+ * Walk stub-rewrite edges from each manifest entry in `roots`,
+ * returning the script URLs for every transitively reachable
+ * `.client.js`. Skips any name already present in `excluded` (these
+ * have a script tag elsewhere). Mutates `excluded` to record every
+ * dep that's been resolved so the caller can pass it to the next
+ * SSR pass without double-emitting. Exported for tests.
+ *
+ * Cycle-safe: a visited set short-circuits any A → B → A loop.
+ */
+export function collectStubDepScripts(
+  manifest: BarefootBuildManifest,
+  base: string,
+  roots: Iterable<string>,
+  excluded: Set<string>,
+): Map<string, CollectedScript> {
+  const result = new Map<string, CollectedScript>()
+  const prefix = base.endsWith('/') ? base : base + '/'
+
+  // Walk the stubDep graph starting from `roots`. `visited` guards
+  // against cycles and double-enqueue; `excluded` is consulted only
+  // when deciding whether to EMIT a script — a node already in
+  // `excluded` has its script tag elsewhere, but we still walk its
+  // own stubDeps so a transitively-deeper miss gets emitted here.
+  const visited = new Set<string>()
+  const queue: string[] = []
+  for (const name of roots) {
+    if (name === '__barefoot__') continue
+    if (visited.has(name)) continue
+    visited.add(name)
+    queue.push(name)
+  }
+
+  while (queue.length > 0) {
+    const name = queue.shift()!
+    const entry = manifest[name]
+    const deps = entry?.stubDeps
+    if (!deps) continue
+    for (const dep of deps) {
+      if (visited.has(dep)) continue
+      visited.add(dep)
+      queue.push(dep)
+      if (excluded.has(dep)) continue
+      excluded.add(dep)
+      const depEntry = manifest[dep]
+      if (depEntry?.clientJs) {
+        const src = prefix + relPathFromComponentsBase(depEntry.clientJs)
+        result.set(dep, { src })
+      }
+    }
+  }
+  return result
+}
+
+function relPathFromComponentsBase(p: string): string {
+  return p.startsWith('components/') ? p.slice('components/'.length) : p
 }

--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -88,6 +88,81 @@ console.log('client code')
     expect(errors).toHaveLength(0)
   })
 
+  // Issue #1243: when a bundle's only reference to a sibling 'use client'
+  // component is the stub rewrite (no JSX), the page-level script loader
+  // needs to know it so the target component's .client.js still ships.
+  // resolveRelativeImports surfaces the per-entry stub targets as
+  // absolute source paths; build.ts converts those to manifest keys.
+  test('reports stub-rewritten use-client targets via stubDepsByManifestKey (#1243)', async () => {
+    const targetPath = resolve(COMPONENTS_DIR, 'DraftTitleEditor.tsx')
+    writeFileSync(targetPath, `'use client'
+export function DraftTitleEditor() {
+  return <div>editor</div>
+}
+`)
+    const clientJs = `import { DraftTitleEditor } from './DraftTitleEditor'
+import { createSignal } from '@barefootjs/client'
+DraftTitleEditor({ initialTitle: '' })
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'IssueCardNode-abc123.js'), clientJs)
+
+    const manifest = {
+      IssueCardNode: { clientJs: 'components/IssueCardNode-abc123.js', markedTemplate: 'components/IssueCardNode.tsx' },
+    }
+
+    const { stubDepsByManifestKey } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    // Parent bundle reaches DraftTitleEditor through the stub rewrite, so
+    // its absolute source path is recorded under the parent's manifest key.
+    expect(stubDepsByManifestKey).toEqual({
+      IssueCardNode: [targetPath],
+    })
+  })
+
+  // Issue #1243: when the same parent imports two stubs from the same
+  // target file (e.g. `import { A, B } from './foo'`), the target should
+  // appear once in stubDeps. The dedup happens at the Set level inside
+  // walkAndCollect — a Set<absPath> can't double-count one resolved path.
+  test('dedupes stubDeps when the parent stubs multiple names from one target (#1243)', async () => {
+    const targetPath = resolve(COMPONENTS_DIR, 'multi.tsx')
+    writeFileSync(targetPath, `'use client'
+export function A() { return <div /> }
+export function B() { return <div /> }
+`)
+    const clientJs = `import { A, B } from './multi'
+A({})
+B({})
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Parent-abc.js'), clientJs)
+
+    const manifest = {
+      Parent: { clientJs: 'components/Parent-abc.js', markedTemplate: 'components/Parent.tsx' },
+    }
+
+    const { stubDepsByManifestKey } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect(stubDepsByManifestKey.Parent).toEqual([targetPath])
+  })
+
+  // Issue #1243: a bundle that doesn't reach any 'use client' sibling
+  // produces no stubDeps entry. The downstream wiring uses presence in
+  // the map to decide whether to clear the manifest field, so the empty
+  // case must be EXPLICITLY absent, not present-with-empty-array.
+  test('omits manifest key from stubDepsByManifestKey when no stubs are emitted (#1243)', async () => {
+    const clientJs = `import { createSignal } from '@barefootjs/client'
+console.log('no stubs here')
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'NoStub-abc.js'), clientJs)
+
+    const manifest = {
+      NoStub: { clientJs: 'components/NoStub-abc.js', markedTemplate: 'components/NoStub.tsx' },
+    }
+
+    const { stubDepsByManifestKey } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect('NoStub' in stubDepsByManifestKey).toBe(false)
+  })
+
   // Regression: bf#1258 — a sibling `.tsx` without the `'use client'`
   // directive is a plain server-side module (e.g. data + utility helpers
   // that happen to live in a `.tsx` file because they shape SSR JSX). The

--- a/packages/cli/src/__tests__/resolve-imports.test.ts
+++ b/packages/cli/src/__tests__/resolve-imports.test.ts
@@ -144,6 +144,39 @@ B({})
     expect(stubDepsByManifestKey.Parent).toEqual([targetPath])
   })
 
+  // Issue #1243 × #1258: when every named binding from a 'use client'
+  // sibling is already declared at top level (esbuild inlined the
+  // target whole), no stub is emitted AND the target's own
+  // `.client.js` is unnecessary for delegation — its registration
+  // rides along in the parent's inlined copy. Lock in: this case
+  // produces NO stubDeps entry, so the page-level loader doesn't
+  // ship a redundant bundle that would only re-do the registration.
+  test('omits manifest key from stubDepsByManifestKey when every binding is already top-level (#1243, #1258)', async () => {
+    writeFileSync(resolve(COMPONENTS_DIR, 'AllInlined.tsx'), `'use client'
+export function AllInlined() {
+  return <div>inlined</div>
+}
+`)
+    // Mirrors the #1258 fixture above: parent bundle has the named
+    // import (which we strip) AND a top-level `function AllInlined`
+    // (esbuild's inlined copy).
+    const clientJs = `import { AllInlined } from './AllInlined'
+import { createComponent, hydrate } from '@barefootjs/client/runtime'
+export function initAllInlined(__scope, _p = {}) { /* ... */ }
+hydrate('AllInlined', { init: initAllInlined, template: (_p) => '<div>inlined</div>' })
+export function AllInlined(_p, __bfKey) { return createComponent('AllInlined', _p, __bfKey) }
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'Host-abc.js'), clientJs)
+
+    const manifest = {
+      Host: { clientJs: 'components/Host-abc.js', markedTemplate: 'components/Host.tsx' },
+    }
+
+    const { stubDepsByManifestKey } = await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    expect('Host' in stubDepsByManifestKey).toBe(false)
+  })
+
   // Issue #1243: a bundle that doesn't reach any 'use client' sibling
   // produces no stubDeps entry. The downstream wiring uses presence in
   // the map to decide whether to clear the manifest field, so the empty

--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -16,7 +16,7 @@ export interface CacheEntry {
   /** Manifest key this entry contributes to (null when the entry produced no manifest row) */
   manifestKey: string | null
   /** Stored manifest row, so cache-hit entries can restore it without recompiling */
-  manifestEntry?: { markedTemplate: string; clientJs?: string }
+  manifestEntry?: { markedTemplate: string; clientJs?: string; stubDeps?: string[] }
   /** Key used to register this entry's types with the postBuild hook */
   typesKey?: string
   /** Adapter-generated types (e.g. Go structs). Restored on cache hit so the

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -69,7 +69,7 @@ export interface BuildResult {
   /** Number of compilation errors */
   errorCount: number
   /** Manifest entries */
-  manifest: Record<string, { clientJs?: string; markedTemplate: string }>
+  manifest: Record<string, { clientJs?: string; markedTemplate: string; stubDeps?: string[] }>
   /** True when any output file on disk was changed (write or delete) */
   changed: boolean
   /**
@@ -394,7 +394,7 @@ export async function build(
   const allFilesSet = new Set(allFiles)
 
   // 3. Manifest baseline (runtime sentinel always present)
-  const manifest: Record<string, { clientJs?: string; markedTemplate: string }> = {
+  const manifest: Record<string, { clientJs?: string; markedTemplate: string; stubDeps?: string[] }> = {
     '__barefoot__': { markedTemplate: '', clientJs: `${runtimeSubdir}/barefoot.js` },
   }
 
@@ -638,7 +638,7 @@ export async function build(
       sourceDirsByManifestKey[entry.manifestKey] = [dirname(sourcePath)]
     }
   }
-  const { errors: resolveErrors } = await resolveRelativeImports({
+  const { errors: resolveErrors, stubDepsByManifestKey } = await resolveRelativeImports({
     distDir: config.outDir,
     manifest,
     sourceDirsByManifestKey,
@@ -649,6 +649,45 @@ export async function build(
   for (const err of resolveErrors) {
     console.error(formatError(err))
     errorCount++
+  }
+
+  // Attach stub-rewrite dependencies to manifest entries (and the cache
+  // copy that survives across builds) so the per-page script loader can
+  // follow them when deciding which `.client.js` files to ship — see
+  // issue #1243. `resolveRelativeImports` returns each bundle's stub
+  // targets as absolute source paths; convert them to manifest keys
+  // here, where the path → key mapping is known via `nextEntries`.
+  const entriesByManifestKey = new Map<string, CacheEntry>()
+  const manifestKeyByEntryPath = new Map<string, string>()
+  for (const [sourcePath, cacheEntry] of Object.entries(nextEntries)) {
+    if (cacheEntry.manifestKey) {
+      entriesByManifestKey.set(cacheEntry.manifestKey, cacheEntry)
+      if (!sourcePath.startsWith('bundle:')) {
+        manifestKeyByEntryPath.set(sourcePath, cacheEntry.manifestKey)
+      }
+    }
+  }
+  for (const [name, depPaths] of Object.entries(stubDepsByManifestKey)) {
+    const depKeys: string[] = []
+    for (const depPath of depPaths) {
+      const depKey = manifestKeyByEntryPath.get(depPath)
+      if (depKey) depKeys.push(depKey)
+    }
+    if (depKeys.length === 0) continue
+    depKeys.sort()
+    const entry = manifest[name]
+    if (entry) entry.stubDeps = depKeys
+    const cacheEntry = entriesByManifestKey.get(name)
+    if (cacheEntry?.manifestEntry) cacheEntry.manifestEntry.stubDeps = depKeys
+  }
+  // Drop stale stubDeps from any manifest entry whose current bundle no
+  // longer reaches a stub (e.g. the user deleted the imperative call).
+  for (const [name, entry] of Object.entries(manifest)) {
+    if (entry && !(name in stubDepsByManifestKey) && entry.stubDeps) {
+      delete entry.stubDeps
+      const cacheEntry = entriesByManifestKey.get(name)
+      if (cacheEntry?.manifestEntry) delete cacheEntry.manifestEntry.stubDeps
+    }
   }
 
   // 6c. Normalize @barefootjs/client* specifiers to the relative barefoot.js
@@ -1199,7 +1238,7 @@ type CompileEntryOutcome =
       deps: Record<string, string>
       outputs: string[]
       manifestKey: string | null
-      manifestEntry?: { markedTemplate: string; clientJs?: string }
+      manifestEntry?: { markedTemplate: string; clientJs?: string; stubDeps?: string[] }
       wroteAny: boolean
       types?: string
       typesKey?: string

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -662,6 +662,12 @@ export async function build(
   for (const [sourcePath, cacheEntry] of Object.entries(nextEntries)) {
     if (cacheEntry.manifestKey) {
       entriesByManifestKey.set(cacheEntry.manifestKey, cacheEntry)
+      // `bundle:` entries are synthetic keys for `bundleEntries`
+      // (separately-built JS, not project-discovered `.tsx`). A stub
+      // target is always a `'use client'` `.tsx` file, so a bundle
+      // entry can never be a stub destination — keep it out of the
+      // path lookup so we don't accidentally map an unrelated
+      // `bundle:foo` key onto a real source path.
       if (!sourcePath.startsWith('bundle:')) {
         manifestKeyByEntryPath.set(sourcePath, cacheEntry.manifestKey)
       }

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -902,10 +902,23 @@ async function walkAndCollect(
         // loader can include the target component's `.client.js` on any
         // page whose bundle reaches it through this stub call (issue
         // #1243). Only record when something was actually stubbed —
-        // names filtered out by `existingTopLevel` are already inlined
-        // into this bundle so their own `.client.js` is unnecessary for
-        // delegation to resolve. The path → manifest-key conversion
-        // happens in `build.ts` where the manifest layout is known.
+        // when every named binding is already in `existingTopLevel`
+        // (esbuild inlined the whole target into this bundle), no stub
+        // is emitted and the page already has the inlined registration,
+        // so the target's standalone `.client.js` is unnecessary.
+        //
+        // Partial-inline edge case: if esbuild inlined SOME bindings
+        // (e.g. `Foo`) but NOT others (`Bar`), `Bar` still triggers a
+        // stub and we ship the target's `.client.js`. Loading it
+        // re-registers `Foo` alongside the parent's already-inlined
+        // `Foo` — `hydrate()` is a plain `Map.set` in all three
+        // runtime registries (`hydrate.ts`, `registry.ts`,
+        // `template.ts`), so the second call silently overwrites
+        // with the same def. Same code in both copies, so the
+        // overwrite is observationally a no-op.
+        //
+        // The path → manifest-key conversion happens in `build.ts`
+        // where the manifest layout is known.
         if (stubsToEmit.length > 0) stubDeps.add(result.path)
         // The stub references the runtime `createComponent` symbol. Every
         // JSX-emitted client bundle already imports it as part of the

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -728,6 +728,16 @@ function detectStrippedReferences(
  * dep is recorded here so `inlineRelativeImports` can verify, after IIFE
  * assembly, that none of the dropped bindings are still referenced in
  * the final bundle. piconic-ai/barefootjs#1227.
+ *
+ * `stubDeps` is a mutable accumulator for the absolute paths of every
+ * `'use client'` sibling that this bundle reaches via a stub rewrite
+ * (the `createComponent(name, ...)` shim emitted in place of the
+ * stripped import). The build pipeline maps these paths to manifest
+ * keys and surfaces them on the manifest entry so the page-level
+ * script loader can follow stub references when deciding which
+ * `.client.js` files to ship — without this the runtime fails with
+ * "Template not found" on pages that only reach a child component
+ * through an imperative stub call. See #1243.
  */
 async function walkAndCollect(
   content: string,
@@ -736,6 +746,7 @@ async function walkAndCollect(
   visiting: Set<string>,
   loggingPath: string,
   stripped: StrippedImport[],
+  stubDeps: Set<string>,
 ): Promise<string> {
   // Parse the body with the TypeScript compiler API and walk every
   // top-level `ImportDeclaration`. Working off the AST — rather than
@@ -887,6 +898,15 @@ async function walkAndCollect(
           .join('\n')
         const replacement = stubBody.length > 0 ? `${stubBody}\n` : ''
         replacements.push({ start: site.start, end: site.endWithNewline, text: replacement })
+        // Record the stub target's absolute path so the page-level script
+        // loader can include the target component's `.client.js` on any
+        // page whose bundle reaches it through this stub call (issue
+        // #1243). Only record when something was actually stubbed —
+        // names filtered out by `existingTopLevel` are already inlined
+        // into this bundle so their own `.client.js` is unnecessary for
+        // delegation to resolve. The path → manifest-key conversion
+        // happens in `build.ts` where the manifest layout is known.
+        if (stubsToEmit.length > 0) stubDeps.add(result.path)
         // The stub references the runtime `createComponent` symbol. Every
         // JSX-emitted client bundle already imports it as part of the
         // umbrella `barefoot.js` runtime (any `<X />` use compiles to a
@@ -952,6 +972,7 @@ async function walkAndCollect(
         visiting,
         loggingPath,
         stripped,
+        stubDeps,
       )
       mod.transpiledBody = replacedBody
       visiting.delete(result.path)
@@ -1027,11 +1048,12 @@ async function inlineRelativeImports(
   loggingPath: string,
   hoistedAcc: string[],
   errorAcc: CompilerError[],
+  stubDeps: Set<string>,
 ): Promise<string> {
   const modules = new Map<string, InlinedModule>()
   const visiting = new Set<string>()
   const stripped: StrippedImport[] = []
-  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath, stripped)
+  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath, stripped, stubDeps)
 
   if (modules.size === 0) {
     // No IIFEs to prepend — the parent content already reflects every
@@ -1101,9 +1123,10 @@ async function inlineRelativeImports(
  */
 export async function resolveRelativeImports(
   options: ResolveRelativeImportsOptions,
-): Promise<{ errors: CompilerError[] }> {
+): Promise<{ errors: CompilerError[]; stubDepsByManifestKey: Record<string, string[]> }> {
   const { distDir, manifest, sourceDirs = [], sourceDirsByManifestKey = {} } = options
   const errors: CompilerError[] = []
+  const stubDepsByManifestKey: Record<string, string[]> = {}
 
   for (const [name, entry] of Object.entries(manifest)) {
     if (!entry.clientJs) continue
@@ -1117,13 +1140,18 @@ export async function resolveRelativeImports(
 
     const perEntryDirs = sourceDirsByManifestKey[name] ?? []
     const hoistedAcc: string[] = []
+    const stubDeps = new Set<string>()
     let next = await inlineRelativeImports(
       content,
       [dirname(filePath), ...perEntryDirs, ...sourceDirs],
       entry.clientJs,
       hoistedAcc,
       errors,
+      stubDeps,
     )
+    if (stubDeps.size > 0) {
+      stubDepsByManifestKey[name] = Array.from(stubDeps).sort()
+    }
 
     // Note: `inlineRelativeImports` runs `detectStrippedReferences` BEFORE
     // the hoisted bare-package imports below are prepended. A stripped
@@ -1153,5 +1181,5 @@ export async function resolveRelativeImports(
     }
   }
 
-  return { errors }
+  return { errors, stubDepsByManifestKey }
 }


### PR DESCRIPTION
## Summary

Closes #1243. The 'use client' import rewriter (#1241) replaces named imports with `createComponent(name, ...)` stubs so an imperative call can reach the runtime registry. But the page-level script loader still gated `.client.js` emission on JSX usage — a page whose bundle reaches a child only via the stub call shipped without that child's bundle, and the runtime warned `Template not found for component: X`.

- `walkAndCollect` now accumulates the resolved absolute path of every stub-rewritten sibling. `build.ts` converts those paths to manifest keys and surfaces them as `stubDeps: string[]` on each manifest entry (cached across builds).
- `BfScripts` accepts optional `manifest` + `base` props; when supplied, it walks the rendered-component set's `stubDeps` transitively and emits a `<script>` for every reachable `.client.js` not already present. Cycle-safe via a visited set.
- Opt-in: omitting the new props keeps the pre-#1243 JSX-driven collector behavior. Existing consumers don't change unless they want the fix.

## Test plan

- [ ] `bun test packages/cli/ packages/adapter-hono/` — 646 tests, 0 fail locally
- [ ] CI green
- [ ] Manual: reproduce the repro from #1243 in a downstream consumer (e.g. desk) by passing `manifest` + `base` to `<BfScripts />` and confirming the `Template not found` warning is gone for a stub-only chain

## Out of scope

- Other adapters (go-template, mojolicious, CSR). The CLI-side `stubDeps` manifest field is adapter-agnostic; each adapter's per-page script collector needs an equivalent walk to use it. Tracked as a follow-up.
- E2E verification in `site/ui/e2e/`. The fix is most visible from a downstream consumer; will follow up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)