### PR TITLE
fix(cli/#1435): preserve ui/meta/index.json generatedAt when content unchanged

### DIFF
--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet ui/meta/ docs/core/llms.txt; then
+          # `--` disambiguates the pathspecs from revisions; without it,
+          # `git diff --quiet docs/core/llms.txt` errors with
+          # "ambiguous argument" when docs/core/llms.txt is clean.
+          if git diff --quiet -- ui/meta/ docs/core/llms.txt; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/packages/cli/src/__tests__/meta-extract-timestamp.test.ts
+++ b/packages/cli/src/__tests__/meta-extract-timestamp.test.ts
@@ -49,6 +49,33 @@ describe('pickGeneratedAt', () => {
     expect(pickGeneratedAt('not-json', entries, fakeNow)).toBe(FIXED_NOW)
   })
 
+  test('returns fresh timestamp when previous generatedAt is not a string', () => {
+    // Parseable but schema-violating — we must not propagate a non-string
+    // into the freshly written MetaIndex.
+    const prevWithNull = JSON.stringify({
+      version: 1,
+      generatedAt: null,
+      components: entries,
+    })
+    expect(pickGeneratedAt(prevWithNull, entries, fakeNow)).toBe(FIXED_NOW)
+
+    const prevWithNumber = JSON.stringify({
+      version: 1,
+      generatedAt: 1234567890,
+      components: entries,
+    })
+    expect(pickGeneratedAt(prevWithNumber, entries, fakeNow)).toBe(FIXED_NOW)
+  })
+
+  test('returns fresh timestamp when previous generatedAt is empty string', () => {
+    const prev = JSON.stringify({
+      version: 1,
+      generatedAt: '',
+      components: entries,
+    })
+    expect(pickGeneratedAt(prev, entries, fakeNow)).toBe(FIXED_NOW)
+  })
+
   test('treats undefined optional fields as identical to omitted fields', () => {
     // JSON.stringify drops undefined values, so this should still match.
     const prev = JSON.stringify({

--- a/packages/cli/src/__tests__/meta-extract-timestamp.test.ts
+++ b/packages/cli/src/__tests__/meta-extract-timestamp.test.ts
@@ -1,0 +1,62 @@
+// `pickGeneratedAt` decides whether `ui/meta/index.json` gets a fresh
+// `generatedAt` timestamp or keeps the previous one. It exists purely so
+// `update-meta.yml` (and `bun run meta:extract` locally) don't produce
+// a 1-line `generatedAt` diff on every run — which would otherwise
+// trigger noisy auto-commits even when nothing real changed.
+
+import { describe, test, expect } from 'bun:test'
+import { pickGeneratedAt } from '../commands/meta-extract'
+import type { MetaIndexEntry } from '../lib/types'
+
+const entries: MetaIndexEntry[] = [
+  {
+    name: 'button',
+    title: 'Button',
+    category: 'input',
+    description: 'desc',
+    tags: [],
+    stateful: false,
+  },
+]
+
+const FIXED_NOW = '2026-05-20T10:00:00.000Z'
+const fakeNow = () => FIXED_NOW
+
+describe('pickGeneratedAt', () => {
+  test('returns fresh timestamp when no previous index.json exists', () => {
+    expect(pickGeneratedAt(null, entries, fakeNow)).toBe(FIXED_NOW)
+  })
+
+  test('preserves previous timestamp when components are byte-identical', () => {
+    const prev = JSON.stringify({
+      version: 1,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      components: entries,
+    })
+    expect(pickGeneratedAt(prev, entries, fakeNow)).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  test('returns fresh timestamp when components actually changed', () => {
+    const prev = JSON.stringify({
+      version: 1,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      components: [{ ...entries[0], description: 'old desc' }],
+    })
+    expect(pickGeneratedAt(prev, entries, fakeNow)).toBe(FIXED_NOW)
+  })
+
+  test('returns fresh timestamp when previous JSON is malformed', () => {
+    expect(pickGeneratedAt('not-json', entries, fakeNow)).toBe(FIXED_NOW)
+  })
+
+  test('treats undefined optional fields as identical to omitted fields', () => {
+    // JSON.stringify drops undefined values, so this should still match.
+    const prev = JSON.stringify({
+      version: 1,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      components: entries,
+    })
+    const nextWithUndef: MetaIndexEntry[] = [{ ...entries[0], subComponents: undefined }]
+    expect(pickGeneratedAt(prev, nextWithUndef, fakeNow)).toBe('2026-01-01T00:00:00.000Z')
+  })
+})

--- a/packages/cli/src/commands/meta-extract.ts
+++ b/packages/cli/src/commands/meta-extract.ts
@@ -14,6 +14,29 @@ import { extractDescription, extractExamples, parsePropsFromDefinition, extractJ
 import { categoryMap, relatedMap, detectTags } from '../lib/categories'
 import type { ComponentMeta, MetaIndex, MetaIndexEntry, PropMeta, SubComponentMeta, SignalMeta, MemoMeta, EffectMeta, CompilerErrorMeta } from '../lib/types'
 
+/**
+ * Decide what `generatedAt` to write for the new `ui/meta/index.json`.
+ * Returns the previous timestamp when the component list is byte-identical
+ * (so the file ends up unchanged on disk), otherwise a fresh ISO timestamp.
+ * Exported for unit testing.
+ */
+export function pickGeneratedAt(
+  previousIndexJson: string | null,
+  nextEntries: MetaIndexEntry[],
+  now: () => string = () => new Date().toISOString(),
+): string {
+  if (previousIndexJson === null) return now()
+  try {
+    const prev = JSON.parse(previousIndexJson) as MetaIndex
+    const prevSig = JSON.stringify({ ...prev, generatedAt: '' })
+    const nextSig = JSON.stringify({ version: 1, generatedAt: '', components: nextEntries })
+    if (prevSig === nextSig) return prev.generatedAt
+  } catch {
+    // Corrupt or unreadable — fall through to a fresh timestamp.
+  }
+  return now()
+}
+
 // Read registry.json for fallback descriptions
 function loadRegistry(root: string): Record<string, { title: string; description: string }> {
   const registryPath = path.join(root, 'ui/registry.json')
@@ -338,16 +361,18 @@ export async function run(_args: string[], ctx: CliContext): Promise<void> {
     count++
   }
 
-  // Write index.json
+  // Write index.json. Preserve the previous `generatedAt` when only the
+  // timestamp would have changed — otherwise every run produces a 1-line
+  // diff in CI even when no component has actually changed, which makes
+  // `update-meta.yml` push useless auto-commits.
+  const indexPath = path.join(ctx.metaDir, 'index.json')
+  const prevRaw = existsSync(indexPath) ? readFileSync(indexPath, 'utf-8') : null
   const index: MetaIndex = {
     version: 1,
-    generatedAt: new Date().toISOString(),
+    generatedAt: pickGeneratedAt(prevRaw, indexEntries),
     components: indexEntries,
   }
-  writeFileSync(
-    path.join(ctx.metaDir, 'index.json'),
-    JSON.stringify(index, null, 2) + '\n',
-  )
+  writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n')
 
   // Generate llms.txt files
   const uiLlmsTxt = generateUiLlmsTxt(index, 'https://ui.barefootjs.dev/r')

--- a/packages/cli/src/commands/meta-extract.ts
+++ b/packages/cli/src/commands/meta-extract.ts
@@ -30,7 +30,12 @@ export function pickGeneratedAt(
     const prev = JSON.parse(previousIndexJson) as MetaIndex
     const prevSig = JSON.stringify({ ...prev, generatedAt: '' })
     const nextSig = JSON.stringify({ version: 1, generatedAt: '', components: nextEntries })
-    if (prevSig === nextSig) return prev.generatedAt
+    // Guard against a corrupt-but-parseable index.json where `generatedAt`
+    // got nulled out, replaced with a number, etc. — preserving such a
+    // value would silently break the `MetaIndex` schema contract.
+    if (prevSig === nextSig && typeof prev.generatedAt === 'string' && prev.generatedAt !== '') {
+      return prev.generatedAt
+    }
   } catch {
     // Corrupt or unreadable — fall through to a fresh timestamp.
   }


### PR DESCRIPTION
## Summary

Follow-up to #1437. After that PR merged, the new `update-meta.yml` workflow started pushing empty-content auto-commits to every PR (see [`8ffb3ee`](https://github.com/piconic-ai/barefootjs/commit/8ffb3ee) on main, which the workflow itself pushed). The components hadn't changed — only `generatedAt` had — but `git diff --quiet` was always false because `meta:extract` rewrites `ui/meta/index.json` with a fresh `new Date().toISOString()` every run.

## Fix

`packages/cli/src/commands/meta-extract.ts`: new `pickGeneratedAt(prev, nextEntries, now?)` helper. If the previous `index.json` exists and serializes (sans timestamp) to the same string as the new one, keep the previous timestamp. Otherwise stamp with `now()`.

Locally this also makes `bun run meta:extract` a clean no-op for everyone after the first run, so contributor PRs stop carrying a stray 1-line meta diff.

## Bonus fix

`update-meta.yml`: `git diff --quiet ui/meta/ docs/core/llms.txt` → `git diff --quiet -- ui/meta/ docs/core/llms.txt`. Without `--`, git reports "ambiguous argument" when the paths happen to have no associated revision (reproduced locally; would have bitten the workflow eventually).

## Test plan

- [x] `packages/cli/src/__tests__/meta-extract-timestamp.test.ts` — 5 cases: no previous file, identical content (preserve), changed content (refresh), malformed JSON (refresh), `undefined` optional fields (preserve).
- [x] Existing `meta-extract-drift.test.ts` + `meta-extract-integration.test.ts` still green (82 / 82).
- [x] Locally: run `bun run meta:extract` twice in a row → `git diff -- ui/meta/ docs/core/llms.txt` empty after both runs.
- [ ] Verify on this PR: `update-meta` workflow does NOT auto-commit (no real changes to meta in this branch).

Closes the follow-up issue described in the comment thread on #1437.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV8AnSHZQz4Yn8mgNAqbaX)_