### PR TITLE
fix(adapters): emit BF101 for JS-only patterns Go/Mojo cannot lower

### DIFF
--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -89,24 +89,35 @@ Some comparators (e.g., `localeCompare`, block bodies) are not supported and wil
 
 ## Limitations
 
-Some JavaScript expressions cannot be translated into marked template syntax. The compiler emits `BF021` for these. Add [`/* @client */`](./client-directive.md) to opt into client-only evaluation.
+Some JavaScript expressions cannot be translated into marked template syntax. Which expressions error depends on the adapter — non-JS template backends (Go `html/template`, Mojolicious EP) have a narrower expression surface than JS-runtime adapters (Hono, etc.) that can execute JS at SSR time.
 
-### Unsupported patterns
+| Pattern | Hono / JS-runtime adapters | Go / Mojo adapters |
+|---|---|---|
+| `.filter()` with destructured param (`({done}) => done`) | works (runs as JS) | **BF101** |
+| `.filter()` with `function` keyword callback | works | **BF101** |
+| `.reduce()`, `.forEach()`, `.flatMap()` | works | **BF101** |
+| Nested higher-order in filter predicate (`x => x.tags.filter(...).length > 0`) | works | **BF101** |
+| Sort comparator using `localeCompare` or a block body | **BF021** (all adapters) | **BF021** |
+| `typeof` in a filter predicate | **BF021** (all adapters) | **BF021** |
+
+`BF021` is raised at the IR layer and applies to every adapter. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) to opt into client-only evaluation and suppress the error.
+
+### Patterns that error on Go / Mojo
 
 **Nested higher-order methods:**
 
 ```tsx
-// ❌ Compile error (BF021)
-{items().filter(x => x.tags().filter(t => t.active).length > 0)}
+// ❌ BF101 on Go/Mojo; works on Hono
+{items().filter(x => x.tags.filter(t => t.active).length > 0).map(...)}
 
 // ✅ Add /* @client */ to evaluate on the client
-{/* @client */ items().filter(x => x.tags().filter(t => t.active).length > 0)}
+{/* @client */ items().filter(x => x.tags.filter(t => t.active).length > 0).map(...)}
 ```
 
-**Unsupported array methods** (`.reduce()`, `.forEach()`, `.flatMap()`):
+**`.reduce()` / `.forEach()` / `.flatMap()`:**
 
 ```tsx
-// ❌ Compile error (BF021)
+// ❌ BF101 on Go/Mojo; works on Hono
 {items().reduce((sum, x) => sum + x.price, 0)}
 
 // ✅ Use /* @client */
@@ -116,27 +127,29 @@ Some JavaScript expressions cannot be translated into marked template syntax. Th
 **Destructuring in predicate parameters:**
 
 ```tsx
-// ❌ Compile error (BF021)
+// ❌ BF101 on Go/Mojo; works on Hono
 {items().filter(({done}) => done).map(...)}
 
-// ✅ Use a named parameter instead
+// ✅ Use a named parameter for adapter portability
 {items().filter(t => t.done).map(...)}
 ```
 
 **Function expressions** (`function` keyword):
 
 ```tsx
-// ❌ Compile error (BF021)
+// ❌ BF101 on Go/Mojo; works on Hono
 {items().filter(function(x) { return x.done })}
 
-// ✅ Use arrow functions instead
+// ✅ Use arrow functions for adapter portability
 {items().filter(x => x.done)}
 ```
+
+### Patterns that error on all adapters
 
 **Unsupported sort comparators** (`localeCompare`, block bodies):
 
 ```tsx
