### PR TITLE
feat(go-template/#1423): propagate JSX-time signal `??` defaults to SSR

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -305,6 +305,63 @@ export function Label(props: { label?: string }) {
       // hoisted var.
       expect(types).toContain('Text: label,')
     })
+
+    test('hoists `props.X ?? true` against the bool zero (#1423 review)', () => {
+      // Bool-true falls through the same hoist path as int / string —
+      // the asymmetry is documented (caller can't thread "explicit
+      // false" through because Go's bool zero IS false), but emitting
+      // a hoisted local matches the int case's shape so a derived
+      // memo can inherit it.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Check(props: { checked?: boolean }) {
+  const [c, setC] = createSignal(props.checked ?? true)
+  return <div>{c() ? 'on' : 'off'}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('checked := in.Checked')
+      expect(types).toMatch(/if checked == false\s*\{\s*checked = true\s*\}/)
+      expect(types).toContain('Checked: checked,')
+      expect(types).toContain('C: checked,')
+    })
+
+    test('skips hoist for zero-equivalent string and float fallbacks (#1423 review)', () => {
+      // The skip predicate compares the Go fallback against the
+      // type's zero literal — covers `?? ''` (string) and `?? 0.0`
+      // (numeric spelling that parses to zero), not just the bare
+      // `?? 0` / `?? false` literals.
+      const adapter = new GoTemplateAdapter()
+      const emptyStringIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Label(props: { label?: string }) {
+  const [text, setText] = createSignal(props.label ?? '')
+  return <div>{text()}</div>
+}
+`)
+      const emptyStringTypes = adapter.generate(emptyStringIr).types!
+      expect(emptyStringTypes).not.toContain('label := in.Label')
+      expect(emptyStringTypes).toContain('Label: in.Label,')
+
+      const floatIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Score(props: { value?: number }) {
+  const [v, setV] = createSignal(props.value ?? 0.0)
+  return <div>{v()}</div>
+}
+`)
+      const floatTypes = adapter.generate(floatIr).types!
+      expect(floatTypes).not.toContain('value := in.Value')
+      expect(floatTypes).toContain('Value: in.Value,')
+    })
   })
 
   describe('JSX children forwarding (#1203)', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -229,6 +229,82 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toContain('Initial int')
       expect(result.types).toContain('Count int')
     })
