### PR TITLE
feat(go-template): lower intrinsic JSX spread on SSR (#1407)

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -296,7 +296,17 @@ func SpreadAttrs(bag any) template.HTMLAttr {
 		if len(key) > 2 && key[0] == 'o' && key[1] == 'n' && !(key[2] >= 'a' && key[2] <= 'z') {
 			continue
 		}
-		if key == "children" || key == "ref" {
+		// `children` is a JSX construct rendered inside the element,
+		// never a DOM attribute. `ref` is intentionally NOT filtered
+		// here so output stays byte-equal with the JS reference
+		// `spreadAttrs` in packages/client/src/runtime/spread-attrs.ts
+		// (which only filters null/false, event handlers, and
+		// children) — aligning Go's filter set diverges from JS in
+		// the opposite direction. Filtering `ref` consistently across
+		// both SSR runtimes is a separate concern tracked alongside
+		// the JS `applyRestAttrs` vs `spreadAttrs` mismatch (#1411
+		// review).
+		if key == "children" {
 			continue
 		}
 		val := rv.MapIndex(reflect.ValueOf(key))

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -84,6 +84,9 @@ func FuncMap() template.FuncMap {
 
 		// Scope comment for fragment roots
 		"bfScopeComment": ScopeComment,
+
+		// JSX intrinsic-element spread lowering (#1407)
+		"bf_spread_attrs": SpreadAttrs,
 	}
 }
 
@@ -115,6 +118,225 @@ func HydrationAttrs(props interface{}) template.HTMLAttr {
 // presence (#1249); use HydrationAttrs instead.
 func IsChild(props interface{}) template.HTMLAttr {
 	return ""
+}
+
+// svgCamelCaseAttrs mirrors SVG_CAMEL_CASE_ATTRS from
+// packages/client/src/runtime/spread-attrs.ts. SVG XML attribute
+// names are case-sensitive; the default camelCase → kebab-case
+// rewrite must NOT apply to these or the SVG stops rendering
+// (#1407). Coordinates with the compile-time SVG_CAMEL_TO_KEBAB
+// table in packages/jsx/src/ir-to-client-js/utils.ts: presentation
+// attrs (clipPath, strokeWidth, …) live there and must NOT appear
+// here, or the same JSX prop would lower to clip-path via the
+// explicit-attr path and stay clipPath via the spread path.
+var svgCamelCaseAttrs = map[string]struct{}{
+	"allowReorder": {}, "attributeName": {}, "attributeType": {}, "autoReverse": {},
+	"baseFrequency": {}, "baseProfile": {}, "calcMode": {}, "clipPathUnits": {},
+	"contentScriptType": {}, "contentStyleType": {}, "diffuseConstant": {}, "edgeMode": {},
+	"externalResourcesRequired": {}, "filterRes": {}, "filterUnits": {}, "glyphRef": {},
+	"gradientTransform": {}, "gradientUnits": {}, "kernelMatrix": {}, "kernelUnitLength": {},
+	"keyPoints": {}, "keySplines": {}, "keyTimes": {}, "lengthAdjust": {}, "limitingConeAngle": {},
+	"markerHeight": {}, "markerUnits": {}, "markerWidth": {}, "maskContentUnits": {},
+	"maskUnits": {}, "numOctaves": {}, "pathLength": {}, "patternContentUnits": {},
+	"patternTransform": {}, "patternUnits": {}, "pointsAtX": {}, "pointsAtY": {}, "pointsAtZ": {},
+	"preserveAlpha": {}, "preserveAspectRatio": {}, "primitiveUnits": {}, "refX": {}, "refY": {},
+	"repeatCount": {}, "repeatDur": {}, "requiredExtensions": {}, "requiredFeatures": {},
+	"specularConstant": {}, "specularExponent": {}, "spreadMethod": {}, "startOffset": {},
+	"stdDeviation": {}, "stitchTiles": {}, "surfaceScale": {}, "systemLanguage": {},
+	"tableValues": {}, "targetX": {}, "targetY": {}, "textLength": {}, "viewBox": {}, "viewTarget": {},
+	"xChannelSelector": {}, "yChannelSelector": {}, "zoomAndPan": {},
+}
+
+// toAttrName mirrors the JSX→HTML attribute-name rewrite from
+// packages/client/src/runtime/spread-attrs.ts. className → class,
+// htmlFor → for, SVG camelCase attrs preserved, other camelCase
+// keys lowered to kebab-case.
+func toAttrName(key string) string {
+	if key == "className" {
+		return "class"
+	}
+	if key == "htmlFor" {
+		return "for"
+	}
+	if _, ok := svgCamelCaseAttrs[key]; ok {
+		return key
+	}
+	// camelCase → kebab-case: insert '-' before each uppercase ASCII
+	// letter, then lowercase. Same shape as the JS regex
+	// /([A-Z])/g → '-$1' → toLowerCase().
+	var b strings.Builder
+	for i, r := range key {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('-')
+			}
+			b.WriteRune(r + 32)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// StyleToCss mirrors styleToCss from
+// packages/client/src/runtime/style.ts. Accepts a string passthrough,
+// or a map (JSON-deserialized object) whose camelCase keys are
+// lowered to kebab-case and joined with `;`. Returns ("", false) for
+// nullish/empty input so callers can omit the attribute entirely.
+func StyleToCss(v any) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return "", false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Map {
+		// Non-object: stringify and return as-is, matching the JS
+		// `typeof value !== 'object'` branch.
+		s := fmt.Sprint(v)
+		if s == "" {
+			return "", false
+		}
+		return s, true
+	}
+	keys := rv.MapKeys()
+	sorted := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if k.Kind() == reflect.String {
+			sorted = append(sorted, k.String())
+		}
+	}
+	sort.Strings(sorted)
+	parts := make([]string, 0, len(sorted))
+	for _, k := range sorted {
+		val := rv.MapIndex(reflect.ValueOf(k))
+		// Skip nil entries (matches the JS `if (v == null) continue`).
+		if !val.IsValid() {
+			continue
+		}
+		if val.Kind() == reflect.Interface || val.Kind() == reflect.Pointer {
+			if val.IsNil() {
+				continue
+			}
+			val = val.Elem()
+		}
+		prop := toAttrName(k)
+		parts = append(parts, fmt.Sprintf("%s:%v", prop, val.Interface()))
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, ";"), true
+}
+
+// SpreadAttrs lowers a JSX intrinsic-element spread bag (#1407) to
+// an HTML attribute string. Mirrors spreadAttrs from
+// packages/client/src/runtime/spread-attrs.ts so SSR output matches
+// what CSR's `applyRestAttrs` writes at hydration.
+//
+// Skip rules: nil/false values, event handlers (`on[A-Z]*`),
+// `children`, `ref`.
+//
+// Key remap: className → class, htmlFor → for, SVG camelCase
+// preserved, other camelCase → kebab-case.
+//
+// `style` is routed through StyleToCss so object literals serialize
+// to a real CSS string instead of Go's default `map[k:v]` form.
+//
+// Booleans: true → bare attribute name, false → omitted.
+// Other scalar values are HTML-escaped via template.HTMLEscapeString.
+// Returns a `template.HTMLAttr` so html/template emits the result
+// verbatim (the function does its own escaping).
+//
+// Keys are sorted alphabetically before emission for deterministic
+// output. SSR/CSR attribute-order divergence is acceptable per the
+// rest-destructure-object-spread-in-map fixture's documented policy
+// — browsers honor the LAST value when a key is duplicated, so
+// pairing with static attrs (`<div class="x" {...rest}>`) is
+// last-wins regardless of order.
+func SpreadAttrs(bag any) template.HTMLAttr {
+	if bag == nil {
+		return ""
+	}
+	rv := reflect.ValueOf(bag)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return ""
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Map {
+		return ""
+	}
+	keys := rv.MapKeys()
+	sortedKeys := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if k.Kind() == reflect.String {
+			sortedKeys = append(sortedKeys, k.String())
+		}
+	}
+	sort.Strings(sortedKeys)
+	parts := make([]string, 0, len(sortedKeys))
+	for _, key := range sortedKeys {
+		// Event handlers (on[A-Z]…) are runtime-only — skip at SSR
+		// the same way packages/client/src/runtime/spread-attrs.ts
+		// does at hydration.
+		if len(key) > 2 && key[0] == 'o' && key[1] == 'n' && key[2] >= 'A' && key[2] <= 'Z' {
+			continue
+		}
+		if key == "children" || key == "ref" {
+			continue
+		}
+		val := rv.MapIndex(reflect.ValueOf(key))
+		if !val.IsValid() {
+			continue
+		}
+		// Unwrap interface wrappers (json.Unmarshal produces
+		// interface{}-wrapped values for map[string]any).
+		v := val
+		for v.Kind() == reflect.Interface || v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				// Skip null entries.
+				v = reflect.Value{}
+				break
+			}
+			v = v.Elem()
+		}
+		if !v.IsValid() {
+			continue
+		}
+		// Boolean values: true → bare attribute, false → omitted.
+		if v.Kind() == reflect.Bool {
+			if !v.Bool() {
+				continue
+			}
+			parts = append(parts, toAttrName(key))
+			continue
+		}
+		// `style` routes through StyleToCss so object literals get a
+		// real CSS string. The JS side does the same.
+		if key == "style" {
+			css, ok := StyleToCss(v.Interface())
+			if !ok {
+				continue
+			}
+			parts = append(parts, fmt.Sprintf(`style="%s"`, template.HTMLEscapeString(css)))
+			continue
+		}
+		// Stringify and escape. fmt.Sprint handles numbers, bools-as-
+		// strings, and arbitrary stringer types the same way the JS
+		// `String(value)` coercion does for the analogous cases.
+		s := fmt.Sprint(v.Interface())
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, toAttrName(key), template.HTMLEscapeString(s)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return template.HTMLAttr(strings.Join(parts, " "))
 }
 
 // BfPropsAttr returns the bf-p attribute with the JSON-serialized

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -161,15 +161,17 @@ func toAttrName(key string) string {
 	if _, ok := svgCamelCaseAttrs[key]; ok {
 		return key
 	}
-	// camelCase → kebab-case: insert '-' before each uppercase ASCII
-	// letter, then lowercase. Same shape as the JS regex
-	// /([A-Z])/g → '-$1' → toLowerCase().
+	// camelCase → kebab-case: mirror the JS reference exactly
+	// (`key.replace(/([A-Z])/g, '-$1').toLowerCase()`). The JS shape
+	// produces a leading `-` for an initial uppercase letter
+	// (`XData` → `-x-data`); both this Go path and the matching JS
+	// runtime are wrong-by-construction for that case (the resulting
+	// HTML attribute name is invalid), but keeping them byte-equal
+	// avoids silent SSR/CSR divergence (#1411 review).
 	var b strings.Builder
-	for i, r := range key {
+	for _, r := range key {
 		if r >= 'A' && r <= 'Z' {
-			if i > 0 {
-				b.WriteByte('-')
-			}
+			b.WriteByte('-')
 			b.WriteRune(r + 32)
 		} else {
 			b.WriteRune(r)
@@ -282,10 +284,16 @@ func SpreadAttrs(bag any) template.HTMLAttr {
 	sort.Strings(sortedKeys)
 	parts := make([]string, 0, len(sortedKeys))
 	for _, key := range sortedKeys {
-		// Event handlers (on[A-Z]…) are runtime-only — skip at SSR
-		// the same way packages/client/src/runtime/spread-attrs.ts
-		// does at hydration.
-		if len(key) > 2 && key[0] == 'o' && key[1] == 'n' && key[2] >= 'A' && key[2] <= 'Z' {
+		// Event handlers — skip at SSR the same way
+		// packages/client/src/runtime/spread-attrs.ts does at
+		// hydration. The JS predicate is
+		// `key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()`,
+		// which is true for any character whose uppercase form is
+		// itself: ASCII A-Z, digits, underscore, and non-letter
+		// symbols. Mirror that here by skipping when key[2] is NOT
+		// a lowercase ASCII letter — so `onClick`, `on_custom`, and
+		// `on0` all match (#1411 review).
+		if len(key) > 2 && key[0] == 'o' && key[1] == 'n' && !(key[2] >= 'a' && key[2] <= 'z') {
 			continue
 		}
 		if key == "children" || key == "ref" {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -869,6 +869,28 @@ func TestSpreadAttrs(t *testing.T) {
 			bag:  map[string]any{"style": "color:red"},
 			want: `style="color:red"`,
 		},
+		// #1411 review parity tests — mirror JS `spreadAttrs` for
+		// edge keys.
+		{
+			name: "leading-uppercase key emits leading dash (parity with JS)",
+			bag:  map[string]any{"XData": "x"},
+			want: `-x-data="x"`,
+		},
+		{
+			name: "event handler with underscore third char skipped (parity with JS)",
+			bag:  map[string]any{"on_custom": "fn", "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "event handler with digit third char skipped (parity with JS)",
+			bag:  map[string]any{"on0": "fn", "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "on followed by lowercase letter NOT treated as event",
+			bag:  map[string]any{"oncology": "x"},
+			want: `oncology="x"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -779,3 +779,142 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestSpreadAttrs(t *testing.T) {
+	tests := []struct {
+		name string
+		bag  any
+		want template.HTMLAttr
+	}{
+		{"nil", nil, ""},
+		{"empty", map[string]any{}, ""},
+		{"non-map", "x", ""},
+		{
+			name: "single string",
+			bag:  map[string]any{"id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "alphabetic order",
+			bag:  map[string]any{"id": "a", "class": "on"},
+			want: `class="on" id="a"`,
+		},
+		{
+			name: "className → class remap",
+			bag:  map[string]any{"className": "foo"},
+			want: `class="foo"`,
+		},
+		{
+			name: "htmlFor → for remap",
+			bag:  map[string]any{"htmlFor": "x"},
+			want: `for="x"`,
+		},
+		{
+			name: "camelCase → kebab-case",
+			bag:  map[string]any{"dataPriority": "high"},
+			want: `data-priority="high"`,
+		},
+		{
+			name: "SVG viewBox preserved",
+			bag:  map[string]any{"viewBox": "0 0 10 10"},
+			want: `viewBox="0 0 10 10"`,
+		},
+		{
+			name: "event handler skipped",
+			bag:  map[string]any{"onClick": "fn", "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "children skipped",
+			bag:  map[string]any{"children": "x", "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "ref skipped",
+			bag:  map[string]any{"ref": "x", "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "nil value skipped",
+			bag:  map[string]any{"a": nil, "b": "x"},
+			want: `b="x"`,
+		},
+		{
+			name: "false skipped",
+			bag:  map[string]any{"hidden": false, "id": "a"},
+			want: `id="a"`,
+		},
+		{
+			name: "true → bare attribute",
+			bag:  map[string]any{"hidden": true, "id": "a"},
+			want: `hidden id="a"`,
+		},
+		{
+			name: "HTML escape value",
+			bag:  map[string]any{"title": `<b>"x"</b>`},
+			want: `title="&lt;b&gt;&#34;x&#34;&lt;/b&gt;"`,
+		},
+		{
+			name: "number stringified",
+			bag:  map[string]any{"tabindex": 0},
+			want: `tabindex="0"`,
+		},
+		{
+			name: "style object lowered to CSS",
+			bag:  map[string]any{"style": map[string]any{"backgroundColor": "red", "color": "white"}},
+			want: `style="background-color:red;color:white"`,
+		},
+		{
+			name: "style string passthrough",
+			bag:  map[string]any{"style": "color:red"},
+			want: `style="color:red"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SpreadAttrs(tt.bag)
+			if got != tt.want {
+				t.Errorf("SpreadAttrs(%v) = %q, want %q", tt.bag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStyleToCss(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  any
+		want   string
+		wantOk bool
+	}{
+		{"nil", nil, "", false},
+		{"empty map", map[string]any{}, "", false},
+		{"string passthrough", "color:red", "color:red", true},
+		{
+			name:   "camelCase keys",
+			input:  map[string]any{"backgroundColor": "red"},
+			want:   "background-color:red",
+			wantOk: true,
+		},
+		{
+			name:   "multiple keys sorted",
+			input:  map[string]any{"color": "white", "backgroundColor": "red"},
+			want:   "background-color:red;color:white",
+			wantOk: true,
+		},
+		{
+			name:   "nil value skipped",
+			input:  map[string]any{"color": "red", "padding": nil},
+			want:   "color:red",
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := StyleToCss(tt.input)
+			if got != tt.want || ok != tt.wantOk {
+				t.Errorf("StyleToCss(%v) = (%q, %v), want (%q, %v)", tt.input, got, ok, tt.want, tt.wantOk)
+			}
+		})
+	}
+}

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -830,9 +830,11 @@ func TestSpreadAttrs(t *testing.T) {
 			want: `id="a"`,
 		},
 		{
-			name: "ref skipped",
+			// Parity with JS `spreadAttrs` — it doesn't filter `ref`,
+			// so neither do we (#1411 review).
+			name: "ref passes through (parity with JS spreadAttrs)",
 			bag:  map[string]any{"ref": "x", "id": "a"},
-			want: `id="a"`,
+			want: `id="a" ref="x"`,
 		},
 		{
 			name: "nil value skipped",

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -128,12 +128,6 @@ runAdapterConformanceTests({
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
-    // #1244 stress catalog #13 (#1324): JSX spread of a reactive object
-    // (`<div {...attrs()} />`). Go templates can't iterate a runtime
-    // hash into `key="value"` pairs with the escaping / event-filter
-    // semantics that Hono / CSR's `applyRestAttrs` provides, so the
-    // adapter surfaces BF101 instead of silently dropping the spread.
-    'jsx-spread-reactive': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1257,6 +1257,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     if (node.type === 'component') {
       const comp = node as IRComponent
+      // `IRComponent.children` are the JSX children passed to *this*
+      // component instance at the call site (`<Child>...</Child>`).
+      // They are part of the PARENT's IR and evaluate in the parent's
+      // render scope, so any spreads inside them belong on the parent's
+      // Props struct. The child component's own template body is a
+      // separate `ComponentIR` with its own `ir.root`, compiled in a
+      // separate `generate()` pass — it never appears in the parent's
+      // IR tree, so the recursion never crosses a component boundary
+      // and the per-component `spreadIdCounter` can't collide across
+      // unrelated components (#1411 review).
       for (const child of comp.children) {
         this.collectSpreadSlotsRecursive(child, result)
       }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4,6 +4,8 @@
  * Generates Go html/template files from BarefootJS IR.
  */
 
+import ts from 'typescript'
+
 import type {
   ComponentIR,
   IRNode,
@@ -88,6 +90,20 @@ interface StaticChildInstance {
    *  through the parent's `{{.Children}}` read; those cases stay on
    *  the existing drop path. */
   childrenHtml: string | null
+}
+
+/**
+ * Top-level (non-loop) JSX intrinsic-element spread slot (#1407).
+ * Collected by `collectSpreadSlots` so the adapter can emit one
+ * `Spread_<slotId> map[string]any` field on the component's Props
+ * struct and initialise it in `NewXxxProps` from the source JS
+ * expression. Loop-internal spreads don't appear here — they emit
+ * the bag inline via the loop's iteration variable instead.
+ */
+interface SpreadSlotInfo {
+  slotId: string
+  expr: string
+  templateExpr: string | undefined
 }
 
 export interface GoTemplateAdapterOptions {
@@ -804,6 +820,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${child.fieldName} ${child.name}Props \`json:"-"\``)
     }
 
+    // (#1407) Add fields for top-level JSX intrinsic-element spreads.
+    // Each non-loop spread gets a `Spread_<slotId> map[string]any`
+    // field; the Go template references it as `.Spread_<slotId>` via
+    // `{{bf_spread_attrs}}`. Loop-internal spreads emit inline and
+    // don't appear here.
+    const spreadSlots = this.collectSpreadSlots(ir.root)
+    for (const slot of spreadSlots) {
+      const jsonTag = this.toJsonTag(slot.slotId)
+      lines.push(`\t${slot.slotId} map[string]any \`json:"${jsonTag}"\``)
+    }
+
     lines.push('}')
     lines.push('')
   }
@@ -975,6 +1002,29 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         lines.push(`\t\t\tChildren: template.HTML(${JSON.stringify(child.childrenHtml)}),`)
       }
       lines.push(`\t\t}),`)
+    }
+
+    // (#1407) Initialise spread bag fields. Unsupported shapes (e.g.
+    // signal getters whose initialValue isn't a plain object literal,
+    // identifiers that don't resolve to a propsParam) fall through to
+    // BF101 below — the field is still declared on the struct so the
+    // template compiles even when the initializer is missing.
+    const spreadSlots = this.collectSpreadSlots(ir.root)
+    for (const slot of spreadSlots) {
+      const goExpr = this.buildSpreadInitializer(slot.expr, ir)
+      if (goExpr) {
+        lines.push(`\t\t${slot.slotId}: ${goExpr},`)
+      } else {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `JSX spread '{...${slot.expr}}' on an intrinsic element has no Go template lowering — only signal getters of plain object literals and rest-prop identifiers are supported in V1`,
+          loc: this.makeLoc(),
+          suggestion: {
+            message: 'Pre-compute the spread bag as a discrete prop, or expand the spread into per-attribute props at the call site.',
+          },
+        })
+      }
     }
 
     lines.push('\t}')
@@ -1149,6 +1199,182 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         this.collectStaticChildInstancesRecursive(child, result, inLoop)
       }
     }
+  }
+
+  /**
+   * Collect top-level (non-loop) JSX intrinsic-element spread slots
+   * from the IR (#1407). Loop-internal spreads are skipped — they
+   * emit the bag inline via the loop's iteration variable in
+   * `elementAttrEmitter.emitSpread`, so they don't need a Props
+   * struct field.
+   *
+   * Walks the IR tree, descending into elements, fragments,
+   * conditionals, providers, async, and components, but stopping at
+   * loop bodies. Each `IRElement.attrs[i].value` of kind `'spread'`
+   * that has a `slotId` becomes one `SpreadSlotInfo` entry.
+   */
+  private collectSpreadSlots(node: IRNode): SpreadSlotInfo[] {
+    const result: SpreadSlotInfo[] = []
+    this.collectSpreadSlotsRecursive(node, result)
+    return result
+  }
+
+  private collectSpreadSlotsRecursive(node: IRNode, result: SpreadSlotInfo[]): void {
+    if (node.type === 'element') {
+      const element = node as IRElement
+      for (const attr of element.attrs) {
+        if (attr.value.kind !== 'spread') continue
+        if (!attr.value.slotId) continue
+        result.push({
+          slotId: attr.value.slotId,
+          expr: attr.value.expr,
+          templateExpr: attr.value.templateExpr,
+        })
+      }
+      for (const child of element.children) {
+        this.collectSpreadSlotsRecursive(child, result)
+      }
+      return
+    }
+    if (node.type === 'fragment') {
+      const fragment = node as IRFragment
+      for (const child of fragment.children) {
+        this.collectSpreadSlotsRecursive(child, result)
+      }
+      return
+    }
+    if (node.type === 'conditional') {
+      const cond = node as IRConditional
+      this.collectSpreadSlotsRecursive(cond.whenTrue, result)
+      if (cond.whenFalse) this.collectSpreadSlotsRecursive(cond.whenFalse, result)
+      return
+    }
+    if (node.type === 'if-statement') {
+      const stmt = node as IRIfStatement
+      this.collectSpreadSlotsRecursive(stmt.consequent, result)
+      if (stmt.alternate) this.collectSpreadSlotsRecursive(stmt.alternate, result)
+      return
+    }
+    if (node.type === 'component') {
+      const comp = node as IRComponent
+      for (const child of comp.children) {
+        this.collectSpreadSlotsRecursive(child, result)
+      }
+      return
+    }
+    if (node.type === 'provider') {
+      const p = node as IRProvider
+      for (const child of p.children) {
+        this.collectSpreadSlotsRecursive(child, result)
+      }
+      return
+    }
+    if (node.type === 'async') {
+      const a = node as IRAsync
+      this.collectSpreadSlotsRecursive(a.fallback, result)
+      for (const child of a.children) {
+        this.collectSpreadSlotsRecursive(child, result)
+      }
+      return
+    }
+    // Loops are intentionally not descended — loop-internal spreads
+    // emit `{{bf_spread_attrs <go-expr>}}` inline from
+    // `elementAttrEmitter.emitSpread` instead of plumbing through a
+    // Props struct field.
+  }
+
+  /**
+   * Parse a JS object-literal source text (the raw string captured
+   * for a signal's `initialValue` or a spread expression's argument)
+   * into a Go `map[string]any{...}` literal source (#1407).
+   *
+   * Supports a deliberately conservative subset so the Go output is
+   * a 1:1 translation of the JS source: string/number/boolean/null
+   * values keyed by identifier or string-literal keys. Returns null
+   * for unsupported shapes (nested objects, computed values,
+   * function calls, spread elements) — callers fall back to BF101.
+   */
+  private parseJsObjectLiteralToGoMap(jsText: string): string | null {
+    const sf = ts.createSourceFile('inline.ts', `(${jsText})`, ts.ScriptTarget.Latest, true)
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let expr: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+    if (!ts.isObjectLiteralExpression(expr)) return null
+    const entries: string[] = []
+    for (const prop of expr.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let key: string
+      if (ts.isIdentifier(prop.name)) {
+        key = prop.name.text
+      } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+        key = prop.name.text
+      } else {
+        return null
+      }
+      const val = prop.initializer
+      let goVal: string
+      if (ts.isStringLiteral(val) || ts.isNoSubstitutionTemplateLiteral(val)) {
+        goVal = JSON.stringify(val.text)
+      } else if (ts.isNumericLiteral(val)) {
+        goVal = val.text
+      } else if (val.kind === ts.SyntaxKind.TrueKeyword) {
+        goVal = 'true'
+      } else if (val.kind === ts.SyntaxKind.FalseKeyword) {
+        goVal = 'false'
+      } else if (val.kind === ts.SyntaxKind.NullKeyword) {
+        goVal = 'nil'
+      } else {
+        return null
+      }
+      entries.push(`${JSON.stringify(key)}: ${goVal}`)
+    }
+    return `map[string]any{${entries.join(', ')}}`
+  }
+
+  /**
+   * Build a Go expression for a JSX spread bag's initial value, to
+   * be placed inside `NewXxxProps`'s return literal (#1407).
+   *
+   * Supported shapes (V1):
+   *   - Signal-getter call (e.g. `attrs()`): look up the signal,
+   *     parse its `initialValue` as a JS object literal, and emit a
+   *     Go `map[string]any{...}` literal.
+   *   - Bare identifier matching a `propsParam`: emit
+   *     `in.<FieldName>` — works when the prop's Go type is already
+   *     a map type (`Record<string, ...>` lowered to `map[string]T`).
+   *
+   * Returns null for unsupported shapes so the caller can raise a
+   * narrowed BF101 with the offending expression.
+   */
+  private buildSpreadInitializer(
+    spreadExpr: string,
+    ir: ComponentIR,
+  ): string | null {
+    const trimmed = spreadExpr.trim()
+    // Signal-getter call: `attrs()` — pluck the signal's initialValue
+    // and translate the JS object literal to a Go map literal.
+    const callMatch = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)$/.exec(trimmed)
+    if (callMatch) {
+      const getterName = callMatch[1]
+      const signal = ir.metadata.signals.find(s => s.getter === getterName)
+      if (signal && signal.initialValue) {
+        const goMap = this.parseJsObjectLiteralToGoMap(signal.initialValue)
+        if (goMap) return goMap
+      }
+      return null
+    }
+    // Bare identifier: rest-prop or destructured-from-props parameter
+    // name. The corresponding Input field is already populated by the
+    // caller of NewXxxProps.
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+      const param = ir.metadata.propsParams.find(p => p.name === trimmed)
+      if (param) {
+        return `in.${this.capitalizeFieldName(param.name)}`
+      }
+    }
+    return null
   }
 
   /**
@@ -3139,34 +3365,59 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`
     },
     emitBooleanAttr: (_value, name) => name,
-    // Spread attributes (`<div {...attrs()} />`) have no idiomatic Go
-    // template form — Go's `{{range}}` over a map can't emit
-    // `key="value"` pairs with HTML escaping in a way that round-trips
-    // through Hono / CSR's `applyRestAttrs` semantics. Record BF101 so
-    // the user gets a clear diagnostic instead of a silently dropped
-    // spread (#1324). The empty return drops the entry from the
-    // attribute list; `${expr}` still appears as the spread's runtime
-    // value in init code, so wrapping in `'use client'` (or pre-
-    // computing the spread as discrete props) recovers the keys.
+    // Spread attributes (`<div {...attrs()} />`) lower through the
+    // `bf_spread_attrs` runtime helper (#1407). Two paths:
+    //   - Top-level spread: the bag was plumbed onto the component's
+    //     Props struct as `.Spread_<slotId>` by `generatePropsStruct`
+    //     + `generateNewPropsFunction`. Emit a reference to it.
+    //   - Loop-internal spread: the bag lives in the loop iteration
+    //     variable (which surfaces as Go template's `.` plus
+    //     property access). Translate the JS expression via
+    //     `convertExpressionToGo` and emit `{{bf_spread_attrs <e>}}`
+    //     inline — no Props plumbing needed.
+    // Slot IDs are assigned at IR build time so identity is stable
+    // across re-emits; if one isn't present we fall back to BF101.
     emitSpread: (value) => {
-      this.errors.push({
-        code: 'BF101',
-        severity: 'error',
-        message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Go template lowering`,
-        loc: this.makeLoc(),
-        suggestion: {
-          // The Go SSR path doesn't currently honor
-          // `IRAttribute.clientOnly` for non-rest spreads, and the
-          // client-JS pipeline skips them too — `/* @client */`
-          // wouldn't apply the spread at hydration either. Recommend
-          // the two workarounds that actually work: move the JSX
-          // into a `'use client'` component (so hydration's
-          // `spreadAttrs` helper applies the bag), or expand the
-          // spread into discrete attribute props at the call site.
-          message: 'Move the JSX into a `\'use client\'` component (so hydration applies the spread via `spreadAttrs`), or expand the spread into discrete attribute props at the call site.',
-        },
-      })
-      return ''
+      if (!value.slotId) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Go template lowering (missing slot id)`,
+          loc: this.makeLoc(),
+          suggestion: {
+            message: 'This usually means a closed-type rest-prop spread was unexpectedly routed through the bag path — file a bug with the source.',
+          },
+        })
+        return ''
+      }
+      if (this.inLoop) {
+        // Inside `{{range $_, $t := .Tasks}}`, the iteration value
+        // surfaces as Go template's `.` (current context). A bare
+        // reference to the loop param therefore translates to `.`,
+        // not `.T` (which is what `convertExpressionToGo` would emit
+        // via the generic identifier path). Property access through
+        // the loop param (`t.attrs`) is already handled by the
+        // member-expression path that returns `.Attrs`.
+        //
+        // The emit path is wired up but end-to-end fixture coverage
+        // is gated on two orthogonal harness gaps: (a) `buildGoPropsInit`
+        // in `test-render.ts` can't pass nested-object arrays from JS
+        // into the Go input struct, and (b) `convertInitialValue`
+        // returns `nil` for complex literal arrays so signal-init
+        // arrays of objects don't reach the SSR template. Both are
+        // pre-existing limitations independent of #1407.
+        const trimmed = value.expr.trim()
+        const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
+        if (currentLoopParam && trimmed === currentLoopParam) {
+          return `{{bf_spread_attrs .}}`
+        }
+        const goExpr = this.convertExpressionToGo(value.expr)
+        // `convertExpressionToGo` already pushes BF101 for
+        // unsupported expressions and returns `""`; pass through to
+        // produce a consistent template that still compiles.
+        return `{{bf_spread_attrs ${goExpr}}}`
+      }
+      return `{{bf_spread_attrs .${value.slotId}}}`
     },
     emitTemplate: (value, name) => `${name}="${this.renderTemplateLiteralParts(value.parts)}"`,
     // Neither variant is legal on intrinsic elements.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -573,11 +573,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Generate Input struct for main component
     this.generateInputStruct(lines, ir, componentName, nestedComponents, propTypeOverrides)
 
+    // Compute spread slot info once and thread it through both
+    // generators — `collectSpreadSlots` walks the IR tree, so caching
+    // here saves a second full walk when the component has nested
+    // structure (#1411 review).
+    const spreadSlots = this.collectSpreadSlots(ir.root)
+
     // Generate Props struct for main component
-    this.generatePropsStruct(lines, ir, componentName, nestedComponents, propTypeOverrides)
+    this.generatePropsStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
 
     // Generate NewXxxProps function
-    this.generateNewPropsFunction(lines, ir, componentName, nestedComponents)
+    this.generateNewPropsFunction(lines, ir, componentName, nestedComponents, spreadSlots)
 
     // Imports come at the top, but `usesHtmlTemplate` is only known
     // after the body has been generated. Compose package + imports +
@@ -733,7 +739,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     ir: ComponentIR,
     componentName: string,
     nestedComponents: NestedComponentInfo[],
-    propTypeOverrides: Map<string, string>
+    propTypeOverrides: Map<string, string>,
+    spreadSlots: SpreadSlotInfo[]
   ): void {
     const propsTypeName = `${componentName}Props`
     lines.push(`// ${propsTypeName} is the props type for the ${componentName} component.`)
@@ -824,8 +831,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Each non-loop spread gets a `Spread_<slotId> map[string]any`
     // field; the Go template references it as `.Spread_<slotId>` via
     // `{{bf_spread_attrs}}`. Loop-internal spreads emit inline and
-    // don't appear here.
-    const spreadSlots = this.collectSpreadSlots(ir.root)
+    // don't appear here. The slot list is computed once in
+    // `generateTypes` and threaded through both struct/init emitters
+    // so the IR walk runs exactly once per `generate()` call (#1411
+    // review).
     for (const slot of spreadSlots) {
       const jsonTag = this.toJsonTag(slot.slotId)
       lines.push(`\t${slot.slotId} map[string]any \`json:"${jsonTag}"\``)
@@ -842,7 +851,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines: string[],
     ir: ComponentIR,
     componentName: string,
-    nestedComponents: NestedComponentInfo[]
+    nestedComponents: NestedComponentInfo[],
+    spreadSlots: SpreadSlotInfo[]
   ): void {
     const inputTypeName = `${componentName}Input`
     const propsTypeName = `${componentName}Props`
@@ -1009,7 +1019,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // identifiers that don't resolve to a propsParam) fall through to
     // BF101 below — the field is still declared on the struct so the
     // template compiles even when the initializer is missing.
-    const spreadSlots = this.collectSpreadSlots(ir.root)
+    // `spreadSlots` is computed once in `generateTypes` and threaded
+    // through to avoid a second IR walk (#1411 review).
     for (const slot of spreadSlots) {
       const goExpr = this.buildSpreadInitializer(slot.expr, ir)
       if (goExpr) {
@@ -1329,6 +1340,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         goVal = JSON.stringify(val.text)
       } else if (ts.isNumericLiteral(val)) {
         goVal = val.text
+      } else if (
+        // TypeScript parses `-1` and `+1` as `PrefixUnaryExpression`
+        // rather than `NumericLiteral` — accept both signs explicitly
+        // so a bag like `{count: -1}` doesn't collapse to BF101
+        // (#1411 review).
+        ts.isPrefixUnaryExpression(val)
+        && (val.operator === ts.SyntaxKind.MinusToken || val.operator === ts.SyntaxKind.PlusToken)
+        && ts.isNumericLiteral(val.operand)
+      ) {
+        const sign = val.operator === ts.SyntaxKind.MinusToken ? '-' : ''
+        goVal = `${sign}${val.operand.text}`
       } else if (val.kind === ts.SyntaxKind.TrueKeyword) {
         goVal = 'true'
       } else if (val.kind === ts.SyntaxKind.FalseKeyword) {

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -24,7 +24,13 @@ let _goAvailable: boolean | null = null
 async function isGoAvailable(): Promise<boolean> {
   if (_goAvailable !== null) return _goAvailable
   try {
-    const proc = Bun.spawn(['go', 'version'], { stdout: 'pipe', stderr: 'pipe' })
+    // If the caller pinned GOTOOLCHAIN to a specific version, run
+    // `go version` under it — `go` itself respects GOTOOLCHAIN and
+    // will auto-fetch the requested toolchain. This means the
+    // availability probe reports the *effective* version, not the
+    // system Go.
+    const env = { ...process.env, GOTOOLCHAIN: process.env.GOTOOLCHAIN ?? 'local' }
+    const proc = Bun.spawn(['go', 'version'], { stdout: 'pipe', stderr: 'pipe', env })
     const stdout = await new Response(proc.stdout).text()
     await proc.exited
     if (proc.exitCode !== 0) { _goAvailable = false; return false }
@@ -237,11 +243,14 @@ ${propsInit}
     // Run `go run .`
     // GOTOOLCHAIN=local prevents Go from downloading a newer toolchain
     // when go.mod specifies a patch version newer than the installed one.
+    // Honour a caller-supplied GOTOOLCHAIN env var so CI / dev environments
+    // with an older system Go can opt into Go's auto-download behaviour
+    // (e.g. `GOTOOLCHAIN=go1.25.6 bun test`).
     const proc = Bun.spawn(['go', 'run', '.'], {
       cwd: tempDir,
       stdout: 'pipe',
       stderr: 'pipe',
-      env: { ...process.env, GOTOOLCHAIN: 'local' },
+      env: { ...process.env, GOTOOLCHAIN: process.env.GOTOOLCHAIN ?? 'local' },
     })
 
     const [stdout, stderr] = await Promise.all([

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -105,8 +105,12 @@ runAdapterConformanceTests({
     // (`<div {...attrs()} />`). Mojo can't loop a runtime hash into
     // `key="value"` pairs with the escaping / event-filter semantics
     // that Hono / CSR's `applyRestAttrs` provides — surfaces BF101
-    // instead of silently dropping the spread.
+    // instead of silently dropping the spread. The Go adapter grew an
+    // SSR lowering for these in #1407; Mojo will follow in a separate
+    // PR.
     'jsx-spread-reactive': [{ code: 'BF101', severity: 'error' }],
+    'jsx-spread-multiple': [{ code: 'BF101', severity: 'error' }],
+    'jsx-spread-static-and-spread': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-tests/fixtures/class-vs-classname.ts
+++ b/packages/adapter-tests/fixtures/class-vs-classname.ts
@@ -9,6 +9,6 @@ export function ClassVsClassname() {
 }
 `,
   expectedHtml: `
-    <div class="container" bf-s="test"><span class="label">Text</span></div>
+    <div bf-s="test" class="container"><span class="label">Text</span></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/client-only-loop-with-sibling-cond.ts
+++ b/packages/adapter-tests/fixtures/client-only-loop-with-sibling-cond.ts
@@ -27,6 +27,6 @@ export function ChatList() {
   // The conditional markers (<!--bf-cond-start:s1--><!--bf-cond-end:s1-->) remain
   // and must appear AFTER the loop markers in the raw output.
   expectedHtml: `
-    <div id="container" bf-s="test" bf="s3"><!--bf-cond-start:s1--><!--bf-cond-end:s1--><button bf="s2">Add</button></div>
+    <div bf-s="test" bf="s3" id="container"><!--bf-cond-start:s1--><!--bf-cond-end:s1--><button bf="s2">Add</button></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/component-with-jsx-children.ts
+++ b/packages/adapter-tests/fixtures/component-with-jsx-children.ts
@@ -28,6 +28,6 @@ export function Card(props: { children?: unknown }) {
 `,
   },
   expectedHtml: `
-    <main data-x="0" bf-s="test" bf="s1"><section bf-s="test_s0"><span>hello</span><span>world</span></section></main>
+    <main bf-s="test" bf="s1" data-x="0"><section bf-s="test_s0"><span>hello</span><span>world</span></section></main>
   `,
 })

--- a/packages/adapter-tests/fixtures/conditional-class.ts
+++ b/packages/adapter-tests/fixtures/conditional-class.ts
@@ -12,6 +12,6 @@ export function ConditionalClass() {
 }
 `,
   expectedHtml: `
-    <div class="off" bf-s="test" bf="s0">Toggle</div>
+    <div bf-s="test" bf="s0" class="off">Toggle</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/context-provider.ts
+++ b/packages/adapter-tests/fixtures/context-provider.ts
@@ -25,6 +25,6 @@ export function ThemeRoot() {
 }
 `,
   expectedHtml: `
-    <div class="root" bf-s="test"><span class="theme" bf-s="test_s0">dark</span></div>
+    <div bf-s="test" class="root"><span bf-s="test_s0" class="theme">dark</span></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/dynamic-attributes.ts
+++ b/packages/adapter-tests/fixtures/dynamic-attributes.ts
@@ -13,6 +13,6 @@ export function DynamicAttributes() {
 }
 `,
   expectedHtml: `
-    <div data-state="closed" data-count="0" bf-s="test" bf="s0">Content</div>
+    <div bf-s="test" bf="s0" data-count="0" data-state="closed">Content</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/event-handlers.ts
+++ b/packages/adapter-tests/fixtures/event-handlers.ts
@@ -21,7 +21,7 @@ export function EventHandlers() {
 `,
   expectedHtml: `
     <div bf-s="test">
-      <input type="text" bf="s0">
+      <input bf="s0" type="text">
       <button bf="s1">Click</button>
       <span bf="s3"><!--bf:s2--><!--/--></span>
       <span bf="s5"><!--bf:s4-->0<!--/--></span>

--- a/packages/adapter-tests/fixtures/if-statement.ts
+++ b/packages/adapter-tests/fixtures/if-statement.ts
@@ -25,6 +25,6 @@ export function IfDemo(props: Props) {
 `,
   props: { variant: '' },
   expectedHtml: `
-    <button class="default" bf-s="test" bf="s1"><!--bf:s0-->0<!--/--></button>
+    <button bf-s="test" bf="s1" class="default"><!--bf:s0-->0<!--/--></button>
   `,
 })

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -69,6 +69,8 @@ import { fixture as asyncBoundary } from './async-boundary'
 // Priority 10: Compiler stress catalog (#1244)
 import { fixture as style3Signals } from './style-3-signals'
 import { fixture as jsxSpreadReactive } from './jsx-spread-reactive'
+import { fixture as jsxSpreadMultiple } from './jsx-spread-multiple'
+import { fixture as jsxSpreadStaticAndSpread } from './jsx-spread-static-and-spread'
 import { fixture as taggedTemplateClassname } from './tagged-template-classname'
 import { fixture as memberExpressionTag } from './member-expression-tag'
 import { fixture as arrowComponent } from './arrow-component'
@@ -153,6 +155,8 @@ export const jsxFixtures: JSXFixture[] = [
   // Priority 10: Compiler stress catalog (#1244)
   style3Signals,
   jsxSpreadReactive,
+  jsxSpreadMultiple,
+  jsxSpreadStaticAndSpread,
   taggedTemplateClassname,
   memberExpressionTag,
   arrowComponent,

--- a/packages/adapter-tests/fixtures/jsx-spread-multiple.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-multiple.ts
@@ -26,6 +26,6 @@ export function JsxSpreadMultiple() {
 }
 `,
   expectedHtml: `
-    <div id="x" class="y" bf-s="test" bf="s0"></div>
+    <div bf-s="test" bf="s0" class="y" id="x"></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/jsx-spread-multiple.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-multiple.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Compiler stress (#1407): two JSX spreads on the same intrinsic element
+ * (`<div {...a()} {...b()} />`). Verifies each spread gets its own slot
+ * id and the bag-emitting helpers concatenate cleanly.
+ *
+ * The two bags carry disjoint keys here. When keys overlap, browsers
+ * honour the last-seen value (HTML parser semantics) regardless of
+ * the lowering's serialisation order — so the user-observable DOM is
+ * insensitive to whether the adapter emits in alphabetic order
+ * (Go bag-based) or source order (Hono passthrough). Attribute order
+ * is normalised in `normalizeHTML` so the cross-adapter comparison
+ * stays byte-equal.
+ */
+export const fixture = createFixture({
+  id: 'jsx-spread-multiple',
+  description: 'Two JSX spreads on the same element get distinct slot ids',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function JsxSpreadMultiple() {
+  const [a, setA] = createSignal<Record<string, string>>({ id: 'x' })
+  const [b, setB] = createSignal<Record<string, string>>({ class: 'y' })
+  return <div onClick={() => setA({ id: 'x2' })} {...a()} {...b()} />
+}
+`,
+  expectedHtml: `
+    <div id="x" class="y" bf-s="test" bf="s0"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-spread-reactive.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-reactive.ts
@@ -18,6 +18,6 @@ export function JsxSpreadReactive() {
 }
 `,
   expectedHtml: `
-    <div id="a" class="on" bf-s="test" bf="s0"></div>
+    <div bf-s="test" bf="s0" class="on" id="a"></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/jsx-spread-static-and-spread.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-static-and-spread.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Compiler stress (#1407): static attribute alongside a JSX spread
+ * (`<div class="x" {...rest()} />`). Browsers honour the last-seen
+ * value when an attribute is duplicated, so when `rest` carries a
+ * `class` key the spread's value wins regardless of source order.
+ *
+ * This fixture pins the disjoint-keys case (static `class`, spread
+ * `id`); the overlapping-keys case is implementation-defined per
+ * adapter (last-wins) and intentionally not covered by a fixture.
+ */
+export const fixture = createFixture({
+  id: 'jsx-spread-static-and-spread',
+  description: 'Static attribute mixed with a JSX spread carrying disjoint keys',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function JsxSpreadStaticAndSpread() {
+  const [rest, setRest] = createSignal<Record<string, string>>({ id: 'a' })
+  return <div class="static-class" onClick={() => setRest({ id: 'b' })} {...rest()} />
+}
+`,
+  expectedHtml: `
+    <div class="static-class" id="a" bf-s="test" bf="s0"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-spread-static-and-spread.ts
+++ b/packages/adapter-tests/fixtures/jsx-spread-static-and-spread.ts
@@ -22,6 +22,6 @@ export function JsxSpreadStaticAndSpread() {
 }
 `,
   expectedHtml: `
-    <div class="static-class" id="a" bf-s="test" bf="s0"></div>
+    <div bf-s="test" bf="s0" class="static-class" id="a"></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/record-index-lookup-via-child-prop.ts
+++ b/packages/adapter-tests/fixtures/record-index-lookup-via-child-prop.ts
@@ -35,6 +35,6 @@ export function Slot({ className, children }: { className: string; children: any
   },
   props: { variant: 'a' },
   expectedHtml: `
-    <span class="base class-a" bf-s="test_s0" bf="s0">hi</span>
+    <span bf-s="test_s0" bf="s0" class="base class-a">hi</span>
   `,
 })

--- a/packages/adapter-tests/fixtures/record-index-lookup.ts
+++ b/packages/adapter-tests/fixtures/record-index-lookup.ts
@@ -25,6 +25,6 @@ export function Variant({ variant }: { variant: 'a' | 'b' }) {
 `,
   props: { variant: 'a' },
   expectedHtml: `
-    <div class="base class-a" bf-s="test" bf="s0">hi</div>
+    <div bf-s="test" bf="s0" class="base class-a">hi</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
@@ -63,8 +63,8 @@ export function RestSpread() {
 `,
   expectedHtml: `
     <ul bf-s="test" bf="s2">
-      <li data-priority="high" tag="urgent" data-key="t1" bf="s1"><!--bf:s0-->one<!--/--></li>
-      <li data-priority="low" tag="normal" data-key="t2" bf="s1"><!--bf:s0-->two<!--/--></li>
+      <li bf="s1" data-key="t1" data-priority="high" tag="urgent"><!--bf:s0-->one<!--/--></li>
+      <li bf="s1" data-key="t2" data-priority="low" tag="normal"><!--bf:s0-->two<!--/--></li>
     </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/return-logical-and.ts
+++ b/packages/adapter-tests/fixtures/return-logical-and.ts
@@ -22,6 +22,6 @@ export function ReturnLogicalAnd() {
 }
 `,
   expectedHtml: `
-    <div style="display:contents" bf-s="test"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+    <div bf-s="test" style="display:contents"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/return-logical-or.ts
+++ b/packages/adapter-tests/fixtures/return-logical-or.ts
@@ -22,6 +22,6 @@ export function ReturnLogicalOr(props: { label?: string }) {
 `,
   props: {},
   expectedHtml: `
-    <div style="display:contents" bf-s="test"><span bf-c="s0">Fallback</span></div>
+    <div bf-s="test" style="display:contents"><span bf-c="s0">Fallback</span></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/return-map.ts
+++ b/packages/adapter-tests/fixtures/return-map.ts
@@ -22,7 +22,7 @@ export function ReturnMap() {
 }
 `,
   expectedHtml: `
-    <div style="display:contents" bf-s="test">
+    <div bf-s="test" style="display:contents">
       <li data-key="a"><!--bf:s0-->a<!--/--></li>
       <li data-key="b"><!--bf:s0-->b<!--/--></li>
     </div>

--- a/packages/adapter-tests/fixtures/return-nullish-coalescing.ts
+++ b/packages/adapter-tests/fixtures/return-nullish-coalescing.ts
@@ -20,6 +20,6 @@ export function ReturnNullishCoalescing(props: { banner?: any }) {
 `,
   props: {},
   expectedHtml: `
-    <div style="display:contents" bf-s="test"><span bf-c="s0">Default</span></div>
+    <div bf-s="test" style="display:contents"><span bf-c="s0">Default</span></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/static-array-children.ts
+++ b/packages/adapter-tests/fixtures/static-array-children.ts
@@ -39,8 +39,8 @@ export function ListItem({ label, className }: { label: string; className?: stri
   },
   expectedHtml: `
     <ul bf-s="test" bf="s1">
-      <li class="text-sm" bf-s="ListItem_*" data-key="Alpha" bf="s1"><!--bf:s0-->Alpha<!--/--></li>
-      <li class="text-sm" bf-s="ListItem_*" data-key="Beta" bf="s1"><!--bf:s0-->Beta<!--/--></li>
+      <li bf-s="ListItem_*" bf="s1" class="text-sm" data-key="Alpha"><!--bf:s0-->Alpha<!--/--></li>
+      <li bf-s="ListItem_*" bf="s1" class="text-sm" data-key="Beta"><!--bf:s0-->Beta<!--/--></li>
     </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
@@ -62,8 +62,8 @@ export function Tag(props: { id: string; variant: 'on' | 'off' }) {
   },
   expectedHtml: `
     <ul bf-s="test" bf="s1">
-      <span class="tag-on" bf-s="Tag_*" data-key="a" bf="s1"><!--bf:s0-->a<!--/--></span>
-      <span class="tag-on" bf-s="Tag_*" data-key="c" bf="s1"><!--bf:s0-->c<!--/--></span>
+      <span bf-s="Tag_*" bf="s1" class="tag-on" data-key="a"><!--bf:s0-->a<!--/--></span>
+      <span bf-s="Tag_*" bf="s1" class="tag-on" data-key="c"><!--bf:s0-->c<!--/--></span>
     </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -46,6 +46,6 @@ export function ReactionBar(props: Props) {
     reactions: { '👍': ['alice', 'bob'] },
   },
   expectedHtml: `
-    <div data-reaction-bar="true" bf-s="test" bf="s2"><button type="button" data-key="👍"><span><!--bf:s0-->👍<!--/--></span><span><!--bf:s1-->2<!--/--></span></button></div>
+    <div bf-s="test" bf="s2" data-reaction-bar="true"><button data-key="👍" type="button"><span><!--bf:s0-->👍<!--/--></span><span><!--bf:s1-->2<!--/--></span></button></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/style-3-signals.ts
+++ b/packages/adapter-tests/fixtures/style-3-signals.ts
@@ -26,6 +26,6 @@ export function Style3Signals() {
 }
 `,
   expectedHtml: `
-    <div style="background:red;color:white;padding:8px" bf-s="test" bf="s0"> hello </div>
+    <div bf-s="test" bf="s0" style="background:red;color:white;padding:8px"> hello </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/style-attribute.ts
+++ b/packages/adapter-tests/fixtures/style-attribute.ts
@@ -9,7 +9,7 @@ export function StyleAttribute() {
 }
 `,
   expectedHtml: `
-    <div style="color: red; font-size: 16px" bf-s="test">Styled</div>
+    <div bf-s="test" style="color: red; font-size: 16px">Styled</div>
   `,
 })
 

--- a/packages/adapter-tests/fixtures/style-object-dynamic.ts
+++ b/packages/adapter-tests/fixtures/style-object-dynamic.ts
@@ -19,6 +19,6 @@ export function StyleObjectDynamic({ color }: { color: string }) {
 `,
   props: { color: 'red' },
   expectedHtml: `
-    <div style="background-color:red;padding:8px" bf-s="test" bf="s0">Hello</div>
+    <div bf-s="test" bf="s0" style="background-color:red;padding:8px">Hello</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/style-object-static.ts
+++ b/packages/adapter-tests/fixtures/style-object-static.ts
@@ -9,6 +9,6 @@ export function StyleObjectStatic() {
 }
 `,
   expectedHtml: `
-    <div style="background:var(--bg-surface);color:var(--text-primary)" bf-s="test">Hello</div>
+    <div bf-s="test" style="background:var(--bg-surface);color:var(--text-primary)">Hello</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/tagged-template-classname.ts
+++ b/packages/adapter-tests/fixtures/tagged-template-classname.ts
@@ -24,6 +24,6 @@ export function TaggedTemplateClassname() {
 }
 `,
   expectedHtml: `
-    <div class="base primary" bf-s="test" bf="s0">x</div>
+    <div bf-s="test" bf="s0" class="base primary">x</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/top-level-ternary.ts
+++ b/packages/adapter-tests/fixtures/top-level-ternary.ts
@@ -22,6 +22,6 @@ export function TopTernaryDemo() {
 }
 `,
   expectedHtml: `
-    <div style="display:contents" bf-s="test"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+    <div bf-s="test" style="display:contents"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/void-elements.ts
+++ b/packages/adapter-tests/fixtures/void-elements.ts
@@ -19,7 +19,7 @@ export function VoidElements() {
     <div bf-s="test">
       <br>
       <hr>
-      <img src="test.png" alt="test">
+      <img alt="test" src="test.png">
       <input type="text">
     </div>
   `,

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -176,7 +176,57 @@ export function normalizeHTML(html: string): string {
     .replace(/>\s+</g, '><')
     // Collapse whitespace
     .replace(/\s+/g, ' ')
+    // Normalize attribute order within tags (#1407). Attribute order is
+    // HTML-semantically irrelevant — `<div id="a" class="b">` and
+    // `<div class="b" id="a">` produce identical DOM — but adapters
+    // diverge: Hono / hono/jsx iterate JS object keys in insertion
+    // order, Go's `bf_spread_attrs` sorts keys for deterministic
+    // output (map[string]any has no insertion order). Sorting
+    // attributes alphabetically inside each tag here lets the SSR
+    // conformance comparison stay byte-equal across adapters.
+    .replace(/<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[^>]+?)?)\s*>/g, (_match, tag, attrs) => {
+      const trimmedAttrs = (attrs as string).trim()
+      if (!trimmedAttrs) return `<${tag}>`
+      const parts = sortHtmlAttributes(trimmedAttrs)
+      return parts.length > 0 ? `<${tag} ${parts.join(' ')}>` : `<${tag}>`
+    })
     .trim()
+}
+
+/**
+ * Tokenise a tag's attribute substring and return the attributes
+ * sorted alphabetically by name. Handles double-quoted, single-
+ * quoted, and bare attribute values, plus boolean (valueless) attrs.
+ */
+function sortHtmlAttributes(attrText: string): string[] {
+  const attrs: string[] = []
+  let i = 0
+  while (i < attrText.length) {
+    while (i < attrText.length && /\s/.test(attrText[i])) i++
+    if (i >= attrText.length) break
+    const nameStart = i
+    while (i < attrText.length && !/[\s=]/.test(attrText[i])) i++
+    const name = attrText.slice(nameStart, i)
+    if (i < attrText.length && attrText[i] === '=') {
+      i++
+      const quote = attrText[i]
+      if (quote === '"' || quote === "'") {
+        i++
+        const valStart = i
+        while (i < attrText.length && attrText[i] !== quote) i++
+        const value = attrText.slice(valStart, i)
+        i++ // skip closing quote
+        attrs.push(`${name}=${quote}${value}${quote}`)
+      } else {
+        const valStart = i
+        while (i < attrText.length && !/\s/.test(attrText[i])) i++
+        attrs.push(`${name}=${attrText.slice(valStart, i)}`)
+      }
+    } else {
+      attrs.push(name)
+    }
+  }
+  return attrs.sort()
 }
 
 /**

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -191,6 +191,17 @@ export function normalizeHTML(html: string): string {
   // non-void tags (`<svg foo="x"/>`, the trailing `/` was consumed
   // as a stray attribute) and `>` characters inside quoted
   // attribute values — are handled correctly (#1411 review).
+  //
+  // **Fixture-author note**: this normalisation is applied to BOTH
+  // expected and actual HTML uniformly, so any fixture that needs to
+  // assert source-order-sensitive attribute emission (duplicate-key
+  // last-wins behaviour, `<meta charset>` ordering in `<head>`,
+  // etc.) cannot use plain `expectedHtml` comparison — those cases
+  // should be pinned via a dedicated assertion in the test file
+  // instead. Today the BarefootJS adapter suite has no such fixture;
+  // if one is added, surface this limitation prominently in its
+  // comment so the next maintainer doesn't wonder why a deliberate
+  // re-ordering "doesn't fail" the conformance check (#1411 review).
   return normalizeTagAttributeOrder(stripped)
 }
 

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -133,7 +133,7 @@ export function normalizeHTML(html: string): string {
   // regex chain so a fallback containing nested `<div>` doesn't mislead
   // any later matcher. See `stripAsyncPlaceholders` for the depth-
   // counted match. (#1298)
-  return stripAsyncPlaceholders(html)
+  const stripped = stripAsyncPlaceholders(html)
     // Remove loop boundary comment markers (template detail, not semantic).
     // Matches both legacy unscoped (`<!--bf-loop-->`) and scoped per-call-site
     // (`<!--bf-loop:l7-->`) forms (#1087). The marker id is `l\d+` — kept
@@ -176,21 +176,97 @@ export function normalizeHTML(html: string): string {
     .replace(/>\s+</g, '><')
     // Collapse whitespace
     .replace(/\s+/g, ' ')
-    // Normalize attribute order within tags (#1407). Attribute order is
-    // HTML-semantically irrelevant — `<div id="a" class="b">` and
-    // `<div class="b" id="a">` produce identical DOM — but adapters
-    // diverge: Hono / hono/jsx iterate JS object keys in insertion
-    // order, Go's `bf_spread_attrs` sorts keys for deterministic
-    // output (map[string]any has no insertion order). Sorting
-    // attributes alphabetically inside each tag here lets the SSR
-    // conformance comparison stay byte-equal across adapters.
-    .replace(/<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[^>]+?)?)\s*>/g, (_match, tag, attrs) => {
-      const trimmedAttrs = (attrs as string).trim()
-      if (!trimmedAttrs) return `<${tag}>`
-      const parts = sortHtmlAttributes(trimmedAttrs)
-      return parts.length > 0 ? `<${tag} ${parts.join(' ')}>` : `<${tag}>`
-    })
     .trim()
+  // Normalize attribute order within tags (#1407). Attribute order is
+  // HTML-semantically irrelevant — `<div id="a" class="b">` and
+  // `<div class="b" id="a">` produce identical DOM — but adapters
+  // diverge: Hono / hono/jsx iterate JS object keys in insertion
+  // order, Go's `bf_spread_attrs` sorts keys for deterministic
+  // output (map[string]any has no insertion order). Sorting
+  // attributes alphabetically inside each tag here lets the SSR
+  // conformance comparison stay byte-equal across adapters.
+  //
+  // The scan is a small purpose-built tokenizer rather than a regex
+  // so two edge cases the regex previously fumbled — self-closing
+  // non-void tags (`<svg foo="x"/>`, the trailing `/` was consumed
+  // as a stray attribute) and `>` characters inside quoted
+  // attribute values — are handled correctly (#1411 review).
+  return normalizeTagAttributeOrder(stripped)
+}
+
+function normalizeTagAttributeOrder(html: string): string {
+  let result = ''
+  let i = 0
+  while (i < html.length) {
+    if (html[i] !== '<' || i + 1 >= html.length) {
+      result += html[i]
+      i++
+      continue
+    }
+    const next = html[i + 1]
+    // Closing tags (`</foo>`), comments (`<!--`), and processing
+    // instructions / doctype (`<!`, `<?`) pass through unchanged —
+    // none of them carry attributes that need sorting.
+    if (next === '/' || next === '!' || next === '?' || !/[a-zA-Z]/.test(next)) {
+      result += html[i]
+      i++
+      continue
+    }
+    // Open tag — scan the tag name, the attrs, an optional
+    // self-close `/`, and the closing `>`.
+    const tagStart = i
+    i++ // skip <
+    const nameStart = i
+    while (i < html.length && /[a-zA-Z0-9-]/.test(html[i])) i++
+    const tagName = html.slice(nameStart, i)
+    // Read body up to `>`, respecting quoted spans so a `>` inside
+    // an attribute value doesn't terminate the tag.
+    let attrText = ''
+    let selfClose = false
+    let closed = false
+    while (i < html.length) {
+      const c = html[i]
+      if (c === '"' || c === "'") {
+        // Consume the quoted span verbatim — `>` inside a quoted
+        // value is legal HTML.
+        attrText += c
+        i++
+        while (i < html.length && html[i] !== c) {
+          attrText += html[i]
+          i++
+        }
+        if (i < html.length) {
+          attrText += html[i]
+          i++
+        }
+        continue
+      }
+      if (c === '/' && i + 1 < html.length && html[i + 1] === '>') {
+        selfClose = true
+        i += 2
+        closed = true
+        break
+      }
+      if (c === '>') {
+        i++
+        closed = true
+        break
+      }
+      attrText += c
+      i++
+    }
+    if (!closed) {
+      // Unterminated tag — emit the raw substring and stop.
+      result += html.slice(tagStart)
+      break
+    }
+    const trimmedAttrs = attrText.trim()
+    const sorted = trimmedAttrs ? sortHtmlAttributes(trimmedAttrs) : []
+    const attrsPart = sorted.length > 0 ? ' ' + sorted.join(' ') : ''
+    const closer = selfClose ? '/>' : '>'
+    result += `<${tagName}${attrsPart}${closer}`
+  }
+  return result
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -74,6 +74,15 @@ interface TransformContext {
   /** Counter for loop marker IDs (l0, l1, ...) — separate from slot IDs so element bf="sN" numbering stays stable across versions (#1087). */
   loopMarkerCounter: number
   /**
+   * Counter for JSX spread bag slot IDs (`Spread_0`, `Spread_1`, ...).
+   * Separate namespace from element slot IDs (`s0`, `s1`, ...) so
+   * adapters that need to plumb the spread bag through a structured
+   * data path (Go template's `.Spread_N`) don't collide with element
+   * scope IDs (#1407). Component-scoped, allocated only when the
+   * spread falls through to the bag-emitting branch.
+   */
+  spreadIdCounter: number
+  /**
    * Memoized free-refs binding environment. Built lazily by
    * `makeBindingEnv` and reused across every `resolveFreeRefs` call as
    * long as `loopParams` content is unchanged. Invalidated by serializing
@@ -226,6 +235,7 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     slotIdCounter: 0,
     asyncIdCounter: 0,
     loopMarkerCounter: 0,
+    spreadIdCounter: 0,
     isRoot: true,
     insideComponentChildren: false,
     loopParams: new Set(),
@@ -342,6 +352,15 @@ function generateSlotId(ctx: TransformContext, forComponent: boolean = false): s
   // passed as children into a child component's scope.
   if (forComponent) return id
   return ctx.insideComponentChildren ? `^${id}` : id
+}
+
+/**
+ * Allocate a component-scoped slot ID for a JSX spread bag (#1407).
+ * Separate namespace from element slot IDs so Go's `Spread_N` field
+ * names never collide with element `bf="sN"` scope IDs.
+ */
+function generateSpreadSlotId(ctx: TransformContext): string {
+  return `Spread_${ctx.spreadIdCounter++}`
 }
 
 /**
@@ -2803,9 +2822,16 @@ function expandSpreadAttribute(
     }))
   }
 
+  // Allocate a component-scoped slot ID so adapters that need a
+  // structured plumbing path (Go's `.Spread_N` struct field) can
+  // address this spread without recomputing identity downstream
+  // (#1407). Hono / Mojo ignore the field; only the Go adapter consumes
+  // it. The closed-type expansion branch above returns before this
+  // point, so closed-type rest spreads stay on the per-key fast path.
+  const slotId = generateSpreadSlotId(ctx)
   return [{
     name: '...',
-    value: AttrValueOf.spread(spreadExpr, ctx.getTemplateJS(attr.expression)),
+    value: AttrValueOf.spread(spreadExpr, ctx.getTemplateJS(attr.expression), slotId),
     loc,
     freeIdentifiers: spreadFreeIdentifiers,
   }]

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -753,6 +753,15 @@ export interface SpreadAttr {
   kind: 'spread'
   expr: string
   templateExpr?: string
+  /**
+   * Component-scoped, stable slot ID assigned at IR-build time for
+   * adapters that need to plumb the spread bag through a structured
+   * data path (Go template's `.Spread_N`, future Mojo `$bf_spread_n`).
+   * Hono ignores it. Only populated when the spread reaches the
+   * bag-emitting branch — closed-type rest spreads short-circuit to
+   * per-key expansion earlier and leave this unset (#1407).
+   */
+  slotId?: string
 }
 
 export interface JsxChildrenAttr {
@@ -791,11 +800,12 @@ export const AttrValueOf = {
   template(parts: IRTemplatePart[]): TemplateAttr {
     return { kind: 'template', parts }
   },
-  spread(expr: string, templateExpr?: string): SpreadAttr {
+  spread(expr: string, templateExpr?: string, slotId?: string): SpreadAttr {
     return {
       kind: 'spread',
       expr,
       ...(templateExpr !== undefined && { templateExpr }),
+      ...(slotId !== undefined && { slotId }),
     }
   },
   jsxChildren(children: IRNode[]): JsxChildrenAttr {


### PR DESCRIPTION
## Summary

Closes the Go side of #1407 by replacing `GoTemplateAdapter.emitSpread`'s BF101 refusal with a real SSR-side lowering. `<div {...attrs()} />` now plumbs the bag through a new `Spread_N map[string]any` field on the component's Props struct and renders via a new `bf_spread_attrs` template helper that mirrors the JS `spreadAttrs` runtime.

Mojo retains BF101 for now; Option 1 for Mojo is a separate follow-up.

## Design decisions (per the planning session)

| Topic | Choice |
|---|---|
| Approach | Option 1 (SSR-side bag lowering) |
| Go bag field type | `map[string]any` |
| Slot strategy | One `Spread_N` field per spread occurrence, allocated at IR build time |
| Loop-internal spread | Supported via inline `{{bf_spread_attrs .}}` against the range iteration value |
| Style object inside spread | Lowered via a Go-side `StyleToCss` port |
| Key order | Alphabetic (matches Go's JSON marshal order) |
| Scope | Go only — Mojo follow-up |

## Issue text correction

The issue claimed `style={{}}` had a "bag-based lowering precedent (#1322 / PR #1331)" that made Option 1 straightforward. In fact #1322 was closed via path (a) — BF101 — and `style-3-signals` is still on `expectedDiagnostics: BF101` in both Go and Mojo. There was no pre-existing bag plumbing on either adapter; this PR builds it from scratch.

## Test plan

- [x] `bun test packages/adapter-go-template/src/__tests__/` — 178 pass / 0 fail
- [x] `bun test packages/adapter-hono/src/__tests__/` — 55 pass / 3 pre-existing fails (unrelated)
- [x] `bun test packages/adapter-mojolicious/src/__tests__/` — 165 pass / 0 fail
- [x] `bun test packages/adapter-tests/src/__tests__/` — 320 pass / 0 fail
- [x] `go test ./runtime/...` — table-driven tests for `SpreadAttrs` and `StyleToCss`

See commit for detailed changelog.

https://claude.ai/code/session_01SA6iS2eBM93tdfi8zvM7gm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SA6iS2eBM93tdfi8zvM7gm)_