### PR TITLE
fix(#1343): pick the visible header logo in theme-switcher e2e

### DIFF
--- a/site/ui/e2e/theme-switcher.spec.ts
+++ b/site/ui/e2e/theme-switcher.spec.ts
@@ -114,7 +114,12 @@ test.describe('ThemeSwitcher', () => {
   })
 
   test('header contains logo and UI link', async ({ page }) => {
-    await expect(page.locator('header a:has(svg)').first()).toBeVisible()
+    // The mobile/desktop header split (#1343) renders two logo `<a>`s in
+    // the DOM and toggles them with `sm:hidden` / `hidden sm:inline-flex`.
+    // `.first()` would pick the DOM-first (mobile) one, which is hidden
+    // on the default desktop viewport. Filter by visibility so the
+    // assertion targets whichever logo the current viewport reveals.
+    await expect(page.locator('header a:has(svg)').filter({ visible: true }).first()).toBeVisible()
     await expect(page.locator('header a:has-text("UI")')).toBeVisible()
     await expect(page.locator('header a:has-text("UI")')).toHaveAttribute('href', '/')
   })


### PR DESCRIPTION
## Summary

`theme-switcher.spec.ts:117`'s `header a:has(svg).first()` picks the DOM-first logo, which since #1343 is the **mobile** wrapper (`flex sm:hidden`). At Playwright's default 1280×720 desktop viewport this is hidden, so `toBeVisible()` times out.

Switch to `.filter({ visible: true }).first()` so the assertion targets whichever logo the current viewport reveals.

## Why this didn't break main

CI's `e2e-site-ui` workflow only triggers on `paths: site/ui/**`. #1343 lives in `site/shared/**`, so the broken test never ran against the post-#1343 header on main. The first PR to modify `packages/**` or `site/ui/**` after that merge (#1342) surfaced it.

## Test plan

- [ ] CI green (this PR triggers `packages/**` ⇒ runs the e2e shard)
- [ ] After merge, rebase #1342 and confirm its CI clears too

🤖 Generated with [Claude Code](https://claude.com/claude-code)