### PR TITLE
fix(jsx/#1414 cell #8): hoist branch-local createSignal pairs to outer init scope

### DIFF
--- a/packages/jsx/src/__tests__/branch-local-signal-pair.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-signal-pair.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for #1414 cell #8: a `createSignal(...)` destructured
+ * pair declared inside an early-return `if`-block silently vanishes from
+ * the emitted client JS. Sibling closures, event handlers, and template
+ * scopes that reference the pair then hit
+ * `ReferenceError: getter is not defined` at runtime, with no compiler
+ * diagnostic.
+ *
+ * The earlier #1414 fixes (#1410 / #1412 / #1415 / #1417) all relied on
+ * **text substitution** — inlining the local's initializer per use site.
+ * That approach can't represent a signal pair, because the pair has
+ * identity: the setter must mutate state observed by the getter, so
+ * duplicating `createSignal(...)` per call site would create disconnected
+ * signals.
+ *
+ * Fix: **hoist** the signal-pair declaration to outer init scope, guarded
+ * by the if-condition. Closures, event handlers, and template references
+ * then resolve at their natural scope without code reshuffle.
+ *
+ * Emitted shape after fix (conceptual):
+ *
+ *     let X, setX
+ *     if (cond) [X, setX] = createSignal(initial)
+ *     // …closures and handlers see X / setX from this outer scope…
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function compile(source: string) {
+  const result = compileJSX(source, 'BranchSignalPair.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  if (!clientJs) throw new Error('no client JS emitted')
+  return { code: clientJs.content }
+}
+
+describe('createSignal pair declared inside an early-return if-block (#1414 cell #8)', () => {
+  test('signal pair + closure getter + event-handler setter — all references resolve', () => {
+    const { code } = compile(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props { kind: 'a' | 'b' }
+
+      export function BranchSignalPair(props: Props) {
+        if (props.kind === 'a') {
+          const [hovered, setHovered] = createSignal(false)
+
+          function attachBar(bar: HTMLElement) {
+            if (hovered()) bar.style.background = 'red'
+          }
+
+          return (
+            <div
+              onMouseEnter={() => setHovered(true)}
+              onMouseLeave={() => setHovered(false)}
+            >
+              <div ref={attachBar}>A</div>
+            </div>
+          )
+        }
+        return <div>B</div>
+      }
+    `)
+
+    // 1. The signal-pair declaration is preserved somewhere in the
+    //    emitted file. The exact shape (top-of-init `let` + branch-guarded
+    //    assignment, vs another representation) is left to the
+    //    implementation, but the createSignal call must survive.
+    expect(code).toContain('createSignal(false)')
+
+    // 2. Both the getter and setter names appear in the init body.
+    //    Without the fix today the entire destructuring statement is
+    //    dropped — neither name is declared.
+    expect(code).toMatch(/\bhovered\b/)
+    expect(code).toMatch(/\bsetHovered\b/)
+
+    // 3. The setter calls inside event handlers reach a declared binding.
+    //    Accepted forms:
+    //    - `let hovered, setHovered` (cell-#8 hoist shape)
+    //    - `const [hovered, setHovered] = createSignal(...)` (legacy)
+    //    - any other declaration that puts `setHovered` in scope
+    //    What we reject is the bare `setHovered(true)` call appearing in
+    //    the body without any declaration anywhere — the original bug.
+    const declRe = /(let|const|var)\s+([\w,\s]*\bsetHovered\b|\[[^\]]*setHovered[^\]]*\])/
+    expect(code).toMatch(declRe)
+  })
+
+  test('sibling branches with independent signal pairs do not cross-pollute', () => {
+    const { code } = compile(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      interface Props { kind: 'a' | 'b' | 'c' }
+
+      export function SiblingPairs(props: Props) {
+        if (props.kind === 'a') {
+          const [aSig, setASig] = createSignal('a-initial')
+          return (
+            <div onClick={() => setASig('a-clicked')}>{aSig()}</div>
+          )
+        }
+        if (props.kind === 'b') {
+          const [bSig, setBSig] = createSignal('b-initial')
+          return (
+            <div onClick={() => setBSig('b-clicked')}>{bSig()}</div>
+          )
+        }
+        return <div>C</div>
+      }
+    `)
+
+    // Both pairs survive
+    expect(code).toContain("createSignal('a-initial')")
+    expect(code).toContain("createSignal('b-initial')")
+    // Both getters / setters referenced in event handlers + template
+    expect(code).toMatch(/\baSig\b/)
+    expect(code).toMatch(/\bsetASig\b/)
+    expect(code).toMatch(/\bbSig\b/)
+    expect(code).toMatch(/\bsetBSig\b/)
+  })
+
+  test('setter passed as function argument to an imported helper resolves', () => {
+    // The Phase 6 file uses `attachHoverTracking(w, setCompactHovered, …)`
+    // where the imported helper takes the setter as a function arg.
+    // Verify that consumer position resolves the same as call-site
+    // setters in event handlers.
+    const { code } = compile(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { wire } from './helpers'
+
+      interface Props { kind: 'a' | 'b' }
+
+      export function HelperArgSetter(props: Props) {
+        if (props.kind === 'a') {
+          const [hovered, setHovered] = createSignal(false)
+          function attachBar(bar: HTMLElement) {
+            wire(bar, setHovered)
+            if (hovered()) bar.style.color = 'red'
+          }
+          return <div ref={attachBar}>A</div>
+        }
+        return <div>B</div>
+      }
+    `)
+
+    expect(code).toContain('createSignal(false)')
+    expect(code).toMatch(/\bhovered\b/)
+    expect(code).toMatch(/\bsetHovered\b/)
+    // Setter passed as a value — bare identifier reference must survive
+    expect(code).toMatch(/wire\([^,]+,\s*setHovered\)/)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -653,6 +653,15 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
         scopeVariables: scopeVars,
         ifStatement: node,
       })
+      // #1414 cell #8: `[X, setX] = createSignal(...)` declarations
+      // inside this branch must round-trip through emission so closures /
+      // event handlers hoisted to outer init scope can reach them.
+      // Tagged with `branchCondition` so the emitter wraps each in
+      // `if (<cond>) [X, setX] = createSignal(...)`. The condition text
+      // mirrors what `conditionalReturns` already records, but as raw JS
+      // for the emit path — destructured-prop rewriting happens later.
+      const branchCondition = node.expression.getText(ctx.sourceFile)
+      collectBranchSignals(node.thenStatement, ctx, branchCondition)
       // Don't set ctx.jsxReturn here - let the final return be processed normally
       // Don't recurse into the if block since we've already captured it
       return
@@ -811,6 +820,48 @@ function collectScopeVariables(
   }
 
   return variables
+}
+
+/**
+ * Walk an if-block body for `createSignal(...)` declarations and add
+ * them to `ctx.signals` tagged with `branchCondition`. The emitter
+ * then wraps each in `if (<branchCondition>) [getter, setter] =
+ * createSignal(<initialValue>)` so closures hoisted to outer init scope
+ * can reach the bindings.
+ *
+ * Only top-level statements of the if-block are inspected — nested
+ * if/for/while blocks aren't supported yet (filed as a follow-up if
+ * the desk migration hits them; the common case is a flat block).
+ */
+function collectBranchSignals(
+  thenStatement: ts.Statement,
+  ctx: AnalyzerContext,
+  branchCondition: string,
+): void {
+  if (!ts.isBlock(thenStatement)) return
+  for (const stmt of thenStatement.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      // Track signals only. Plain (non-signal) branch-local consts are
+      // already covered by `_branchScopeVars` text substitution
+      // (#1410 / #1412 / #1415 / #1417); they don't need a hoisted
+      // declaration because the substitution pass eliminates the
+      // identifier before emit. Signal pairs can't be substituted
+      // (identity matters — see #1414 cell #8), so they're the only
+      // declaration kind that needs hoisting.
+      if (!isSignalDeclaration(decl, ctx)) continue
+      // Collect using the standard signal-emit path, then tag the
+      // most recently added entry with `branchCondition`. This keeps
+      // signal-shape detection logic (type inference, setter binding,
+      // initialFreeIdentifiers) in one place.
+      const before = ctx.signals.length
+      collectSignal(decl, ctx)
+      const after = ctx.signals.length
+      for (let i = before; i < after; i++) {
+        ctx.signals[i].branchCondition = branchCondition
+      }
+    }
+  }
 }
 
 // =============================================================================

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -90,6 +90,7 @@ function buildSignalPlan(
     setter: signal.setter,
     initialValueExpr: resolveSignalInitialValue(signal, ctx, lookups),
     controlledEffect: buildControlledSignalEffect(signal, lookups),
+    branchCondition: signal.branchCondition,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -38,6 +38,20 @@ export interface SignalEmitPlan {
    * the signal declaration that syncs the prop value into the setter.
    */
   controlledEffect: ControlledSignalEffectPlan | null
+  /**
+   * When set, the signal was declared inside an early-return `if`-block
+   * and only the marked branch reaches its `createSignal(...)` call.
+   * Stringifier emits:
+   *
+   *     let getter, setter
+   *     if (<branchCondition>) [getter, setter] = createSignal(<initial>)
+   *
+   * instead of the standard unconditional `const [getter, setter] = …`.
+   * Closures and event handlers hoisted to outer init scope close over
+   * the `let` bindings and resolve regardless of branch. See #1414
+   * cell #8.
+   */
+  branchCondition?: string
 }
 
 export interface ControlledSignalEffectPlan {

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -60,6 +60,29 @@ function emitConstant(lines: string[], plan: ConstantEmitPlan): void {
 }
 
 function emitSignal(lines: string[], plan: SignalEmitPlan): void {
+  if (plan.branchCondition) {
+    // #1414 cell #8: signal declared inside an early-return `if`-block.
+    // Hoist as `let` so closures and event handlers hoisted to outer
+    // init scope can close over the bindings, and assign inside an
+    // `if (<branchCondition>) { ... }` so the `createSignal(...)` only
+    // runs when the branch is taken. Sibling branches with different
+    // signals coexist because each gets its own `let` + guarded assign.
+    if (plan.setter) {
+      lines.push(`  let ${plan.getter}, ${plan.setter}`)
+      lines.push(`  if (${plan.branchCondition}) {`)
+      lines.push(`    ;[${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr})`)
+      lines.push(`  }`)
+    } else {
+      lines.push(`  let ${plan.getter}`)
+      lines.push(`  if (${plan.branchCondition}) {`)
+      lines.push(`    ;[${plan.getter}] = createSignal(${plan.initialValueExpr})`)
+      lines.push(`  }`)
+    }
+    // Controlled effects don't apply to branch-conditioned signals — a
+    // controlled signal is one whose initial value comes from `props.X`,
+    // which doesn't intersect with the early-return-branch case.
+    return
+  }
   if (plan.setter) {
     lines.push(`  const [${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr})`)
   } else {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -932,6 +932,20 @@ export interface SignalInfo {
    * the final string.
    */
   initialFreeIdentifiers?: ReadonlySet<string>
+  /**
+   * When set, this signal was declared inside an early-return `if`-block
+   * and only the marked branch reaches its `createSignal(...)` call. Emit
+   * picks the conditional shape:
+   *
+   *     let getter, setter
+   *     if (<branchCondition>) [getter, setter] = createSignal(<initialValue>)
+   *
+   * Closures and event handlers hoisted to outer init scope close over the
+   * `let` binding, so their references resolve regardless of branch. The
+   * value is the raw JS condition text (already destructured-prop-aware
+   * if applicable) — emitters substitute it verbatim. See #1414 cell #8.
+   */
+  branchCondition?: string
 }
 
 export interface MemoInfo {


### PR DESCRIPTION
Closes #1414 cell #8.

## Summary

A `createSignal(...)` destructured pair declared inside an early-return `if`-block silently vanished from the emitted client JS. Sibling closures, event handlers, and template references then hit `ReferenceError: getter is not defined` at runtime, with no compiler diagnostic.

The earlier #1414 follow-ups (#1410 / #1412 / #1415 / #1417) all relied on **text substitution** — inlining the local's initializer per use site. That works for values whose identity doesn't matter (literal JSX, ternary JSX, strings). It can't represent a signal pair: the setter must mutate state observed by the getter, so duplicating `createSignal(...)` per call site would create disconnected signals.

This PR **hoists** the signal-pair declaration to outer init scope, guarded by the if-condition.

## Repro (closed by this PR)

```tsx
'use client'
import { createSignal } from '@barefootjs/client'

interface Props { kind: 'a' | 'b' }

export function BranchSignalPair(props: Props) {
  if (props.kind === 'a') {
    const [hovered, setHovered] = createSignal(false)
    return (
      <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
        {hovered() ? 'on' : 'off'}
      </div>
    )
  }
  return <div>B</div>
}
```

Before: `ReferenceError: setHovered is not defined`; `createSignal(false)` line missing from emit.

After: emit shape becomes

```js
let hovered, setHovered
if (props.kind === 'a') {
  ;[hovered, setHovered] = createSignal(false)
}
// closures and event handlers hoisted to outer init scope close over
// the `let` bindings and resolve regardless of branch.
```

Identity is preserved; only one signal pair created per render, only when the branch is taken; sibling branches with their own signal pairs coexist (each gets its own `let` + guarded assign).

## Changes

- **`types.ts`** — `SignalInfo.branchCondition?: string`. Raw JS condition text for the owning `if`-block. Absent for top-level signals (the unchanged path).
- **`analyzer.ts`** — new `collectBranchSignals` walks the early-return if-block's top-level statements, registers any `createSignal(...)` declarations via the existing `collectSignal` path, and tags each freshly-added entry with `branchCondition`. Called from the existing `ifStatement → jsxReturn` handler that previously dropped the if-block contents on the floor.
- **`plan/declaration-emit.ts`** + **`plan/build-declaration-emit.ts`** — thread `branchCondition` from `SignalInfo` to `SignalEmitPlan`.
- **`stringify/declaration-emit.ts`** — when `plan.branchCondition` is set, emit the `let` + guarded `;[X, setX] = createSignal(...)` shape instead of the unconditional `const [...]`. Controlled effects don't apply to this shape (controlled signals read `props.X`, never intersect with early-return branches).

## Test plan

New test `packages/jsx/src/__tests__/branch-local-signal-pair.test.ts` (3 cases):

1. **signal pair + closure getter + event-handler setter** — all references resolve to a declared binding (i.e. the `createSignal(false)` survives + both `hovered` and `setHovered` get declared somewhere).
2. **sibling branches with independent signal pairs** — both pairs survive, neither cross-pollutes the other branch's bindings.
3. **setter passed as function argument to imported helper** — the Phase 6 shape (`attachHoverTracking(w, setCompactHovered, …)`) — the bare-identifier reference survives.

Verified red→green: with only `branch-local-signal-pair.test.ts` changes (analyzer / emit reverted), all 3 tests fail. With the full PR, all 3 pass.

Full `bun test packages/jsx`: 1309 pass / 4 pre-existing fail (same baseline as `origin/main` — 0 regressions).

`bun run --filter '@barefootjs/jsx' build` (typecheck): clean.

## Out of scope

- **`createMemo` / `createEffect` inside early-return if-blocks** — same shape applies. Not encountered in piconic-ai/desk #86 Phase 6 yet, so left for a follow-up to keep this PR minimal. The `collectBranchSignals` helper is structured to extend trivially.
- **Nested if-blocks** (e.g. `if (a) { if (b) { const [...] = ... } }`). `collectBranchSignals` walks `Block.statements` only.

## Real-world validation

piconic-ai/desk #86 Phase 6's `IssueCardNodeImpl.tsx` compact-view branch:

```tsx
if (data.compact) {
  const [compactHovered, setCompactHovered] = createSignal(false)
  const [compactNearestSide, setCompactNearestSide] = createSignal<...>(null)

  function attachCompactWrapper(w) { /* reads compactHovered() */ }
  function attachCompactBar(bar)    { /* reads compactHovered() */ }
  function attachCompactResize(handle) { /* reads compactHovered() */ }

  return (
    <div ref={attachCompactWrapper}
         onMouseEnter={() => setCompactHovered(true)}
         onMouseLeave={() => { setCompactHovered(false); setCompactNearestSide(null) }}>
      ...
    </div>
  )
}
```

Before this PR: `ReferenceError: compactHovered is not defined`, cards fail to render.

After: all 9 catalog cards render correctly with 0 console errors.
