### PR TITLE
fix(jsx/#1244): CSR emit collapses element spread + explicit attrs into one spreadAttrs({...}) merge

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -122,6 +122,10 @@ runAdapterConformanceTests({
     // limitation declarative: when the Go adapter grows a native
     // rest-lowering, dropping these entries flips the contract on.
     'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1244 catalog: rest spread back onto the root element. Same
+    // refusal shape as the read-only variant above — `paramBindings`
+    // is non-empty so BF104 fires regardless of how `rest` is used.
+    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
     // #1244 stress catalog #13 (#1324): JSX spread of a reactive object

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -85,6 +85,10 @@ runAdapterConformanceTests({
     // refusal regardless of whether the binding is rest or plain.
     // Pinning the contract here makes the limitation declarative.
     'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1244 catalog: rest spread back onto the root element. Same
+    // refusal shape as the read-only variant above — `paramBindings`
+    // is non-empty so BF104 fires regardless of how `rest` is used.
+    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
     // #1244 stress catalog #11 (#1322): JS object literal in an

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -75,6 +75,7 @@ import { fixture as arrowComponent } from './arrow-component'
 import { fixture as childrenJsxExpression } from './children-jsx-expression'
 import { fixture as fragmentWrappedChildrenJsxExpression } from './fragment-wrapped-children-jsx-expression'
 import { fixture as restDestructureObjectInMap } from './rest-destructure-object-in-map'
+import { fixture as restDestructureObjectSpreadInMap } from './rest-destructure-object-spread-in-map'
 import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
 import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
 
@@ -160,6 +161,10 @@ export const jsxFixtures: JSXFixture[] = [
   // #1310: rest destructure in .map() — Hono/CSR lowers via #1309,
   // Go/Mojo refuse the loop destructure shape with BF104.
   restDestructureObjectInMap,
+  // #1244 catalog: rest spread back onto the root element. Same
+  // adapter contract as the read-only variant above (Hono/CSR via
+  // #1309, Go/Mojo BF104).
+  restDestructureObjectSpreadInMap,
   restDestructureArrayInMap,
   restDestructureNestedInMap,
 ]

--- a/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
@@ -1,0 +1,70 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Object rest destructure in a `.map()` callback with the rest spread
+ * back onto the root element (`{ id, title, ...rest }` + `{...rest}`
+ * on `<li>`).
+ *
+ * Catalog entry from #1244 (compiler-stress): "Destructured loop param —
+ * `tasks.map(({ id, title, ...rest }) => …)` with rest spread back onto
+ * the root". Companion to `rest-destructure-object-in-map`, which only
+ * reads from `rest` as a text node — neither existing fixture exercises
+ * the spread-back-to-root shape that #1244 specifically called out.
+ *
+ * Why a dedicated fixture: spreading the residual back onto the root
+ * touches both the IIFE residual accessor (`(({ id: __bfR0, ... }) =>
+ * __bfRest)(__bfItem())`) and `spreadAttrs` / `applyRestAttrs` in one
+ * emit path — so a regression in either lowering shows up here. The
+ * non-identifier key (`'data-priority'`) also pins the
+ * `RestExcludeKey.isIdent=false` branch of the IIFE emit (the explicitly-
+ * destructured `title` sibling key is identifier-named; the rest
+ * residual carries `data-priority` through to the spread).
+ *
+ * Text-template adapters (Go, Mojo) refuse the whole destructure shape
+ * with BF104 regardless of whether the rest is spread or read; the
+ * per-adapter `expectedDiagnostics` declarations pin that contract.
+ * When either adapter grows a native lowering, dropping the diagnostic
+ * here is the single edit that flips the contract on.
+ *
+ * SSR / CSR attribute-order divergence (surfaced limitation):
+ * Hono SSR serializes the residual-object attributes BEFORE the
+ * explicit `data-key` (`data-priority="high" tag="urgent"
+ * data-key="t1"`), while the CSR template literal emits the explicit
+ * attribute first followed by `${spreadAttrs(...)}` (`data-key="t1"
+ * data-priority="high" tag="urgent"`). Both forms carry the same
+ * attributes and produce structurally identical DOM — only the
+ * serialization order differs. Same shape as the
+ * `style-object-static` / `top-level-ternary` skips; the fixture is
+ * therefore listed in `csr-conformance.test.ts` `skipFixtures` until
+ * the two emit paths converge on JSX source order (`explicit
+ * {...rest}` → explicit attrs first, then spread).
+ */
+export const fixture = createFixture({
+  id: 'rest-destructure-object-spread-in-map',
+  description: 'Object rest destructure in .map() with {...rest} on the root (#1244)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Task = { id: string; title: string; 'data-priority': string; tag: string }
+export function RestSpread() {
+  const [tasks, setTasks] = createSignal<Task[]>([
+    { id: 't1', title: 'one', 'data-priority': 'high', tag: 'urgent' },
+    { id: 't2', title: 'two', 'data-priority': 'low', tag: 'normal' },
+  ])
+  return (
+    <ul onClick={() => setTasks(t => t)}>
+      {tasks().map(({ id, title, ...rest }) => (
+        <li key={id} {...rest}>{title}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-priority="high" tag="urgent" data-key="t1" bf="s1"><!--bf:s0-->one<!--/--></li>
+      <li data-priority="low" tag="normal" data-key="t2" bf="s1"><!--bf:s0-->two<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -49,6 +49,21 @@ describe('CSR Conformance Tests', () => {
     'return-logical-or',
     'return-nullish-coalescing',
     'return-map',
+    // #1244 catalog: `{...rest}` spread back onto the root of a
+    // destructured loop param when there is no non-`key` explicit attr.
+    // The collision-safe merge emit (#1244) only triggers when a
+    // non-`key` explicit attr coexists with the spread (so JSX
+    // rightmost-wins is at risk); a lone `<li key={id} {...rest}>` keeps
+    // the legacy inline form to preserve the unconditional
+    // `data-key="${value}"` debug contract (`spreadAttrs` would otherwise
+    // skip `key={undefined}`). That leaves Hono SSR emitting the
+    // residual-object attributes before `data-key` (the synthesized
+    // hydrationAttr is appended at end) and CSR emitting `data-key`
+    // before the spread (source order). Both forms parse to identical
+    // DOM — no JSX-semantics violation, only attribute-order divergence.
+    // The collision shape that DOES violate semantics is locked in by
+    // `compiler-stress-1244.test.ts` (Layer 1).
+    'rest-destructure-object-spread-in-map',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
+++ b/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
@@ -113,4 +113,26 @@ describe('spreadAttrs', () => {
     const out = spreadAttrs({ style: 'color:red' })
     expect(out).toBe('style="color:red"')
   })
+
+  // #1244: SVG XML attribute names are case-sensitive. Lower-casing
+  // `viewBox` to `view-box` makes the browser treat it as an unknown
+  // attribute, so the SVG no longer scales / hit-tests — surfaced as
+  // the Form Builder e2e regression when the merge-emit path started
+  // routing `viewBox` through `spreadAttrs`. `stroke-width` and
+  // friends are CSS-style presentation attrs and stay kebab-case.
+  test('SVG case-sensitive attrs preserve camelCase; CSS-style presentation attrs kebab-case', () => {
+    const out = spreadAttrs({
+      viewBox: '0 0 24 24',
+      preserveAspectRatio: 'xMidYMid meet',
+      clipPath: 'url(#c)',
+      strokeWidth: 2,
+      strokeLinecap: 'round',
+    })
+    expect(out).toContain('viewBox="0 0 24 24"')
+    expect(out).toContain('preserveAspectRatio="xMidYMid meet"')
+    expect(out).toContain('clipPath="url(#c)"')
+    expect(out).toContain('stroke-width="2"')
+    expect(out).toContain('stroke-linecap="round"')
+    expect(out).not.toContain('view-box')
+  })
 })

--- a/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
+++ b/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
@@ -118,21 +118,34 @@ describe('spreadAttrs', () => {
   // `viewBox` to `view-box` makes the browser treat it as an unknown
   // attribute, so the SVG no longer scales / hit-tests — surfaced as
   // the Form Builder e2e regression when the merge-emit path started
-  // routing `viewBox` through `spreadAttrs`. `stroke-width` and
-  // friends are CSS-style presentation attrs and stay kebab-case.
-  test('SVG case-sensitive attrs preserve camelCase; CSS-style presentation attrs kebab-case', () => {
+  // routing `viewBox` through `spreadAttrs`.
+  //
+  // CSS-style SVG presentation attrs (`strokeWidth`, `clipPath`, …) are
+  // NOT case-sensitive — they lower to kebab-case to match how the
+  // compile-time `SVG_CAMEL_TO_KEBAB` table writes them on the explicit-
+  // attr path. Mixing the two would diverge: `<svg clipPath={...} />`
+  // emits `clip-path="..."` while `<svg {...{ clipPath: ... }} />` would
+  // emit `clipPath="..."`. The allowlist therefore covers only XML attr
+  // names that have no kebab-case mirror (`viewBox`, `clipPathUnits`).
+  test('SVG XML camelCase preserved; CSS-style presentation attrs kebab-case', () => {
     const out = spreadAttrs({
       viewBox: '0 0 24 24',
       preserveAspectRatio: 'xMidYMid meet',
+      clipPathUnits: 'objectBoundingBox',
       clipPath: 'url(#c)',
       strokeWidth: 2,
       strokeLinecap: 'round',
     })
     expect(out).toContain('viewBox="0 0 24 24"')
     expect(out).toContain('preserveAspectRatio="xMidYMid meet"')
-    expect(out).toContain('clipPath="url(#c)"')
+    expect(out).toContain('clipPathUnits="objectBoundingBox"')
+    // Presentation attrs share the kebab-case spelling of the compile-
+    // time `SVG_CAMEL_TO_KEBAB` table so spread vs explicit-attr paths
+    // produce the same DOM attribute.
+    expect(out).toContain('clip-path="url(#c)"')
     expect(out).toContain('stroke-width="2"')
     expect(out).toContain('stroke-linecap="round"')
     expect(out).not.toContain('view-box')
+    expect(out).not.toContain('clip-path-units')
   })
 })

--- a/packages/client/src/runtime/spread-attrs.ts
+++ b/packages/client/src/runtime/spread-attrs.ts
@@ -9,11 +9,49 @@
 import { styleToCss } from './style'
 
 /**
+ * SVG attributes that are case-sensitive and MUST stay in camelCase.
+ *
+ * The default JSX-prop → HTML-attribute rewrite lower-cases camelCase
+ * (`fooBar` → `foo-bar`), which is correct for HTML attrs and for the
+ * CSS-style SVG presentation attrs (`strokeWidth` → `stroke-width`).
+ * The XML-namespaced SVG attrs below, though, are case-sensitive in
+ * the spec: `viewBox` lower-cased to `view-box` makes the browser
+ * treat it as an unknown user attribute and the SVG no longer renders
+ * (pointer events stop hitting the inner geometry — surfaced as the
+ * Form Builder e2e regression in #1244's merge-emit follow-up).
+ *
+ * The list mirrors React DOM's `DOMProperty` case-preserving entries
+ * (only the attributes that appear on actual SVG elements; ARIA and
+ * XLink namespaces are unrelated and handled by their `aria-*` /
+ * `xlink:*` literal prefix).
+ */
+const SVG_CAMEL_CASE_ATTRS: ReadonlySet<string> = new Set([
+  'allowReorder', 'attributeName', 'attributeType', 'autoReverse',
+  'baseFrequency', 'baseProfile', 'calcMode', 'clipPath', 'clipPathUnits',
+  'contentScriptType', 'contentStyleType', 'diffuseConstant', 'edgeMode',
+  'externalResourcesRequired', 'filterRes', 'filterUnits', 'glyphRef',
+  'gradientTransform', 'gradientUnits', 'kernelMatrix', 'kernelUnitLength',
+  'keyPoints', 'keySplines', 'keyTimes', 'lengthAdjust', 'limitingConeAngle',
+  'markerHeight', 'markerUnits', 'markerWidth', 'maskContentUnits',
+  'maskUnits', 'numOctaves', 'pathLength', 'patternContentUnits',
+  'patternTransform', 'patternUnits', 'pointsAtX', 'pointsAtY', 'pointsAtZ',
+  'preserveAlpha', 'preserveAspectRatio', 'primitiveUnits', 'refX', 'refY',
+  'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures',
+  'specularConstant', 'specularExponent', 'spreadMethod', 'startOffset',
+  'stdDeviation', 'stitchTiles', 'surfaceScale', 'systemLanguage',
+  'tableValues', 'targetX', 'targetY', 'textLength', 'viewBox', 'viewTarget',
+  'xChannelSelector', 'yChannelSelector', 'zoomAndPan',
+])
+
+/**
  * Convert an object to an HTML attribute string.
  * Aligned with applyRestAttrs conventions: skips null/undefined/false,
  * event handlers, maps className→class and htmlFor→for. The `style`
  * prop is routed through `styleToCss` so object literals serialize to
  * a real CSS string (matching the reactive `applyRestAttrs` path).
+ *
+ * SVG attributes listed in `SVG_CAMEL_CASE_ATTRS` are preserved
+ * verbatim — the SVG XML spec is case-sensitive for those names.
  */
 export function spreadAttrs(obj: Record<string, unknown>): string {
   if (!obj || typeof obj !== 'object') return ''
@@ -29,8 +67,12 @@ export function spreadAttrs(obj: Record<string, unknown>): string {
       if (css != null) parts.push(`style="${css}"`)
       continue
     }
-    // Map JSX prop names to HTML attribute names
-    const attr = key === 'className' ? 'class' : key === 'htmlFor' ? 'for'
+    // Map JSX prop names to HTML attribute names. Case-sensitive SVG
+    // attrs keep their camelCase per the spec; HTML / CSS-style SVG
+    // presentation attrs lower-case to kebab-case.
+    const attr = key === 'className' ? 'class'
+      : key === 'htmlFor' ? 'for'
+      : SVG_CAMEL_CASE_ATTRS.has(key) ? key
       : key.replace(/([A-Z])/g, '-$1').toLowerCase()
     parts.push(value === true ? attr : `${attr}="${value}"`)
   }

--- a/packages/client/src/runtime/spread-attrs.ts
+++ b/packages/client/src/runtime/spread-attrs.ts
@@ -20,6 +20,14 @@ import { styleToCss } from './style'
  * (pointer events stop hitting the inner geometry — surfaced as the
  * Form Builder e2e regression in #1244's merge-emit follow-up).
  *
+ * Coordinates with the compile-time `SVG_CAMEL_TO_KEBAB` table in
+ * `packages/jsx/src/ir-to-client-js/utils.ts`: presentation attrs
+ * (`clipPath`, `strokeWidth`, …) live there and must NOT appear here,
+ * or the same JSX prop would lower to `clip-path` via the explicit-
+ * attr path and stay `clipPath` via the spread path — a silent
+ * divergence. The list below is XML attribute names that have no
+ * kebab-case mirror (`viewBox`, `clipPathUnits`, …).
+ *
  * The list mirrors React DOM's `DOMProperty` case-preserving entries
  * (only the attributes that appear on actual SVG elements; ARIA and
  * XLink namespaces are unrelated and handled by their `aria-*` /
@@ -27,7 +35,7 @@ import { styleToCss } from './style'
  */
 const SVG_CAMEL_CASE_ATTRS: ReadonlySet<string> = new Set([
   'allowReorder', 'attributeName', 'attributeType', 'autoReverse',
-  'baseFrequency', 'baseProfile', 'calcMode', 'clipPath', 'clipPathUnits',
+  'baseFrequency', 'baseProfile', 'calcMode', 'clipPathUnits',
   'contentScriptType', 'contentStyleType', 'diffuseConstant', 'edgeMode',
   'externalResourcesRequired', 'filterRes', 'filterUnits', 'glyphRef',
   'gradientTransform', 'gradientUnits', 'kernelMatrix', 'kernelUnitLength',

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1950,7 +1950,14 @@ describe('Client JS generation', () => {
       expect(content).toContain('spreadAttrs(')
     })
 
-    test('multiple computed spreads on same element both emit spreadAttrs (#545)', () => {
+    test('multiple computed spreads on same element merge into one spreadAttrs({...}) call (#545)', () => {
+      // When spreads share an element with a non-spread attr (`viewBox`
+      // here), both spreads must reach the runtime so neither is silently
+      // dropped. The collision-safe emit (#1244) collapses them into a
+      // single `spreadAttrs({...sizeAttrs, ...colorAttrs, "viewBox": ...})`
+      // call — JS object-literal evaluation handles rightmost-wins per
+      // JSX semantics. The contract here is "no spread is dropped": both
+      // identifier names must appear inside the merge object.
       const source = `
         export function Icon(props: { size?: string, color?: string }) {
           const sizeAttrs = { width: props.size ?? '24', height: props.size ?? '24' }
@@ -1965,10 +1972,28 @@ describe('Client JS generation', () => {
       expect(clientJs).toBeDefined()
       const content = clientJs!.content
 
-      // Both spreads should emit spreadAttrs
-      const matches = content.match(/spreadAttrs\(/g)
-      expect(matches).not.toBeNull()
-      expect(matches!.length).toBeGreaterThanOrEqual(2)
+      // Extract the body of the spreadAttrs({...}) merge call by
+      // counting braces — a non-greedy regex can't span the nested
+      // object-literal splices the constant-inlining pass produces.
+      const callStart = content.indexOf('spreadAttrs({')
+      expect(callStart).toBeGreaterThan(-1)
+      let depth = 1
+      let i = callStart + 'spreadAttrs({'.length
+      while (depth > 0 && i < content.length) {
+        const ch = content[i]
+        if (ch === '{') depth++
+        else if (ch === '}') depth--
+        i++
+      }
+      const mergeBody = content.slice(callStart + 'spreadAttrs({'.length, i - 1)
+
+      // viewBox literal lives in the merge as a key/value pair.
+      expect(mergeBody).toMatch(/"viewBox":\s*"0 0 24 24"/)
+      // Two `...` splice tokens — one per source spread. `sizeAttrs` /
+      // `colorAttrs` are inlined as object literals by the constant-
+      // inlining pass, so the count is on the splice tokens.
+      const spliceCount = (mergeBody.match(/\.\.\./g) ?? []).length
+      expect(spliceCount).toBeGreaterThanOrEqual(2)
     })
 
     test('rest props spread is NOT emitted as spreadAttrs (#545)', () => {

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -457,6 +457,62 @@ describe('destructured loop param with rest spread back onto the root', () => {
     `
     expectNoFatalErrors(compile(src))
   })
+
+  // Regression contract for #1244: when an explicit attribute on the
+  // loop body root collides with a key inside `rest`, JSX/React semantics
+  // say the rightmost wins — `rest` is to the right of the explicit
+  // attribute in source order, so `rest.data-priority` must override.
+  //
+  // HTML's duplicate-attribute parse rule is first-wins. Emitting tokens
+  // in source order (`data-priority="medium" ${spreadAttrs(rest)}`) lands
+  // a `<li data-priority="medium" data-priority="REST">` in the parsed
+  // DOM; the browser keeps `medium` (the first occurrence) and silently
+  // inverts the JSX semantics. The fix collapses both into a single
+  // `spreadAttrs({"data-priority": "medium", ...rest})` call so JS
+  // object-literal evaluation does the rightmost-wins resolution before
+  // serialization — the helper emits a single attribute per key.
+  //
+  // Both emit sites carry the same merge: `mapArray`'s per-item factory
+  // (`irToHtmlTemplate`) and the `hydrate(..., { template })` SSR lambda
+  // (`generateCsrTemplate`).
+  test('CSR emit: spread + colliding explicit attr merge into a single spreadAttrs({...}) call', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      type Task = { id: string; title: string; 'data-priority': string }
+      export function Demo() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().map(({ id, title, ...rest }) => (
+              <li key={id} data-priority="medium" {...rest}>{title}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const c = compile(src)
+    expectNoFatalErrors(c)
+
+    // Inline-token form would be the silently-inverted shape — assert
+    // its absence on the loop body root.
+    expect(c.clientJs).not.toMatch(/<li[^>]*data-priority="medium"[^>]*\$\{spreadAttrs\(/)
+
+    // Both emit sites (mapArray renderItem + hydrate template lambda)
+    // must open `spreadAttrs({` carrying the explicit `"data-priority":
+    // "medium"` member. Counting prefixes — rather than a full balanced
+    // match — keeps the regex robust against nested destructure
+    // patterns (`{ id: __bfR0, title: __bfR1, ...__bfRest }`) inside
+    // the IIFE residual accessor on the runtime path.
+    const mergePrefixes = c.clientJs.match(/spreadAttrs\(\{"data-priority":\s*"medium"/g)
+    expect(mergePrefixes).not.toBeNull()
+    expect(mergePrefixes!.length).toBeGreaterThanOrEqual(2)
+    // The merge object splices the rest expression so a runtime
+    // `data-priority` in rest can override the literal `medium`.
+    // Runtime path: IIFE residual accessor. SSR template path: the
+    // destructured `rest` local. Both reach the same merge call.
+    expect(c.clientJs).toMatch(/spreadAttrs\(\{"data-priority":\s*"medium",\s*\.\.\./)
+  })
 })
 
 describe('nested destructuring in loop param', () => {

--- a/packages/jsx/src/__tests__/staged-ir/01-template-scope.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/01-template-scope.test.ts
@@ -109,7 +109,11 @@ describe('Template scope: init-locals never leak into template body', () => {
     `)
 
     expectNoBareNames(templateBody, ['\\bcached\\b'])
-    expect(templateBody).toMatch(/spreadAttrs\(undefined\)/)
+    // The mixed `{...cached} data-n={...}` triggers the collision-safe
+    // merge emit (#1244): both lower into one `spreadAttrs({...})` call
+    // with the init-scope-only `cached` reference substituted to
+    // `...(undefined)` (object-spread of undefined is a runtime no-op).
+    expect(templateBody).toMatch(/spreadAttrs\(\{[^}]*\.\.\.\(undefined\)[^}]*\}\)/)
   })
 
   test('init-scope condition in ternary → undefined (false branch wins on init render)', () => {

--- a/packages/jsx/src/__tests__/template-closure.test.ts
+++ b/packages/jsx/src/__tests__/template-closure.test.ts
@@ -135,7 +135,16 @@ describe('#1128 — template body never reaches init-scope identifiers', () => {
     expect(tpl).toMatch(/active:\s*true/)
   })
 
-  test('init-scope spread object emits spreadAttrs(undefined) — runtime null-guards it to empty string', () => {
+  test('init-scope spread object spliced into merged spreadAttrs as ...(undefined) — runtime null-guards each spread', () => {
+    // `{...cached} data-n={n()}` triggers the collision-safe merge emit
+    // (#1244): both attrs land inside one `spreadAttrs({ "data-n": ...,
+    // ...(undefined) })` call. The init-scope-only `cached` reference is
+    // substituted with `undefined` (UNSAFE rewrite); object-spread of
+    // `undefined` is a no-op at runtime, and `spreadAttrs` skips the
+    // null/undefined values for `data-n`'s reactive accessor on initial
+    // render. The contract here is "`cached` doesn't leak into the
+    // template body" and "the spread of undefined is spliced into the
+    // merge".
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -151,8 +160,9 @@ describe('#1128 — template body never reaches init-scope identifiers', () => {
     const tpl = templateBody(clientJs)
 
     expect(tpl).not.toMatch(/\bcached\b/)
-    // spreadAttrs() in @barefootjs/client null-guards undefined → ''.
-    expect(tpl).toMatch(/spreadAttrs\(undefined\)/)
+    // Merged spreadAttrs({...}) form with `...(undefined)` for the
+    // init-scope spread reference.
+    expect(tpl).toMatch(/spreadAttrs\(\{[^}]*\.\.\.\(undefined\)[^}]*\}\)/)
   })
 
   test('init-scope conditional condition picks the false branch on initial render', () => {

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -174,119 +174,119 @@ function renderTemplateAttrPart(
 }
 
 /**
- * Emit element attribute tokens.
+ * Source-of-truth predicates for the collision-safe spread-attrs merge
+ * shared by all three CSR-side emit paths (`irToHtmlTemplate`,
+ * `irToComponentTemplate`, `generateCsrTemplate`). (#1244)
  *
- * When a `{...spread}` shares an element with non-`key` user attrs, the
- * source-order inline emission would silently invert JSX rightmost-wins
- * semantics on key collision: browser HTML parsing keeps the FIRST
- * occurrence of a duplicate attribute, so `class="x" ${spreadAttrs(rest)}`
- * leaves `class="x"` in the parsed DOM even when `rest.class` is supposed
- * to override (rest is to the right in JSX source). Instead we emit a
- * single `spreadAttrs({merged})` call whose argument is an object literal
+ * Why merge: when a `{...spread}` shares an element with non-`key` user
+ * attrs, source-order inline emission silently inverts JSX rightmost-
+ * wins on collision. Browser HTML parsing keeps the FIRST occurrence
+ * of a duplicate attribute, so `class="x" ${spreadAttrs(rest)}` leaves
+ * `class="x"` in the parsed DOM even when `rest.class` should override
+ * (rest is to the right in JSX source). The merge collapses both into
+ * one `spreadAttrs({merged})` call whose argument is an object literal
  * built in source order — JS object-literal evaluation resolves the
  * rightmost-wins collision before serialization, so the helper sees a
- * deduplicated map and emits a single attribute per key. (#1244)
+ * deduplicated map and emits a single attribute per key.
  *
- * `key` (which becomes `data-key`) is intentionally kept outside the merge
- * to preserve the unconditional `data-key="${value}"` emit contract
- * (`templateAttrExpr` special-case at line 97): `spreadAttrs` skips
- * `undefined` values, so a `key={undefined}` mistake would silently lose
- * its `data-key="undefined"` debug surface inside the merge.
+ * `key` (which becomes `data-key`) is intentionally kept outside the
+ * merge to preserve the unconditional `data-key="${value}"` emit
+ * contract (`templateAttrExpr` special-case): `spreadAttrs` skips
+ * `undefined` values, so a `key={undefined}` mistake would silently
+ * lose its `data-key="undefined"` debug surface inside the merge.
  *
- * The merge path runs only when both a spread and a non-`key` non-spread
- * attr coexist; otherwise the legacy inline path is used so existing
- * fixtures (no collision possible) keep their attribute order.
- *
- * `valueExprForExpression` / `valueExprForTemplate` are injected because
- * the two call sites (`irToHtmlTemplate`, `irToComponentTemplate`) lower
- * expressions to JS differently — `wrap`-only vs constant-inlining
- * + props-object rewrite. Keeping that knob outside the helper means
- * neither caller leaks its emit conventions into the merge logic.
+ * The three emit paths share these predicates and the
+ * `buildSpreadAttrsMergeCall` builder so the merge contract has a
+ * single source of truth. Per-path differences (expression lowering,
+ * spread-name detection, `clientOnly` handling) are injected via the
+ * `MergeContext` callbacks. Without the consolidation, future fixes
+ * could land at one emit site and not the others — exactly the
+ * structural drift pattern #1244 §A / §B flagged.
  */
-function renderElementAttrParts(args: {
-  attrs: ReadonlyArray<IRAttribute>
-  wrap: (expr: string) => string
-  loopDepth: number
-  restSpreadNames?: Set<string>
-  valueExprForExpression: (v: Extract<AttrValue, { kind: 'expression' }>) => string
-  valueExprForTemplate: (v: Extract<AttrValue, { kind: 'template' }>) => string
-  /** Optional per-attr filter (defaults to identity) used by component template path
-   *  to skip `clientOnly` attrs. */
-  attrFilter?: (a: IRAttribute) => boolean
-}): string[] {
-  const { attrs, wrap, loopDepth, restSpreadNames, valueExprForExpression, valueExprForTemplate, attrFilter } = args
-  const filtered = attrFilter ? attrs.filter(attrFilter) : attrs
+export interface MergeContext {
+  /** True when the rest-prop form runtime path handles separately. */
+  isFilteredSpread: (v: Extract<AttrValue, { kind: 'spread' }>) => boolean
+  /** Whether to honour `attr.clientOnly` (component / CSR template paths do). */
+  honorClientOnly: boolean
+}
 
-  const hasMergeableSpread = filtered.some(a => {
-    if (a.value.kind !== 'spread') return false
-    return !restSpreadNames?.has(a.value.expr)
+/** Return true if this attribute should participate in the merge object. */
+function isMergeableAttr(a: IRAttribute, ctx: MergeContext): boolean {
+  if (ctx.honorClientOnly && a.clientOnly) return false
+  if (a.name === 'key') return false
+  const v = a.value
+  if (v.kind === 'jsx-children') return false
+  if (v.kind === 'boolean-shorthand') return false
+  if (v.kind === 'spread') return !ctx.isFilteredSpread(v)
+  return true
+}
+
+/** Return true if the element should switch to the merge emit form. */
+function shouldUseSpreadAttrsMerge(
+  attrs: ReadonlyArray<IRAttribute>,
+  ctx: MergeContext,
+): boolean {
+  const hasMergeableSpread = attrs.some(a => {
+    if (ctx.honorClientOnly && a.clientOnly) return false
+    return a.value.kind === 'spread' && !ctx.isFilteredSpread(a.value)
   })
-  const hasNonKeyExplicit = filtered.some(a => {
+  if (!hasMergeableSpread) return false
+  return attrs.some(a => {
+    if (ctx.honorClientOnly && a.clientOnly) return false
     if (a.name === 'key') return false
-    if (a.value.kind === 'spread') return false
-    if (a.value.kind === 'jsx-children') return false
-    if (a.value.kind === 'boolean-shorthand') return false
+    const v = a.value
+    if (v.kind === 'spread') return false
+    if (v.kind === 'jsx-children') return false
+    if (v.kind === 'boolean-shorthand') return false
     return true
   })
+}
 
-  if (!hasMergeableSpread || !hasNonKeyExplicit) {
-    // Legacy inline path — keep when there's no collision risk.
-    return filtered
-      .map((a) => {
-        const attrName = a.name === '...'
-          ? '...'
-          : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
-        return renderTemplateAttrPart(a, attrName, wrap, restSpreadNames)
-      })
-      .filter(Boolean)
-  }
-
-  // Merge path: build `spreadAttrs({...source-order...})` so JS object-
-  // literal evaluation does rightmost-wins. `key` (→ `data-key`) is kept
-  // outside the merge to preserve the unconditional emit contract.
+/**
+ * Build the `${spreadAttrs({...})}` merge call for an element's
+ * already-filtered mergeable attrs (`isMergeableAttr` true for each).
+ *
+ * Per-path expression lowering is injected through the callbacks so
+ * the merge object construction stays adapter-agnostic. The three
+ * lowerers correspond to the three emit paths' transform rules
+ * (`wrap` for `irToHtmlTemplate`, `transformExpr` with `useTemplate`
+ * for the other two).
+ */
+function buildSpreadAttrsMergeCall(args: {
+  attrs: ReadonlyArray<IRAttribute>
+  spreadExprFor: (v: Extract<AttrValue, { kind: 'spread' }>) => string
+  expressionExprFor: (v: Extract<AttrValue, { kind: 'expression' }>) => string
+  templateExprFor: (v: Extract<AttrValue, { kind: 'template' }>) => string
+}): string {
+  const { attrs, spreadExprFor, expressionExprFor, templateExprFor } = args
   const objMembers: string[] = []
-  for (const a of filtered) {
+  for (const a of attrs) {
     const v = a.value
-    if (a.name === 'key') continue
-    if (v.kind === 'jsx-children') continue
     if (v.kind === 'spread') {
-      if (restSpreadNames?.has(v.expr)) continue
-      objMembers.push(`...(${wrap(v.expr)})`)
+      objMembers.push(`...(${spreadExprFor(v)})`)
       continue
     }
-    const attrName = toHtmlAttrName(a.name)
-    const memberKey = JSON.stringify(attrName)
-    let valueExpr: string
+    const memberKey = JSON.stringify(toHtmlAttrName(a.name))
     switch (v.kind) {
       case 'boolean-attr':
-        valueExpr = 'true'
-        break
-      case 'boolean-shorthand':
-        valueExpr = 'true'
+        objMembers.push(`${memberKey}: true`)
         break
       case 'literal':
-        valueExpr = JSON.stringify(v.value)
+        objMembers.push(`${memberKey}: ${JSON.stringify(v.value)}`)
         break
       case 'expression':
-        valueExpr = valueExprForExpression(v)
+        objMembers.push(`${memberKey}: ${expressionExprFor(v)}`)
         break
       case 'template':
-        valueExpr = valueExprForTemplate(v)
+        objMembers.push(`${memberKey}: ${templateExprFor(v)}`)
+        break
+      case 'boolean-shorthand':
+      case 'jsx-children':
+        // Pre-filtered out by `isMergeableAttr`. Skip defensively.
         break
     }
-    objMembers.push(`${memberKey}: ${valueExpr}`)
   }
-
-  const parts: string[] = [`\${spreadAttrs({${objMembers.join(', ')}})}`]
-
-  const keyAttr = filtered.find(a => a.name === 'key')
-  if (keyAttr) {
-    const attrName = keyAttrName(loopDepth)
-    const part = renderTemplateAttrPart(keyAttr, attrName, wrap, restSpreadNames)
-    if (part) parts.push(part)
-  }
-
-  return parts
+  return `\${spreadAttrs({${objMembers.join(', ')}})}`
 }
 
 /** Convert an IR node tree to an HTML template string (for conditionals/loops).
@@ -312,14 +312,41 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
 
   switch (node.type) {
     case 'element': {
-      const attrParts = renderElementAttrParts({
-        attrs: node.attrs,
-        wrap: wrapExpr,
-        loopDepth,
-        restSpreadNames,
-        valueExprForExpression: (v) => wrapExpr(v.expr),
-        valueExprForTemplate: (v) => wrapExpr(attrValueToString(v) ?? ''),
-      })
+      // Merge context shared with `irToComponentTemplate` /
+      // `generateCsrTemplate`. `irToHtmlTemplate` does not honour
+      // `clientOnly` (templates here are for conditionals / loops only),
+      // and its spread rest-name detector uses `v.expr` directly (no
+      // `templateExpr` fallback — those live on the SSR template path).
+      const mergeCtx: MergeContext = {
+        isFilteredSpread: (v) => !!restSpreadNames?.has(v.expr),
+        honorClientOnly: false,
+      }
+      const useMerge = shouldUseSpreadAttrsMerge(node.attrs, mergeCtx)
+      const firstMergeableIdx = useMerge
+        ? node.attrs.findIndex(a => isMergeableAttr(a, mergeCtx))
+        : -1
+      const mergeCall = useMerge
+        ? buildSpreadAttrsMergeCall({
+            attrs: node.attrs.filter(a => isMergeableAttr(a, mergeCtx)),
+            spreadExprFor: (v) => wrapExpr(v.expr),
+            expressionExprFor: (v) => wrapExpr(v.expr),
+            templateExprFor: (v) => wrapExpr(attrValueToString(v) ?? ''),
+          })
+        : null
+
+      const attrParts = node.attrs
+        .map((a, idx) => {
+          if (useMerge && isMergeableAttr(a, mergeCtx)) {
+            // Only the first mergeable attr emits the merge call; the
+            // others are already represented inside the merge object.
+            return idx === firstMergeableIdx ? mergeCall! : ''
+          }
+          const attrName = a.name === '...'
+            ? '...'
+            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
+          return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
+        })
+        .filter(Boolean)
 
       const hoistedScopeAttr = maybeHoistedScopeAttr(inHoistedChildren, node)
       if (hoistedScopeAttr) attrParts.push(hoistedScopeAttr)
@@ -763,29 +790,35 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       // via `spreadAttrs({...source-order...})` so JS object-literal
       // evaluation resolves the collision before serialization. (#1244)
       //
-      // The merge path mirrors `irToHtmlTemplate`'s helper but uses this
-      // path's `transformExpr` for expression / template lowering, and
-      // the `templateExpr ?? expr` rest-prop detector for spread filtering.
+      // Reuses the shared `shouldUseSpreadAttrsMerge` / `isMergeableAttr` /
+      // `buildSpreadAttrsMergeCall` helpers so the merge contract has one
+      // source of truth across all three CSR-side emit paths. Per-path
+      // wiring this path injects:
+      //   - `clientOnly` skip (SSR template defers `/* @client */` attrs
+      //     to hydrate's `reactiveAttrs`).
+      //   - `templateExpr ?? expr` rest-prop detector — the SSR-side
+      //     rest-name set is keyed by the template-form expression.
+      //   - `transformExpr` (constant inlining + props-object rewrite)
+      //     and `useTemplate: true` for template literal AttrValues.
       // `key` stays inline below (outer loops skip it entirely; inner
       // loops emit `data-key-N` unconditionally per the reconciliation
       // contract).
-      const isFilteredSpread = (v: AttrValue): boolean => {
-        if (v.kind !== 'spread') return false
-        const spreadExpr = v.templateExpr ?? v.expr
-        return !!restSpreadNames?.has(spreadExpr)
+      const mergeCtx: MergeContext = {
+        isFilteredSpread: (v) => !!restSpreadNames?.has(v.templateExpr ?? v.expr),
+        honorClientOnly: true,
       }
-      const hasMergeableSpread = node.attrs.some(a =>
-        !a.clientOnly && a.value.kind === 'spread' && !isFilteredSpread(a.value)
-      )
-      const hasNonKeyExplicit = node.attrs.some(a => {
-        if (a.clientOnly) return false
-        if (a.name === 'key') return false
-        if (a.value.kind === 'spread') return false
-        if (a.value.kind === 'jsx-children') return false
-        if (a.value.kind === 'boolean-shorthand') return false
-        return true
-      })
-      const useMerge = hasMergeableSpread && hasNonKeyExplicit
+      const useMerge = shouldUseSpreadAttrsMerge(node.attrs, mergeCtx)
+      const firstMergeableIdx = useMerge
+        ? node.attrs.findIndex(a => isMergeableAttr(a, mergeCtx))
+        : -1
+      const mergeCall = useMerge
+        ? buildSpreadAttrsMergeCall({
+            attrs: node.attrs.filter(a => isMergeableAttr(a, mergeCtx)),
+            spreadExprFor: (v) => transformExpr(v.expr, v.templateExpr),
+            expressionExprFor: (v) => transformExpr(v.expr, v.templateExpr),
+            templateExprFor: (v) => transformExpr(attrValueToString(v, { useTemplate: true }) ?? ''),
+          })
+        : null
 
       const attrParts = node.attrs
         .map((a, idx) => {
@@ -794,54 +827,12 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
           // createEffect is the sole authority on the attribute.
           if (a.clientOnly) return ''
           const v = a.value
-          // Merge path: replace the first mergeable attr with a single
-          // `${spreadAttrs({...merged...})}` token and elide every other
-          // mergeable attr (they're already inside the merge object).
-          // `key` stays inline below.
-          if (useMerge && a.name !== 'key' && v.kind !== 'jsx-children' && v.kind !== 'boolean-shorthand') {
-            const isMergeable = (attr: IRAttribute): boolean => {
-              if (attr.clientOnly) return false
-              if (attr.name === 'key') return false
-              const av = attr.value
-              if (av.kind === 'jsx-children') return false
-              if (av.kind === 'boolean-shorthand') return false
-              if (av.kind === 'spread') return !isFilteredSpread(av)
-              return true
-            }
-            // Only the first mergeable attr emits the spreadAttrs call;
-            // later mergeable attrs return '' so they don't double-emit.
-            const firstMergeableIdx = node.attrs.findIndex(isMergeable)
-            if (idx !== firstMergeableIdx) return ''
-            const objMembers: string[] = []
-            for (const m of node.attrs) {
-              if (!isMergeable(m)) continue
-              const mv = m.value
-              if (mv.kind === 'spread') {
-                objMembers.push(`...(${transformExpr(mv.expr, mv.templateExpr)})`)
-                continue
-              }
-              const memberKey = JSON.stringify(toHtmlAttrName(m.name))
-              switch (mv.kind) {
-                case 'boolean-attr':
-                  objMembers.push(`${memberKey}: true`)
-                  break
-                case 'literal':
-                  objMembers.push(`${memberKey}: ${JSON.stringify(mv.value)}`)
-                  break
-                case 'expression':
-                  objMembers.push(`${memberKey}: ${transformExpr(mv.expr, mv.templateExpr)}`)
-                  break
-                case 'template': {
-                  const tmplStr = attrValueToString(mv, { useTemplate: true }) ?? ''
-                  objMembers.push(`${memberKey}: ${transformExpr(tmplStr)}`)
-                  break
-                }
-              }
-            }
-            return `\${spreadAttrs({${objMembers.join(', ')}})}`
+          if (useMerge && isMergeableAttr(a, mergeCtx)) {
+            // Only the first mergeable attr emits the merge call.
+            return idx === firstMergeableIdx ? mergeCall! : ''
           }
           if (v.kind === 'spread') {
-            if (isFilteredSpread(v)) return ''
+            if (mergeCtx.isFilteredSpread(v)) return ''
             return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           // Skip key for outer loop elements (reconcileTemplates sets data-key at runtime).
@@ -1175,38 +1166,29 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
   switch (node.type) {
     case 'element': {
       // Same JSX-rightmost-wins merge rationale as `irToHtmlTemplate` /
-      // `irToComponentTemplate`: when a `{...spread}` shares an element
-      // with non-`key` user attrs, emit a single `spreadAttrs({...})` so
-      // JS object-literal evaluation resolves the collision before
-      // serialization (browser HTML parse is first-wins on duplicate
-      // attributes, which inverts the JSX semantic). (#1244)
-      const isFilteredSpread = (v: AttrValue): boolean => {
-        if (v.kind !== 'spread') return false
-        const spreadExpr = v.templateExpr ?? v.expr
-        return !!restSpreadNames?.has(spreadExpr)
+      // `irToComponentTemplate`: a `{...spread}` mixed with non-`key`
+      // explicit attrs collapses into one `spreadAttrs({...})` call so
+      // JS object-literal evaluation resolves rightmost-wins before
+      // serialization. (#1244) The same shared helpers
+      // (`shouldUseSpreadAttrsMerge`, `isMergeableAttr`,
+      // `buildSpreadAttrsMergeCall`) keep the contract aligned with
+      // the other two CSR-side emit paths.
+      const mergeCtx: MergeContext = {
+        isFilteredSpread: (v) => !!restSpreadNames?.has(v.templateExpr ?? v.expr),
+        honorClientOnly: true,
       }
-      const hasMergeableSpread = node.attrs.some(a =>
-        !a.clientOnly && a.value.kind === 'spread' && !isFilteredSpread(a.value)
-      )
-      const hasNonKeyExplicit = node.attrs.some(a => {
-        if (a.clientOnly) return false
-        if (a.name === 'key') return false
-        if (a.value.kind === 'spread') return false
-        if (a.value.kind === 'jsx-children') return false
-        if (a.value.kind === 'boolean-shorthand') return false
-        return true
-      })
-      const useMerge = hasMergeableSpread && hasNonKeyExplicit
-      const isMergeable = (attr: IRAttribute): boolean => {
-        if (attr.clientOnly) return false
-        if (attr.name === 'key') return false
-        const av = attr.value
-        if (av.kind === 'jsx-children') return false
-        if (av.kind === 'boolean-shorthand') return false
-        if (av.kind === 'spread') return !isFilteredSpread(av)
-        return true
-      }
-      const firstMergeableIdx = useMerge ? node.attrs.findIndex(isMergeable) : -1
+      const useMerge = shouldUseSpreadAttrsMerge(node.attrs, mergeCtx)
+      const firstMergeableIdx = useMerge
+        ? node.attrs.findIndex(a => isMergeableAttr(a, mergeCtx))
+        : -1
+      const mergeCall = useMerge
+        ? buildSpreadAttrsMergeCall({
+            attrs: node.attrs.filter(a => isMergeableAttr(a, mergeCtx)),
+            spreadExprFor: (v) => transformExpr(v.expr, v.templateExpr),
+            expressionExprFor: (v) => transformExpr(v.expr, v.templateExpr),
+            templateExprFor: (v) => transformExpr(attrValueToString(v, { useTemplate: true }) ?? ''),
+          })
+        : null
 
       const attrParts = node.attrs
         .map((a, idx) => {
@@ -1218,41 +1200,12 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           // entirely here.
           if (a.clientOnly) return ''
           const v = a.value
-          if (useMerge && isMergeable(a)) {
-            // Only the first mergeable attr emits the spreadAttrs call;
-            // every other mergeable attr returns '' (its key/value is
-            // already inside the merge object).
-            if (idx !== firstMergeableIdx) return ''
-            const objMembers: string[] = []
-            for (const m of node.attrs) {
-              if (!isMergeable(m)) continue
-              const mv = m.value
-              if (mv.kind === 'spread') {
-                objMembers.push(`...(${transformExpr(mv.expr, mv.templateExpr)})`)
-                continue
-              }
-              const memberKey = JSON.stringify(toHtmlAttrName(m.name))
-              switch (mv.kind) {
-                case 'boolean-attr':
-                  objMembers.push(`${memberKey}: true`)
-                  break
-                case 'literal':
-                  objMembers.push(`${memberKey}: ${JSON.stringify(mv.value)}`)
-                  break
-                case 'expression':
-                  objMembers.push(`${memberKey}: ${transformExpr(mv.expr, mv.templateExpr)}`)
-                  break
-                case 'template': {
-                  const valueStr = attrValueToString(mv, { useTemplate: true }) ?? ''
-                  objMembers.push(`${memberKey}: ${transformExpr(valueStr)}`)
-                  break
-                }
-              }
-            }
-            return `\${spreadAttrs({${objMembers.join(', ')}})}`
+          if (useMerge && isMergeableAttr(a, mergeCtx)) {
+            // Only the first mergeable attr emits the merge call.
+            return idx === firstMergeableIdx ? mergeCall! : ''
           }
           if (v.kind === 'spread') {
-            if (isFilteredSpread(v)) return ''
+            if (mergeCtx.isFilteredSpread(v)) return ''
             return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           const attrName = a.name === 'key'

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -173,6 +173,122 @@ function renderTemplateAttrPart(
   }
 }
 
+/**
+ * Emit element attribute tokens.
+ *
+ * When a `{...spread}` shares an element with non-`key` user attrs, the
+ * source-order inline emission would silently invert JSX rightmost-wins
+ * semantics on key collision: browser HTML parsing keeps the FIRST
+ * occurrence of a duplicate attribute, so `class="x" ${spreadAttrs(rest)}`
+ * leaves `class="x"` in the parsed DOM even when `rest.class` is supposed
+ * to override (rest is to the right in JSX source). Instead we emit a
+ * single `spreadAttrs({merged})` call whose argument is an object literal
+ * built in source order — JS object-literal evaluation resolves the
+ * rightmost-wins collision before serialization, so the helper sees a
+ * deduplicated map and emits a single attribute per key. (#1244)
+ *
+ * `key` (which becomes `data-key`) is intentionally kept outside the merge
+ * to preserve the unconditional `data-key="${value}"` emit contract
+ * (`templateAttrExpr` special-case at line 97): `spreadAttrs` skips
+ * `undefined` values, so a `key={undefined}` mistake would silently lose
+ * its `data-key="undefined"` debug surface inside the merge.
+ *
+ * The merge path runs only when both a spread and a non-`key` non-spread
+ * attr coexist; otherwise the legacy inline path is used so existing
+ * fixtures (no collision possible) keep their attribute order.
+ *
+ * `valueExprForExpression` / `valueExprForTemplate` are injected because
+ * the two call sites (`irToHtmlTemplate`, `irToComponentTemplate`) lower
+ * expressions to JS differently — `wrap`-only vs constant-inlining
+ * + props-object rewrite. Keeping that knob outside the helper means
+ * neither caller leaks its emit conventions into the merge logic.
+ */
+function renderElementAttrParts(args: {
+  attrs: ReadonlyArray<IRAttribute>
+  wrap: (expr: string) => string
+  loopDepth: number
+  restSpreadNames?: Set<string>
+  valueExprForExpression: (v: Extract<AttrValue, { kind: 'expression' }>) => string
+  valueExprForTemplate: (v: Extract<AttrValue, { kind: 'template' }>) => string
+  /** Optional per-attr filter (defaults to identity) used by component template path
+   *  to skip `clientOnly` attrs. */
+  attrFilter?: (a: IRAttribute) => boolean
+}): string[] {
+  const { attrs, wrap, loopDepth, restSpreadNames, valueExprForExpression, valueExprForTemplate, attrFilter } = args
+  const filtered = attrFilter ? attrs.filter(attrFilter) : attrs
+
+  const hasMergeableSpread = filtered.some(a => {
+    if (a.value.kind !== 'spread') return false
+    return !restSpreadNames?.has(a.value.expr)
+  })
+  const hasNonKeyExplicit = filtered.some(a => {
+    if (a.name === 'key') return false
+    if (a.value.kind === 'spread') return false
+    if (a.value.kind === 'jsx-children') return false
+    if (a.value.kind === 'boolean-shorthand') return false
+    return true
+  })
+
+  if (!hasMergeableSpread || !hasNonKeyExplicit) {
+    // Legacy inline path — keep when there's no collision risk.
+    return filtered
+      .map((a) => {
+        const attrName = a.name === '...'
+          ? '...'
+          : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
+        return renderTemplateAttrPart(a, attrName, wrap, restSpreadNames)
+      })
+      .filter(Boolean)
+  }
+
+  // Merge path: build `spreadAttrs({...source-order...})` so JS object-
+  // literal evaluation does rightmost-wins. `key` (→ `data-key`) is kept
+  // outside the merge to preserve the unconditional emit contract.
+  const objMembers: string[] = []
+  for (const a of filtered) {
+    const v = a.value
+    if (a.name === 'key') continue
+    if (v.kind === 'jsx-children') continue
+    if (v.kind === 'spread') {
+      if (restSpreadNames?.has(v.expr)) continue
+      objMembers.push(`...(${wrap(v.expr)})`)
+      continue
+    }
+    const attrName = toHtmlAttrName(a.name)
+    const memberKey = JSON.stringify(attrName)
+    let valueExpr: string
+    switch (v.kind) {
+      case 'boolean-attr':
+        valueExpr = 'true'
+        break
+      case 'boolean-shorthand':
+        valueExpr = 'true'
+        break
+      case 'literal':
+        valueExpr = JSON.stringify(v.value)
+        break
+      case 'expression':
+        valueExpr = valueExprForExpression(v)
+        break
+      case 'template':
+        valueExpr = valueExprForTemplate(v)
+        break
+    }
+    objMembers.push(`${memberKey}: ${valueExpr}`)
+  }
+
+  const parts: string[] = [`\${spreadAttrs({${objMembers.join(', ')}})}`]
+
+  const keyAttr = filtered.find(a => a.name === 'key')
+  if (keyAttr) {
+    const attrName = keyAttrName(loopDepth)
+    const part = renderTemplateAttrPart(keyAttr, attrName, wrap, restSpreadNames)
+    if (part) parts.push(part)
+  }
+
+  return parts
+}
+
 /** Convert an IR node tree to an HTML template string (for conditionals/loops).
  *  @param loopDepth - Current nesting depth inside inner loops. 0 = outer loop level.
  *    When > 0, `key` attributes are converted to `data-key-{depth}` instead of `data-key`.
@@ -196,14 +312,14 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
 
   switch (node.type) {
     case 'element': {
-      const attrParts = node.attrs
-        .map((a) => {
-          const attrName = a.name === '...'
-            ? '...'
-            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
-          return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
-        })
-        .filter(Boolean)
+      const attrParts = renderElementAttrParts({
+        attrs: node.attrs,
+        wrap: wrapExpr,
+        loopDepth,
+        restSpreadNames,
+        valueExprForExpression: (v) => wrapExpr(v.expr),
+        valueExprForTemplate: (v) => wrapExpr(attrValueToString(v) ?? ''),
+      })
 
       const hoistedScopeAttr = maybeHoistedScopeAttr(inHoistedChildren, node)
       if (hoistedScopeAttr) attrParts.push(hoistedScopeAttr)
@@ -641,16 +757,91 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
 
   switch (node.type) {
     case 'element': {
+      // When a `{...spread}` shares an element with other non-`key` user
+      // attrs, source-order inline emission inverts JSX rightmost-wins on
+      // collision (browser HTML parsing keeps the FIRST duplicate). Merge
+      // via `spreadAttrs({...source-order...})` so JS object-literal
+      // evaluation resolves the collision before serialization. (#1244)
+      //
+      // The merge path mirrors `irToHtmlTemplate`'s helper but uses this
+      // path's `transformExpr` for expression / template lowering, and
+      // the `templateExpr ?? expr` rest-prop detector for spread filtering.
+      // `key` stays inline below (outer loops skip it entirely; inner
+      // loops emit `data-key-N` unconditionally per the reconciliation
+      // contract).
+      const isFilteredSpread = (v: AttrValue): boolean => {
+        if (v.kind !== 'spread') return false
+        const spreadExpr = v.templateExpr ?? v.expr
+        return !!restSpreadNames?.has(spreadExpr)
+      }
+      const hasMergeableSpread = node.attrs.some(a =>
+        !a.clientOnly && a.value.kind === 'spread' && !isFilteredSpread(a.value)
+      )
+      const hasNonKeyExplicit = node.attrs.some(a => {
+        if (a.clientOnly) return false
+        if (a.name === 'key') return false
+        if (a.value.kind === 'spread') return false
+        if (a.value.kind === 'jsx-children') return false
+        if (a.value.kind === 'boolean-shorthand') return false
+        return true
+      })
+      const useMerge = hasMergeableSpread && hasNonKeyExplicit
+
       const attrParts = node.attrs
-        .map((a) => {
+        .map((a, idx) => {
           // `/* @client */` defers the attribute to hydrate via
           // `reactiveAttrs`. Skip from the SSR template so init's
           // createEffect is the sole authority on the attribute.
           if (a.clientOnly) return ''
           const v = a.value
+          // Merge path: replace the first mergeable attr with a single
+          // `${spreadAttrs({...merged...})}` token and elide every other
+          // mergeable attr (they're already inside the merge object).
+          // `key` stays inline below.
+          if (useMerge && a.name !== 'key' && v.kind !== 'jsx-children' && v.kind !== 'boolean-shorthand') {
+            const isMergeable = (attr: IRAttribute): boolean => {
+              if (attr.clientOnly) return false
+              if (attr.name === 'key') return false
+              const av = attr.value
+              if (av.kind === 'jsx-children') return false
+              if (av.kind === 'boolean-shorthand') return false
+              if (av.kind === 'spread') return !isFilteredSpread(av)
+              return true
+            }
+            // Only the first mergeable attr emits the spreadAttrs call;
+            // later mergeable attrs return '' so they don't double-emit.
+            const firstMergeableIdx = node.attrs.findIndex(isMergeable)
+            if (idx !== firstMergeableIdx) return ''
+            const objMembers: string[] = []
+            for (const m of node.attrs) {
+              if (!isMergeable(m)) continue
+              const mv = m.value
+              if (mv.kind === 'spread') {
+                objMembers.push(`...(${transformExpr(mv.expr, mv.templateExpr)})`)
+                continue
+              }
+              const memberKey = JSON.stringify(toHtmlAttrName(m.name))
+              switch (mv.kind) {
+                case 'boolean-attr':
+                  objMembers.push(`${memberKey}: true`)
+                  break
+                case 'literal':
+                  objMembers.push(`${memberKey}: ${JSON.stringify(mv.value)}`)
+                  break
+                case 'expression':
+                  objMembers.push(`${memberKey}: ${transformExpr(mv.expr, mv.templateExpr)}`)
+                  break
+                case 'template': {
+                  const tmplStr = attrValueToString(mv, { useTemplate: true }) ?? ''
+                  objMembers.push(`${memberKey}: ${transformExpr(tmplStr)}`)
+                  break
+                }
+              }
+            }
+            return `\${spreadAttrs({${objMembers.join(', ')}})}`
+          }
           if (v.kind === 'spread') {
-            const spreadExpr = v.templateExpr ?? v.expr
-            if (restSpreadNames?.has(spreadExpr)) return ''
+            if (isFilteredSpread(v)) return ''
             return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           // Skip key for outer loop elements (reconcileTemplates sets data-key at runtime).
@@ -983,8 +1174,42 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
 
   switch (node.type) {
     case 'element': {
+      // Same JSX-rightmost-wins merge rationale as `irToHtmlTemplate` /
+      // `irToComponentTemplate`: when a `{...spread}` shares an element
+      // with non-`key` user attrs, emit a single `spreadAttrs({...})` so
+      // JS object-literal evaluation resolves the collision before
+      // serialization (browser HTML parse is first-wins on duplicate
+      // attributes, which inverts the JSX semantic). (#1244)
+      const isFilteredSpread = (v: AttrValue): boolean => {
+        if (v.kind !== 'spread') return false
+        const spreadExpr = v.templateExpr ?? v.expr
+        return !!restSpreadNames?.has(spreadExpr)
+      }
+      const hasMergeableSpread = node.attrs.some(a =>
+        !a.clientOnly && a.value.kind === 'spread' && !isFilteredSpread(a.value)
+      )
+      const hasNonKeyExplicit = node.attrs.some(a => {
+        if (a.clientOnly) return false
+        if (a.name === 'key') return false
+        if (a.value.kind === 'spread') return false
+        if (a.value.kind === 'jsx-children') return false
+        if (a.value.kind === 'boolean-shorthand') return false
+        return true
+      })
+      const useMerge = hasMergeableSpread && hasNonKeyExplicit
+      const isMergeable = (attr: IRAttribute): boolean => {
+        if (attr.clientOnly) return false
+        if (attr.name === 'key') return false
+        const av = attr.value
+        if (av.kind === 'jsx-children') return false
+        if (av.kind === 'boolean-shorthand') return false
+        if (av.kind === 'spread') return !isFilteredSpread(av)
+        return true
+      }
+      const firstMergeableIdx = useMerge ? node.attrs.findIndex(isMergeable) : -1
+
       const attrParts = node.attrs
-        .map((a) => {
+        .map((a, idx) => {
           // `/* @client */` defers the attribute to hydrate. The
           // `reactiveAttrs` push in collect-elements wires a
           // `createEffect` that sets the attribute via the existing
@@ -993,9 +1218,41 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
           // entirely here.
           if (a.clientOnly) return ''
           const v = a.value
+          if (useMerge && isMergeable(a)) {
+            // Only the first mergeable attr emits the spreadAttrs call;
+            // every other mergeable attr returns '' (its key/value is
+            // already inside the merge object).
+            if (idx !== firstMergeableIdx) return ''
+            const objMembers: string[] = []
+            for (const m of node.attrs) {
+              if (!isMergeable(m)) continue
+              const mv = m.value
+              if (mv.kind === 'spread') {
+                objMembers.push(`...(${transformExpr(mv.expr, mv.templateExpr)})`)
+                continue
+              }
+              const memberKey = JSON.stringify(toHtmlAttrName(m.name))
+              switch (mv.kind) {
+                case 'boolean-attr':
+                  objMembers.push(`${memberKey}: true`)
+                  break
+                case 'literal':
+                  objMembers.push(`${memberKey}: ${JSON.stringify(mv.value)}`)
+                  break
+                case 'expression':
+                  objMembers.push(`${memberKey}: ${transformExpr(mv.expr, mv.templateExpr)}`)
+                  break
+                case 'template': {
+                  const valueStr = attrValueToString(mv, { useTemplate: true }) ?? ''
+                  objMembers.push(`${memberKey}: ${transformExpr(valueStr)}`)
+                  break
+                }
+              }
+            }
+            return `\${spreadAttrs({${objMembers.join(', ')}})}`
+          }
           if (v.kind === 'spread') {
-            const spreadExpr = v.templateExpr ?? v.expr
-            if (restSpreadNames?.has(spreadExpr)) return ''
+            if (isFilteredSpread(v)) return ''
             return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
           const attrName = a.name === 'key'


### PR DESCRIPTION
## Summary

- Reproduces and fixes a JSX-semantics violation in the CSR emit path
  surfaced while writing the catalog test for #1244's
  "Destructured loop param — `tasks.map(({ id, title, ...rest }) => …)`
  with `rest` spread back onto the root" item.
- When a JSX element has `{...spread}` alongside non-`key` explicit attrs,
  source-order inline emission silently inverts JSX rightmost-wins on
  collision (HTML's duplicate-attribute parse rule keeps the FIRST
  occurrence). Hono SSR already got this right via its JSX runtime;
  CSR landed `<element explicit ${spreadAttrs(rest)}>` and the explicit
  value survived browser parsing.
- The fix collapses both into a single
  `spreadAttrs({...source-order-members...})` call so JS object-literal
  evaluation resolves the collision before serialization. Applied
  identically across all three CSR-side emit paths (`irToHtmlTemplate`,
  `irToComponentTemplate`, `generateCsrTemplate`). `key` (→ `data-key`)
  stays outside the merge to preserve the unconditional
  `data-key="${value}"` debug contract.

## Verified failure mode (before this PR)

Source:

```jsx
<li key={id} data-priority="medium" {...rest}>{title}</li>
// rest.data-priority === 'high'
```

Rendered DOM after browser parsing:

| Adapter | data-priority value | JSX semantics |
|---------|--------------------|--------------|
| Hono SSR | `'high'` | ✅ |
| CSR (before fix) | `'medium'` | ❌ |
| CSR (after fix) | `'high'` | ✅ |

## Contract pinning

- New fixture `rest-destructure-object-spread-in-map` (Hono / Go / Mojo
  green; CSR skipped — cosmetic-only attribute-order divergence for the
  no-collision lone-spread case).
- New `compiler-stress-1244.test.ts` test asserts both emit sites carry
  the merged `spreadAttrs({"data-priority": "medium", ...rest})` form.
- Three pre-existing tests updated to the new merged shape
  (`client-js-generation`, `template-closure`,
  `staged-ir/01-template-scope`). Behavioural contracts (init-scope
  leak detection, no spread dropped) are preserved.

## Test plan

- [x] `bun test packages/jsx packages/client packages/adapter-hono packages/adapter-go-template packages/adapter-mojolicious packages/adapter-tests`
  → 2385 pass / 0 fail / 33 skip / 3 todo
- [x] Manual SSR + CSR DOM check confirms `rest.data-priority` wins on
  both adapters after fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)