### PR TITLE
fix(jsx/#1422): substitute branch-local consts in nested function bodies

### DIFF
--- a/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression tests for #1422: when the same identifier name is declared
+ * as `const` inside multiple early-return `if`-blocks of a `'use client'`
+ * component, barefoot's hoist pass kept only one declaration in outer
+ * init scope — the last one encountered. Sibling branches' nested
+ * function declarations ended up reading the wrong value at runtime.
+ *
+ * Distinct from #1414 (single-branch reference leakage). The bug here is
+ * that nested function declarations inside a branch are captured by the
+ * analyzer via the `collectFunction` path with their bodies as raw text.
+ * The text references the branch-local `const`, but since multiple
+ * branches declare the same name, only one survives as a top-level
+ * binding — every branch's closure resolves to that one value.
+ *
+ * Fix: in `collectFunction`, walk the function's ancestor chain for any
+ * enclosing conditional-return `if`-block and text-substitute its
+ * `scopeVariables` references in the captured body. Mirrors the existing
+ * `_branchScopeVars` route in `jsx-to-ir.ts` that handles JSX-return
+ * raw-text capture (ref callbacks, event handlers, `{local()}` child
+ * positions).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsContent(result: ReturnType<typeof compileJSX>): string {
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('same-name branch-local const referenced from nested function decl (#1422)', () => {
+  test('two sibling branches with same-name const — each closure reads its branch value', () => {
+    const source = `
+      'use client'
+
+      interface Props { mode: 'a' | 'b' }
+
+      export function TwoBranches(props: Props) {
+        if (props.mode === 'a') {
+          const size = 'small'
+          function attachA(el: HTMLElement) {
+            el.dataset.size = size
+          }
+          return <div ref={attachA}>A</div>
+        }
+        const size = 'large'
+        function attachB(el: HTMLElement) {
+          el.dataset.size = size
+        }
+        return <div ref={attachB}>B</div>
+      }
+    `
+    const result = compileJSX(source, 'TwoBranches.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+
+    // attachA's body must reference 'small', not 'large'.
+    expect(content).toMatch(/attachA[\s\S]*?dataset\.size\s*=\s*\('small'\)/)
+    // attachB stays as a top-level reference: `size` resolves to 'large' via the
+    // outer init-scope const. Either form is acceptable as long as the value
+    // observed at runtime is 'large'.
+    const attachBBody = content.match(/attachB\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}/)?.[0] ?? ''
+    if (!attachBBody.includes("'large'")) {
+      // If not inlined, the bare `size` reference must resolve to the only
+      // outer-scope `const size = 'large'`.
+      expect(content).toMatch(/const\s+size\s*=\s*'large'/)
+      expect(attachBBody).toMatch(/\bsize\b/)
+    }
+  })
+
+  test('three branches with same-name const (matches desk #86 phase 6 shape)', () => {
+    const source = `
+      'use client'
+
+      interface Props { mode: 'a' | 'b' | 'c' }
+
+      export function BranchLocalSameNameCollision(props: Props) {
+        if (props.mode === 'a') {
+          const size = 'small'
+          function attachA(el: HTMLElement) {
+            el.dataset.size = size
+          }
+          return <div ref={attachA}>A</div>
+        }
+        if (props.mode === 'b') {
+          const size = 'medium'
+          function attachB(el: HTMLElement) {
+            el.dataset.size = size
+          }
+          return <div ref={attachB}>B</div>
+        }
+        const size = 'large'
+        function attachC(el: HTMLElement) {
+          el.dataset.size = size
+        }
+        return <div ref={attachC}>C</div>
+      }
+    `
+    const result = compileJSX(source, 'ThreeBranches.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+
+    // Each branch closure reads its own branch's value.
+    const attachABody = content.match(/attachA\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}/)?.[0] ?? ''
+    const attachBBody = content.match(/attachB\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}/)?.[0] ?? ''
+
+    expect(attachABody).toContain("'small'")
+    expect(attachBBody).toContain("'medium'")
+
+    // attachA must NOT read 'large' or 'medium'.
+    expect(attachABody).not.toContain("'large'")
+    expect(attachABody).not.toContain("'medium'")
+    // attachB must NOT read 'large' or 'small'.
+    expect(attachBBody).not.toContain("'large'")
+    expect(attachBBody).not.toContain("'small'")
+  })
+
+  test('mixed initializer kinds (string vs number) under the same identifier', () => {
+    const source = `
+      'use client'
+
+      interface Props { mode: 'a' | 'b' | 'c' }
+
+      export function MixedKinds(props: Props) {
+        if (props.mode === 'a') {
+          const value = 'string-value'
+          function attachA(el: HTMLElement) {
+            el.dataset.value = String(value)
+          }
+          return <div ref={attachA}>A</div>
+        }
+        if (props.mode === 'b') {
+          const value = 42
+          function attachB(el: HTMLElement) {
+            el.dataset.value = String(value)
+          }
+          return <div ref={attachB}>B</div>
+        }
+        const value = true
+        function attachC(el: HTMLElement) {
+          el.dataset.value = String(value)
+        }
+        return <div ref={attachC}>C</div>
+      }
+    `
+    const result = compileJSX(source, 'MixedKinds.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+
+    const attachABody = content.match(/attachA\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}/)?.[0] ?? ''
+    const attachBBody = content.match(/attachB\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}/)?.[0] ?? ''
+
+    expect(attachABody).toContain("'string-value'")
+    expect(attachBBody).toContain('42')
+
+    expect(attachABody).not.toContain('42')
+    expect(attachBBody).not.toContain("'string-value'")
+  })
+
+  test('non-colliding branch-local — substitution still applies (covers prior single-branch shape)', () => {
+    // Same fix path covers the prior single-branch case where a closure
+    // references a branch-local without a same-name sibling. Without
+    // substitution the bare `wrapperHeight` would leak to outer scope
+    // and ReferenceError at runtime.
+    const source = `
+      'use client'
+
+      interface Props { kind: 'a' | 'b' }
+
+      export function SingleBranch(props: Props) {
+        if (props.kind === 'a') {
+          const wrapperHeight = '36px'
+          function attachWrapper(w: HTMLElement) {
+            w.style.minHeight = wrapperHeight
+          }
+          return <div ref={attachWrapper}>A</div>
+        }
+        return <div>B</div>
+      }
+    `
+    const result = compileJSX(source, 'SingleBranch.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+
+    // The wrapperHeight identifier must NOT survive as a free reference;
+    // it must be substituted with its literal value. The function body may
+    // appear in arrow form (init scope) or `function (...) {...}` form
+    // (module scope) depending on whether it still references any
+    // init-required name after substitution.
+    expect(content).toContain("'36px'")
+    expect(content).not.toMatch(/=\s*wrapperHeight\b/)
+  })
+})

--- a/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
@@ -227,6 +227,41 @@ describe('same-name branch-local const referenced from nested function decl (#14
     expect(content).not.toMatch(/=\s*\$size\b/)
   })
 
