### PR TITLE
fix(jsx/#1434): preserve .filter()/.toSorted() chain on loops inside conditional branches

### DIFF
--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2635,5 +2635,40 @@ describe('Client JS generation', () => {
       const js = result.files.find(f => f.type === 'clientJs')!.content
       expect(js).toContain('.toSorted(')
     })
+
+    test('event delegation walks the chained array (filter()/toSorted() reach itemLookup)', () => {
+      // When the per-item event delegation uses `.find()` for keyed loops
+      // or `array[idx]` for unkeyed loops, the array it walks must be the
+      // same shape mapArray reconciled into the DOM — otherwise a click on
+      // a filtered/sorted item resolves the wrong source-array entry.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Repro() {
+          const [items, setItems] = createSignal([{ id: 1, done: false }, { id: 2, done: true }])
+          const [show] = createSignal(true)
+          return (
+            <div>
+              {show()
+                ? (
+                  <ul>
+                    {items().filter(i => !i.done).map(i => (
+                      <li key={i.id} onClick={() => setItems(prev => prev.filter(p => p.id !== i.id))}>{i.id}</li>
+                    ))}
+                  </ul>
+                )
+                : <p>off</p>}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      // Delegated click-handler lookup must `.find()` against the filtered
+      // array, not the raw `items()` array.
+      expect(js).toMatch(/items\(\)\.filter\([^)]+\)\.find\(/)
+    })
   })
 })

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2535,4 +2535,105 @@ describe('Client JS generation', () => {
       expect(js).toMatch(/__disposers\.push\(createDisposableEffect\(\(\)\s*=>\s*\{[\s\S]*?insert\(__branchScope/)
     })
   })
+
+  describe('filter/sort chain inside conditional branch (#1434)', () => {
+    test('preserves .filter() in mapArray when the loop is inside a ternary branch', () => {
+      // Regression for #1434: `.filter().map()` inside a conditional branch
+      // silently dropped the `.filter()` call, breaking reactivity for any
+      // signal read inside the predicate.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Repro() {
+          const [items] = createSignal([{ id: 1, done: false }, { id: 2, done: true }])
+          const [showDone, setShowDone] = createSignal(false)
+          return (
+            <div>
+              <button onClick={() => setShowDone(v => !v)}>toggle</button>
+              {items().length === 0
+                ? <p>empty</p>
+                : (
+                  <ul>
+                    {items().filter(i => i.done === showDone()).map(i => (
+                      <li key={i.id}>{i.id}</li>
+                    ))}
+                  </ul>
+                )}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      expect(js).toContain('.filter(i =>')
+      expect(js).toContain('showDone()')
+    })
+
+    test('preserves .filter() with a block-body predicate inside a ternary branch', () => {
+      // The doc-supported "block body with simple statements" predicate must
+      // survive the same way as the expression-body form.
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Repro() {
+          const [items] = createSignal([{ id: 1, done: false }, { id: 2, done: true }])
+          const [showDone, setShowDone] = createSignal(false)
+          return (
+            <div>
+              <button onClick={() => setShowDone(v => !v)}>toggle</button>
+              {items().length === 0
+                ? <p>empty</p>
+                : (
+                  <ul>
+                    {items().filter(i => {
+                      if (showDone()) return i.done
+                      return !i.done
+                    }).map(i => (
+                      <li key={i.id}>{i.id}</li>
+                    ))}
+                  </ul>
+                )}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      expect(js).toContain('.filter(i =>')
+      expect(js).toContain('showDone()')
+    })
+
+    test('preserves .toSorted() comparator inside a conditional branch', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Repro() {
+          const [items] = createSignal([{ id: 1, n: 2 }, { id: 2, n: 1 }])
+          const [show] = createSignal(true)
+          return (
+            <div>
+              {show()
+                ? (
+                  <ul>
+                    {items().toSorted((a, b) => a.n - b.n).map(i => (
+                      <li key={i.id}>{i.id}</li>
+                    ))}
+                  </ul>
+                )
+                : <p>off</p>}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      expect(js).toContain('.toSorted(')
+    })
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -903,6 +903,16 @@ function collectBranchLoops(
         bindings: branchBindings,
         innerLoops: useElementReconciliation ? innerLoopsCollected : undefined,
         useElementReconciliation: useElementReconciliation || undefined,
+        filterPredicate: n.filterPredicate ? {
+          param: n.filterPredicate.param,
+          raw: n.filterPredicate.raw,
+        } : undefined,
+        sortComparator: n.sortComparator ? {
+          paramA: n.sortComparator.paramA,
+          paramB: n.sortComparator.paramB,
+          raw: n.sortComparator.raw,
+        } : undefined,
+        chainOrder: n.chainOrder,
       })
       // Don't recurse into the loop — nested loops are handled by the loop's own reconciliation.
     },

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
@@ -11,7 +11,7 @@
  */
 
 import type { BranchLoop } from '../../types'
-import { varSlotId, wrapLoopParamAsAccessor } from '../../utils'
+import { buildChainedArrayExpr, varSlotId, wrapLoopParamAsAccessor } from '../../utils'
 import { buildBranchCompositePlan } from './build-composite-loop'
 import { buildBranchLoopDelegationPlan } from './build-event-delegation'
 import { buildReactiveEffectsPlan } from './build-reactive-effects'
@@ -47,7 +47,7 @@ export function buildBranchLoopPlan(loop: BranchLoop): BranchLoopPlan {
     containerSlotId,
     containerVar,
     markerId: loop.markerId,
-    arrayExpr: loop.array,
+    arrayExpr: buildChainedArrayExpr(loop),
     keyFn: loopKeyFn(loop),
     paramHead,
     paramUnwrap,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
@@ -86,9 +86,10 @@ export function buildBranchCompositePlan(loop: BranchLoop, cv: string): Composit
     kind: 'composite',
     containerVar: `__loop_${cv}`,
     markerId: loop.markerId,
-    // Branch-scoped loops use the raw array expression (no filter/sort chaining
-    // path — BranchLoop doesn't carry those fields).
-    arrayExpr: loop.array,
+    // Chain `.filter()` / `.toSorted()` onto the source array so the mapArray
+    // call emitted inside the branch tracks signals read by the predicate
+    // / comparator (#1434).
+    arrayExpr: buildChainedArrayExpr(loop),
     keyFn: loopKeyFn(loop),
     paramHead,
     paramUnwrap,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -10,7 +10,7 @@
  */
 
 import type { TopLevelLoop, BranchLoop, LoopChildEvent } from '../../types'
-import { varSlotId, substituteLoopBindings } from '../../utils'
+import { buildChainedArrayExpr, varSlotId, substituteLoopBindings } from '../../utils'
 import type {
   EventDelegationPlan,
   ItemLookup,
@@ -22,7 +22,11 @@ export function buildDynamicLoopDelegationPlan(elem: TopLevelLoop): EventDelegat
     containerVar: `_${varSlotId(elem.slotId)}`,
     events: elem.bindings.events,
     itemLookup: buildKeyedOrIndexLookup({
-      array: elem.array,
+      // Chain `.filter()` / `.toSorted()` so the index-based lookup walks
+      // the same array shape mapArray reconciled into the DOM (#1434).
+      // Keyed `.find()` is identity-based and works either way; using the
+      // chained array keeps the two delegation paths consistent.
+      array: buildChainedArrayExpr(elem),
       param: elem.param,
       paramBindings: elem.paramBindings,
       key: elem.key,
@@ -37,7 +41,8 @@ export function buildBranchLoopDelegationPlan(loop: BranchLoop, cv: string): Eve
     containerVar: `__loop_${cv}`,
     events: loop.bindings.events,
     itemLookup: buildKeyedOrIndexLookup({
-      array: loop.array,
+      // See note on `buildDynamicLoopDelegationPlan` above (#1434).
+      array: buildChainedArrayExpr(loop),
       param: loop.param,
       paramBindings: loop.paramBindings,
       key: loop.key,
@@ -58,7 +63,10 @@ export function buildStaticArrayDelegationPlan(elem: TopLevelLoop): EventDelegat
     events: elem.bindings.events,
     itemLookup: {
       kind: 'static-index',
-      arrayExpr: elem.array,
+      // Static arrays render through the same `.filter()`/`.toSorted()`
+      // chain at runtime, so the indexOf lookup must walk the chained
+      // array too (#1434).
+      arrayExpr: buildChainedArrayExpr(elem),
       param: elem.param,
       mapPreamble: elem.mapPreamble ?? null,
       siblingOffset: elem.siblingOffset ?? null,

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -274,6 +274,19 @@ export interface BranchLoop extends LoopCore {
   nestedComponents?: IRLoopChildComponent[]
   innerLoops?: NestedLoop[]
   useElementReconciliation?: boolean
+  // Filter / sort chain metadata — must be carried so the mapArray call
+  // emitted inside the branch keeps the `.filter()` / `.toSorted()` chain
+  // and tracks signals read by the predicate / comparator (#1434).
+  filterPredicate?: {
+    param: string
+    raw: string
+  }
+  sortComparator?: {
+    paramA: string
+    paramB: string
+    raw: string
+  }
+  chainOrder?: 'filter-sort' | 'sort-filter'
   // Per-item bindings (events / reactiveAttrs / reactiveTexts / refs / conditionals)
   // now live on `LoopCore.bindings` — see issue #1244 §B.
 }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -5,7 +5,7 @@
 
 import ts from 'typescript'
 import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode } from '../types'
-import type { TopLevelLoop } from './types'
+import type { TopLevelLoop, BranchLoop } from './types'
 import { replaceInExprContexts } from '../scanner/js-scanner'
 import {
   BF_KEY as DATA_KEY,
@@ -124,8 +124,13 @@ export function exhaustiveAttrValue(value: never): never {
  * Build the chained array expression for reconcileList.
  * Chains .toSorted() and .filter() in the correct order based on chainOrder.
  * Always uses .toSorted() (non-mutating) regardless of source method.
+ *
+ * Accepts both top-level and branch-scoped loops — branch loops carry the
+ * same `filterPredicate` / `sortComparator` / `chainOrder` shape so the
+ * mapArray call emitted inside a conditional branch preserves the chain
+ * (#1434).
  */
-export function buildChainedArrayExpr(elem: TopLevelLoop): string {
+export function buildChainedArrayExpr(elem: TopLevelLoop | BranchLoop): string {
   const sortExpr = elem.sortComparator
     ? `.toSorted((${elem.sortComparator.paramA}, ${elem.sortComparator.paramB}) => ${elem.sortComparator.raw})`
     : ''


### PR DESCRIPTION
Fixes #1434.

## Summary

`BranchLoop` — the loop variant emitted for a `.map()` inside a ternary arm — did not carry the `filterPredicate` / `sortComparator` / `chainOrder` metadata that `IRLoop` extracts from `.filter()` / `.sort()` calls. As a result, `collectBranchLoops` dropped the chain on the floor and the branch-scoped `mapArray` was emitted with the raw source array — the `.filter()` was silently discarded and any signal read inside the predicate (e.g. `showDone()` in the issue's repro) was never tracked.

The reporter's repro becomes a no-op on click because `mapArray(() => items(), …)` only subscribes to `items()`, not `showDone()`.

## Changes

- **`types.ts`** — add `filterPredicate?` / `sortComparator?` / `chainOrder?` to `BranchLoop` (same shape as `TopLevelLoop`).
- **`collect-elements.ts`** — propagate the three fields from `IRLoop` when building `BranchLoop` in `collectBranchLoops()`. Previously only `TopLevelLoop` got them.
- **`utils.ts`** — widen `buildChainedArrayExpr(elem: TopLevelLoop)` → `(elem: TopLevelLoop | BranchLoop)` so the same helper can chain `.toSorted()` / `.filter()` for both variants.
- **`build-branch-loop.ts`** + **`build-composite-loop.ts`** — call `buildChainedArrayExpr(loop)` instead of `loop.array` when constructing the `arrayExpr` for the emitted `mapArray`. The previous comment "Branch-scoped loops use the raw array expression (no filter/sort chaining path)" called out the gap explicitly.
- **`client-js-generation.test.ts`** — three regression tests covering: expression-body predicate, block-body predicate (the exact shape from the issue), and `.toSorted()` comparator — all inside a ternary branch.

## After the fix

```js
mapArray(() => items().filter(i => { if (showDone()) return i.done; return !i.done }), __loop_s3, …)
```

The chain survives, so `mapArray`'s effect subscribes to `showDone()` and the list re-renders on toggle.

## Test plan

- [x] New regression tests pass (3/3).
- [x] `packages/jsx` full suite: 1328 pass, 4 pre-existing `primitive-resolver-*` failures unrelated to this fix (verified by stashing the change and reproducing the same 4 failures on the base).
- [x] `packages/adapter-tests` conformance: 345/345 pass.
- [x] `packages/client` runtime: pass.
- [x] Manually inspected emitted client JS for the issue's repro — `.filter()` (block-body) now appears inside `mapArray(() => …)`.

## Out of scope

The SSR template (`hydrate({ template })`) also omits `.filter()` from the inlined `.map()` — but this is a pre-existing limitation that affects top-level loops too, and is not what the issue describes (reactivity, not initial render). Worth a separate issue.

Fixes #1434

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVQZhcfvmWPWKgMdzbfcyd)_