### PR TITLE
fix(jsx/#1244): accept literal key={null} / key={undefined} / ternary-with-falsy

### DIFF
--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -723,14 +723,71 @@ describe('computed key', () => {
 })
 
 describe('key edge values', () => {
-  // SURFACED LIMITATION (#1244 sub-issue): BF023 (missing key) currently
-  // fires when a literal-falsy key (`key={0}`, `key={false}`,
-  // `key={null}`) is reachable through a ternary. The intended
-  // behaviour is either to accept the value verbatim (ints + booleans
-  // are valid React-style keys) or to diagnose with a more specific
-  // "key cannot be falsy" code, not the generic missing-key error. The
-  // body asserts a clean compile. Drop `.todo` once fixed.
-  test.todo('key={0}, key={false}, key={null} via ternary — accepted as a key', () => {
+  // BF023 (missing-key) used to fire on explicit literal-falsy keys
+  // (`key={null}`, `key={undefined}`) and on any ternary chain whose
+  // branches reached one of those literals — silently routing what
+  // React treats as a runtime warning into a hard compile error with a
+  // misleading "missing key" message. The user explicitly wrote the
+  // value; treat it as a runtime concern and let `mapArray`'s
+  // `String()` coercion produce the per-item key (`"null"`,
+  // `"undefined"`, `"0"`, `"false"`). Numeric / boolean keys were
+  // always accepted; the relaxation extends the same policy to the
+  // `null` / `undefined` literals and to ternaries that mix them.
+  //
+  // (#1244 catalog "key={0}, key={false}, key={null}".)
+  test('key={0} literal accepted as a numeric key', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Demo() {
+        const [items] = createSignal<{ v: number }[]>([])
+        return <ul>{items().map(it => <li key={0}>{it.v}</li>)}</ul>
+      }
+    `
+    expectNoFatalErrors(compile(src))
+  })
+
+  test('key={false} literal accepted (lowers to "false" at runtime)', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Demo() {
+        const [items] = createSignal<{ v: number }[]>([])
+        return <ul>{items().map(it => <li key={false}>{it.v}</li>)}</ul>
+      }
+    `
+    expectNoFatalErrors(compile(src))
+  })
+
+  test('key={null} literal accepted (no BF023 false-positive)', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Demo() {
+        const [items] = createSignal<{ v: number }[]>([])
+        return <ul>{items().map(it => <li key={null}>{it.v}</li>)}</ul>
+      }
+    `
+    expectNoFatalErrors(compile(src))
+  })
+
+  test('key={undefined} literal accepted (no BF023 false-positive)', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Demo() {
+        const [items] = createSignal<{ v: number }[]>([])
+        return <ul>{items().map(it => <li key={undefined}>{it.v}</li>)}</ul>
+      }
+    `
+    expectNoFatalErrors(compile(src))
+  })
+
+  test('ternary key mixing 0, false, null — accepted', () => {
+    // Per-item differentiated key via index. mapArray's `String()`
+    // coercion produces `"0"`, `"false"`, `"null"` — distinct strings,
+    // so reconciliation behaves as if the user had written explicit
+    // index strings.
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/missing-key-in-list.test.ts
+++ b/packages/jsx/src/__tests__/missing-key-in-list.test.ts
@@ -60,7 +60,14 @@ describe('BF023 — MISSING_KEY_IN_LIST', () => {
     expect(errs[0].severity).toBe('error')
   })
 
-  test('a-2: key={undefined} literal raises BF023', () => {
+  // The literal `null` / `undefined` cases used to raise BF023 with a
+  // generic "missing key" message. Per #1244 catalog "key={0}, key={false},
+  // key={null}" the user-explicit literal value is now accepted —
+  // `mapArray`'s `String()` coercion produces `"null"` / `"undefined"`
+  // as the per-item key, matching React's runtime-warn-only stance.
+  // The `nullable-type` check below (test a-3) is preserved for
+  // INFERRED nullability (`item.id` where `id?: string`).
+  test('a-2: key={undefined} literal compiles without BF023', () => {
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -70,11 +77,10 @@ describe('BF023 — MISSING_KEY_IN_LIST', () => {
       }
     `
     const errs = errorsFor(ErrorCodes.MISSING_KEY_IN_LIST, source)
-    expect(errs).toHaveLength(1)
-    expect(errs[0].severity).toBe('error')
+    expect(errs).toHaveLength(0)
   })
 
-  test('a-2: key={null} literal raises BF023', () => {
+  test('a-2: key={null} literal compiles without BF023', () => {
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -84,9 +90,7 @@ describe('BF023 — MISSING_KEY_IN_LIST', () => {
       }
     `
     const errs = errorsFor(ErrorCodes.MISSING_KEY_IN_LIST, source)
-    expect(errs).toHaveLength(1)
-    expect(errs[0].severity).toBe('error')
-    expect(errs[0].suggestion?.message).toContain('stable identifier')
+    expect(errs).toHaveLength(0)
   })
 
   test('a-3: key type includes undefined raises BF023', () => {

--- a/packages/jsx/src/__tests__/missing-key-in-list.test.ts
+++ b/packages/jsx/src/__tests__/missing-key-in-list.test.ts
@@ -93,6 +93,25 @@ describe('BF023 — MISSING_KEY_IN_LIST', () => {
     expect(errs).toHaveLength(0)
   })
 
+  test('a-3: key with inferred-nullable type inside a ternary still raises BF023', () => {
+    // Regression guard for #1244: the original "accept literal null/undefined"
+    // PR (#1358) skipped the type-based nullable check for ALL ConditionalExpression
+    // keys, which silently dropped legitimate inferred-nullable diagnostics
+    // on ternary branches. The bypass must trigger ONLY when at least one
+    // branch is an explicit `null` / `undefined` literal — i.e. the user
+    // deliberately opted into a null key. Otherwise the type-driven check
+    // still applies.
+    const source = `
+      interface Item { id: string; fallback?: string; cond: boolean }
+      export function List({ items }: { items: Item[] }) {
+        return <ul>{items.map(item => <li key={item.cond ? item.id : item.fallback}>{item.id}</li>)}</ul>
+      }
+    `
+    const errs = errorsFor(ErrorCodes.MISSING_KEY_IN_LIST, source)
+    expect(errs).toHaveLength(1)
+    expect(errs[0].suggestion?.message).toContain('non-null assertion')
+  })
+
   test('a-3: key type includes undefined raises BF023', () => {
     // Use a plain prop-typed component so @barefootjs/client is not needed.
     // The checker resolves item.id as `string | undefined` from the interface.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2103,6 +2103,30 @@ function normalizeKeyExpr(expr: string): string {
 type KeyProblem = 'missing' | 'nullable-type'
 
 /**
+ * True when at least one branch of `cond` (or its nested conditionals)
+ * is an explicit `null` / `undefined` literal — the shape the catalog
+ * "key={0}, key={false}, key={null}" item carves out as user-opted-in.
+ *
+ * Used by `classifyKeyProblem` to gate the conditional bypass of the
+ * type-based nullable check. Without this narrowing, a ternary like
+ * `key={cond ? item.id : item.fallback}` (where `fallback?: string`)
+ * would also skip the check and silently drop a legitimate
+ * inferred-nullability diagnostic.
+ */
+function conditionalHasExplicitNullishBranch(cond: ts.ConditionalExpression): boolean {
+  return branchHasExplicitNullish(cond.whenTrue) || branchHasExplicitNullish(cond.whenFalse)
+}
+
+function branchHasExplicitNullish(branch: ts.Expression): boolean {
+  let b: ts.Expression = branch
+  while (ts.isParenthesizedExpression(b)) b = b.expression
+  if (b.kind === ts.SyntaxKind.NullKeyword) return true
+  if (ts.isIdentifier(b) && b.text === 'undefined') return true
+  if (ts.isConditionalExpression(b)) return conditionalHasExplicitNullishBranch(b)
+  return false
+}
+
+/**
  * Classify a key expression as problematic or fine.
  * Returns a KeyProblem string when the key is missing or has a
  * type-system-derived nullable type, or null when the key looks valid.
@@ -2150,11 +2174,16 @@ function classifyKeyProblem(
   if (expr.kind === ts.SyntaxKind.NullKeyword) return null
   if (ts.isIdentifier(expr) && expr.text === 'undefined') return null
 
-  // Conditional expressions: the type-based nullable check below would
-  // see the branch union (often `T | null`) and false-positive on
-  // legitimate per-item differentiated keys
-  // (`key={i === 0 ? 0 : i === 1 ? false : null}`). Defer to runtime.
-  if (ts.isConditionalExpression(expr)) return null
+  // Conditional expressions that include an explicit `null` / `undefined`
+  // literal in any branch (possibly nested) are the user opting into a
+  // per-item differentiated key with a falsy branch
+  // (`key={i === 0 ? 0 : i === 1 ? false : null}`). The type-based
+  // check below would see the branch union (`T | null`) and
+  // false-positive — bypass for the deliberate-opt-in case only. A
+  // ternary with NO explicit literal branch (`key={cond ? item.id :
+  // item.fallback}` where `fallback?: string`) still runs the type
+  // check, so inferred nullability is still surfaced.
+  if (ts.isConditionalExpression(expr) && conditionalHasExplicitNullishBranch(expr)) return null
 
   // Type-based nullable check for INFERRED nullability (e.g. `item.id`
   // where `id?: string`). The user didn't explicitly opt into a null

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2100,12 +2100,26 @@ function normalizeKeyExpr(expr: string): string {
   return out
 }
 
-type KeyProblem = 'missing' | 'literal-undefined' | 'literal-null' | 'nullable-type'
+type KeyProblem = 'missing' | 'nullable-type'
 
 /**
  * Classify a key expression as problematic or fine.
- * Returns a KeyProblem string when the key is missing or has an illegal value/type,
- * or null when the key looks valid.
+ * Returns a KeyProblem string when the key is missing or has a
+ * type-system-derived nullable type, or null when the key looks valid.
+ *
+ * Explicit literal `null` / `undefined` (`key={null}`, `key={undefined}`),
+ * and ternary chains whose branches reach those literals, are intentionally
+ * NOT flagged: the user wrote the value verbatim, mapArray's `String()`
+ * coercion produces a deterministic per-item key (`"null"`, `"undefined"`,
+ * `"0"`, `"false"`), and React's own behaviour for those values is a
+ * runtime warning rather than a hard compile error. Surfacing them as
+ * BF023 ("Missing key") was misleading both as a code (the key IS present)
+ * and as a category (a single-item ternary that resolves to `null` for
+ * one branch is perfectly fine reconciliation-wise). The type-based
+ * `nullable-type` check is preserved for INFERRED nullability
+ * (`item.id` where `id?: string`) — those are surface bugs the user
+ * didn't make a deliberate choice about. (#1244 catalog "key={0},
+ * key={false}, key={null}".)
  */
 function classifyKeyProblem(
   keyAttr: ts.JsxAttribute | undefined,
@@ -2113,12 +2127,12 @@ function classifyKeyProblem(
 ): KeyProblem | null {
   if (!keyAttr) return 'missing'
 
-  // `key` without an initializer is a JSX boolean shorthand → effectively undefined
-  if (!keyAttr.initializer) return 'literal-undefined'
+  // `key` without an initializer is a JSX boolean shorthand → no value.
+  if (!keyAttr.initializer) return 'missing'
 
-  // `key={}` — empty expression (syntax oddity, treat as missing)
+  // `key={}` — empty expression (syntax oddity, treat as missing).
   if (ts.isJsxExpression(keyAttr.initializer) && !keyAttr.initializer.expression) {
-    return 'literal-undefined'
+    return 'missing'
   }
 
   let expr: ts.Expression | undefined
@@ -2131,11 +2145,20 @@ function classifyKeyProblem(
 
   if (!expr) return null
 
-  // Literal null / undefined identifiers
-  if (expr.kind === ts.SyntaxKind.NullKeyword) return 'literal-null'
-  if (ts.isIdentifier(expr) && expr.text === 'undefined') return 'literal-undefined'
+  // Explicit `key={null}` / `key={undefined}` — user-written value;
+  // accepted as a runtime-coerced string key.
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return null
+  if (ts.isIdentifier(expr) && expr.text === 'undefined') return null
 
-  // Type-based nullable check (available when checker is wired in)
+  // Conditional expressions: the type-based nullable check below would
+  // see the branch union (often `T | null`) and false-positive on
+  // legitimate per-item differentiated keys
+  // (`key={i === 0 ? 0 : i === 1 ? false : null}`). Defer to runtime.
+  if (ts.isConditionalExpression(expr)) return null
+
+  // Type-based nullable check for INFERRED nullability (e.g. `item.id`
+  // where `id?: string`). The user didn't explicitly opt into a null
+  // key here; the type system caught a missing field at the source.
   if (checker) {
     const type = checker.getTypeAtLocation(expr)
     const isNullable = type.isUnion()
@@ -2154,9 +2177,6 @@ function classifyKeyProblem(
 function keyErrorSuggestion(problem: KeyProblem): string {
   if (problem === 'nullable-type') {
     return "The key prop's type may be null or undefined. Narrow it with a non-null assertion (e.g. `item.id!`) or change the source type to be required."
-  }
-  if (problem === 'literal-null' || problem === 'literal-undefined') {
-    return 'Replace the literal with a stable identifier, e.g. `key={item.id}`. Use the second arrow parameter `(item, i) => ... key={i}` as a fallback for static lists.'
   }
   return 'Add a key prop, e.g. `<li key={item.id}>...</li>`. Use the second arrow parameter `(item, i) => ... key={i}` as a fallback for static lists.'
 }


### PR DESCRIPTION
## Summary

Working on issue #1244's catalog item "`key={0}`, `key={false}`, `key={null}` — what happens?".

**Before:** `classifyKeyProblem` raised BF023 ("Missing key in list rendering") for any explicit `key={null}` or `key={undefined}` literal, and for any ternary chain that could reach one of those literals (the type-based nullable check saw the branch union `T | null` and false-positived). Both the code and the category were misleading: the key IS present, and React's own behaviour for these values is a runtime warning, not a compile error.

**After:** Explicit literal `null` / `undefined` keys are accepted — `mapArray`'s `String()` coercion produces the per-item key (`"null"`, `"undefined"`). `ConditionalExpression` keys skip the type-based nullable check so per-item differentiated ternaries (`key={i === 0 ? 0 : i === 1 ? false : null}`) lower cleanly. Numeric / boolean keys (`0`, `false`) were already accepted; this extends the same policy.

**Preserved:** Key truly missing (no attribute / bare `<el key>` / `key={}`) still raises BF023. INFERRED nullability via the type checker (`item.id` where `id?: string`) still raises BF023 — the user didn't deliberately opt into a null key, the type system caught a missing field at the source.

## Behaviour matrix

| Input | Before | After |
|---|---|---|
| `key={0}` | accept | accept |
| `key={false}` | accept | accept |
| `key={null}` | BF023 ❌ | accept |
| `key={undefined}` | BF023 ❌ | accept |
| `key={""}` | accept | accept |
| `key={i === 0 ? 0 : i === 1 ? false : null}` | BF023 ❌ | accept |
| `key={item.id}` where `id?: string` | BF023 | BF023 (unchanged) |
| `key` attribute missing | BF023 | BF023 (unchanged) |

## Test plan

- [x] `bun test packages/jsx packages/client packages/adapter-*` → 2395 pass / 0 fail / 2 todo (down from 3 — this PR replaces one `test.todo`)
- [x] Five new Layer 1 cases in `compiler-stress-1244.test.ts` (`0` / `false` / `null` / `undefined` / ternary)
- [x] Two existing BF023 suite tests (`a-2: key={null}`, `a-2: key={undefined}`) flipped to "no error" with docstring noting the new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)