### PR TITLE
docs(core): drop my-app from Quick Start create command

### DIFF
--- a/site/core/pages/quick-start.tsx
+++ b/site/core/pages/quick-start.tsx
@@ -24,7 +24,7 @@ const TITLE = 'Quick Start'
 const DESCRIPTION =
   'Scaffold a BarefootJS app in under five minutes — Counter component, dev server, deploy.'
 
-const CREATE_COMMAND = 'barefootjs@latest my-app'
+const CREATE_COMMAND = 'barefootjs@latest'
 
 const PRELUDE_MD = `Scaffold a BarefootJS app, run it locally, and tour the generated project. About five minutes.
 


### PR DESCRIPTION
## Summary

The Quick Start tabs displayed `npm create barefootjs@latest my-app` (and the bun/pnpm/yarn equivalents). Copy-pasting that command locks the reader into the literal `my-app` directory.

Drop the positional. `create-barefootjs` then prompts for a target directory with `my-app` pre-filled — Enter accepts the default, typing overrides. Better behavior for anyone who actually pastes the command.

Source: `packages/create-barefootjs/src/index.ts` — the interactive `text({ message: 'Target directory', defaultValue: 'my-app' })` branch runs when no positional is given on a TTY.

After tabs:
- npm: `npm create barefootjs@latest`
- bun: `bun create barefootjs`
- pnpm: `pnpm create barefootjs`
- yarn: `yarn create barefootjs`

The `cd my-app` and the `--adapter go-template` example in Next steps are unchanged — those still document the resolved name, and the flag-forwarding example reads more clearly with a concrete positional.

## Test plan

- [ ] `bun run --filter barefootjs-site dev`, visit `/docs/quick-start`, confirm the npm tab shows `npm create barefootjs@latest` and the other tabs match
- [ ] `/docs/quick-start.md` raw view shows the same command in the section 1 code block
- [ ] Run `npm create barefootjs@latest` in a scratch dir and confirm it prompts for a target with `my-app` as the default

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjYHWRVSHM4cgHhsETkqzr)_