-// ❌ Compile error (BF021)
+// ❌ BF021 (all adapters)
 {items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}
 
 // ✅ Use /* @client */

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -706,6 +706,60 @@ export function TodoStatus() {
 `)
       expect(result.template).toContain('bf_every .Todos "Done"')
     })
+
+    test('nested higher-order in filter predicate → BF101', () => {
+      // Predicate body contains an inner `.filter()` call —
+      // `renderFilterExpr` cannot lower this to a Go template action.
+      // Previously this fell through to the `[UNSUPPORTED-FILTER-EXPR]`
+      // placeholder which compiled into a broken template at runtime;
+      // adapters now emit BF101 with the offending expression.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; name: string; tags: { active: boolean }[] }
+
+export function TodoList() {
+  const [items, setItems] = createSignal<Todo[]>([])
+  return (
+    <ul>
+      {items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => (
+        <li key={t.id}>{t.name}</li>
+      ))}
+    </ul>
+  )
+}
+`, adapter)
+      adapter.generate(ir)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101.length).toBeGreaterThan(0)
+      expect(bf101[0].message).toContain('Filter predicate')
+    })
+
+    test('nested higher-order in filter predicate + /* @client */ suppresses BF101', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; name: string; tags: { active: boolean }[] }
+
+export function TodoList() {
+  const [items, setItems] = createSignal<Todo[]>([])
+  return (
+    <ul>
+      {/* @client */ items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => (
+        <li key={t.id}>{t.name}</li>
+      ))}
+    </ul>
+  )
+}
+`, adapter)
+      adapter.generate(ir)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101).toEqual([])
+    })
   })
 
   describe('find/findIndex - adapter specific', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -45,6 +45,7 @@ import {
   isBooleanAttr,
   parseExpression,
   isSupported,
+  exprToString,
   identifierPath,
   emitParsedExpr,
   emitIRNode,
@@ -3072,8 +3073,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         return `or (${left}) (${right})`
       }
 
-      default:
-        return '[UNSUPPORTED-FILTER-EXPR]'
+      default: {
+        // The filter predicate body contains a node kind we can't lower
+        // to a Go template action — most commonly a nested higher-order
+        // (`x => x.tags.filter(...).length > 0`). Surface BF101 with the
+        // offending expression so the user can either rewrite the
+        // predicate or add `/* @client */`. Returning the placeholder
+        // string previously let the template through with a literal
+        // `[UNSUPPORTED-FILTER-EXPR]` token that only failed at
+        // `text/template` execution time.
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Filter predicate contains an expression that cannot be lowered to a Go template action: ${exprToString(expr)}`,
+          loc: this.makeLoc(),
+          suggestion: {
+            message: 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Rewrite the predicate to avoid nested higher-order methods (`.filter()` / `.map()` / etc. inside the predicate body)',
+          },
+        })
+        return 'false'
+      }
     }
   }
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -269,6 +269,50 @@ export function Page() {
     expect(result.template).not.toContain('children =>')
   })
 
