### PR TITLE
fix(#1345): make Studio handoff actually runnable

### DIFF
--- a/packages/cli/src/__tests__/studio.test.ts
+++ b/packages/cli/src/__tests__/studio.test.ts
@@ -4,8 +4,9 @@ import path from 'path'
 import os from 'os'
 import {
   parseStudioUrl,
+  applyCssOverrides,
   applyTokenOverrides,
-  appendCSSOverrides,
+  resolveTokensCss,
   type StudioConfig,
 } from '../commands/studio'
 
@@ -32,7 +33,191 @@ describe('parseStudioUrl', () => {
   })
 })
 
-// ── applyTokenOverrides ──
+// ── applyCssOverrides (the primary path — direct CSS patching) ──
+
+const TOKENS_CSS_FIXTURE = `:root {
+  --font-sans: -apple-system, sans-serif;
+  --spacing: 0.25rem;
+  --radius: 0.625rem;
+  --primary: oklch(0.205 0 0);
+  --secondary: oklch(0.97 0 0);
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+}
+
+.dark {
+  --primary: oklch(0.35 0 0);
+  --secondary: oklch(0.269 0 0);
+}
+`
+
+describe('applyCssOverrides', () => {
+  let tmpDir: string
+  let cssPath: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-studio-css-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+    cssPath = path.join(tmpDir, 'tokens.css')
+    writeFileSync(cssPath, TOKENS_CSS_FIXTURE)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function read(): string {
+    return readFileSync(cssPath, 'utf-8')
+  }
+
+  test('rewrites --spacing in :root', () => {
+    applyCssOverrides(cssPath, { spacing: '0.3rem' })
+    expect(read()).toContain('--spacing: 0.3rem;')
+    expect(read()).not.toContain('--spacing: 0.25rem;')
+  })
+
+  test('rewrites --radius in :root', () => {
+    applyCssOverrides(cssPath, { radius: '0' })
+    expect(read()).toContain('--radius: 0;')
+    expect(read()).not.toContain('--radius: 0.625rem;')
+  })
+
+  test('rewrites --font-sans via font key mapping', () => {
+    applyCssOverrides(cssPath, { font: 'inter' })
+    expect(read()).toContain('--font-sans: "Inter", sans-serif;')
+  })
+
+  test('passes through unknown font keys verbatim', () => {
+    applyCssOverrides(cssPath, { font: '"Custom Font", monospace' })
+    expect(read()).toContain('--font-sans: "Custom Font", monospace;')
+  })
+
+  test('writes color light value to :root and dark value to .dark', () => {
+    applyCssOverrides(cssPath, {
+      tokens: {
+        primary: { light: 'oklch(0.5 0.2 240)', dark: 'oklch(0.7 0.15 240)' },
+      },
+    })
+    const css = read()
+    // :root block keeps the light value
+    const rootBlock = css.slice(css.indexOf(':root'), css.indexOf('.dark'))
+    expect(rootBlock).toContain('--primary: oklch(0.5 0.2 240);')
+    // .dark block keeps the dark value
+    const darkBlock = css.slice(css.indexOf('.dark'))
+    expect(darkBlock).toContain('--primary: oklch(0.7 0.15 240);')
+  })
+
+  test('only writes light value when dark is absent', () => {
+    applyCssOverrides(cssPath, {
+      tokens: { secondary: { light: 'oklch(0.5 0 0)' } },
+    })
+    const css = read()
+    // :root updated, .dark untouched
+    expect(css.slice(css.indexOf(':root'), css.indexOf('.dark'))).toContain('--secondary: oklch(0.5 0 0);')
+    expect(css.slice(css.indexOf('.dark'))).toContain('--secondary: oklch(0.269 0 0);')
+  })
+
+  test('appends a new color into .dark when no existing declaration', () => {
+    // .dark does NOT have --radius. Adding it should append under the
+    // Studio overrides comment so re-applies stay idempotent.
+    applyCssOverrides(cssPath, {
+      tokens: { background: { dark: 'oklch(0.1 0 0)' } },
+    })
+    const css = read()
+    const darkBlock = css.slice(css.indexOf('.dark'))
+    expect(darkBlock).toContain('Studio overrides')
+    expect(darkBlock).toContain('--background: oklch(0.1 0 0);')
+  })
+
+  test('Sharp shadow preset rewrites all four shadow vars', () => {
+    applyCssOverrides(cssPath, { style: 'Sharp' })
+    const css = read()
+    expect(css).toContain('--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.04);')
+    expect(css).toContain('--shadow: 0 1px 2px 0 rgb(0 0 0 / 0.06);')
+    expect(css).toContain('--shadow-md: 0 2px 4px -1px rgb(0 0 0 / 0.08);')
+    expect(css).toContain('--shadow-lg: 0 4px 8px -2px rgb(0 0 0 / 0.1);')
+  })
+
+  test('unknown style names leave the CSS untouched', () => {
+    applyCssOverrides(cssPath, { style: 'Unknown' })
+    expect(read()).toBe(TOKENS_CSS_FIXTURE)
+  })
+
+  test('is idempotent: applying the same config twice yields the same file', () => {
+    const config: StudioConfig = {
+      spacing: '0.3rem',
+      radius: '1rem',
+      font: 'figtree',
+      tokens: { primary: { light: 'oklch(0.5 0.2 240)', dark: 'oklch(0.7 0.15 240)' } },
+      style: 'Soft',
+    }
+    applyCssOverrides(cssPath, config)
+    const once = read()
+    applyCssOverrides(cssPath, config)
+    expect(read()).toBe(once)
+  })
+
+  test('rewrites in place when applying different configs sequentially', () => {
+    applyCssOverrides(cssPath, { spacing: '0.3rem' })
+    applyCssOverrides(cssPath, { spacing: '0.5rem' })
+    const css = read()
+    expect(css).toContain('--spacing: 0.5rem;')
+    expect(css).not.toContain('--spacing: 0.3rem;')
+  })
+})
+
+// ── resolveTokensCss ──
+
+describe('resolveTokensCss', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `bf-studio-resolve-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('finds tokens.css under <paths.tokens>/', () => {
+    mkdirSync(path.join(tmpDir, 'tokens'), { recursive: true })
+    const target = path.join(tmpDir, 'tokens', 'tokens.css')
+    writeFileSync(target, ':root {}')
+    expect(resolveTokensCss(tmpDir, 'tokens')).toBe(target)
+  })
+
+  test('falls back to public/tokens.css (default adapter scaffold)', () => {
+    mkdirSync(path.join(tmpDir, 'public'), { recursive: true })
+    const target = path.join(tmpDir, 'public', 'tokens.css')
+    writeFileSync(target, ':root {}')
+    expect(resolveTokensCss(tmpDir, 'tokens')).toBe(target)
+  })
+
+  test('falls back to static/tokens.css', () => {
+    mkdirSync(path.join(tmpDir, 'static'), { recursive: true })
+    const target = path.join(tmpDir, 'static', 'tokens.css')
+    writeFileSync(target, ':root {}')
+    expect(resolveTokensCss(tmpDir, 'tokens')).toBe(target)
+  })
+
+  test('returns undefined when nothing matches', () => {
+    expect(resolveTokensCss(tmpDir, 'tokens')).toBeUndefined()
+  })
+
+  test('prefers <paths.tokens>/ over public/ when both exist', () => {
+    mkdirSync(path.join(tmpDir, 'tokens'), { recursive: true })
+    mkdirSync(path.join(tmpDir, 'public'), { recursive: true })
+    const primary = path.join(tmpDir, 'tokens', 'tokens.css')
+    writeFileSync(primary, ':root {}')
+    writeFileSync(path.join(tmpDir, 'public', 'tokens.css'), ':root {}')
+    expect(resolveTokensCss(tmpDir, 'tokens')).toBe(primary)
+  })
+})
+
+// ── applyTokenOverrides (tokens.json — monorepo path, best-effort) ──
 
 describe('applyTokenOverrides', () => {
   let tmpDir: string
@@ -133,43 +318,6 @@ describe('applyTokenOverrides', () => {
     applyTokenOverrides(tokensPath, { style: 'Unknown' })
 
     expect(readTokens(tokensPath).shadows[0].value).toBe('original')
-  })
-})
-
-// ── appendCSSOverrides ──
-
-describe('appendCSSOverrides', () => {
-  let tmpDir: string
-
-  beforeEach(() => {
-    tmpDir = path.join(os.tmpdir(), `bf-studio-css-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    mkdirSync(tmpDir, { recursive: true })
-  })
-
-  afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true })
-  })
-
-  test('appends --spacing to :root block', () => {
-    const cssPath = path.join(tmpDir, 'tokens.css')
-    writeFileSync(cssPath, ':root {\n  --radius: 0.625rem;\n}\n')
-
-    appendCSSOverrides(cssPath, { spacing: '0.3rem' })
-
-    const result = readFileSync(cssPath, 'utf-8')
-    expect(result).toContain('--spacing: 0.3rem;')
-    expect(result).toContain('Studio overrides')
-    expect(result).toContain('--radius: 0.625rem;')
-  })
-
-  test('does nothing when no spacing override', () => {
-    const cssPath = path.join(tmpDir, 'tokens.css')
-    const original = ':root {\n  --radius: 0.625rem;\n}\n'
-    writeFileSync(cssPath, original)
-
-    appendCSSOverrides(cssPath, { style: 'Sharp' })
-
-    expect(readFileSync(cssPath, 'utf-8')).toBe(original)
   })
 })
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1,13 +1,17 @@
 // `barefoot studio apply <url>` — Apply a Studio-encoded token config
 // (from a `?c=...` URL) onto an existing project's tokens.
 //
