### PR TITLE
docs(#1365): add Known limitations section + known-limitation label convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Quick decision guide:
 
 `renderToTest` resolution limits (known): the IR analyzer does NOT resolve `Record<T, string>[key]` indexed lookups or default-prop values. For variant components (`const sizeClasses: Record<Size, string> = {...}` + `${sizeClasses[size]}`), the `.classes` array in IR only contains the base class tokens, not the per-variant ones. Verify variant resolution at the adapter conformance layer instead, or add a fixture in `packages/adapter-tests/fixtures/`. See `ui/components/ui/button/index.test.tsx` for the existing workaround pattern.
 
+Tracked limitations across the compiler, adapters, and runtime live under the [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation) label — that label URL is the source of truth. Adapter-internal declarations (`skipJsx`, `skipFixtures`, `expectedDiagnostics`) carry a docstring pointer back to the per-issue URL.
+
 Workflow for editing a UI component:
 1. Run `bun run bf docs <component>` (and `bf debug graph <component>` if `"use client"`) for the API surface.
 2. Add or update the IR test (red).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
 
 ---
 
+## Known limitations
+
+Tracked patterns the compiler / adapters / runtime don't yet handle are aggregated under the [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation) label. Each issue documents the shape, affected fixtures, available workaround, and fix direction.
+
+---
+
 ## Acknowledgements
 
 This project is inspired by and built with:


### PR DESCRIPTION
## Summary

- README: new `Known limitations` section linking to the [`known-limitation` label URL](https://github.com/piconic-ai/barefootjs/labels/known-limitation) as the auto-aggregated source of truth.
- CLAUDE.md: pointer to the same label URL added directly after the existing `renderToTest` resolution limits paragraph. Adapter-internal declarations (`skipJsx` / `skipFixtures` / `expectedDiagnostics`) keep their docstring pointer back to the per-issue URL.
- Audit also filed sixteen `known-limitation` issues (#1377-#1392):
  - Go adapter only: #1377 (`??` branch selection), #1378 (`.map()` `data-key` shape divergence), #1379 (scope marker lost through `.Children` interpolation — Go-side deferral from #1326)
  - Mojo adapter only: #1380 (bare-variable refs in conditional branches lack `my` declaration), #1381 (dynamic `style={{}}` has no BF101 lift), #1382 (`bf->comment("loop:<id>")` boundary markers not emitted for clientOnly loops)
  - Go + Mojo shared: #1383 (no SSR context-propagation mechanism), #1384 (BF104 destructure in `.map()`), #1385 (BF103 sibling-imported child component), #1386 (BF101 JS object literal in attribute), #1387 (BF101 tagged-template-literal callee), #1388 (BF101 JSX spread of reactive object), #1389 (templatePrimitives V1 identifier-path-only)
  - CSR: #1390 (rest-spread attribute-order divergence from SSR)
  - Compiler / IR analyzer: #1391 (`Record<T, string>[key]` unresolved), #1392 (default-prop values unresolved)

Closes #1365.

## Test plan

- [x] README `Known limitations` link resolves to the `known-limitation` label URL
- [x] CLAUDE.md addition declares the label URL as the single source of truth
- [x] All sixteen new issues carry the `known-limitation` label
- [x] Each issue body references parent #1244 / #1365, lists affected fixtures, workaround, and fix direction

