### PR TITLE
feat(site): reorder package manager tabs to npm/yarn/pnpm/bun, npm default

### DIFF
--- a/site/ui/components/package-manager-tabs.tsx
+++ b/site/ui/components/package-manager-tabs.tsx
@@ -3,7 +3,7 @@
  * PackageManagerTabs Component
  *
  * A tabbed interface for displaying installation commands
- * for different package managers (pnpm, npm, yarn, bun).
+ * for different package managers (npm, yarn, pnpm, bun).
  *
  * Uses value switching (single code display area) instead of
  * HTML switching (4 separate TabsContent panels) to minimize
@@ -23,7 +23,7 @@ const tabTriggerActive = 'bg-background text-foreground shadow-sm dark:border-in
 const tabTriggerInactive = 'text-foreground dark:text-muted-foreground'
 
 export function PackageManagerTabs(props: PackageManagerTabsProps) {
-  const [selected, setSelected] = createSignal('bun')
+  const [selected, setSelected] = createSignal('npm')
 
   const fullCommand = createMemo(() => {
     const prefix = selected() === 'bun' ? 'bunx --bun'
@@ -36,10 +36,10 @@ export function PackageManagerTabs(props: PackageManagerTabsProps) {
   return (
     <div className="flex flex-col gap-2 w-full">
       <div role="tablist" className="bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]">
-        <button role="tab" aria-selected={selected() === 'bun'} data-state={selected() === 'bun' ? 'active' : 'inactive'} onClick={() => setSelected('bun')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'bun' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'bun' ? 0 : -1}>bun</button>
         <button role="tab" aria-selected={selected() === 'npm'} data-state={selected() === 'npm' ? 'active' : 'inactive'} onClick={() => setSelected('npm')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'npm' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'npm' ? 0 : -1}>npm</button>
-        <button role="tab" aria-selected={selected() === 'pnpm'} data-state={selected() === 'pnpm' ? 'active' : 'inactive'} onClick={() => setSelected('pnpm')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'pnpm' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'pnpm' ? 0 : -1}>pnpm</button>
         <button role="tab" aria-selected={selected() === 'yarn'} data-state={selected() === 'yarn' ? 'active' : 'inactive'} onClick={() => setSelected('yarn')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'yarn' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'yarn' ? 0 : -1}>yarn</button>
+        <button role="tab" aria-selected={selected() === 'pnpm'} data-state={selected() === 'pnpm' ? 'active' : 'inactive'} onClick={() => setSelected('pnpm')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'pnpm' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'pnpm' ? 0 : -1}>pnpm</button>
+        <button role="tab" aria-selected={selected() === 'bun'} data-state={selected() === 'bun' ? 'active' : 'inactive'} onClick={() => setSelected('bun')} className={`${tabTriggerBase} ${tabTriggerFocus} ${selected() === 'bun' ? tabTriggerActive : tabTriggerInactive}`} tabindex={selected() === 'bun' ? 0 : -1}>bun</button>
       </div>
       <div className="relative group">
         <pre className="p-4 pr-12 bg-muted rounded-lg overflow-x-auto text-sm font-mono border">

--- a/site/ui/e2e/installation-tabs.spec.ts
+++ b/site/ui/e2e/installation-tabs.spec.ts
@@ -15,24 +15,24 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await expect(tablist.getByRole('tab', { name: 'yarn' })).toBeVisible()
   })
 
-  test('bun tab is selected by default', async ({ page }) => {
-    const tablist = page.locator('[role="tablist"]').first()
-    const bunTab = tablist.getByRole('tab', { name: 'bun' })
-    await expect(bunTab).toHaveAttribute('aria-selected', 'true')
-  })
-
-  test('shows bun command by default', async ({ page }) => {
-    await expect(page.locator('text=bunx --bun bf add checkbox')).toBeVisible()
-  })
-
-  test('clicking npm tab switches content', async ({ page }) => {
+  test('npm tab is selected by default', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
     const npmTab = tablist.getByRole('tab', { name: 'npm', exact: true })
-
-    await npmTab.click()
-
     await expect(npmTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('shows npm command by default', async ({ page }) => {
     await expect(page.locator('text=npx bf add checkbox')).toBeVisible()
+  })
+
+  test('clicking bun tab switches content', async ({ page }) => {
+    const tablist = page.locator('[role="tablist"]').first()
+    const bunTab = tablist.getByRole('tab', { name: 'bun' })
+
+    await bunTab.click()
+
+    await expect(bunTab).toHaveAttribute('aria-selected', 'true')
+    await expect(page.locator('text=bunx --bun bf add checkbox')).toBeVisible()
   })
 
   test('clicking pnpm tab switches content', async ({ page }) => {
@@ -57,27 +57,27 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
 
   test('switching tabs updates aria-selected correctly', async ({ page }) => {
     const tablist = page.locator('[role="tablist"]').first()
-    const bunTab = tablist.getByRole('tab', { name: 'bun' })
     const npmTab = tablist.getByRole('tab', { name: 'npm', exact: true })
+    const bunTab = tablist.getByRole('tab', { name: 'bun' })
     const pnpmTab = tablist.getByRole('tab', { name: 'pnpm' })
 
     // Initial state
-    await expect(bunTab).toHaveAttribute('aria-selected', 'true')
-    await expect(npmTab).toHaveAttribute('aria-selected', 'false')
-
-    // Switch to npm
-    await npmTab.click()
-    await expect(bunTab).toHaveAttribute('aria-selected', 'false')
     await expect(npmTab).toHaveAttribute('aria-selected', 'true')
+    await expect(bunTab).toHaveAttribute('aria-selected', 'false')
+
+    // Switch to bun
+    await bunTab.click()
+    await expect(npmTab).toHaveAttribute('aria-selected', 'false')
+    await expect(bunTab).toHaveAttribute('aria-selected', 'true')
 
     // Switch to pnpm
     await pnpmTab.click()
-    await expect(npmTab).toHaveAttribute('aria-selected', 'false')
+    await expect(bunTab).toHaveAttribute('aria-selected', 'false')
     await expect(pnpmTab).toHaveAttribute('aria-selected', 'true')
 
-    // Switch back to bun
-    await bunTab.click()
+    // Switch back to npm
+    await npmTab.click()
     await expect(pnpmTab).toHaveAttribute('aria-selected', 'false')
-    await expect(bunTab).toHaveAttribute('aria-selected', 'true')
+    await expect(npmTab).toHaveAttribute('aria-selected', 'true')
   })
 })


### PR DESCRIPTION
## Summary
- Reorder install tabs in `site/ui/components/package-manager-tabs.tsx` to `npm, yarn, pnpm, bun` and switch the default selection from `bun` to `npm` so the most familiar command is shown first.
- Update `site/ui/e2e/installation-tabs.spec.ts` to match the new default (npm tab selected, `npx bf add checkbox` shown by default) and the new switching scenarios.

## Notes
- `deno` was intentionally **not** added. The CLI (`packages/cli/src/lib/pm.ts`) only types/handles `npm | bun | pnpm | yarn`, so deno support would require CLI changes as well and isn't validated.
- `yarn` / `pnpm` are already first-class in `commandsFor()` (`yarn dlx` / `pnpm dlx`), so showing them by default is fine.

## Test plan
- [ ] `site/ui/e2e/installation-tabs.spec.ts` passes against the deployed docs (default tab = npm, switching to bun/pnpm/yarn shows the expected command).
- [ ] Visually confirm the Installation block on any `/components/*` page renders the tabs in `npm yarn pnpm bun` order with `npx bf add <component>` displayed by default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFYUprZZPTDyjbBvAd8UCS)_