### PR TITLE
fix: alpha onboarding pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@
 Requires Node 22+.
 
 ```sh
-npm create barefootjs@latest my-app
-cd my-app
+npm create barefootjs@latest
+```
+
+You'll be prompted for a target directory (defaults to `my-app`). After scaffolding:
+
+```sh
+cd my-app   # or whatever name you entered at the prompt
 npm install
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@
 
 ---
 
+## Quick Start
+
+Requires Node 22+.
+
+```sh
+npm create barefootjs@latest my-app
+cd my-app
+npm install
+npm run dev
+```
+
+Then open the URL the dev server prints (defaults to `http://localhost:8787`). The starter app ships a Counter component you can edit at `components/Counter.tsx`.
+
+The full walkthrough — adapter / CSS choices, generated layout, and the alpha pkg-pr-new install path — lives in [`docs/core/quick-start.md`](./docs/core/quick-start.md).
+
+> While BarefootJS is in alpha (pre-first-npm-publish), `npm create barefootjs@latest` 404s on the npm registry. Use the [pkg-pr-new install path](./docs/core/quick-start.md#alpha-install-from-pkg-pr-new) until the first publish.
+
+---
+
 ## Design Principles
 
 - **Backend Freedom** — Same JSX works with Hono, Go, Mojolicious, etc. No Node.js lock-in.

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -8,11 +8,12 @@
 - Why BarefootJS?
 - Design Philosophy
 
-### 2. [Quick Start](https://barefootjs.dev/docs/quick-start)
+### 2. [Quick Start](./quick-start.md)
 
 - Scaffold an app with `npm create barefootjs@latest`
 - Run the dev server and edit the starter Counter
 - Tour of the generated project structure
+- Alpha workaround for installing from pkg-pr-new previews
 
 ### 3. [Core Concepts](./core-concepts.md)
 

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -15,7 +15,7 @@ BarefootJS is designed so both humans and AI agents can build components without
 `renderToTest()` verifies component structure, signals, events, and accessibility against the compiler's IR — in milliseconds, without a browser. Real interactions and visual behavior still need E2E tests, but structural issues are caught before you get there:
 
 ```tsx
-import { renderToTest } from '@barefootjs/test-utils'
+import { renderToTest } from '@barefootjs/test'
 
 test('Counter has a button with click handler', () => {
   const ir = renderToTest(<Counter />)
@@ -59,8 +59,8 @@ bf search settings-form --json
 bf docs field --json
 bf docs switch --json
 bf gen component settings-form field switch label
-# edit ui/components/ui/settings-form/index.tsx
-bun test ui/components/ui/settings-form/index.test.tsx
+# edit components/ui/settings-form/index.tsx
+bun test components/ui/settings-form/index.test.tsx
 bf debug graph settings-form
 ```
 

--- a/docs/core/quick-start.md
+++ b/docs/core/quick-start.md
@@ -14,32 +14,38 @@ This page walks through scaffolding a runnable BarefootJS app, starting the dev 
 <!-- tabs:pm -->
 <!-- tab:npm -->
 ```sh
-npm create barefootjs@latest my-app
+npm create barefootjs@latest
 ```
 
 <!-- tab:bun -->
 ```sh
-bun create barefootjs my-app
+bun create barefootjs
 ```
 
 <!-- tab:pnpm -->
 ```sh
-pnpm create barefootjs my-app
+pnpm create barefootjs
 ```
 
 <!-- tab:yarn -->
 ```sh
-yarn create barefootjs my-app
+yarn create barefootjs
 ```
 
 <!-- /tabs -->
 
-You'll be prompted for an adapter (default: **Hono** on Cloudflare Workers) and a CSS library (default: **UnoCSS**). Pass `--yes` to accept all defaults.
+You'll be prompted for three things:
+
+1. **Target directory** (default: `my-app`)
+2. **Adapter** (default: **Hono** on Cloudflare Workers)
+3. **CSS library** (default: **UnoCSS**)
+
+Pass `--yes` to accept every default — including `my-app` for the directory — without prompting.
 
 ## 2. Install and run
 
 ```sh
-cd my-app
+cd my-app   # the name you entered at the prompt (default: my-app)
 npm install
 npm run dev
 ```

--- a/docs/core/quick-start.md
+++ b/docs/core/quick-start.md
@@ -114,7 +114,7 @@ Save the file — `bf build --watch` recompiles and `wrangler dev` live-reloads.
 
 ## 5. Next steps
 
-- `bf docs <component>` — show props, variants, examples for a registry component (after running `bf add <name>`, you may need to extract meta first with `bf meta extract`).
+- `bf docs <component>` — show props, variants, examples for a registry component (`bf add` writes `meta/<name>.json` automatically, so this works straight after).
 - `bf debug graph <component>` — show the signal dependency graph before editing a `"use client"` component.
 - `bf add <name>` — add another shadcn/ui-style component from `https://ui.barefootjs.dev/`.
 - `bf search <query>` — find components and docs across the registry.

--- a/docs/core/quick-start.md
+++ b/docs/core/quick-start.md
@@ -1,0 +1,150 @@
+---
+title: Quick Start
+description: Scaffold a BarefootJS app, run the dev server, and tour the generated layout
+---
+
+# Quick Start
+
+This page walks through scaffolding a runnable BarefootJS app, starting the dev server, and editing the starter Counter. It assumes Node 22+ and one of npm / bun / pnpm / yarn.
+
+> **Alpha note** — until the first npm publish, `npm create barefootjs@latest` is not yet on the registry. See [Alpha: install from pkg-pr-new](#alpha-install-from-pkg-pr-new) at the bottom of this page for the temporary install path.
+
+## 1. Scaffold
+
+<!-- tabs:pm -->
+<!-- tab:npm -->
+```sh
+npm create barefootjs@latest my-app
+```
+
+<!-- tab:bun -->
+```sh
+bun create barefootjs my-app
+```
+
+<!-- tab:pnpm -->
+```sh
+pnpm create barefootjs my-app
+```
+
+<!-- tab:yarn -->
+```sh
+yarn create barefootjs my-app
+```
+
+<!-- /tabs -->
+
+You'll be prompted for an adapter (default: **Hono** on Cloudflare Workers) and a CSS library (default: **UnoCSS**). Pass `--yes` to accept all defaults.
+
+## 2. Install and run
+
+```sh
+cd my-app
+npm install
+npm run dev
+```
+
+`npm run dev` runs three watchers in parallel:
+
+- `bf build --watch` — recompiles JSX → marked template + client JS
+- `unocss --watch` — regenerates `public/uno.css` from class usage
+- `wrangler dev --live-reload` — serves the Hono worker on `http://localhost:8787`
+
+Open the URL the dev server prints. You'll see a Counter with **+1**, **-1**, and **Reset** buttons — all server-rendered first, then hydrated.
+
+## 3. Generated layout
+
+```
+my-app/
+├── barefoot.config.ts     # paths, build options, adapter
+├── server.tsx             # entry: Hono app
+├── renderer.tsx           # HTML shell + asset wiring
+├── components/
+│   ├── Counter.tsx        # the starter component ("use client")
+│   └── ui/
+│       ├── button/        # added by `bf add button` at scaffold time
+│       └── slot/
+├── meta/index.json        # local component registry index
+├── public/                # build output (committed: no, gitignored)
+├── uno.config.ts          # UnoCSS preset + scan globs
+├── wrangler.jsonc         # Cloudflare Workers config
+└── tsconfig.json
+```
+
+The single source of truth for project layout is `barefoot.config.ts`:
+
+```ts
+import { createConfig } from '@barefootjs/hono/build'
+
+export default createConfig({
+  paths: {
+    components: 'components/ui',  // where `bf add` lands registry items
+    tokens: 'tokens',
+    meta: 'meta',
+  },
+  components: ['components'],     // source dirs to compile
+  outDir: 'public',
+})
+```
+
+## 4. Edit the Counter
+
+`components/Counter.tsx` is a `"use client"` component using signals:
+
+```tsx
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+import { Button } from '@/components/ui/button'
+
+export function Counter({ initial = 0 }: { initial?: number }) {
+  const [count, setCount] = createSignal(initial)
+  const doubled = createMemo(() => count() * 2)
+
+  return (
+    <div className="counter">
+      <p>count: {count()}</p>
+      <p>doubled: {doubled()}</p>
+      <Button onClick={() => setCount(n => n + 1)}>+1</Button>
+    </div>
+  )
+}
+```
+
+Save the file — `bf build --watch` recompiles and `wrangler dev` live-reloads.
+
+## 5. Next steps
+
+- `bf docs <component>` — show props, variants, examples for a registry component (after running `bf add <name>`, you may need to extract meta first with `bf meta extract`).
+- `bf debug graph <component>` — show the signal dependency graph before editing a `"use client"` component.
+- `bf add <name>` — add another shadcn/ui-style component from `https://ui.barefootjs.dev/`.
+- `bf search <query>` — find components and docs across the registry.
+
+Read on:
+
+- [Core Concepts](./core-concepts.md) — the four design principles
+- [Reactivity](./reactivity.md) — `createSignal`, `createEffect`, `createMemo`
+- [Components](./components.md) — authoring, props, context, slots
+- [Adapters](./adapters.md) — Hono, Go template, writing your own
+
+## Alpha: install from pkg-pr-new
+
+Until the packages are published to npm, install from per-PR previews built by [pkg-pr-new](https://github.com/stackblitz-labs/pkg-pr.new). The latest preview URLs are commented on each PR. To bootstrap:
+
+```sh
+# 1. Install create-barefootjs from the latest pkg-pr-new build:
+mkdir -p /tmp/bf-installer && cd /tmp/bf-installer && npm init -y >/dev/null
+npm install https://pkg.pr.new/piconic-ai/barefootjs/create-barefootjs@<PR-or-SHA>
+
+# 2. Scaffold:
+cd ~/projects
+./tmp/bf-installer/node_modules/.bin/create-barefootjs my-app --yes
+
+# 3. Rewrite @barefootjs/* deps in the generated package.json
+#    from "latest" → "https://pkg.pr.new/.../<pkg>@<SHA>" (use the same
+#    SHA pkg-pr-new pinned on create-barefootjs's @barefootjs/cli dep).
+
+# 4. Continue normally:
+cd my-app && npm install && npm run dev
+```
+
+This restriction goes away the moment the first npm publish lands.

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -74,6 +74,79 @@
       "import": "./src/app.ts"
     }
   },
+  "//publishConfig": "When npm/pkg-pr-new packs this package, swap each subpath's `types` to the dist/*.d.ts produced by `tsgo --emitDeclarationOnly`. Downstream consumers' `tsc --noEmit` then walks pure-declaration files instead of our TS source — which transitively pulled `process` / `fs` references and forced every scaffold to install @types/node. Runtime `import` still points at TS source so existing bun + esbuild paths keep working; a future change can repoint these to dist/*.js once subpath bundles exist.",
+  "publishConfig": {
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./src/index.ts"
+      },
+      "./adapter": {
+        "types": "./dist/adapter/index.d.ts",
+        "import": "./src/adapter/index.ts"
+      },
+      "./scripts": {
+        "types": "./dist/scripts.d.ts",
+        "import": "./src/scripts.tsx"
+      },
+      "./portals": {
+        "types": "./dist/portals.d.ts",
+        "import": "./src/portals.tsx"
+      },
+      "./portal": {
+        "types": "./dist/portal-ssr.d.ts",
+        "import": "./src/portal-ssr.tsx"
+      },
+      "./dialog-context": {
+        "types": "./dist/dialog-context.d.ts",
+        "import": "./src/dialog-context.tsx"
+      },
+      "./client-shim": {
+        "types": "./dist/client-shim.d.ts",
+        "import": "./src/client-shim.ts"
+      },
+      "./preload": {
+        "types": "./dist/preload.d.ts",
+        "import": "./src/preload.tsx"
+      },
+      "./dev": {
+        "types": "./dist/dev.d.ts",
+        "import": "./src/dev.tsx"
+      },
+      "./dev-worker": {
+        "types": "./dist/dev-worker.d.ts",
+        "import": "./src/dev-worker.ts"
+      },
+      "./jsx/jsx-runtime": {
+        "types": "./dist/jsx/jsx-runtime/index.d.ts",
+        "import": "./src/jsx/jsx-runtime/index.ts"
+      },
+      "./jsx/jsx-dev-runtime": {
+        "types": "./dist/jsx/jsx-dev-runtime/index.d.ts",
+        "import": "./src/jsx/jsx-dev-runtime/index.ts"
+      },
+      "./async": {
+        "types": "./dist/async.d.ts",
+        "import": "./src/async.tsx"
+      },
+      "./utils": {
+        "types": "./dist/utils.d.ts",
+        "import": "./src/utils.ts"
+      },
+      "./test-render": {
+        "bun": "./src/test-render.ts"
+      },
+      "./build": {
+        "types": "./dist/build.d.ts",
+        "import": "./src/build.ts"
+      },
+      "./app": {
+        "types": "./dist/app.d.ts",
+        "import": "./src/app.ts"
+      }
+    }
+  },
   "files": [
     "dist",
     "src"
@@ -83,7 +156,9 @@
     "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
   },
   "keywords": [
     "hono",

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -9,7 +9,7 @@
 //   is bundled inline so the published CLI is self-contained.
 
 import { build } from 'esbuild'
-import { chmodSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -17,6 +17,12 @@ const here = dirname(fileURLToPath(import.meta.url))
 const pkgDir = resolve(here, '..')
 const entry = resolve(pkgDir, 'src/index.ts')
 const outfile = resolve(pkgDir, 'dist/index.js')
+// Monorepo `docs/core/` lives three levels up from `packages/cli/`.
+// We copy it into `dist/docs/core/` so `bf guide` can read framework
+// docs from the installed npm package, not just from a monorepo
+// checkout. Only `dist` is in `files`, so this path is what ships.
+const docsSrc = resolve(pkgDir, '../../docs/core')
+const docsDst = resolve(pkgDir, 'dist/docs/core')
 
 await build({
   entryPoints: [entry],
@@ -34,5 +40,20 @@ await build({
 
 // Make the bundle executable so `bin` symlinks work.
 chmodSync(outfile, 0o755)
+
+// Ship framework docs alongside the bundle so `bf guide` works in
+// scaffolded apps. We don't gate on file extension — `scanCoreDocs`
+// already filters to .md.
+if (existsSync(docsSrc)) {
+  if (existsSync(docsDst)) rmSync(docsDst, { recursive: true, force: true })
+  cpSync(docsSrc, docsDst, { recursive: true })
+  console.log(`Copied: ${docsSrc} -> ${docsDst}`)
+} else {
+  // pkg-pr-new / published-tarball flows always have docs/core in the
+  // source tree. A missing source dir means the build is happening
+  // somewhere unexpected; warn but don't fail — `bf guide` will surface
+  // its own error if the dir is missing at runtime.
+  console.warn(`Warning: ${docsSrc} not found; bf guide will fail in the built CLI.`)
+}
 
 console.log(`Built: ${outfile}`)

--- a/packages/cli/src/__tests__/add-remote.test.ts
+++ b/packages/cli/src/__tests__/add-remote.test.ts
@@ -223,6 +223,33 @@ describe('addFromRegistry', () => {
     expect(existsSync(path.join(tmpDir, 'components/ui/button/index.tsx'))).toBe(false)
   })
 
+  test('writes meta/<name>.json for each added component so bf docs works after add', async () => {
+    // The registry's `<name>.json` ships sources only — `registry:ui`
+    // files — so before this behavior was wired in, `bf add button`
+    // left `meta/` empty and `bf docs button` failed with a "not
+    // found" error. Lock it in: meta extraction runs against the
+    // freshly-written source and the index lists the new entry.
+    globalThis.fetch = async () => new Response(JSON.stringify(buttonItem), { status: 200 })
+
+    await addFromRegistry(['button'], 'https://example.com/r/', tmpDir, config, false)
+
+    const buttonMetaPath = path.join(tmpDir, 'meta/button.json')
+    expect(existsSync(buttonMetaPath)).toBe(true)
+    const buttonMeta = JSON.parse(readFileSync(buttonMetaPath, 'utf-8'))
+    expect(buttonMeta.name).toBe('button')
+    // `source` is relative to projectDir — locks in the path shape the
+    // scaffolded app expects (not `ui/components/ui/...` from the monorepo).
+    expect(buttonMeta.source).toBe(path.join('components/ui/button/index.tsx'))
+
+    // index.json should pick the new entry up via rebuildMetaIndex.
+    const indexPath = path.join(tmpDir, 'meta/index.json')
+    expect(existsSync(indexPath)).toBe(true)
+    const index = JSON.parse(readFileSync(indexPath, 'utf-8'))
+    const names = (index.components as Array<{ name: string }>).map(c => c.name)
+    expect(names).toContain('button')
+    expect(names).toContain('slot')
+  })
+
   test('resolves requires dependencies transitively', async () => {
     const slotItem: RegistryItem = {
       $schema: 'https://ui.shadcn.com/schema/registry-item.json',

--- a/packages/cli/src/__tests__/guide.test.ts
+++ b/packages/cli/src/__tests__/guide.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, spyOn } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
 import { createContext } from '../context'
+import type { CliContext } from '../context'
 
 // We test the guide command's behavior indirectly through docs-loader
 // and directly test the command's run function for edge cases.
@@ -63,6 +67,39 @@ describe('bf guide', () => {
       expect(parsed.content).toBeDefined()
     } finally {
       logSpy.mockRestore()
+    }
+  })
+
+  test('errors with both candidate paths when docs/core is missing everywhere', async () => {
+    // Simulates a scaffolded app installed from a hypothetically-broken
+    // CLI tarball (no bundled docs) — `ctx.root` is a fresh tmp dir
+    // with no `docs/core`, and the source-mode bundled path doesn't
+    // exist either when bun runs TS directly. The error must surface
+    // both candidate paths so the user can see what's missing.
+    const fakeRoot = mkdtempSync(path.join(tmpdir(), 'bf-guide-noroot-'))
+    const ctx: CliContext = {
+      root: fakeRoot,
+      metaDir: path.join(fakeRoot, 'meta'),
+      jsonFlag: false,
+      config: null,
+      projectDir: null,
+    }
+    const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit')
+    }) as never)
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { run } = await import('../commands/guide')
+      expect(() => run([], ctx)).toThrow('exit')
+      const errors = errorSpy.mock.calls.map(c => c.join(' ')).join('\n')
+      expect(errors).toContain('Core documentation not found.')
+      expect(errors).toContain(path.join(fakeRoot, 'docs/core'))
+      expect(errors).toContain('(monorepo)')
+      expect(errors).toContain('(bundled CLI)')
+    } finally {
+      exitSpy.mockRestore()
+      errorSpy.mockRestore()
+      rmSync(fakeRoot, { recursive: true, force: true })
     }
   })
 

--- a/packages/cli/src/__tests__/init-gate.test.ts
+++ b/packages/cli/src/__tests__/init-gate.test.ts
@@ -1,0 +1,92 @@
+// `bf init` is internal — the user-facing entry is
+// `npm create barefootjs@latest`, which sets BAREFOOT_INIT_VIA_CREATE=1
+// before spawning the CLI. This test pins that contract by running the
+// raw CLI binary without the sentinel and asserting the redirect.
+//
+// We spawn the CLI rather than calling the run() function directly so
+// the test exercises the same entry point a user would hit when
+// typing `bf init` in their shell — including the env-var gate.
+
+import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const CLI_ENTRY = path.join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'index.ts',
+)
+
+function mktmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bf-init-gate-test-'))
+}
+
+interface RunResult {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}
+
+function runCli(args: string[], env: Record<string, string | undefined>): RunResult {
+  // Strip the sentinel from inherited env so a parent test runner that
+  // happened to set it can't accidentally let `bf init` through.
+  const cleanEnv: Record<string, string> = {}
+  for (const [k, v] of Object.entries({ ...process.env, ...env })) {
+    if (v === undefined) continue
+    if (k === 'BAREFOOT_INIT_VIA_CREATE') continue
+    cleanEnv[k] = v
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) cleanEnv[k] = v
+  }
+  const result = spawnSync('bun', [CLI_ENTRY, ...args], {
+    env: cleanEnv,
+    encoding: 'utf-8',
+    cwd: mktmp(),
+  })
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+describe('bf init is internal — only create-barefootjs can invoke it', () => {
+  test('direct `bf init` exits non-zero and points users at npm create', () => {
+    const r = runCli(['init'], {})
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('`bf init` is internal')
+    expect(r.stderr).toContain('npm create barefootjs@latest')
+  })
+
+  test('flags are not parsed before the gate fires (no half-init footgun)', () => {
+    // A direct caller passing `--name foo --adapter hono` should still
+    // be bounced. We assert via the redirect text rather than checking
+    // for absence of side effects because the gate runs first thing
+    // inside run() before any filesystem writes.
+    const r = runCli(['init', '--name', 'foo', '--adapter', 'hono'], {})
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('`bf init` is internal')
+  })
+
+  test('gate passes when BAREFOOT_INIT_VIA_CREATE=1 is set (sanity)', () => {
+    // We don't run a full init here — that would touch the network for
+    // the registry probe. Instead we run inside a directory that already
+    // has a barefoot.config.ts, which trips the next guard inside init
+    // and exits with a different, init-specific error message. Hitting
+    // that error proves the env-var gate let us through.
+    const cwd = mktmp()
+    writeFileSync(path.join(cwd, 'barefoot.config.ts'), 'export default {}')
+    const result = spawnSync('bun', [CLI_ENTRY, 'init'], {
+      env: { ...process.env, BAREFOOT_INIT_VIA_CREATE: '1' },
+      encoding: 'utf-8',
+      cwd,
+    })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('barefoot.config.ts already exists')
+    expect(result.stderr).not.toContain('`bf init` is internal')
+  })
+})

--- a/packages/cli/src/__tests__/preview-generate.test.ts
+++ b/packages/cli/src/__tests__/preview-generate.test.ts
@@ -25,6 +25,22 @@ describe('generatePreview', () => {
     }
   })
 