+  test('chained branch-locals — substitution fixpoints across initializer references', () => {
+    // Copilot review feedback: a branch-local initializer can itself
+    // reference an earlier branch-local. A single replacement pass
+    // would inline the second const but leave the first still bare in
+    // the body. The fixpoint loop closes this.
+    const source = `
+      'use client'
+
+      interface Props { kind: 'a' | 'b' }
+
+      export function ChainedLocals(props: Props) {
+        if (props.kind === 'a') {
+          const a = 1
+          const b = a + 1
+          function attach(el: HTMLElement) {
+            el.dataset.value = String(b)
+          }
+          return <div ref={attach}>A</div>
+        }
+        return <div>B</div>
+      }
+    `
+    const result = compileJSX(source, 'ChainedLocals.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+    // After fixpoint substitution: `b` → `(a + 1)` → `((1) + 1)`.
+    // Neither `a` nor `b` should survive as a bare identifier read in
+    // the attach body.
+    const attachBody = content.match(/attach\s*=[^{]*\{[\s\S]*?\}/)?.[0] ?? ''
+    expect(attachBody).not.toMatch(/=\s*String\(b\)/)
+    expect(attachBody).not.toMatch(/\(a\s*\+\s*1\)/)
+    // The final inlined form preserves the numeric literal.
+    expect(attachBody).toContain('1')
+  })
+
   test('non-colliding branch-local — substitution still applies (covers prior single-branch shape)', () => {
     // Same fix path covers the prior single-branch case where a closure
     // references a branch-local without a same-name sibling. Without

--- a/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts
@@ -159,6 +159,74 @@ describe('same-name branch-local const referenced from nested function decl (#14
     expect(attachBBody).not.toContain("'string-value'")
   })
 
+  test('destructured param shadows branch-local of the same name', () => {
+    // Copilot review feedback: param-binding detection must recurse
+    // into `ObjectBindingPattern` / `ArrayBindingPattern` so a
+    // destructured param like `function f({ size }: { size: string })`
+    // correctly shadows an outer branch-local `size`. Without the
+    // recursive walk the substitution wrongly rewrites the param read
+    // and the function body sees the wrong value.
+    const source = `
+      'use client'
+
+      interface Props { mode: 'a' | 'b' }
+
+      export function DestructuredParam(props: Props) {
+        if (props.mode === 'a') {
+          const size = 'small'
+          function attach({ size }: { size: string }) {
+            // Reads must reference the destructured param, NOT the
+            // outer branch-local — text substitution must skip
+            // identifiers shadowed by destructured params.
+            return size
+          }
+          return <div ref={() => attach({ size: 'inner' })}>A</div>
+        }
+        return <div>B</div>
+      }
+    `
+    const result = compileJSX(source, 'DestructuredParam.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+    const attachBody = content.match(/attach\s*=[^{]*\{[\s\S]*?\breturn\b[^}]*\}/)?.[0] ?? ''
+    // The branch-local `('small')` literal must NOT be injected — the
+    // param shadows it.
+    expect(attachBody).not.toContain("'small'")
+    // The `return size` reference must survive verbatim.
+    expect(attachBody).toMatch(/return\s+size\b/)
+  })
+
+  test('branch-local identifier containing `$` substitutes correctly', () => {
+    // Copilot review feedback: identifier-aware boundaries must allow
+    // `$` as a name char (and escape it for regex use). Pre-fix the
+    // `\\b` boundary treated `$` as a separator, and a name like
+    // `wrapperHeight$0` would either fail to match or partial-match a
+    // bare `wrapperHeight`.
+    const source = `
+      'use client'
+
+      interface Props { kind: 'a' | 'b' }
+
+      export function DollarIdent(props: Props) {
+        if (props.kind === 'a') {
+          const $size = '36px'
+          function attach(el: HTMLElement) {
+            el.style.minHeight = $size
+          }
+          return <div ref={attach}>A</div>
+        }
+        return <div>B</div>
+      }
+    `
+    const result = compileJSX(source, 'DollarIdent.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+    const content = clientJsContent(result)
+    // The branch-local should be substituted to its literal.
+    expect(content).toContain("'36px'")
+    // The bare `$size` reference must not survive (would ReferenceError at runtime).
+    expect(content).not.toMatch(/=\s*\$size\b/)
+  })
+
   test('non-colliding branch-local — substitution still applies (covers prior single-branch shape)', () => {
     // Same fix path covers the prior single-branch case where a closure
     // references a branch-local without a same-name sibling. Without

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -823,6 +823,33 @@ function collectScopeVariables(
 }
 
 /**
+ * Collect the set of identifier names bound by a function's parameter
+ * list, recursing into `ObjectBindingPattern` / `ArrayBindingPattern`
+ * so destructured params like `function f({ size })` or
+ * `function f([size])` correctly contribute `size` to the bound set.
+ * Mirrors `addBindingNames` inside `extractFreeIdentifiersFromNode`.
+ * #1422.
+ */
+function collectParamBindingNames(
+  params: ts.NodeArray<ts.ParameterDeclaration>,
+): Set<string> {
+  const out = new Set<string>()
+  const addBindingNames = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      out.add(name.text)
+    } else if (ts.isObjectBindingPattern(name)) {
+      name.elements.forEach(e => addBindingNames(e.name))
+    } else if (ts.isArrayBindingPattern(name)) {
+      name.elements.forEach(e => {
+        if (!ts.isOmittedExpression(e)) addBindingNames(e.name)
+      })
+    }
+  }
+  for (const p of params) addBindingNames(p.name)
+  return out
+}
+
+/**
  * Walk the ancestor chain of `node` looking for any enclosing
  * conditional-return `if`-block. Returns a map from branch-local const
  * name to the text of its initializer. Innermost branch wins on
@@ -1820,22 +1847,40 @@ function collectFunction(
   if (node.body && ctx.conditionalReturns.length > 0) {
     const branchVars = collectEnclosingBranchVars(node, ctx)
     if (branchVars.size > 0) {
-      const paramNames = new Set(params.map(p => p.name))
+      const paramNames = collectParamBindingNames(node.parameters)
       const branchNames: string[] = []
       const branchSubs = new Map<string, string>()
       for (const [varName, initText] of branchVars) {
-        // Params shadow outer names inside the function body.
+        // Params shadow outer names inside the function body. This
+        // handles destructured params (`({ size })`, `([size])`) via
+        // the recursive BindingName walk, not just bare identifiers.
         if (paramNames.has(varName)) continue
         branchNames.push(varName)
         branchSubs.set(varName, initText)
       }
       if (branchNames.length > 0) {
-        // `(?<!\.)` skips member-access tail names like `el.dataset.size`
-        // so substitution only fires on free-identifier reads. Property
-        // keys in object literals and destructure binding names still
-        // slip through — same trade-off as the existing
-        // `_branchScopeVars` regex in `jsx-to-ir.ts`.
-        const re = new RegExp(`(?<!\\.)\\b(${branchNames.join('|')})\\b`, 'g')
+        // Identifier-aware boundaries: `\b` treats `$` as a word
+        // separator, which both breaks substitution for valid JS
+        // identifiers containing `$` and lets `foo$bar` partial-match
+        // a `foo` branch name. Use `(?<![\w$])` / `(?![\w$])` to
+        // anchor at true identifier boundaries. The leading guard also
+        // excludes member-access tails (`el.dataset.size`) — `.` is
+        // not in `[\w$]`, but the previous char before `.` is, so the
+        // identifier after `.` still has a `\w` before it once you
+        // step past the dot. We add `(?<![.\w$])` explicitly to skip
+        // the member-access case.
+        //
+        // Branch names are JS identifiers so they have no regex
+        // metacharacters except `$`, which is escaped here for safety
+        // (regex `$` means end-of-input).
+        const escaped = branchNames.map(n => n.replace(/\$/g, '\\$'))
+        const re = new RegExp(`(?<![.\\w$])(${escaped.join('|')})(?![\\w$])`, 'g')
+        // NOTE: this is text-level replacement and so will also rewrite
+        // occurrences inside string literals / comments inside the
+        // captured body. Same trade-off as the existing
+        // `_branchScopeVars` regex in `jsx-to-ir.ts`; users who need
+        // single-evaluation or string-literal-safe semantics should
+        // hoist the local to outer init scope themselves.
         body = body.replace(re, (_m, n) => `(${branchSubs.get(n)!})`)
       }
     }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -823,6 +823,38 @@ function collectScopeVariables(
 }
 
 /**
+ * Walk the ancestor chain of `node` looking for any enclosing
+ * conditional-return `if`-block. Returns a map from branch-local const
+ * name to the text of its initializer. Innermost branch wins on
+ * collision (lexical shadowing). JSX-bearing initializers are skipped —
+ * substituting them as raw text would emit JSX as TypeScript syntax,
+ * which is invalid in raw-JS capture contexts (function bodies, ref
+ * callbacks, event handlers). #1422.
+ */
+function collectEnclosingBranchVars(
+  node: ts.Node,
+  ctx: AnalyzerContext,
+): Map<string, string> {
+  const result = new Map<string, string>()
+  let current: ts.Node | undefined = node.parent
+  while (current) {
+    for (const cr of ctx.conditionalReturns) {
+      if (cr.ifStatement.thenStatement !== current) continue
+      for (const decl of cr.scopeVariables) {
+        if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+        const varName = decl.name.text
+        // Innermost wins — skip if a deeper branch already set this name.
+        if (result.has(varName)) continue
+        if (initializerShapeContainsJsx(decl.initializer)) continue
+        result.set(varName, ctx.getJS(decl.initializer))
+      }
+    }
+    current = current.parent
+  }
+  return result
+}
+
+/**
  * Walk an if-block body for `createSignal(...)` declarations and add
  * them to `ctx.signals` tagged with `branchCondition`. The emitter
  * then wraps each in `if (<branchCondition>) [getter, setter] =
@@ -1768,9 +1800,46 @@ function collectFunction(
     defaultValue: p.initializer ? ctx.getJS(p.initializer) : undefined,
     isRest: !!p.dotDotDotToken || undefined,
   }))
-  const body = node.body ? ctx.getJS(node.body) : ''
+  let body = node.body ? ctx.getJS(node.body) : ''
   const typedBody = node.body ? node.body.getText(ctx.sourceFile) : undefined
   const returnType = typeNodeToTypeInfo(node.type, ctx.sourceFile)
+
+  // #1422: a function declaration nested inside an early-return `if`-block
+  // is captured here with its body as raw text. Downstream
+  // (`compute-scope`) hoists it to outer init scope when it references
+  // any init-required name, so bare references to branch-local consts
+  // resolve at outer scope — wrong-value (when sibling branches declare
+  // the same name) or undefined (single-branch case). The
+  // `_branchScopeVars` text-substitution in `jsx-to-ir.ts` already covers
+  // raw-text capture inside the JSX return (ref callbacks, event
+  // handlers, `{local()}` child positions) but doesn't reach function
+  // declarations because they're collected in this analyzer pass before
+  // Phase 1 runs. Substitute branch-local references in the body here
+  // — same trade-off as #547 / #1410 / #1412 / #1415: text-level
+  // substitution duplicates the initializer per use site.
+  if (node.body && ctx.conditionalReturns.length > 0) {
+    const branchVars = collectEnclosingBranchVars(node, ctx)
+    if (branchVars.size > 0) {
+      const paramNames = new Set(params.map(p => p.name))
+      const branchNames: string[] = []
+      const branchSubs = new Map<string, string>()
+      for (const [varName, initText] of branchVars) {
+        // Params shadow outer names inside the function body.
+        if (paramNames.has(varName)) continue
+        branchNames.push(varName)
+        branchSubs.set(varName, initText)
+      }
+      if (branchNames.length > 0) {
+        // `(?<!\.)` skips member-access tail names like `el.dataset.size`
+        // so substitution only fires on free-identifier reads. Property
+        // keys in object literals and destructure binding names still
+        // slip through — same trade-off as the existing
+        // `_branchScopeVars` regex in `jsx-to-ir.ts`.
+        const re = new RegExp(`(?<!\\.)\\b(${branchNames.join('|')})\\b`, 'g')
+        body = body.replace(re, (_m, n) => `(${branchSubs.get(n)!})`)
+      }
+    }
+  }
 
   // Check if function contains JSX
   const containsJsx = body.includes('<') && (body.includes('/>') || body.includes('</'))

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1881,7 +1881,19 @@ function collectFunction(
         // `_branchScopeVars` regex in `jsx-to-ir.ts`; users who need
         // single-evaluation or string-literal-safe semantics should
         // hoist the local to outer init scope themselves.
-        body = body.replace(re, (_m, n) => `(${branchSubs.get(n)!})`)
+        //
+        // Fixpoint iteration: a branch-local initializer can itself
+        // reference an earlier branch-local (e.g.
+        // `const a = 1; const b = a + 1; function f() { return b }`
+        // → first pass rewrites `b` to `(a + 1)`, leaving a fresh `a`
+        // that the next pass rewrites to `(1)`). Bound by
+        // `branchNames.length + 1` — the worst-case chain length.
+        const maxIter = branchNames.length + 1
+        for (let i = 0; i < maxIter; i++) {
+          const next = body.replace(re, (_m, n) => `(${branchSubs.get(n)!})`)
+          if (next === body) break
+          body = next
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #1422.

Function declarations nested inside an early-return `if`-block were captured by the analyzer with their body as raw text. When `compute-scope` hoisted them to outer init scope (or left them at module level), the bare references to branch-local `const`s resolved at outer scope — to the **wrong value** when sibling branches declared the same name, or to `undefined` in the single-branch case. No compiler diagnostic was raised.

### Before

```js
// repro: 3 sibling branches each with `const size = '...'`
size = "large",              // only the last branch's value survives
attachA = el => { el.dataset.size = size },   // reads 'large' ❌
attachB = el => { el.dataset.size = size },   // reads 'large' ❌
attachC = el => { el.dataset.size = size }    // reads 'large' ✓
```

### After

```js
const attachA = (el) => { el.dataset.size = ('small') }
const attachB = (el) => { el.dataset.size = ('medium') }
const size = 'large'
const attachC = (el) => { el.dataset.size = size }
```

## Fix

The existing `_branchScopeVars` text-substitution in `jsx-to-ir.ts` covers raw-text capture inside the JSX return (ref callbacks, event handlers, `{local()}` child positions) — but it runs in Phase 1, after the analyzer has already captured nested function bodies via `collectFunction`.

`collectFunction` now walks the function's ancestor chain for any enclosing conditional-return `if`-block and text-substitutes the branch's `scopeVariables` references in the captured body. The regex uses a `(?<!\.)` lookbehind so member-access tails (`el.dataset.size`) are not falsely rewritten. Function params shadow outer names and are excluded from substitution.

Same trade-off as the prior #547 / #1410 / #1412 / #1415 fixes: text-level substitution duplicates the initializer per use site. Users who need single-evaluation semantics for side-effectful initializers should hoist the local to outer init scope themselves.

## Test plan

- [x] `packages/jsx/src/__tests__/branch-local-same-name-collision.test.ts` — 4 new cases (2-branch, 3-branch, mixed kinds, non-colliding single-branch)
- [x] Existing `branch-local-*` / `early-return-*` / `jsx-branch-local-*` tests still green
- [x] Full `bun test` in `packages/jsx` — only pre-existing failures (alias resolver) unrelated to this change
- [x] `packages/client` tests — 277 pass
- [x] `packages/adapter-tests` — 338 pass

https://claude.ai/code/session_01KrZXCbgtSQ7sUSBa3F3Q5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrZXCbgtSQ7sUSBa3F3Q5i)_