-// Reads `paths.tokens` from `barefoot.config.ts`, then:
-//   1. Patches `<tokens>/tokens.json` with color / spacing / radius / font /
-//      shadow overrides decoded from the Studio URL.
-//   2. Regenerates `<tokens>/tokens.css` from the patched JSON if the
-//      monorepo's token module is reachable (skipped silently otherwise).
-//   3. Appends CSS variable overrides that aren't represented in
-//      tokens.json (e.g. `--spacing`) to `<tokens>/tokens.css`.
+// Primary action: rewrite CSS variable values inside the project's
+// `tokens.css` so the change is visible on the next page load. The
+// runtime reads `tokens.css`, not `tokens.json`, so direct CSS
+// patching is the source of truth for end-user apps. Search order:
+// `<paths.tokens>/tokens.css` → `public/tokens.css` → `static/tokens.css`.
+//
+// Secondary action (best-effort): if `<paths.tokens>/tokens.json`
+// exists (monorepo convention), patch it too so a subsequent
+// tokens-build pipeline regenerates `tokens.css` from the same JSON.
+// Silent skip when the file isn't there — end-user scaffolds don't
+// ship a tokens.json.
 
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import path from 'path'
@@ -19,6 +23,39 @@ export interface StudioConfig {
   spacing?: string
   radius?: string
   font?: string
+}
+
+// Font key → font-family value mapping (mirrors Studio's font picker).
+const FONT_MAP: Record<string, string> = {
+  system: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
+  inter: '"Inter", sans-serif',
+  'noto-sans': '"Noto Sans", sans-serif',
+  'nunito-sans': '"Nunito Sans", sans-serif',
+  figtree: '"Figtree", sans-serif',
+}
+
+// Shadow presets — mirror Studio's stylePresets. Names use the bare
+// shadow token (no leading `--`) so we can share with the JSON-patching
+// path that uses bare names too.
+const SHADOW_PRESETS: Record<string, Record<string, string>> = {
+  Sharp: {
+    'shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
+    'shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
+    'shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
+    'shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
+  },
+  Soft: {
+    'shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
+    'shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
+    'shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
+    'shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
+  },
+  Compact: {
+    'shadow-sm': 'none',
+    'shadow': 'none',
+    'shadow-md': 'none',
+    'shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  },
 }
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -35,10 +72,11 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  if (!ctx.config || !ctx.projectDir) {
-    console.error('Error: project config not found. Run `barefoot init` first.')
-    process.exit(1)
-  }
+  // The CSS lookup falls back to bare cwd when `barefoot.config.ts` is
+  // missing, so an app that hasn't run the scaffolder yet still gets a
+  // useful error pointing at the directory we searched.
+  const projectDir = ctx.projectDir ?? process.cwd()
+  const tokensRelDir = ctx.config?.paths.tokens ?? 'tokens'
 
   const studioConfig = parseStudioUrl(url)
   if (!studioConfig) {
@@ -46,22 +84,26 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  const tokensDir = path.resolve(ctx.projectDir, ctx.config.paths.tokens)
-  const tokensJsonPath = path.join(tokensDir, 'tokens.json')
-  const tokensCssPath = path.join(tokensDir, 'tokens.css')
-
-  if (!existsSync(tokensJsonPath)) {
-    console.error(`Error: ${path.relative(ctx.projectDir, tokensJsonPath)} not found.`)
-    console.error('       Studio overrides need an existing tokens.json to patch.')
+  // ── 1. Patch tokens.css (primary, end-user source of truth) ──
+  const cssPath = resolveTokensCss(projectDir, tokensRelDir)
+  if (!cssPath) {
+    console.error('Error: tokens.css not found. Checked:')
+    for (const p of candidateCssPaths(projectDir, tokensRelDir)) {
+      console.error(`  - ${path.relative(projectDir, p)}`)
+    }
+    console.error('       Run `npm create barefootjs@latest` to scaffold a project first.')
     process.exit(1)
   }
 
-  applyTokenOverrides(tokensJsonPath, studioConfig)
-  console.log(`  Patched ${path.relative(ctx.projectDir, tokensJsonPath)}`)
+  applyCssOverrides(cssPath, studioConfig)
+  console.log(`  Patched ${path.relative(projectDir, cssPath)}`)
 
-  await generateTokensCSS(ctx.root, tokensJsonPath, tokensDir, ctx.config.paths.tokens)
-
-  appendCSSOverrides(tokensCssPath, studioConfig)
+  // ── 2. Patch tokens.json (best-effort, monorepo convention) ──
+  const tokensJsonPath = path.join(projectDir, tokensRelDir, 'tokens.json')
+  if (existsSync(tokensJsonPath)) {
+    applyTokenOverrides(tokensJsonPath, studioConfig)
+    console.log(`  Patched ${path.relative(projectDir, tokensJsonPath)}`)
+  }
 }
 
 function printUsage(): void {
@@ -86,7 +128,125 @@ export function parseStudioUrl(url: string): StudioConfig | undefined {
   }
 }
 
-// ── Token override logic ──
+// ── tokens.css resolution ──
+
+function candidateCssPaths(projectDir: string, tokensRelDir: string): string[] {
+  // Order matches how adapters scaffold. `public/` covers every shipped
+  // adapter today (hono, hono-node, csr, mojo, echo). `<paths.tokens>/`
+  // covers monorepo / hand-built layouts where the source CSS lives
+  // next to tokens.json. `static/` is kept as a generic fallback for
+  // adapters that mirror the Go-template convention.
+  return [
+    path.join(projectDir, tokensRelDir, 'tokens.css'),
+    path.join(projectDir, 'public', 'tokens.css'),
+    path.join(projectDir, 'static', 'tokens.css'),
+  ]
+}
+
+export function resolveTokensCss(projectDir: string, tokensRelDir: string): string | undefined {
+  for (const p of candidateCssPaths(projectDir, tokensRelDir)) {
+    if (existsSync(p)) return p
+  }
+  return undefined
+}
+
+// ── tokens.css patching ──
+
+interface BlockOverrides {
+  /** Overrides for `:root { ... }` (light-mode + non-color tokens). */
+  root: Record<string, string>
+  /** Overrides for `.dark { ... }` (dark-mode color tokens). */
+  dark: Record<string, string>
+}
+
+function buildBlockOverrides(config: StudioConfig): BlockOverrides {
+  const root: Record<string, string> = {}
+  const dark: Record<string, string> = {}
+
+  if (config.spacing) root['--spacing'] = config.spacing
+  if (config.radius) root['--radius'] = config.radius
+  if (config.font) {
+    root['--font-sans'] = FONT_MAP[config.font] ?? config.font
+  }
+  if (config.style) {
+    const preset = SHADOW_PRESETS[config.style]
+    if (preset) {
+      for (const [name, value] of Object.entries(preset)) {
+        root[`--${name}`] = value
+      }
+    }
+  }
+  if (config.tokens) {
+    for (const [name, values] of Object.entries(config.tokens)) {
+      if (values.light !== undefined) root[`--${name}`] = values.light
+      if (values.dark !== undefined) dark[`--${name}`] = values.dark
+    }
+  }
+
+  return { root, dark }
+}
+
+export function applyCssOverrides(cssPath: string, config: StudioConfig): void {
+  const overrides = buildBlockOverrides(config)
+  let css = readFileSync(cssPath, 'utf-8')
+  css = patchBlock(css, /:root\s*\{/, overrides.root)
+  css = patchBlock(css, /\.dark\s*\{/, overrides.dark)
+  writeFileSync(cssPath, css)
+}
+
+/**
+ * Replace CSS variable declarations inside the first block matched by
+ * `openRe`. Existing declarations are rewritten in place; new ones are
+ * appended just before the closing brace under a `Studio overrides`
+ * comment so re-runs stay idempotent (the second run finds them in
+ * place and rewrites instead of re-appending).
+ */
+function patchBlock(css: string, openRe: RegExp, overrides: Record<string, string>): string {
+  if (Object.keys(overrides).length === 0) return css
+
+  const openMatch = openRe.exec(css)
+  if (!openMatch) return css
+
+  const blockStart = openMatch.index + openMatch[0].length
+  let depth = 1
+  let blockEnd = -1
+  for (let i = blockStart; i < css.length; i++) {
+    const ch = css[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) { blockEnd = i; break }
+    }
+  }
+  if (blockEnd === -1) return css
+
+  let block = css.slice(blockStart, blockEnd)
+  const toAppend: Array<[string, string]> = []
+
+  for (const [name, value] of Object.entries(overrides)) {
+    const re = new RegExp(`(${escapeRegex(name)}\\s*:\\s*)[^;]+(;)`)
+    if (re.test(block)) {
+      block = block.replace(re, `$1${value}$2`)
+    } else {
+      toAppend.push([name, value])
+    }
+  }
+
+  if (toAppend.length > 0) {
+    const lines = toAppend.map(([n, v]) => `  ${n}: ${v};`).join('\n')
+    const trailing = block.match(/\s*$/)?.[0] ?? ''
+    block = block.slice(0, block.length - trailing.length) +
+      `\n\n  /* ── Studio overrides ── */\n${lines}\n`
+  }
+
+  return css.slice(0, blockStart) + block + css.slice(blockEnd)
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// ── tokens.json patching (best-effort, monorepo convention) ──
 
 export function applyTokenOverrides(tokensJsonPath: string, config: StudioConfig): void {
   const raw = readFileSync(tokensJsonPath, 'utf-8')
@@ -107,15 +267,7 @@ export function applyTokenOverrides(tokensJsonPath: string, config: StudioConfig
   }
 
   if (config.font) {
-    // Font key → font-family value mapping (mirrors Studio's font picker).
-    const fontMap: Record<string, string> = {
-      system: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
-      inter: '"Inter", sans-serif',
-      'noto-sans': '"Noto Sans", sans-serif',
-      'nunito-sans': '"Nunito Sans", sans-serif',
-      figtree: '"Figtree", sans-serif',
-    }
-    const fontValue = fontMap[config.font] || config.font
+    const fontValue = FONT_MAP[config.font] || config.font
     applySimpleOverride(tokensData, '--font-sans', fontValue)
   }
 
@@ -178,79 +330,9 @@ function applySimpleOverride(tokensData: any, name: string, value: string): void
 }
 
 function applyShadowPreset(tokensData: any, styleName: string): void {
-  // Preset names mirror Studio's stylePresets. Bare keys to match tokens.json.
-  const presets: Record<string, Record<string, string>> = {
-    Sharp: {
-      'shadow-sm': '0 1px 2px 0 rgb(0 0 0 / 0.04)',
-      'shadow': '0 1px 2px 0 rgb(0 0 0 / 0.06)',
-      'shadow-md': '0 2px 4px -1px rgb(0 0 0 / 0.08)',
-      'shadow-lg': '0 4px 8px -2px rgb(0 0 0 / 0.1)',
-    },
-    Soft: {
-      'shadow-sm': '0 1px 3px 0 rgb(0 0 0 / 0.06)',
-      'shadow': '0 2px 6px 0 rgb(0 0 0 / 0.08), 0 1px 3px -1px rgb(0 0 0 / 0.06)',
-      'shadow-md': '0 6px 12px -2px rgb(0 0 0 / 0.08), 0 3px 6px -3px rgb(0 0 0 / 0.06)',
-      'shadow-lg': '0 12px 24px -4px rgb(0 0 0 / 0.08), 0 6px 10px -5px rgb(0 0 0 / 0.06)',
-    },
-    Compact: {
-      'shadow-sm': 'none',
-      'shadow': 'none',
-      'shadow-md': 'none',
-      'shadow-lg': '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-    },
-  }
-
-  const shadows = presets[styleName]
+  const shadows = SHADOW_PRESETS[styleName]
   if (!shadows) return
-
   for (const [name, value] of Object.entries(shadows)) {
     applySimpleOverride(tokensData, name, value)
-  }
-}
-
-/**
- * Append CSS variable overrides that aren't part of tokens.json
- * (e.g., `--spacing` is a Tailwind v4 variable, not in our token schema).
- */
-export function appendCSSOverrides(cssPath: string, config: StudioConfig): void {
-  if (!existsSync(cssPath)) return
-
-  const lines: string[] = []
-  if (config.spacing) {
-    lines.push(`  --spacing: ${config.spacing};`)
-  }
-
-  if (lines.length === 0) return
-
-  const existing = readFileSync(cssPath, 'utf-8')
-  const rootCloseIdx = existing.indexOf('}')
-  if (rootCloseIdx === -1) return
-
-  const patched = existing.slice(0, rootCloseIdx) +
-    `\n  /* ── Studio overrides ── */\n${lines.join('\n')}\n` +
-    existing.slice(rootCloseIdx)
-
-  writeFileSync(cssPath, patched)
-}
-
-async function generateTokensCSS(
-  root: string,
-  tokensJsonPath: string,
-  tokensDir: string,
-  tokensRelDir: string,
-): Promise<void> {
-  try {
-    const { loadTokens, generateCSS } = await import(
-      path.resolve(root, 'site/shared/tokens/index')
-    )
-    const tokenSet = await loadTokens(tokensJsonPath)
-    const css = generateCSS(tokenSet)
-    writeFileSync(path.join(tokensDir, 'tokens.css'), css)
-    console.log(`  Regenerated ${tokensRelDir}/tokens.css`)
-  } catch {
-    // Token generation requires the monorepo's `site/shared/tokens` module.
-    // In a published CLI bundle this is unreachable; the user re-runs their
-    // build pipeline to project tokens.json into tokens.css.
-    console.log(`  Skipped tokens.css regeneration (run your tokens build pipeline)`)
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,9 +14,10 @@ const ctx = await createContext(jsonFlag)
 function printUsage() {
   console.log(`Usage: barefoot <command> [options]
 
+Scaffold a new project with \`npm create barefootjs@latest\`, then:
+
 Commands:
   build [--minify] [--force] [--watch]  Compile components using barefoot.config.ts
-  init [--name <name>] [--adapter <name>]  Initialize a new BarefootJS project
   add <component...> [--force] [--registry <url>] Add components to your project
   studio apply <url>          Apply Studio token overrides to this project's tokens
   search <query> [--dir <path>] [--registry <url>] Search components and documentation
@@ -38,7 +39,7 @@ Options:
   --debug                     (test) Output signal change trace log
 
 Workflow:
-  1. barefoot init                         — Initialize project
+  1. npm create barefootjs@latest          — Scaffold a new project
   2. barefoot search <query>               — Find components and docs
   3. barefoot add <component...>           — Add to your project
   4. barefoot ui <component>               — Learn props and usage

--- a/site/ui/e2e/studio.spec.ts
+++ b/site/ui/e2e/studio.spec.ts
@@ -12,7 +12,7 @@ test.describe('Studio Export & URL', () => {
     await page.goto('/studio')
     const codeEl = page.locator('[data-studio-export-code]')
     await expect(codeEl).toBeVisible()
-    const text = await codeEl.textContent()
+    const text = await codeEl.inputValue()
     expect(text).toContain('barefoot studio apply')
     expect(text).toContain('/studio')
   })
@@ -22,14 +22,14 @@ test.describe('Studio Export & URL', () => {
     const codeEl = page.locator('[data-studio-export-code]')
 
     // Get initial command text
-    const initialText = await codeEl.textContent()
+    const initialText = await codeEl.inputValue()
 
     // Open style dropdown and select Sharp
     await page.locator('[data-studio-style-trigger]').click()
     await page.locator('[data-studio-preset="Sharp"]').click()
 
     // Export command should update and contain ?c= with encoded config
-    const updatedText = await codeEl.textContent()
+    const updatedText = await codeEl.inputValue()
     expect(updatedText).not.toBe(initialText)
     expect(updatedText).toContain('?c=')
   })
@@ -76,10 +76,10 @@ test.describe('Studio Export & URL', () => {
     await page.locator('[data-studio-preset="Soft"]').click()
 
     const codeEl = page.locator('[data-studio-export-code]')
-    const text = await codeEl.textContent()
+    const text = await codeEl.inputValue()
 
     // Extract the ?c= value from the command
-    const match = text?.match(/\?c=([^"]+)/)
+    const match = text.match(/\?c=([^"]+)/)
     expect(match).toBeTruthy()
 
     // Decode and verify it's valid JSON
@@ -184,8 +184,8 @@ test.describe('Studio Export & URL', () => {
 
     // Verify the export command re-encodes the same config
     const codeEl = page.locator('[data-studio-export-code]')
-    const text = await codeEl.textContent()
-    const cMatch = text?.match(/\?c=([^"]+)/)
+    const text = await codeEl.inputValue()
+    const cMatch = text.match(/\?c=([^"]+)/)
     expect(cMatch).toBeTruthy()
 
     const decoded = JSON.parse(atob(decodeURIComponent(cMatch![1])))

--- a/site/ui/e2e/studio.spec.ts
+++ b/site/ui/e2e/studio.spec.ts
@@ -8,12 +8,12 @@ test.describe('Studio Export & URL', () => {
     })
   })
 
-  test('export bar shows a valid barefoot init --from command', async ({ page }) => {
+  test('export bar shows a valid barefoot studio apply command', async ({ page }) => {
     await page.goto('/studio')
     const codeEl = page.locator('[data-studio-export-code]')
     await expect(codeEl).toBeVisible()
     const text = await codeEl.textContent()
-    expect(text).toContain('barefoot init --from')
+    expect(text).toContain('barefoot studio apply')
     expect(text).toContain('/studio')
   })
 

--- a/site/ui/pages/studio.tsx
+++ b/site/ui/pages/studio.tsx
@@ -775,7 +775,7 @@ function ExportBar() {
   return (
     <div className="flex items-center justify-center gap-3 px-4 py-2 bg-card border-t">
       <code className="rounded-md bg-muted border px-3 py-1.5 font-mono text-[11px] text-foreground max-w-xl truncate" data-studio-export-code>
-        barefoot init --from "https://ui.barefootjs.dev/studio?c=..."
+        barefoot studio apply "https://ui.barefootjs.dev/studio?c=..."
       </code>
       <button className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium whitespace-nowrap shrink-0" data-studio-copy>
         <IconCopy />
@@ -1660,9 +1660,9 @@ const studioScript = `
     var baseUrl = location.origin + '/studio';
     if (Object.keys(config).length > 0) {
       var encoded = encodeConfig(config);
-      codeEl.textContent = 'barefoot init --from "' + baseUrl + '?c=' + encoded + '"';
+      codeEl.textContent = 'barefoot studio apply "' + baseUrl + '?c=' + encoded + '"';
     } else {
-      codeEl.textContent = 'barefoot init --from "' + baseUrl + '"';
+      codeEl.textContent = 'barefoot studio apply "' + baseUrl + '"';
     }
   }
 

--- a/site/ui/pages/studio.tsx
+++ b/site/ui/pages/studio.tsx
@@ -774,9 +774,13 @@ function ZoomControls() {
 function ExportBar() {
   return (
     <div className="flex items-center justify-center gap-3 px-4 py-2 bg-card border-t">
-      <code className="rounded-md bg-muted border px-3 py-1.5 font-mono text-[11px] text-foreground max-w-xl truncate" data-studio-export-code>
-        barefoot studio apply "https://ui.barefootjs.dev/studio?c=..."
-      </code>
+      <input
+        type="text"
+        readonly
+        className="rounded-md bg-muted border px-3 py-1.5 font-mono text-[11px] text-foreground flex-1 max-w-xl outline-none"
+        data-studio-export-code
+        value={`barefoot studio apply "https://ui.barefootjs.dev/studio?c=..."`}
+      />
       <button className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium whitespace-nowrap shrink-0" data-studio-copy>
         <IconCopy />
         <span data-studio-copy-label>Copy</span>
@@ -1660,9 +1664,9 @@ const studioScript = `
     var baseUrl = location.origin + '/studio';
     if (Object.keys(config).length > 0) {
       var encoded = encodeConfig(config);
-      codeEl.textContent = 'barefoot studio apply "' + baseUrl + '?c=' + encoded + '"';
+      codeEl.value = 'barefoot studio apply "' + baseUrl + '?c=' + encoded + '"';
     } else {
-      codeEl.textContent = 'barefoot studio apply "' + baseUrl + '"';
+      codeEl.value = 'barefoot studio apply "' + baseUrl + '"';
     }
   }
 
@@ -1691,6 +1695,13 @@ const studioScript = `
     }
   }
 
+  // ── Export input: select-all on focus so the user can verify and copy
+  // the full URL even when it overflows the visible width ──
+  document.addEventListener('focusin', function(e) {
+    var input = e.target.closest('[data-studio-export-code]');
+    if (input) input.select();
+  });
+
   // ── Copy button ──
   document.addEventListener('click', function(e) {
     var btn = e.target.closest('[data-studio-copy]');
@@ -1698,7 +1709,7 @@ const studioScript = `
     e.preventDefault();
     var codeEl = document.querySelector('[data-studio-export-code]');
     if (!codeEl) return;
-    var text = codeEl.textContent;
+    var text = codeEl.value;
     navigator.clipboard.writeText(text).then(function() {
       var label = btn.querySelector('[data-studio-copy-label]');
       if (label) {


### PR DESCRIPTION
## Summary

Ref #1345 (part 1: Studio handoff).

- Rewrite `barefoot studio apply` to patch `tokens.css` directly (the runtime source of truth), so the command works on apps scaffolded with `npm create barefootjs@latest`. Search order: `<paths.tokens>/tokens.css` → `public/tokens.css` → `static/tokens.css`. `tokens.json` patching is kept as a best-effort step for the monorepo convention.
- Fix the Studio Export Bar to emit `barefoot studio apply "<url>"` instead of the non-existent `barefoot init --from "<url>"`.
- Drop `init` from the public CLI help; `npm create barefootjs@latest` is now the single documented entry point for new projects. The switch case stays so `create-barefootjs` can keep delegating internally.

The CLI documentation page (the other half of #1345) is not in this PR.

## Before / after

Before, in a fresh `npm create barefootjs@latest` app:

```
$ barefoot studio apply "https://ui.barefootjs.dev/studio?c=..."
Error: tokens/tokens.json not found.
       Studio overrides need an existing tokens.json to patch.
```

After:

```
$ barefoot studio apply "https://ui.barefootjs.dev/studio?c=..."
  Patched public/tokens.css
```

## Test plan

- [x] `bun test` in `packages/cli` — 446 pass, including 27 in `studio.test.ts` covering in-place rewrite, append-for-new-tokens, idempotency, sequential apply with different configs, shadow presets, and the `resolveTokensCss` lookup order.
- [x] End-to-end smoke: scaffold `~/tmp/bf-studio-test` via `barefoot init`, run `barefoot studio apply <url>` twice with the same payload (md5 unchanged → idempotent), then apply a different payload and confirm in-place rewrite of `--primary`, `--spacing`, `--radius`, `--font-sans`, and the `--shadow-*` family.
- [ ] Playwright e2e (`site/ui/e2e/studio.spec.ts`) — locator updated to match the new emit; CI to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)