### PR TITLE
feat(jsx/#1244): per-item ref callbacks fire on every renderItem (mount + remount)

### DIFF
--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -878,37 +878,28 @@ describe('two refs on the same element via a composeRefs helper', () => {
 })
 
 describe('ref callback re-invocation on remount under the same key', () => {
-  // SURFACED LIMITATION (#1244 catalog: "ref callback re-invocation when
-  // the element re-mounts under the same key"): a `ref={fn}` on a JSX
-  // element inside `.map()` is silently dropped at compile time. The
-  // emitted `mapArray` per-item factory creates the DOM node but never
-  // calls `fn(__el)` — so the callback fires neither on the initial
-  // mount of a keyed item nor when that same key is unmounted and
-  // remounted later (the runtime case the E2E `ref-remount` fixme is
-  // chasing).
+  // #1244 catalog item "ref callback re-invocation when the element
+  // re-mounts under the same key". Pre-fix, a `ref={fn}` on a JSX
+  // element inside `.map()` was silently dropped at compile time:
+  // the user's const went unreferenced and the emitted `mapArray`
+  // per-item factory never called it, so the callback fired neither
+  // on the initial mount of a keyed item nor when that same key was
+  // unmounted and remounted later.
   //
-  // For comparison: refs on a top-level element compile to a single
-  // `if (_sN) (fn)(_sN)` line at the end of `init`, and refs inside a
-  // conditional branch compile inside the branch's `bindEvents` so they
-  // re-attach on swap (#1071 path). The loop case has no equivalent
-  // collection point — `collectFromElement` writes `ctx.refElements`,
-  // but the per-item factory built by the loop planner does not consume
-  // it. The fix needs the loop planner to surface the per-item ref
-  // alongside its other per-item bindings and the stringifier to emit
-  // `(fn)(__el)` inside the factory, so every insert (initial mount or
-  // remount) re-runs the callback with the new DOM element.
+  // The fix collects per-item refs (`TopLevelLoop.childRefs`) and
+  // emits `(fn)(__rf)` inside the multi-line factory body — once per
+  // `renderItem` invocation, which is every actual mount (SSR
+  // hydration, initial CSR creation, same-key remount). mapArray
+  // does not call `renderItem` for same-key reactive updates, so
+  // the same callback does not over-fire on plain prop changes.
   //
-  // The body asserts the intended emit shape: the emitted client JS
-  // must contain a *call* to the user-supplied ref callback (named
-  // `attach` in the source). Today the const is dropped entirely
-  // because nothing references it. We deliberately avoid pinning the
-  // call site to specific factory-internal variable names (`__el`,
-  // `__existing`, …) — those are implementation details of the loop
-  // stringifier. Whether the call lands inside the mapArray factory
-  // (so remount re-fires it) is the Layer 6 E2E's job to verify;
-  // Layer 1 just locks in that the callback isn't silently dropped.
-  // Drop `.todo` once fixed.
-  test.todo('the ref callback is invoked from the emitted client JS', () => {
+  // The Layer 1 assertion verifies the call appears in the emit. We
+  // deliberately avoid pinning the call site to specific factory-
+  // internal variable names (`__el`, `__existing`, …); whether the
+  // call lands inside the `mapArray` factory (so remount re-fires
+  // it) is the Layer 6 E2E's job (`ref-remount` fixme in
+  // `site/ui/e2e/stress-1244.spec.ts`).
+  test('the ref callback is invoked from the emitted client JS', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -925,7 +916,12 @@ describe('ref callback re-invocation on remount under the same key', () => {
     `
     const c = compile(src)
     expectNoFatalErrors(c)
-    expect(c.clientJs).toMatch(/\battach\s*\(/)
+    // `attach` must appear as the callee of a call expression. The compiler's
+    // `emitRefCall` wraps the bare identifier as `(attach)(...)` for symmetry
+    // with the prop-access form `(_p.cb)?.(...)`, so the regex accepts an
+    // optional surrounding `(...)` around the identifier. The shape of the
+    // wrapper is an internal detail we don't want to over-pin here.
+    expect(c.clientJs).toMatch(/\battach\b\s*(?:\)\s*)?\(/)
   })
 })
 

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -877,6 +877,58 @@ describe('two refs on the same element via a composeRefs helper', () => {
   })
 })
 
+describe('ref callback re-invocation on remount under the same key', () => {
+  // SURFACED LIMITATION (#1244 catalog: "ref callback re-invocation when
+  // the element re-mounts under the same key"): a `ref={fn}` on a JSX
+  // element inside `.map()` is silently dropped at compile time. The
+  // emitted `mapArray` per-item factory creates the DOM node but never
+  // calls `fn(__el)` — so the callback fires neither on the initial
+  // mount of a keyed item nor when that same key is unmounted and
+  // remounted later (the runtime case the E2E `ref-remount` fixme is
+  // chasing).
+  //
+  // For comparison: refs on a top-level element compile to a single
+  // `if (_sN) (fn)(_sN)` line at the end of `init`, and refs inside a
+  // conditional branch compile inside the branch's `bindEvents` so they
+  // re-attach on swap (#1071 path). The loop case has no equivalent
+  // collection point — `collectFromElement` writes `ctx.refElements`,
+  // but the per-item factory built by the loop planner does not consume
+  // it. The fix needs the loop planner to surface the per-item ref
+  // alongside its other per-item bindings and the stringifier to emit
+  // `(fn)(__el)` inside the factory, so every insert (initial mount or
+  // remount) re-runs the callback with the new DOM element.
+  //
+  // The body asserts the intended emit shape: the emitted client JS
+  // must contain a *call* to the user-supplied ref callback (named
+  // `attach` in the source). Today the const is dropped entirely
+  // because nothing references it. We deliberately avoid pinning the
+  // call site to specific factory-internal variable names (`__el`,
+  // `__existing`, …) — those are implementation details of the loop
+  // stringifier. Whether the call lands inside the mapArray factory
+  // (so remount re-fires it) is the Layer 6 E2E's job to verify;
+  // Layer 1 just locks in that the callback isn't silently dropped.
+  // Drop `.todo` once fixed.
+  test.todo('the ref callback is invoked from the emitted client JS', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type T = { id: string; label: string }
+      export function Demo() {
+        const [items, setItems] = createSignal<T[]>([])
+        const attach = (el: HTMLElement | null) => { void el }
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(it => <li key={it.id} ref={attach}>{it.label}</li>)}
+          </ul>
+        )
+      }
+    `
+    const c = compile(src)
+    expectNoFatalErrors(c)
+    expect(c.clientJs).toMatch(/\battach\s*\(/)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Spread / value shape (TODO grid: value-shape edges)
 // ---------------------------------------------------------------------------

--- a/packages/jsx/src/ir-to-client-js/build-references.ts
+++ b/packages/jsx/src/ir-to-client-js/build-references.ts
@@ -155,6 +155,11 @@ export function buildReferencesGraph(ctx: ClientJsContext, irRoot: IRNode): Refe
     for (const attr of elem.childReactiveAttrs) {
       addExprEdges(ROOT_SOURCE, attr.expression, 'template-closure')
     }
+    if (elem.childRefs) {
+      for (const ref of elem.childRefs) {
+        addExprEdges(ROOT_SOURCE, ref.callback, 'init-body')
+      }
+    }
   }
 
   // identifiers.ts L137-139

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -5,7 +5,7 @@
 import { type IRNode, type IRElement, type IRComponent, type IRLoop, type IRProp, pickAttrMetaFromIR } from '../types'
 import type { ClientJsContext, ConditionalBranchChildComponent, ConditionalBranchReactiveAttr, BranchLoop, ConditionalBranchTextEffect, ConditionalElement, LoopChildBranchSummary, LoopChildConditional, LoopChildEvent, LoopChildReactiveAttr, NestedLoop } from './types'
 import { attrValueToString, freeIdsFromRefs, quotePropName, PROPS_PARAM } from './utils'
-import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts } from './reactivity'
+import { classifyReactivity, decideWrapForAttr, decideWrapForChildProp, decideWrapFromAstFlags, collectEventHandlersFromIR, collectConditionalBranchEvents, collectConditionalBranchRefs, collectConditionalBranchChildComponents, collectLoopChildEventsWithNesting, collectLoopChildReactiveAttrs, collectLoopChildReactiveTexts, collectLoopChildRefs } from './reactivity'
 import { irToHtmlTemplate, irToPlaceholderTemplate, irChildrenToJsExpr } from './html-template'
 import { expandDynamicPropValue, expandConstantForReactivity } from './prop-handling'
 import { walkIR, stopAt } from './walker'
@@ -494,12 +494,14 @@ export function collectElements(
       const childEvents: LoopChildEvent[] = []
       const childReactiveAttrs: LoopChildReactiveAttr[] = []
       const childReactiveTexts: import('./types').LoopChildReactiveText[] = []
+      const childRefs: import('./types').LoopChildRef[] = []
       const childConditionals: import('./types').LoopChildConditional[] = []
       for (const child of l.children) {
         childHandlers.push(...collectEventHandlersFromIR(child))
         childEvents.push(...collectLoopChildEventsWithNesting(child))
         childReactiveAttrs.push(...collectLoopChildReactiveAttrs(child, ctx, l.param, l.paramBindings))
         childReactiveTexts.push(...collectLoopChildReactiveTexts(child, ctx, l.param, l.paramBindings))
+        childRefs.push(...collectLoopChildRefs(child))
         childConditionals.push(...collectLoopChildConditionals(child, ctx, siblingOffsets, l.param, l.paramBindings))
       }
 
@@ -582,6 +584,7 @@ export function collectElements(
         childEvents,
         childReactiveAttrs,
         childReactiveTexts,
+        childRefs: childRefs.length > 0 ? childRefs : undefined,
         childConditionals,
         childComponent: l.childComponent,
         nestedComponents: l.nestedComponents,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -37,6 +37,7 @@ import { buildLoopReactiveEffectsPlan } from './build-reactive-effects'
 import { buildComponentLoopPlan } from './build-component-loop'
 import { buildTopLevelCompositePlan } from './build-composite-loop'
 import type {
+  LoopChildRefBinding,
   LoopPlan,
   PlainLoopPlan,
   StaticLoopMaterializePlan,
@@ -75,6 +76,14 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
   const hasReactive = elem.childReactiveAttrs.length > 0
     || elem.childReactiveTexts.length > 0
     || (elem.childConditionals?.length ?? 0) > 0
+  // `childRefs` are imperative (one-shot per renderItem invocation), not
+  // reactive — but they share the multi-line layout requirement with
+  // `reactiveEffects` because both need `__el` as a stable handle inside
+  // the factory body (#1244).
+  const childRefs: readonly LoopChildRefBinding[] = (elem.childRefs ?? []).map(r => ({
+    childSlotId: r.childSlotId,
+    wrappedCallback: wrap(r.callback),
+  }))
 
   return {
     kind: 'plain',
@@ -88,6 +97,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
     mapPreambleWrapped: elem.mapPreamble ? wrap(elem.mapPreamble) : '',
     template: elem.template,
     reactiveEffects: hasReactive ? buildLoopReactiveEffectsPlan(elem) : null,
+    childRefs,
     bodyIsMultiRoot: elem.bodyIsMultiRoot ?? false,
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -20,6 +20,7 @@ import type {
   LoopChildEvent,
   LoopChildReactiveAttr,
   LoopChildReactiveText,
+  LoopChildRef,
   TopLevelLoop,
 } from '../../types'
 import type { IRLoopChildComponent } from '../../../types'
@@ -62,12 +63,33 @@ interface PlainLoopVariant extends DynamicLoopCommon {
   /** Resolved reactive-effects plan — null forces the single-line renderItem shape. */
   reactiveEffects: ReactiveEffectsPlan | null
   /**
+   * Imperative ref callbacks on elements inside the loop body (#1244).
+   * Non-empty forces the multi-line renderItem layout so each callback can
+   * fire inside the `mapArray` per-item factory — initial mount, SSR
+   * hydration, and same-key remount after unmount all re-run the callback
+   * with the just-built (or just-hydrated) DOM element. Each `callback`
+   * string is already wrapped with the loop-param accessor.
+   */
+  childRefs: readonly LoopChildRefBinding[]
+  /**
    * True when the loop body is a multi-root JSX Fragment. Forces the
    * multi-line renderItem layout, multi-root template clone, per-item
    * `<!--bf-loop-i-->` marker emission, and `qsaItem` slot lookups (#1212).
    */
   bodyIsMultiRoot: boolean
 }
+
+/** Per-item ref callback resolved against a child slot for emission. */
+export interface LoopChildRefBinding {
+  /** bf slot ID of the target element (root or descendant of the body). */
+  childSlotId: string
+  /** Callback expression, already wrapped via `wrapLoopParamAsAccessor`. */
+  wrappedCallback: string
+}
+
+// Re-export the IR-side type so callers that build the plan can spell it
+// without reaching into '../../types'.
+export type { LoopChildRef }
 
 /**
  * Loop body is a single child component (with or without nested child

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/types.ts
@@ -45,6 +45,7 @@ export type {
   StaticLoopPlan,
   StaticLoopMaterializePlan,
   NestedComponentInit,
+  LoopChildRefBinding,
 } from './loop'
 export type {
   EventDelegationPlan,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -24,13 +24,13 @@
  * passed in via `topIndent`.
  */
 
-import { varSlotId } from '../../utils'
+import { emitRefCall, varSlotId } from '../../utils'
 import { emitAttrUpdate } from '../../emit-reactive'
 import { stringifyReactiveEffects } from './reactive-effects'
 import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse'
 import { stringifyComponentLoop } from './component-loop'
 import { stringifyCompositeLoop } from './composite-loop'
-import type { LoopPlan, PlainLoopPlan, StaticLoopPlan } from '../plan/types'
+import type { LoopChildRefBinding, LoopPlan, PlainLoopPlan, StaticLoopPlan } from '../plan/types'
 
 /**
  * Single dispatch over `LoopPlan` (#1253). Narrows on `plan.kind` and
@@ -91,11 +91,15 @@ export function stringifyPlainLoop(
     mapPreambleWrapped,
     template,
     reactiveEffects,
+    childRefs,
     bodyIsMultiRoot,
   } = plan
 
-  if (reactiveEffects === null && !bodyIsMultiRoot) {
-    // Single-line renderItem (no reactive effects, single root).
+  // `childRefs` need `__el` as a handle to call the user's callback inside
+  // the factory, so they force the multi-line layout the same way reactive
+  // effects do (#1244).
+  if (reactiveEffects === null && !bodyIsMultiRoot && childRefs.length === 0) {
+    // Single-line renderItem (no reactive effects, single root, no refs).
     const unwrapInline = paramUnwrap ? `${paramUnwrap} ` : ''
     const preamble = mapPreambleWrapped ? `${mapPreambleWrapped}; ` : ''
     const cloneExpr = emitTemplateCloneInline(template)
@@ -105,7 +109,7 @@ export function stringifyPlainLoop(
     return
   }
 
-  // Multi-line renderItem (reactive effects present and/or multi-root).
+  // Multi-line renderItem (reactive effects present and/or multi-root and/or refs).
   lines.push(`${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   const bodyIndent = topIndent + '  '
   if (paramUnwrap) lines.push(`${bodyIndent}${paramUnwrap}`)
@@ -119,8 +123,36 @@ export function stringifyPlainLoop(
   if (reactiveEffects !== null) {
     stringifyReactiveEffects(lines, reactiveEffects, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot })
   }
+  emitLoopChildRefs(lines, childRefs, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot })
   lines.push(`${bodyIndent}return __el`)
   lines.push(`${topIndent}}, '${markerId}')`)
+}
+
+/**
+ * Emit `(callback)(__rf)` for each ref on a per-item slot, looking the
+ * target up via `qsa(__el, ...)` so a ref on the body root and a ref on
+ * any descendant share the same emit shape (#1244).
+ *
+ * Fires unconditionally on every `mapArray` `renderItem` invocation —
+ * which corresponds to every actual mount: SSR hydration (`__existing`
+ * is the SSR element), initial CSR creation, and same-key remount after
+ * unmount (the previous scope was disposed, so this is a fresh element).
+ * mapArray does not call `renderItem` for same-key reactive updates;
+ * those flow through per-item signal `setItem(...)` instead.
+ */
+function emitLoopChildRefs(
+  lines: string[],
+  refs: readonly LoopChildRefBinding[],
+  opts: { indent: string; elVar: string; bodyIsMultiRoot: boolean },
+): void {
+  if (refs.length === 0) return
+  const { indent, elVar, bodyIsMultiRoot } = opts
+  const lookup = bodyIsMultiRoot ? 'qsaItem' : 'qsa'
+  for (const ref of refs) {
+    const varName = `__rf_${varSlotId(ref.childSlotId)}`
+    lines.push(`${indent}{ const ${varName} = ${lookup}(${elVar}, '[bf="${ref.childSlotId}"]')`)
+    lines.push(`${indent}if (${varName}) ${emitRefCall(ref.wrappedCallback, varName)} }`)
+  }
 }
 
 export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -9,6 +9,7 @@ import type {
   ConditionalBranchRef,
   LoopChildEvent,
   LoopChildReactiveAttr,
+  LoopChildRef,
   LoopChildReactiveText,
   NestedLoop,
 } from './types'
@@ -312,6 +313,29 @@ export function collectConditionalBranchRefs(node: IRNode): ConditionalBranchRef
     if (el.slotId && el.ref) {
       refs.push({
         slotId: el.slotId,
+        callback: el.ref,
+      })
+    }
+  })
+  return refs
+}
+
+/**
+ * Collect imperative ref callbacks from a loop body for use inside the
+ * `mapArray` per-item factory (#1244). Mirrors `collectConditionalBranchRefs`
+ * but produces `LoopChildRef` keyed on the bf slot id, matching the rest of
+ * the loop's per-item collectors.
+ *
+ * `traverseElements` already stops at nested loops, so refs on elements
+ * inside a `.map().map()` are picked up by that nested loop's own
+ * collection pass, not by the outer one.
+ */
+export function collectLoopChildRefs(node: IRNode): LoopChildRef[] {
+  const refs: LoopChildRef[] = []
+  traverseElements(node, (el) => {
+    if (el.slotId && el.ref) {
+      refs.push({
+        childSlotId: el.slotId,
         callback: el.ref,
       })
     }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -323,6 +323,24 @@ export interface LoopChildReactiveAttr extends AttrMeta {
   expression: string // Expression that reads signals
 }
 
+/**
+ * Imperative ref callback on an element inside a loop body (#1244 catalog
+ * "ref callback re-invocation on remount under the same key"). Emitted
+ * inside the `mapArray` per-item factory so every `renderItem` invocation
+ * — initial mount, SSR hydration, and same-key remount after unmount —
+ * re-runs the callback with the just-built (or just-hydrated) DOM element.
+ *
+ * Mirrors `ConditionalBranchRef` but keyed on `childSlotId` to stay
+ * consistent with the loop's other per-item collectors (`LoopChildEvent`,
+ * `LoopChildReactiveAttr`, `LoopChildReactiveText`).
+ */
+export interface LoopChildRef {
+  /** bf slot ID of the element bearing the ref. */
+  childSlotId: string
+  /** Ref callback expression. May reference the loop param. */
+  callback: string
+}
+
 export interface LoopChildReactiveText {
   slotId: string // bf comment marker slot ID (e.g., 's7' → <!--bf:s7-->)
   expression: string // Expression that reads signals
@@ -401,6 +419,7 @@ export interface TopLevelLoop extends LoopCore {
   childEvents: LoopChildEvent[] // Detailed event info for delegation
   childReactiveAttrs: LoopChildReactiveAttr[] // Reactive attributes in loop children
   childReactiveTexts: LoopChildReactiveText[] // Reactive text interpolations in loop children
+  childRefs?: LoopChildRef[] // Imperative ref callbacks on loop children (#1244)
   childConditionals?: LoopChildConditional[] // Reactive conditionals in loop children
   childComponent?: IRLoopChildComponent // For createComponent-based rendering
   nestedComponents?: IRLoopChildComponent[] // For nested components in loop bodies


### PR DESCRIPTION
## Summary

Catalog item from [#1244](https://github.com/piconic-ai/barefootjs/issues/1244):

> [ ] ref callback re-invocation when the element re-mounts under the same key

Before this PR, `<el ref={fn}>` inside a `.map()` was silently dropped at compile time — the user's `const fn = ...` went unreferenced and the emitted `mapArray` per-item factory never called it. The callback fired neither on initial mount of a keyed item nor when that same key was unmounted and remounted later.

The fix collects per-item refs (`TopLevelLoop.childRefs`) and emits `(fn)(__rf)` inside the multi-line factory body — once per `renderItem` invocation, which is every actual mount: SSR hydration, initial CSR creation, and same-key remount after unmount. `mapArray` does not call `renderItem` for same-key reactive updates (those flow through per-item signal `setItem(...)`), so the callback does not over-fire on plain prop changes.

For comparison:

- Top-level refs compile to `if (_sN) (fn)(_sN)` at the end of `init`.
- Refs inside a conditional branch compile inside the branch's `bindEvents` so they re-attach on swap (#1071 path).
- Loop items previously had no equivalent collection point — `collectFromElement` writes to `ctx.refElements`, but the loop visitor in `collectElements` intentionally stops at the loop scope. The per-item factory built by the loop planner did not consume any refs.

## Commits

1. **`test(jsx/#1244): pin ref re-invocation on same-key remount as todo`** — original `.todo` lock-in (was the whole previous draft scope).
2. **`feat(jsx/#1244): collect per-item ref callbacks into TopLevelLoop IR`** — `LoopChildRef` + `collectLoopChildRefs` + threading through `collectElements` + reference-graph edge so the callback identifier survives dead-code elim.
3. **`feat(jsx/#1244): emit per-item ref calls inside the plain-loop factory`** — `PlainLoopVariant.childRefs` + plan + stringifier emits `qsa(__el, '[bf="<slot>"]')` + `emitRefCall`. Non-empty refs force the multi-line factory layout the same way reactive effects do. Multi-root bodies use `qsaItem` (#1212 pattern).
4. **`test(jsx/#1244): drop .todo on the ref re-invocation stress entry`** — assertion now runs against the corrected compiler.

## Scope

Plain top-level loops only — covers the most common shape (`<el key={…} ref={…}>` inside a `.map()`). Composite / component / branch / nested loops still drop refs; those paths each need the same wiring and will land in follow-ups so the diff stays bisectable. The Layer 6 E2E (`ref-remount` `test.fixme` in `site/ui/e2e/stress-1244.spec.ts`) is still pending a demo page.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/compiler-stress-1244.test.ts -t 'ref callback re-invocation'` — passes
- [x] `bun test packages/jsx` — 1244 pass, 3 todo, 0 fail (no regression)
- [x] `bun test packages/adapter-tests` — 316 pass, 0 fail
- [x] `bun test packages/client` — 267 pass, 0 fail
- [x] `bunx tsc --noEmit` in packages/jsx — clean
- [ ] Follow-up PRs cover composite / component / branch / nested loop variants
- [ ] Layer 6 E2E (`/stress/1244/ref-remount` demo page) confirms remount runtime semantics