### PR TITLE
fix(jsx/#1404): resolve chained init-locals consumed by 'if (cond) return <jsx/>'

### DIFF
--- a/packages/jsx/src/__tests__/chained-init-local-template.test.ts
+++ b/packages/jsx/src/__tests__/chained-init-local-template.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for #1404: a `'use client'` component with chained
+ * init-locals consumed only by an `if (cond) return <jsx/>` early
+ * return emitted a `template:` lambda whose `cond` evaluated as
+ * `undefined`. SSR then always took the wrong branch — visible as a
+ * flash of the wrong content before hydrate corrected it.
+ *
+ * The cascade had two layers:
+ *
+ *  1. `populateCsrInlinable` (`compute-inlinability.ts`) rebuilt its
+ *     substitution env once per iter of the fixed-point loop. When the
+ *     dependent (`isCompressed`) appeared in the same iter as its
+ *     dependency (`width`) was finalised, the env didn't yet carry
+ *     `width`'s substitution. The post-substitution
+ *     `isInlinableInTemplate` re-ran relocate on the un-substituted
+ *     text, fell `width` back to `undefined` (init-local without
+ *     inlinable form), and froze `(undefined < 154)` into
+ *     `ctx.csrInlinable`. Fix: rebuild env per-const inside the loop
+ *     so each iteration is monotonic.
+ *
+ *  2. `extractFreeIdentifiersFromNode` (`analyzer.ts`) walked through
+ *     TypeScript type nodes (`as { compact?: boolean }`), pulling the
+ *     type's property keys into the const's `freeIdentifiers` set.
+ *     Those non-runtime identifiers reclassified `data` as
+ *     `external-name` → unsafe → its transitive consumer
+ *     `isCompressed` got demoted to `depends-on-unsafe`, producing a
+ *     spurious BF061. Fix: stop the visitor at any `ts.TypeNode` so
+ *     type-only identifiers stay out of the free-id set.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function findHydrate(content: string): string {
+  const line = content.split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe('chained init-local consumed by `if (cond) return <jsx/>` (#1404)', () => {
+  test('issue exact repro: chained init-locals with `as T` cast resolve to real bridged form', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props { data: unknown }
+
+      export function InitLocalCast(props: Props) {
+        const [count] = createSignal(0)
+        const data = props.data as { compact?: boolean; width?: number }
+        const width = data.width ?? 256
+        const isCompressed = width < 154
+
+        if (isCompressed) return <div>compressed: {count()}</div>
+        if (data.compact) return <div>compact: {count()}</div>
+        return <div>detail: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'InitLocalCast.tsx', { adapter })
+
+    // No spurious BF061 from the type-annotation identifiers being
+    // collected as free-id references.
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    const hydrate = findHydrate(clientJs.content)
+
+    // The if-statement condition's chained-init-local expands through
+    // both hops to the bridged prop form, not `undefined`.
+    expect(hydrate).toContain('(_p.data.width ?? 256) < 154')
+    expect(hydrate).not.toContain('undefined < 154')
+  })
+
+  test('chain works without a type cast on the alias const', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function NoCast(props: { data: { compact?: boolean; width?: number } }) {
+        const [count] = createSignal(0)
+        const data = props.data
+        const width = data.width ?? 256
+        const isCompressed = width < 154
+
+        if (isCompressed) return <div>compressed: {count()}</div>
+        return <div>detail: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'NoCast.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    expect(findHydrate(clientJs.content)).toContain('(_p.data.width ?? 256) < 154')
+  })
+
+  test('longer chain (4 hops) still resolves in a single fixed-point pass', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function LongChain(props: { x: { y: { z: number } } }) {
+        const [n] = createSignal(0)
+        const a = props.x
+        const b = a.y
+        const c = b.z
+        const d = c < 10
+
+        if (d) return <div>small: {n()}</div>
+        return <div>large: {n()}</div>
+      }
+    `
+    const result = compileJSX(source, 'LongChain.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // Per-hop parens come from the chain resolver wrapping each
+    // substituted value in `(...)` — semantically equivalent to
+    // `_p.x.y.z`, just structurally protected against precedence
+    // surprises in the surrounding expression.
+    expect(findHydrate(result.files.find(f => f.type === 'clientJs')!.content)).toMatch(/\(+_p\.x\)?\.y\)?\.z\)? < 10/)
+  })
+
+  test('type-only identifiers in `as` cast do not leak into freeIdentifiers', () => {
+    // Direct guard for the second layer of the fix: a type-annotation
+    // identifier shadowing a local const must not pull the alias into
+    // the `external-name` bucket.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Shape { width?: number }
+
+      export function TypeShadow(props: { data: unknown }) {
+        const [count] = createSignal(0)
+        // The type-key 'width' appears in the cast. Pre-fix this
+        // poisoned data's freeIdentifiers and demoted it to
+        // external-name, cascading BF061 onto isCompressed.
+        const data = props.data as Shape
+        const w = data.width ?? 256
+        const isCompressed = w < 154
+
+        if (isCompressed) return <div>compressed: {count()}</div>
+        return <div>detail: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'TypeShadow.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    expect(findHydrate(result.files.find(f => f.type === 'clientJs')!.content)).toContain('(_p.data.width ?? 256) < 154')
+  })
+
+  test('cast variant still produces correct content (not the wrong branch)', () => {
+    // SSR-side correctness guard: the template's ternary must select
+    // the right branch. Pre-fix, `(undefined < 154)` is always false,
+    // so SSR always rendered the `else` branch — the compressed
+    // content would only appear after hydrate. Compile-time check:
+    // the template literal contains the resolved condition, not the
+    // bare fallback.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ThreeWay(props: { data: unknown }) {
+        const [n] = createSignal(0)
+        const data = props.data as { compact?: boolean; width?: number }
+        const w = data.width ?? 256
+        const isCompressed = w < 154
+
+        if (isCompressed) return <span>S: {n()}</span>
+        if (data.compact) return <em>C: {n()}</em>
+        return <strong>D: {n()}</strong>
+      }
+    `
+    const result = compileJSX(source, 'ThreeWay.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const hydrate = findHydrate(result.files.find(f => f.type === 'clientJs')!.content)
+    expect(hydrate).toContain('(_p.data.width ?? 256) < 154')
+    expect(hydrate).toContain('_p.data.compact')
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1783,7 +1783,13 @@ function extractValueBranches(node: ts.Expression, ctx: AnalyzerContext): string
 
 /**
  * Extract free identifier references from an AST node by walking the tree.
- * Skips property keys, member access properties, and bound parameter names.
+ * Skips property keys, member access properties, bound parameter names,
+ * and identifiers nested inside TypeScript type nodes (`as { … }` cast
+ * type, type parameter constraints, return type annotations). Type-only
+ * identifiers never reference runtime bindings — including them in the
+ * free-id set surfaces them as init-locals downstream and demotes the
+ * referenced const to `external-name`, which cascades into spurious
+ * BF061 diagnostics and `(undefined …)` template fallbacks (#1404).
  */
 export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
   const ids = new Set<string>()
@@ -1796,6 +1802,11 @@ export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
   }
 
   function visit(n: ts.Node): void {
+    // Type-only nodes (`as { compact?: boolean }`, `: Props`, …) carry
+    // identifiers that exist solely in the type checker — they aren't
+    // emitted, so they can't be runtime references. Stop the descent
+    // here.
+    if (ts.isTypeNode(n)) return
     if (ts.isIdentifier(n)) {
       const parent = n.parent
       if (parent && ts.isPropertyAccessExpression(parent) && parent.name === n) return

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -319,12 +319,27 @@ function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv): v
   // Fixed-point loop: each iteration resolves any const whose
   // substitution succeeds. Bounded by `localConstants.length + 1` —
   // longest possible chain.
+  //
+  // The env (constSubs merged into baseEnv) is rebuilt for EACH const
+  // inside the iter, not once per iter. When two consts in the same
+  // source order chain (`const a = props.x; const b = a.y < 1`), the
+  // dependent (`b`) must observe `a`'s substitution before its own
+  // `csrSubstitute` runs — otherwise `a` stays a bare identifier in
+  // `b`'s value, the post-substitution `isInlinableInTemplate` re-runs
+  // relocate on the un-substituted text and falls `a` back to
+  // `undefined` (init-local without inlinable form), and `b`'s
+  // `csrInlinable` entry freezes that fallback into `(undefined < 1)`.
+  // The user-visible defect is BF061-shape templates emitting
+  // `(undefined < N)` for `if`-statement conditions built from chained
+  // init-locals (#1404). Rebuilding env inside the loop costs an extra
+  // Map merge per const but keeps the substitution table monotonic
+  // within an iter.
   const maxIter = ctx.localConstants.length + 1
   for (let iter = 0; iter < maxIter; iter++) {
     let progressed = false
-    const env = buildEnvWithConsts()
     for (const c of ctx.localConstants) {
       if (finalised.has(c.name)) continue
+      const env = buildEnvWithConsts()
       // Use raw `value` (not `templateValue`) so the relocate gate
       // sees `props.X` and can detect bridged-arg calls. The final
       // emit-time substitution applies the bare-prop rewrite.


### PR DESCRIPTION
## Summary

Closes #1404.

A `'use client'` component with chained init-locals consumed only by an `if (cond) return <jsx/>` early return emitted a `template:` lambda whose `cond` evaluated as `undefined`. SSR then always took the wrong branch — visible as a flash of incorrect content before hydrate corrected it.

### Why the issue's proposed approaches got bypassed

The issue listed three fix directions:

1. **BF061 message extension** — documentation-only, doesn't actually fix the template.
2. **`clientOnly` carve-out on `IRIfStatement`** — adds `/* @client */` as an escape hatch users can opt into.
3. **Inline the chained const into the template** — fix without escape hatch.

Investigating turned up that (3) was *almost* working. The chained-const inliner (`populateCsrInlinable`) already had a fixed-point loop with the right shape; one tiny scheduling bug and one analyzer-side false-positive were the only things keeping it from resolving the user's exact case. Once both are fixed, the issue's repro compiles with no diagnostic and the template emits the real bridged form. The escape hatch (option 2) becomes unnecessary for this shape.

### Two-layer root cause

**Layer 1 — env staleness inside the fixed-point loop** (`compute-inlinability.ts:populateCsrInlinable`)

The substitution env was rebuilt once per iter, not once per const. When the dependent (`isCompressed = width < 154`) was processed in the same iter as its dependency (`width = data.width ?? 256`) was finalised, the env didn't yet carry `width`'s substitution. The post-substitution `isInlinableInTemplate` re-ran relocate on the un-substituted text, fell `width` back to `undefined` (init-local without inlinable form), and froze `(undefined < 154)` into `ctx.csrInlinable`.

```diff
   for (let iter = 0; iter < maxIter; iter++) {
     let progressed = false
-    const env = buildEnvWithConsts()
     for (const c of ctx.localConstants) {
       if (finalised.has(c.name)) continue
+      const env = buildEnvWithConsts()
       ...
```

**Layer 2 — type-node identifiers leak into `freeIdentifiers`** (`analyzer.ts:extractFreeIdentifiersFromNode`)

The visitor walked through TypeScript type nodes (`as { compact?: boolean; width?: number }`, `: Props`, type parameter constraints) and pulled the type's property keys into the const's `freeIdentifiers` set. Those non-runtime identifiers reclassified `data` as `external-name` (unsafe), and the downstream demote-on-unsafe in `toLegacyInlinability` propagated that onto every transitive consumer — producing a spurious BF061 *even after* Layer 1's fix made the template resolve correctly.

```diff
   function visit(n: ts.Node): void {
+    if (ts.isTypeNode(n)) return
     if (ts.isIdentifier(n)) { ... }
     ...
```

### Net result

| Layer | Before | After |
|---|---|---|
| Issue repro with `as { ... }` cast | template = `(undefined < 154)`, SSR wrong branch, BF061 fires | template = `((_p.data.width ?? 256) < 154)`, SSR right branch, no diagnostic |
| Repro without cast | template = `(undefined < 154)`, SSR wrong branch, no BF061 (silently broken) | template = `((_p.data.width ?? 256) < 154)`, SSR right branch |
| Longer chain (4 hops) | `(undefined < 10)` | `(((_p.x).y).z) < 10` |

### Scope of behavioral change

- `packages/jsx/src/ir-to-client-js/compute-inlinability.ts` — move `buildEnvWithConsts()` from once-per-iter to once-per-const inside `populateCsrInlinable`.
- `packages/jsx/src/analyzer.ts` — `extractFreeIdentifiersFromNode` skips at `ts.isTypeNode(n)`.
- `packages/jsx/src/__tests__/chained-init-local-template.test.ts` — new file. Five shapes:
  1. Issue exact repro (3-way dispatch on chained init-locals through `as T` cast).
  2. Same chain without the cast (already-broken-but-silent variant).
  3. 4-hop chain.
  4. Direct guard for the type-node-leak layer (`as Shape` where Shape declares a property whose name shadows a local).
  5. Compile-time SSR correctness check — template emits the resolved condition, not the bare fallback.

## Test plan

- [x] `bun test` in `packages/jsx` — 1281 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 320 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 207 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 174 pass / 0 fail.
- [x] `bun test` in `packages/client` — 277 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)