### PR TITLE
fix(adapter-go-template/#1440): propagate unsupported-filter sentinel so template stays syntactically valid

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -737,6 +737,66 @@ export function TodoList() {
       expect(bf101[0].message).toContain('Filter predicate')
     })
 
+    test('nested higher-order under `.length` emits a syntactically valid Go template (#1440 review)', () => {
+      // Regression for the Copilot review on #1440: the BF101 fallback
+      // used to return the literal string `'false'` from `renderFilterExpr`,
+      // but parent branches (`member` → `${obj}.Length`) would then build
+      // `false.Length` on top of it, producing `{{if gt false.Length 0}}`
+      // — syntactically invalid Go template that crashed `text/template`
+      // parsing with a cascade of confusing secondary errors. The fix
+      // propagates the unsupported state up so the final emitted action
+      // collapses to just `{{if false}}`, which is at least parseable.
+      const adapter = new GoTemplateAdapter()
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; name: string; tags: { active: boolean }[] }
+
+export function TodoList() {
+  const [items, setItems] = createSignal<Todo[]>([])
+  return (
+    <ul>
+      {items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => (
+        <li key={t.id}>{t.name}</li>
+      ))}
+    </ul>
+  )
+}
+`, adapter)
+      expect(result.template).toContain('{{if false}}')
+      expect(result.template).not.toContain('false.Length')
+      expect(result.template).not.toContain('[UNSUPPORTED-FILTER-EXPR]')
+    })
+
+    test('state does not bleed between independent filter expressions in the same component (#1440 review)', () => {
+      // After a filter expression hits the BF101 default branch, the
+      // depth-scoped reset must clear `filterExprUnsupported` so a
+      // subsequent supported filter in the same component still renders
+      // its real predicate instead of degrading to the `false` fallback.
+      const adapter = new GoTemplateAdapter()
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; name: string; done: boolean; tags: { active: boolean }[] }
+
+export function TodoList() {
+  const [items, setItems] = createSignal<Todo[]>([])
+  return (
+    <div>
+      <ul>{items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+      <ul>{items().filter(t => !t.done).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+    </div>
+  )
+}
+`, adapter)
+      // First (unsupported) loop collapses to {{if false}}; second
+      // (supported) loop still renders `not .Done`.
+      expect(result.template).toContain('{{if false}}')
+      expect(result.template).toContain('{{if not .Done}}')
+    })
+
     test('nested higher-order in filter predicate + /* @client */ suppresses BF101', () => {
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -191,6 +191,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   name = 'go-template'
   extension = '.tmpl'
 
+  // Recursion-scoped state for `renderFilterExpr`. `filterExprDepth`
+  // tracks nesting so the outer call resets `filterExprUnsupported`
+  // before each independent filter expression; the flag itself is set
+  // in the `default` branch (BF101 emission) and propagated by parent
+  // branches so the final template stays syntactically valid even
+  // when a child rendered to the fallback sentinel (#1440 review).
+  private filterExprDepth = 0
+  private filterExprUnsupported = false
+
   /**
    * Identifier-path callees the Go runtime can render in template
    * scope (#1188). The relocate pass consults this map to mark
@@ -2974,6 +2983,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     param: string,
     localVarMap: Map<string, string> = new Map()
   ): string {
+    // Top-of-recursion: clear the unsupported sentinel so a previous
+    // filter expression's failure doesn't poison this one. Parents
+    // (`member` / `binary` / `unary` / `logical` / `call`) check the
+    // flag after each child render and propagate `false` upward so the
+    // emitted template stays syntactically valid even when the default
+    // branch had to bail out (#1440 review).
+    if (this.filterExprDepth === 0) this.filterExprUnsupported = false
+    this.filterExprDepth++
+    try {
+      return this.renderFilterExprNode(expr, param, localVarMap)
+    } finally {
+      this.filterExprDepth--
+    }
+  }
+
+  private renderFilterExprNode(
+    expr: ParsedExpr,
+    param: string,
+    localVarMap: Map<string, string>
+  ): string {
     switch (expr.kind) {
       case 'identifier': {
         // Check if it's the loop param
@@ -3004,6 +3033,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         // Nested member access or local var.prop
         const obj = this.renderFilterExpr(expr.object, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
         return `${obj}.${this.capitalizeFieldName(expr.property)}`
       }
 
@@ -3016,11 +3046,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
           return `$.${this.capitalizeFieldName(expr.callee.name)}`
         }
-        return this.renderFilterExpr(expr.callee, param, localVarMap)
+        const result = this.renderFilterExpr(expr.callee, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
+        return result
       }
 
       case 'unary': {
         const arg = this.renderFilterExpr(expr.argument, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
         if (expr.op === '!') {
           // Wrap in parens if arg is a function call (eq, ne, gt, etc.) for Go template syntax
           const needsParens = this.isGoFunctionCall(expr.argument)
@@ -3034,7 +3067,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
       case 'binary': {
         const left = this.renderFilterExpr(expr.left, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
         const right = this.renderFilterExpr(expr.right, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
 
         switch (expr.op) {
           case '===':
@@ -3066,7 +3101,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
       case 'logical': {
         const left = this.renderFilterExpr(expr.left, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
         const right = this.renderFilterExpr(expr.right, param, localVarMap)
+        if (this.filterExprUnsupported) return 'false'
         if (expr.op === '&&') {
           return `and (${left}) (${right})`
         }
@@ -3078,10 +3115,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // to a Go template action — most commonly a nested higher-order
         // (`x => x.tags.filter(...).length > 0`). Surface BF101 with the
         // offending expression so the user can either rewrite the
-        // predicate or add `/* @client */`. Returning the placeholder
-        // string previously let the template through with a literal
-        // `[UNSUPPORTED-FILTER-EXPR]` token that only failed at
-        // `text/template` execution time.
+        // predicate or add `/* @client */`. Set the recursion-wide
+        // `filterExprUnsupported` flag so parent branches return `false`
+        // instead of wrapping the sentinel into `false.Length` / `gt
+        // false.Length 0` etc. — the build will fail on BF101 anyway,
+        // but the emitted template must still be syntactically valid
+        // so `text/template` parsing doesn't blow up with a cascade of
+        // confusing secondary errors (#1440 review).
+        this.filterExprUnsupported = true
         this.errors.push({
           code: 'BF101',
           severity: 'error',


### PR DESCRIPTION
## Summary

Follow-up to the Copilot review on #1440: when `renderFilterExpr` hit the BF101 default branch it returned the literal string `'false'` as a placeholder, but parent branches (`member` → `${obj}.Length`, `binary` → `gt ${left} ${right}`) kept building on top of it. A nested higher-order under `.length` therefore rendered as `{{if gt false.Length 0}}` — syntactically invalid Go template that `text/template` rejects with a cascade of confusing secondary errors that mask the real BF101 diagnostic.

### Fix

Track the unsupported state with a depth-scoped recursion flag on the adapter:
- The outer call (depth 0) resets `filterExprUnsupported` so a previous failure doesn't poison the current one.
- The `default` branch sets the flag and emits BF101.
- Each parent branch (`member` / `call` / `unary` / `binary` / `logical`) short-circuits to `'false'` after a child render if the flag is set.

Result: the failing predicate collapses to a clean `{{if false}}`, independent filter expressions in the same component keep rendering their real predicates (no state bleed), and BF101 remains the visible diagnostic.

### Before / after

```diff
- {{if gt false.Length 0}}<li ...>...</li>{{end}}
+ {{if false}}<li ...>...</li>{{end}}
```

Mojo already short-circuits at the entry of `renderPerlFilterExpr` via `containsHigherOrder`, so it doesn't have the same issue — verified its template emits `% if (0) {` for the same input.

## Test plan

- [x] `bun test packages/adapter-go-template` — 195 pass / 2 skip (Go binary unavailable) / 0 fail
- [x] Two new regression tests under `higher-order methods - regression`:
  - `nested higher-order under .length emits a syntactically valid Go template` — asserts `{{if false}}` appears and `false.Length` / `[UNSUPPORTED-FILTER-EXPR]` do not.
  - `state does not bleed between independent filter expressions in the same component` — asserts a supported `.filter(t => !t.done)` still renders as `{{if not .Done}}` after a preceding unsupported one collapses to `{{if false}}`.
- [ ] Verify on CI with `go` available that the template actually parses.

https://claude.ai/code/session_01CSZT1HbhwCFhcFpzBs3rJP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSZT1HbhwCFhcFpzBs3rJP)_