### PR TITLE
fix(mojo): break convertHigherOrderExpr ↔ unsupported-emitter recursion (#1421)

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -128,6 +128,12 @@ runAdapterConformanceTests({
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1421: branch-local higher-order chain at an attribute
+    // (`const merged = [a, b].filter(Boolean).join(' ')` referenced as
+    // `className={merged}`). `convertExpressionToGo` already refuses
+    // the array-literal callee with BF101 — the shared fixture pins the
+    // contract so the Mojo / Go refusal shapes stay aligned.
+    'branch-local-filter-join': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -101,6 +101,14 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #1421: branch-local higher-order chain inlined at an attribute
+    // (`const merged = [a, b].filter(Boolean).join(' ')` referenced as
+    // `className={merged}`). The array-literal callee isn't a signal /
+    // prop the Mojo expression translator can lower into Embedded Perl,
+    // so `convertHigherOrderExpr` records BF101. The pin also locks in
+    // the recursion-cycle fix — before the cycle guard, this fixture
+    // crashed `bf build` with `RangeError: Maximum call stack size`.
+    'branch-local-filter-join': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining
@@ -259,6 +267,38 @@ export function Page() {
 `)
     expect(result.template).not.toContain('begin %>')
     expect(result.template).not.toContain('children =>')
+  })
+
+  test('breaks the convertHigherOrderExpr ↔ unsupported-emitter loop (#1421)', () => {
+    // Regression: a branch-local `.filter(Boolean).join(' ')` chain
+    // referenced at an attribute used to crash `bf build` with
+    // `RangeError: Maximum call stack size exceeded`. The parser
+    // returns `unsupported` for the array-literal callee while keeping
+    // the full original `raw`, so `MojoTopLevelEmitter.unsupported` →
+    // `_convertExpressionToPerlPublic` → `convertExpressionToPerl`
+    // re-detected `.filter` and re-entered `convertHigherOrderExpr`
+    // forever. The in-flight guard breaks the cycle and surfaces a
+    // BF101 instead.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(
+      `
+"use client"
+function Slot({ children, className }: { children?: unknown; className?: string }) {
+  if (children) {
+    const merged = [className].filter(Boolean).join(' ')
+    return <div className={merged}>x</div>
+  }
+  return <div>fallback</div>
+}
+export { Slot }
+`.trimStart(),
+      'slot.tsx',
+      { adapter },
+    )
+    const bf101 = result.errors?.find(e => e.code === 'BF101')
+    expect(bf101).toBeDefined()
+    expect(bf101!.message).toContain('higher-order')
+    expect(bf101!.message).toContain('.filter(Boolean).join')
   })
 
   test('does not leak module-level export statements into the .html.ep template', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1280,7 +1280,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
           message: "The Mojo adapter cannot lower this `.filter()` / `.every()` / `.some()` chain — typically because the array source is a JS array literal or a non-signal expression the AST classifier doesn't recognise. Move the expression into a `'use client'` component (so hydration computes it client-side), or rewrite it to operate on a signal getter or a prop directly.",
         },
       })
-      return ''
+      // Return a Perl empty-string literal — safe in every context the
+      // result might land in (`<%= '' %>`, `% if ('') {`, attribute
+      // interpolation, template-literal substitution). Returning a raw
+      // empty string here would produce `<%= %>`, which Embedded Perl
+      // rejects as a syntax error and would mask the BF101 diagnostic
+      // behind an opaque template-compilation failure.
+      return "''"
     }
     this.higherOrderInFlight.add(expr)
     try {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -151,6 +151,21 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * Re-entry guard for `convertHigherOrderExpr` (#1421).
+   *
+   * `MojoTopLevelEmitter.unsupported` falls back to the regex pipeline
+   * via `_convertExpressionToPerlPublic`, which re-detects the
+   * `.filter|every|some` short-circuit and re-enters
+   * `convertHigherOrderExpr` with the same raw text. When the parser
+   * carries the full original expression down to every nested
+   * `unsupported` node (e.g. an array-literal callee that the AST
+   * can't classify), the cycle has no terminator and the JS stack
+   * blows. The guard records the expression on entry, emits BF101 on
+   * second visit, and bails out — so the user sees an actionable
+   * diagnostic instead of `RangeError: Maximum call stack size`.
+   */
+  private higherOrderInFlight: Set<string> = new Set()
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so
    * the per-attribute `emitSpread` callback can build a propsObject
@@ -173,6 +188,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this.propsObjectName = ir.metadata.propsObjectName ?? null
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
     this.errors = []
+    this.higherOrderInFlight = new Set()
     this.childrenCaptureCounter = 0
 
     // Mirror of the Go adapter's BF103 check (#1266): when a child
@@ -1254,8 +1270,25 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * - todos().filter(t => t.done).length > 0 → scalar(grep { $_->{done} } @{$todos}) > 0
    */
   private convertHigherOrderExpr(expr: string): string {
-    const parsed = parseExpression(expr)
-    return this.renderParsedExprToPerl(parsed)
+    if (this.higherOrderInFlight.has(expr)) {
+      this.errors.push({
+        code: 'BF101',
+        severity: 'error',
+        message: `Cannot lower higher-order chain to Embedded Perl: ${expr.trim()}`,
+        loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        suggestion: {
+          message: "The Mojo adapter cannot lower this `.filter()` / `.every()` / `.some()` chain — typically because the array source is a JS array literal or a non-signal expression the AST classifier doesn't recognise. Move the expression into a `'use client'` component (so hydration computes it client-side), or rewrite it to operate on a signal getter or a prop directly.",
+        },
+      })
+      return ''
+    }
+    this.higherOrderInFlight.add(expr)
+    try {
+      const parsed = parseExpression(expr)
+      return this.renderParsedExprToPerl(parsed)
+    } finally {
+      this.higherOrderInFlight.delete(expr)
+    }
   }
 
   /**

--- a/packages/adapter-tests/fixtures/branch-local-filter-join.ts
+++ b/packages/adapter-tests/fixtures/branch-local-filter-join.ts
@@ -1,0 +1,37 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Branch-local higher-order chain at an attribute position (#1421).
+ *
+ * Mirrors the scaffold `Slot` shape: `const merged = [a, b].filter(Boolean)
+ * .join(' ')` declared inside an `if (...)` branch, then referenced at a
+ * JSX attribute. Branch-local inlining (#1415) substitutes the chain's
+ * RHS into the attribute position, so the adapter receives the full
+ * higher-order expression to translate.
+ *
+ * The Hono adapter inlines the expression verbatim (the CSR runtime
+ * computes it at hydration time). Template-language adapters (Mojo, Go)
+ * can't lower an array-literal callee into their expression dialect, so
+ * they record BF101 instead — see each adapter's `expectedDiagnostics`.
+ *
+ * Pre-fix regression: Mojo's `convertHigherOrderExpr` ↔ unsupported-
+ * emitter loop had no terminator and crashed `bf build` with a Node
+ * stack overflow before this fixture's compile finished.
+ */
+export const fixture = createFixture({
+  id: 'branch-local-filter-join',
+  description: 'Branch-local .filter(Boolean).join() chain inlined at an attribute',
+  source: `
+function BranchLocalFilterJoin({ on, label }: { on?: boolean; label?: string }) {
+  if (on) {
+    const merged = [label, 'extra'].filter(Boolean).join(' ')
+    return <div className={merged}>x</div>
+  }
+  return <div>fallback</div>
+}
+export { BranchLocalFilterJoin }
+`,
+  expectedHtml: `
+    <div>fallback</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/branch-local-filter-join.ts
+++ b/packages/adapter-tests/fixtures/branch-local-filter-join.ts
@@ -32,6 +32,6 @@ function BranchLocalFilterJoin({ on, label }: { on?: boolean; label?: string }) 
 export { BranchLocalFilterJoin }
 `,
   expectedHtml: `
-    <div>fallback</div>
+    <div bf-s="test">fallback</div>
   `,
 })

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -46,6 +46,7 @@ import { fixture as nullishCoalescingJsx } from './nullish-coalescing-jsx'
 import { fixture as logicalOrJsx } from './logical-or-jsx'
 import { fixture as branchSelfClosing } from './branch-self-closing'
 import { fixture as branchMap } from './branch-map'
+import { fixture as branchLocalFilterJoin } from './branch-local-filter-join'
 import { fixture as returnLogicalAnd } from './return-logical-and'
 import { fixture as returnLogicalOr } from './return-logical-or'
 import { fixture as returnNullishCoalescing } from './return-nullish-coalescing'
@@ -134,6 +135,7 @@ export const jsxFixtures: JSXFixture[] = [
   logicalOrJsx,
   branchSelfClosing,
   branchMap,
+  branchLocalFilterJoin,
   returnLogicalAnd,
   returnLogicalOr,
   returnNullishCoalescing,

--- a/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
+++ b/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
@@ -82,6 +82,12 @@ const statelessFixtures = new Set([
   'static-array-children',
   'if-statement',
   'top-level-ternary',
+  // #1421: fallback branch is rendered at SSR (no `on` prop), but the
+  // emitted client JS still wires up the truthy branch's `className`
+  // slot. The marker for that slot doesn't appear in the falsy-branch
+  // expectedHtml — same SSR/CSR-branch divergence that motivates
+  // `if-statement` / `top-level-ternary`.
+  'branch-local-filter-join',
 ])
 
 describe('SSR-Hydration Contract', () => {


### PR DESCRIPTION
Closes #1421.

## Summary

`bf build` under `--adapter mojo` crashed with `RangeError: Maximum call stack size exceeded` whenever a `"use client"` component declared a branch-local higher-order chain referenced at a JSX attribute — the exact shape the scaffold's `Slot` uses (`[className, childClass].filter(Boolean).join(' ')`).

Root cause (per the issue): `MojoTopLevelEmitter.unsupported` → `_convertExpressionToPerlPublic` → `convertExpressionToPerl` re-detects `.filter|every|some` and re-enters `convertHigherOrderExpr` with the same raw text. The parser carries the full original expression down to every nested `unsupported` node (an array-literal callee can't be classified), so the cycle has no terminator.

## Fix

Add a per-expression in-flight guard on `MojoAdapter`. On second visit `convertHigherOrderExpr` records BF101 with the offending expression and bails out, so the user sees an actionable diagnostic instead of a silent stack overflow. Same refusal shape the Go adapter already emits for unsupported expressions.

## Changes

- `packages/adapter-mojolicious/src/adapter/mojo-adapter.ts` — `higherOrderInFlight: Set<string>` field + entry/exit guard in `convertHigherOrderExpr`; reset alongside `errors` in `generate()`.
- `packages/adapter-tests/fixtures/branch-local-filter-join.ts` — new shared fixture exercising the scaffold-Slot shape.
- `packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts` — fixture wired into `expectedDiagnostics` with the BF101 contract; plus a focused regression test asserting the BF101 message references the offending `.filter(Boolean).join` chain.
- `packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts` — same fixture pinned to BF101 (Go already emits this; we're pinning the cross-adapter contract).

## Test plan

- [x] Mojo adapter test file passes (162 pass / 0 fail)
- [x] Go-template adapter test file passes (184 pass / 0 fail)
- [x] Repro from the issue (`[className].filter(Boolean).join(' ')` inside an `if (children)` branch) no longer stack-overflows and instead records a single BF101 with the offending expression in the message
- [ ] Verify `npm create barefootjs@latest -- --adapter mojo --yes` no longer crashes at `bf build` — out of scope; the scaffold's Slot still uses an unsupported pattern so the scaffold itself needs a follow-up fix (likely tracked under #1416 / #1419).

https://claude.ai/code/session_01BKEfhKqCXXB2LQeffa9BUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKEfhKqCXXB2LQeffa9BUE)_