### PR TITLE
fix(jsx/#1414 follow-up): substitute branch locals inside raw-captured JS (cells 5b & 7)

### DIFF
--- a/packages/jsx/src/__tests__/branch-local-in-raw-capture.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-in-raw-capture.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for the remaining #1414 cells. #1415 covered the
+ * element-attribute position (`style={local}`, `className={local}`,
+ * generic `attr={local}`) by short-circuiting bare-identifier
+ * attribute values to their initializer AST before the
+ * attribute-shape probes. Two cells remained where the branch local
+ * was reached through a path that doesn't visit a bare-identifier
+ * substitution site:
+ *
+ *   - **Cell 5b** — `ref={(el) => use(local)}` — the ref callback's
+ *     body is captured verbatim via `ctx.getJS`, so the local
+ *     identifier appears unchanged in the emitted init function.
+ *   - **Cell 7** — `{local()}` — the JSX expression's root is a
+ *     CallExpression, not an Identifier, so
+ *     `transformExpressionInner`'s identifier check passes through
+ *     and the scalar fallback emits the raw `local()` text into
+ *     both the template lambda and the init `createEffect`.
+ *
+ * Fix: in `buildIfStatementChain`, around each branch's
+ * `transformNode` call, override `ctx.getJS` so every raw-text
+ * capture substitutes branch-local identifiers with their
+ * initializer text. JSX-bearing initializers are skipped (text
+ * substitution into raw JS would emit JSX as TypeScript syntax —
+ * invalid); those are still handled by the existing JSX-child
+ * identifier-substitution route from #1410.
+ *
+ * Trade-off: text-level substitution duplicates the initializer per
+ * use site. A local read with side effects evaluates at every use,
+ * not once at declaration. Same trade-off as #547 / #1410 / #1412
+ * — users who need single-evaluation semantics hoist the local to
+ * outer init scope.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsContent(result: ReturnType<typeof compileJSX>): string {
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+function hydrateLine(result: ReturnType<typeof compileJSX>): string {
+  const line = clientJsContent(result).split('\n').find(l => l.includes('hydrate('))
+  if (!line) throw new Error('no hydrate() call in client JS')
+  return line
+}
+
+describe('branch-local references inside raw-captured JS (#1414 follow-ups)', () => {
+  test('cell 7: call-typed branch local at `{local()}` child position', () => {
+    // Pre-fix: emitted `${local()}` in the template lambda and
+    // `const __val = local()` in the init createEffect, both with
+    // `local` undeclared at outer scope. Post-fix: the arrow
+    // initializer is substituted at every use site so the value
+    // evaluates correctly.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function fmt(v: number) { return 'v=' + v }
+
+      export function CallTyped(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = () => fmt(count())
+          return <div>A: {local()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'CallTyped.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blocal\b/)
+    // The call's arrow body lands at both the template substitution
+    // (count() bridged to its initial value at template scope) and
+    // the init createEffect (count() runs reactively).
+    expect(hydrateLine(result)).toContain('fmt((0))')
+    expect(content).toContain('fmt(count())')
+  })
+
+  test('cell 7b: scalar-returning function-valued branch local', () => {
+    // Same shape, simpler initializer — guards that the substitution
+    // doesn't depend on the body containing a signal read.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ScalarFunc(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = () => 42
+          return <div>A: {local()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'ScalarFunc.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blocal\b/)
+    expect(hydrateLine(result)).toContain('(() => 42)()')
+  })
+
+  test('cell 5b: scalar branch local referenced inside a `ref` callback body', () => {
+    // The ref callback's body is captured as raw text. Pre-fix the
+    // identifier appeared unchanged in `(el) => { el.dataset.flag =
+    // local }` at outer init scope. Post-fix the scalar initializer
+    // text replaces every reference.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function RefCallback(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const label = 'highlighted'
+          return <div ref={(el) => { el.dataset.flag = label }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'RefCallback.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\blabel\b/)
+    expect(content).toContain("'highlighted'")
+  })
+
+  test('cell 5b variant: branch local referenced inside an event handler body', () => {
+    // Same raw-text-capture surface as ref callbacks. Event handlers
+    // ride through `ctx.getJS(attr.initializer.expression)` and
+    // would otherwise leak the same way.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function EventHandler(props: { kind: 'a' | 'b' }) {
+        const [count, setCount] = createSignal(0)
+        if (props.kind === 'a') {
+          const inc = 7
+          return <button onClick={() => setCount(count() + inc)}>A: {count()}</button>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'EventHandler.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const content = clientJsContent(result)
+    expect(content).not.toMatch(/\binc\b/)
+    expect(content).toContain('count() + (7)')
+  })
+
+  test('cell 5 (JSX in ref callback) is a known limitation — substitution skipped to avoid emitting JSX into raw JS', () => {
+    // Substituting a JSX initializer into raw text would emit
+    // `<span>x</span>` inside `(el) => { el.appendChild(<span>x</span>) }`
+    // — TypeScript JSX in a JS string. The substitution skips JSX-
+    // shaped initializers; the resulting `local` identifier still
+    // leaks. Document this with a snapshot so the limitation is
+    // visible in tests and so a future runtime helper for
+    // imperatively mounting branch-local JSX has a regression target.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function JsxInRef(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = <span>x</span>
+          return <div ref={(el) => { el.appendChild(local) }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'JsxInRef.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    // The skipped substitution leaves `local` in the init body.
+    // No diagnostic is emitted — this is a documented limitation,
+    // not a silent regression. Filing as a separate workstream
+    // when a runtime helper for imperatively mounting branch-local
+    // JSX lands.
+    expect(clientJsContent(result)).toContain('local')
+  })
+
+  test('sibling branches: substitution overlay does not leak to other branches', () => {
+    // Each branch installs its own `getJS` override, restored
+    // before the next branch starts.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Siblings(props: { kind: 'a' | 'b' | 'c' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = () => 'A-only'
+          return <div>A: {local()} {count()}</div>
+        }
+        if (props.kind === 'b') {
+          const local = () => 'B-only'
+          return <div>B: {local()} {count()}</div>
+        }
+        return <div>C: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'Siblings.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const hydrate = hydrateLine(result)
+    expect(hydrate).toContain('A-only')
+    expect(hydrate).toContain('B-only')
+    // C branch must not see either sibling's local.
+    expect(hydrate).not.toMatch(/\blocal\b/)
+  })
+})

--- a/packages/jsx/src/__tests__/branch-local-in-raw-capture.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-in-raw-capture.test.ts
@@ -156,37 +156,6 @@ describe('branch-local references inside raw-captured JS (#1414 follow-ups)', ()
     expect(content).toContain('count() + (7)')
   })
 
-  test('cell 5 (JSX in ref callback) is a known limitation — substitution skipped to avoid emitting JSX into raw JS', () => {
-    // Substituting a JSX initializer into raw text would emit
-    // `<span>x</span>` inside `(el) => { el.appendChild(<span>x</span>) }`
-    // — TypeScript JSX in a JS string. The substitution skips JSX-
-    // shaped initializers; the resulting `local` identifier still
-    // leaks. Document this with a snapshot so the limitation is
-    // visible in tests and so a future runtime helper for
-    // imperatively mounting branch-local JSX has a regression target.
-    const source = `
-      'use client'
-      import { createSignal } from '@barefootjs/client'
-
-      export function JsxInRef(props: { kind: 'a' | 'b' }) {
-        const [count] = createSignal(0)
-        if (props.kind === 'a') {
-          const local = <span>x</span>
-          return <div ref={(el) => { el.appendChild(local) }}>A: {count()}</div>
-        }
-        return <div>B: {count()}</div>
-      }
-    `
-    const result = compileJSX(source, 'JsxInRef.tsx', { adapter })
-    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
-    // The skipped substitution leaves `local` in the init body.
-    // No diagnostic is emitted — this is a documented limitation,
-    // not a silent regression. Filing as a separate workstream
-    // when a runtime helper for imperatively mounting branch-local
-    // JSX lands.
-    expect(clientJsContent(result)).toContain('local')
-  })
-
   test('sibling branches: substitution overlay does not leak to other branches', () => {
     // Each branch installs its own `getJS` override, restored
     // before the next branch starts.

--- a/packages/jsx/src/__tests__/jsx-branch-local-in-callback.test.ts
+++ b/packages/jsx/src/__tests__/jsx-branch-local-in-callback.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Diagnostic tests for BF047 (#1414 cell 5).
+ *
+ * A JSX-typed `const X = <jsx/>` declared inside an early-return
+ * `if`-block cannot be referenced from a callback body (ref / event
+ * handler). Substituting the JSX literal into the raw-captured
+ * callback body would produce TS JSX inside a JS string (invalid);
+ * leaving the bare identifier produces a runtime ReferenceError at
+ * hydrate. Fail loud at compile time and point at the
+ * children-position workaround.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { ErrorCodes } from '../errors'
+
+const adapter = new TestAdapter()
+
+function findBF047(errors: ReturnType<typeof compileJSX>['errors']) {
+  return errors.filter(e => e.code === ErrorCodes.JSX_BRANCH_LOCAL_IN_CALLBACK)
+}
+
+describe('BF047 — JSX-typed branch local referenced inside a callback body', () => {
+  test('fires for ref={(el) => use(local)} where `local` is a JSX literal in if-block', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function JsxInRef(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = <span>x</span>
+          return <div ref={(el) => { el.appendChild(local) }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'JsxInRef.tsx', { adapter })
+    const matches = findBF047(result.errors)
+    expect(matches).toHaveLength(1)
+    expect(matches[0].severity).toBe('error')
+    expect(matches[0].message).toContain("'local'")
+    // Workaround pointer in the message.
+    expect(matches[0].message).toContain('{local}')
+  })
+
+  test('fires for event-handler body that references a JSX branch local', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function JsxInClick(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = <span>x</span>
+          return <div onClick={() => { document.body.appendChild(local) }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'JsxInClick.tsx', { adapter })
+    expect(findBF047(result.errors)).toHaveLength(1)
+  })
+
+  test('fires for ternary-JSX initializer too (the #1412 shape)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TernaryJsxInRef(props: { kind: 'a' | 'b'; show: boolean }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = props.show ? <span>x</span> : null
+          return <div ref={(el) => { if (local) el.appendChild(local as any) }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'TernaryJsxInRef.tsx', { adapter })
+    expect(findBF047(result.errors)).toHaveLength(1)
+  })
+
+  test('does NOT fire for scalar branch local in ref callback (#1417 handles it)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ScalarInRef(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const label = 'highlighted'
+          return <div ref={(el) => { el.dataset.flag = label }}>A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'ScalarInRef.tsx', { adapter })
+    expect(findBF047(result.errors)).toHaveLength(0)
+  })
+
+  test('does NOT fire when the JSX branch local is used only as a child (#1410 inlines it)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function JsxAsChild(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = <span>x</span>
+          return <div ref={(el) => el.focus()}>{local} A: {count()}</div>
+        }
+        return <div>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'JsxAsChild.tsx', { adapter })
+    expect(findBF047(result.errors)).toHaveLength(0)
+  })
+
+  test('sibling branches do not cross-pollute the JSX-local name set', () => {
+    // Each branch installs its own `_jsxBranchLocalNames`; a JSX
+    // local in branch A must not flag a same-named scalar local in
+    // branch B's callback.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Siblings(props: { kind: 'a' | 'b' }) {
+        const [count] = createSignal(0)
+        if (props.kind === 'a') {
+          const local = <span>x</span>
+          return <div>{local} A: {count()}</div>
+        }
+        const local = 'hello'
+        return <div ref={(el) => { el.title = local }}>B: {count()}</div>
+      }
+    `
+    const result = compileJSX(source, 'Siblings.tsx', { adapter })
+    expect(findBF047(result.errors)).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -44,6 +44,16 @@ export const ErrorCodes = {
   SIGNAL_GETTER_NOT_CALLED: 'BF044',
   JSX_IN_LOCAL_FUNCTION: 'BF045',
   COMPONENT_REQUIRED_PROP_MISSING: 'BF046',
+  // A JSX-typed `const X = <jsx/>` declared inside an early-return
+  // `if`-block is referenced inside a raw-captured callback body
+  // (`ref={(el) => use(X)}`, `onClick={() => use(X)}`). The
+  // multi-return pipeline has no way to keep the JSX live as a
+  // runtime value here — substituting the JSX literal into the
+  // emitted callback body would produce TS JSX inside a JS string
+  // (invalid), and leaving the bare identifier produces a runtime
+  // ReferenceError at hydrate. Fail loud with workaround pointers
+  // (#1414 cell 5).
+  JSX_BRANCH_LOCAL_IN_CALLBACK: 'BF047',
 
   // Import errors (BF050-BF059)
   SHARED_PROGRAM_REQUIRED: 'BF050',
@@ -136,6 +146,10 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.COMPONENT_REQUIRED_PROP_MISSING]:
     'Built-in component is missing a required prop.',
+
+  [ErrorCodes.JSX_BRANCH_LOCAL_IN_CALLBACK]:
+    "JSX-typed local declared inside an `if`-block cannot be referenced from a callback body (ref / event handler). " +
+    "Render it as a child instead: `<div ref={...}>{local}</div>`.",
 
   [ErrorCodes.SHARED_PROGRAM_REQUIRED]:
     'Shared ts.Program required for type-based reactivity classification. This source imports a Reactive<T>-branded library (e.g. @barefootjs/form) whose getters cannot be classified by regex alone. Pass `options.program` (built via `createProgramForCorpus`) so the analyzer can resolve the brand through the TypeChecker.',

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -3879,10 +3879,66 @@ function buildIfStatementChain(
     }
     ctx._branchScopeVars = branchScopeVars
 
+    // #1414 cells 5 & 7: branch-local references that don't reach the
+    // bare-identifier substitution sites (`transformExpressionInner`
+    // for child position, `getAttributeValue` for attribute position)
+    // still leak as undeclared names at outer init scope. The shapes
+    // that miss the existing routes are:
+    //   - `{local()}` — the JSX expression's root is a CallExpression
+    //     (not an Identifier), so `transformExpressionInner`'s
+    //     identifier check doesn't fire.
+    //   - `ref={(el) => use(local)}` — the ref callback's body is
+    //     captured verbatim via `ctx.getJS`, so the local appears
+    //     unchanged in the emitted init function.
+    // Override `ctx.getJS` for the duration of this branch's
+    // `transformNode` so every raw-text capture (call args, ref
+    // callbacks, event handlers, etc.) substitutes branch locals at
+    // the source level. Same trade-off as the JSX-function-inlining
+    // path (#569) and `inlineableJsxConsts` (#1412): substituting
+    // is text-level, so a local read with side effects gets evaluated
+    // at every use site rather than once at declaration. Users who
+    // need single-evaluation semantics should still hoist the local
+    // to outer init scope themselves.
+    const branchNames: string[] = []
+    const branchSubs = new Map<string, string>()
+    const baseGetJS = ctx.analyzer.getJS.bind(ctx.analyzer)
+    for (const [name, initExpr] of branchScopeVars) {
+      // JSX-bearing initializers are handled by the existing
+      // identifier-substitution route in `transformExpressionInner`
+      // (#1410). Text substitution into raw-captured JS would emit
+      // the JSX as TypeScript syntax inside a JS string — invalid.
+      if (initializerShapeContainsJsx(initExpr)) continue
+      branchNames.push(name)
+      branchSubs.set(name, baseGetJS(initExpr))
+    }
+    // Identifier names are syntactically [A-Za-z_$][A-Za-z0-9_$]*, all of
+    // which are regex-safe — no escape needed.
+    const branchPattern = branchNames.length > 0
+      ? new RegExp(`\\b(${branchNames.join('|')})\\b`, 'g')
+      : null
+    const prevCtxGetJS = ctx.getJS
+    const prevAnalyzerGetJS = ctx.analyzer.getJS
+    if (branchPattern) {
+      const substitutedGetJS = (n: ts.Node): string => {
+        const text = baseGetJS(n)
+        return text.replace(branchPattern, (_match, name) => `(${branchSubs.get(name)!})`)
+      }
+      ctx.getJS = substitutedGetJS
+      ctx.analyzer.getJS = substitutedGetJS
+    }
+
     // Transform the JSX return in the then branch
     // Reset isRoot so each branch gets needsScope=true
     ctx.isRoot = true
-    const consequent = transformNode(condReturn.jsxReturn, ctx)
+    let consequent: IRNode | null
+    try {
+      consequent = transformNode(condReturn.jsxReturn, ctx)
+    } finally {
+      if (branchPattern) {
+        ctx.getJS = prevCtxGetJS
+        ctx.analyzer.getJS = prevAnalyzerGetJS
+      }
+    }
 
     ctx._branchScopeVars = prevBranchScopeVars
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -111,6 +111,15 @@ interface TransformContext {
    * sibling branches do not see each other's locals.
    */
   _branchScopeVars?: Map<string, ts.Expression>
+  /**
+   * Subset of `_branchScopeVars` names whose initializer carries JSX
+   * (so text substitution into raw-captured callback bodies is unsafe
+   * — TS JSX in JS syntax is invalid). `processAttributes` consults
+   * this set when extracting ref / event-handler bodies and emits
+   * BF047 if any of these names appears as a free identifier in the
+   * callback body. See #1414 cell 5.
+   */
+  _jsxBranchLocalNames?: Set<string>
 }
 
 /**
@@ -2936,6 +2945,32 @@ function computeReactivityFlags(
   }
 }
 
+/**
+ * Emit BF047 if a ref / event-handler callback body references a
+ * JSX-typed branch-local — the multi-return pipeline has no way to
+ * keep the JSX live as a runtime value here (substituting the JSX
+ * literal into the emitted callback body would produce TS JSX
+ * inside a JS string, and leaving the bare identifier produces a
+ * runtime ReferenceError at hydrate). See #1414 cell 5.
+ */
+function reportJsxBranchLocalInCallback(expr: ts.Expression, ctx: TransformContext): void {
+  const jsxNames = ctx._jsxBranchLocalNames
+  if (!jsxNames || jsxNames.size === 0) return
+  const refs = extractFreeIdentifiersFromNode(expr)
+  for (const name of refs) {
+    if (jsxNames.has(name)) {
+      ctx.analyzer.errors.push(
+        createError(
+          ErrorCodes.JSX_BRANCH_LOCAL_IN_CALLBACK,
+          getSourceLocation(expr, ctx.sourceFile, ctx.filePath),
+          { message: `JSX-typed branch local '${name}' referenced inside a callback body (ref / event handler). Render it as a child instead: \`<div ref={...}>{${name}}</div>\`.` },
+        ),
+      )
+      return
+    }
+  }
+}
+
 function processAttributes(
   attributes: ts.JsxAttributes,
   ctx: TransformContext
@@ -2960,6 +2995,7 @@ function processAttributes(
     // `ref` field for the client-JS emitter.
     if (name === 'ref') {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
+        reportJsxBranchLocalInCallback(attr.initializer.expression, ctx)
         ref = ctx.getJS(attr.initializer.expression)
       }
       continue
@@ -2972,6 +3008,7 @@ function processAttributes(
     if (/^on[A-Z]/.test(name)) {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         const eventName = name.slice(2).toLowerCase()
+        reportJsxBranchLocalInCallback(attr.initializer.expression, ctx)
         events.push({
           name: eventName,
           originalAttr: name,
@@ -3868,16 +3905,29 @@ function buildIfStatementChain(
     // init scope. Saved/restored around `transformNode` so sibling
     // branches and outer scope don't see each other's locals.
     const prevBranchScopeVars = ctx._branchScopeVars
+    const prevJsxBranchLocalNames = ctx._jsxBranchLocalNames
     const branchScopeVars = new Map<string, ts.Expression>()
+    const jsxBranchLocalNames = new Set<string>()
     if (prevBranchScopeVars) {
       for (const [k, v] of prevBranchScopeVars) branchScopeVars.set(k, v)
+    }
+    if (prevJsxBranchLocalNames) {
+      for (const n of prevJsxBranchLocalNames) jsxBranchLocalNames.add(n)
     }
     for (const decl of condReturn.scopeVariables) {
       if (ts.isIdentifier(decl.name) && decl.initializer) {
         branchScopeVars.set(decl.name.text, decl.initializer)
+        if (initializerShapeContainsJsx(decl.initializer)) {
+          jsxBranchLocalNames.add(decl.name.text)
+        } else {
+          // A shadowing non-JSX declaration in a nested branch lifts
+          // the parent's JSX flag for this name.
+          jsxBranchLocalNames.delete(decl.name.text)
+        }
       }
     }
     ctx._branchScopeVars = branchScopeVars
+    ctx._jsxBranchLocalNames = jsxBranchLocalNames
 
     // #1414 cells 5 & 7: branch-local references that don't reach the
     // bare-identifier substitution sites (`transformExpressionInner`
@@ -3941,6 +3991,7 @@ function buildIfStatementChain(
     }
 
     ctx._branchScopeVars = prevBranchScopeVars
+    ctx._jsxBranchLocalNames = prevJsxBranchLocalNames
 
     if (!consequent) {
       continue


### PR DESCRIPTION
## Summary

Follow-up to #1415. Closes cells 5b and 7 of the #1414 matrix by substitution; closes cell 5 by a fail-loud diagnostic.

#1415 covered the element-attribute position by short-circuiting bare-identifier attribute values to their initializer AST before the attribute-shape probes. Two cells remained where the branch-local was reached through code paths that don't visit a bare-identifier substitution site, plus one cell that cannot be lowered at all:

- **Cell 7** — `{local()}` at JSX-child position. The expression's root is `CallExpression`, not `Identifier`, so `transformExpressionInner`'s identifier check passes through and the scalar fallback emits the raw `local()` text into both the template lambda and the init `createEffect`.
- **Cell 5b** — `ref={(el) => use(local)}` / event handler bodies referencing a **scalar** branch local. The callback body is captured verbatim via `ctx.getJS`, so the identifier appears unchanged in the emitted init function.
- **Cell 5** — `ref={(el) => use(local)}` referencing a **JSX-typed** branch local. Has no valid lowering (see below); needs a compile-time error.

## Two fixes

### 1. Substitute scalar branch locals inside raw-captured JS (cells 5b & 7)

In `buildIfStatementChain`, around each branch's `transformNode` call, override `ctx.getJS` so every raw-text capture substitutes branch-local identifiers with their initializer text:

```ts
const substitutedGetJS = (n: ts.Node): string => {
  const text = baseGetJS(n)
  return text.replace(branchPattern, (_match, name) => `(${branchSubs.get(name)!})`)
}
ctx.getJS = substitutedGetJS
ctx.analyzer.getJS = substitutedGetJS
```

Pattern is restored before the next branch — sibling branches don't see each other's locals.

**JSX-bearing initializers are skipped from the substitution.** Text substitution into raw JS would emit TS JSX syntax inside a JS string — invalid. JSX-typed branch locals used at JSX-child position continue to use the identifier-substitution route from #1410.

**Side benefit**: scalar branch locals referenced inside **event handler bodies** (`onClick={() => setCount(count() + inc)}` where `inc` is a branch local) — not enumerated in the issue but on the same `ctx.getJS(callback.body)` code path — now resolve via the same substitution.

### 2. Error BF047 for JSX branch local inside callback body (cell 5)

JSX-typed branch locals in callback bodies have no valid lowering:

- Substituting the JSX literal into the raw-captured callback body would emit TS JSX inside a JS string — invalid.
- Leaving the bare identifier produces a runtime `ReferenceError` at hydrate — silent failure.

`processAttributes` now extracts free identifiers from each ref / event-handler initializer expression and emits **BF047** when any of them appears in `_jsxBranchLocalNames` (populated by `buildIfStatementChain` alongside `_branchScopeVars`):

```
ERROR[BF047]: JSX-typed branch local 'local' referenced inside a callback body (ref / event handler).
Render it as a child instead: `<div ref={...}>{local}</div>`.
```

The diagnostic names the offending local and points at the children-position workaround. The `_jsxBranchLocalNames` set is restored alongside `_branchScopeVars` so sibling / nested branches don't cross-pollute.

### Recommended workaround for cell 5

```tsx
const local = <span>x</span>
return <div ref={(el) => onMount(el)}>{local}</div>   // local as child, ref does element work
```

`{local}` rides through the #1410 JSX-child inlining route and lands as a real DOM child; the `ref` callback only deals with the element.

## Updated matrix coverage

| # | Initializer | Position | Status |
|---|---|---|---|
| 1 | JSX literal | `{/* @client */ local}` | ✅ #1410 |
| 2 | ternary-JSX | `{/* @client */ local}` | ✅ #1412 |
| 3 | string | `style={local}` | ✅ #1415 |
| 4 | string | `className={local}` | ✅ #1415 |
| 6 | ternary-string | `style={local}` | ✅ #1415 |
| 5b | string | `ref={(el) => use(local)}` | ✅ **this PR** |
| 7 | call (`() => …`) | `{local()}` | ✅ **this PR** |
| 5 | JSX literal | `ref={(el) => use(local)}` | 🛑 **BF047 (this PR)** |

## Trade-off

Text-level substitution duplicates the initializer per use site. A local read with side effects evaluates at every use, not once at declaration. Same trade-off as #547 / #1410 / #1412 — users who need single-evaluation semantics hoist the local to outer init scope.

## Validated

- `packages/jsx/src/__tests__/branch-local-in-raw-capture.test.ts` — 5 substitution shapes (cell 7, cell 7b, cell 5b ref + event-handler variant, sibling isolation).
- `packages/jsx/src/__tests__/jsx-branch-local-in-callback.test.ts` — 6 BF047 shapes (ref + onClick + ternary-JSX initializer fires; scalar in ref + JSX-as-child + sibling-shadow don't fire).

## Test plan

- [x] `bun test` in `packages/jsx` — 1310 pass / 0 fail.
- [x] `bun test` in `packages/adapter-tests` — 330 pass / 0 fail.
- [x] `bun test` in `packages/adapter-hono` — 211 pass / 0 fail.
- [x] `bun test` in `packages/adapter-go-template` — 178 pass / 0 fail.
- [x] `bun run typecheck:tests` / `bun run build` in `packages/jsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)