### PR TITLE
test(client/#1367): cover late Promise resolution + rename to dispose-effect

### DIFF
--- a/packages/client/__tests__/dispose-effect.test.ts
+++ b/packages/client/__tests__/dispose-effect.test.ts
@@ -1,25 +1,24 @@
 /**
- * Regression test for #1366 — Runtime: cancel requestAnimationFrame on unmount
+ * Effect disposal contract — covers #1366 (rAF) and #1367 (async / Suspense).
  *
- * Verifies the recommended pattern from the issue's repro:
+ * The shared invariant is: once a scope is disposed, no late callback —
+ * whether from `requestAnimationFrame`, a Promise resolution, a
+ * `setTimeout`, or a `createResource` body when that primitive lands —
+ * can resurrect effects owned by the disposed scope. The mechanism is
+ * the cleanup chain in `disposeEffect`: cancel any handle the user
+ * registered via `onCleanup`, and (defensively) remove every owned
+ * effect from its signals' subscriber sets so late `setSignal` calls
+ * are inert against the disposed subtree.
  *
- *   createEffect(() => {
- *     const h = requestAnimationFrame(() => setT(performance.now()))
- *     onCleanup(() => cancelAnimationFrame(h))
- *   })
- *
- * Invariants:
- *   1. When the scope disposes before the next frame, the rAF handle
- *      is cancelled by onCleanup and the callback never runs.
- *   2. Even if the user forgets onCleanup and the rAF *does* fire after
- *      dispose, signal writes from the late callback cannot resurrect
- *      effects owned by the disposed scope.
+ * The Pulse repro from #1366 is the rAF instance of this contract; the
+ * `createResource` / `Suspense` repro from #1367 is the Promise
+ * instance. The same primitives are responsible for both.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { createSignal, createEffect, createRoot, onCleanup } from '../src/reactive'
 
-describe('onCleanup with requestAnimationFrame (#1366)', () => {
+describe('disposeEffect — cleanup chain and late-write isolation', () => {
   let originalRAF: typeof globalThis.requestAnimationFrame | undefined
   let originalCAF: typeof globalThis.cancelAnimationFrame | undefined
   let frames: Map<number, FrameRequestCallback>
@@ -85,7 +84,7 @@ describe('onCleanup with requestAnimationFrame (#1366)', () => {
     expect(callbackFired).toBe(false)
   })
 
-  test('Pulse-style: signal-writing rAF callback cancelled before next frame', () => {
+  test('Pulse-style: signal-writing rAF callback cancelled before next frame (#1366)', () => {
     // Mirrors the issue's repro exactly: a reader effect subscribes to
     // the signal (the {t()} text bind in the JSX body), and a writer
     // effect schedules an rAF that calls setT. Synchronous dispose
@@ -147,6 +146,39 @@ describe('onCleanup with requestAnimationFrame (#1366)', () => {
     tickFrame()
 
     expect(readerRuns).toBe(1)
+  })
+
+  test('late Promise resolution cannot re-run a disposed reader (#1367)', async () => {
+    // Mirrors the createResource / Suspense scenario from #1367: a
+    // pending async write resolves into a scope that was already
+    // disposed. The reader effect (signal subscriber) must have been
+    // unsubscribed on dispose, so the late setSignal is a no-op
+    // against the subtree — equivalent to Solid's Owner.cancelled
+    // contract but implemented at the subscriber level.
+    const [data, setData] = createSignal<string | null>(null)
+    let readerRuns = 0
+    let disposeFn!: () => void
+
+    createRoot((dispose) => {
+      disposeFn = dispose
+      createEffect(() => {
+        readerRuns++
+        data()
+      })
+      // Stand-in for `fetch(...).then(setData)` inside a Suspense body.
+      Promise.resolve('done').then((v) => setData(v))
+    })
+
+    expect(readerRuns).toBe(1)
+
+    disposeFn()
+    await Promise.resolve() // let the queued .then fire setData
+
+    expect(readerRuns).toBe(1)
+    // Signal value still got written — only the *effect chain* is
+    // isolated. Direct readers outside the scope (none here) would
+    // observe the new value, which matches Solid's semantics.
+    expect(data()).toBe('done')
   })
 
   test('rAF scheduled before an effect re-run is cancelled by the previous cleanup', () => {


### PR DESCRIPTION
Closes #1367.

## Summary

#1367 catalogs a scenario where a `createResource` body resolves into a `Suspense` scope that has been disposed in the meantime, with the concern that the late `setSignal` could write to disposed DOM. The fix landed in #1394 (`disposeEffect` correctly disposing every child) removed the structural cause: the disposed scope's reader effects are unsubscribed from their signals, so a late `setSignal` is inert against the subtree — regardless of whether the trigger is `requestAnimationFrame`, a Promise, a `setTimeout`, or a future `createResource` body.

This PR adds the Promise-shaped regression alongside the rAF ones to lock the invariant in for both trigger shapes, and renames the test file now that the file's scope spans the disposal contract broadly rather than a single issue.

## Changes

- `packages/client/__tests__/raf-unmount-1366.test.ts` → `packages/client/__tests__/dispose-effect.test.ts` — rename. The issue-specific tests still annotate `(#1366)` / `(#1367)` inline so the cross-reference is preserved.
- Add `late Promise resolution cannot re-run a disposed reader (#1367)` test — mirrors the `createResource` / `Suspense` scenario: dispatch a Promise inside the scope, dispose synchronously, await the queued `.then`, assert the reader effect did not re-run.
- Update the file's leading docstring to describe the shared invariant (rAF + Promise + future `createResource` all share the same cleanup chain).

## Notes

- `createResource` and client-side `Suspense` primitives do not exist in barefootjs today. When they land, their cancellation contract is already enforced by the existing disposal mechanism — no new primitive-level work is needed for the late-write invariant. A separate issue should track the resource state machine (loading / error / hydration coordination), which is orthogonal to this contract.
- The `Unmount during in-flight <Async> resolution` fixme stub in `site/ui/e2e/stress-1244.spec.ts` is left intact for the same reason it was in #1394: per-catalog-entry route maintenance cost outweighs duplicate coverage of a browser-independent invariant.

## Test plan

- [x] `bun test packages/client/__tests__/dispose-effect.test.ts` — 5 / 5 pass
- [x] Promise test fails synthetically if the disposed reader is not unsubscribed (verified by short-circuiting `disposeSubtree`'s `dep.delete` step locally)

https://claude.ai/code/session_01XQ9dKimgieoiTP17w747n8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ9dKimgieoiTP17w747n8)_