### PR TITLE
fix(jsx/#1409 follow-up): inline outer-scope ternary-typed JSX locals at use sites

### DIFF
--- a/packages/jsx/src/__tests__/inlineable-jsx-consts.test.ts
+++ b/packages/jsx/src/__tests__/inlineable-jsx-consts.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression tests for the #1409 follow-up: outer-scope locals whose
+ * initializer holds JSX at a non-root position — `cond ? <jsx/> :
+ * null`, `flag && <jsx/>`, `value ?? <jsx/>` — left their identifier
+ * bare in the emitted client JS and tripped a runtime
+ * `ReferenceError` when referenced from a JSX expression.
+ *
+ *   const cLocal = props.show ? <span>shown</span> : null
+ *   …
+ *   {/* @client * / cLocal}                   // ← `cLocal` undefined at hydrate
+ *
+ * #1410 already handled the case where such locals lived INSIDE an
+ * early-return if-block (via `_branchScopeVars`). This pass extends
+ * the same inline-at-use-site treatment to outer-scope locals:
+ * `analyzer.inlineableJsxConsts` registers any const whose initializer
+ * contains JSX at a non-root position, and `transformExpressionInner`
+ * re-enters the dispatch chain with the initializer expression so the
+ * ternary / binary lowers to IRConditional with `clientOnly`
+ * preserved.
+ *
+ * Pure JSX-literal initializers stay on the existing `jsxConstants`
+ * path (#547) — registered in `analyzer.jsxConstants` and inlined via
+ * the `transformNode` shim.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsContent(result: ReturnType<typeof compileJSX>): string {
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+function hydrateLine(result: ReturnType<typeof compileJSX>): string {
+  const line = clientJsContent(result).split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe('outer-scope inlineable JSX-typed consts (#1409 follow-up)', () => {
+  test("issue exact follow-up repro: ternary-typed local declared after early returns inlines at the @client use site", () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props { kind: 'a' | 'b' | 'c'; show: boolean }
+
+      export function EarlyReturnOuterTernary(props: Props) {
+        const [count] = createSignal(0)
+
+        if (props.kind === 'a') {
+          return <div><span>view A: {count()}</span></div>
+        }
+        if (props.kind === 'b') {
+          return <div><span>view B: {count()}</span></div>
+        }
+
+        const cLocal = props.show ? <span>shown</span> : null
+        return (
+          <div>
+            <span>view C: {count()}</span>
+            {/* @client */ cLocal}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'EarlyReturnOuterTernary.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    // Pre-fix: `updateClientMarker(__scope, 's*', cLocal)` referenced
+    // an undeclared name at outer init scope.
+    expect(content).not.toMatch(/\bcLocal\b/)
+    // The ternary lowers to a clientOnly IRConditional → routes through
+    // `insert()`, and `props.show` is bridged to `_p.show`.
+    expect(content).toContain('insert(__scope')
+    expect(content).toMatch(/_p\.show/)
+  })
+
+  test('outer-scope ternary-typed JSX local without early returns also resolves', () => {
+    // The bug isn't actually about early returns — it's about
+    // ternary-typed JSX locals at outer scope generally. This guards
+    // the same fix on a layout that doesn't involve `if`-statement
+    // returns.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TernaryLocalNoEarly(props: { show: boolean }) {
+        const [count] = createSignal(0)
+        const local = props.show ? <span>shown</span> : null
+        return <div>view: {count()}{/* @client */ local}</div>
+      }
+    `
+    const result = compileJSX(source, 'TernaryLocalNoEarly.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blocal\b/)
+    expect(content).toContain('insert(__scope')
+  })
+
+  test('logical-AND-typed JSX local also inlines (`flag && <jsx/>`)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function AndLocal(props: { show: boolean }) {
+        const [count] = createSignal(0)
+        const local = props.show && <span>shown</span>
+        return <div>view: {count()}{local}</div>
+      }
+    `
+    const result = compileJSX(source, 'AndLocal.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blocal\b/)
+  })
+
+  test('nullish-coalescing-typed JSX local also inlines (`prop ?? <fallback/>`)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function NullishLocal(props: { label: string | null }) {
+        const [count] = createSignal(0)
+        const local = props.label ?? <span>default</span>
+        return <div>view: {count()}{local}</div>
+      }
+    `
+    const result = compileJSX(source, 'NullishLocal.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blocal\b/)
+  })
+
+  test('non-JSX-shaped local is left alone (no spurious inlining)', () => {
+    // Regression guard: a const initializer with no JSX at all must
+    // stay on the regular `localConstants` path. The
+    // `inlineableJsxConsts` map only catches JSX-bearing shapes — a
+    // ternary on two scalars must not get caught and routed through
+    // the JSX-expression dispatcher (which would otherwise return
+    // `null` for both leaves and produce a wrong-shape IR).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ScalarLocal(props: { flag: boolean }) {
+        const [count] = createSignal(0)
+        const label = props.flag ? 'yes' : 'no'
+        return <div>{label}: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'ScalarLocal.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // The chained-const inliner substitutes `label` to its value in
+    // the template. Either `'yes'` (truthy literal in `_p.flag ?
+    // 'yes' : 'no'`) or the ternary itself must appear — what must NOT
+    // appear is an `insert(__scope` call (the IRConditional-with-
+    // clientOnly route), which would mean the JSX dispatcher
+    // mistakenly took ownership of a non-JSX ternary.
+    expect(clientJsContent(result)).not.toContain('insert(__scope')
+  })
+
+  test("JSX inside a helper function body doesn't trip the JSX-shape detector", () => {
+    // The detector walks into the initializer's AST, but stops at any
+    // function / arrow boundary so JSX inside a callback isn't counted.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function HelperJsx(props: { items: string[] }) {
+        const [count] = createSignal(0)
+        const formatter = (item: string) => <span>{item}</span>  // JSX is INSIDE the arrow body
+        return <div>view: {count()}{props.items.map(formatter)}</div>
+      }
+    `
+    const result = compileJSX(source, 'HelperJsx.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // `formatter` is an arrow function, not an inlineable-JSX shape.
+    // Its body's JSX is handled through the `jsxFunctions` (#569) path.
+  })
+
+  test('pure JSX literal local is still handled by `jsxConstants` (#547)', () => {
+    // Regression guard: the new `inlineableJsxConsts` path is consulted
+    // only after the existing `jsxConstants` check misses. Pure JSX
+    // literals must continue to route through the #547 inlining shim.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function PureJsxLocal() {
+        const [count] = createSignal(0)
+        const local = <span>literal</span>
+        return <div>view: {count()}{local}</div>
+      }
+    `
+    const result = compileJSX(source, 'PureJsxLocal.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // Inlined directly: the template contains the literal span, not a
+    // reference to `local`.
+    expect(hydrateLine(result)).toContain('<span>literal</span>')
+    expect(clientJsContent(result)).not.toMatch(/\blocal\b/)
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -100,6 +100,21 @@ export interface AnalyzerContext {
   typeDefinitions: TypeDefinition[]
   /** Maps constant names to their JSX initializer AST nodes (#547) */
   jsxConstants: Map<string, ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment>
+  /**
+   * Maps constant names to initializer AST nodes whose shape contains
+   * JSX at a non-root position — ternary with JSX on either side,
+   * logical-AND / OR / nullish-coalescing with JSX on either side,
+   * parenthesized wrappers around any of the above. The pure-JSX-
+   * literal case (root JSX) stays in `jsxConstants` and routes through
+   * the #547 `transformNode` shim; this map is consulted only after
+   * that miss and routes through `transformExpressionInner` so the
+   * existing JSX-expression dispatcher handles the lowering, including
+   * `clientOnly` propagation. Without this, an outer-scope ternary-
+   * typed JSX local referenced from a JSX expression left a bare
+   * identifier in the emitted client JS at init scope and tripped a
+   * runtime ReferenceError (#1409 follow-up).
+   */
+  inlineableJsxConsts: Map<string, ts.Expression>
   /** Maps function names to their JSX return AST and parameter names (#569) */
   jsxFunctions: Map<string, {
     jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
@@ -195,6 +210,7 @@ export function createAnalyzerContext(
     ambientGlobals: new Set(),
     typeDefinitions: [],
     jsxConstants: new Map(),
+    inlineableJsxConsts: new Map(),
     jsxFunctions: new Map(),
     reactiveFactories: new Map(),
     signalTupleRefs: new Map(),

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1833,6 +1833,35 @@ export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
 }
 
 /**
+ * Check if a const initializer expression contains JSX at a non-root
+ * position — ternary with JSX on either side, logical-AND / OR /
+ * nullish-coalescing with JSX on either side, parenthesized wrappers
+ * around any of the above. Used to qualify constants for `inlineableJsxConsts`
+ * (#1409 follow-up): pure JSX literals already go through `jsxConstants`,
+ * but ternary-typed JSX locals (`cond ? <jsx/> : null`) need the same
+ * inline-at-use-site treatment so a downstream `{/* @client * /
+ * cLocal}` doesn't leak the bare identifier into the emitted client
+ * JS. The walk stops at function / arrow boundaries so JSX inside a
+ * helper's body isn't mistaken for the initializer's own JSX.
+ */
+function initializerShapeContainsJsx(node: ts.Node): boolean {
+  let found = false
+  function visit(n: ts.Node): void {
+    if (found) return
+    if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
+      found = true
+      return
+    }
+    if (ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n) || ts.isArrowFunction(n)) {
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
+  return found
+}
+
+/**
  * Check if an AST node contains an arrow function or function expression.
  */
 function nodeContainsArrow(node: ts.Node): boolean {
@@ -1934,6 +1963,16 @@ function collectConstant(
     if (ts.isJsxElement(init) || ts.isJsxSelfClosingElement(init) || ts.isJsxFragment(init)) {
       isJsx = true
       ctx.jsxConstants.set(name, init)
+    } else if (initializerShapeContainsJsx(init)) {
+      // Non-root JSX initializer (ternary / `&&` / `||` / `??` whose
+      // operand is JSX). Stored here so `transformExpressionInner` can
+      // inline at the use site instead of leaving the bare identifier
+      // in the emitted client JS — the same way pure-JSX literals are
+      // inlined via `jsxConstants`, but routed through the JSX-
+      // expression dispatcher so the conditional / binary shape lowers
+      // to IRConditional (with `clientOnly` preserved when applicable)
+      // (#1409 follow-up).
+      ctx.inlineableJsxConsts.set(name, init)
     }
 
     // Detect arrow function constants with JSX return (#569)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1158,6 +1158,19 @@ function transformExpressionInner(
     if (branchInit) {
       return transformExpressionInner(branchInit, ctx, node, isClientOnly)
     }
+
+    // #1409 follow-up: same inlining for outer-scope consts whose
+    // initializer holds JSX at a non-root position
+    // (`cond ? <jsx/> : null`, `flag && <jsx/>`, `value ?? <jsx/>`).
+    // The pure-JSX-literal case is handled by `jsxConstants` above;
+    // these are picked up by the analyzer into `inlineableJsxConsts`
+    // and routed through the same `transformExpressionInner` re-entry
+    // so the dispatcher lowers the ternary / binary to IRConditional
+    // with `clientOnly` propagated.
+    const inlineableInit = ctx.analyzer.inlineableJsxConsts.get(expr.text)
+    if (inlineableInit) {
+      return transformExpressionInner(inlineableInit, ctx, node, isClientOnly)
+    }
   }
 
   // Delegate all other JSX-structural dispatch to the shared core (#971).


### PR DESCRIPTION
## Summary

Follow-up to #1410 (closes the [follow-up comment](https://github.com/piconic-ai/barefootjs/issues/1409#issuecomment-4485711533) on #1409).

#1410 handled JSX-typed `const X = …` declared **inside an early-return `if`-block** via `_branchScopeVars`. A symmetric crash class remained for **outer-scope** locals whose initializer holds JSX at a non-root position — ternary with JSX on either side, `&&` / `||` / `??` with JSX on either side:

```tsx
export function EarlyReturnOuterTernary(props: { kind: 'a' | 'b' | 'c'; show: boolean }) {
  const [count] = createSignal(0)
  if (props.kind === 'a') return <div><span>view A: {count()}</span></div>
  if (props.kind === 'b') return <div><span>view B: {count()}</span></div>

  const cLocal = props.show ? <span>shown</span> : null   // ← ternary-typed JSX local
  return <div><span>view C: {count()}</span>{/* @client */ cLocal}</div>
}
```

Pre-fix the emitted init function carried `updateClientMarker(__scope, 's2', cLocal)` with `cLocal` undeclared at outer init scope → `ReferenceError: cLocal is not defined`. No compiler diagnostic.

### Why #1410 didn't catch this

#1410's `_branchScopeVars` only covered locals declared **inside** the if-block's `then` body (collected by `analyzer.ts:collectScopeVariables`). The follow-up local lives at the component body's top level, so it goes into `localConstants` — but the pure-JSX-literal check in `collectConstant` (`isJsxElement / isJsxFragment / isJsxSelfClosingElement` after paren unwrap) misses the ternary shape and the const never makes it into `jsxConstants`. Result: neither inlined (no `jsxConstants` entry) nor emitted in init body (JSX in init body isn't representable in barefoot's runtime), and the bare identifier leaked.

### Fix

New `analyzer.inlineableJsxConsts: Map<string, ts.Expression>` parallel to `jsxConstants`. The analyzer registers any const whose initializer (after paren unwrap) contains JSX at a non-root position; `transformExpressionInner` consults it after the existing `jsxConstants` and `_branchScopeVars` lookups and re-enters the dispatch chain with the initializer expression — the ternary / binary lowers through the existing JSX-expression dispatcher (`transformJsxExpression`) to IRConditional with `clientOnly` preserved.

```diff
   if (ts.isIdentifier(expr)) {
     const jsxNode = ctx.analyzer.jsxConstants.get(expr.text)
     if (jsxNode) return transformNode(jsxNode, ctx)

     const branchInit = ctx._branchScopeVars?.get(expr.text)
     if (branchInit) return transformExpressionInner(branchInit, ctx, node, isClientOnly)

+    const inlineableInit = ctx.analyzer.inlineableJsxConsts.get(expr.text)
+    if (inlineableInit) return transformExpressionInner(inlineableInit, ctx, node, isClientOnly)
   }
```

The JSX-shape detector walks the initializer AST but stops at any function / arrow boundary so JSX inside a callback (`(item) => <span>{item}</span>`) isn't mistaken for an inlineable shape.

### Validated

`packages/jsx/src/__tests__/inlineable-jsx-consts.test.ts` — seven shapes:

1. Issue follow-up exact repro (ternary local declared after early returns, `@client` reference).
2. Same shape without early returns — guards that the bug isn't actually about early-return position.
3. `flag && <jsx/>` form.
4. `value ?? <fallback/>` form.
5. Non-JSX-shaped scalar ternary stays on the regular `localConstants` path (no spurious `insert()`).
6. JSX inside a helper-function body doesn't trip the detector.
7. Pure JSX literal still routes through `jsxConstants` (#547).

## Test plan

- [x] `bun test` in `packages/jsx` — 1293 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 320 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 207 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 174 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)