### PR TITLE
fix(#1343): also dedupe the UI link locator in theme-switcher e2e

### DIFF
--- a/site/ui/e2e/theme-switcher.spec.ts
+++ b/site/ui/e2e/theme-switcher.spec.ts
@@ -114,13 +114,17 @@ test.describe('ThemeSwitcher', () => {
   })
 
   test('header contains logo and UI link', async ({ page }) => {
-    // The mobile/desktop header split (#1343) renders two logo `<a>`s in
-    // the DOM and toggles them with `sm:hidden` / `hidden sm:inline-flex`.
-    // `.first()` would pick the DOM-first (mobile) one, which is hidden
-    // on the default desktop viewport. Filter by visibility so the
-    // assertion targets whichever logo the current viewport reveals.
+    // The mobile/desktop header split (#1343) renders both the logo and
+    // the UI nav link twice — once for mobile (`flex sm:hidden`) and
+    // once for desktop (`hidden sm:inline-flex`). `.first()` and a bare
+    // `toBeVisible()` (which is strict mode) both fail: `.first()`
+    // picks the DOM-first (mobile) one which is hidden on the default
+    // 1280x720 desktop viewport, and strict mode trips on the 2 matches.
+    // Filter by visibility so each assertion targets whichever copy the
+    // current viewport reveals.
     await expect(page.locator('header a:has(svg)').filter({ visible: true }).first()).toBeVisible()
-    await expect(page.locator('header a:has-text("UI")')).toBeVisible()
-    await expect(page.locator('header a:has-text("UI")')).toHaveAttribute('href', '/')
+    const uiLink = page.locator('header a:has-text("UI")').filter({ visible: true }).first()
+    await expect(uiLink).toBeVisible()
+    await expect(uiLink).toHaveAttribute('href', '/')
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1346. My logo-locator fix was incomplete — the mobile/desktop split renders the **UI nav link** twice too (once as the mobile shortcut, once as the desktop nav). Strict-mode \`toBeVisible()\` rejects 2 matches, so the next two assertions in the same test still fail on \`e2e-site-ui (4)\`:

\`\`\`
strict mode violation: locator('header a:has-text("UI")') resolved to 2 elements:
  1) <a href="/" class="text-sm font-medium ...">UI</a>           (mobile shortcut, hidden on desktop)
  2) <a href="/" class="relative ... text-foreground">…</a>       (desktop nav link)
\`\`\`

Apply the same \`.filter({ visible: true }).first()\` shape so each viewport sees exactly one match.

## Test plan

- [ ] CI green
- [ ] After merge, rebase #1342 again and confirm its CI clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)