### PR TITLE
feat(mojolicious): lower intrinsic JSX spread on SSR (#1407 follow-up)

### DIFF
--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -421,9 +421,15 @@ sub spread_attrs ($self, $bag) {
         my $val = $bag->{$key};
         # null / undef → drop.
         next unless defined $val;
-        # Boolean false (Perl-side: empty string or 0 produced by
-        # a JSON unmarshal of `false`) → drop. Boolean true → bare
-        # attribute.
+        # Boolean values arrive as Mojo::JSON sentinel objects
+        # (`Mojo::JSON::true` / `false`) — both from JSON-deserialised
+        # props and from the test harness's `toPerlLiteral`
+        # (which emits the sentinels rather than plain 0/1 to avoid
+        # conflating booleans with numeric attribute values like
+        # `tabindex="0"`). The contract is: callers MUST use the
+        # sentinels for boolean values; plain Perl scalars 0/1
+        # render as numeric attribute values, matching how JS
+        # `spreadAttrs` treats a `0`/`1` JS number.
         if (ref($val) eq 'JSON::PP::Boolean' || ref($val) eq 'Mojo::JSON::_Bool') {
             next unless $val;
             push @parts, _to_attr_name($key);

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -309,4 +309,141 @@ sub round ($self, $value) {
     return POSIX::floor($n + 0.5);
 }
 
+# ---------------------------------------------------------------------------
+# JSX intrinsic-element spread (#1407)
+# ---------------------------------------------------------------------------
+#
+# Mirrors the JS `spreadAttrs` runtime
+# (`packages/client/src/runtime/spread-attrs.ts`) and the Go adapter's
+# `bf.SpreadAttrs` so SSR output stays byte-equal across the three
+# adapters. Generated Mojo templates invoke this as
+# `<%== bf->spread_attrs($bag) %>`.
+#
+# Skip rules: nil/false values, event handlers (`on[A-Z]…` shape
+# matching JS `key[2] === key[2].toUpperCase()` — true for any
+# character whose uppercase is itself, including digits and
+# underscore), `children`. `ref` is intentionally NOT filtered,
+# matching the JS reference.
+#
+# Key remap: className → class, htmlFor → for; SVG camelCase
+# attrs preserved (case-sensitive XML spec); other camelCase keys
+# lowered to kebab-case with a leading `-` for an initial
+# uppercase letter (mirrors JS `key.replace(/([A-Z])/g, '-$1')`).
+#
+# `style` is routed through `_style_to_css` so object literals
+# serialise to a real CSS string instead of Perl's default
+# `HASH(0x...)` form.
+#
+# Output is deterministic: keys are sorted alphabetically before
+# emission, matching the Go adapter's `sort.Strings(keys)` policy
+# and Mojo::JSON's marshal order.
+#
+# The return value is a Mojo::ByteStream so the calling template's
+# `<%==` raw-emit skips re-escaping (the helper has already
+# HTML-escaped each value).
+
+my %SVG_CAMEL_CASE_ATTRS = map { $_ => 1 } qw(
+    allowReorder attributeName attributeType autoReverse
+    baseFrequency baseProfile calcMode clipPathUnits
+    contentScriptType contentStyleType diffuseConstant edgeMode
+    externalResourcesRequired filterRes filterUnits glyphRef
+    gradientTransform gradientUnits kernelMatrix kernelUnitLength
+    keyPoints keySplines keyTimes lengthAdjust limitingConeAngle
+    markerHeight markerUnits markerWidth maskContentUnits
+    maskUnits numOctaves pathLength patternContentUnits
+    patternTransform patternUnits pointsAtX pointsAtY pointsAtZ
+    preserveAlpha preserveAspectRatio primitiveUnits refX refY
+    repeatCount repeatDur requiredExtensions requiredFeatures
+    specularConstant specularExponent spreadMethod startOffset
+    stdDeviation stitchTiles surfaceScale systemLanguage
+    tableValues targetX targetY textLength viewBox viewTarget
+    xChannelSelector yChannelSelector zoomAndPan
+);
+
+sub _to_attr_name ($key) {
+    return 'class' if $key eq 'className';
+    return 'for'   if $key eq 'htmlFor';
+    return $key    if $SVG_CAMEL_CASE_ATTRS{$key};
+    # camelCase → kebab-case, with a leading `-` for an initial
+    # uppercase letter (JS-reference parity, even though that case
+    # produces an HTML-invalid attribute name — same documented
+    # behaviour as the Go adapter's `toAttrName`).
+    my $out = $key;
+    $out =~ s/([A-Z])/-\L$1/g;
+    return $out;
+}
+
+sub _html_escape ($value) {
+    # Match the JS `String(v)` → setAttribute path, which escapes
+    # ", &, <, >. Go's `template.HTMLEscapeString` produces the
+    # same shape (using &#34; for the double-quote rather than the
+    # named entity); align here so the byte-equal contract holds.
+    my $s = defined $value ? "$value" : '';
+    $s =~ s/&/&amp;/g;
+    $s =~ s/</&lt;/g;
+    $s =~ s/>/&gt;/g;
+    $s =~ s/"/&#34;/g;
+    $s =~ s/'/&#39;/g;
+    return $s;
+}
+
+sub _style_to_css ($value) {
+    return undef unless defined $value;
+    # Non-hashref values pass through stringified — matches the JS
+    # `typeof value !== 'object'` branch in `styleToCss`.
+    if (ref($value) ne 'HASH') {
+        my $s = "$value";
+        return length $s ? $s : undef;
+    }
+    my @parts;
+    for my $key (sort keys %$value) {
+        my $v = $value->{$key};
+        next unless defined $v;
+        my $prop = $key;
+        $prop =~ s/([A-Z])/-\L$1/g;
+        push @parts, "$prop:$v";
+    }
+    return @parts ? join(';', @parts) : undef;
+}
+
+sub spread_attrs ($self, $bag) {
+    return '' unless defined $bag && ref($bag) eq 'HASH';
+    my @parts;
+    for my $key (sort keys %$bag) {
+        # Event handlers: skip when key starts `on` and the third
+        # character is its own uppercase form (uppercase letter,
+        # digit, underscore, …). Mirrors the JS predicate.
+        if (length($key) > 2 && substr($key, 0, 2) eq 'on') {
+            my $c = substr($key, 2, 1);
+            next if uc($c) eq $c;
+        }
+        next if $key eq 'children';
+        my $val = $bag->{$key};
+        # null / undef → drop.
+        next unless defined $val;
+        # Boolean false (Perl-side: empty string or 0 produced by
+        # a JSON unmarshal of `false`) → drop. Boolean true → bare
+        # attribute.
+        if (ref($val) eq 'JSON::PP::Boolean' || ref($val) eq 'Mojo::JSON::_Bool') {
+            next unless $val;
+            push @parts, _to_attr_name($key);
+            next;
+        }
+        # `style` routes through `_style_to_css` so object literals
+        # serialise to a real CSS string.
+        if ($key eq 'style') {
+            my $css = _style_to_css($val);
+            next unless defined $css && length $css;
+            push @parts, qq{style="} . _html_escape($css) . qq{"};
+            next;
+        }
+        my $name = _to_attr_name($key);
+        push @parts, $name . qq{="} . _html_escape($val) . qq{"};
+    }
+    return '' unless @parts;
+    # Return a Mojo::ByteStream so the calling template's `<%==`
+    # raw-emit doesn't re-escape the already-escaped values.
+    return b(join(' ', @parts));
+}
+
 1;

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -374,10 +374,20 @@ sub _to_attr_name ($key) {
 }
 
 sub _html_escape ($value) {
-    # Match the JS `String(v)` → setAttribute path, which escapes
-    # ", &, <, >. Go's `template.HTMLEscapeString` produces the
-    # same shape (using &#34; for the double-quote rather than the
-    # named entity); align here so the byte-equal contract holds.
+    # HTML attribute-value escape for SSR string emission. The
+    # spread bag's values reach the browser as part of a generated
+    # `key="..."` substring inside the rendered HTML, so the
+    # escape set has to cover everything that could break either
+    # the surrounding double-quoted attribute or the enclosing
+    # tag: `&`, `<`, `>`, `"`, and `'`. Matches Go's
+    # `template.HTMLEscapeString` semantics byte-for-byte (using
+    # `&#34;` / `&#39;` for quotes rather than the named entities)
+    # so the SSR output is identical across the Go and Mojo
+    # adapters (#1407, #1413 review). The CSR-side
+    # `applyRestAttrs` calls `el.setAttribute(name, String(value))`
+    # — which does its own DOM-level escaping in the browser —
+    # so JS doesn't need an explicit escape pass; Perl/Go emit a
+    # string, so we do.
     my $s = defined $value ? "$value" : '';
     $s =~ s/&/&amp;/g;
     $s =~ s/</&lt;/g;

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -101,16 +101,6 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
-    // #1244 stress catalog #13 (#1324): JSX spread of a reactive object
-    // (`<div {...attrs()} />`). Mojo can't loop a runtime hash into
-    // `key="value"` pairs with the escaping / event-filter semantics
-    // that Hono / CSR's `applyRestAttrs` provides — surfaces BF101
-    // instead of silently dropping the spread. The Go adapter grew an
-    // SSR lowering for these in #1407; Mojo will follow in a separate
-    // PR.
-    'jsx-spread-reactive': [{ code: 'BF101', severity: 'error' }],
-    'jsx-spread-multiple': [{ code: 'BF101', severity: 'error' }],
-    'jsx-spread-static-and-spread': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -780,33 +780,23 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     emitBooleanAttr: (_value, name) => name,
     emitTemplate: (value, name) =>
       `${name}="<%= ${this.convertTemplateLiteralPartsToPerl(value.parts)} %>"`,
-    // Spread attributes (`<div {...attrs()} />`) have no idiomatic
-    // Embedded Perl form — looping over a hash with key-by-key
-    // attribute emission requires HTML escaping and event-handler
-    // filtering that don't round-trip through Hono / CSR's
-    // `applyRestAttrs` semantics. Record BF101 so the user gets a
-    // diagnostic instead of a silently dropped spread (#1324).
+    // Spread attributes (`<div {...attrs()} />`) lower through the
+    // `bf->spread_attrs` Perl runtime helper (#1407), mirroring the
+    // Go adapter's `bf_spread_attrs` and the JS `spreadAttrs` from
+    // `@barefootjs/client/runtime`. The bag's source JS expression
+    // is translated to a Perl expression via `convertExpressionToPerl`
+    // (e.g. `attrs()` → `$attrs`, `props.bag` → `$bag`); the helper
+    // accepts a hashref and emits a Mojo::ByteStream with sorted,
+    // escaped `key="value"` pairs.
+    //
+    // No struct-field plumbing is needed on Perl: templates evaluate
+    // expressions inline against the props hash, so the spread
+    // identifier resolves directly. `IRAttribute.slotId` is set by
+    // the IR pass but the Mojo adapter ignores it — the slot field
+    // exists only for the Go adapter's static-typed Props struct.
     emitSpread: (value) => {
-      this.errors.push({
-        code: 'BF101',
-        severity: 'error',
-        message: `JSX spread '{...${value.expr}}' on an intrinsic element has no Mojo template lowering`,
-        loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-        suggestion: {
-          // The Mojo SSR path doesn't currently honor
-          // `IRAttribute.clientOnly` for non-rest spreads, and the
-          // client-JS pipeline skips them too — `/* @client */`
-          // wouldn't apply the spread at hydration either. Recommend
-          // the only two workarounds that actually work today: move
-          // the JSX into a `'use client'` component (where the
-          // hydrated runtime's `spreadAttrs` helper handles the bag),
-          // or expand the spread into discrete attribute props at the
-          // call site so each key reaches a lowering the adapter
-          // supports.
-          message: 'Move the JSX into a `\'use client\'` component (so hydration applies the spread via `spreadAttrs`), or expand the spread into discrete attribute props at the call site.',
-        },
-      })
-      return ''
+      const perlExpr = this.convertExpressionToPerl(value.expr)
+      return `<%== bf->spread_attrs(${perlExpr}) %>`
     },
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -794,7 +794,16 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // identifier resolves directly. `IRAttribute.slotId` is set by
     // the IR pass but the Mojo adapter ignores it — the slot field
     // exists only for the Go adapter's static-typed Props struct.
+    //
+    // Gate unsupported shapes (object literals, tagged-template
+    // literals, etc.) up front via `refuseUnsupportedAttrExpression`
+    // so a spread like `{...{id: 'x'}}` surfaces BF101 instead of
+    // letting `convertExpressionToPerl` emit invalid Embedded Perl
+    // that would crash at render time (#1413 review).
     emitSpread: (value) => {
+      if (this.refuseUnsupportedAttrExpression(value.expr, '...')) {
+        return ''
+      }
       const perlExpr = this.convertExpressionToPerl(value.expr)
       return `<%== bf->spread_attrs(${perlExpr}) %>`
     },

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -434,14 +434,75 @@ function parseLiteral(expr: string): unknown {
   if (expr === 'false') return false
   if (expr === '[]') return []
   if (/^['"](.*)['"]$/.test(expr)) return expr.slice(1, -1)
+  // Plain JS object literal (#1407 follow-up): `{ id: 'a', class: 'on' }`.
+  // Sufficient for spread-bag signal initial values used by the
+  // `jsx-spread-*` fixture family — keys are bare identifiers or
+  // string literals, values are scalars. Anything more elaborate
+  // (nested objects, function calls, identifiers) keeps returning
+  // null and the harness falls back to its existing `undef`
+  // behaviour.
+  const trimmed = expr.trim()
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    const inner = trimmed.slice(1, -1).trim()
+    if (!inner) return {}
+    const obj: Record<string, unknown> = {}
+    // Split on commas at depth 0; values may contain `:` so use a
+    // simple state machine instead of a regex.
+    const pairs: string[] = []
+    let depth = 0
+    let start = 0
+    let quote: string | null = null
+    for (let i = 0; i < inner.length; i++) {
+      const c = inner[i]
+      if (quote) {
+        if (c === quote && inner[i - 1] !== '\\') quote = null
+        continue
+      }
+      if (c === '"' || c === "'") {
+        quote = c
+        continue
+      }
+      if (c === '{' || c === '[') depth++
+      else if (c === '}' || c === ']') depth--
+      else if (c === ',' && depth === 0) {
+        pairs.push(inner.slice(start, i))
+        start = i + 1
+      }
+    }
+    pairs.push(inner.slice(start))
+    for (const pair of pairs) {
+      const colonIdx = pair.indexOf(':')
+      if (colonIdx < 0) return null
+      let key = pair.slice(0, colonIdx).trim()
+      const val = pair.slice(colonIdx + 1).trim()
+      // Strip key quotes if any.
+      const keyMatch = key.match(/^['"](.*)['"]$/)
+      if (keyMatch) key = keyMatch[1]
+      const parsedVal = parseLiteral(val)
+      if (parsedVal === null && val !== 'null') return null
+      obj[key] = parsedVal
+    }
+    return obj
+  }
   return null
 }
 
 function toPerlLiteral(value: unknown): string {
-  if (typeof value === 'string') return `'${value}'`
+  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`
   if (typeof value === 'number') return String(value)
   if (typeof value === 'boolean') return value ? '1' : '0'
   if (Array.isArray(value)) return '[]'
+  // Plain object → Perl hashref literal. Used by the spread-bag
+  // signal initial values (#1407 follow-up). Keys are quoted as
+  // Perl strings; values recurse so nested-but-simple shapes
+  // still work.
+  if (value && typeof value === 'object') {
+    const entries: string[] = []
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      entries.push(`'${key.replace(/'/g, "\\'")}' => ${toPerlLiteral(v)}`)
+    }
+    return `{${entries.join(', ')}}`
+  }
   return 'undef'
 }
 

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -195,6 +195,11 @@ use utf8;
 use lib '${LIB_DIR}';
 use Mojolicious;
 use Mojo::Template;
+# Boolean values in spread bags arrive as Mojo::JSON::true /
+# Mojo::JSON::false from the JS-side toPerlLiteral so
+# BarefootJS::spread_attrs can detect them via ref() and apply
+# boolean-attr semantics (#1407 follow-up, #1413 review).
+use Mojo::JSON;
 
 use BarefootJS;
 
@@ -434,13 +439,13 @@ function parseLiteral(expr: string): unknown {
   if (expr === 'false') return false
   if (expr === '[]') return []
   if (/^['"](.*)['"]$/.test(expr)) return expr.slice(1, -1)
-  // Plain JS object literal (#1407 follow-up): `{ id: 'a', class: 'on' }`.
-  // Sufficient for spread-bag signal initial values used by the
-  // `jsx-spread-*` fixture family — keys are bare identifiers or
-  // string literals, values are scalars. Anything more elaborate
-  // (nested objects, function calls, identifiers) keeps returning
-  // null and the harness falls back to its existing `undef`
-  // behaviour.
+  // JS object literal (#1407 follow-up): `{ id: 'a', class: 'on' }`.
+  // Used for spread-bag signal initial values in the `jsx-spread-*`
+  // fixture family. Supports nested objects and arrays via
+  // recursive `parseLiteral`. Trailing commas (`{ id: 'a', }`) are
+  // accepted by skipping empty segments. Anything the recursive
+  // call can't handle (identifiers, function calls, member access)
+  // surfaces as null from the inner call and bubbles up.
   const trimmed = expr.trim()
   if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
     const inner = trimmed.slice(1, -1).trim()
@@ -471,6 +476,9 @@ function parseLiteral(expr: string): unknown {
     }
     pairs.push(inner.slice(start))
     for (const pair of pairs) {
+      // Skip empty segments — typically a trailing comma's tail
+      // (#1413 review).
+      if (!pair.trim()) continue
       const colonIdx = pair.indexOf(':')
       if (colonIdx < 0) return null
       let key = pair.slice(0, colonIdx).trim()
@@ -487,19 +495,35 @@ function parseLiteral(expr: string): unknown {
   return null
 }
 
+/**
+ * Perl single-quoted string escape: `'` AND `\` need escaping.
+ * Perl single quotes treat a trailing backslash as escaping the
+ * closing quote (`'foo\'` is invalid), so values ending in `\`
+ * must double the backslash (#1413 review).
+ */
+function perlSingleQuote(s: string): string {
+  return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
 function toPerlLiteral(value: unknown): string {
-  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`
+  if (typeof value === 'string') return perlSingleQuote(value)
   if (typeof value === 'number') return String(value)
-  if (typeof value === 'boolean') return value ? '1' : '0'
+  // JS booleans → Mojo::JSON sentinel objects so `BarefootJS::spread_attrs`
+  // can detect them via `ref()` and apply boolean-attr semantics
+  // (true → bare attribute, false → omitted). Emitting plain Perl
+  // 0/1 would conflate genuine numeric values with booleans and
+  // turn `disabled: false` into `disabled="0"` (#1413 review).
+  if (typeof value === 'boolean') return value ? 'Mojo::JSON::true' : 'Mojo::JSON::false'
   if (Array.isArray(value)) return '[]'
   // Plain object → Perl hashref literal. Used by the spread-bag
   // signal initial values (#1407 follow-up). Keys are quoted as
-  // Perl strings; values recurse so nested-but-simple shapes
-  // still work.
+  // Perl strings (escaped via `perlSingleQuote` so values
+  // containing `\` or `'` round-trip safely); values recurse so
+  // nested-but-simple shapes still work.
   if (value && typeof value === 'object') {
     const entries: string[] = []
     for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-      entries.push(`'${key.replace(/'/g, "\\'")}' => ${toPerlLiteral(v)}`)
+      entries.push(`${perlSingleQuote(key)} => ${toPerlLiteral(v)}`)
     }
     return `{${entries.join(', ')}}`
   }

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -438,7 +438,13 @@ function parseLiteral(expr: string): unknown {
   if (expr === 'true') return true
   if (expr === 'false') return false
   if (expr === '[]') return []
-  if (/^['"](.*)['"]$/.test(expr)) return expr.slice(1, -1)
+  // String literal — require matching opener/closer (the previous
+  // regex `^['"]…['"]$` accepted mixed quotes like `'foo"`) and
+  // unescape JS-style escape sequences so `'a\\'b'` round-trips as
+  // `a\'b` instead of leaking the source-level escapes into the
+  // Perl literal (#1413 review).
+  const stringMatch = expr.match(/^(['"])(.*)\1$/s)
+  if (stringMatch) return unescapeJsString(stringMatch[2])
   // JS object literal (#1407 follow-up): `{ id: 'a', class: 'on' }`.
   // Used for spread-bag signal initial values in the `jsx-spread-*`
   // fixture family. Keys may be bare identifiers or string
@@ -466,7 +472,19 @@ function parseLiteral(expr: string): unknown {
     for (let i = 0; i < inner.length; i++) {
       const c = inner[i]
       if (quote) {
-        if (c === quote && inner[i - 1] !== '\\') quote = null
+        // Quote-termination check: count consecutive backslashes
+        // immediately before the current position. An EVEN count
+        // means each `\\` pair represents a literal backslash and
+        // the quote is unescaped, closing the string. An ODD
+        // count means the trailing `\` escapes the quote, so the
+        // string keeps going. The naive `inner[i-1] !== '\\'`
+        // check mis-classifies even runs (`\\"`) as escaped
+        // (#1413 review).
+        if (c === quote) {
+          let backslashes = 0
+          for (let j = i - 1; j >= 0 && inner[j] === '\\'; j--) backslashes++
+          if (backslashes % 2 === 0) quote = null
+        }
         continue
       }
       if (c === '"' || c === "'") {
@@ -489,9 +507,11 @@ function parseLiteral(expr: string): unknown {
       if (colonIdx < 0) return null
       let key = pair.slice(0, colonIdx).trim()
       const val = pair.slice(colonIdx + 1).trim()
-      // Strip key quotes if any.
-      const keyMatch = key.match(/^['"](.*)['"]$/)
-      if (keyMatch) key = keyMatch[1]
+      // Strip key quotes if any — require matching open/close
+      // quote and unescape, same shape as the value-side string
+      // literal handling above (#1413 review).
+      const keyMatch = key.match(/^(['"])(.*)\1$/s)
+      if (keyMatch) key = unescapeJsString(keyMatch[2])
       const parsedVal = parseLiteral(val)
       if (parsedVal === null && val !== 'null') return null
       obj[key] = parsedVal
@@ -499,6 +519,32 @@ function parseLiteral(expr: string): unknown {
     return obj
   }
   return null
+}
+
+/**
+ * Unescape a JS string-literal body (the content between the
+ * matching opening and closing quotes, not the quotes themselves).
+ * Handles the common single-character escapes `\\`, `\'`, `\"`,
+ * `\n`, `\r`, `\t`, `\0`, and the backslash-anything fallback that
+ * mirrors JS's "unknown escape is the character itself" semantics.
+ * Hex / unicode / octal escapes are intentionally out of scope —
+ * the spread-bag fixture corpus uses ASCII identifiers and short
+ * literal values, so the harness doesn't need a full JS string
+ * decoder (#1413 review).
+ */
+function unescapeJsString(s: string): string {
+  return s.replace(/\\(.)/g, (_, c) => {
+    switch (c) {
+      case 'n': return '\n'
+      case 'r': return '\r'
+      case 't': return '\t'
+      case '0': return '\0'
+      // `\\`, `\'`, `\"`, and any other single-character escape
+      // collapse to the literal character (matches JS semantics
+      // for unrecognised escapes).
+      default: return c
+    }
+  })
 }
 
 /**

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -441,11 +441,17 @@ function parseLiteral(expr: string): unknown {
   if (/^['"](.*)['"]$/.test(expr)) return expr.slice(1, -1)
   // JS object literal (#1407 follow-up): `{ id: 'a', class: 'on' }`.
   // Used for spread-bag signal initial values in the `jsx-spread-*`
-  // fixture family. Supports nested objects and arrays via
-  // recursive `parseLiteral`. Trailing commas (`{ id: 'a', }`) are
-  // accepted by skipping empty segments. Anything the recursive
-  // call can't handle (identifiers, function calls, member access)
-  // surfaces as null from the inner call and bubbles up.
+  // fixture family. Keys may be bare identifiers or string
+  // literals; values are scalars (string / number / boolean /
+  // null) or nested object literals via recursive `parseLiteral`.
+  // Non-empty array values (`[1, 2]`) are NOT supported — only
+  // the `[]` empty-array literal recognised by the early-return
+  // above lowers. Trailing commas (`{ id: 'a', }`) are accepted
+  // by skipping empty segments (#1413 review). Anything the
+  // recursive call can't handle (identifiers, function calls,
+  // member access, non-empty arrays) surfaces as null and bubbles
+  // up so the harness falls back to its existing `undef`
+  // behaviour.
   const trimmed = expr.trim()
   if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
     const inner = trimmed.slice(1, -1).trim()

--- a/packages/adapter-mojolicious/t/spread_attrs.t
+++ b/packages/adapter-mojolicious/t/spread_attrs.t
@@ -1,0 +1,122 @@
+use Test2::V0;
+
+# spread_attrs — JSX intrinsic-element spread runtime helper (#1407
+# follow-up). Mirrors the JS `spreadAttrs` in
+# packages/client/src/runtime/spread-attrs.ts and the Go adapter's
+# `bf.SpreadAttrs` so SSR output stays byte-equal across the three
+# adapters. Cross-adapter parity regressions surface here first.
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use Mojo::JSON qw(true false);
+
+use BarefootJS;
+
+# `BarefootJS->new` requires a controller; the runtime spread
+# helper is a pure function of $self + bag, so a bare blessed hash
+# is sufficient.
+my $bf = bless { c => undef, config => {} }, 'BarefootJS';
+
+# spread_attrs returns Mojo::ByteStream so callers can `<%==` it
+# without re-escaping. Stringify here for assertion convenience.
+sub run { return "" . $bf->spread_attrs(@_) }
+
+subtest 'basic shapes' => sub {
+    is run(undef),       '', 'undef bag → empty';
+    is run({}),          '', 'empty bag → empty';
+    is run('not a hash'), '', 'non-hash scalar → empty';
+    is run({id => 'a'}), 'id="a"', 'single string';
+};
+
+subtest 'alphabetic key order (deterministic SSR)' => sub {
+    is run({id => 'a', class => 'on'}),
+       'class="on" id="a"',
+       'sorted by key name';
+};
+
+subtest 'key remapping' => sub {
+    is run({className => 'foo'}), 'class="foo"',  'className → class';
+    is run({htmlFor   => 'x'}),   'for="x"',      'htmlFor → for';
+    is run({dataPriority => 'high'}),
+       'data-priority="high"',
+       'camelCase → kebab-case';
+    # SVG XML attrs are case-sensitive — preserve verbatim.
+    is run({viewBox => '0 0 10 10'}),
+       'viewBox="0 0 10 10"',
+       'SVG viewBox preserved';
+    is run({clipPathUnits => 'userSpaceOnUse'}),
+       'clipPathUnits="userSpaceOnUse"',
+       'SVG clipPathUnits preserved';
+    # JS-reference parity (#1411): a leading uppercase letter
+    # emits a leading dash. The resulting HTML attribute name is
+    # invalid in both the JS and Perl/Go runtimes, but the byte-
+    # equal output across the three adapters matters more.
+    is run({XData => 'x'}),
+       '-x-data="x"',
+       'leading-uppercase emits leading dash (JS-reference parity)';
+};
+
+subtest 'event handlers — JS predicate parity' => sub {
+    # JS: `key.startsWith('on') && key.length > 2 && key[2] === key[2].toUpperCase()`.
+    is run({onClick => 'fn', id => 'a'}), 'id="a"',
+       'onClick skipped (uppercase third char)';
+    is run({on_custom => 'fn', id => 'a'}), 'id="a"',
+       'on_custom skipped (underscore third char)';
+    is run({on0 => 'fn', id => 'a'}), 'id="a"',
+       'on0 skipped (digit third char)';
+    is run({oncology => 'x'}), 'oncology="x"',
+       'on + lowercase letter NOT treated as event';
+};
+
+subtest 'children skipped, ref passed through (JS-reference parity)' => sub {
+    is run({children => 'x', id => 'a'}), 'id="a"',
+       'children skipped';
+    # JS `spreadAttrs` does NOT filter `ref` (`applyRestAttrs` does
+    # — that's a separate divergence). Match the JS reference so
+    # SSR stays byte-equal with Hono / Go.
+    is run({ref => 'x', id => 'a'}), 'id="a" ref="x"',
+       'ref passes through';
+};
+
+subtest 'boolean values via Mojo::JSON sentinels' => sub {
+    # The contract: callers MUST use Mojo::JSON::true/false for
+    # booleans. Plain scalar 0/1 render as numeric values.
+    is run({hidden => true, id => 'a'}),
+       'hidden id="a"',
+       'true → bare attribute';
+    is run({hidden => false, id => 'a'}),
+       'id="a"',
+       'false → omitted';
+    # Plain numeric 0 renders as a value (matches HTML
+    # `tabindex="0"` use case).
+    is run({tabindex => 0}),
+       'tabindex="0"',
+       'plain scalar 0 → numeric attribute value';
+};
+
+subtest 'nullish skip' => sub {
+    is run({a => undef, b => 'x'}),
+       'b="x"',
+       'undef value omitted';
+};
+
+subtest 'HTML escape' => sub {
+    is run({title => '<b>"x"</b>'}),
+       'title="&lt;b&gt;&#34;x&#34;&lt;/b&gt;"',
+       'angle brackets and quotes escaped';
+    is run({alt => "tom & jerry"}),
+       'alt="tom &amp; jerry"',
+       'ampersand escaped';
+};
+
+subtest 'style object lowering' => sub {
+    is run({style => {backgroundColor => 'red', color => 'white'}}),
+       'style="background-color:red;color:white"',
+       'style hashref → CSS string';
+    is run({style => 'color:red'}),
+       'style="color:red"',
+       'style scalar passthrough';
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Brings the Mojolicious adapter to parity with the Go adapter's #1407 SSR-side JSX spread lowering. `<div {...attrs()} />` now compiles to `<%== bf->spread_attrs($attrs) %>` and renders via a new `BarefootJS::spread_attrs` Perl helper.

Follow-up to #1411 (merged): the Go side landed there, the Mojo side was deferred.

## Design

Mojo has no struct-field plumbing — Perl templates evaluate expressions inline against the props hash, so the spread identifier (`$attrs`, `$bag`, etc.) resolves directly. The `IRAttribute.slotId` field set by the IR pass is ignored on this path; it exists only for the Go adapter's statically-typed Props struct.

- `convertExpressionToPerl(value.expr)` translates the JS expression to Perl (e.g. `attrs()` → `$attrs`, `props.bag` → `$bag`).
- `emitSpread` wraps it in `<%== bf->spread_attrs(...) %>` and lets the helper do the rest.
- Component-prop spread (which uses Perl's native `%{$expr}` hash-deref) is unchanged.

## Parity with Go / JS

`BarefootJS::spread_attrs` mirrors the rules in `bf_spread_attrs` (Go) and `spreadAttrs` (JS):

- Skip event handlers (`on[A-Z]…` predicate matching JS `key[2] === key[2].toUpperCase()`), `children`.
- **Don't** skip `ref` (matches JS reference; aligning JS `spreadAttrs` vs `applyRestAttrs` is a separate concern).
- Remap `className` → `class`, `htmlFor` → `for`.
- SVG camelCase attrs preserved (`viewBox`, `clipPathUnits`, etc.).
- camelCase → kebab-case via `s/([A-Z])/-\L$1/g` (leading uppercase produces a leading `-`, byte-equal with JS / Go).
- `style` object → CSS string via `_style_to_css`.
- HTML-escape values (`&`, `<`, `>`, `"`, `'`).
- Alphabetic key order for deterministic output (matches Go's `sort.Strings(keys)` and Mojo::JSON marshal order).
- Returns a `Mojo::ByteStream` so the calling template's `<%==` raw-emit skips re-escaping.

## Harness change

`test-render.ts`'s `parseLiteral` / `toPerlLiteral` now recognise plain JS object literals so signal initial values like `createSignal({id: 'a', class: 'on'})` reach the Mojo template scope as a hashref rather than `undef`. This unblocks the `jsx-spread-reactive` fixture's signal-init shape; nested or function-laden literals still return `null`.

## Test plan

- [x] `bun test packages/adapter-mojolicious/src/__tests__/` — 165 pass / 0 fail / 19 skip (skips are Perl-unrelated)
- [x] All 3 `jsx-spread-*` fixtures pass on Mojo with `expectedHtml` parity:
  - `jsx-spread-reactive`
  - `jsx-spread-multiple`
  - `jsx-spread-static-and-spread`
- [x] Mojo's BF101 `expectedDiagnostics` entries removed
- [x] No regressions on Go adapter (508 pass / 0 fail) or adapter-tests (320 pass / 0 fail)
- [x] Hono unchanged (55 pass / 3 pre-existing context-bridge fails)

## Related

- #1407 (parent)
- #1411 (Go side, merged)

https://claude.ai/code/session_01SA6iS2eBM93tdfi8zvM7gm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SA6iS2eBM93tdfi8zvM7gm)_