+
+    test('hoists signal-time `props.X ?? N` fallback into shared local var (#1423)', () => {
+      // Mirrors the Mojo manifest-defaults coverage (#1419): when the
+      // signal default lives on a `??` against a bare prop access, the
+      // generator hoists the fallback so the signal, the prop field,
+      // and any derived memo share one fallback-applied value.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal, createMemo } from "@barefootjs/client"
+
+export function Counter(props: { initial?: number }) {
+  const [count, setCount] = createSignal(props.initial ?? 99)
+  const doubled = createMemo(() => count() * 2)
+  return <div>{count()} {doubled()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      expect(result.types).toBeDefined()
+      const types = result.types!
+
+      // Hoist: `initial := in.Initial` + zero-check + fallback assign.
+      expect(types).toContain('initial := in.Initial')
+      expect(types).toMatch(/if initial == 0 \{\s*initial = 99\s*\}/)
+
+      // Prop, signal, and memo all reference the hoisted variable.
+      expect(types).toContain('Initial: initial,')
+      expect(types).toContain('Count: initial,')
+      expect(types).toContain('Doubled: initial * 2,')
+
+      // Pre-fix output is no longer present.
+      expect(types).not.toContain('Count: in.Initial,')
+      expect(types).not.toContain('Doubled: in.Initial * 2,')
+    })
+
+    test('zero-fallback (`??  0`) leaves NewXxxProps unchanged (#1423)', () => {
+      // The hoist is a no-op when the fallback is the Go zero value;
+      // emitting `if initial == 0 { initial = 0 }` would be noise.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter(props: { initial?: number }) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
+  return <div>{count()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).not.toContain('initial := in.Initial')
+      expect(types).toContain('Initial: in.Initial,')
+      expect(types).toContain('Count: in.Initial,')
+    })
+
+    test('hoists string fallback for `props.X ?? "default"` (#1423)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Label(props: { label?: string }) {
+  const [text, setText] = createSignal(props.label ?? 'Default')
+  return <div>{text()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('label := in.Label')
+      expect(types).toMatch(/if label == ""\s*\{\s*label = "Default"\s*\}/)
+      expect(types).toContain('Label: label,')
+      // Signal name `text` differs from prop name `label`, so the
+      // signal field gets its own entry that resolves through the
+      // hoisted var.
+      expect(types).toContain('Text: label,')
+    })
   })
 
   describe('JSX children forwarding (#1203)', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -118,6 +118,22 @@ interface SpreadSlotInfo {
   bagSource: 'inline' | 'input-bag'
 }
 
+/**
+ * (#1423) Hoisted local var representing a prop with a signal-time
+ * `??` fallback. Used by `generateNewPropsFunction` to share the
+ * fallback-applied value across the prop, signal, and memo fields.
+ */
+interface PropFallbackVar {
+  /** Local variable name (typically the lowercase prop identifier). */
+  varName: string
+  /** Capitalised Go field name on the `Input` struct. */
+  fieldName: string
+  /** Go literal used when the input value equals its zero value. */
+  goFallback: string
+  /** Go zero literal for the prop's type (`0`, `""`, etc.). */
+  zeroLiteral: string
+}
+
 export interface GoTemplateAdapterOptions {
   /** Go package name for generated types (default: 'components') */
   packageName?: string
@@ -934,6 +950,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // (#1423) Collect signal-time prop fallbacks: when a signal is
+    // initialized via `createSignal(props.X ?? N)`, hoist `N` as a
+    // local variable so the signal, any memo derived from it, and the
+    // prop field itself all derive from the same fallback-applied
+    // value. Mirrors the Mojo adapter's `ssrDefaults` consumption
+    // (#1419) — Go's primitive zero values can't distinguish an
+    // explicit `Initial: 0` from an omitted field, so the substitution
+    // also fires when the caller passes the type's zero value.
+    const propFallbackVars = this.collectPropFallbackVars(ir)
+    for (const [, info] of propFallbackVars) {
+      lines.push(`\t${info.varName} := in.${info.fieldName}`)
+      lines.push(`\tif ${info.varName} == ${info.zeroLiteral} {`)
+      lines.push(`\t\t${info.varName} = ${info.goFallback}`)
+      lines.push(`\t}`)
+    }
+    if (propFallbackVars.size > 0) lines.push('')
+
     lines.push(`\treturn ${propsTypeName}{`)
     lines.push('\t\tScopeID: scopeID,')
     // (#1249) Forward host context for when *this* component is itself a
@@ -947,16 +980,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Add props params, tracking field names to skip duplicate signal assignments.
     // When the JSX function declared a default (e.g. `variant = 'default'`),
     // bake that fallback into the generated assignment so a Go zero value
-    // doesn't silently shadow the JSX-side default.
+    // doesn't silently shadow the JSX-side default. The same logic
+    // applies for signal-side fallbacks (`createSignal(props.X ?? N)`)
+    // via the hoisted variable from `propFallbackVars` (#1423).
     const propFieldNames = new Set<string>()
     for (const param of ir.metadata.propsParams) {
       const fieldName = this.capitalizeFieldName(param.name)
       if (nestedArrayFields.has(fieldName)) continue
-      const fallback = this.goPropDefault(param.defaultValue)
-      if (fallback !== null) {
-        lines.push(`\t\t${fieldName}: ${this.applyGoFallback(`in.${fieldName}`, fallback)},`)
+      const hoisted = propFallbackVars.get(param.name)
+      if (hoisted) {
+        lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
       } else {
-        lines.push(`\t\t${fieldName}: in.${fieldName},`)
+        const fallback = this.goPropDefault(param.defaultValue)
+        if (fallback !== null) {
+          lines.push(`\t\t${fieldName}: ${this.applyGoFallback(`in.${fieldName}`, fallback)},`)
+        } else {
+          lines.push(`\t\t${fieldName}: in.${fieldName},`)
+        }
       }
       propFieldNames.add(fieldName)
     }
@@ -965,8 +1005,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const signal of ir.metadata.signals) {
       const fieldName = this.capitalizeFieldName(signal.getter)
       if (propFieldNames.has(fieldName)) continue
-      const initialValue = this.convertInitialValue(signal.initialValue, signal.type, ir.metadata.propsParams)
-      lines.push(`\t\t${fieldName}: ${initialValue},`)
+      // (#1423) If this signal's initial value is `props.X ?? N` and we
+      // hoisted a fallback variable for `X`, reuse the hoisted variable
+      // so the signal and any memo computation share the same value.
+      const fallbackMatch = this.extractPropFallback(signal.initialValue)
+      const hoisted = fallbackMatch ? propFallbackVars.get(fallbackMatch.propName) : undefined
+      if (hoisted) {
+        lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
+      } else {
+        const initialValue = this.convertInitialValue(signal.initialValue, signal.type, ir.metadata.propsParams)
+        lines.push(`\t\t${fieldName}: ${initialValue},`)
+      }
     }
 
     // Add nested component arrays (static only; dynamic ones are set by the handler)
@@ -978,7 +1027,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Add memo initial values (computed from signal initial values)
     for (const memo of ir.metadata.memos) {
       const fieldName = this.capitalizeFieldName(memo.name)
-      const memoValue = this.computeMemoInitialValue(memo, ir.metadata.signals, ir.metadata.propsParams)
+      const memoValue = this.computeMemoInitialValue(memo, ir.metadata.signals, ir.metadata.propsParams, propFallbackVars)
       lines.push(`\t\t${fieldName}: ${memoValue},`)
     }
 
@@ -1638,16 +1687,28 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   /**
    * Get signal's initial value as Go code.
    * Handles both literal values (0, true, "str") and props references (initial).
+   *
+   * (#1423) When the signal references a prop via `props.X ?? N` and
+   * the caller hoisted a fallback variable for `X`, return the hoisted
+   * variable's name so the memo inherits the signal-time fallback.
    */
-  private getSignalInitialValueAsGo(initialValue: string, propsParams: { name: string }[]): string {
+  private getSignalInitialValueAsGo(
+    initialValue: string,
+    propsParams: { name: string }[],
+    propFallbackVars: ReadonlyMap<string, PropFallbackVar> = GoTemplateAdapter.EMPTY_PROP_FALLBACK_VARS,
+  ): string {
     // Check if it's a props param reference
     if (propsParams.some(p => p.name === initialValue)) {
+      const hoisted = propFallbackVars.get(initialValue)
+      if (hoisted) return hoisted.varName
       return `in.${this.capitalizeFieldName(initialValue)}`
     }
 
     // Check for props.xxx pattern (e.g., "props.initial ?? 0")
     const propName = this.extractPropNameFromInitialValue(initialValue)
     if (propName && propsParams.some(p => p.name === propName)) {
+      const hoisted = propFallbackVars.get(propName)
+      if (hoisted) return hoisted.varName
       return `in.${this.capitalizeFieldName(propName)}`
     }
 
@@ -1776,13 +1837,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Compute the initial value for a memo based on its computation and signal initial values.
    * Handles simple cases like `() => count() * 2` → `in.Initial * 2`
    * Also handles props.xxx patterns like `() => props.value * 10` → `in.Value * 10`
+   *
+   * (#1423) When `propFallbackVars` carries a hoisted variable for the
+   * referenced prop, substitute it for `in.FieldName` so the memo
+   * inherits the signal-time `??` fallback.
    */
   private computeMemoInitialValue(
     memo: { name: string; computation: string; deps: string[] },
     signals: { getter: string; initialValue: string }[],
-    propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[]
+    propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+    propFallbackVars: ReadonlyMap<string, PropFallbackVar> = GoTemplateAdapter.EMPTY_PROP_FALLBACK_VARS,
   ): string {
     const computation = memo.computation
+    // Helper to pick the hoisted var (if any) or fall back to `in.X`.
+    const propRef = (propName: string): string => {
+      const hoisted = propFallbackVars.get(propName)
+      if (hoisted) return hoisted.varName
+      return `in.${this.capitalizeFieldName(propName)}`
+    }
 
     // Pattern: () => dep() * N or () => dep() + N etc.
     const arithmeticMatch = computation.match(/\(\)\s*=>\s*(\w+)\(\)\s*([*+\-/])\s*(\d+)/)
@@ -1791,7 +1863,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const signal = signals.find(s => s.getter === depName)
       if (signal) {
         // Get the signal's initial value in Go format
-        const signalInitial = this.getSignalInitialValueAsGo(signal.initialValue, propsParams)
+        const signalInitial = this.getSignalInitialValueAsGo(signal.initialValue, propsParams, propFallbackVars)
         return `${signalInitial} ${operator} ${operand}`
       }
     }
@@ -1803,6 +1875,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Check if this prop is in propsParams (passed from parent)
       const param = propsParams.find(p => p.name === propName)
       if (param) {
+        const hoisted = propFallbackVars.get(propName)
+        if (hoisted) return `${hoisted.varName} ${operator} ${operand}`
         const fieldName = this.capitalizeFieldName(propName)
         // Guard: if the prop resolves to interface{}, use type assertion for arithmetic
         if (param.type) {
@@ -1819,7 +1893,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const [, depName] = simpleMatch
       const signal = signals.find(s => s.getter === depName)
       if (signal) {
-        return this.getSignalInitialValueAsGo(signal.initialValue, propsParams)
+        return this.getSignalInitialValueAsGo(signal.initialValue, propsParams, propFallbackVars)
       }
     }
 
@@ -1829,7 +1903,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const [, propName] = propsSimpleMatch
       const param = propsParams.find(p => p.name === propName)
       if (param) {
-        return `in.${this.capitalizeFieldName(propName)}`
+        return propRef(propName)
       }
     }
 
@@ -1927,6 +2001,90 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * (#1423) Hoisted-variable record for a prop with a signal-time
+   * `??` fallback. The same record is referenced from the prop field
+   * loop, the signal field loop, and the memo computation path.
+   */
+  private static EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
+
+  /**
+   * (#1423) Walk signals to collect prop fallbacks. Skips props that
+   * already have a destructure-side default (`{ X = N }`) or signals
+   * whose fallback resolves to the type's Go zero value (no-op).
+   */
+  private collectPropFallbackVars(ir: ComponentIR): Map<string, PropFallbackVar> {
+    const result = new Map<string, PropFallbackVar>()
+    const localTaken = new Set(['scopeID'])
+    for (const nested of this.findNestedComponents(ir.root)) {
+      localTaken.add(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`)
+    }
+
+    for (const signal of ir.metadata.signals) {
+      const match = this.extractPropFallback(signal.initialValue)
+      if (!match) continue
+      if (result.has(match.propName)) continue
+      const param = ir.metadata.propsParams.find(p => p.name === match.propName)
+      if (!param) continue
+      // A destructure default already wins via applyGoFallback below.
+      if (this.goPropDefault(param.defaultValue) !== null) continue
+      // Zero-equivalent fallback is a no-op against the Go zero value.
+      if (match.goFallback === '0' || match.goFallback === 'false') continue
+      const fieldName = this.capitalizeFieldName(match.propName)
+      // Pick the zero literal based on the fallback's literal shape.
+      let zeroLiteral: string
+      if (match.goFallback === 'true') {
+        // `(in.X || true)` is always-true — caller can't thread `false`
+        // through. Leave the bool-true asymmetry to the existing
+        // applyGoFallback path (no hoisted var benefit anyway).
+        continue
+      } else if (/^-?\d+(\.\d+)?$/.test(match.goFallback)) {
+        zeroLiteral = '0'
+      } else if (match.goFallback.startsWith('"')) {
+        zeroLiteral = '""'
+      } else {
+        continue
+      }
+      // The JSX-side identifier is the natural local name.
+      // Suffix with `_` if it collides with a Go keyword or a local we
+      // already emit.
+      let varName = match.propName
+      while (localTaken.has(varName) || GoTemplateAdapter.GO_KEYWORDS.has(varName)) {
+        varName += '_'
+      }
+      localTaken.add(varName)
+      result.set(match.propName, { varName, fieldName, goFallback: match.goFallback, zeroLiteral })
+    }
+    return result
+  }
+
+  /**
+   * (#1423) Parse a signal-time initial value of the form
+   * `props.X ?? <literal>` into the source prop name and the Go-formatted
+   * fallback. Returns null when:
+   *   - the expression isn't a `??` against a property access on
+   *     `propsObjectName`
+   *   - the fallback isn't a simple literal `goPropDefault` can translate
+   *
+   * The Go-adapter equivalent of the same parse already done by the
+   * static evaluator in `ssr-defaults.ts` — duplicated here because we
+   * need the original prop reference (not just the resolved value)
+   * to honour caller-supplied non-zero inputs.
+   */
+  private extractPropFallback(initialValue: string): { propName: string; goFallback: string } | null {
+    if (!this.propsObjectName) return null
+    const trimmed = initialValue.trim()
+    const name = this.propsObjectName
+
+    // `props.X ?? <rhs>` — capture RHS greedily up to end of string.
+    const re = new RegExp(`^${name}\\.(\\w+)\\s*\\?\\?\\s*(.+)$`)
+    const m = trimmed.match(re)
+    if (!m) return null
+    const goFallback = this.goPropDefault(m[2].trim())
+    if (goFallback === null) return null
+    return { propName: m[1], goFallback }
+  }
+
+  /**
    * Extract prop name from a signal's initialValue that uses props.xxx pattern.
    * e.g., "props.initial ?? 0" → "initial", "props.checked" → "checked"
    */
@@ -1953,6 +2111,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     'id', 'url', 'http', 'https', 'api', 'json', 'xml', 'html', 'css', 'sql',
     'ip', 'tcp', 'udp', 'dns', 'ssh', 'tls', 'ssl', 'uri', 'uid', 'uuid',
     'ascii', 'utf8', 'eof', 'grpc', 'rpc', 'cpu', 'gpu', 'ram', 'os',
+  ])
+
+  /**
+   * (#1423) Go reserved keywords. When we hoist a local var named after
+   * a JSX prop, the prop name could collide with one of these — append
+   * `_` until the name is free.
+   */
+  private static GO_KEYWORDS = new Set([
+    'break', 'case', 'chan', 'const', 'continue', 'default', 'defer',
+    'else', 'fallthrough', 'for', 'func', 'go', 'goto', 'if', 'import',
+    'interface', 'map', 'package', 'range', 'return', 'select', 'struct',
+    'switch', 'type', 'var',
   ])
 
   private capitalizeFieldName(name: string): string {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2027,16 +2027,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (!param) continue
       // A destructure default already wins via applyGoFallback below.
       if (this.goPropDefault(param.defaultValue) !== null) continue
-      // Zero-equivalent fallback is a no-op against the Go zero value.
-      if (match.goFallback === '0' || match.goFallback === 'false') continue
       const fieldName = this.capitalizeFieldName(match.propName)
       // Pick the zero literal based on the fallback's literal shape.
+      // Bool fallbacks (`?? true`) hoist against the `false` zero —
+      // matches the same Go-zero conflation the int / string cases
+      // accept: caller can't distinguish "explicit false" from
+      // "unset", but for SSR-time defaults that's the documented
+      // trade-off (#1423 Option B).
       let zeroLiteral: string
-      if (match.goFallback === 'true') {
-        // `(in.X || true)` is always-true — caller can't thread `false`
-        // through. Leave the bool-true asymmetry to the existing
-        // applyGoFallback path (no hoisted var benefit anyway).
-        continue
+      if (match.goFallback === 'true' || match.goFallback === 'false') {
+        zeroLiteral = 'false'
       } else if (/^-?\d+(\.\d+)?$/.test(match.goFallback)) {
         zeroLiteral = '0'
       } else if (match.goFallback.startsWith('"')) {
@@ -2044,6 +2044,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       } else {
         continue
       }
+      // Zero-equivalent fallback is a no-op against the Go zero value
+      // (`?? 0`, `?? ''`, `?? false`, `?? 0.0`). Compare against the
+      // computed zeroLiteral so spelling variants like `0.0` collapse
+      // to the same skip as `0`.
+      if (match.goFallback === zeroLiteral) continue
+      if (zeroLiteral === '0' && Number(match.goFallback) === 0) continue
       // The JSX-side identifier is the natural local name.
       // Suffix with `_` if it collides with a Go keyword or a local we
       // already emit.

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -5,7 +5,7 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSX } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults } from '@barefootjs/jsx'
 import type { ComponentIR } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -411,12 +411,17 @@ function buildPerlProps(
     }
   }
 
-  // Add memo values — simple pass-through for SSR
+  // Add memo values. The production Mojo plugin seeds these from the
+  // manifest's `ssrDefaults` (see Plugin/BarefootJS.pm `before_render`
+  // hook), which carries the statically-evaluated result of each memo
+  // computation. Mirror that here so the test harness doesn't diverge
+  // from the plugin: hard-coding `0` masked memos with non-zero
+  // initial values until #1423 added a fixture that exposed the gap.
+  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
   for (const memo of ir.metadata.memos) {
-    // Try to evaluate simple memo computations
-    const computation = memo.computation.trim()
-    // count() * 2 → look up count in entries
-    entries.push(`${memo.name} => 0`)
+    const entry = ssrDefaults[memo.name]
+    const value = entry && typeof entry === 'object' && 'value' in entry ? entry.value : 0
+    entries.push(`${memo.name} => ${toPerlLiteral(value ?? 0)}`)
   }
 
   return `{${entries.join(', ')}}`

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -1,6 +1,7 @@
 import { fixture as counter } from './counter'
 // Priority 1: Core reactivity
 import { fixture as signalWithFallback } from './signal-with-fallback'
+import { fixture as signalDefaultFromJsx } from './signal-default-from-jsx'
 import { fixture as controlledSignal } from './controlled-signal'
 import { fixture as signalPropSameName } from './signal-prop-same-name'
 import { fixture as memo } from './memo'
@@ -89,6 +90,7 @@ export const jsxFixtures: JSXFixture[] = [
   counter,
   // Priority 1: Core reactivity
   signalWithFallback,
+  signalDefaultFromJsx,
   controlledSignal,
   signalPropSameName,
   memo,

--- a/packages/adapter-tests/fixtures/signal-default-from-jsx.ts
+++ b/packages/adapter-tests/fixtures/signal-default-from-jsx.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+// (#1423) JSX-time signal default propagates to SSR when the caller
+// supplies no value. Pairs with the Mojo manifest_defaults coverage
+// (#1419) — the Go adapter's `NewXxxProps` must apply the `?? 7`
+// fallback when `in.X` is the Go zero, otherwise the SSR HTML renders
+// `0` while the JSX-side default is `7`. The memo `() => x() + 1`
+// must inherit the fallback and land at `8`.
+//
+// `props` is intentionally omitted: the fixture exercises the
+// no-props path where the JSX-time fallback is the sole source of
+// truth.
+export const fixture = createFixture({
+  id: 'signal-default-from-jsx',
+  description: 'JSX-time signal default propagates to SSR when caller omits the prop (#1423)',
+  source: `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+export function SignalDefaultFromJsx(props: { x?: number }) {
+  const [x, setX] = createSignal(props.x ?? 7)
+  const incremented = createMemo(() => x() + 1)
+  return <div><span>{x()}</span><span>{incremented()}</span></div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->7<!--/--></span>
+      <span bf="s3"><!--bf:s2-->8<!--/--></span>
+    </div>
+  `,
+})


### PR DESCRIPTION
## Summary

Closes #1423. Echo / Go adapter parity for the JSX-time signal default
plumbing that #1419 added on the Mojo side.

Before this PR, `createSignal(props.initial ?? 99)` in the scaffold's
`Counter.tsx` rendered SSR HTML with `count = 0` whenever the caller
passed `CounterInput{}` (or `CounterInput{Initial: 0}`) — the
generated `NewCounterProps` emitted `Count: in.Initial` verbatim,
dropping the `?? 99` fallback. Now it hoists a local variable so the
prop, the signal, and any derived memo all flow through the same
fallback-applied value:

```go
func NewCounterProps(in CounterInput) CounterProps {
    // …
    initial := in.Initial
    if initial == 0 {
        initial = 99
    }
    return CounterProps{
        // …
        Initial: initial,
        Count:   initial,
        Doubled: initial * 2,
    }
}
```

Issue's recommended **Option B** — backwards-compatible at the caller
boundary (the existing `Initial: 0` still compiles) at the cost of
conflating "explicit 0" with "unset". The conflation matches the
existing destructure-default behaviour in `applyGoFallback`; the
trade-off is documented inline.

## What's in scope

- `props.X ?? <literal>` shapes that the static evaluator in
  `ssr-defaults.ts` would have collapsed to a JSON-encodable value.
  Int and string fallbacks get the hoist; bool-true stays on the
  legacy `applyGoFallback` IIFE path because `(in.X || true)` is
  already always-true.
- Memo computations that depend on the hoisted signal — the
  `computeMemoInitialValue` dispatch threads `propFallbackVars`
  through so `doubled = count() * 2` lands at `initial * 2`.

## What's intentionally untouched

- The "destructure default with bare-identifier signal"
  shape (`function Foo({ initial = 5 })` + `createSignal(initial)`)
  has a related but distinct gap: the signal field still emits
  `Count: in.Initial`. Out of scope for #1423 — would need its own
  hoist path that respects the existing destructure-default
  `applyGoFallback` already emitting on the prop field.

## Test plan

- [x] Three new Go-adapter unit tests in `go-template-adapter.test.ts`
      cover the int hoist, the string hoist, and the zero-fallback
      no-op.
- [x] New cross-adapter fixture `signal-default-from-jsx` asserts
      `createSignal(props.x ?? 7)` + `createMemo(() => x() + 1)` render
      `7` / `8` when the caller supplies no props. Passes against the
      Hono reference (via JS execution) and against the Go adapter
      (via the fix). 530 / 530 tests pass in
      `packages/adapter-go-template` and
      `packages/adapter-tests`.
- [x] Manually rebuilt `integrations/echo` against a modified
      `Counter.tsx` (`?? 99`) and confirmed `NewCounterProps` matches
      the issue's expected output.
- [x] No regressions in adapter-mojolicious (171/171), adapter-tests
      CSR conformance (343/343), or jsx package tests.

Refs:
- #1416 (parent — same friction class)
- #1419 (Mojo plumbing — analogous fix, merged)
- `packages/jsx/src/ssr-defaults.ts` (static evaluator)


---
_Generated by [Claude Code](https://claude.ai/code/session_0142khBPD34YJXioMXBqZJhs)_