### PR TITLE
feat(adapter-hono/#1431): BfScripts entryRoots prop for manually-mounted components

### DIFF
--- a/packages/adapter-hono/src/__tests__/bfscripts-entry-roots.test.tsx
+++ b/packages/adapter-hono/src/__tests__/bfscripts-entry-roots.test.tsx
@@ -1,0 +1,135 @@
+/** @jsxImportSource hono/jsx */
+/**
+ * BfScripts `entryRoots` prop (#1431).
+ *
+ * Background: `<BfScripts manifest base />` walks `stubDeps` only for
+ * components whose SSR template ran during the request (the
+ * `bfOutputScripts` set populated by `addScriptCollection`'s injected
+ * snippet). A page that renders a `'use client'` component via a
+ * manual `<script type="module">import "X.client.js"; render(root, "X", props)`
+ * bootstrap — instead of SSR'ing `<X />` — never lands `X` in
+ * `bfOutputScripts`. BfScripts has no root to walk, and `X`'s
+ * `stubDeps` (children reached only through the imperative
+ * `createComponent` stub rewrite, #1240) never ship as `<script>` tags.
+ *
+ * `entryRoots` lets the caller declare those manually-mounted entry
+ * components so their `stubDeps` get walked. The caller's own inline
+ * `<script type="module">` handles `X.client.js`, so `X` itself stays
+ * in the `excluded` set — only its deps get emitted.
+ *
+ * Real-world: piconic-ai/desk #86 — `DeskCanvasPage` skips SSR of
+ * `<DeskCanvas />` (its template body calls `useYjs()` / `fetch()` —
+ * fatal on Cloudflare Workers) and manually mounts via the inline
+ * script. Without `entryRoots`, `IssueCardNodeImpl.client.js` (reached
+ * via `DeskCanvas → IssueCardNode (.ts) → IssueCardNodeImpl (.tsx)`)
+ * doesn't ship, and the runtime renders the red `[IssueCardNodeImpl]`
+ * placeholder for every card.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { jsxRenderer } from 'hono/jsx-renderer'
+import { BfScripts } from '../scripts'
+import type { BarefootBuildManifest } from '../app'
+
+const MANIFEST: BarefootBuildManifest = {
+  __barefoot__: { clientJs: 'components/barefoot.js' },
+  'canvas/DeskCanvas': {
+    clientJs: 'components/canvas/DeskCanvas.client.js',
+    stubDeps: ['canvas/nodes/IssueCardNodeImpl'],
+  },
+  'canvas/nodes/IssueCardNodeImpl': {
+    clientJs: 'components/canvas/nodes/IssueCardNodeImpl.client.js',
+  },
+  'canvas/catalog/IssueCardCatalog': {
+    clientJs: 'components/canvas/catalog/IssueCardCatalog.client.js',
+    stubDeps: ['canvas/nodes/IssueCardNodeImpl'],
+  },
+}
+
+function mountApp(entryRoots?: string[]) {
+  const app = new Hono()
+  app.use(
+    '*',
+    jsxRenderer(({ children }) => (
+      <html lang="en">
+        <body>
+          {children}
+          <BfScripts manifest={MANIFEST} base="/static/components/" entryRoots={entryRoots} />
+        </body>
+      </html>
+    )),
+  )
+  app.get('/', (c) => c.render(<div id="canvas-root" />))
+  return app
+}
+
+describe('BfScripts entryRoots (#1431)', () => {
+  test('omitted entryRoots → manually-mounted components miss their stubDeps (baseline regression)', async () => {
+    const res = await mountApp().fetch(new Request('http://localhost/'))
+    const html = await res.text()
+    // DeskCanvas isn't in `bfOutputScripts` (no SSR), and we passed no
+    // entryRoots, so its stubDep IssueCardNodeImpl is NOT emitted.
+    expect(html).not.toContain('IssueCardNodeImpl.client.js')
+  })
+
+  test('entryRoots: ["canvas/DeskCanvas"] → walks its stubDeps even though it was not SSR-rendered', async () => {
+    const res = await mountApp(['canvas/DeskCanvas']).fetch(new Request('http://localhost/'))
+    const html = await res.text()
+    // The whole point of #1431: the manually-mounted root's stubDeps
+    // get emitted as `<script type="module" src=...>` tags.
+    expect(html).toContain('/static/components/canvas/nodes/IssueCardNodeImpl.client.js')
+  })
+
+  test('entryRoots does NOT emit a script for the root itself (caller already does that via the inline mount)', async () => {
+    const res = await mountApp(['canvas/DeskCanvas']).fetch(new Request('http://localhost/'))
+    const html = await res.text()
+    // The caller's own inline `<script type="module">import "DeskCanvas.client.js"`
+    // already loads the root; BfScripts must NOT add a duplicate
+    // `<script src=...DeskCanvas.client.js>` that would re-run hydration.
+    expect(html).not.toContain('/static/components/canvas/DeskCanvas.client.js')
+  })
+
+  test('multiple entryRoots are all walked', async () => {
+    const res = await mountApp(['canvas/DeskCanvas', 'canvas/catalog/IssueCardCatalog']).fetch(
+      new Request('http://localhost/'),
+    )
+    const html = await res.text()
+    // Both roots share the same stubDep; it must be emitted (once is fine
+    // because the underlying walker dedupes against `excluded`/`visited`).
+    const occurrences = html.match(/IssueCardNodeImpl\.client\.js/g) ?? []
+    expect(occurrences.length).toBe(1)
+  })
+
+  test('an entry name listed in BOTH outputSet and entryRoots is not double-emitted as a script tag', async () => {
+    // Simulate the case where the caller's manually-mounted root ALSO
+    // happens to be SSR'd elsewhere (unusual but legal). The script
+    // for the root itself stays out (the caller's inline mount handles
+    // it / outputSet excludes it), and the stubDep emits once.
+    const app = new Hono()
+    app.use(
+      '*',
+      jsxRenderer(({ children }) => (
+        <html lang="en">
+          <body>
+            {children}
+            <BfScripts manifest={MANIFEST} base="/static/components/" entryRoots={['canvas/DeskCanvas']} />
+          </body>
+        </html>
+      )),
+    )
+    app.get('/', (c) => {
+      // Simulate addScriptCollection having pushed DeskCanvas during SSR.
+      const set: Set<string> = c.get('bfOutputScripts') || new Set()
+      set.add('canvas/DeskCanvas')
+      c.set('bfOutputScripts', set)
+      return c.render(<div id="canvas-root" />)
+    })
+    const res = await app.fetch(new Request('http://localhost/'))
+    const html = await res.text()
+    const deskMatches = html.match(/DeskCanvas\.client\.js/g) ?? []
+    const implMatches = html.match(/IssueCardNodeImpl\.client\.js/g) ?? []
+    expect(deskMatches.length).toBe(0)
+    expect(implMatches.length).toBe(1)
+  })
+})

--- a/packages/adapter-hono/src/scripts.tsx
+++ b/packages/adapter-hono/src/scripts.tsx
@@ -53,6 +53,23 @@ export interface BfScriptsProps {
    * needs the URL prefix to emit a working `<script src>`.
    */
   base?: string
+  /**
+   * Extra manifest keys to treat as walk roots in addition to the
+   * SSR-rendered set. Use this for pages that mount a `'use client'`
+   * component via an inline `<script type="module">import "X.client.js"; render(root, "X", …)`
+   * instead of SSR'ing `<X />` directly. Without `entryRoots`, the
+   * walker has no anchor for `X`'s `stubDeps` and any sibling `'use
+   * client'` `.tsx` reached only through the imperative
+   * `createComponent` stub rewrite (#1240) never ships as a
+   * `<script>`, leaving the runtime registry empty and rendering
+   * `[ComponentName]` placeholders.
+   *
+   * The caller's inline `<script type="module">import …</script>`
+   * already loads the root bundle, so the root itself is *not*
+   * emitted as a separate `<script src>` — only the transitively
+   * reached `stubDeps` are. See #1431.
+   */
+  entryRoots?: string[]
 }
 
 /**
@@ -75,9 +92,19 @@ export function BfScripts(props: BfScriptsProps = {}) {
 
     const scripts: CollectedScript[] = c.get('bfCollectedScripts') || []
     const outputSet: Set<string> = c.get('bfOutputScripts') || new Set()
-    const { manifest, base } = props
+    const { manifest, base, entryRoots } = props
+    // `entryRoots` extends both the walk-root set AND the `excluded` set.
+    // Walk-root so the root's `stubDeps` get visited (the manually-mounted
+    // component never SSR'd, so it isn't in `bfOutputScripts`). Excluded
+    // so the root's own `.client.js` isn't re-emitted — the caller's
+    // inline `<script type="module">import "X.client.js"; render(...)`
+    // already loaded it. See #1431.
+    const roots = entryRoots && entryRoots.length > 0
+      ? new Set([...outputSet, ...entryRoots])
+      : outputSet
+    if (entryRoots) for (const r of entryRoots) outputSet.add(r)
     const stubScripts = manifest && base
-      ? collectStubDepScripts(manifest, base, outputSet, outputSet)
+      ? collectStubDepScripts(manifest, base, roots, outputSet)
       : new Map<string, CollectedScript>()
     // Record stub-derived names on the same context flag so any later
     // SSR pass (e.g. a Suspense boundary that renders after this point)


### PR DESCRIPTION
Closes #1431.

## Summary

`<BfScripts manifest base />` only walks `stubDeps` for components whose SSR template ran (the `bfOutputScripts` set populated by `addScriptCollection`'s injected snippet). Pages that bootstrap a `'use client'` component via an inline `<script type="module">import "X.client.js"; render(root, "X", props)` — instead of SSR'ing `<X />` — never land `X` in `bfOutputScripts`, so BfScripts has no root to walk for its `stubDeps`. Any sibling `'use client'` `.tsx` reached only through the imperative `createComponent` stub rewrite (#1240) misses its `<script>` tag; the runtime registry stays empty and renders the red `[ChildName]` placeholder.

This PR adds `entryRoots?: string[]` to `BfScriptsProps`. Listed names are added to both the walk-root set (so their `stubDeps` get walked) and the `excluded` set (so the root's own `.client.js` isn't re-emitted — the caller's inline mount already loaded it).

## Real-world

piconic-ai/desk #86. `DeskCanvasPage` skips SSR of `<DeskCanvas />` because its template body calls `useYjs()` (opens a WebSocket) and `fetch()` for the items API — both fatal on Cloudflare Workers. With `<BfScripts entryRoots={['canvas/DeskCanvas']} />`, `IssueCardNodeImpl.client.js` (reached via `DeskCanvas → IssueCardNode (.ts) → IssueCardNodeImpl (.tsx)`) ships and every card hydrates instead of rendering as `[IssueCardNodeImpl]`.

## API

```tsx
<BfScripts
  manifest={manifest}
  base="/static/components/"
  entryRoots={['canvas/DeskCanvas']}
/>
```

Backwards compatible — when omitted, behavior is identical to today.

## Test plan

New `packages/adapter-hono/src/__tests__/bfscripts-entry-roots.test.tsx` (5 cases, all via `Hono.fetch()`):

1. Baseline regression — omitted `entryRoots` doesn't emit deps for manually-mounted roots.
2. `entryRoots: ['X']` walks X's `stubDeps` and emits each reachable `.client.js`.
3. The root itself is NOT emitted — caller's inline mount handles it.
4. Multiple roots — both walked, shared deps dedupe.
5. A name in both `outputSet` and `entryRoots` doesn't double-emit.

`bun test packages/adapter-hono` — 220 pass / 4 pre-existing fail (all in `ssr-context-bridge.test.ts`, unrelated to this change — confirmed via stash-isolated run).

`bun test packages/jsx packages/cli` — 2026 pass / 8 pre-existing fail (resolver/CLI tests unrelated to adapter-hono).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
