### PR TITLE
fix(jsx/#1405): unwrap TS type assertions when capturing JSX return expressions

### DIFF
--- a/packages/jsx/src/__tests__/jsx-return-type-assertion.test.ts
+++ b/packages/jsx/src/__tests__/jsx-return-type-assertion.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for #1405: a `'use client'` component whose JSX
+ * return is wrapped in a TypeScript type assertion (`as X`, `<T>expr`,
+ * `expr satisfies X`, `expr!`) was treated as if it had no JSX return.
+ *
+ * For multi-return bodies that meant the early `if (cond) return
+ * <jsx/> as X` branch never registered as a conditional return —
+ * `findJsxReturnInBlock` only unwrapped parentheses. The if-statement
+ * then fell into the "preserve top-level imperative statement"
+ * branch, emitting the raw JSX (`<div ref={attachHost}>...</div>`)
+ * verbatim into the client JS init body → `SyntaxError: Unexpected
+ * token '<'` at module load.
+ *
+ * For trailing returns the same gap meant `ctx.jsxReturn` held the
+ * outer `AsExpression`, which `transformNode` in
+ * `buildIfStatementChain` couldn't lower → the if-statement's
+ * `alternate` was `null` and the template only rendered the early
+ * branch.
+ *
+ * The fix routes every return-position capture site through a single
+ * `unwrapJsxTransparent` helper that strips the same set of wrappers
+ * the IR dispatcher (`transformJsxExpression`) already handles:
+ * parentheses, `as`, `satisfies`, `!`, `<T>`, partially-emitted.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function findHydrate(content: string): string {
+  const line = content.split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe("JSX return through TypeScript type assertion (#1405)", () => {
+  test('issue exact repro: multi-return + ref={fn} + `as X` cast compiles cleanly', () => {
+    const source = `
+      'use client'
+      import { createSignal, onCleanup } from '@barefootjs/client'
+
+      export function RawJsxLeak(props: { width: number }): HTMLElement {
+        const [count] = createSignal(0)
+        const isSmall = props.width < 100
+
+        function attachHost(host: HTMLElement) {
+          onCleanup(() => host.removeAttribute('data-attached'))
+          host.setAttribute('data-attached', 'true')
+        }
+
+        if (isSmall) {
+          return (
+            <div ref={attachHost}>
+              <div>small: {count()}</div>
+            </div>
+          ) as unknown as HTMLElement
+        }
+        return (
+          <div ref={attachHost}>
+            <div>large: {count()}</div>
+          </div>
+        ) as unknown as HTMLElement
+      }
+    `
+    const result = compileJSX(source, 'RawJsxLeak.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    // No raw JSX leaks into the init body.
+    expect(clientJs.content).not.toMatch(/return \(\s*<div\s+ref=/)
+
+    // Init body wires both branches' refs through the slot binding.
+    // Pre-fix only the trailing branch had a slot/ref wiring.
+    const refCalls = clientJs.content.match(/\(attachHost\)\(/g) ?? []
+    expect(refCalls.length).toBe(2)
+
+    // The hydrate template lowers to a ternary covering both branches.
+    const hydrate = findHydrate(clientJs.content)
+    expect(hydrate).toContain('template:')
+    expect(hydrate).toMatch(/_p\.width < 100\) \?/)
+    expect(hydrate).toContain('small:')
+    expect(hydrate).toContain('large:')
+  })
+
+  test('`satisfies` on early-return JSX is also detected as a conditional return', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function SatisfiesWrap(props: { kind: 'a' | 'b' }) {
+        const [n] = createSignal(0)
+        if (props.kind === 'a') {
+          return (<span>A: {n()}</span>) satisfies unknown
+        }
+        return <button>B: {n()}</button>
+      }
+    `
+    const result = compileJSX(source, 'SatisfiesWrap.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    const hydrate = findHydrate(clientJs.content)
+    expect(hydrate).toContain('template:')
+    expect(hydrate).toContain('<span')
+    expect(hydrate).toContain('<button')
+  })
+
+  test('`!` non-null assertion on JSX return preserves analysis', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function NonNullWrap(props: { flag: boolean }) {
+        const [n] = createSignal(0)
+        if (props.flag) {
+          return <span>T: {n()}</span>!
+        }
+        return <em>F: {n()}</em>
+      }
+    `
+    const result = compileJSX(source, 'NonNullWrap.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    const hydrate = findHydrate(clientJs.content)
+    expect(hydrate).toContain('template:')
+    expect(hydrate).toContain('<span')
+    expect(hydrate).toContain('<em')
+  })
+
+  test('arrow-shorthand component body with `as X` cast still works', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export const Shorthand = (props: { label: string }) => (
+        <button>{props.label}</button>
+      ) as unknown as HTMLElement
+    `
+    const result = compileJSX(source, 'Shorthand.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    // No reactive primitives → no client JS needed. The point of this
+    // test is that compilation reaches a clean end without producing
+    // an empty / broken template fallback.
+    expect(clientJs).toBeDefined()
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -540,11 +540,7 @@ function analyzeComponentBody(
     // inner `<div/>` (equivalent to the pre-refactor `return (<div/>)`
     // unwrap at the block level).
     if (!ctx.componentBodyBlock) {
-      let shorthand = body as ts.Expression
-      while (ts.isParenthesizedExpression(shorthand)) {
-        shorthand = shorthand.expression
-      }
-      ctx.jsxReturn = shorthand
+      ctx.jsxReturn = unwrapJsxTransparent(body as ts.Expression)
     }
 
     visitComponentBody(body, ctx)
@@ -714,11 +710,7 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
   // longer touches `jsxReturn`; it retains its other job (walking through
   // statements to collect signals / memos / effects / functions).
   if (ts.isReturnStatement(node) && node.expression) {
-    let retExpr = node.expression
-    while (ts.isParenthesizedExpression(retExpr)) {
-      retExpr = retExpr.expression
-    }
-    ctx.jsxReturn = retExpr
+    ctx.jsxReturn = unwrapJsxTransparent(node.expression)
   }
 
   // Skip recursion into function bodies (arrow functions, function expressions, function declarations)
@@ -759,16 +751,42 @@ function findJsxReturnInBlock(
 }
 
 /**
- * Extract JSX element from an expression, handling parenthesized expressions.
+ * Strip JSX-transparent wrappers from an expression. Matches the
+ * "transparent: unwrap and recurse" set in `transformJsxExpression`
+ * (`jsx-to-ir.ts`): parentheses + TS type-only wrappers (`as`,
+ * `satisfies`, `!`, `<T>`, partially-emitted). Returning-position JSX
+ * may carry any of these without changing semantics; the analyzer must
+ * see through them so `if (cond) return <jsx/> as X` registers as a
+ * conditional return (#1405). Without this, the wrapped early-return
+ * was treated as a verbatim init-body statement and its JSX leaked
+ * unprocessed into the emitted client JS.
+ */
+export function unwrapJsxTransparent(expr: ts.Expression): ts.Expression {
+  let current = expr
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    current.kind === ts.SyntaxKind.PartiallyEmittedExpression
+  ) {
+    current = (current as ts.AsExpression | ts.ParenthesizedExpression | ts.SatisfiesExpression | ts.NonNullExpression | ts.TypeAssertion).expression
+  }
+  return current
+}
+
+/**
+ * Extract JSX element from an expression, handling parenthesized
+ * expressions and TS type-only wrappers (`as`, `satisfies`, `!`,
+ * `<T>`).
  */
 function extractJsxFromExpression(
   expr: ts.Expression
 ): ts.JsxElement | ts.JsxFragment | ts.JsxSelfClosingElement | null {
-  if (ts.isJsxElement(expr) || ts.isJsxFragment(expr) || ts.isJsxSelfClosingElement(expr)) {
-    return expr
-  }
-  if (ts.isParenthesizedExpression(expr)) {
-    return extractJsxFromExpression(expr.expression)
+  const inner = unwrapJsxTransparent(expr)
+  if (ts.isJsxElement(inner) || ts.isJsxFragment(inner) || ts.isJsxSelfClosingElement(inner)) {
+    return inner
   }
   return null
 }
@@ -1607,8 +1625,7 @@ function extractSingleJsxReturn(
     if (ts.isReturnStatement(node)) {
       returnCount++
       if (node.expression) {
-        let expr: ts.Expression = node.expression
-        while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+        const expr = unwrapJsxTransparent(node.expression)
         if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
           jsxReturn = expr
         }
@@ -1647,8 +1664,7 @@ export function isMultiReturnJsxFunctionBody(body: ts.Block): boolean {
         allReturnsAreJsxOrNull = false
         return
       }
-      let expr: ts.Expression = node.expression
-      while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+      const expr = unwrapJsxTransparent(node.expression)
       const isJsx =
         ts.isJsxElement(expr) ||
         ts.isJsxSelfClosingElement(expr) ||


### PR DESCRIPTION
## Summary

Closes #1405.

A `'use client'` component whose JSX return was wrapped in a TypeScript type assertion (`as X`, `<T>expr`, `expr satisfies X`, `expr!`) failed to be recognized as a JSX return by the analyzer. The user-visible symptoms (from #1405):

- Raw JSX leaks into the emitted `.client.js` init body — `SyntaxError: Unexpected token '<'` at module load.
- The hydrate template lambda silently drops the early branch; SSR always renders the trailing return regardless of which branch the runtime would have taken.
- Browser console: `[BarefootJS] Template not found for component: X` (the registry never sees `hydrate()` because the module load throws).

### Root cause

The IR dispatcher (`transformJsxExpression` in `jsx-to-ir.ts`) already strips a wider set of transparent wrappers:

```ts
case ts.SyntaxKind.ParenthesizedExpression:
case ts.SyntaxKind.AsExpression:
case ts.SyntaxKind.SatisfiesExpression:
case ts.SyntaxKind.NonNullExpression:
case ts.SyntaxKind.TypeAssertionExpression:
case ts.SyntaxKind.PartiallyEmittedExpression:
  return transformJsxExpression(node.expression, ctx, isClientOnly)
```

The analyzer's return-position capture sites only unwrapped `ParenthesizedExpression`, so a JSX return wrapped in any of the other (TS-only) forms didn't register:

- `findJsxReturnInBlock` → early-return branches inside `if (cond) { return <jsx/> as X }` were missed, fell into the "preserve top-level imperative statement" path, and the raw JSX text was emitted verbatim into the init body.
- `visitComponentBody` trailing-return capture → `ctx.jsxReturn` held the outer `AsExpression`, which `transformNode(jsxReturn)` in `buildIfStatementChain` couldn't lower → the if-statement IR's `alternate` was `null` and the template only rendered the early branch.
- `analyzeComponentBody` arrow-shorthand capture (`() => (<div/>) as X`).
- `extractSingleJsxReturn` / `isMultiReturnJsxFunctionBody` (JSX helper classification).

### Fix

Add `unwrapJsxTransparent` covering the same set as the IR dispatcher and route every return-position capture site through it. Single helper, five call sites updated, no behavior change for already-working shapes.

### Why not a diagnostic

The issue's option 1 was \"fire BF??? for this shape\". The compiler can simply handle the type assertion correctly — `transformJsxExpression` was already prepared to do so. Adding a diagnostic when the IR layer can do the right thing would just be friction.

### Scope of behavioral change

- `packages/jsx/src/analyzer.ts` — new `unwrapJsxTransparent` helper + five call-site updates (arrow shorthand, trailing-return capture, `findJsxReturnInBlock`, `extractSingleJsxReturn`, `isMultiReturnJsxFunctionBody`).
- `packages/jsx/src/__tests__/jsx-return-type-assertion.test.ts` — new file. Four shapes:
  1. The issue's exact repro (multi-return + `ref={fn}` + `as unknown as HTMLElement`) — compiles cleanly, both branches' slots wired, template ternary covers both.
  2. `satisfies` on early-return JSX.
  3. `!` non-null assertion on JSX return.
  4. Arrow-shorthand component body with `as X` cast.

## Test plan

- [x] `bun test` in `packages/jsx` — 1276 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 320 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 207 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 174 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)