### PR TITLE
fix(jsx/#1409): inline early-return scope variables at JSX use sites

### DIFF
--- a/packages/jsx/src/__tests__/early-return-scope-var-ref.test.ts
+++ b/packages/jsx/src/__tests__/early-return-scope-var-ref.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for #1409: a JSX expression in an early-return
+ * branch that referenced a `const` declared inside that same
+ * `if`-block compiled to a `.client.js` whose `createEffect(() =>
+ * updateClientMarker(__scope, 's*', localVar))` (or template
+ * `${localVar}`) was emitted at outer init scope — where `localVar`
+ * doesn't exist. Runtime then fired `ReferenceError: localVar is not
+ * defined` and the component failed to mount.
+ *
+ * Fix: extend the IR-level JSX-const inlining (#547) to also inline
+ * `const X = …` declared inside an early-return `if`-block. When a
+ * JSX expression's identifier matches one of these branch-scope
+ * variables, `transformExpressionInner` re-enters the dispatch chain
+ * with the initializer expression in place of the identifier — JSX
+ * literal → inline element, dynamic shape (ternary / `&&` / `??`) →
+ * preserve `@client` and emit IRConditional, scalar → emit the
+ * initializer text directly. The branch overlay is saved/restored
+ * around each `transformNode(condReturn.jsxReturn)` call so sibling
+ * branches don't see each other's locals.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsContent(result: ReturnType<typeof compileJSX>): string {
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+function hydrateLine(result: ReturnType<typeof compileJSX>): string {
+  const line = clientJsContent(result).split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe('JSX expression referencing a local declared inside an early-return if-block (#1409)', () => {
+  test("issue exact repro: `/* @client */` reference to a JSX-valued scope var inlines at use site", () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function EarlyReturnLocalRef(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+
+        if (props.kind === 'a') {
+          const aLocal = <span>(a local)</span>
+          return (
+            <div>
+              <span>view A: {count()}</span>
+              {/* @client */ aLocal}
+            </div>
+          )
+        }
+        return (
+          <div>
+            <span>view B: {count()}</span>
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'EarlyReturnLocalRef.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+
+    // Pre-fix: emitted `updateClientMarker(__scope, 's4', aLocal)` at
+    // outer init scope — `aLocal` undefined. Post-fix: the JSX is
+    // inlined directly into the template, so the createEffect /
+    // updateClientMarker block is not needed at all for this static
+    // shape.
+    expect(content).not.toContain('updateClientMarker')
+    expect(content).not.toMatch(/\baLocal\b/)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).toContain('<span>(a local)</span>')
+  })
+
+  test('scalar (string literal) scope var substitutes into the @client emit', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function StringLocal(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const label = 'hello'
+          return <div><span>view A: {count()}</span>{/* @client */ label}</div>
+        }
+        return <div><span>view B: {count()}</span></div>
+      }
+    `
+    const result = compileJSX(source, 'StringLocal.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    // The bare `label` identifier must not appear in the emitted init
+    // function — it's resolved to its initializer value at IR-build
+    // time.
+    expect(content).not.toMatch(/updateClientMarker\([^)]*\blabel\b[^)]*\)/)
+    expect(content).toContain("updateClientMarker(__scope, 's4', 'hello')")
+  })
+
+  test('ternary scope var (`readOnly ? null : <jsx/>`) routes to client-only conditional', () => {
+    // Mirror of the user's real-world case from
+    // piconic-ai/desk #86 Phase 6:
+    //   `const compactResize = readOnly ? null : <div .../>`
+    //   `{/* @client */ compactResize}`
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function CompactResize(props: { kind: 'a' | 'b'; readOnly: boolean }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const compactResize = props.readOnly ? null : <div class="handle">resize</div>
+          return <div><span>view A: {count()}</span>{/* @client */ compactResize}</div>
+        }
+        return <div><span>view B: {count()}</span></div>
+      }
+    `
+    const result = compileJSX(source, 'CompactResize.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    // Pre-fix: `updateClientMarker(__scope, 's*', compactResize)`
+    // referenced an undeclared name. Post-fix: the ternary becomes an
+    // IRConditional with `clientOnly: true`, routed through `insert()`
+    // — and `props.readOnly` is rewritten to `_p.readOnly`.
+    expect(content).not.toMatch(/\bcompactResize\b/)
+    expect(content).toContain('insert(__scope')
+    expect(content).toMatch(/_p\.readOnly/)
+  })
+
+  test('non-`/* @client */` reference to a JSX-valued scope var also works (template emits inline)', () => {
+    // The scope issue was symmetric: even without `@client`, the
+    // template lambda referenced the undeclared name at module
+    // scope — same `ReferenceError` surface at first render.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function NoClient(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const aLocal = <span>(a local)</span>
+          return <div><span>view A: {count()}</span>{aLocal}</div>
+        }
+        return <div><span>view B: {count()}</span></div>
+      }
+    `
+    const result = compileJSX(source, 'NoClient.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\baLocal\b/)
+    expect(hydrateLine(result)).toContain('<span>(a local)</span>')
+  })
+
+  test('sibling branches do not see each other\'s scope variables', () => {
+    // Regression guard: the overlay is saved/restored per-branch.
+    // If it leaked, branch B's reference to `branchALocal` would
+    // resolve to branch A's initializer — wrong content.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Sibling(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const branchALocal = <span>only-A</span>
+          return <div><span>view A: {count()}</span>{branchALocal}</div>
+        }
+        return <div><span>view B: {count()}</span></div>
+      }
+    `
+    const result = compileJSX(source, 'Sibling.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    // Branch A's content includes "only-A". Branch B does not.
+    expect(hydrate).toContain('only-A')
+    // Branch B's template must not reference the leaked name.
+    expect(hydrate).not.toMatch(/\bbranchALocal\b/)
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -89,6 +89,19 @@ interface TransformContext {
    * `renderChild('Pkg.Comp', ...)` which fails the registry lookup.
    */
   _componentNamespaces?: Map<string, Map<string, string>>
+  /**
+   * Per-branch overlay of `const X = expr` declared inside an early-
+   * return `if`-block, populated by `buildIfStatementChain` before
+   * transforming the consequent JSX (#1409). When a JSX expression
+   * references one of these names, `transformExpression` inlines the
+   * initializer at the use site — the same way module-scope JSX
+   * constants are inlined via `analyzer.jsxConstants` (#547) — instead
+   * of leaving the identifier to leak into the emitted client JS at
+   * outer init scope where the binding doesn't exist. Saved/restored
+   * around each `transformNode(condReturn.jsxReturn, ctx)` call so
+   * sibling branches do not see each other's locals.
+   */
+  _branchScopeVars?: Map<string, ts.Expression>
 }
 
 /**
@@ -1095,15 +1108,33 @@ function transformExpression(
 
   const expr = node.expression
 
-  // Check for bare signal/memo identifier (BF044)
-  checkBareSignalOrMemoIdentifier(expr, ctx)
-
   // Check for @client directive in prefix style: {/* @client */ expr}.
   // Detection is centralised in `hasLeadingClientDirective` so JSX-child,
   // attribute, and component-prop positions agree — a substring match on
   // `getFullText()` would false-positive on string literals or trailing
   // comments containing "@client".
   const isClientOnly = hasLeadingClientDirective(expr, ctx.sourceFile)
+
+  return transformExpressionInner(expr, ctx, node, isClientOnly)
+}
+
+/**
+ * Inner dispatch for JSX-child expressions. Separated so a substituted
+ * expression (e.g. inlining a branch scope variable's initializer at
+ * the use site, #1409) can re-enter the dispatch chain with a
+ * different `expr` than the original `node.expression`. The `node`
+ * argument is preserved as the original JsxExpression so source
+ * locations on the produced IR still point at the use site, not at
+ * the substitution target.
+ */
+function transformExpressionInner(
+  expr: ts.Expression,
+  ctx: TransformContext,
+  node: ts.JsxExpression,
+  isClientOnly: boolean,
+): IRNode | null {
+  // Check for bare signal/memo identifier (BF044)
+  checkBareSignalOrMemoIdentifier(expr, ctx)
 
   // #547: Inline a JSX constant referenced by identifier. Unique to JSX-child
   // position — conditional branches and return position don't resolve
@@ -1113,6 +1144,19 @@ function transformExpression(
     const jsxNode = ctx.analyzer.jsxConstants.get(expr.text)
     if (jsxNode) {
       return transformNode(jsxNode, ctx)
+    }
+
+    // #1409: Same inlining for `const X = …` declared inside an
+    // early-return `if`-block. The scope variable's initializer takes
+    // the identifier's place — handles `<jsx/>` (JsxElement), dynamic
+    // shapes (`cond ? <jsx/> : null`, `&&`, `??`), and scalar leaves
+    // alike. Without this, a reference like `{/* @client */ aLocal}`
+    // leaves the identifier in the emitted client JS at outer init
+    // scope where `aLocal` doesn't exist — runtime
+    // `ReferenceError: aLocal is not defined`.
+    const branchInit = ctx._branchScopeVars?.get(expr.text)
+    if (branchInit) {
+      return transformExpressionInner(branchInit, ctx, node, isClientOnly)
     }
   }
 
@@ -3761,10 +3805,31 @@ function buildIfStatementChain(
     const condition = ctx.getJS(condReturn.condition)
     const templateCondition = rewriteBarePropRefs(condition, condReturn.condition, ctx)
 
+    // #1409: overlay each branch's `const X = …` declarations onto
+    // `ctx._branchScopeVars` so a JSX expression that references one
+    // of them inlines the initializer at the use site instead of
+    // leaving the bare identifier in the emitted client JS at outer
+    // init scope. Saved/restored around `transformNode` so sibling
+    // branches and outer scope don't see each other's locals.
+    const prevBranchScopeVars = ctx._branchScopeVars
+    const branchScopeVars = new Map<string, ts.Expression>()
+    if (prevBranchScopeVars) {
+      for (const [k, v] of prevBranchScopeVars) branchScopeVars.set(k, v)
+    }
+    for (const decl of condReturn.scopeVariables) {
+      if (ts.isIdentifier(decl.name) && decl.initializer) {
+        branchScopeVars.set(decl.name.text, decl.initializer)
+      }
+    }
+    ctx._branchScopeVars = branchScopeVars
+
     // Transform the JSX return in the then branch
     // Reset isRoot so each branch gets needsScope=true
     ctx.isRoot = true
     const consequent = transformNode(condReturn.jsxReturn, ctx)
+
+    ctx._branchScopeVars = prevBranchScopeVars
+
     if (!consequent) {
       continue
     }


### PR DESCRIPTION
## Summary

Closes #1409.

A `'use client'` component whose early `return <jsx/>` body referenced a `const X = …` declared inside that same `if`-block left the bare identifier in the emitted output. The init function's `createEffect(() => updateClientMarker(__scope, 's*', X))` and the template lambda's `${X}` both ran at outer / module scope where `X` doesn't exist — runtime fired `ReferenceError: X is not defined` and the component failed to mount. No compiler diagnostic surfaced.

```tsx
// Issue's repro shape
export function EarlyReturnLocalRef(props: { kind: 'a' | 'b' }) {
  const [count] = createSignal(0)
  if (props.kind === 'a') {
    const aLocal = <span>(a local)</span>       // ← declared inside the if-block
    return <div><span>view A: {count()}</span>{/* @client */ aLocal}</div>
  }
  return <div><span>view B: {count()}</span></div>
}
```

### Why the broken state existed

`IRIfStatement.scopeVariables` already preserved each branch's local declarations, but no downstream emit consumer used them — the binding contract was "track the names so the IR is well-formed," not "make them resolvable at the use site." The `IRExpression` for the use site kept the bare identifier `aLocal`, and both the template lambda and `emit-reactive.ts`'s `updateClientMarker` block emitted that identifier as-is into outer init scope.

### Fix

Extend the existing JSX-const inlining (#547) to also inline branch-scope variables. The change is structural, no new diagnostic introduced:

1. New `TransformContext._branchScopeVars` overlay — saved/restored around each `transformNode(condReturn.jsxReturn, ctx)` call in `buildIfStatementChain`.
2. `transformExpression` splits into a thin wrapper + `transformExpressionInner` so a substituted expression can re-enter the dispatch chain with `expr` replaced but `node` (the JsxExpression for source-location purposes) preserved.
3. The identifier branch in `transformExpressionInner` now checks `_branchScopeVars` after the existing `jsxConstants` check. A match recurses with the initializer expression in place of the identifier.

This unifies every shape under one route:

| Scope var initializer | Outcome |
|---|---|
| `<jsx/>` literal | Inlined as IRElement (`@client` becomes a no-op for the static shape, matching the manual `{/* @client */ <jsx/>}` workaround) |
| `cond ? <jsx/> : null` etc. | IRConditional with `clientOnly: true` preserved → routes through `insert()` |
| `'hello'` scalar | Initializer text substituted directly → `updateClientMarker(__scope, 'sN', 'hello')` |

### Side effects

- Sibling branches and outer scope don't see each other's locals (overlay is saved/restored).
- Nested if-statements inherit the parent overlay (a parent's scope var stays visible inside the child branch).
- Non-`@client` references to JSX scope vars also now work (they had the same symmetric scope leak).

### Validated by

`packages/jsx/src/__tests__/early-return-scope-var-ref.test.ts` — five shapes:
1. Issue exact repro (`/* @client */` JSX scope var).
2. Scalar string scope var (`label = 'hello'`).
3. Ternary with JSX (`compactResize = readOnly ? null : <div/>`) — the user's piconic-ai/desk#86 Phase 6 case.
4. Non-`@client` JSX scope var (symmetric leak).
5. Sibling-branch isolation guard.

## Test plan

- [x] `bun test` in `packages/jsx` — 1286 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 320 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 207 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 174 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)