### PR TITLE
docs(core/#1345): add CLI Workflow page reflecting new bf interface

### DIFF
--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -8,13 +8,19 @@
 - Why BarefootJS?
 - Design Philosophy
 
-### 2. Getting Started
+### 2. [CLI Workflow](./cli.md)
+
+- The `bf` command — discover, scaffold, test, preview, debug
+- Linear walkthrough: `search → docs → add → bun test → preview → debug`
+- AI coding workflows with `--json` output
+
+### 3. Getting Started
 
 - Installation
 - Quick Start (5-minute tutorial)
 - Project Structure
 
-### 3. [Core Concepts](./core-concepts.md)
+### 4. [Core Concepts](./core-concepts.md)
 
 - [Backend Freedom](./core-concepts/backend-freedom.md) — How adapters let the same JSX run on any server
 - [MPA-style Development](./core-concepts/mpa-style.md) — Server-rendering by default, JS only where marked
@@ -22,7 +28,7 @@
 - [AI-native Development](./core-concepts/ai-native.md) — Testable IR, CLI discovery, AI-assisted workflows
 - [How It Works](./core-concepts/how-it-works.md) — Two-phase compilation, hydration markers, clean overrides
 
-### 4. [Reactivity](./reactivity.md)
+### 5. [Reactivity](./reactivity.md)
 
 - [`createSignal`](./reactivity/create-signal.md) — Create a reactive value
 - [`createEffect`](./reactivity/create-effect.md) — Run side effects when dependencies change
@@ -32,13 +38,13 @@
 - [`untrack`](./reactivity/untrack.md) — Read signals without tracking dependencies
 - [Props Reactivity](./reactivity/props-reactivity.md) — Gotchas with destructuring
 
-### 5. [Templates & Rendering](./rendering.md)
+### 6. [Templates & Rendering](./rendering.md)
 
 - [JSX Compatibility](./rendering/jsx-compatibility.md) — What works, what doesn't, and what differs
 - [Fragment](./rendering/fragment.md) — Fragment support and hydration behavior
 - [`/* @client */` Directive](./rendering/client-directive.md) — Skip server evaluation for client-only expressions
 
-### 6. [Components](./components.md)
+### 7. [Components](./components.md)
 
 - [Component Authoring](./components/component-authoring.md) — Server components, client components, and the compilation model
 - [Props & Type Safety](./components/props-type-safety.md) — Typing props, defaults, and rest spreading
@@ -46,14 +52,14 @@
 - [Context API](./components/context-api.md) — Sharing state with `createContext` / `useContext`
 - [Portals](./components/portals.md) — Rendering elements outside their parent DOM hierarchy
 
-### 7. [Adapters](./adapters.md)
+### 8. [Adapters](./adapters.md)
 
 - [Adapter Architecture](./adapters/adapter-architecture.md) — How adapters work, the `TemplateAdapter` interface, and the IR contract
 - [Hono Adapter](./adapters/hono-adapter.md) — Configuration and output format for Hono / JSX-based servers
 - [Go Template Adapter](./adapters/go-template-adapter.md) — Configuration and output format for Go `html/template`
 - [Writing a Custom Adapter](./adapters/custom-adapter.md) — Step-by-step guide to implementing your own adapter
 
-### 8. [Advanced](./advanced.md)
+### 9. [Advanced](./advanced.md)
 
 - [IR Schema Reference](./advanced/ir-schema.md) — Node types, metadata, hydration markers
 - [Compiler Internals](./advanced/compiler-internals.md) — Pipeline phases, reactivity analysis, code generation

--- a/docs/core/cli.md
+++ b/docs/core/cli.md
@@ -1,0 +1,277 @@
+---
+title: CLI Workflow
+description: Build, discover, and debug components with the bf CLI — the spec-first feedback loop
+---
+
+# CLI Workflow
+
+`bf` is the BarefootJS command-line tool. It handles everything between *"I need a button"* and *"the signal graph looks right"* — without leaving your terminal, and without scraping component source files.
+
+## Install
+
+```bash
+npm create barefootjs@latest my-app
+cd my-app
+```
+
+The `npm create` flow scaffolds the project and installs `@barefootjs/cli`, exposing the `bf` command via `npx bf` or `bun run bf`. From inside the project root:
+
+```bash
+bf --help
+```
+
+## The Loop
+
+A typical component workflow is one straight line:
+
+```
+search → docs → add → (gen test) → bun test → preview → debug
+```
+
+You rarely need every step, but each one stands alone. The rest of this page walks the loop end-to-end with a single example — adding a `Button`, verifying it, previewing it, and inspecting its reactivity.
+
+---
+
+## 1. Discover — `bf search`
+
+Find a component or a doc page by name, category, or tag.
+
+```bash
+bf search button
+```
+
+```
+NAME                     TYPE        CATEGORY        DESCRIPTION
+----------------------------------------------------------------
+button                   component   input           A versatile button component with variants
+button-group             component   input           Grouped action buttons sharing visual context
+toggle                   component   input           Two-state button for on/off settings
+...
+```
+
+`bf search` indexes the public registry (`https://ui.barefootjs.dev/r` by default) plus framework docs. Use `--registry <url>` to point at a private mirror, or `--dir <path>` to search a local checkout.
+
+## 2. Read — `bf docs` and `bf guide`
+
+Two layers of documentation, two commands:
+
+| Command | What it shows |
+|---------|---------------|
+| `bf docs <component>` | Per-component API: props, examples, accessibility notes, slots |
+| `bf guide [topic]`    | Framework guides: reactivity, adapters, rendering, concepts |
+
+```bash
+bf docs button
+```
+
+```
+# Button
+Category: input | Stateful: no
+Tags: aria
+
+## Props
+  variant: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
+  size:    'default' | 'sm' | 'lg' | 'icon'
+  ...
+```
+
+```bash
+bf guide                    # list all topics
+bf guide reactivity         # show one topic
+```
+
+Both commands accept `--json` for machine-readable output (useful for editor integrations and AI agents — see [AI workflows](#ai-coding-workflows) below).
+
+## 3. Add — `bf add`
+
+Copy a component into your project, with its dependencies resolved transitively.
+
+```bash
+bf add button
+```
+
+The component lands in `ui/components/ui/button/` — source you own and can edit. Add multiple components in one shot:
+
+```bash
+bf add button input field label
+```
+
+Use `--force` to overwrite an existing copy, or `--registry <url>` to pull from a private registry.
+
+## 4. Build something new — `bf gen`
+
+When you need a component that doesn't exist in the registry, scaffold it instead of writing from scratch.
+
+```bash
+bf gen component signup-form input button field
+```
+
+This creates:
+
+- `ui/components/ui/signup-form/index.tsx` — JSX skeleton that composes the listed components
+- `ui/components/ui/signup-form/index.test.tsx` — IR test stub
+- `ui/components/ui/signup-form/index.preview.tsx` — preview entry
+
+For an existing component that lacks a test, generate just the test:
+
+```bash
+bf gen test button
+```
+
+For preview-only generation (the visual playground entry):
+
+```bash
+bf gen preview button
+```
+
+## 5. Verify — IR tests
+
+Component tests run against the compiler's IR — structure, signals, event handlers, accessibility — in milliseconds, without a browser.
+
+```bash
+bun test ui/components/ui/button/index.test.tsx
+```
+
+```tsx
+import { renderToTest } from '@barefootjs/test-utils'
+import { Button } from './index'
+
+test('Button renders an accessible button', () => {
+  const ir = renderToTest(<Button>Submit</Button>)
+
+  expect(ir).toContainElement('button')
+  expect(ir).toHaveAccessibleName('Submit')
+})
+```
+
+This is the spec-first feedback loop: change the component, re-run the IR test, get an answer in milliseconds. Real interactions and visual regressions still need E2E tests, but the structural issues are caught here.
+
+See [AI-native Development](./core-concepts/ai-native.md) for the full rationale and `renderToTest` reference.
+
+## 6. Preview — `bf preview`
+
+Open the visual playground for a component:
+
+```bash
+bf preview button
+```
+
+Run with no argument to list what's previewable in the current project:
+
+```bash
+bf preview
+```
+
+```
+46 previewable component(s):
+  accordion
+  alert
+  alert-dialog
+  ...
+
+Open one with: bf preview <component>
+```
+
+> **Note:** `bf preview` requires the BarefootJS monorepo source tree. A standalone build is tracked in [#885](https://github.com/piconic-ai/barefootjs/issues/885); in the meantime, clone the monorepo locally for visual checks.
+
+## 7. Debug reactivity — `bf debug`
+
+When a signal doesn't update what you expect, four sub-commands tell you why.
+
+```bash
+bf debug graph button         # signal dependency graph
+bf debug trace button count   # trace one signal's propagation path
+bf debug fallbacks button     # list Solid-style wrap-by-default bindings
+bf debug signals button       # signal initialization trace
+```
+
+```bash
+bf debug graph counter
+```
+
+```
+Counter
+├─ signal: count (initial: 0)
+└─ effect: count() → text@s0
+```
+
+`debug trace` is the workhorse: given a signal, it shows every reactive consumer that reruns when the signal changes — effects, memos, attribute bindings, text slots, child component updates.
+
+`debug fallbacks` (formerly `why-wrap`) reports expressions the compiler wrapped to preserve reactivity through prop boundaries. Use it when a value isn't updating and you suspect a destructured prop is the culprit. See [Props Reactivity](./reactivity/props-reactivity.md) for the underlying mechanic.
+
+## 8. Apply design tokens — `bf tokens`
+
+List the active design tokens:
+
+```bash
+bf tokens                      # all tokens
+bf tokens --category spacing   # one category
+```
+
+Apply a token override exported from [Studio](https://barefootjs.dev/studio):
+
+```bash
+bf tokens apply "https://studio.barefootjs.dev/?p=..."
+```
+
+This patches `tokens.css` (the runtime source of truth) directly, with a best-effort `tokens.json` patch retained for the monorepo convention. Studio's Export Bar emits the exact `bf tokens apply` command for you to paste.
+
+---
+
+## AI Coding Workflows
+
+Every `bf` command supports `--json` for structured output, designed so AI coding agents (Claude Code, Cursor, etc.) can drive the loop without scraping component source files.
+
+```bash
+bf search dialog --json
+bf docs accordion --json
+bf debug graph counter --json
+```
+
+This is the same pipeline humans use — discover → read → add → test → debug — except the agent calls commands instead of clicking links. A typical agent loop for "add a settings form":
+
+```bash
+bf search settings-form              # is there one already?
+bf docs field                        # learn the Field API
+bf docs switch                       # learn the Switch API
+bf gen component settings-form field switch label  # scaffold
+# edit ui/components/ui/settings-form/index.tsx
+bun test ui/components/ui/settings-form/index.test.tsx  # verify IR
+bf debug graph settings-form         # confirm reactivity
+```
+
+See [AI-native Development](./core-concepts/ai-native.md) for the IR test layer that makes this loop fast, and `CLAUDE.md` in the project root for the Claude Code conventions BarefootJS expects.
+
+---
+
+## Command Reference
+
+```
+Daily:
+  bf add <comp...>             Add component(s) to your project
+  bf docs <comp>               Show docs for a component
+  bf guide [topic]             Show framework guides
+  bf search <query>            Search components and docs
+  bf preview [comp]            Open visual preview (no arg lists previewable)
+  bf build                     Compile components using barefoot.config.ts
+
+Create:
+  bf gen component <name> <comps...>   Scaffold a new component + IR test
+  bf gen test <comp>                   Generate IR test from existing source
+  bf gen preview <comp>                Generate preview entry
+
+Tokens:
+  bf tokens [--category <cat>]         List design tokens
+  bf tokens apply <url>                Apply Studio token overrides
+
+Debug:
+  bf debug graph <comp>                Signal dependency graph
+  bf debug trace <comp> <signal>       Trace one signal's propagation
+  bf debug fallbacks <comp>            Wrap-by-default fallback bindings
+  bf debug signals <comp>              Signal initialization trace
+
+Options:
+  --json                       Machine-readable output
+```
+
+Run `bf --help` for the up-to-date version.

--- a/docs/core/cli.md
+++ b/docs/core/cli.md
@@ -172,7 +172,7 @@ bf preview
 Open one with: bf preview <component>
 ```
 
-> **Note:** `bf preview` requires the BarefootJS monorepo source tree. A standalone build is tracked in [#885](https://github.com/piconic-ai/barefootjs/issues/885); in the meantime, clone the monorepo locally for visual checks.
+> **Note:** Standalone `bf preview` for npm-installed projects is tracked in [#885](https://github.com/piconic-ai/barefootjs/issues/885). Until then, browse the live previews at [ui.barefootjs.dev/components](https://ui.barefootjs.dev) — every registry component has a hosted preview page at `/components/<name>`.
 
 ## 7. Debug reactivity — `bf debug`
 

--- a/site/core/lib/navigation.ts
+++ b/site/core/lib/navigation.ts
@@ -45,6 +45,7 @@ export function getDocsNavLinks(slug: string): {
 
 export const navigation: NavItem[] = [
   { title: 'Introduction', slug: 'introduction' },
+  { title: 'CLI Workflow', slug: 'cli' },
   {
     title: 'Core Concepts',
     slug: 'core-concepts',

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -122,7 +122,6 @@ export const navSections: NavSection[] = [
   {
     heading: 'Tools',
     entries: [
-      { title: 'CLI', href: 'https://barefootjs.dev/docs/cli' },
       { title: 'Studio', href: '/studio' },
     ],
   },

--- a/site/ui/components/shared/nav-data.ts
+++ b/site/ui/components/shared/nav-data.ts
@@ -122,7 +122,7 @@ export const navSections: NavSection[] = [
   {
     heading: 'Tools',
     entries: [
-      { title: 'CLI', href: '/docs/cli' },
+      { title: 'CLI', href: 'https://barefootjs.dev/docs/cli' },
       { title: 'Studio', href: '/studio' },
     ],
   },


### PR DESCRIPTION
Closes the remaining "Pending" item in #1345: ship the `/docs/cli` page that `nav-data.ts:125` already linked to but had no destination for.

## What's in the page

A linear "Hello, button" walkthrough that takes a newcomer through the full loop:

```
search → docs → add → (gen test) → bun test → preview → debug
```

Each step shows the actual `bf` command, sample output, and the `--json` / flag knobs. Followed by:

- **`bf tokens` / `bf tokens apply`** section linking back to Studio.
- **AI Coding Workflows** section showing the same loop driven by `--json` output, with a concrete agent example for "add a settings form."
- **Command Reference** mirroring `bf --help`.

## Placement decision

Lives in **site/core (`barefootjs.dev`)** rather than site/ui, because:

- The CLI is a framework-level tool (compiler, adapters, reactivity debugging) that spans both core and UI surfaces, not a UI-components concern.
- Sits next to `adapters.md` / `core-concepts.md` as Markdown for low-friction updates as the CLI evolves.
- The build auto-discovers `docs/core/*.md` so no plumbing is needed.

The `site/ui` sidebar link in `nav-data.ts:125` is updated to the absolute URL `https://barefootjs.dev/docs/cli`, keeping discoverability from ui.barefootjs.dev intact.

## Files

- `docs/core/cli.md` — new
- `site/core/lib/navigation.ts` — adds `{ title: 'CLI Workflow', slug: 'cli' }` after Introduction
- `docs/core/README.md` — TOC reshuffle (new §2, sections renumbered to §3–§9)
- `site/ui/components/shared/nav-data.ts` — sidebar link points to `https://barefootjs.dev/docs/cli`

## Reflects PR #1353 rename

Every command name uses the post-#1353 vocabulary — `docs` / `guide` / `gen` / `debug` / `tokens` — with no leftover `barefoot ui`, `scaffold`, `inspect`, `why-update`, etc. The page also notes that `bf preview` with no argument lists previewable components (new behaviour).

## Verified locally

- `bun run site/core/build.ts` succeeds and bundles `cli` into `dist/content.json`.
- `bun run site/core/server.tsx` serves `/docs/cli` with the correct `<h1>CLI Workflow</h1>` title and renders code blocks.
- Sidebar on `/docs/introduction` shows the new "CLI Workflow" entry pointing to `/docs/cli`.
- `grep 'barefoot ' docs/core/cli.md` returns nothing — no old command names slipped through.

## Not verified

- E2E (Playwright) for the docs site — these need a working browser env.
- Visual check of the site/ui sidebar with the new absolute URL.
- `bf meta extract` regeneration of `docs/core/llms.txt` (the new page has the required frontmatter, so the next run picks it up automatically).

https://claude.ai/code/session_01YHAk8fL3vZVd7JUojjx3yb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHAk8fL3vZVd7JUojjx3yb)_