+  describe('emits BF101 for JS-only filter / array patterns the Mojo adapter cannot lower to EP', () => {
+    // These patterns previously fell through Mojo's regex pipeline and
+    // emitted broken Embedded Perl silently (e.g. `$items->{filter}->[...]`
+    // for a destructured filter, `[grep {...}]->{length}` for nested
+    // higher-order). The Go adapter rejects them via its
+    // `convertExpressionToGo` / `renderFilterExpr` gates with BF101;
+    // these tests pin Mojo to the same contract so users on
+    // non-JS-runtime adapters see a compile error and can either
+    // rewrite or add `/* @client */`.
+    const wrap = (body: string) => `'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<any[]>([])
+  return ${body}
+}`
+
+    const cases: { name: string; body: string; needle: string }[] = [
+      { name: 'reduce',            body: `<div>{items().reduce((s, x) => s + x, 0)}</div>`,                                                          needle: '.reduce(' },
+      { name: 'forEach',           body: `<ul>{items().forEach(x => x)}</ul>`,                                                                       needle: '.forEach(' },
+      { name: 'flatMap',           body: `<ul>{items().flatMap(x => x.tags).map(t => <li key={t}>{t}</li>)}</ul>`,                                  needle: '.flatMap(' },
+      { name: 'destructured filter param', body: `<ul>{items().filter(({done}) => done).map(t => <li key={t.id}>{t.name}</li>)}</ul>`,              needle: '.filter(' },
+      { name: 'function-keyword filter',   body: `<ul>{items().filter(function(x) { return x.done }).map(t => <li key={t.id}>{t.name}</li>)}</ul>`, needle: '.filter(' },
+      { name: 'nested higher-order in filter predicate', body: `<ul>{items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => <li key={t.id}>{t.name}</li>)}</ul>`, needle: 'higher-order' },
+    ]
+
+    for (const { name, body, needle } of cases) {
+      test(`${name} → BF101`, () => {
+        const adapter = new MojoAdapter()
+        const result = compileJSX(wrap(body), 'C.tsx', { adapter })
+        const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
+        expect(bf101.length).toBeGreaterThan(0)
+        expect(bf101.some(e => e.message.includes(needle))).toBe(true)
+      })
+
+      test(`${name} + /* @client */ suppresses BF101`, () => {
+        const adapter = new MojoAdapter()
+        const wrappedBody = body.replace(/\{(?!\/\* @client \*\/)/, '{/* @client */ ')
+        const result = compileJSX(wrap(wrappedBody), 'C.tsx', { adapter })
+        const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
+        expect(bf101).toEqual([])
+      })
+    }
+  })
+
   test('breaks the convertHigherOrderExpr ↔ unsupported-emitter loop (#1421)', () => {
     // Regression: a branch-local `.filter(Boolean).join(' ')` chain
     // referenced at an attribute used to crash `bf build` with

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -38,6 +38,8 @@ import {
   isBooleanAttr,
   parseExpression,
   isSupported,
+  containsHigherOrder,
+  exprToString,
   identifierPath,
   stringifyParsedExpr,
   emitParsedExpr,
@@ -902,6 +904,24 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     param: string,
     localVarMap: Map<string, string> = new Map(),
   ): string {
+    // Nested higher-order in a filter predicate body (e.g.
+    // `x => x.tags.filter(t => t.active).length > 0`) — the emitter
+    // lowers the inner grep to a Perl anonymous array ref, but the
+    // surrounding `.length` / member accesses translate to
+    // `[ ... ]->{length}` which is undef at runtime. Surface BF101
+    // up-front instead of shipping silently-broken EP.
+    if (containsHigherOrder(expr)) {
+      this.errors.push({
+        code: 'BF101',
+        severity: 'error',
+        message: `Filter predicate contains a nested higher-order method that cannot be lowered to Embedded Perl: ${exprToString(expr)}`,
+        loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        suggestion: {
+          message: 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Rewrite the predicate to avoid nested `.filter()` / `.map()` / `.some()` / `.every()` inside the predicate body',
+        },
+      })
+      return '0'
+    }
     return emitParsedExpr(expr, new MojoFilterEmitter(param, localVarMap))
   }
 
@@ -1112,8 +1132,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   }
 
   private convertExpressionToPerl(expr: string): string {
-    // Handle higher-order array methods via ParsedExpr AST
-    if (/\.\s*(?:filter|every|some)\s*\(/.test(expr)) {
+    // Handle higher-order array methods via ParsedExpr AST.
+    // `filter|every|some` lower to Embedded Perl (grep). The rest
+    // (`reduce|reduceRight|forEach|flatMap|flat|findLast|findLastIndex`)
+    // can't lower to EP at all — route them through the same AST path
+    // so `convertHigherOrderExpr`'s `isSupported` gate emits BF101
+    // instead of falling into the regex pipeline that mangles
+    // `$items->{reduce}->{...}` etc.
+    if (/\.\s*(?:filter|every|some|reduce|reduceRight|forEach|flatMap|flat|findLast|findLastIndex)\s*\(/.test(expr)) {
       return this.convertHigherOrderExpr(expr)
     }
 
@@ -1291,6 +1317,26 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this.higherOrderInFlight.add(expr)
     try {
       const parsed = parseExpression(expr)
+      // Parity gate with the Go adapter's `convertExpressionToGo`: if the
+      // parsed expression isn't supported (e.g. `.reduce()` / `.forEach()`,
+      // destructured filter param, function-keyword callback) we cannot
+      // lower it to Embedded Perl. Emit BF101 and return a safe Perl
+      // empty-string literal so downstream concatenation doesn't blow up.
+      const support = isSupported(parsed)
+      if (!support.supported) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Cannot lower higher-order chain to Embedded Perl: ${expr.trim()}`,
+          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message: support.reason
+              ? `${support.reason}\n\nOptions:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl`
+              : 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl',
+          },
+        })
+        return "''"
+      }
       return this.renderParsedExprToPerl(parsed)
     } finally {
       this.higherOrderInFlight.delete(expr)

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -484,7 +484,7 @@ function checkSupport(expr: ParsedExpr): SupportResult {
 /**
  * Check if expression contains any higher-order method calls.
  */
-function containsHigherOrder(expr: ParsedExpr): boolean {
+export function containsHigherOrder(expr: ParsedExpr): boolean {
   switch (expr.kind) {
     case 'higher-order':
       return true

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -238,7 +238,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody } from './expression-parser'
+export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder } from './expression-parser'
 export type { ParsedExpr, ParsedStatement, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 
 // Debug analysis


### PR DESCRIPTION
## Summary

An audit of `bf guide rendering/jsx-compatibility` surfaced that patterns the guide promised would emit `BF021` universally **actually emitted no diagnostic at all** and silently produced broken templates. This PR closes that gap.

### Audit findings (before this PR)

| Pattern | Go | Hono | Mojo |
|---|---|---|---|
| `.reduce()` / `.forEach()` / `.flatMap()` | BF101 ✅ | OK (runs as JS) | **silently broken Perl** ❌ |
| Destructured filter param `({done}) => done` | BF101 ✅ | OK | **silently broken Perl** ❌ |
| `function`-keyword filter callback | BF101 ✅ | OK | **silently broken Perl** ❌ |
| Nested higher-order in filter predicate | **literal `[UNSUPPORTED-FILTER-EXPR]` placeholder in template** ❌ | OK | **silently broken Perl** ❌ |

The guide claimed BF021 for all of these, but no diagnostic was emitted at the IR layer. Only the Go adapter raised BF101 via `convertExpressionToGo`, and even that missed nested higher-order in filter predicates.

### Direction (agreed with maintainer)

- **JS-runtime adapters (Hono, etc.)** can evaluate these natively at SSR time, so leaving them as-is is desirable. **Hono already passes them through and works** — no change needed.
- **Go / Mojo adapters** cannot lower these to EP / `html/template`, so they must reliably surface a compile-time error (BF101).
- Update the guide to reflect the per-adapter reality.

### Changes

| File | Change |
|---|---|
| `docs/core/rendering/jsx-compatibility.md` | Replace "BF021 across all adapters" with a per-adapter table — Hono works natively; Go/Mojo emit BF101 |
| `packages/jsx/src/expression-parser.ts` + `src/index.ts` | Export `containsHigherOrder` |
| `packages/adapter-mojolicious/.../mojo-adapter.ts` | (1) Extend the higher-order regex precheck to also route `reduce \| reduceRight \| forEach \| flatMap \| flat \| findLast \| findLastIndex` through the AST path. (2) Add `isSupported` gate in `convertHigherOrderExpr`. (3) Add `containsHigherOrder` guard in `renderPerlFilterExpr` for nested higher-order |
| `packages/adapter-go-template/.../go-template-adapter.ts` | Replace the placeholder string in `renderFilterExpr`'s default branch with a BF101 diagnostic carrying the offending expression |
| `*/src/__tests__/*.test.ts` | Mojo: 12 cases (6 patterns × BF101 + `/* @client */` suppression). Go: 2 cases (nested HOM + suppression) |

### After this PR

| Pattern | Go | Hono | Mojo |
|---|---|---|---|
| reduce / forEach / flatMap | BF101 | OK | BF101 |
| Destructured filter param | BF101 | OK | BF101 |
| function-keyword filter | BF101 | OK | BF101 |
| Nested HOM | BF101 | OK | BF101 |
| + `/* @client */` | OK | OK | OK |
| Supported baseline (`.filter(t => !t.done)`, etc.) | OK | OK | OK |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/unsupported-expression.test.ts` — existing BF021 tests, 16/16 pass
- [x] `bun test packages/adapter-mojolicious` — 176 pass / 4 skip (perl unavailable) / 0 fail
- [x] `bun test packages/adapter-go-template` — 193 pass / 2 skip (go unavailable) / 0 fail
- [x] Full jsx package — 4 pre-existing failures (`primitive-resolver-alias`) unrelated to this PR (reproduced on main)
- [x] `bun run bf guide rendering/jsx-compatibility` renders correctly
- [ ] Verify adapter conformance on CI with Go / Perl available

## Follow-ups (out of scope)

- **Lift the gate to the IR layer via adapter capability declarations**: each adapter currently re-implements the same gate; an IR-layer capability-driven design could centralize this (larger architectural change).
- **Unify the error messages**: Mojo's "Cannot lower higher-order chain..." and Go's "Expression not supported..." differ slightly; align in a follow-up if desired.
- **`extractFilterPredicate` `unsupportedReason`**: currently the destruct / function-keyword paths return `result: null` without a `unsupportedReason`; surfacing a more specific reason would improve the BF101 message text.

https://claude.ai/code/session_01CSZT1HbhwCFhcFpzBs3rJP