### PR TITLE
fix(jsx/#1414): inline branch-scope locals at element-attribute positions

### DIFF
--- a/packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for the #1414 matrix follow-up. The
+ * "inline at use sites" pass added in #1410 (then extended in #1412
+ * for ternary-typed JSX initializers) was shaped around the
+ * `{/* @client * / X}` JSX-child position. Element-attribute
+ * positions (`style={local}`, `className={local}`, generic
+ * `attr={local}`) took a different code path through
+ * `getAttributeValue` → template emit and didn't visit the inline
+ * pass, so a branch-local string identifier leaked into the
+ * emitted template lambda and tripped `ReferenceError: local is
+ * not defined` at hydrate.
+ *
+ * Fix: in `getAttributeValue`, when an attribute value is a bare
+ * identifier that resolves to a `_branchScopeVars` entry with a
+ * non-JSX initializer, substitute the identifier's AST with the
+ * initializer's AST before the downstream attribute-shape probes
+ * (template-literal / ternary / generic-expression). JSX-bearing
+ * initializers are skipped because attribute positions can't host
+ * JSX; those keep the JSX-child-position inlining route from
+ * #1410.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsContent(result: ReturnType<typeof compileJSX>): string {
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+function hydrateLine(result: ReturnType<typeof compileJSX>): string {
+  const line = clientJsContent(result).split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe('branch-local at element-attribute position (#1414)', () => {
+  test('string local at `style` attribute substitutes the literal', () => {
+    // Pre-fix: template lambda referenced `local` at outer scope.
+    // Post-fix: the identifier is substituted with the literal,
+    // and `styleToCss('color:red')` evaluates fine at hydrate.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function CaseStringAtStyle(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = 'color:red'
+          return <div style={local}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'CaseStringAtStyle.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).not.toMatch(/\blocal\b/)
+    expect(hydrate).toContain("'color:red'")
+  })
+
+  test('string local at `className` attribute substitutes the literal', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function CaseStringAtClass(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = 'foo bar'
+          return <div className={local}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'CaseStringAtClass.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).not.toMatch(/\blocal\b/)
+    expect(hydrate).toContain("'foo bar'")
+  })
+
+  test('ternary-string branch local at `style` attribute (#1414 case 6)', () => {
+    // Speculative case in the matrix that turns out to share the
+    // same fix: the ternary initializer doesn't contain JSX, so it
+    // qualifies for substitution. The downstream attribute path
+    // detects the ConditionalExpression shape and routes through
+    // the existing ternary template handling.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function CaseTernaryStringAtStyle(props: { kind: 'a' | 'b'; warn: boolean }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = props.warn ? 'color:orange' : 'color:green'
+          return <div style={local}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'CaseTernaryStringAtStyle.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).not.toMatch(/\blocal\b/)
+    expect(hydrate).toContain("color:orange")
+    expect(hydrate).toContain("color:green")
+    // The branch's `props.warn` reference is correctly bridged to `_p.warn`.
+    expect(hydrate).toMatch(/_p\.warn/)
+  })
+
+  test('string local at generic `data-*` attribute', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function CaseDataAttr(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = 'flagged'
+          return <div data-status={local}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'CaseDataAttr.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).not.toMatch(/\blocal\b/)
+    expect(hydrate).toContain("'flagged'")
+  })
+
+  test('branch-local with JSX initializer at attribute position stays unmodified', () => {
+    // Regression guard: the substitution must skip initializers that
+    // contain JSX. Attribute values can't host JSX, and the
+    // existing JSX-child-position fix (#1410) handles those at the
+    // `@client` use site. Substituting here would emit malformed
+    // template output.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function JsxLocalAttr(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          // Contrived: JSX literal local. Using it as an attribute
+          // value isn't a real pattern; this test guards that the
+          // substitution doesn't crash or emit JSX into the attr text.
+          const local = <span>x</span>
+          // Use the local at the @client child position (the real
+          // pattern), and a separate plain title attribute. The
+          // template must not contain a bare \`local\` identifier.
+          return <div title="t">{/* @client */ local}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'JsxLocalAttr.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    // JSX literal is inlined at the @client child position (per #1410).
+    const hydrate = hydrateLine(result)
+    expect(hydrate).toContain('<span>x</span>')
+    expect(hydrate).not.toMatch(/\blocal\b/)
+  })
+
+  test('outer-scope string const at attribute position keeps existing inliner path', () => {
+    // Negative-side regression: an outer-scope const at attribute
+    // position must keep going through `compute-inlinability`
+    // (chained-const resolution + relocate), not through the
+    // branch-scope substitution that only fires for `_branchScopeVars`
+    // entries.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function OuterScopeAttr(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        const local = 'foo bar'
+        return <div className={local}>view: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'OuterScopeAttr.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    // compute-inlinability already inlines this outer-scope string
+    // const at template scope, so `local` does NOT appear as a bare
+    // identifier and the value text is in the attribute.
+    expect(hydrate).not.toMatch(/\blocal\b/)
+    expect(hydrate).toContain('foo bar')
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1844,7 +1844,7 @@ export function extractFreeIdentifiersFromNode(node: ts.Node): Set<string> {
  * JS. The walk stops at function / arrow boundaries so JSX inside a
  * helper's body isn't mistaken for the initializer's own JSX.
  */
-function initializerShapeContainsJsx(node: ts.Node): boolean {
+export function initializerShapeContainsJsx(node: ts.Node): boolean {
   let found = false
   function visit(n: ts.Node): void {
     if (found) return

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -36,7 +36,7 @@ import { createError, ErrorCodes, internalInvariant } from './errors'
 import { containsReactiveExpression } from './reactivity-checker'
 import { rewriteBarePropRefs as rewriteBarePropRefsCore } from './prop-rewrite'
 import { resolveFreeRefs, type BindingEnvironment } from './free-refs'
-import { extractFreeIdentifiersFromNode } from './analyzer'
+import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer'
 import { iterateJsTokens } from './scanner/js-scanner'
 
 // =============================================================================
@@ -3032,7 +3032,24 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
   // The distinction between "dynamic" (JSX expression) and "reactive" (needs client updates)
   // is handled separately in client JS generation
   if (ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-    const expr = attr.initializer.expression
+    let expr = attr.initializer.expression
+
+    // #1414: a bare-identifier attribute value that resolves to a
+    // local declared inside the surrounding early-return `if`-block
+    // would leak into the emitted template lambda at outer scope
+    // (`style={local}` → `${styleToCss(local)}` → ReferenceError at
+    // hydrate). Substitute the identifier with the initializer's AST
+    // so downstream attribute processing (template-literal /
+    // ternary / generic-expression paths below) sees the resolved
+    // form. JSX-bearing initializers are skipped — attribute values
+    // can't host JSX, so the substitution would produce invalid
+    // output; the JSX-child-position fix (#1410) covers those.
+    if (ts.isIdentifier(expr)) {
+      const branchInit = ctx._branchScopeVars?.get(expr.text)
+      if (branchInit && !initializerShapeContainsJsx(branchInit)) {
+        expr = branchInit
+      }
+    }
 
     // Check for bare signal/memo identifier (BF044)
     checkBareSignalOrMemoIdentifier(expr, ctx)


### PR DESCRIPTION
## Summary

Closes #1414 cells 3, 4, and 6.

#1410 added an inline-at-use-site pass that substitutes a JSX-child reference to a local declared inside an early-return `if`-block with the local's initializer expression. The pass was wired into `transformExpression` (the JSX-child position), but **element-attribute values traverse a different code path** through `getAttributeValue`, so a branch-local identifier consumed at `style={local}` / `className={local}` / generic-attr position leaked into the emitted template lambda at outer scope and tripped `ReferenceError: local is not defined` at hydrate. No compiler diagnostic.

### Matrix coverage

From the issue's matrix:

| # | Initializer | Consumer position | Status |
|---|---|---|---|
| 1 | `<span/>` JSX literal | `{/* @client */ local}` JSX child | ✅ #1410 |
| 2 | `cond ? <jsx/> : null` ternary-JSX | `{/* @client */ local}` JSX child | ✅ #1412 |
| 3 | `'color:red'` string | `style={local}` attr | ✅ **this PR** |
| 4 | `'foo bar'` string | `className={local}` attr | ✅ **this PR** |
| 6 | `cond ? '1' : '2'` ternary-string | `style={local}` attr | ✅ **this PR** |
| 5 | JSX local in `ref={() => use(local)}` closure body | — | follow-up |
| 7 | `useSomething()` call-typed local at `{local()}` | — | follow-up |

### Fix

In `getAttributeValue` (`jsx-to-ir.ts`), when the attribute value is a bare identifier that resolves to a `_branchScopeVars` entry with a non-JSX initializer, substitute the identifier's AST with the initializer's AST **before** the downstream attribute-shape probes (template-literal / ternary / generic-expression). The downstream processing then operates on the resolved form: a string-literal initializer lands as a literal in the attribute value, a `ConditionalExpression` initializer routes through the existing ternary path, etc.

```diff
   if (ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-    const expr = attr.initializer.expression
+    let expr = attr.initializer.expression
+
+    if (ts.isIdentifier(expr)) {
+      const branchInit = ctx._branchScopeVars?.get(expr.text)
+      if (branchInit && !initializerShapeContainsJsx(branchInit)) {
+        expr = branchInit
+      }
+    }

     checkBareSignalOrMemoIdentifier(expr, ctx)
     // … existing attribute-shape probes operate on `expr`
   }
```

JSX-bearing initializers are skipped at attribute position because attribute values can't host JSX; those continue to use the JSX-child-position inlining route from #1410. The same `initializerShapeContainsJsx` predicate that gates the `inlineableJsxConsts` registration (#1412) is exported and reused here to keep one source of truth for the JSX-shape detection.

### Out of scope (follow-ups)

- **Cell 5**: JSX-typed local consumed inside a `ref={() => use(local)}` closure body. Substitution must walk into the closure body, not just the top-level expression. The current fix is shallow.
- **Cell 7**: `useSomething()` call-typed local at `{local()}` child position. The use site is a `CallExpression`, not a bare `Identifier`; the dispatcher's `CallExpression` arm doesn't check `_branchScopeVars`. Substituting would produce `{useSomething()()}` which calls the result of the original call — wrong semantic. Likely needs a different shape (e.g. emit a clear BF06* diagnostic).

### Validated

`packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts` — six shapes:
1. String local at `style` attribute (Case 3).
2. String local at `className` attribute (Case 4).
3. Ternary-string local at `style` attribute (Case 6).
4. String local at generic `data-status` attribute.
5. JSX local at JSX-child position keeps the #1410 inlining route (regression guard).
6. Outer-scope string const keeps the existing `compute-inlinability` route (negative guard).

## Test plan

- [x] `bun test` in `packages/jsx` — 1299 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 330 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 211 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 178 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)