+  describe('componentsBasePath', () => {
+    test('default keeps the monorepo registry layout (backwards compat)', () => {
+      const meta = loadComponent(metaDir, 'button')
+      const result = generatePreview(meta)
+      expect(result.filePath).toBe('ui/components/ui/button/index.preview.tsx')
+    })
+
+    test('scaffolded apps land previews under paths.components, not ui/components/ui', () => {
+      // Mirrors what `resolveScaffoldLayout` returns for a project with
+      // the default scaffold config (`paths.components = 'components/ui'`).
+      const meta = loadComponent(metaDir, 'button')
+      const result = generatePreview(meta, 'components/ui')
+      expect(result.filePath).toBe('components/ui/button/index.preview.tsx')
+    })
+  })
+
   describe('determinism', () => {
     test('same meta produces identical output', () => {
       const meta = loadComponent(metaDir, 'button')

--- a/packages/cli/src/__tests__/resolve-source.test.ts
+++ b/packages/cli/src/__tests__/resolve-source.test.ts
@@ -1,0 +1,84 @@
+// `resolveComponentSource` is the shared lookup behind `bf debug graph`,
+// `bf debug signals`, `bf debug trace`, and `bf debug fallbacks`. The
+// scaffold puts the user's own components at `components/<Name>.tsx`
+// (top of the source dir) while registry items land under
+// `components/ui/<name>/index.tsx`. This suite pins both layouts plus
+// the `searched` transcript so the matching CLI error message stays
+// honest about where it actually looked.
+
+import { describe, test, expect } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { resolveComponentSource } from '../lib/resolve-source'
+import type { CliContext } from '../context'
+
+function mktmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bf-resolve-source-'))
+}
+
+function ctxFor(projectDir: string, sourceDirs: string[] = []): CliContext {
+  return {
+    root: projectDir, // no monorepo above the tmp dir — `ui/components/ui` won't exist
+    metaDir: path.join(projectDir, 'meta'),
+    jsonFlag: false,
+    config: {
+      paths: { components: 'components/ui', tokens: 'tokens', meta: 'meta' },
+      sourceDirs,
+    },
+    projectDir,
+  }
+}
+
+describe('resolveComponentSource', () => {
+  test('finds a top-level scaffold component via sourceDirs (components/Counter.tsx)', () => {
+    // Mirrors the scaffold layout: `barefoot.config.ts` has
+    // `components: ['components']`, the user's Counter.tsx lives at the
+    // root of that dir. The pre-fix resolver only searched
+    // `paths.components` (i.e. `components/ui/`) and missed it.
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'Counter.tsx'), 'export {}')
+    try {
+      const searched: string[] = []
+      const r = resolveComponentSource('Counter', ctxFor(projectDir, ['components']), searched)
+      expect(r).not.toBeNull()
+      expect(r!.filePath).toBe(path.join(projectDir, 'components', 'Counter.tsx'))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('finds a registry-style component under paths.components/<name>/index.tsx', () => {
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components', 'ui', 'button'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'ui', 'button', 'index.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('button', ctxFor(projectDir))
+      expect(r).not.toBeNull()
+      expect(r!.filePath).toBe(path.join(projectDir, 'components', 'ui', 'button', 'index.tsx'))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null and populates `searched` with every candidate it tried', () => {
+    // Drives the "Looked in:" error transcript surfaced by the debug
+    // commands when the user types an unknown component name.
+    const projectDir = mktmp()
+    try {
+      const searched: string[] = []
+      const r = resolveComponentSource('NoSuchComponent', ctxFor(projectDir, ['components']), searched)
+      expect(r).toBeNull()
+      expect(searched.length).toBeGreaterThan(0)
+      // Includes both paths.components and the sourceDirs layout.
+      expect(searched.some(p => p.endsWith('/components/ui/NoSuchComponent/index.tsx'))).toBe(true)
+      expect(searched.some(p => p.endsWith('/components/NoSuchComponent.tsx'))).toBe(true)
+      // Does NOT include the monorepo `ui/components/ui/...` path —
+      // that's a confusing no-op outside the monorepo.
+      expect(searched.some(p => p.includes('/ui/components/ui/'))).toBe(false)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/scaffold-layout.test.ts
+++ b/packages/cli/src/__tests__/scaffold-layout.test.ts
@@ -1,0 +1,74 @@
+// `resolveScaffoldLayout` decides where `bf gen *` writes files. The pre-
+// -fix `bf gen component` / `bf gen preview` always wrote relative to
+// `ctx.root` — which in a scaffolded app is `node_modules/`. The next
+// `npm install` would have wiped any generated user code. This suite
+// pins the two-branch behavior (monorepo vs. project) so a future
+// `bf gen *` command can stay scaffold-safe by default.
+
+import { describe, test, expect } from 'bun:test'
+import { resolveScaffoldLayout } from '../lib/scaffold-layout'
+import { scaffold } from '../lib/scaffold'
+import type { CliContext } from '../context'
+
+function ctx(overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    root: '/repo',
+    metaDir: '/repo/meta',
+    jsonFlag: false,
+    config: null,
+    projectDir: null,
+    ...overrides,
+  }
+}
+
+describe('resolveScaffoldLayout', () => {
+  test('monorepo mode (no config): writes under ctx.root using the registry layout', () => {
+    const layout = resolveScaffoldLayout(ctx())
+    expect(layout.writeRoot).toBe('/repo')
+    expect(layout.componentsBasePath).toBe('ui/components/ui')
+  })
+
+  test('project mode: writes under projectDir using paths.components from barefoot.config.ts', () => {
+    const layout = resolveScaffoldLayout(
+      ctx({
+        projectDir: '/Users/me/my-app',
+        config: {
+          paths: { components: 'components/ui', tokens: 'tokens', meta: 'meta' },
+        },
+      }),
+    )
+    expect(layout.writeRoot).toBe('/Users/me/my-app')
+    expect(layout.componentsBasePath).toBe('components/ui')
+  })
+
+  test('custom paths.components (e.g. src/ui) propagates through', () => {
+    const layout = resolveScaffoldLayout(
+      ctx({
+        projectDir: '/project',
+        config: {
+          paths: { components: 'src/ui', tokens: 'tokens', meta: 'meta' },
+        },
+      }),
+    )
+    expect(layout.writeRoot).toBe('/project')
+    expect(layout.componentsBasePath).toBe('src/ui')
+  })
+})
+
+describe('scaffold (componentsBasePath wiring)', () => {
+  // `metaDir = ''` is enough — we only assert the path shape, not the
+  // body. The previous `scaffold(name, [], metaDir)` always returned
+  // `ui/components/ui/<name>/...`, even for scaffolded apps where that
+  // landed in `node_modules`.
+  test('default base path matches the monorepo layout', () => {
+    const result = scaffold('my-card', [], '')
+    expect(result.componentPath).toBe('ui/components/ui/my-card/index.tsx')
+    expect(result.testPath).toBe('ui/components/ui/my-card/index.test.tsx')
+  })
+
+  test('passing a scaffold path lands files under that project dir, not ui/components/ui', () => {
+    const result = scaffold('my-card', [], '', 'components/ui')
+    expect(result.componentPath).toBe('components/ui/my-card/index.tsx')
+    expect(result.testPath).toBe('components/ui/my-card/index.test.tsx')
+  })
+})

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import type { BarefootConfig } from '../context'
 import { resolveDependencies } from '../lib/dependency-resolver'
+import { extractMetaForFile } from './meta-extract'
 import type { MetaIndex, MetaIndexEntry, ComponentMeta, RegistryItem } from '../lib/types'
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -39,12 +40,34 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const projectDir = ctx.projectDir
   const config = ctx.config
 
+  // Resolution order for source-of-truth:
+  //   1. Explicit `--registry <url>` always wins (used for staging URLs,
+  //      local mirrors, pkg-pr-new previews, etc.).
+  //   2. Monorepo dev: in the BarefootJS source repo, `ui/components/ui/`
+  //      exists next to `ctx.root` and `addFromLocal` lets contributors
+  //      iterate without a network round-trip.
+  //   3. Everywhere else (i.e. scaffolded apps): fall back to the public
+  //      registry. Before this, `bf add button` in a scaffolded app went
+  //      down `addFromLocal` and failed with "not found in source
+  //      registry" because it was looking inside `node_modules/`.
+  const monorepoSourceDir = path.resolve(ctx.root, 'ui/components/ui')
+  const monorepoMode = existsSync(monorepoSourceDir)
+
   if (registryUrl) {
     await addFromRegistry(componentNames, registryUrl, projectDir, config, force, false)
-  } else {
+  } else if (monorepoMode) {
     addFromLocal(componentNames, ctx, projectDir, config, force)
+  } else {
+    await addFromRegistry(componentNames, DEFAULT_REGISTRY_URL, projectDir, config, force, false)
   }
 }
+
+// Default UI registry. Mirrors `commands/init.ts`'s constant so a
+// freshly scaffolded app and a follow-up `bf add` both reach the same
+// host. Keeping a duplicate constant here (rather than re-exporting
+// init's) avoids importing init's full surface, which carries a
+// spinner / TTY-prompt dependency.
+const DEFAULT_REGISTRY_URL = 'https://ui.barefootjs.dev/r/'
 
 /**
  * Fetch a single registry item. Returns null if skipErrors is true and fetch fails.
@@ -150,6 +173,11 @@ export async function addFromRegistry(
 
   const added: string[] = []
   const skipped: string[] = []
+  // `index.tsx` paths we just wrote. Each one is a freshly-added
+  // component whose meta we still need to extract — the registry only
+  // ships sources (`registry:ui` files), so without this step
+  // `meta/<name>.json` stays missing and `bf docs <name>` fails.
+  const writtenIndexPaths: string[] = []
 
   for (const [filePath, content] of fileMap) {
     // Map path: "components/ui/xxx/..." → config.paths.components/xxx/...
@@ -170,6 +198,28 @@ export async function addFromRegistry(
     mkdirSync(path.dirname(destPath), { recursive: true })
     writeFileSync(destPath, content)
     added.push(filePath)
+    if (destPath.endsWith(`${path.sep}index.tsx`) && filePath.startsWith('components/ui/')) {
+      writtenIndexPaths.push(destPath)
+    }
+  }
+
+  // Extract meta for each freshly-written component so `bf docs <name>`
+  // resolves immediately after `bf add`. We swallow per-file extraction
+  // failures (malformed source, analyzer crash) instead of failing the
+  // whole add — the source files are already on disk and the user can
+  // re-run `bf meta extract` to retry. `silent` callers (e.g. init)
+  // still get the warning via stderr so transient bugs aren't hidden.
+  for (const indexPath of writtenIndexPaths) {
+    try {
+      const { meta } = extractMetaForFile(indexPath, projectDir)
+      writeFileSync(
+        path.join(destMetaDir, `${meta.name}.json`),
+        JSON.stringify(meta, null, 2) + '\n',
+      )
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`  Warning: failed to extract meta for ${indexPath}: ${msg}`)
+    }
   }
 
   // Rebuild meta/index.json if meta dir exists

--- a/packages/cli/src/commands/debug-fallbacks.ts
+++ b/packages/cli/src/commands/debug-fallbacks.ts
@@ -27,9 +27,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const { buildComponentGraph } = await import('@barefootjs/jsx')
 
-  const resolved = resolveComponentSource(componentName, ctx)
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
   if (!resolved) {
     console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/debug-graph.ts
+++ b/packages/cli/src/commands/debug-graph.ts
@@ -18,10 +18,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const { buildComponentGraph, formatComponentGraph, graphToJSON } = await import('@barefootjs/jsx')
 
-  const resolved = resolveComponentSource(componentName, ctx)
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
   if (!resolved) {
     console.error(`Error: Cannot find component "${componentName}".`)
-    console.error('Looked in: ui/components/ui/, and by file path.')
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/debug-signals.ts
+++ b/packages/cli/src/commands/debug-signals.ts
@@ -19,9 +19,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const { buildComponentGraph, generateStaticTrace, formatSignalTrace } = await import('@barefootjs/jsx')
 
-  const resolved = resolveComponentSource(componentName, ctx)
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
   if (!resolved) {
     console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/debug-trace.ts
+++ b/packages/cli/src/commands/debug-trace.ts
@@ -19,9 +19,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const { buildComponentGraph, traceUpdatePath, formatUpdatePath } = await import('@barefootjs/jsx')
 
-  const resolved = resolveComponentSource(componentName, ctx)
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
   if (!resolved) {
     console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/gen-component.ts
+++ b/packages/cli/src/commands/gen-component.ts
@@ -4,6 +4,7 @@ import { writeFileSync, mkdirSync, existsSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
 import { scaffold } from '../lib/scaffold'
+import { resolveScaffoldLayout } from '../lib/scaffold-layout'
 
 export function run(args: string[], ctx: CliContext): void {
   if (args.length < 2) {
@@ -13,17 +14,18 @@ export function run(args: string[], ctx: CliContext): void {
   }
 
   const [componentName, ...useComponents] = args
-  const result = scaffold(componentName, useComponents, ctx.metaDir)
+  const { writeRoot, componentsBasePath } = resolveScaffoldLayout(ctx)
+  const result = scaffold(componentName, useComponents, ctx.metaDir, componentsBasePath)
 
   // Write component file
-  const componentAbsPath = path.join(ctx.root, result.componentPath)
+  const componentAbsPath = path.join(writeRoot, result.componentPath)
   if (existsSync(componentAbsPath)) {
     console.error(`Error: ${result.componentPath} already exists. Delete it first or choose a different name.`)
     process.exit(1)
   }
 
   // Write test file
-  const testAbsPath = path.join(ctx.root, result.testPath)
+  const testAbsPath = path.join(writeRoot, result.testPath)
   const testDir = path.dirname(testAbsPath)
   if (!existsSync(testDir)) {
     mkdirSync(testDir, { recursive: true })

--- a/packages/cli/src/commands/gen-preview.ts
+++ b/packages/cli/src/commands/gen-preview.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { loadComponent } from '../lib/meta-loader'
 import { generatePreview } from '../lib/preview-generate'
+import { resolveScaffoldLayout } from '../lib/scaffold-layout'
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
   const force = args.includes('--force')
@@ -16,8 +17,9 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   }
 
   const meta = loadComponent(ctx.metaDir, name)
-  const result = generatePreview(meta)
-  const absPath = path.join(ctx.root, result.filePath)
+  const { writeRoot, componentsBasePath } = resolveScaffoldLayout(ctx)
+  const result = generatePreview(meta, componentsBasePath)
+  const absPath = path.join(writeRoot, result.filePath)
 
   if (existsSync(absPath) && !force) {
     console.error(`Error: ${result.filePath} already exists. Use --force to overwrite.`)

--- a/packages/cli/src/commands/gen-test.ts
+++ b/packages/cli/src/commands/gen-test.ts
@@ -1,8 +1,7 @@
 // bf gen test — generate IR test from existing component source.
 
-import { existsSync } from 'fs'
-import path from 'path'
 import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
 import { generateTestTemplate } from '../lib/test-template'
 
 export function run(args: string[], ctx: CliContext): void {
@@ -12,10 +11,13 @@ export function run(args: string[], ctx: CliContext): void {
     process.exit(1)
   }
 
-  const standardPath = path.join(ctx.root, 'ui/components/ui', componentName, 'index.tsx')
-  if (!existsSync(standardPath)) {
-    console.error(`Error: Source file not found: ui/components/ui/${componentName}/index.tsx`)
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
-  console.log(generateTestTemplate(standardPath))
+  console.log(generateTestTemplate(resolved.filePath))
 }

--- a/packages/cli/src/commands/guide.ts
+++ b/packages/cli/src/commands/guide.ts
@@ -1,9 +1,40 @@
 // bf guide — show framework documentation (concepts, API, guides).
+//
+// Two doc roots are searched, in order:
+//   1. <ctx.root>/docs/core         — monorepo working copy
+//   2. <cli-package-dir>/docs/core  — docs bundled into the published
+//                                     CLI (see packages/cli/scripts/build.mjs)
+// The fallback lets `bf guide` work in scaffolded apps where the
+// monorepo `docs/` tree obviously isn't present.
 
 import path from 'path'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
+import { fileURLToPath } from 'node:url'
 import type { CliContext } from '../context'
 import { scanCoreDocs, resolveDoc, parseFrontmatter } from '../lib/docs-loader'
+
+const thisFile = fileURLToPath(import.meta.url)
+
+/**
+ * Return the first existing `docs/core` directory in the search order
+ * documented at the top of this file. Returns `null` only when both
+ * candidates are missing — the caller renders the user-facing error.
+ */
+function findDocsDir(ctx: CliContext): string | null {
+  const monorepoDocs = path.join(ctx.root, 'docs/core')
+  if (existsSync(monorepoDocs)) return monorepoDocs
+
+  // In the bundled CLI, `dist/index.js` sits next to `dist/docs/core`.
+  // In source mode (running TS directly via `bun packages/cli/src/index.ts`)
+  // `import.meta.url` points at `packages/cli/src/commands/guide.ts`,
+  // so the same `..` walk lands at `packages/cli/src` and `docs/core`
+  // won't be there — that's fine, the monorepo fallback above already
+  // handled it.
+  const bundledDocs = path.resolve(path.dirname(thisFile), 'docs/core')
+  if (existsSync(bundledDocs)) return bundledDocs
+
+  return null
+}
 
 function printDocList(docs: ReturnType<typeof scanCoreDocs>, jsonFlag: boolean) {
   if (jsonFlag) {
@@ -45,14 +76,24 @@ function printDoc(slug: string, filePath: string, jsonFlag: boolean) {
 }
 
 export function run(args: string[], ctx: CliContext): void {
-  const docsDir = path.join(ctx.root, 'docs/core')
+  const docsDir = findDocsDir(ctx)
+  if (!docsDir) {
+    const monorepoDocs = path.join(ctx.root, 'docs/core')
+    const bundledDocs = path.resolve(path.dirname(thisFile), 'docs/core')
+    console.error('Error: Core documentation not found.')
+    console.error('Looked in:')
+    console.error(`  - ${monorepoDocs} (monorepo)`)
+    console.error(`  - ${bundledDocs} (bundled CLI)`)
+    console.error('Reinstall @barefootjs/cli — the published tarball should include docs.')
+    process.exit(1)
+  }
 
   const query = args.join(' ')
   if (!query) {
     // List all available documents
     const docs = scanCoreDocs(docsDir)
     if (docs.length === 0) {
-      console.error(`Error: Core documentation not found at ${docsDir}. Are you in the BarefootJS monorepo?`)
+      console.error(`Error: No documents found at ${docsDir}.`)
       process.exit(1)
     }
     printDocList(docs, ctx.jsonFlag)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,16 @@
-// `barefoot init` — Scaffold a runnable starter app for an adapter
-// (currently Hono). Counter component + server + npm scripts so the user
-// can `npm install && npm run dev` and see a working page. The single
-// project config is `barefoot.config.ts`, carrying both `paths` (consumed
-// by registry tooling) and the build options.
+// `barefoot init` — Internal scaffolding helper, invoked exclusively
+// by `create-barefootjs`. The user-facing entry point is
+// `npm create barefootjs@latest`, which sets BAREFOOT_INIT_VIA_CREATE=1
+// before spawning this command. Direct `bf init` invocations are
+// refused with a redirect message so users land on the documented flow
+// (which also handles "is the target directory empty?" pre-flight,
+// which init itself does not).
+//
+// Scaffold output: barefoot.config.ts + server + components/Counter +
+// npm scripts so the user can `npm install && npm run dev` and see a
+// working page. The single project config is `barefoot.config.ts`,
+// carrying both `paths` (consumed by registry tooling) and the build
+// options.
 
 import { existsSync, mkdirSync, writeFileSync } from 'fs'
 import path from 'path'
@@ -40,7 +48,24 @@ function parseFlags(args: string[]): InitFlags {
   return flags
 }
 
+// Sentinel set by create-barefootjs when it spawns the CLI. Anything
+// else (a curious user running `bf init` directly, a stale shell
+// history line) is bounced with a redirect — keeping `bf init` strictly
+// internal means the empty-directory pre-flight in create-barefootjs is
+// guaranteed to run, so we can't half-scaffold over a populated tree.
+const INIT_GATE_ENV = 'BAREFOOT_INIT_VIA_CREATE'
+
 export async function run(args: string[], ctx: CliContext): Promise<void> {
+  if (process.env[INIT_GATE_ENV] !== '1') {
+    console.error('`bf init` is internal — invoke it via `npm create barefootjs@latest`.')
+    console.error('')
+    console.error('Quick start:')
+    console.error('  npm create barefootjs@latest my-app')
+    console.error('  # or: bun create barefootjs my-app')
+    console.error('  # or: pnpm create barefootjs my-app')
+    process.exit(1)
+  }
+
   const projectDir = process.cwd()
   const flags = parseFlags(args)
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -59,10 +59,10 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   if (process.env[INIT_GATE_ENV] !== '1') {
     console.error('`bf init` is internal — invoke it via `npm create barefootjs@latest`.')
     console.error('')
-    console.error('Quick start:')
-    console.error('  npm create barefootjs@latest my-app')
-    console.error('  # or: bun create barefootjs my-app')
-    console.error('  # or: pnpm create barefootjs my-app')
+    console.error('Quick start (you\'ll be prompted for a target directory):')
+    console.error('  npm create barefootjs@latest')
+    console.error('  # or: bun create barefootjs')
+    console.error('  # or: pnpm create barefootjs')
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/meta-extract.ts
+++ b/packages/cli/src/commands/meta-extract.ts
@@ -279,7 +279,21 @@ export function extractMetaForFile(
 }
 
 export async function run(_args: string[], ctx: CliContext): Promise<void> {
-  const componentsDir = path.join(ctx.root, 'ui/components/ui')
+  // Two layouts to support:
+  //   - Monorepo dev: components live at `<root>/ui/components/ui/` and
+  //     `<root>/docs/core/` is present. Pre-fix behavior — kept verbatim.
+  //   - Scaffolded app: components live at
+  //     `<projectDir>/<paths.components>/` (default `components/ui`).
+  //     The pre-fix command scanned `<ctx.root>/ui/components/ui` —
+  //     which in a scaffolded app is `node_modules/ui/components/ui/`,
+  //     where the only files are leftover scaffolding artifacts. We
+  //     then overwrote `meta/index.json` with the partial result,
+  //     clobbering meta written by `bf add`.
+  const inProject = ctx.config !== null && ctx.projectDir !== null
+  const componentsDir = inProject
+    ? path.resolve(ctx.projectDir!, ctx.config!.paths.components)
+    : path.join(ctx.root, 'ui/components/ui')
+  const writeRoot = inProject ? ctx.projectDir! : ctx.root
 
   // Ensure output directory exists
   if (!existsSync(ctx.metaDir)) {
@@ -298,7 +312,7 @@ export async function run(_args: string[], ctx: CliContext): Promise<void> {
   for (const filePath of files) {
     const { meta, subComponents: subComponentsList } = extractMetaForFile(
       filePath,
-      ctx.root,
+      writeRoot,
       registry,
     )
 
@@ -339,15 +353,20 @@ export async function run(_args: string[], ctx: CliContext): Promise<void> {
   const uiLlmsTxt = generateUiLlmsTxt(index, 'https://ui.barefootjs.dev/r')
   writeFileSync(path.join(ctx.metaDir, 'llms.txt'), uiLlmsTxt)
 
+  // Display paths relative to the user's project root so the summary
+  // matches what they'd `cd` into. In monorepo mode this is the same
+  // `ui/meta/` it always printed; in scaffolded apps it's `meta/`
+  // (or whatever `paths.meta` resolves to).
+  const metaRel = path.relative(writeRoot, ctx.metaDir) || '.'
   const docsDir = path.join(ctx.root, 'docs/core')
   if (existsSync(docsDir)) {
     const coreDocs = scanCoreDocs(docsDir)
     const coreLlmsTxt = generateCoreLlmsTxt(coreDocs, 'https://barefootjs.dev/docs')
     writeFileSync(path.join(docsDir, 'llms.txt'), coreLlmsTxt)
-    console.log(`Extracted metadata for ${count} components → ui/meta/`)
-    console.log('Generated: ui/meta/llms.txt, docs/core/llms.txt')
+    console.log(`Extracted metadata for ${count} components → ${metaRel}/`)
+    console.log(`Generated: ${metaRel}/llms.txt, docs/core/llms.txt`)
   } else {
-    console.log(`Extracted metadata for ${count} components → ui/meta/`)
-    console.log('Generated: ui/meta/llms.txt')
+    console.log(`Extracted metadata for ${count} components → ${metaRel}/`)
+    console.log(`Generated: ${metaRel}/llms.txt`)
   }
 }

--- a/packages/cli/src/commands/meta-extract.ts
+++ b/packages/cli/src/commands/meta-extract.ts
@@ -220,6 +220,64 @@ function mapCompilerErrors(ctx: AnalyzerContext): CompilerErrorMeta[] | undefine
   }))
 }
 
+/**
+ * Build a `ComponentMeta` for a single component file. Pure with respect
+ * to the filesystem on input — callers handle writing the JSON out.
+ *
+ * The bulk-scan `run()` below uses this in a loop; `bf add` uses it
+ * one-at-a-time to keep `meta/<name>.json` in sync with each newly
+ * fetched registry item. The `source` field is computed relative to
+ * `projectRoot` so the same helper produces correct paths in both the
+ * monorepo (`ui/components/ui/...`) and scaffolded apps
+ * (`components/ui/...`).
+ */
+export function extractMetaForFile(
+  filePath: string,
+  projectRoot: string,
+  registry: Record<string, { title: string; description: string }> = {},
+): { meta: ComponentMeta; subComponents: SubComponentMeta[] } {
+  const name = fileToName(filePath)
+  const source = readFileSync(filePath, 'utf-8')
+
+  const analyzerCtx = analyzeComponent(source, filePath)
+
+  const description = extractDescription(source) || registry[name]?.description || ''
+  const title = registry[name]?.title || toTitle(name)
+  const examples = extractExamples(source)
+
+  const props = extractMainProps(analyzerCtx, source)
+  const subComponentsList = extractSubComponents(analyzerCtx, source)
+  const variants = extractVariants(analyzerCtx)
+  const dependencies = extractDependencies(analyzerCtx)
+  const accessibility = extractAccessibility(source)
+  const category = categoryMap[name] || 'display'
+  const tags = detectTags(source)
+  const related = relatedMap[name] || []
+
+  const meta: ComponentMeta = {
+    name,
+    title,
+    category,
+    description,
+    tags,
+    stateful: analyzerCtx.hasUseClientDirective && analyzerCtx.signals.length > 0,
+    props,
+    subComponents: subComponentsList.length > 0 ? subComponentsList : undefined,
+    variants: Object.keys(variants).length > 0 ? variants : undefined,
+    examples,
+    accessibility,
+    dependencies,
+    related,
+    source: path.relative(projectRoot, filePath),
+    signals: mapSignals(analyzerCtx),
+    memos: mapMemos(analyzerCtx),
+    effects: mapEffects(analyzerCtx),
+    compilerErrors: mapCompilerErrors(analyzerCtx),
+  }
+
+  return { meta, subComponents: subComponentsList }
+}
+
 export async function run(_args: string[], ctx: CliContext): Promise<void> {
   const componentsDir = path.join(ctx.root, 'ui/components/ui')
 
@@ -238,61 +296,25 @@ export async function run(_args: string[], ctx: CliContext): Promise<void> {
   let count = 0
 
   for (const filePath of files) {
-    const name = fileToName(filePath)
-    const source = readFileSync(filePath, 'utf-8')
-
-    // Compiler-based analysis
-    const analyzerCtx = analyzeComponent(source, filePath)
-
-    // JSDoc-based extraction (regex)
-    const description = extractDescription(source) || registry[name]?.description || ''
-    const title = registry[name]?.title || toTitle(name)
-    const examples = extractExamples(source)
-
-    // Map analyzer data to metadata
-    const props = extractMainProps(analyzerCtx, source)
-    const subComponentsList = extractSubComponents(analyzerCtx, source)
-    const variants = extractVariants(analyzerCtx)
-    const dependencies = extractDependencies(analyzerCtx)
-    const accessibility = extractAccessibility(source)
-    const category = categoryMap[name] || 'display'
-    const tags = detectTags(source)
-    const related = relatedMap[name] || []
-
-    const meta: ComponentMeta = {
-      name,
-      title,
-      category,
-      description,
-      tags,
-      stateful: analyzerCtx.hasUseClientDirective && analyzerCtx.signals.length > 0,
-      props,
-      subComponents: subComponentsList.length > 0 ? subComponentsList : undefined,
-      variants: Object.keys(variants).length > 0 ? variants : undefined,
-      examples,
-      accessibility,
-      dependencies,
-      related,
-      source: `ui/components/ui/${name}/index.tsx`,
-      signals: mapSignals(analyzerCtx),
-      memos: mapMemos(analyzerCtx),
-      effects: mapEffects(analyzerCtx),
-      compilerErrors: mapCompilerErrors(analyzerCtx),
-    }
+    const { meta, subComponents: subComponentsList } = extractMetaForFile(
+      filePath,
+      ctx.root,
+      registry,
+    )
 
     // Write per-component JSON
     writeFileSync(
-      path.join(ctx.metaDir, `${name}.json`),
+      path.join(ctx.metaDir, `${meta.name}.json`),
       JSON.stringify(meta, null, 2) + '\n',
     )
 
     // Build index entry
     const indexEntry: MetaIndexEntry = {
-      name,
-      title,
-      category,
-      description,
-      tags,
+      name: meta.name,
+      title: meta.title,
+      category: meta.category,
+      description: meta.description,
+      tags: meta.tags,
       stateful: meta.stateful,
     }
     if (subComponentsList.length > 0) {

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -12,9 +12,15 @@
 import { existsSync, readdirSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
+import { resolveScaffoldLayout } from '../lib/scaffold-layout'
 
 function listPreviewableComponents(ctx: CliContext): string[] {
-  const componentsDir = path.join(ctx.root, 'ui/components/ui')
+  // Mirror `bf gen preview`'s write location so the lister and the
+  // generator agree on where previews live. Pre-fix this hardcoded
+  // `ui/components/ui` against `ctx.root` and silently returned [] in
+  // every scaffolded app.
+  const { writeRoot, componentsBasePath } = resolveScaffoldLayout(ctx)
+  const componentsDir = path.join(writeRoot, componentsBasePath)
   if (!existsSync(componentsDir)) return []
   const names: string[] = []
   for (const name of readdirSync(componentsDir)) {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -16,6 +16,14 @@ const thisDir = path.dirname(fileURLToPath(import.meta.url))
 export interface BarefootConfig {
   name?: string
   paths: BarefootPaths
+  /**
+   * Source directories that `bf build` compiles, mirrored from
+   * `barefoot.config.ts`'s `components` array. Used by commands like
+   * `bf debug graph` to locate user-authored components living outside
+   * `paths.components` — the scaffold's `components/Counter.tsx` is at
+   * `components/`, not `components/ui/`.
+   */
+  sourceDirs?: string[]
 }
 
 export interface CliContext {
@@ -89,7 +97,7 @@ export async function createContext(jsonFlag: boolean): Promise<CliContext> {
     try {
       const buildConfig = await loadBuildConfigCached(found.tsConfigPath)
       const paths: BarefootPaths = { ...DEFAULT_PATHS, ...(buildConfig.paths ?? {}) }
-      const config: BarefootConfig = { paths }
+      const config: BarefootConfig = { paths, sourceDirs: buildConfig.components }
       const metaDir = path.resolve(found.dir, paths.meta)
       return { root, metaDir, jsonFlag, config, projectDir: found.dir }
     } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,7 +63,10 @@ switch (command) {
   }
 
   case 'init': {
-    // Internal: invoked by create-barefootjs. Not shown in --help.
+    // Internal: gated by BAREFOOT_INIT_VIA_CREATE=1, which only
+    // create-barefootjs sets. Direct `bf init` invocations are
+    // refused inside ./commands/init with a redirect to
+    // `npm create barefootjs@latest`. Not shown in --help.
     const { run } = await import('./commands/init')
     await run(filteredArgs.slice(1), ctx)
     break

--- a/packages/cli/src/lib/adapters/csr.ts
+++ b/packages/cli/src/lib/adapters/csr.ts
@@ -187,6 +187,7 @@ export const CSR_ADAPTER: AdapterTemplate = {
   },
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
+    '@barefootjs/test': 'latest',
     '@types/bun': '^1.1.0',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -536,6 +536,7 @@ export const ECHO_ADAPTER: AdapterTemplate = {
   },
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
+    '@barefootjs/test': 'latest',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/adapters/hono-node.ts
+++ b/packages/cli/src/lib/adapters/hono-node.ts
@@ -259,6 +259,7 @@ export const HONO_NODE_ADAPTER: AdapterTemplate = {
   },
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
+    '@barefootjs/test': 'latest',
     '@types/node': '^22.0.0',
     concurrently: '^9.0.0',
     tsx: '^4.19.0',

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -200,6 +200,11 @@ export const HONO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@cloudflare/workers-types': '^4.20250101.0',
+    // `@barefootjs/test` powers `renderToTest()` — the canonical
+    // millisecond IR test the docs (and `bf gen test`) point new users
+    // at. Without it the scaffold's `bun test` is a no-op and any
+    // generated `index.test.tsx` fails with a module-not-found error.
+    '@barefootjs/test': 'latest',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -218,6 +218,7 @@ export const MOJO_ADAPTER: AdapterTemplate = {
   },
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
+    '@barefootjs/test': 'latest',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/meta-loader.ts
+++ b/packages/cli/src/lib/meta-loader.ts
@@ -57,7 +57,10 @@ export async function fetchRegistryItem(registryUrl: string, name: string): Prom
 export function loadComponent(metaDir: string, name: string): ComponentMeta {
   const filePath = path.join(metaDir, `${name}.json`)
   if (!existsSync(filePath)) {
-    console.error(`Error: Component "${name}" not found. Available components are in ui/meta/index.json.`)
+    const indexPath = path.join(metaDir, 'index.json')
+    console.error(`Error: Component "${name}" not found at ${filePath}.`)
+    console.error(`Available components are listed in ${indexPath}.`)
+    console.error(`If you just ran \`bf add ${name}\`, run \`bf meta extract\` to regenerate the meta index.`)
     process.exit(1)
   }
   return JSON.parse(readFileSync(filePath, 'utf-8'))

--- a/packages/cli/src/lib/preview-generate.ts
+++ b/packages/cli/src/lib/preview-generate.ts
@@ -70,8 +70,17 @@ function isSimpleJsx(code: string): boolean {
 
 /**
  * Generate preview code from component metadata.
+ * @param meta - Component metadata loaded from `meta/<name>.json`.
+ * @param componentsBasePath - Directory the preview file is placed under,
+ *   relative to the project root. Monorepo default mirrors the registry
+ *   layout (`ui/components/ui`); scaffolded apps pass
+ *   `barefoot.config.ts`'s `paths.components` (typically `components/ui`)
+ *   so the preview lands next to the component, not in `node_modules`.
  */
-export function generatePreview(meta: ComponentMeta): PreviewGenerateResult {
+export function generatePreview(
+  meta: ComponentMeta,
+  componentsBasePath: string = 'ui/components/ui',
+): PreviewGenerateResult {
   const pascalName = toPascalCase(meta.name)
   const hasVariants = meta.variants != null && Object.keys(meta.variants).length > 0
   const hasSubComponents = meta.subComponents != null && meta.subComponents.length > 0
@@ -143,7 +152,7 @@ export function generatePreview(meta: ComponentMeta): PreviewGenerateResult {
   return {
     code: lines.join('\n'),
     previewNames,
-    filePath: `ui/components/ui/${meta.name}/index.preview.tsx`,
+    filePath: `${componentsBasePath}/${meta.name}/index.preview.tsx`,
   }
 }
 

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -3,7 +3,11 @@
 // Resolution order:
 // 1. Direct file path (absolute or relative)
 // 2. ui/components/ui/<name>/index.tsx (monorepo layout)
-// 3. project-config-derived component directory (paths.components from barefoot.config.ts)
+// 3. project-config `paths.components` (where `bf add` lands registry items)
+// 4. `barefoot.config.ts`'s `components` source dirs (where the user
+//    keeps their own app components — e.g. the scaffold's
+//    `components/Counter.tsx`)
+// 5. Current working directory (PascalCase fallback)
 
 import { existsSync } from 'fs'
 import path from 'path'
@@ -14,39 +18,75 @@ export interface ResolvedSource {
   componentName?: string
 }
 
-export function resolveComponentSource(nameOrPath: string, ctx: CliContext): ResolvedSource | null {
+/**
+ * Try a single candidate path and return it (resolved) if the file exists.
+ * Always appends to `searched` so callers can build a transcript for error messages.
+ */
+function tryCandidate(candidate: string, searched: string[]): string | null {
+  searched.push(candidate)
+  return existsSync(candidate) ? candidate : null
+}
+
+export function resolveComponentSource(
+  nameOrPath: string,
+  ctx: CliContext,
+  searched: string[] = [],
+): ResolvedSource | null {
   // 1. Direct file path
   if (nameOrPath.endsWith('.tsx') || nameOrPath.endsWith('.ts')) {
     const abs = path.isAbsolute(nameOrPath) ? nameOrPath : path.resolve(nameOrPath)
-    if (existsSync(abs)) {
-      return { filePath: abs }
-    }
+    const hit = tryCandidate(abs, searched)
+    if (hit) return { filePath: hit }
   }
 
-  // 2. ui/components/ui/<name>/index.tsx (monorepo)
-  const monoPath = path.join(ctx.root, 'ui/components/ui', nameOrPath, 'index.tsx')
-  if (existsSync(monoPath)) {
-    return { filePath: monoPath }
+  // 2. ui/components/ui/<name>/index.tsx (monorepo). Skip the candidate
+  //    entirely when the monorepo root isn't present — in a scaffolded
+  //    app `ctx.root` resolves to `node_modules/`, and listing
+  //    `node_modules/ui/components/ui/...` in error transcripts is
+  //    noise that confuses users about where their components are.
+  if (existsSync(path.join(ctx.root, 'ui/components/ui'))) {
+    const monoHit = tryCandidate(
+      path.join(ctx.root, 'ui/components/ui', nameOrPath, 'index.tsx'),
+      searched,
+    )
+    if (monoHit) return { filePath: monoHit }
   }
 
-  // 3. paths.components from barefoot.config.ts
+  // 3. paths.components from barefoot.config.ts (registry-item layout)
   if (ctx.config && ctx.projectDir) {
-    const configPath = path.join(ctx.projectDir, ctx.config.paths.components, nameOrPath, 'index.tsx')
-    if (existsSync(configPath)) {
-      return { filePath: configPath }
-    }
-    // Also try direct file
-    const directPath = path.join(ctx.projectDir, ctx.config.paths.components, `${nameOrPath}.tsx`)
-    if (existsSync(directPath)) {
-      return { filePath: directPath }
+    const configIndex = tryCandidate(
+      path.join(ctx.projectDir, ctx.config.paths.components, nameOrPath, 'index.tsx'),
+      searched,
+    )
+    if (configIndex) return { filePath: configIndex }
+
+    const configFlat = tryCandidate(
+      path.join(ctx.projectDir, ctx.config.paths.components, `${nameOrPath}.tsx`),
+      searched,
+    )
+    if (configFlat) return { filePath: configFlat }
+
+    // 4. Source dirs from barefoot.config.ts's `components` array. The
+    //    scaffold puts user-authored components (Counter.tsx) here, not
+    //    under `paths.components`. Try both flat (Counter.tsx) and
+    //    nested (Counter/index.tsx) layouts.
+    for (const dir of ctx.config.sourceDirs ?? []) {
+      const flat = tryCandidate(
+        path.join(ctx.projectDir, dir, `${nameOrPath}.tsx`),
+        searched,
+      )
+      if (flat) return { filePath: flat }
+      const nested = tryCandidate(
+        path.join(ctx.projectDir, dir, nameOrPath, 'index.tsx'),
+        searched,
+      )
+      if (nested) return { filePath: nested }
     }
   }
 
-  // 4. Try as a PascalCase component name in current directory
-  const cwdPath = path.resolve(`${nameOrPath}.tsx`)
-  if (existsSync(cwdPath)) {
-    return { filePath: cwdPath }
-  }
+  // 5. PascalCase component name in the current working directory
+  const cwdHit = tryCandidate(path.resolve(`${nameOrPath}.tsx`), searched)
+  if (cwdHit) return { filePath: cwdHit }
 
   return null
 }

--- a/packages/cli/src/lib/scaffold-layout.ts
+++ b/packages/cli/src/lib/scaffold-layout.ts
@@ -1,0 +1,43 @@
+// Shared layout resolver for `bf gen *` commands.
+//
+// `bf gen component` / `bf gen preview` need to know two things to put a
+// new file in the right place:
+//
+//   - `writeRoot`            : the absolute base directory to write under.
+//                              In the monorepo this is `ctx.root` (the
+//                              monorepo checkout); in a scaffolded app it's
+//                              `ctx.projectDir` (where the user's barefoot
+//                              project lives). Pre-fix code always used
+//                              `ctx.root`, which in scaffolded apps
+//                              resolved to `node_modules/`, polluting it
+//                              with user code that the next `npm install`
+//                              would wipe.
+//
+//   - `componentsBasePath`   : project-root-relative dir where the new
+//                              component lands. Monorepo: `ui/components/ui`
+//                              (the registry layout). Scaffolded app:
+//                              `barefoot.config.ts`'s `paths.components`
+//                              (typically `components/ui`).
+//
+// Keeping both behind one helper means future `bf gen *` commands stay
+// scaffold-aware by construction.
+
+import type { CliContext } from '../context'
+
+export interface ScaffoldLayout {
+  writeRoot: string
+  componentsBasePath: string
+}
+
+export function resolveScaffoldLayout(ctx: CliContext): ScaffoldLayout {
+  if (ctx.config && ctx.projectDir) {
+    return {
+      writeRoot: ctx.projectDir,
+      componentsBasePath: ctx.config.paths.components,
+    }
+  }
+  return {
+    writeRoot: ctx.root,
+    componentsBasePath: 'ui/components/ui',
+  }
+}

--- a/packages/cli/src/lib/scaffold.ts
+++ b/packages/cli/src/lib/scaffold.ts
@@ -30,8 +30,19 @@ export interface ScaffoldResult {
  * Generate a component skeleton and basic IR test.
  * @param componentName - Name for the new component (kebab-case, e.g. "settings-form")
  * @param useComponents - Names of existing components to compose (e.g. ["input", "switch", "button"])
+ * @param metaDir - Where to find existing component meta JSON (drives the
+ *   `"use client"` decision + sub-component import list).
+ * @param componentsBasePath - Directory the new component is written under,
+ *   relative to the project root. Monorepo: `ui/components/ui` (default).
+ *   Scaffolded app: pass `barefoot.config.ts`'s `paths.components`
+ *   (typically `components/ui`) so files don't land in `node_modules/ui/...`.
  */
-export function scaffold(componentName: string, useComponents: string[], metaDir: string): ScaffoldResult {
+export function scaffold(
+  componentName: string,
+  useComponents: string[],
+  metaDir: string,
+  componentsBasePath: string = 'ui/components/ui',
+): ScaffoldResult {
   const metas = useComponents.map(name => ({ name, meta: loadMeta(metaDir, name) }))
   const found = metas.filter(m => m.meta !== null) as { name: string; meta: ComponentMeta }[]
   const notFound = metas.filter(m => m.meta === null).map(m => m.name)
@@ -48,7 +59,7 @@ export function scaffold(componentName: string, useComponents: string[], metaDir
   // Generate test code
   const testCode = generateTestCode(componentName, needsClient)
 
-  const basePath = `ui/components/ui/${componentName}`
+  const basePath = `${componentsBasePath}/${componentName}`
 
   return {
     componentCode,

--- a/packages/create-barefootjs/src/index.ts
+++ b/packages/create-barefootjs/src/index.ts
@@ -169,6 +169,10 @@ async function main(): Promise<void> {
       // line so a "foo/bar/bazz" positional shows as `cd foo/bar/bazz`
       // instead of just `cd bazz`.
       BAREFOOT_INIT_PROJECT_PATH: projectName,
+      // Sentinel — the only way `bf init` runs. Direct invocations
+      // (without this var) are bounced with a redirect to
+      // `npm create barefootjs@latest`. See packages/cli/src/commands/init.ts.
+      BAREFOOT_INIT_VIA_CREATE: '1',
     },
   })
 

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -21,6 +21,26 @@
       "types": "./src/jsx-dev-runtime/index.d.ts"
     }
   },
+  "//publishConfig": "When npm/pkg-pr-new packs this package, swap `types` to the built dist/*.d.ts files so downstream `tsc --noEmit` doesn't walk into our TS source (where Node imports like `fs` / `process` would force every consumer to install @types/node). Runtime `import` stays at src — current monorepo + esbuild consumers transpile on the fly, and a future publish-ready dist would point this at dist/index.js once subpath bundles exist (none yet for ./scanner).",
+  "publishConfig": {
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./src/index.ts"
+      },
+      "./scanner": {
+        "types": "./dist/scanner/js-scanner.d.ts",
+        "import": "./src/scanner/js-scanner.ts"
+      },
+      "./jsx-runtime": {
+        "types": "./src/jsx-runtime/index.d.ts"
+      },
+      "./jsx-dev-runtime": {
+        "types": "./src/jsx-dev-runtime/index.d.ts"
+      }
+    }
+  },
   "files": [
     "dist",
     "src"
@@ -31,7 +51,9 @@
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test && bun run typecheck:tests",
     "typecheck:tests": "tsgo --noEmit -p __tests__/tsconfig.json",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
   },
   "keywords": [
     "jsx",

--- a/scripts/swap-publish-config.mjs
+++ b/scripts/swap-publish-config.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+//
+// Merge / restore `publishConfig` overrides on package.json.
+//
+// Why this script exists:
+// Several workspace packages (`@barefootjs/jsx`, `@barefootjs/hono`) ship
+// their TS source via `exports` so the in-monorepo dev loop (bun test,
+// `bf build`, etc.) reads source directly — no rebuild between edits.
+// That works at runtime because bun + esbuild transpile on the fly, but
+// breaks downstream `tsc --noEmit`: TypeScript walks into our raw .ts
+// files in `node_modules`, sees `import fs from 'node:fs'`, and demands
+// the consumer install `@types/node` + add `"node"` to tsconfig.types
+// just to type-check the scaffold.
+//
+// The packages keep their src-pointed `exports` in-tree (so monorepo dev
+// stays untouched) and a `publishConfig` block holds the dist-pointed
+// `exports` for the published tarball. npm + bun only merge a small
+// allow-list of `publishConfig` keys at pack time (registry, tag, etc.),
+// so a manual swap is required.
+//
+// Usage (wired through package.json scripts):
+//   "scripts": {
+//     "prepack":  "node ../../scripts/swap-publish-config.mjs pack",
+//     "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
+//   }
+//
+// `pack` snapshots package.json to package.json.publish-bak and merges
+// every key from `publishConfig` into the top-level (overwriting). The
+// `publishConfig` block + the sibling `//publishConfig` comment field
+// are removed from the snapshot so consumers don't see them in the
+// shipped manifest. `unpack` restores from the backup unconditionally.
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { argv, cwd, exit } from 'node:process'
+
+const PKG_PATH = resolve(cwd(), 'package.json')
+const BAK_PATH = `${PKG_PATH}.publish-bak`
+
+function usage() {
+  console.error('Usage: swap-publish-config.mjs <pack|unpack>')
+  exit(2)
+}
+
+const mode = argv[2]
+if (mode !== 'pack' && mode !== 'unpack') usage()
+
+if (mode === 'pack') {
+  if (existsSync(BAK_PATH)) {
+    // A previous pack didn't run postpack — refuse rather than
+    // silently overwrite the backup and lose the original.
+    console.error(
+      `[swap-publish-config] ${BAK_PATH} already exists. ` +
+      `A previous pack didn't complete; restore it manually before retrying.`,
+    )
+    exit(1)
+  }
+  const raw = readFileSync(PKG_PATH, 'utf-8')
+  const pkg = JSON.parse(raw)
+  if (!pkg.publishConfig) {
+    // Nothing to swap. Still create the backup so `postpack` doesn't
+    // need to special-case "no publishConfig" — it always restores.
+    writeFileSync(BAK_PATH, raw)
+    exit(0)
+  }
+
+  // Merge each publishConfig key into the top-level. Object values are
+  // replaced wholesale rather than deep-merged so a package can swap
+  // its full `exports` map without leaking the src-pointed entries.
+  const merged = { ...pkg }
+  for (const [k, v] of Object.entries(pkg.publishConfig)) {
+    merged[k] = v
+  }
+  delete merged.publishConfig
+  delete merged['//publishConfig']
+
+  writeFileSync(BAK_PATH, raw)
+  writeFileSync(PKG_PATH, JSON.stringify(merged, null, 2) + '\n')
+  exit(0)
+}
+
+// unpack
+if (!existsSync(BAK_PATH)) {
+  // postpack runs even when prepack didn't (e.g. pack failed early).
+  // Treat missing backup as a no-op — there's nothing to restore.
+  exit(0)
+}
+renameSync(BAK_PATH, PKG_PATH)

--- a/site/core/pages/quick-start.tsx
+++ b/site/core/pages/quick-start.tsx
@@ -175,7 +175,7 @@ This runs \`bf build\`, generates the final \`uno.css\`, and calls \`wrangler de
 - Pick a different backend by passing \`--adapter\` to the scaffolder:
 
   \`\`\`bash
-  npm create barefootjs@latest my-app -- --adapter go-template
+  npm create barefootjs@latest -- --adapter go-template
   \`\`\`
 
   See [Adapter Architecture](./adapters/adapter-architecture.md) for the full list.

--- a/site/shared/components/package-manager-tabs.tsx
+++ b/site/shared/components/package-manager-tabs.tsx
@@ -6,9 +6,10 @@ import { createSignal, createMemo } from '@barefootjs/client'
 //   dlx    — run a one-shot binary (default). `command` is the bare CLI;
 //            tabs render `npx <cmd>` / `bunx --bun <cmd>` / etc.
 //   create — `npm create <starter>` family. `command` is the part after
-//            `create`, e.g. `barefootjs@latest my-app`. The npm tab keeps
-//            `@latest`; the others strip it (only npm honours that suffix
-//            in the create-* flow).
+//            `create`, e.g. `barefootjs@latest` (no positional — the
+//            scaffolder prompts for the target dir). The npm tab keeps
+//            `@latest`; the others strip it (only npm honours that
+//            suffix in the create-* flow).
 export interface PackageManagerTabsProps {
   command: string
   mode?: 'dlx' | 'create'


### PR DESCRIPTION
## Summary

Onboarding adjustment PR — opening as a base for small iterative tweaks toward the alpha. Tag `cr-tracked` so pkg-pr-new can publish per-commit previews and the rest of the verification (scaffold → install → write a few sample apps) can run against real published packages.

This first change tightens the `bf init` boundary:

- **Before**: typing `bf init` in a shell happily scaffolded into any directory that didn't already contain a `barefoot.config.ts` — including the BarefootJS monorepo root. The "is the target directory empty?" pre-flight only lives in `create-barefootjs`, so the direct path was a footgun. (Also: `bf init --help` did not print help; the `--help` flag was silently ignored and a scaffold ran.)
- **After**: `bf init` requires the `BAREFOOT_INIT_VIA_CREATE=1` sentinel that `create-barefootjs` already controls. Direct invocations exit non-zero with a redirect to `npm create barefootjs@latest`.

## Why a sentinel rather than removing the dispatch entry

`create-barefootjs` invokes the CLI via `spawnSync('node', [cliBin, 'init', ...])`, so the `init` case in the dispatcher still has to exist. Adding a single env-var check inside `commands/init.ts` keeps the change small and testable, and the integration tests in `packages/adapter-hono/.../scaffold.test.ts` continue to pass because they go through `create-barefootjs` (which sets the sentinel).

## Onboarding issues I'm tracking on the side

While running through the docs as a new user I hit a few other rough edges worth queueing up:

- `docs/core/README.md` links to `./quick-start` / `https://barefootjs.dev/docs/quick-start` but there's no `quick-start.md` in the repo — link target only exists on the docs site.
- Scaffolded `package.json` uses `@barefootjs/* ` at `"latest"`, so `npm install` 404s against npm until the first publish. This PR's pkg-pr-new build is the workaround until publish.
- Top-level `README.md` has no install / quick-start section at all — only the warning banner and design principles.

Happy to roll any of these into follow-up commits on this branch once the gate change is in.

## Test plan

- [x] `bun test packages/cli/src/__tests__/init-gate.test.ts` (3 new tests cover: direct invocation refused, flag forms also refused, sentinel lets the call through to the next guard)
- [x] `bun test packages/cli/src/__tests__/` — 422 pass
- [x] `bun test packages/create-barefootjs` — 14 pass (existing scenarios unaffected because they spawn via create-barefootjs which sets the sentinel)
- [x] Manual: `node packages/create-barefootjs/dist/index.js gate-check --yes` scaffolds successfully; `node packages/cli/dist/index.js init` is refused with the redirect message


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxoiN5W4KmTX6hkCyP8jfy)_